### PR TITLE
Python coverage audit: measure the gap, then close the worst of it

### DIFF
--- a/docs/python-coverage-audit.md
+++ b/docs/python-coverage-audit.md
@@ -1,0 +1,430 @@
+# Python Coverage Audit — 2026-07-27
+
+Measured, not estimated. Every number below comes from a real command
+run against `origin/main @ 57b030b01` in this repo.
+
+**Method**
+
+```bash
+python -m pip install coverage pytest-cov pytest-xdist
+python -m pytest tests/ -q -m "not livedata" -p no:randomly -n 4 --dist loadfile \
+  --cov=src --cov=server --cov-report=term
+```
+
+`-m "not livedata"` mirrors what CI actually gates on, so these are
+**CI-blocking** coverage numbers, not "if you also had live exports"
+numbers. `-n 4 --dist loadfile` keeps each test file on one worker;
+the full suite runs in ~4 minutes instead of ~22 serial.
+
+---
+
+## 1. Headline numbers
+
+| | Before | After | Δ |
+|---|---|---|---|
+| Tests collected (`not livedata`) | 3,927 | 4,012 | **+85** |
+| Tests passing | 3,926 | 4,011 | +85 |
+| Total statement coverage (`src/` + `server.py`) | **80.1%** | **80.5%** | +0.4pp |
+| Statements missed | 6,570 | 6,431 | −139 |
+
+One test fails in the parallel run both before and after —
+`tests/intel/test_endpoints.py::TestLeagueScoping::test_reads_go_through_the_league_resolver`.
+It **passes serially** (`python -m pytest tests/intel/test_endpoints.py`
+→ 21 passed). It is a cross-file registry-state leak that only appears
+under `--dist loadfile` grouping, pre-existing and unrelated to this
+branch. Not fixed here — it is a test-isolation issue in a file this
+work did not otherwise touch.
+
+### Coverage of the modules that actually decide money
+
+| Module | Before | After |
+|---|---|---|
+| `src/api/data_contract.py` (valuation engine) | 79.8% | 80.1% |
+| `src/canonical/player_valuation.py` (Hill curves) | 97.7% | 97.7% |
+| `src/trade/finder.py` | 95.7% | 95.7% |
+| `src/trade/suggestions.py` | 94.1% | 94.1% |
+| `src/league_intel/replacement.py` | 95.0% | 95.0% |
+| `src/trade/faab_recommender.py` | 93.2% | 93.2% |
+| `src/trade/faab_contention.py` | 85.4% | 85.4% |
+| **`src/trade/waiver.py`** | **27.0%** | **99.2%** |
+| `server.py` | 51.3% | 51.8% |
+
+The honest read: **the money paths were already well covered by line
+count.** The exception was `src/trade/waiver.py` — live behind
+`POST /api/waiver/suggestions`, and the only module under `src/trade/`
+with no dedicated test file at all.
+
+The valuation engine's 80% is the more interesting number, and section
+3 explains why the line percentage overstates the real protection.
+
+---
+
+## 2. Ranked gaps: uncovered statements × logic density
+
+Ranked by *consequence*, not raw miss count. Density judged by reading:
+branching, arithmetic, error handling, external-input parsing.
+
+| # | Module | Stmts | Miss | Cov | Density | Why it ranks here |
+|---|---|---|---|---|---|---|
+| 1 | `src/api/data_contract.py` | 2,889 | 585 | 79.8% | **Very high** | Every live player value. Dense arithmetic + branching. The 585 misses are concentrated in scrape-bridge/enrichment branches, but stage constants had *zero* CI-blocking assertions (§3). |
+| 2 | `server.py` | 4,511 | 2,195 | 51.3% | **High** | Largest absolute hole. Much is route glue and error handlers, but includes league resolution, auth gating, and every trade/terminal entry point. |
+| 3 | `src/trade/waiver.py` | 122 | 89 | 27.0% | **High** | Live endpoint. FAAB bid arithmetic = literal money. **Closed → 99.2%.** |
+| 4 | `src/ros/scrape.py` | 277 | 207 | 25.3% | Medium | External HTML/JSON parsing — high density, but network-bound and seasonal. |
+| 5 | `src/api/chat.py` | 113 | 113 | **0.0%** | Medium | Entirely untested module. |
+| 6 | `src/ros/sources/draftsharks_ros.py` | 92 | 92 | **0.0%** | Medium | External-input parser, zero coverage. |
+| 7 | `src/ros/sources/fantasypros_ros_overall.py` | 59 | 59 | **0.0%** | Medium | Same. |
+| 8 | `src/ros/sources/fantasypros_ros_idp.py` | 43 | 43 | **0.0%** | Medium | Same. |
+| 9 | `src/ros/api.py` | 182 | 115 | 36.8% | Medium | ROS surface. |
+| 10 | `src/scoring/feature_engineering.py` | 50 | 45 | 10.0% | Medium | Arithmetic-dense but offline/analytical, not live valuation. |
+| 11 | `src/scoring/archetype_model.py` | 53 | 46 | 13.2% | Medium | As above. |
+| 12 | `src/scoring/backtest.py` | 57 | 51 | 10.5% | Low-Med | Offline tooling. |
+| 13 | `src/public_league/awards.py` | 900 | 76 | 91.6% | Low | Big module, mostly already covered; remainder is display copy. |
+
+Deliberately ranked *low* despite large miss counts: `src/api/terminal.py`
+(153 miss / 80.0%) and `src/api/sleeper_overlay.py` (119 miss / 82.5%)
+— both are aggregation/display layers over already-validated values.
+
+---
+
+## 3. High line-coverage, weak assertions
+
+Coverage is a floor. These execute a lot and assert little; the
+percentage they contribute is not protection.
+
+### W-1 — `tests/api/test_market_corridor_clamp.py::test_fallback_chain_covers_all_scope_sources` *(fixed in this branch)*
+
+The clearest case in the repo. Its docstring claimed:
+
+> "Safety rail: every IDP-scope and offense-scope value+rank source in
+> the registry should be somewhere in the fallback chain… Catches a new
+> source being added to `_RANKING_SOURCES` without being added to the
+> anchor chain."
+
+It computed `offense_sources`, `idp_sources`, `chain_offense`,
+`chain_idp` — and **compared none of them**. Ruff flagged all four as
+`F841` unused. The only real assertions were that each chain's first
+element matches the declared primary anchor. The promised guard did not
+exist.
+
+Fixed by renaming to
+`test_fallback_chain_starts_with_the_declared_primary_anchor`, removing
+the dead locals, and rewriting the docstring to describe what is
+verified. The registry-coverage assertion was **not** added: an inline
+comment records that the chain is a deliberately curated shortlist, so
+a subset assertion would be wrong. Clears 4 pre-existing ruff errors.
+
+### W-2 — `tests/api/test_single_source_resolution.py`
+
+Executes **31.7% of `src/api/data_contract.py`** (917 of 2,889
+statements) on its own:
+
+```
+$ python -m pytest tests/api/test_single_source_resolution.py \
+    --cov=src.api.data_contract --cov-report=term
+src/api/data_contract.py    2889   1972  31.7%
+18 passed
+```
+
+Its 18 tests assert **no computed value whatsoever** — only boolean
+flags (`isSingleSource`, `isStructurallySingleSource`), name-normalisation
+equality, and allowlist membership. Nearly a third of the valuation
+engine's line coverage comes from a file that would stay green if every
+player's value changed.
+
+Not a criticism of the tests — they correctly cover what they are for.
+The point is that `data_contract.py`'s 80% must not be read as "80% of
+the valuation logic is verified".
+
+### W-3 — the `livedata` CI blind spot (structural)
+
+`tests/conftest.py::_LIVEDATA_MODULES` marks 16 modules `livedata`; CI
+runs `-m "not livedata"`, so they are **deselected**. Among them are
+`test_data_contract.py`, `test_single_curve_live.py`,
+`test_pick_rookie_anchor.py` and `test_picks_end_to_end.py` — i.e. most
+of the whole-board valuation assertions.
+
+Before this branch, grepping the live constants across `tests/`:
+
+| Pipeline stage | Referenced only in |
+|---|---|
+| `_SINGLE_SOURCE_VALUE_RETENTION` / `singleSourceValuePenaltyApplied` | `test_single_curve_live.py` *(livedata)*, `test_data_contract.py` *(livedata)*, `test_compact_view.py` (**fixture field name only, no math**) |
+| `_ALPHA_SHRINKAGE` / `alphaShrinkage` | same three |
+| `_apply_pick_year_discount_to_blend` | `test_picks_end_to_end.py` *(livedata)*, `test_frontend_migration.py` |
+| pick tethering / `_rookie_pool_value` | `test_pick_rookie_anchor.py` *(livedata)*, `test_data_contract.py` *(livedata)* |
+
+So the single-source haircut, α-shrinkage and pick tethering had **no
+CI-blocking test at all**. Changing `0.30` to `0.50` — a board-wide
+repricing — would have gone green in CI.
+
+### W-4 — guards that cannot fire, cited in source as if they can
+
+`src/api/data_contract.py` (~line 7281) says:
+
+> "…`tests/api/test_single_curve_live.py::TestOffenseHasNoCalibrationLayer`
+> fails if that reference ever starts mutating live values."
+
+It cannot. That module is `livedata` (deselected in CI) **and** every
+test in it calls `self.skipTest("No live data")` when no export is on
+disk. Two independent reasons it never runs in CI. The same applies to
+`TestVolatilityPassIsRemoved` and `TestValueChain` in that file.
+
+This is the exact anti-pattern the audit brief warned about. Addressed
+by adding CI-blocking, synthetic-fixture equivalents
+(`TestRetiredPassesStayRetired`) rather than touching the livedata
+copies, which remain useful as live-board checks.
+
+---
+
+## 4. Defects
+
+### D-1 — one out-of-range source value rescales the entire board *(UNRESOLVED — documented, not fixed)*
+
+**Where** `src/api/data_contract.py::_compute_unified_rankings`, the
+`value_source_max` construction (~line 6597) feeding the value-direct
+branch (~line 6673):
+
+```python
+if raw_f > value_source_max.get(key, 0.0):
+    value_source_max[key] = raw_f      # unbounded max
+...
+value = raw_f / site_max * 9999.0      # every player divided by it
+```
+
+`site_max` is an unbounded maximum over the pool. Because the formula
+is `raw / site_max × 9999`, **a single out-of-scale cell in one
+value-based source deflates every player's contribution from that
+source, proportionally.**
+
+**Reproduced through the real entry point** (`build_api_data_contract`,
+120-player board, one extra row):
+
+| Player | Clean | +1 row at `ktcSfTep=99990` | +1 row at `950000` |
+|---|---|---|---|
+| Player 000 | 9999 | 5474 (**−45.3%**) | 5049 (**−49.5%**) |
+| Player 010 | 9202 | 5038 (−45.3%) | 4647 (−49.5%) |
+| Player 040 | 6814 | 3730 (−45.3%) | 3441 (−49.5%) |
+| Player 080 | 3630 | 1987 (−45.3%) | 1833 (−49.5%) |
+
+99990 is a plausible extra-digit scrape glitch; 950000 is the shape of
+a rank-encoding value leaking into a value column. Both are silent —
+no warning, no health alert, correct-looking ordering, ~45% wrong
+magnitudes everywhere.
+
+**What already protects it, and what does not.** `_safe_num` rejects
+non-finite input (`inf`, `nan`, non-numeric), so those cannot poison
+`site_max` — verified, and now regression-tested. Nothing anywhere
+validates that a value-based source's numbers stay inside its declared
+0–9999 scale: `src/api/source_health_alerts.py` only checks staleness,
+and `src/api/startup_validation.py` has no range check.
+
+**Why not fixed here.** The guard is unambiguous in *need* but not in
+*shape*, and the choice changes numbers:
+clamp `site_max` at 9,999? drop the offending row? reject the source as
+unhealthy and fall back? Each has different consequences for a real bad
+scrape. CLAUDE.md rule 3 (preserve working behaviour absent a verified
+flaw) plus rule 7 (smallest correct change) make this a decision for the
+owner, not a unilateral edit.
+
+**Pinned meanwhile.** `TestSiteMaxContamination` in
+`tests/api/test_valuation_degraded_inputs.py` has two tests: one asserts
+the non-finite guard holds (a real regression guard), one *characterises*
+the current deflation and tells the next reader to update this document
+when a range guard is added.
+
+### D-2 — `/api/draft-capital` does not honour the documented 503 *(UNRESOLVED — documented, not fixed)*
+
+CLAUDE.md's error table lists `/api/draft-capital` among endpoints that
+must return `503 data_not_ready` "whenever the loaded contract's
+`leagueKey` doesn't match the request".
+
+It returns **200**. `get_draft_capital` calls
+`_resolve_league_for_request(request)` **without**
+`require_loaded_contract=True`, then for any non-default league builds a
+Sleeper-derived answer from that league's own roster data. The handler's
+own docstring describes this as intentional ("Angle-finder + roster picks
+still work across leagues via the Sleeper overlay").
+
+So CLAUDE.md and the code disagree, and the code's divergence looks
+deliberate and newer.
+
+**The safety-relevant part is fine**: it consults the *requested*
+league's Sleeper ID, not the loaded league's — verified by test and by
+mutation (pointing it at `default_cfg.sleeper_league_id` turns the test
+red). No cross-league roster leak.
+
+**The subtler issue**: the fallback prices League B's picks using
+`latest_contract_data`, which is League A's contract. Pick values follow
+the *scoring profile*, and there is no profile check on this path —
+`/api/data` 503s when profiles differ
+(`test_api_data_503s_when_scoring_profile_differs`), `/api/draft-capital`
+does not. With the two leagues on different profiles, League B gets
+League A's rankings.
+
+**Why not fixed here.** Three defensible resolutions (503 per the table /
+add a profile guard mirroring `/api/data` / keep the fallback and correct
+CLAUDE.md), and choosing between them is a product decision. Also,
+`server.py` endpoints are actively being worked on by another agent this
+session.
+
+**Pinned meanwhile.** `TestDraftCapitalCrossLeagueFallback` in
+`tests/api/test_league_isolation_invariants.py` characterises the actual
+behaviour and hard-asserts the no-cross-league-roster-leak property.
+
+### D-3 — CLAUDE.md stage 10 documents code that does not exist *(documentation defect)*
+
+CLAUDE.md's Live Value Pipeline lists as stage 10:
+
+> "IDP calibration post-pass (`_apply_idp_calibration_post_pass` reads
+> `config/idp_calibration.json`), contained by the market corridor clamp"
+
+Neither exists:
+
+```bash
+$ grep -rn "_apply_idp_calibration_post_pass" --include=*.py .   # no matches
+$ ls config/idp_calibration.json                                  # No such file
+```
+
+`src/api/data_contract.py` is explicit — "**Phase 4c: removed** — The
+IDP calibration post-pass … has been retired." The market corridor clamp
+half of stage 10 *is* real and wired
+(`_apply_market_corridor_clamp`, line 7265).
+
+The live pipeline therefore has 11 implemented stages, not 12. Left for
+the owner to correct in CLAUDE.md rather than edited here — other agents
+are working against that file this session. Pinned by
+`TestRetiredPassesStayRetired::test_idp_calibration_config_and_helper_are_really_gone`
+so the drift cannot widen unnoticed.
+
+### D-4 — `leagueKey` echo on 503 is inconsistent *(minor, documented)*
+
+CLAUDE.md: league-aware endpoints "all stamp `leagueKey` on their
+response". On the 503 path, `/api/trade/simulate` and `/api/terminal` do;
+`/api/trade/suggestions` and `/api/trade/finder` do not — their body is
+`{"error": "data_not_ready", "message": "..."}` with the league named
+only in prose.
+
+Low impact (the status code and `error` code clients branch on are
+correct everywhere), and adding a field is an API-shape change, so not
+altered. Pinned by
+`test_leaguekey_echo_on_503_is_inconsistent_across_routes`.
+
+### D-5 — pre-existing parallel-run test isolation leak *(not fixed)*
+
+`tests/intel/test_endpoints.py::TestLeagueScoping::test_reads_go_through_the_league_resolver`
+expects an empty registry (404 `no_leagues_configured`) and gets 503
+`data_not_ready` when another file's registry state precedes it on the
+same xdist worker. Passes serially; fails under `-n 4 --dist loadfile`,
+before and after this branch. Only affects parallel runs, which CI does
+not currently use.
+
+---
+
+## 5. Tests added
+
+All are pure-logic, no network, no `livedata` marker — they run in CI.
+**Every test below was verified to fail against a deliberate mutation of
+the code it covers** (see §6).
+
+| File | Tests | Covers |
+|---|---|---|
+| `tests/api/test_valuation_pipeline_stages.py` | 24 | Single-source haircut (0.30, exactly, and pick exemption); α-shrinkage routing (0.10 for IDP + picks, flat blend for offense); value-direct vs Hill voting membership; routed-curve reference denominators; percentile clamp past N=500 driven through the pipeline; pick-year discount reaching `rankDerivedValue`; λ·MAD staying retired; CI-blocking retired-pass guards |
+| `tests/api/test_valuation_degraded_inputs.py` | 14 | Empty/absent sources; zero variance; negative/zero/None/non-finite; site-max contamination (D-1); ties; duplicate names; no-NaN-escapes sweep |
+| `tests/api/test_league_isolation_invariants.py` | 17 | No raw Sleeper league ID on `/api/leagues` (anon + authed); league-scoped endpoints refusing foreign leagues; unknown/inactive 400 sweep; D-2 and D-4 characterisation |
+| `tests/trade/test_waiver.py` | 30 | Two-source minimum; `MIN_WAIVER_VALUE` floor; roster exclusion; rookie window; full FAAB bid arithmetic; grouping/caps; degraded inputs; drop candidates |
+| **Total** | **85** | |
+
+Plus one existing test corrected (W-1).
+
+---
+
+## 6. Mutation verification
+
+Each mutation was applied to the source, the suite run, then reverted.
+
+| # | Mutation | Result |
+|---|---|---|
+| 1 | `_SINGLE_SOURCE_VALUE_RETENTION` 0.30 → 0.50 | 4 red (`1500→2000`, `1200→2000`) |
+| 2 | `_ALPHA_SHRINKAGE` 0.10 → 0.25 | 3 red |
+| 3 | `use_hierarchical_blend = True` (routes offense through the α path) | 2 red (`6000→3600`) |
+| 4 | `_PERCENTILE_REFERENCE_N` 500 → 800 | 1 red |
+| 5 | `_MAD_PENALTY_LAMBDA` 0.0 → 0.5 | 4 red |
+| 6 | pick-year discount application disabled | 2 red |
+| 7 | remove clamp in `data_contract` only | **green** — clamp is defence-in-depth; `percentile_to_value` clamps too |
+| 8 | remove **both** clamps | 1 red (`2370 ≠ 2335`) |
+| D1 | remove `math.isfinite` from `_safe_num` | 2 red (`OverflowError`) |
+| D4 | phase-1 positivity gate disabled | 1 red (`900 → 6405`) |
+| D3′ | `sourceSpread` stamp drops `0.0` | 2 red |
+| R1 | revive `offenseCalibrationMultiplier` | 1 red |
+| V1 | add `dlfSf` to `_VALUE_BASED_SOURCES` | 2 red |
+| V2 | mark the ROOKIE Hill master `routed=True` | 2 red |
+| W1 | remove waiver two-source minimum | 2 red |
+| W2 | FAAB `0.05 + 0.25·share` → `0.10 + …` | 5 red |
+| W3 | remove waiver roster exclusion | 1 red |
+| W4 | `MIN_WAIVER_VALUE` 500 → 200 | 2 red |
+| W5 | drop-candidate sort reversed | 1 red |
+| L1 | `public_dict` leaks `sleeperLeagueId` | 3 red |
+| L2 | draft-capital uses default league's Sleeper ID | 1 red |
+
+Mutation 7 is worth keeping: it proves the percentile clamp is
+implemented twice, so removing either one alone is silently harmless.
+The test was rewritten mid-audit after it initially passed against a
+clamp removal — the first version re-implemented the formula instead of
+driving the pipeline, which is the same manufactured-confidence failure
+this document criticises elsewhere.
+
+---
+
+## 7. Which parts of the valuation pipeline still have no meaningful test
+
+The most useful section for the owner. Numbering follows CLAUDE.md's
+12 stages.
+
+**Now covered by CI-blocking tests (this branch):** stage 2 clamp,
+stage 4 value-direct voting membership, stage 6 α-routing, stage 7
+count-aware tiers (already unit-tested in `test_count_aware_blend.py`),
+stage 8 λ retirement, stage 9 haircut, stage 12 pick-year discount.
+
+**Still without a meaningful CI-blocking test:**
+
+1. **Stage 11 — pick tethering.** The largest remaining hole. Current-year
+   slot picks inherit the merged rookie pool's values, and that logic is
+   exercised only by `test_pick_rookie_anchor.py` and
+   `test_picks_end_to_end.py` — **both `livedata`, both deselected in
+   CI**. A regression that mis-tethers every 2027 pick would ship green.
+   Hardest to fixture (needs a rookie pool plus 72 slot picks), which is
+   presumably why it was left to the live board.
+
+2. **Stage 3/5 — per-source curve routing.** This branch adds guards that
+   the routed scope curves share one reference denominator and that the
+   ROOKIE master stays unrouted. What is still unasserted is that a
+   *specific source key* routes to a *specific* curve: `_curve_for_source`
+   is a **nested closure inside `_compute_unified_rankings`**, so it
+   cannot be imported and called directly. Testing it properly needs
+   either a per-source curve stamp on the row or lifting the closure to
+   module scope. Mis-routing IDP sources to the OFFENSE master would
+   shift every defender without failing anything.
+
+3. **Stage 10 — market corridor clamp band arithmetic.**
+   `test_market_corridor_clamp.py` covers anchor selection and helpers;
+   the P90 drift-band computation itself is not asserted numerically.
+   (Stage 10's IDP-calibration half does not exist — D-3.)
+
+4. **Stage 6 — the pick-row anchor widening.** CLAUDE.md: "Pick rows
+   widen the anchor set to include `ktcSfTep` so the two real pick
+   markets average as peers." No test asserts the widened set.
+
+5. **The Hampel filter *inside* the pipeline.** `test_hampel_filter.py`
+   unit-tests the function thoroughly, but nothing asserts that a real
+   outlier source is dropped from a player's blend end-to-end, or that
+   `_SINGLE_SOURCE_VALUE_RETENTION` fires on a row reduced to one source
+   *by Hampel* (as opposed to one that only ever had one).
+
+6. **`server.py` at 51.8%.** Route-level behaviour for most endpoints is
+   untested. Highest-value remaining targets: `_resolve_league_for_request`
+   pass 3 (a user's saved `activeLeagueKey` pointing at an inactive
+   league silently falls through to the default — untested), and the
+   `/api/rankings/overrides` delta merge under partial source failure.
+
+7. **`src/api/chat.py` (0%), `src/ros/sources/*` (0%).** Whole modules
+   with no test. The ROS source parsers take untrusted external HTML/JSON
+   — the classic place for a silent parse regression.

--- a/tests/api/test_league_isolation_invariants.py
+++ b/tests/api/test_league_isolation_invariants.py
@@ -1,0 +1,399 @@
+"""Architectural invariants for the multi-league split.
+
+CLAUDE.md calls the scoring-profile / leagueKey split "the single
+most important architectural rule for multi-league".  Two of its
+clauses had no direct test:
+
+1. **"no endpoint exposes raw Sleeper IDs to the UI"** — the whole
+   point of the opaque ``key``.  ``LeagueConfig.public_dict`` omits
+   ``sleeper_league_id`` today, but nothing asserted it, so adding one
+   field to that dict would have leaked every league's Sleeper ID to
+   any caller of ``/api/leagues`` with a green suite.
+
+2. **league-scoped endpoints must refuse a league they have no
+   rosters for** — asserted individually for ``/api/trade/simulate``
+   in ``test_league_routing.py``, but not as a sweep.  A newly added
+   league-scoped route that forgets ``require_loaded_contract=True``
+   would silently serve League A's rosters to a League B request.
+
+The sharing half of the rule (same scoring profile ⇒ one shared
+ranking output) is already covered by
+``test_league_routing.py::test_api_data_serves_shared_rankings_for_same_profile``
+and ``::test_api_data_503s_when_scoring_profile_differs``; this module
+does not duplicate it.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+import server
+from src.api import league_registry
+
+
+SLEEPER_IDS = {
+    "main": "111111111111111111",
+    "side": "222222222222222222",
+    "retired": "333333333333333333",
+}
+
+
+@pytest.fixture
+def registry_with_distinct_sleeper_ids(tmp_path, monkeypatch):
+    """Three leagues whose Sleeper IDs are long, unique, greppable digits.
+
+    Realistic Sleeper IDs (18-digit strings) rather than "L-MAIN" so a
+    substring scan of the serialized response is meaningful and cannot
+    collide with ordinary content.
+    """
+    path = tmp_path / "registry.json"
+    path.write_text(
+        json.dumps(
+            {
+                "defaultLeagueKey": "main",
+                "leagues": [
+                    {
+                        "key": "main",
+                        "displayName": "Main",
+                        "sleeperLeagueId": SLEEPER_IDS["main"],
+                        "scoringProfile": "superflex_tep15_ppr1",
+                        "active": True,
+                        "idpEnabled": True,
+                        "rosterSettings": {"teamCount": 12},
+                        "aliases": ["primary"],
+                    },
+                    {
+                        "key": "side",
+                        "displayName": "Side",
+                        "sleeperLeagueId": SLEEPER_IDS["side"],
+                        "scoringProfile": "ppr_standard",
+                        "active": True,
+                        "rosterSettings": {"teamCount": 10},
+                    },
+                    {
+                        "key": "retired",
+                        "displayName": "Retired",
+                        "sleeperLeagueId": SLEEPER_IDS["retired"],
+                        "active": False,
+                        "rosterSettings": {},
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    from src.api import user_kv
+
+    monkeypatch.setattr(user_kv, "USER_KV_PATH", tmp_path / "user_kv.sqlite")
+    user_kv._SETUP_DONE.clear()
+
+    monkeypatch.setattr(server, "_is_authenticated", lambda request: True)
+    # Never touch Sleeper for the live display-name overlay.
+    monkeypatch.setattr(server, "_fetch_sleeper_league_name", lambda _id: None)
+    # The POST trade routes resolve an auth session before the league
+    # check; without this they 401 before reaching the code under test.
+    monkeypatch.setattr(
+        server,
+        "_get_auth_session",
+        lambda request: {
+            "username": "alice",
+            "auth_method": "sleeper",
+            "sleeper_user_id": "oA",
+        },
+    )
+
+    yield
+
+    league_registry.reload_registry()
+
+
+# ── Invariant 1: no raw Sleeper league IDs on the wire ───────────────
+
+
+class TestNoSleeperIdLeak:
+    def test_public_dict_omits_the_sleeper_league_id(self, registry_with_distinct_sleeper_ids):
+        """Unit-level guard on the serializer itself."""
+        for cfg in league_registry.active_leagues():
+            public = cfg.public_dict()
+            assert cfg.sleeper_league_id  # fixture really does set one
+            assert cfg.sleeper_league_id not in json.dumps(public)
+            # And no key smells like a Sleeper id passthrough.
+            assert "sleeperLeagueId" not in public
+            assert "leagueId" not in public
+
+    def test_api_leagues_response_contains_no_sleeper_id(
+        self, registry_with_distinct_sleeper_ids, monkeypatch
+    ):
+        """End-to-end guard on the documented public endpoint.
+
+        Scans the whole serialized body, so a leak nested anywhere —
+        including inside ``userDefaultTeam`` — is caught.
+        """
+        monkeypatch.setattr(server, "_get_auth_session", lambda request: None)
+
+        with TestClient(server.app, raise_server_exceptions=True) as c:
+            res = c.get("/api/leagues")
+
+        assert res.status_code == 200
+        body = res.text
+        for key, sleeper_id in SLEEPER_IDS.items():
+            assert sleeper_id not in body, f"/api/leagues leaked {key}'s Sleeper ID"
+
+    def test_api_leagues_still_returns_the_opaque_key_and_settings(
+        self, registry_with_distinct_sleeper_ids, monkeypatch
+    ):
+        """The no-leak assertion must not be vacuously satisfied by an
+        empty response — the useful fields have to actually be there."""
+        monkeypatch.setattr(server, "_get_auth_session", lambda request: None)
+
+        with TestClient(server.app, raise_server_exceptions=True) as c:
+            payload = c.get("/api/leagues").json()
+
+        keys = {entry["key"] for entry in payload["leagues"]}
+        assert keys == {"main", "side"}  # 'retired' is inactive
+        main = next(e for e in payload["leagues"] if e["key"] == "main")
+        assert main["displayName"] == "Main"
+        assert main["rosterSettings"] == {"teamCount": 12}
+        assert main["idpEnabled"] is True
+        assert main["scoringProfile"] == "superflex_tep15_ppr1"
+        assert payload["defaultKey"] == "main"
+
+    def test_authenticated_view_also_leaks_nothing(
+        self, registry_with_distinct_sleeper_ids, monkeypatch
+    ):
+        """The authed branch adds ``userDefaultTeam`` via a Sleeper
+        lookup keyed on the league ID — the ID must stay server-side."""
+        monkeypatch.setattr(
+            server,
+            "_get_auth_session",
+            lambda request: {"username": "jason", "sleeper_user_id": "U-JASON"},
+        )
+        monkeypatch.setattr(
+            server,
+            "_fetch_sleeper_user_team",
+            lambda league_id, user_id: {"ownerId": user_id, "teamName": "Brisket Crew"},
+        )
+
+        with TestClient(server.app, raise_server_exceptions=True) as c:
+            res = c.get("/api/leagues")
+
+        assert res.status_code == 200
+        # The enrichment really did run (otherwise this is vacuous).
+        assert "Brisket Crew" in res.text
+        for sleeper_id in SLEEPER_IDS.values():
+            assert sleeper_id not in res.text
+
+
+# ── Invariant 2: league-scoped endpoints refuse the wrong league ─────
+
+
+# Routes CLAUDE.md lists as needing the specific league's rosters.
+# Each must 503 ``data_not_ready`` when the loaded contract belongs to
+# a different league.
+#
+# ``/api/draft-capital`` is deliberately NOT in this list even though
+# CLAUDE.md's table includes it: the endpoint implements a documented
+# cross-league Sleeper-derived fallback instead of 503ing.  That
+# divergence is characterised in ``TestDraftCapitalCrossLeagueFallback``
+# and written up as Defect D-2 in docs/python-coverage-audit.md rather
+# than silently "fixed" here.
+LEAGUE_SCOPED_GETS = [
+    "/api/terminal",
+]
+LEAGUE_SCOPED_POSTS = [
+    "/api/trade/simulate",
+    "/api/trade/suggestions",
+    "/api/trade/finder",
+]
+
+
+def _install_contract_for_league(monkeypatch, league_key: str) -> None:
+    """Stub ``latest_contract_data`` stamped for ``league_key``.
+
+    Must be called INSIDE the TestClient context so app startup can't
+    clobber it — same constraint as ``test_league_routing.py``.
+    """
+    monkeypatch.setattr(
+        server,
+        "latest_contract_data",
+        {
+            "meta": {"leagueKey": league_key},
+            "players": {"stub": {"name": "Stub"}},
+            "playersArray": [{"name": "Stub"}],
+            "sleeper": {"teams": [{"ownerId": "oA", "name": "Team A", "players": []}]},
+        },
+    )
+
+
+class TestLeagueScopedEndpointsRefuseForeignLeagues:
+    @pytest.mark.parametrize("path", LEAGUE_SCOPED_GETS)
+    def test_get_endpoints_503_for_a_league_with_no_loaded_rosters(
+        self, registry_with_distinct_sleeper_ids, monkeypatch, path
+    ):
+        with TestClient(server.app, raise_server_exceptions=True) as c:
+            _install_contract_for_league(monkeypatch, "main")
+            res = c.get(path, params={"leagueKey": "side"})
+
+        assert res.status_code == 503, f"{path} served a foreign league"
+        body = res.json()
+        assert body["error"] == "data_not_ready"
+        assert body.get("leagueKey") == "side"
+
+    @pytest.mark.parametrize("path", LEAGUE_SCOPED_POSTS)
+    def test_post_endpoints_503_for_a_league_with_no_loaded_rosters(
+        self, registry_with_distinct_sleeper_ids, monkeypatch, path
+    ):
+        with TestClient(server.app, raise_server_exceptions=True) as c:
+            _install_contract_for_league(monkeypatch, "main")
+            res = c.post(path, json={"leagueKey": "side"})
+
+        assert res.status_code == 503, f"{path} served a foreign league"
+        body = res.json()
+        assert body["error"] == "data_not_ready"
+        # The message names the refused league even where the body
+        # carries no ``leagueKey`` field (see the echo test below).
+        assert "side" in body["message"]
+
+    def test_leaguekey_echo_on_503_is_inconsistent_across_routes(
+        self, registry_with_distinct_sleeper_ids, monkeypatch
+    ):
+        """CLAUDE.md: league-aware endpoints "all stamp leagueKey on
+        their response".  On the 503 path only some do.
+
+        Characterisation, not endorsement — the status code and error
+        code (the part clients branch on) are correct everywhere.
+        Recorded as a minor finding in docs/python-coverage-audit.md.
+        """
+        with TestClient(server.app, raise_server_exceptions=True) as c:
+            _install_contract_for_league(monkeypatch, "main")
+            simulate = c.post("/api/trade/simulate", json={"leagueKey": "side"}).json()
+            finder = c.post("/api/trade/finder", json={"leagueKey": "side"}).json()
+
+        assert simulate.get("leagueKey") == "side"
+        assert "leagueKey" not in finder
+
+    @pytest.mark.parametrize("path", LEAGUE_SCOPED_GETS + LEAGUE_SCOPED_POSTS)
+    def test_every_league_scoped_route_rejects_unknown_and_inactive_keys(
+        self, registry_with_distinct_sleeper_ids, monkeypatch, path
+    ):
+        """The documented 400 contract, swept across all of them."""
+        with TestClient(server.app, raise_server_exceptions=True) as c:
+            _install_contract_for_league(monkeypatch, "main")
+
+            if path in LEAGUE_SCOPED_GETS:
+                unknown = c.get(path, params={"leagueKey": "does-not-exist"})
+                inactive = c.get(path, params={"leagueKey": "retired"})
+            else:
+                unknown = c.post(path, json={"leagueKey": "does-not-exist"})
+                inactive = c.post(path, json={"leagueKey": "retired"})
+
+        assert unknown.status_code == 400, path
+        assert unknown.json()["error"] == "unknown_league"
+        assert inactive.status_code == 400, path
+        assert inactive.json()["error"] == "inactive_league"
+
+
+# ── /api/draft-capital: documented divergence, characterised ─────────
+
+
+class TestDraftCapitalCrossLeagueFallback:
+    """CLAUDE.md says this route 503s on a league mismatch.  It does not.
+
+    The handler resolves the league WITHOUT ``require_loaded_contract``
+    and, for any non-default league, builds a Sleeper-derived answer
+    from that league's own roster data.  The docstring on
+    ``get_draft_capital`` describes this as intentional.
+
+    Rather than pick a side, these tests pin what is actually
+    guaranteed today — and, critically, assert the part that would be
+    a real data leak if it broke: League A's roster/pick ownership
+    must never appear under a League B request.
+
+    See docs/python-coverage-audit.md, Defect D-2, for the open
+    question (503 per the table vs. keep the fallback and fix the doc).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_network(self, monkeypatch):
+        """The fallback calls Sleeper; tests must not.
+
+        Records the league IDs requested so the assertions below can
+        prove which league's rosters were consulted.
+        """
+        self.fetched: list[str] = []
+
+        from src.api import draft_capital_fallback
+
+        def _fake_build(sleeper_league_id, contract, **kwargs):
+            self.fetched.append(str(sleeper_league_id))
+            return {
+                "teams": [],
+                "source": "sleeper-derived",
+                "_sleeperLeagueIdUsed": str(sleeper_league_id),
+            }
+
+        monkeypatch.setattr(draft_capital_fallback, "build_sleeper_derived", _fake_build)
+
+    def test_foreign_league_gets_its_own_rosters_not_the_loaded_league_s(
+        self, registry_with_distinct_sleeper_ids, monkeypatch
+    ):
+        with TestClient(server.app, raise_server_exceptions=True) as c:
+            _install_contract_for_league(monkeypatch, "main")
+            res = c.get("/api/draft-capital", params={"leagueKey": "side"})
+
+        # Current behaviour: 200 with a Sleeper-derived payload.
+        assert res.status_code == 200
+        assert res.json()["leagueKey"] == "side"
+
+        # The safety-critical part: it consulted SIDE's Sleeper league,
+        # never MAIN's.  A regression here would serve one league's
+        # pick ownership under another league's name.
+        assert self.fetched == [SLEEPER_IDS["side"]]
+        assert SLEEPER_IDS["main"] not in self.fetched
+
+    def test_response_still_echoes_the_requested_league_key(
+        self, registry_with_distinct_sleeper_ids, monkeypatch
+    ):
+        with TestClient(server.app, raise_server_exceptions=True) as c:
+            _install_contract_for_league(monkeypatch, "main")
+            res = c.get("/api/draft-capital", params={"leagueKey": "side"})
+        assert res.json()["leagueKey"] == "side"
+
+    def test_unknown_and_inactive_keys_are_still_rejected(
+        self, registry_with_distinct_sleeper_ids, monkeypatch
+    ):
+        """The 400 half of the contract IS honoured here."""
+        with TestClient(server.app, raise_server_exceptions=True) as c:
+            _install_contract_for_league(monkeypatch, "main")
+            unknown = c.get("/api/draft-capital", params={"leagueKey": "nope"})
+            inactive = c.get("/api/draft-capital", params={"leagueKey": "retired"})
+
+        assert unknown.status_code == 400
+        assert unknown.json()["error"] == "unknown_league"
+        assert inactive.status_code == 400
+        assert inactive.json()["error"] == "inactive_league"
+
+
+# ── The documented alias behaviour ───────────────────────────────────
+
+
+class TestAliasCanonicalisation:
+    def test_alias_resolves_and_the_response_echoes_the_canonical_key(
+        self, registry_with_distinct_sleeper_ids, monkeypatch
+    ):
+        """``primary`` is an alias of ``main``; responses must report
+        the canonical key so the frontend never learns alias names."""
+        with TestClient(server.app, raise_server_exceptions=True) as c:
+            _install_contract_for_league(monkeypatch, "main")
+            res = c.get("/api/terminal", params={"leagueKey": "primary"})
+
+        assert res.status_code != 400
+        body = res.json()
+        if isinstance(body, dict) and "leagueKey" in body:
+            assert body["leagueKey"] == "main"

--- a/tests/api/test_market_corridor_clamp.py
+++ b/tests/api/test_market_corridor_clamp.py
@@ -176,32 +176,25 @@ class TestFallbackAnchor(unittest.TestCase):
         self.assertIsNone(val)
         self.assertIsNone(src)
 
-    def test_fallback_chain_covers_all_scope_sources(self):
-        """Safety rail: every IDP-scope and offense-scope value+rank
-        source in the registry should be somewhere in the fallback
-        chain for its asset class.  Catches a new source being added
-        to _RANKING_SOURCES without being added to the anchor chain
-        — which would silently reintroduce the gap we're fixing."""
-        from src.api.data_contract import _RANKING_SOURCES
-        from src.canonical.idp_backbone import (
-            SOURCE_SCOPE_OVERALL_IDP,
-            SOURCE_SCOPE_OVERALL_OFFENSE,
-        )
+    def test_fallback_chain_starts_with_the_declared_primary_anchor(self):
+        """Each asset class's fallback chain leads with its primary anchor.
 
-        offense_sources = {
-            s["key"]
-            for s in _RANKING_SOURCES
-            if s.get("scope") == SOURCE_SCOPE_OVERALL_OFFENSE
-            and not s.get("excludes_rookies")  # rookie-only boards aren't anchors
-        }
-        idp_sources = {
-            s["key"] for s in _RANKING_SOURCES if s.get("scope") == SOURCE_SCOPE_OVERALL_IDP
-        }
-        chain_offense = set(_MARKET_ANCHOR_FALLBACKS.get("offense") or [])
-        chain_idp = set(_MARKET_ANCHOR_FALLBACKS.get("idp") or [])
-        # The chain is a curated shortlist — we don't require every
-        # offense source, just confirm the chain is non-empty and
-        # starts with the declared primary anchors.
+        NOTE ON SCOPE — this test used to be named
+        ``test_fallback_chain_covers_all_scope_sources`` and its
+        docstring claimed it was a "safety rail" catching "a new source
+        being added to _RANKING_SOURCES without being added to the
+        anchor chain".  It never did that: it built
+        ``offense_sources`` / ``idp_sources`` / ``chain_offense`` /
+        ``chain_idp`` and then compared none of them (ruff F841 flagged
+        all four as unused).  The only assertions were — and still are
+        — the two below.
+
+        The registry-coverage check was deliberately dropped, because
+        the chain is a curated shortlist rather than every scope
+        source, so a subset assertion would be wrong.  Renamed and the
+        dead locals removed so the name and docstring describe what is
+        actually verified.  See docs/python-coverage-audit.md (W-1).
+        """
         self.assertEqual(
             _MARKET_ANCHOR_FALLBACKS["offense"][0],
             _MARKET_ANCHOR_BY_ASSET_CLASS["offense"],
@@ -210,6 +203,11 @@ class TestFallbackAnchor(unittest.TestCase):
             _MARKET_ANCHOR_FALLBACKS["idp"][0],
             _MARKET_ANCHOR_BY_ASSET_CLASS["idp"],
         )
+        # The chains must at least be non-empty — an empty chain would
+        # make the assertions above IndexError rather than pass, but be
+        # explicit so intent is unambiguous.
+        self.assertTrue(_MARKET_ANCHOR_FALLBACKS["offense"])
+        self.assertTrue(_MARKET_ANCHOR_FALLBACKS["idp"])
 
 
 class TestPercentileHelper(unittest.TestCase):

--- a/tests/api/test_valuation_degraded_inputs.py
+++ b/tests/api/test_valuation_degraded_inputs.py
@@ -1,0 +1,368 @@
+"""Degraded and hostile inputs to the valuation pipeline.
+
+"Full confidence" lives here more than in the happy path: a scrape
+that half-fails, a source that publishes one absurd cell, a vendor
+that ties every rank.  None of those should crash, and — more
+importantly — none should silently reprice players.
+
+Two guards get explicit regression tests because they are *load
+bearing and invisible*:
+
+  * ``_safe_num`` rejecting non-finite values.  It is the only thing
+    standing between one ``inf`` cell and a board-wide repricing —
+    ``value_source_max`` takes an unbounded max, and the value-direct
+    formula divides by it.  See ``TestSiteMaxContamination``.
+  * negative / zero source values being dropped rather than voted.
+
+A known **unfixed** gap is characterised (not asserted as correct) in
+``TestSiteMaxContamination.test_out_of_range_finite_value_rescales_the_board``
+— see ``docs/python-coverage-audit.md``.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from src.api import data_contract as dc
+
+
+IDP_POSITIONS = ("DL", "LB", "DB")
+
+
+def _row(name: str, position: str, **sites: Any) -> dict[str, Any]:
+    if position == "PICK":
+        asset_class = "pick"
+    elif position in IDP_POSITIONS:
+        asset_class = "idp"
+    else:
+        asset_class = "offense"
+    return {
+        "canonicalName": name,
+        "displayName": name,
+        "position": position,
+        "assetClass": asset_class,
+        "canonicalSiteValues": dict(sites),
+        "values": {
+            "overall": 0,
+            "rawComposite": None,
+            "finalAdjusted": None,
+            "displayValue": None,
+        },
+        "sourceCount": 0,
+        "sourcePresence": {},
+        "rookie": False,
+    }
+
+
+def _anchor_qb() -> dict[str, Any]:
+    return _row("Anchor QB", "QB", ktcSfTep=9999, idpTradeCalc=9999)
+
+
+def _by_name(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {r["canonicalName"]: r for r in rows}
+
+
+# ── Empty / absent sources ───────────────────────────────────────────
+
+
+class TestEmptyAndAbsentSources:
+    def test_empty_player_array_does_not_crash(self):
+        rows: list[dict[str, Any]] = []
+        dc._compute_unified_rankings(rows, {})
+        assert rows == []
+
+    def test_rows_with_no_source_coverage_get_no_value(self):
+        """A player nobody ranks must be left unvalued, not zero-valued.
+
+        Stamping 0 would place them at the bottom of a real board;
+        leaving them unstamped keeps them off it entirely.
+        """
+        rows = [_row("Ghost", "WR"), _row("Also Ghost", "RB")]
+        dc._compute_unified_rankings(rows, {})
+        for r in rows:
+            assert r.get("rankDerivedValue") is None
+
+    def test_a_source_missing_from_every_row_does_not_disturb_the_others(self):
+        """Simulates a source CSV that failed to fetch entirely.
+
+        The surviving sources must produce exactly the values they
+        would have produced on their own.
+        """
+        with_absent = [
+            _row("Star", "WR", ktcSfTep=9000, idpTradeCalc=9000),
+            _row("Mid", "WR", ktcSfTep=4500, idpTradeCalc=4500),
+            _anchor_qb(),
+        ]
+        dc._compute_unified_rankings(with_absent, {})
+        got = _by_name(with_absent)
+        # Two agreeing value-direct sources ⇒ n=2 mean ⇒ the raw value.
+        assert got["Star"]["rankDerivedValue"] == 9000
+        assert got["Mid"]["rankDerivedValue"] == 4500
+
+    def test_canonical_site_values_of_none_is_tolerated(self):
+        """A row whose site-value map is ``None``, not ``{}``."""
+        broken = _row("Broken", "WR")
+        broken["canonicalSiteValues"] = None
+        rows = [broken, _anchor_qb()]
+        dc._compute_unified_rankings(rows, {})
+        assert _by_name(rows)["Broken"].get("rankDerivedValue") is None
+        # The healthy row is unaffected.
+        assert _by_name(rows)["Anchor QB"]["rankDerivedValue"] == 9999
+
+
+# ── Zero variance ────────────────────────────────────────────────────
+
+
+class TestZeroVariance:
+    """Every value identical — the classic division-by-zero shape."""
+
+    def test_identical_values_across_pool_do_not_divide_by_zero(self):
+        rows = [_row(f"Clone {i}", "WR", ktcSfTep=5000, idpTradeCalc=5000) for i in range(5)]
+        dc._compute_unified_rankings(rows, {})
+        for r in rows:
+            # All tied at the top of both boards ⇒ all normalise to 9999.
+            assert r["rankDerivedValue"] == 9999
+            assert r["sourceSpread"] == 0.0
+
+    def test_identical_values_within_one_player_give_zero_spread(self):
+        rows = [
+            _row("Agreed", "WR", ktcSfTep=5000, idpTradeCalc=5000),
+            _anchor_qb(),
+        ]
+        dc._compute_unified_rankings(rows, {})
+        agreed = _by_name(rows)["Agreed"]
+        assert agreed["rankDerivedValue"] == 5000
+        assert agreed["sourceSpread"] == 0.0
+        # stdev across 2 identical contributions is also 0, not None.
+        assert agreed["hillValueSpread"] == 0.0
+
+
+# ── Non-positive and non-finite values ───────────────────────────────
+
+
+class TestNonPositiveAndNonFiniteValues:
+    def test_negative_zero_and_none_are_all_treated_as_absent(self):
+        """A negative site value must not vote, and must not be clamped
+        to 0 and voted either — it is missing data, not a cheap player.
+
+        Each of these rows therefore rests on its single remaining
+        source (idpTradeCalc=3000) and takes the single-source haircut:
+        3000 × 0.30 = 900.
+        """
+        rows = [
+            _row("Neg", "WR", ktcSfTep=-500, idpTradeCalc=3000),
+            _row("Zero", "WR", ktcSfTep=0, idpTradeCalc=3000),
+            _row("Nil", "WR", ktcSfTep=None, idpTradeCalc=3000),
+            _anchor_qb(),
+        ]
+        dc._compute_unified_rankings(rows, {})
+        got = _by_name(rows)
+        for name in ("Neg", "Zero", "Nil"):
+            assert got[name]["rankDerivedValue"] == 900, name
+            assert got[name]["singleSourceValuePenaltyApplied"] is True
+
+    def test_safe_num_rejects_non_finite_and_non_numeric(self):
+        """``_safe_num`` is the coercion gate every site value passes.
+
+        This is not a trivia test: ``value_source_max`` takes an
+        unbounded ``max()`` over these values and the value-direct
+        branch divides by it, so an ``inf`` reaching that dict prices
+        every player in the source at zero.  Keep this guard.
+        """
+        assert dc._safe_num(float("inf")) is None
+        assert dc._safe_num(float("-inf")) is None
+        assert dc._safe_num(float("nan")) is None
+        assert dc._safe_num("not-a-number") is None
+        assert dc._safe_num(None) is None
+        # Booleans are explicitly not numbers here.
+        assert dc._safe_num(True) is None
+        # Genuine numbers pass through unchanged.
+        assert dc._safe_num(4200) == 4200.0
+        assert dc._safe_num("4200") == 4200.0
+
+
+class TestSiteMaxContamination:
+    """The value-direct branch is ``raw / site_max × 9999``.
+
+    ``site_max`` is an unbounded max over the pool, so one bad cell in
+    a value-based source rescales *every* player in that source.
+    """
+
+    def test_non_finite_values_never_become_the_site_max(self):
+        """Regression guard for a board-wide repricing.
+
+        Built through the real entry point so the ``_safe_num``
+        coercion in ``_canonical_site_values`` is in the path.  Here
+        the values must be *identical* with and without the poisoned
+        row.
+
+        Removing the ``math.isfinite`` guard breaks this two ways,
+        both verified by mutation:
+          * via ``build_api_data_contract`` the ``inf`` reaches
+            ``_to_int_or_none`` and raises ``OverflowError``;
+          * calling ``_compute_unified_rankings`` directly with an
+            ``inf`` cell (no coercion layer) makes it ``site_max``,
+            and every other player's contribution from that source
+            collapses toward zero — measured at ~50% board-wide.
+        """
+        clean = dc.build_api_data_contract(_payload())
+        poisoned = dc.build_api_data_contract(_payload(corrupt=float("inf")))
+
+        clean_vals = _contract_values(clean)
+        poisoned_vals = _contract_values(poisoned)
+
+        for name, value in clean_vals.items():
+            assert (
+                poisoned_vals[name] == value
+            ), f"{name} was repriced by a non-finite cell in another row"
+
+    def test_out_of_range_finite_value_rescales_the_board(self):
+        """CHARACTERISATION of a known, unfixed gap — not an endorsement.
+
+        ``_safe_num`` only rejects non-finite values.  A finite but
+        out-of-scale cell (e.g. an extra digit: 99990 on a board that
+        tops out at 9999) is accepted, becomes ``site_max``, and
+        deflates every player's contribution from that source.
+
+        This test pins the CURRENT behaviour so that whenever a range
+        guard is added the change is deliberate and visible, rather
+        than landing silently.  See ``docs/python-coverage-audit.md``
+        (Defect D-1) for the numbers and the open policy question.
+        """
+        clean = _contract_values(dc.build_api_data_contract(_payload()))
+        poisoned = _contract_values(dc.build_api_data_contract(_payload(corrupt=99990)))
+
+        # Today: every player is deflated, and by the same proportion.
+        deflated = [
+            poisoned[n] / clean[n] for n in clean if clean[n] and poisoned.get(n) is not None
+        ]
+        assert deflated, "fixture produced no comparable players"
+        assert all(r < 0.75 for r in deflated), (
+            "expected the documented board-wide deflation; if this now "
+            "passes at ~1.0 a range guard has been added — update "
+            "docs/python-coverage-audit.md D-1 and turn this into a "
+            "no-contamination assertion"
+        )
+
+
+def _payload(corrupt: Any = None) -> dict[str, Any]:
+    """120 spread-out players, optionally plus one corrupt cell.
+
+    Sized past the point where everything crowds the top of the Hill
+    curve — with only a handful of rows every value pins near 9999 and
+    a contamination bug is invisible.
+    """
+    positions = ["QB", "RB", "WR", "TE"]
+    players: dict[str, Any] = {}
+    n = 120
+    for i in range(n):
+        ktc = int(9500 - (9000 * i / (n - 1)))
+        players[f"Player {i:03d}"] = {
+            "position": positions[i % 4],
+            "team": "FA",
+            "_sites": 2,
+            "_canonicalSiteValues": {"ktcSfTep": ktc, "idpTradeCalc": ktc},
+        }
+    if corrupt is not None:
+        players["Glitch Guy"] = {
+            "position": "WR",
+            "team": "FA",
+            "_sites": 2,
+            "_canonicalSiteValues": {"ktcSfTep": corrupt, "idpTradeCalc": 4000},
+        }
+    return {"players": players}
+
+
+def _contract_values(contract: dict[str, Any]) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for row in contract.get("playersArray") or []:
+        name = row.get("displayName")
+        value = row.get("rankDerivedValue")
+        if name and name != "Glitch Guy" and isinstance(value, (int, float)):
+            out[str(name)] = int(value)
+    return out
+
+
+# ── Ties and duplicates ──────────────────────────────────────────────
+
+
+class TestTiesAndDuplicates:
+    def test_tied_source_values_produce_identical_player_values(self):
+        """Two players a vendor ranks identically must price identically.
+
+        Any tie-break that leaked into the *value* (rather than only
+        into the display ordering) would make the board depend on dict
+        iteration order.
+        """
+        rows = [
+            _row("Tie A", "WR", ktcSfTep=4000, idpTradeCalc=4000),
+            _row("Tie B", "WR", ktcSfTep=4000, idpTradeCalc=4000),
+            _row("Lower", "WR", ktcSfTep=3000, idpTradeCalc=3000),
+            _anchor_qb(),
+        ]
+        dc._compute_unified_rankings(rows, {})
+        got = _by_name(rows)
+        assert got["Tie A"]["rankDerivedValue"] == got["Tie B"]["rankDerivedValue"]
+        assert got["Tie A"]["rankDerivedValue"] > got["Lower"]["rankDerivedValue"]
+
+    def test_tied_rank_signal_values_also_tie(self):
+        """Same, for a rank-encoded source rather than a value source."""
+        rows = [
+            _row("Tie A", "WR", dlfSf=950000, idpTradeCalc=4000),
+            _row("Tie B", "WR", dlfSf=950000, idpTradeCalc=4000),
+            _anchor_qb(),
+        ]
+        dc._compute_unified_rankings(rows, {})
+        got = _by_name(rows)
+        assert got["Tie A"]["rankDerivedValue"] == got["Tie B"]["rankDerivedValue"]
+
+    def test_duplicate_names_are_valued_independently(self):
+        """Two rows sharing a name must not merge or overwrite.
+
+        The pipeline keys its working maps on row index, so a duplicate
+        display name (a real scrape hazard — two players, same name)
+        must keep each row's own evidence.
+        """
+        rows = [
+            _row("Josh Allen", "QB", ktcSfTep=9000, idpTradeCalc=9000),
+            _row("Josh Allen", "LB", ktcSfTep=2000, idpTradeCalc=2000),
+            _anchor_qb(),
+        ]
+        dc._compute_unified_rankings(rows, {})
+        values = [r["rankDerivedValue"] for r in rows if r["position"] in ("QB", "LB")]
+        assert 9000 in values
+        # The LB row keeps its own (much lower) evidence rather than
+        # inheriting the QB's.
+        assert max(values) != min(values)
+
+
+# ── Sanity: no NaN ever escapes into the contract ────────────────────
+
+
+class TestNoNaNEscapes:
+    def test_no_stamped_value_is_nan(self):
+        """A NaN in any numeric stamp would poison sorting downstream."""
+        rows = [
+            _row("Split", "WR", ktcSfTep=9000, idpTradeCalc=1000),
+            _row("Solo", "WR", ktcSfTep=4000),
+            _row("Def", "LB", idpTradeCalc=6000, dlfIdp=900000),
+            _anchor_qb(),
+        ]
+        dc._compute_unified_rankings(rows, {})
+        numeric_fields = (
+            "rankDerivedValue",
+            "_blendedValueUncapped",
+            "sourceSpread",
+            "hillValueSpread",
+            "anchorValue",
+            "subgroupBlendValue",
+            "subgroupDelta",
+            "alphaShrinkage",
+        )
+        for row in rows:
+            for field in numeric_fields:
+                value = row.get(field)
+                if isinstance(value, float):
+                    assert not math.isnan(value), f"{row['canonicalName']}.{field} is NaN"
+                    assert math.isfinite(value), f"{row['canonicalName']}.{field} not finite"

--- a/tests/api/test_valuation_pipeline_stages.py
+++ b/tests/api/test_valuation_pipeline_stages.py
@@ -1,0 +1,549 @@
+"""Numeric stage tests for the live valuation pipeline.
+
+``src/api/data_contract.py::_compute_unified_rankings`` is the single
+code path that decides every live player value (CLAUDE.md "Live Value
+Pipeline", 12 stages).  Its individual helpers — the Hampel filter and
+``count_aware_mean_median_blend`` — already have unit tests
+(``test_hampel_filter.py``, ``test_count_aware_blend.py``), and the
+whole-board behaviour is asserted in ``test_data_contract.py`` /
+``test_single_curve_live.py``.
+
+The gap this module closes: **both of those whole-board modules are in
+``_LIVEDATA_MODULES``** (tests/conftest.py), so CI's
+``-m "not livedata"`` gate deselects them.  Before this file, the
+stage arithmetic below — the single-source haircut, α-shrinkage
+routing, the percentile clamp and the pick-year discount — had **no
+CI-blocking test at all**.  A refactor that changed any of these
+constants would go green in CI and silently reprice the entire board.
+
+Every assertion here is an exact number with the arithmetic worked out
+in a comment.  These are pure-logic tests over synthetic rows: no
+network, no live exports, no ``livedata`` marker.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.api import data_contract as dc
+
+
+IDP_POSITIONS = ("DL", "LB", "DB")
+
+
+def _row(name: str, position: str, **sites: Any) -> dict[str, Any]:
+    """Minimal synthetic player row in ``playersArray`` shape.
+
+    Mirrors the fixture helper in ``test_single_source_resolution.py``
+    so both modules stress the same entry point the same way.
+    """
+    if position == "PICK":
+        asset_class = "pick"
+    elif position in IDP_POSITIONS:
+        asset_class = "idp"
+    else:
+        asset_class = "offense"
+    return {
+        "canonicalName": name,
+        "displayName": name,
+        "position": position,
+        "assetClass": asset_class,
+        "canonicalSiteValues": dict(sites),
+        "values": {
+            "overall": 0,
+            "rawComposite": None,
+            "finalAdjusted": None,
+            "displayValue": None,
+        },
+        "sourceCount": 0,
+        "sourcePresence": {},
+        "rookie": False,
+    }
+
+
+def _anchor_qb() -> dict[str, Any]:
+    """A top-of-board offense row.
+
+    Both value-direct sources publish on a ``raw / site_max × 9999``
+    scale, so pinning one row at 9999 in both fixes the site maxima and
+    makes every other row's value-direct contribution exactly its own
+    raw number.  Without this the maxima float with the fixture.
+    """
+    return _row("Anchor QB", "QB", ktcSfTep=9999, idpTradeCalc=9999)
+
+
+def _by_name(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {r["canonicalName"]: r for r in rows}
+
+
+# ── Stage 9: single-source haircut ───────────────────────────────────
+
+
+class TestSingleSourceHaircut:
+    """Non-pick rows resting on ONE post-Hampel source keep 30%.
+
+    ``_SINGLE_SOURCE_VALUE_RETENTION = 0.30`` (CLAUDE.md stage 9).
+    """
+
+    def test_retention_constant_is_030(self):
+        assert dc._SINGLE_SOURCE_VALUE_RETENTION == 0.30
+
+    def test_offense_single_source_keeps_exactly_30_percent(self):
+        """Solo row votes 5000 value-direct; haircut → 5000 × 0.30 = 1500."""
+        rows = [
+            _row("Solo Guy", "WR", ktcSfTep=5000),
+            _row("Duo Guy", "WR", ktcSfTep=5000, idpTradeCalc=5000),
+            _anchor_qb(),
+        ]
+        dc._compute_unified_rankings(rows, {})
+        got = _by_name(rows)
+
+        # Duo Guy: two sources agree at 5000 → n=2 mean → 5000, no haircut.
+        assert got["Duo Guy"]["rankDerivedValue"] == 5000
+        assert got["Duo Guy"].get("singleSourceValuePenaltyApplied") is not True
+
+        # Solo Guy: identical raw 5000, one source → 5000 × 0.30 = 1500.
+        assert got["Solo Guy"]["rankDerivedValue"] == 1500
+        assert got["Solo Guy"]["singleSourceValuePenaltyApplied"] is True
+
+    def test_haircut_also_rewrites_the_uncapped_blend_stamp(self):
+        """``_blendedValueUncapped`` must carry the haircut too.
+
+        The rookie-anchor pass falls back to this field for rookies past
+        ``OVERALL_RANK_LIMIT``; leaving it unpenalised would let an
+        unranked single-source rookie price picks at full value.
+        """
+        rows = [_row("Solo Guy", "WR", ktcSfTep=5000), _anchor_qb()]
+        dc._compute_unified_rankings(rows, {})
+        solo = _by_name(rows)["Solo Guy"]
+        assert solo["_blendedValueUncapped"] == 1500
+
+    def test_pick_rows_are_exempt_from_the_haircut(self):
+        """Picks are excluded by the ``not row_is_pick`` guard.
+
+        A pick and an offense row with the same lone 4000 vote must
+        diverge: pick keeps 4000, offense drops to 4000 × 0.30 = 1200.
+        """
+        year = dc.current_rookie_draft_year()
+        rows = [
+            _row(f"{year} Pick 2.05", "PICK", ktcSfTep=4000),
+            _row("Solo WR", "WR", ktcSfTep=4000),
+            _anchor_qb(),
+        ]
+        dc._compute_unified_rankings(rows, {})
+        got = _by_name(rows)
+
+        assert got[f"{year} Pick 2.05"]["rankDerivedValue"] == 4000
+        assert got[f"{year} Pick 2.05"].get("singleSourceValuePenaltyApplied") is not True
+        assert got["Solo WR"]["rankDerivedValue"] == 1200
+        assert got["Solo WR"]["singleSourceValuePenaltyApplied"] is True
+
+
+# ── Stage 6: hierarchical anchor + α-shrinkage ───────────────────────
+
+
+class TestAlphaShrinkageRouting:
+    """α=0.10 applies to IDP and picks ONLY; offense blends flat.
+
+    center = anchor + α·(subgroup_center − anchor)   [IDP, picks]
+    center = count_aware_mean_median(all_values)     [offense]
+    """
+
+    def test_alpha_constant_is_010(self):
+        assert dc._ALPHA_SHRINKAGE == 0.10
+
+    def test_idp_row_combines_anchor_and_subgroup_at_alpha(self):
+        """IDP: rdv must equal anchor + 0.10 × subgroupDelta, exactly."""
+        rows = [
+            _row("Def Guy", "LB", idpTradeCalc=6000, dlfIdp=900000),
+            _row("Anchor LB", "LB", idpTradeCalc=8000, dlfIdp=950000),
+            _anchor_qb(),
+        ]
+        dc._compute_unified_rankings(rows, {})
+        defguy = _by_name(rows)["Def Guy"]
+
+        anchor = defguy["anchorValue"]
+        delta = defguy["subgroupDelta"]
+        assert anchor is not None and delta is not None
+        assert defguy["alphaShrinkage"] == 0.10
+
+        # The stamped diagnostics must reconstruct the stamped value.
+        expected = int(round(anchor + 0.10 * delta))
+        assert defguy["rankDerivedValue"] == pytest.approx(expected, abs=1)
+
+        # And the subgroup must actually be pulled 90% of the way back
+        # to the anchor — not averaged in as a peer.
+        subgroup = defguy["subgroupBlendValue"]
+        assert subgroup is not None
+        assert abs(defguy["rankDerivedValue"] - anchor) < abs(subgroup - anchor) / 2
+
+    def test_offense_row_is_flat_blended_with_zero_alpha_stamp(self):
+        """Offense must NOT shrink toward the cross-market anchor.
+
+        Two value-direct sources disagreeing 9000 vs 3000 blend flat to
+        the n=2 mean 6000 — not to 9000 + 0.1×(3000−9000) = 8400.
+        """
+        rows = [
+            _row("Split Guy", "WR", ktcSfTep=9000, idpTradeCalc=3000),
+            _anchor_qb(),
+        ]
+        dc._compute_unified_rankings(rows, {})
+        split = _by_name(rows)["Split Guy"]
+
+        assert split["alphaShrinkage"] == 0.0
+        assert split["rankDerivedValue"] == 6000
+
+    def test_pick_rows_use_the_hierarchical_path(self):
+        """Picks carry the live α stamp, like IDP (CLAUDE.md stage 6)."""
+        year = dc.current_rookie_draft_year()
+        rows = [
+            _row(f"{year} Pick 1.01", "PICK", ktcSfTep=7000, idpTradeCalc=7000),
+            _anchor_qb(),
+        ]
+        dc._compute_unified_rankings(rows, {})
+        pick = _by_name(rows)[f"{year} Pick 1.01"]
+        assert pick["alphaShrinkage"] == 0.10
+
+
+# ── Stage 4: which sources vote value-direct vs via the Hill curve ───
+
+
+class TestValueDirectSourceMembership:
+    """``_VALUE_BASED_SOURCES`` decides *how* a source votes.
+
+    Members bypass the Hill curve entirely and vote
+    ``raw / site_max × 9999``; everyone else votes
+    rank → percentile → Hill.  Adding a key to this frozenset silently
+    switches that source's whole contribution mechanism.
+
+    Before this test the membership was referenced only in
+    ``test_single_curve_live.py`` and ``test_data_contract.py`` — both
+    ``livedata``, both deselected by CI's ``-m "not livedata"`` — plus
+    ``tests/ros/test_isolation.py``, which snapshots the set to detect
+    import-time mutation rather than asserting its contents.
+    """
+
+    def test_exactly_two_sources_vote_value_direct(self):
+        assert dc._VALUE_BASED_SOURCES == frozenset({"ktcSfTep", "idpTradeCalc"})
+
+    def test_value_direct_voting_is_linear_in_the_raw_value(self):
+        """Demonstrate the consequence, so the assertion above has teeth.
+
+        ``ktcSfTep`` is value-direct: contribution is
+        ``raw / site_max × 9999``, i.e. LINEAR in the published number.
+        With ``_anchor_qb`` pinning ``site_max`` at 9999, a row at half
+        the scale contributes exactly half.
+
+        Both rows below rest on KTC alone, so both take the 0.30
+        haircut and the ratio between them survives it:
+            5000 / 9999 × 9999 × 0.30 = 1500
+            2500 / 9999 × 9999 × 0.30 =  750
+        """
+        rows = [
+            _row("Half KTC", "WR", ktcSfTep=5000),
+            _row("Quarter KTC", "WR", ktcSfTep=2500),
+            _anchor_qb(),
+        ]
+        dc._compute_unified_rankings(rows, {})
+        got = _by_name(rows)
+        assert got["Half KTC"]["rankDerivedValue"] == 1500
+        assert got["Quarter KTC"]["rankDerivedValue"] == 750
+
+    def test_rank_voting_is_not_linear_in_the_ordinal(self):
+        """The contrast case: a rank source goes through the Hill curve.
+
+        Ranks 1 and 2 out of a 500-row reference are a hair apart on the
+        curve, nothing like the 2:1 gap the value-direct path produces
+        for a 2:1 raw-value gap.  This is why membership of
+        ``_VALUE_BASED_SOURCES`` is load-bearing rather than cosmetic.
+        """
+        rows = [
+            _row("Rank One", "WR", dlfSf=999800, idpTradeCalc=4000),
+            _row("Rank Two", "WR", dlfSf=999700, idpTradeCalc=4000),
+            _anchor_qb(),
+        ]
+        dc._compute_unified_rankings(rows, {})
+        got = _by_name(rows)
+        one = got["Rank One"]["rankDerivedValue"]
+        two = got["Rank Two"]["rankDerivedValue"]
+        assert one > two  # the curve does decay...
+        assert two > one * 0.9  # ...but nowhere near linearly
+
+
+# ── Stage 2: percentile clamp past the fixed reference pool ──────────
+
+
+class TestPercentileReferenceClamp:
+    """Ranks past ``_PERCENTILE_REFERENCE_N`` clamp to the curve tail.
+
+    Deliberate top-500-board behaviour (CLAUDE.md stage 2).  The clamp
+    is what stops a rank-signal source from driving p > 1.0 into the
+    Hill curve, where it would keep producing ever-smaller values and
+    silently re-order the deep board.
+    """
+
+    def test_reference_n_is_500(self):
+        assert dc._PERCENTILE_REFERENCE_N == 500
+
+    def test_every_routed_curve_shares_the_same_reference_denominator(self):
+        """All routed scope curves normalise against the same N.
+
+        If one scope's reference drifted, two sources covering the same
+        player would place him at different percentiles for the same
+        rank — a silent, position-dependent repricing.
+        """
+        block = dc._build_hill_curves_block()
+        routed = {k: v for k, v in block.items() if v.get("routed")}
+        assert set(routed) == {"global", "offense", "idp"}
+        for key, entry in routed.items():
+            assert entry["referenceN"] == dc._PERCENTILE_REFERENCE_N, key
+
+    def test_rookie_master_is_fit_only_and_not_routed(self):
+        """CLAUDE.md stage 5: "the ROOKIE master is refit tooling only".
+
+        Rookie-only sources ladder-translate into combined-pool space
+        before curve selection, so routing the ROOKIE curve would
+        double-apply the rookie adjustment.
+        """
+        assert dc._build_hill_curves_block()["rookie"]["routed"] is False
+
+    def test_pipeline_flattens_every_rank_past_the_reference(self):
+        """Drive real rows through the pipeline, not a re-implementation.
+
+        A rank-signal source (``dlfSf``) covers 560 players.  Ranks past
+        ``_PERCENTILE_REFERENCE_N`` clamp to p=1.0, so every one of them
+        must receive the *same* contribution from that source — the
+        deep board flattens instead of continuing to decay.
+
+        Constructed so the rank source is the ONLY differentiator: all
+        560 rows carry an identical second source, so any spread left in
+        the tail can only have come from the rank source.
+        """
+        n = dc._PERCENTILE_REFERENCE_N
+        total = n + 60
+
+        rows = [_anchor_qb()]
+        for i in range(total):
+            # dlfSf is rank-encoded (999900 − rank×100): descending
+            # values mean descending ranks, 1..total.
+            rows.append(
+                _row(
+                    f"P{i:04d}",
+                    "WR",
+                    dlfSf=999900 - (i + 1) * 100,
+                    idpTradeCalc=4000,
+                )
+            )
+        dc._compute_unified_rankings(rows, {})
+        got = _by_name(rows)
+
+        # Read the pre-cap blend: it is stamped on EVERY contributing
+        # row, whereas ``rankDerivedValue`` is only stamped inside
+        # ``OVERALL_RANK_LIMIT`` (800) and would make this assertion
+        # depend on the rank cap rather than on the percentile clamp.
+        deep_a = got[f"P{n + 10:04d}"]["_blendedValueUncapped"]
+        deep_b = got[f"P{total - 1:04d}"]["_blendedValueUncapped"]
+        assert deep_a == deep_b, "ranks past the reference must not keep decaying"
+
+        # A row inside the reference must still be worth strictly more —
+        # otherwise the clamp has swallowed the whole board, which would
+        # make the assertion above vacuously true.
+        shallow = got["P0009"]["_blendedValueUncapped"]
+        assert shallow > deep_a
+
+
+# ── Stage 12: multiplicative future-year pick discount ───────────────
+
+
+class TestPickYearDiscountThroughTheBlend:
+    """``_apply_pick_year_discount_to_blend`` runs pre-sort on picks.
+
+    ``_pick_year_discount_for`` is unit-tested in
+    ``test_current_draft_year.py``; what is untested off the livedata
+    path is that the multiplier actually reaches ``rankDerivedValue``.
+    """
+
+    def test_future_year_picks_are_multiplied_by_the_configured_factor(self):
+        """Identical raw picks must diverge by exactly the config factors.
+
+        ``config/weights/pick_year_discount.json`` offsets:
+          offset 0 → 1.00, offset 1 → 0.82, offset 2 → 0.66.
+        All three picks vote an identical 7000, so:
+          offset 0 → 7000
+          offset 1 → 7000 × 0.82 = 5740
+          offset 2 → 7000 × 0.66 = 4620
+        """
+        year = dc.current_rookie_draft_year()
+        rows = [
+            _row(f"{year} Pick 1.01", "PICK", ktcSfTep=7000, idpTradeCalc=7000),
+            _row(f"{year + 1} Pick 1.01", "PICK", ktcSfTep=7000, idpTradeCalc=7000),
+            _row(f"{year + 2} Pick 1.01", "PICK", ktcSfTep=7000, idpTradeCalc=7000),
+            _anchor_qb(),
+        ]
+        dc._compute_unified_rankings(rows, {})
+        got = _by_name(rows)
+
+        assert got[f"{year} Pick 1.01"]["rankDerivedValue"] == 7000
+        assert got[f"{year + 1} Pick 1.01"]["rankDerivedValue"] == 5740
+        assert got[f"{year + 2} Pick 1.01"]["rankDerivedValue"] == 4620
+
+    def test_current_year_pick_carries_no_discount_stamp(self):
+        """offset 0 → multiplier 1.0 → the row is left untouched."""
+        year = dc.current_rookie_draft_year()
+        rows = [
+            _row(f"{year} Pick 1.01", "PICK", ktcSfTep=7000, idpTradeCalc=7000),
+            _anchor_qb(),
+        ]
+        dc._compute_unified_rankings(rows, {})
+        assert _by_name(rows)[f"{year} Pick 1.01"].get("pickYearDiscount") is None
+
+    def test_discount_is_stamped_for_audit_on_discounted_picks(self):
+        year = dc.current_rookie_draft_year()
+        rows = [
+            _row(f"{year + 1} Pick 1.01", "PICK", ktcSfTep=7000, idpTradeCalc=7000),
+            _anchor_qb(),
+        ]
+        dc._compute_unified_rankings(rows, {})
+        assert _by_name(rows)[f"{year + 1} Pick 1.01"]["pickYearDiscount"] == 0.82
+
+    def test_players_are_never_year_discounted(self):
+        """The discount is gated to ``assetClass == 'pick'``.
+
+        A player row whose name happens to start with a future year
+        must keep its full value.
+        """
+        year = dc.current_rookie_draft_year()
+        rows = [
+            _row(f"{year + 1} Guy", "WR", ktcSfTep=7000, idpTradeCalc=7000),
+            _anchor_qb(),
+        ]
+        dc._compute_unified_rankings(rows, {})
+        got = _by_name(rows)[f"{year + 1} Guy"]
+        assert got["rankDerivedValue"] == 7000
+        assert got.get("pickYearDiscount") is None
+
+
+# ── Stage 8 (retired): λ·MAD penalty must stay off ───────────────────
+
+
+class TestMadPenaltyStaysRetired:
+    """``_MAD_PENALTY_LAMBDA = 0.0`` since 2026-04-20.
+
+    ``sourceSpread`` is a pure diagnostic.  If λ is ever switched back
+    on by accident, every high-disagreement player silently loses
+    value — so pin both the constant and the observable consequence.
+    """
+
+    def test_lambda_is_zero(self):
+        assert dc._MAD_PENALTY_LAMBDA == 0.0
+
+    def test_high_disagreement_row_is_not_penalised(self):
+        """Sources split 9000/3000 → flat mean 6000, no MAD deduction.
+
+        ``sourceSpread`` is still stamped (diagnostic), but must not
+        have moved the value.
+        """
+        rows = [
+            _row("Split Guy", "WR", ktcSfTep=9000, idpTradeCalc=3000),
+            _anchor_qb(),
+        ]
+        dc._compute_unified_rankings(rows, {})
+        split = _by_name(rows)["Split Guy"]
+
+        assert split["rankDerivedValue"] == 6000
+        assert split["sourceSpread"] == 3000.0  # diagnostic only
+        assert split["madPenaltyApplied"] is None
+
+
+# ── Retired passes must stay retired (CI-blocking versions) ──────────
+
+
+def _synthetic_contract() -> dict[str, Any]:
+    """A contract built from a synthetic payload — no live exports."""
+    positions = ["QB", "RB", "WR", "TE", "LB", "DL", "DB"]
+    players: dict[str, Any] = {}
+    for i in range(40):
+        value = 9500 - i * 200
+        players[f"Player {i:03d}"] = {
+            "position": positions[i % len(positions)],
+            "team": "FA",
+            "_sites": 2,
+            "_canonicalSiteValues": {"ktcSfTep": value, "idpTradeCalc": value},
+        }
+    return dc.build_api_data_contract({"players": players})
+
+
+class TestRetiredPassesStayRetired:
+    """Guards against silently reviving a deleted value-moving pass.
+
+    Equivalents of these live in ``test_single_curve_live.py``
+    (``TestOffenseHasNoCalibrationLayer``, ``TestVolatilityPassIsRemoved``,
+    ``TestValueChain``) and ``src/api/data_contract.py`` cites them in a
+    source comment as the thing that "fails if that reference ever
+    starts mutating live values".
+
+    They cannot do that job.  That module is in ``_LIVEDATA_MODULES``,
+    so CI's ``-m "not livedata"`` deselects it — and even when
+    selected each guard calls ``skipTest`` unless a live export is on
+    disk.  Two independent reasons it never runs in CI.
+
+    These versions build the contract from a synthetic payload, so
+    they run everywhere, every time.  Keep both: the livedata copies
+    additionally check the real board.
+    """
+
+    RETIRED_STAMPS = (
+        # IDP calibration post-pass (retired; see "Phase 4c: removed").
+        "rankDerivedValueUncalibrated",
+        "canonicalConsensusRankUncalibrated",
+        "idpCalibrationMultiplier",
+        "idpFamilyScale",
+        "idpCalibrationPositionRank",
+        # Volatility compression pass (retired).
+        "preVolatilityValue",
+        "volatilityCompressionApplied",
+        # Offense calibration — deliberately never applied to live values.
+        "offenseCalibrationMultiplier",
+    )
+
+    def test_no_row_carries_a_retired_pass_stamp(self):
+        contract = _synthetic_contract()
+        rows = contract.get("playersArray") or []
+        assert rows, "fixture produced no rows — the guard would be vacuous"
+
+        offenders: list[str] = []
+        for row in rows:
+            for stamp in self.RETIRED_STAMPS:
+                if row.get(stamp) is not None:
+                    offenders.append(f"{row.get('displayName')}::{stamp}={row[stamp]}")
+        assert not offenders, (
+            "a retired value-moving pass appears to have been revived: " f"{offenders[:5]}"
+        )
+
+    def test_idp_calibration_config_and_helper_are_really_gone(self):
+        """CLAUDE.md still documents stage 10 as
+        ``_apply_idp_calibration_post_pass`` reading
+        ``config/idp_calibration.json``.  Neither exists — the pass was
+        retired ("Phase 4c: removed").  Pin that so the docs and the
+        code cannot drift further apart unnoticed.
+
+        If a calibration pass is ever genuinely reintroduced, this test
+        should be deleted in the same PR that adds tests for the new
+        chain — not quietly amended.
+        """
+        assert not hasattr(dc, "_apply_idp_calibration_post_pass")
+
+        from pathlib import Path
+
+        repo_root = Path(dc.__file__).resolve().parents[2]
+        assert not (repo_root / "config" / "idp_calibration.json").exists()
+
+    def test_market_corridor_clamp_is_still_wired(self):
+        """The clamp that DOES survive stage 10 must stay callable.
+
+        Complements the retirement guards above: this is the one
+        containment pass the live pipeline still runs.
+        """
+        assert callable(getattr(dc, "_apply_market_corridor_clamp", None))

--- a/tests/trade/test_waiver.py
+++ b/tests/trade/test_waiver.py
@@ -1,0 +1,355 @@
+"""Tests for ``src/trade/waiver.py``.
+
+This module backs the live ``POST /api/waiver/suggestions`` endpoint
+but had **no dedicated test file** — 27% statement coverage, the
+weakest of anything under ``src/trade/``.  Everything below is a
+behaviour/number assertion over synthetic contracts: no network, no
+live board.
+
+The gates pinned here are the ones with real money consequences:
+
+  * the **two-source minimum**, added to kill the "weird" waiver
+    suggestions whose value rested on a single ranking list;
+  * the ``MIN_WAIVER_VALUE`` floor;
+  * rostered-player exclusion (the whole point of a waiver list);
+  * the pre-draft rookie suppression window;
+  * the FAAB bid arithmetic, which is what the user actually spends.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.trade import waiver as w
+
+
+def _player(
+    name: str,
+    position: str,
+    value: int,
+    *,
+    sources: int = 3,
+    rookie: bool = False,
+    rank: int | None = None,
+) -> dict[str, Any]:
+    return {
+        "displayName": name,
+        "canonicalName": name,
+        "position": position,
+        "rankDerivedValue": value,
+        "sourceCount": sources,
+        "rookie": rookie,
+        "canonicalConsensusRank": rank,
+    }
+
+
+def _contract(*players: dict[str, Any]) -> dict[str, Any]:
+    return {"playersArray": list(players)}
+
+
+@pytest.fixture()
+def rookies_allowed(monkeypatch):
+    """Pin the date-dependent rookie window OPEN.
+
+    ``_rookies_eligible_today`` keys off the calendar, so without this
+    the rookie assertions would pass or fail depending on the month the
+    suite runs in.
+    """
+    monkeypatch.setattr(w, "_rookies_eligible_today", lambda: True)
+
+
+@pytest.fixture()
+def rookies_suppressed(monkeypatch):
+    monkeypatch.setattr(w, "_rookies_eligible_today", lambda: False)
+
+
+# ── The two-source minimum ───────────────────────────────────────────
+
+
+class TestTwoSourceMinimum:
+    """A single-source player must never be surfaced as a pickup.
+
+    Regression guard: single-source rows already take a 70% haircut in
+    the valuation pipeline, but one that still clears ``MIN_WAIVER_VALUE``
+    would otherwise be recommended off one list's opinion.
+    """
+
+    def test_single_source_player_is_excluded(self, rookies_allowed):
+        out = w.find_waiver_targets(
+            _contract(_player("Solo Guy", "WR", 4000, sources=1)),
+            sleeper_teams=[],
+        )
+        assert out["total"] == 0
+        assert out["by_position"] == {}
+
+    def test_two_source_player_is_included(self, rookies_allowed):
+        out = w.find_waiver_targets(
+            _contract(_player("Duo Guy", "WR", 4000, sources=2)),
+            sleeper_teams=[],
+        )
+        assert out["total"] == 1
+        assert [c["name"] for c in out["by_position"]["WR"]] == ["Duo Guy"]
+
+    def test_missing_or_garbage_source_count_is_treated_as_zero(self, rookies_allowed):
+        """A row with no usable ``sourceCount`` fails the gate closed."""
+        missing = _player("No Count", "WR", 4000)
+        del missing["sourceCount"]
+        garbage = _player("Bad Count", "WR", 4000)
+        garbage["sourceCount"] = "three"
+
+        out = w.find_waiver_targets(_contract(missing, garbage), sleeper_teams=[])
+        assert out["total"] == 0
+
+
+# ── Value floor and roster exclusion ─────────────────────────────────
+
+
+class TestValueFloorAndRosterExclusion:
+    def test_min_waiver_value_default_is_500(self):
+        assert w.MIN_WAIVER_VALUE == 500
+
+    def test_player_below_the_floor_is_dropped(self, rookies_allowed):
+        """499 is out, 500 is in — the gate is ``< min_value``."""
+        out = w.find_waiver_targets(
+            _contract(
+                _player("Just Under", "WR", 499),
+                _player("Exactly At", "RB", 500),
+            ),
+            sleeper_teams=[],
+        )
+        names = {c["name"] for cs in out["by_position"].values() for c in cs}
+        assert names == {"Exactly At"}
+
+    def test_rostered_players_are_excluded_case_insensitively(self, rookies_allowed):
+        out = w.find_waiver_targets(
+            _contract(
+                _player("Taken Guy", "WR", 4000),
+                _player("Free Guy", "WR", 3000),
+            ),
+            sleeper_teams=[{"players": ["  TAKEN guy "]}],
+        )
+        assert [c["name"] for c in out["by_position"]["WR"]] == ["Free Guy"]
+
+    def test_kickers_and_defenses_are_opt_in(self, rookies_allowed):
+        contract = _contract(
+            _player("Boot Foot", "K", 4000),
+            _player("Steel Curtain", "DEF", 4000),
+            _player("Real WR", "WR", 4000),
+        )
+        default = w.find_waiver_targets(contract, sleeper_teams=[])
+        assert set(default["by_position"]) == {"WR"}
+
+        opted_in = w.find_waiver_targets(contract, sleeper_teams=[], include_kicker_def=True)
+        assert set(opted_in["by_position"]) == {"WR", "K", "DEF"}
+
+
+# ── Pre-draft rookie window ──────────────────────────────────────────
+
+
+class TestRookieWindow:
+    def test_rookies_suppressed_and_flagged(self, rookies_suppressed):
+        out = w.find_waiver_targets(
+            _contract(
+                _player("Rook", "WR", 4000, rookie=True),
+                _player("Vet", "WR", 3000),
+            ),
+            sleeper_teams=[],
+        )
+        assert [c["name"] for c in out["by_position"]["WR"]] == ["Vet"]
+        assert out["rookies_excluded"] is True
+
+    def test_rookies_included_when_window_open(self, rookies_allowed):
+        out = w.find_waiver_targets(
+            _contract(_player("Rook", "WR", 4000, rookie=True)),
+            sleeper_teams=[],
+        )
+        assert [c["name"] for c in out["by_position"]["WR"]] == ["Rook"]
+        assert out["rookies_excluded"] is False
+
+
+# ── FAAB bid arithmetic ──────────────────────────────────────────────
+
+
+class TestFaabBidArithmetic:
+    """``_compute_faab_bid`` decides what the user actually spends.
+
+    share      = value / max(value, top_value_in_pool)
+    aggressive = round(budget × (0.05 + 0.25 × share))
+    reasonable = round(aggressive × 0.70)
+    lowball    = round(aggressive × 0.35)
+    """
+
+    def test_top_of_pool_gets_the_full_30_percent_band(self):
+        """share = 1.0 → 0.05 + 0.25 = 0.30 → 100 × 0.30 = 30.
+
+        reasonable = round(30 × 0.70) = 21
+        lowball    = round(30 × 0.35) = 10.5 → 10 (banker's rounding)
+        """
+        agg, reas, low = w._compute_faab_bid(5000, league_budget=100, top_value_in_pool=5000)
+        assert agg == 30
+        assert reas == 21
+        assert low == round(30 * 0.35)
+
+    def test_half_value_player_gets_a_smaller_share(self):
+        """share = 0.5 → 0.05 + 0.125 = 0.175 → 100 × 0.175 = 17.5 → 18."""
+        agg, reas, low = w._compute_faab_bid(2500, league_budget=100, top_value_in_pool=5000)
+        assert agg == round(100 * (0.05 + 0.25 * 0.5))
+        assert agg == 18
+        assert reas == round(18 * 0.70)
+        assert low == round(18 * 0.35)
+
+    def test_bids_scale_with_the_budget(self):
+        """A 50-point budget halves the same share's bid: 50 × 0.30 = 15."""
+        agg, _, _ = w._compute_faab_bid(5000, league_budget=50, top_value_in_pool=5000)
+        assert agg == 15
+
+    def test_zero_and_negative_inputs_bid_nothing(self):
+        assert w._compute_faab_bid(0, league_budget=100) == (0, 0, 0)
+        assert w._compute_faab_bid(-100, league_budget=100) == (0, 0, 0)
+        assert w._compute_faab_bid(5000, league_budget=0) == (0, 0, 0)
+
+    def test_every_nonzero_bid_is_at_least_one_dollar(self):
+        """A tiny share must never round down to a $0 bid."""
+        agg, reas, low = w._compute_faab_bid(1, league_budget=1, top_value_in_pool=9999)
+        assert agg >= 1 and reas >= 1 and low >= 1
+
+    def test_bids_are_attached_to_candidates_and_use_remaining_faab(self, rookies_allowed):
+        """The user's remaining FAAB is the budget, not a flat 100."""
+        out = w.find_waiver_targets(
+            _contract(_player("Top Guy", "WR", 5000)),
+            sleeper_teams=[],
+            user_faab_remaining=40,
+        )
+        bid = out["by_position"]["WR"][0]["bid"]
+        # Sole candidate ⇒ share 1.0 ⇒ 40 × 0.30 = 12.
+        assert bid["aggressive"] == 12
+        assert bid["reasonable"] == round(12 * 0.70)
+
+    def test_missing_faab_falls_back_to_a_100_budget(self, rookies_allowed):
+        for remaining in (None, 0, -5):
+            out = w.find_waiver_targets(
+                _contract(_player("Top Guy", "WR", 5000)),
+                sleeper_teams=[],
+                user_faab_remaining=remaining,
+            )
+            assert out["by_position"]["WR"][0]["bid"]["aggressive"] == 30
+
+
+# ── Grouping, ordering and caps ──────────────────────────────────────
+
+
+class TestGroupingAndCaps:
+    def test_candidates_are_sorted_by_value_and_capped_per_position(self, rookies_allowed):
+        players = [_player(f"WR{i}", "WR", 1000 + i * 100) for i in range(10)]
+        out = w.find_waiver_targets(_contract(*players), sleeper_teams=[], per_position_limit=3)
+        got = [c["name"] for c in out["by_position"]["WR"]]
+        # Highest value first, capped at 3.
+        assert got == ["WR9", "WR8", "WR7"]
+        assert out["total"] == 3
+
+    def test_idp_positions_collapse_into_families(self, rookies_allowed):
+        """DE/DT/EDGE → DL, ILB/OLB → LB, CB/S → DB."""
+        out = w.find_waiver_targets(
+            _contract(
+                _player("Edge Guy", "EDGE", 4000),
+                _player("Tackle Guy", "DT", 3000),
+                _player("Inside Guy", "ILB", 3500),
+                _player("Corner Guy", "CB", 2000),
+            ),
+            sleeper_teams=[],
+        )
+        assert set(out["by_family"]) == {"DL", "LB", "DB"}
+        # Family lists are re-sorted across their member positions.
+        assert [c["name"] for c in out["by_family"]["DL"]] == ["Edge Guy", "Tackle Guy"]
+
+    def test_total_counts_capped_entries_not_raw_candidates(self, rookies_allowed):
+        players = [_player(f"WR{i}", "WR", 1000 + i) for i in range(8)]
+        players += [_player(f"RB{i}", "RB", 1000 + i) for i in range(8)]
+        out = w.find_waiver_targets(_contract(*players), sleeper_teams=[], per_position_limit=2)
+        assert out["total"] == 4
+
+
+# ── Degraded inputs ──────────────────────────────────────────────────
+
+
+class TestDegradedInputs:
+    def test_missing_players_array_returns_empty_shape(self):
+        out = w.find_waiver_targets({}, sleeper_teams=[])
+        assert out == {
+            "by_position": {},
+            "by_family": {},
+            "total": 0,
+            "rookies_excluded": False,
+        }
+
+    def test_non_list_players_array_returns_empty_shape(self):
+        out = w.find_waiver_targets({"playersArray": "nope"}, sleeper_teams=[])
+        assert out["total"] == 0
+
+    def test_non_dict_rows_and_teams_are_skipped(self, rookies_allowed):
+        contract = {"playersArray": ["junk", None, _player("Real Guy", "WR", 4000)]}
+        out = w.find_waiver_targets(contract, sleeper_teams=["junk", None])
+        assert [c["name"] for c in out["by_position"]["WR"]] == ["Real Guy"]
+
+    def test_none_value_and_unnamed_rows_are_skipped(self, rookies_allowed):
+        nameless = _player("", "WR", 4000)
+        valueless = _player("No Value", "WR", 4000)
+        valueless["rankDerivedValue"] = None
+        out = w.find_waiver_targets(_contract(nameless, valueless), sleeper_teams=[])
+        assert out["total"] == 0
+
+    def test_none_sleeper_teams_means_nobody_is_rostered(self, rookies_allowed):
+        out = w.find_waiver_targets(_contract(_player("Free Guy", "WR", 4000)), sleeper_teams=None)
+        assert out["total"] == 1
+
+
+# ── Drop candidates ──────────────────────────────────────────────────
+
+
+class TestDropCandidates:
+    def test_returns_lowest_value_roster_players_bottom_up(self):
+        out = w.find_drop_candidates(
+            _contract(
+                _player("Stud", "WR", 9000),
+                _player("Mid", "RB", 4000),
+                _player("Scrub", "TE", 300),
+                _player("Not Mine", "WR", 100),
+            ),
+            user_team_players=["Stud", "Mid", "Scrub"],
+            limit=2,
+        )
+        assert [c["name"] for c in out] == ["Scrub", "Mid"]
+
+    def test_empty_roster_returns_nothing(self):
+        assert w.find_drop_candidates(_contract(_player("A", "WR", 100)), []) == []
+
+    def test_missing_players_array_returns_empty(self):
+        assert w.find_drop_candidates({}, ["Anyone"]) == []
+        assert w.find_drop_candidates({"playersArray": "nope"}, ["Anyone"]) == []
+
+    def test_deep_rank_gets_an_explicit_rationale(self):
+        out = w.find_drop_candidates(
+            _contract(_player("Deep Guy", "WR", 400, rank=250)),
+            user_team_players=["Deep Guy"],
+        )
+        assert out[0]["rationale"] == "rank #250 on consensus"
+
+    def test_shallow_rank_falls_back_to_generic_rationale(self):
+        out = w.find_drop_candidates(
+            _contract(_player("Shallow Guy", "WR", 400, rank=12)),
+            user_team_players=["Shallow Guy"],
+        )
+        assert out[0]["rationale"] == "low value vs roster average"
+
+    def test_zero_and_negative_values_are_skipped(self):
+        out = w.find_drop_candidates(
+            _contract(
+                _player("Zero Guy", "WR", 0),
+                _player("Neg Guy", "WR", -50),
+                _player("Real Guy", "WR", 100),
+            ),
+            user_team_players=["Zero Guy", "Neg Guy", "Real Guy"],
+        )
+        assert [c["name"] for c in out] == ["Real Guy"]


### PR DESCRIPTION
## What this is

A measured coverage audit of the Python side, plus tests where the measurement said they buy the most confidence. Full write-up: **`docs/python-coverage-audit.md`**.

Everything here is `tests/**` plus one new doc. **No `src/` or `server.py` behaviour is changed** — `git diff main...HEAD -- src/ server.py` is empty. The defects that would need a code change are documented as unresolved, with reproduction numbers, rather than closed by fiat.

## Headline numbers

Measured with `-m "not livedata"`, so these are what CI actually gates on.

| | Before | After |
|---|---|---|
| Tests (`not livedata`) | 3,927 | **4,012** |
| Total coverage (`src/` + `server.py`) | **80.1%** | **80.5%** |
| `src/api/data_contract.py` | 79.8% | 80.1% |
| `src/trade/waiver.py` | **27.0%** | **99.2%** |
| `server.py` | 51.3% | 51.8% |

## The finding that matters most

The test-to-code ratio looked healthy, and by line coverage the money paths mostly were: `finder.py` 95.7%, `suggestions.py` 94.1%, `replacement.py` 95.0%, `player_valuation.py` 97.7%. The real problem was **where the coverage came from**.

`tests/conftest.py::_LIVEDATA_MODULES` marks 16 modules `livedata`, and CI deselects them. Grepping the live valuation constants before this branch:

- `_SINGLE_SOURCE_VALUE_RETENTION` (the 30% single-source haircut)
- `_ALPHA_SHRINKAGE` (α=0.10, IDP + picks)
- pick tethering
- `_VALUE_BASED_SOURCES` membership

…were referenced **only** in `livedata` modules, plus one fixture that merely names a field. Changing `0.30` to `0.50` — repricing every single-source player on the board — would have gone **green in CI**.

Worse: `src/api/data_contract.py` cites one of those deselected tests in a source comment as the thing that "fails if that reference ever starts mutating live values". It cannot. That module is deselected **and** every test in it calls `skipTest` without a live export on disk. Two independent reasons it never runs. This PR adds synthetic-fixture equivalents that do run, and leaves the livedata copies alone.

## Tests added (85, all CI-blocking, all mutation-verified)

| File | N | Covers |
|---|---|---|
| `tests/api/test_valuation_pipeline_stages.py` | 24 | Single-source haircut (0.30 exactly + pick exemption); α-shrinkage routing; value-direct vs Hill voting membership; routed-curve reference denominators; percentile clamp past N=500 driven through the pipeline; pick-year discount; λ·MAD staying retired; CI-blocking retired-pass guards |
| `tests/api/test_valuation_degraded_inputs.py` | 14 | Empty/absent sources; zero variance; negative/zero/None/non-finite; site-max contamination; ties; duplicate names; no-NaN sweep |
| `tests/api/test_league_isolation_invariants.py` | 17 | No raw Sleeper league ID on `/api/leagues` (anon + authed); league-scoped endpoints refusing foreign leagues; unknown/inactive 400 sweep |
| `tests/trade/test_waiver.py` | 30 | Two-source minimum; value floor; roster exclusion; rookie window; full FAAB bid arithmetic; grouping/caps; degraded inputs; drop candidates |

**Every test was watched fail.** 20 mutations applied to the source, suite run, reverted — full table in §6 of the audit doc. Examples: haircut `0.30→0.50` turns 4 red (`1500→2000`); routing offense through the α path turns 2 red (`6000→3600`); disabling the phase-1 positivity gate turns 1 red (`900→6405`); leaking `sleeperLeagueId` from `public_dict` turns 3 red.

One mutation is worth calling out. Removing the percentile clamp in `data_contract.py` alone leaves the suite **green**, because `percentile_to_value` clamps again internally — the clamp is defence-in-depth. My first version of that test only passed because it re-implemented the formula instead of driving the pipeline, which is the same manufactured-confidence failure this PR is about. It was rewritten to drive 560 real rows and now goes red when both clamps go.

## Defects found

**D-1 — one out-of-range source value rescales the entire board.** *Unresolved, documented.*
`value_source_max` takes an unbounded `max()` and the value-direct branch divides by it (`raw / site_max × 9999`). Reproduced through `build_api_data_contract` on a 120-player board: one row at `ktcSfTep=99990` (a plausible extra-digit scrape glitch) deflates **every** player by **45.3%**; one at `950000` by **49.5%**. Silent — ordering still looks correct, magnitudes are ~half. `_safe_num` blocks `inf`/`nan`/strings, and nothing anywhere validates the declared 0–9999 range (`source_health_alerts.py` only checks staleness). Not fixed because the *shape* of the guard is a policy call — clamp `site_max`? drop the row? reject the source as unhealthy? — and each choice moves numbers. Pinned by a regression test on the guard that does exist, plus a characterisation test that instructs the next reader to update the doc when a range guard lands.

**D-2 — `/api/draft-capital` doesn't honour its documented 503.** *Unresolved, documented.*
CLAUDE.md's table says 503 on league mismatch; it returns 200 and serves a Sleeper-derived fallback its own docstring calls intentional. No roster leak — verified it consults the *requested* league's Sleeper ID, and mutation-tested. But it prices League B's picks from League A's `latest_contract_data` with **no scoring-profile check**, where `/api/data` 503s when profiles differ.

**D-3 — CLAUDE.md stage 10 documents code that doesn't exist.**
`_apply_idp_calibration_post_pass` and `config/idp_calibration.json`: zero matches, no such file. `data_contract.py` says "Phase 4c: removed". The live pipeline has 11 implemented stages, not 12. Left for you to correct in CLAUDE.md rather than edited here, since other agents are working against that file.

**W-1 — a "safety rail" test that guarded nothing.** *Fixed here.*
`test_fallback_chain_covers_all_scope_sources` claimed to catch a source added to `_RANKING_SOURCES` but missing from the anchor chain. It built four sets and compared none of them (ruff `F841` flagged all four as unused). Renamed to describe what it actually verifies, dead locals removed. The registry-coverage assertion was deliberately **not** added — an inline comment records that the chain is a curated shortlist, so a subset assertion would be wrong.

Also documented: **D-4** (`leagueKey` not echoed on 503 by `/api/trade/suggestions` and `/api/trade/finder`) and **D-5** (a pre-existing test-isolation leak in `tests/intel/test_endpoints.py` that appears only under parallel runs; passes serially, unrelated to this branch).

## What still has no meaningful test

The most useful section of the audit doc (§7) is the honest inventory of what remains unprotected:

1. **Pick tethering (stage 11)** — the largest remaining hole. Covered only by `test_pick_rookie_anchor.py` and `test_picks_end_to_end.py`, both `livedata`, both deselected. A regression mis-tethering every 2027 pick ships green.
2. **Per-source curve routing** — `_curve_for_source` is a nested closure inside `_compute_unified_rankings`, so no test can assert a given source routes to a given curve without a per-source curve stamp or lifting the closure to module scope.
3. **Market corridor clamp band arithmetic** — anchor selection is covered; the P90 drift band is not asserted numerically.
4. **Hampel *inside* the pipeline** — the function is well unit-tested, but nothing asserts an outlier is dropped end-to-end, or that the haircut fires on a row reduced to one source *by Hampel*.
5. **`server.py` at 51.8%**, **`src/api/chat.py` at 0%**, **`src/ros/sources/*` at 0%** (untrusted external parsers).

## Verification

```
python -m pytest tests/ -q -m "not livedata"   # 4,011 passed
python -m ruff check <changed files>           # All checks passed (0.6.9)
python -m ruff format --check .                # 542 files already formatted
```

One test fails under **parallel** runs only — `tests/intel/test_endpoints.py::TestLeagueScoping::test_reads_go_through_the_league_resolver` — both before and after this branch. It passes serially (`python -m pytest tests/intel/test_endpoints.py` → 21 passed). Pre-existing cross-file registry-state leak, documented as D-5, not touched here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_