### PR TITLE
Route usability sweep: 3 fixes + full 38-route defect inventory

### DIFF
--- a/docs/route-usability-audit.md
+++ b/docs/route-usability-audit.md
@@ -375,8 +375,23 @@ Observed:
  ..."
 ```
 
-All 88 events are `NEWS`. The contract for the same league carries 109
-trades and 785 waivers. So:
+Counted in the DOM: **88 events, 80 `NEWS`, 0 `TRADE`.** The contract
+for the same league carries 109 trades and 785 waivers.
+
+Clicking the **Trades** filter confirms it is dead, and the empty state
+blames the reader for it:
+
+```
+[default (All)] events=88  NEWS=80  TRADE=0
+[type=Trades]   events=0   NEWS=0   TRADE=0
+  "No activity in this view
+   Try widening the scope or changing the type filter."
+```
+
+Widening the scope cannot help. There is no scope in which this page
+has a trade to show.
+
+So:
 
 * the page's own description ("Trades + news in one chronological
   feed") is false;
@@ -563,7 +578,7 @@ are from the loaded sequential sweep and are upper bounds — see M-3.
 | `/intel` | PASS (honest empty) | `/api/intel/summary` 503 `data_not_ready`; UI says "No intel snapshot yet — the first crawl hasn't run", matching the API's own message |
 | `/league` | PASS | 2,784 chars, settled 4.5s — resolves fine on a warm backend; 3 seasons / 12 managers / 190 trades / 1,092 waivers / defending champion all render |
 | `/league-comparison` | PASS | 2,399 chars; not caught by the `/league` prefix gate (`"/league-comparison".startsWith("/league/")` is false) |
-| `/league/activity` | **DEFECT** (empty-state lie + 2 dead controls) | F-2 — 88 events, all NEWS, 0 trades against 109 in the contract |
+| `/league/activity` | **DEFECT** (empty-state lie + 2 dead controls) | F-2 — 88 events / 80 NEWS / **0 TRADE** against 109 trades in the contract; the Trades filter returns "No activity in this view" and tells you to widen a scope that cannot help |
 | `/league/phases` | **FIXED** | FIX-3 — was 282 chars / empty body / structurally dead; now 759 chars, 12 rows, all 12 franchises classified |
 | `/login` | PASS (markup) | form + submit render; invisible-button issue is CSS-layer, F-5 |
 | `/more` | PASS | 1,230 chars, settled 1.6s |
@@ -593,6 +608,26 @@ are from the loaded sequential sweep and are upper bounds — see M-3.
 No route produced an uncaught `pageerror`, a React error boundary, a
 500, or a blank white page. The only genuinely non-functional surface
 was `/league/phases`, now fixed.
+
+---
+
+## Suite status on this branch
+
+```
+$ python3 -m pytest tests/ -q -m "not livedata"
+3927 passed, 325 deselected, 1 warning, 4 subtests passed in 1084.20s (0:18:04)
+
+$ npx vitest run            # frontend, both projects
+Test Files  63 passed (63)
+     Tests  1219 passed (1219)
+
+$ python3 -m ruff format --check .
+538 files already formatted
+```
+
+`python -m ruff check` reports 49 findings repo-wide; all pre-existing
+(this branch changes no `.py` files, and `pr-validation.yml` lints
+changed files only, so the blocking gate has nothing to look at).
 
 ---
 

--- a/docs/route-usability-audit.md
+++ b/docs/route-usability-audit.md
@@ -1,0 +1,618 @@
+# Route usability audit — 2026-07-27
+
+Every Next.js route under `frontend/app` walked as a signed-in user
+against a warm backend, looking for hard failures, console errors,
+failed network requests, empty-state lies, silent fallbacks, and dead
+controls.
+
+Three defects were fixed on `claude/route-usability-sweep`; the rest is
+recorded here. Read [Method](#method) first — one finding in this
+document (F-1) is the reason two previous agents could not get the
+stack up, and one measurement caveat (M-2) invalidates any audit that
+skips it.
+
+---
+
+## Method
+
+### Topology — this is the part that matters
+
+Production nginx splits by prefix
+(`deploy/nginx/chaseupside-proxy.conf`):
+
+```
+location /api/     -> dynasty_backend  (:8000)
+location /         -> dynasty_frontend (:3000)
+```
+
+`location /api/` is a longer prefix match than `location /`, so **every**
+`/api/*` request from the browser goes to the FastAPI backend. The 22
+route handlers under `frontend/app/api/**` are never reached in
+production.
+
+That matters for auditing because the frontend references 48 distinct
+`/api/*` paths client-side, and only 22 have a Next handler. Point a
+browser straight at `:3000` and you get 404s on `/api/health`,
+`/api/leagues`, `/api/user/state`, `/api/terminal`, `/api/data`, and
+`/api/ros/*`. Those endpoints all exist and answer fine — on the
+backend, which is where nginx sends them. None of those 404s can happen
+in production. An audit run that way reports a dozen phantom defects,
+and that is exactly what the first pass of this one did.
+
+The sweep therefore ran against a 40-line Node reverse proxy on `:8080`
+reproducing exactly that split, so the browser saw one origin and the
+same routing production uses.
+
+### Stack
+
+Booted from the committed snapshot in `exports/latest/`, offline, no
+credentials — backend `:8000` (`ALLOW_DEFAULT_LOGIN_DEV=1`,
+`E2E_TEST_MODE=1`, `RATE_LIMIT_BYPASS_IPS=127.0.0.1`, scraper browser
+path pointed at an empty dir), frontend production build on `:3000`.
+Auth via `POST /api/test/create-session`. Verified before walking:
+
+```
+/api/status  -> 200, has_data = True, player_count = 1095
+/api/data    -> 200 authenticated, 1095 players, 5,602,258 bytes
+/api/leagues -> 200, dynasty_main / superflex_tep15_ppr1 / idpEnabled
+```
+
+Per route, captured: navigation status, `page.on('pageerror')`,
+`page.on('console')`, every response with status >= 400, every `/api/*`
+call with its status, and a 1.5s-interval growth curve of rendered text
+length + `<tbody> tr` count over a 40s observation window.
+
+Dynamic-route parameters were resolved from the live APIs, never
+guessed:
+
+| Route | Parameter | Source |
+|---|---|---|
+| `/league/player/[playerId]` | `10229` (Rashee Rice) | `/api/public/league/players` |
+| `/league/franchise/[owner]` | `1012114412049731584` (Joey) | `sections.franchise.index[0].ownerId` |
+| `/league/rivalry/[pair]` | `1012114412049731584-vs-711452264774041600` | `sections.rivalries.pairs[0].ownerIds` |
+| `/league/week/[season]/[week]` | `2025/17` | `weeklyRecap.byKey` |
+| `/league/weekly/[…]/[matchup]` | `2025/17/1` | `sections.weekly.weeks[0].matchups[].matchupId` |
+| `/league/articles/[season]/[week]` | `2025/17` | `/api/league/articles?season=2025&week=17` |
+| `/league/articles/…/[matchupId]/[mode]` | `2025/17/1/preview` | same, `mode: "preview"` |
+| `/rankings/[position]` | `qb`, `idp`, `picks` | `POSITION_ALIASES` in the route file |
+
+---
+
+## Measurement caveats — read before trusting any number here
+
+**M-1 — `/api/health` returning 503 is normal offline.** Already
+documented in `tests/e2e/README.md`. It appears in the console log of
+essentially every route in this audit and is not a defect.
+`StaleDataBanner` explicitly tolerates it (`if (!res.ok && res.status
+!== 503) return`).
+
+**M-2 — settle detection is the whole ballgame.** Four sweeps of this
+app produced four different answers, and the first three were wrong.
+`/angle` read as a blank page (72 chars) until measured properly, at
+which point it settles at 5.3s with 1,916 chars. `/draft` read as
+66 chars; it is actually 7,607 chars and 72 rows at 2.1s.
+
+Causes, in the order they bit:
+1. A fixed sleep is not enough — the 5.6MB contract lands late.
+2. Waiting for the string "Loading" to disappear misses every page
+   that uses `SkeletonTable` instead, which is most of them.
+3. Early-exiting on "text length stable for 4s" false-positives when a
+   page pauses mid-load for an auth round-trip.
+4. `networkidle` never fires on pages that poll on an interval.
+
+What worked: observe for a fixed 40s, record the growth curve, judge
+from the final state. **Any conclusion in a route audit that is not
+backed by a growth curve should be treated as unverified.**
+
+**M-3 — backend contention distorts everything.** `server.py` runs a
+single uvicorn worker with no `workers` argument, and every page load
+pulls a 5.6MB contract. Running any second probe alongside the sweep
+produced a 30s timeout on `POST /api/test/create-session` and a route
+that appeared to make zero API calls. Sequential runs only.
+
+**M-4 — `/design` trips skeleton heuristics on purpose.** It is the
+design-system gallery and renders `Skeleton` / `SkeletonTable`
+components as specimens. `stuck=true` there is a false positive.
+
+**M-5 — three data-dependent surfaces cannot be judged offline.** The
+snapshot is a single day, so `/api/data/rank-history` returns
+`{"days":30,"history":{}}`, no player carries `rankHistory`, and
+`rankChange` is 0 or null for all 1,095. `/trending` ("No movers in
+this window"), the `/edge` delta columns, and `/trades` retro grading
+are honestly empty here and need a multi-day environment to verify.
+
+---
+
+## Fixed on this branch
+
+### FIX-1 — `/trades` asserted a trade count it did not have
+
+The page header rendered:
+
+```
+0 trades in the last 365 days, graded at alpha=1.65.
+```
+
+while the contract was still in flight, and again directly above the
+red "Couldn't load trade data" banner on the error path. Captured
+verbatim from the error path:
+
+```
+"LedgerTrade History0 trades in the last 365 days, graded at
+ alpha=1.65.Couldn't load trade datanetwork exploded"
+```
+
+The count comes from `analyzeSleeperTradeHistory(rawData, rows, ...)`,
+which returns an empty analysis when `rawData` is absent — so "0" meant
+"nothing loaded", not "no trades exist". The snapshot behind this audit
+carries **109 Sleeper trades** and 785 waivers
+(`sleeper.trades.length === 109`), so the statement was false.
+
+Fixed in `frontend/app/trades/page.jsx`: the header states what is
+happening while loading or failing, and only asserts a count once the
+contract is in.
+
+Test: `frontend/__tests__/components/trades-header-honesty.test.jsx`
+— 2 of 3 fail before, 3 pass after.
+
+Verified in the browser after rebuilding. Sampled every 700ms while the
+28 skeleton elements were still on screen, then read the settled header:
+
+```
+early samples (skeleton up -> claims "0 trades"?):
+  [{"skel":28,"claims0":false}, x6]
+final rows: 22
+header: "LEDGER / Trade History / 109 trades in the last 365 days,
+         graded at alpha=1.65."
+```
+
+109 is exactly `sleeper.trades.length` in the snapshot — the page now
+reports the number it actually has.
+
+### FIX-2 — `/tools/source-health` failed silently
+
+`SourceHealthStrip` returned `null` whenever the `/api/status` fetch
+failed. That component is the entire body of `/tools/source-health`, so
+the route rendered a title, a subtitle, and a legend explaining dot
+colours — for dots that were not on the page. Nothing distinguished
+"every source is healthy" from "the status endpoint is down".
+
+Reproduced by forcing `/api/status` to 500 in a fresh browser context
+(a warm HTTP cache masks it):
+
+```
+##### healthy
+  strip rendered: true  | alerts: 0
+  ... "Sources · 4 · 2h ago · 2 issues" ...
+##### status-500
+  strip rendered: false | alerts: 0
+  ... legend text only, no strip, no error ...
+```
+
+Fixed in `frontend/components/SourceHealthStrip.jsx`. The `inline`
+variant still hides itself on failure — that behaviour is documented
+and deliberate ("we don't want a broken-status card cluttering an
+otherwise-functional page") and is unchanged. The `page` variant now
+surfaces the failure and distinguishes "couldn't reach `/api/status`"
+from "runtime reports no enabled sources". A transient poll failure no
+longer blanks a strip that already holds a good payload. Reuses the
+existing `.source-health-strip--down` / `.source-health-dot--down`
+rules; no CSS touched.
+
+Test: `frontend/__tests__/components/source-health-strip.test.jsx`
+— 3 of 5 fail before, 5 pass after.
+
+Verified in the browser after rebuilding, both paths:
+
+```
+##### /tools/source-health (healthy)
+  strip: true | role: region
+  summary: "Sources · 4 · 2h ago · 2 issues"
+##### /tools/source-health (status-500)
+  strip: true | role: status
+  summary: "Source health unavailable — Couldn't reach /api/status (HTTP 500)."
+```
+
+### FIX-3 — `/league/phases` was structurally dead
+
+**The highest-value finding in this audit.** The route rendered a
+heading and a subtitle and nothing else, on every run, for everyone:
+
+```
+/league/phases  http=200  settled=3071ms  len=282  rows=0
+```
+
+282 characters is the global nav plus the heading plus the subtitle.
+The body was empty.
+
+Root cause: the route's entire body is `<TeamPhasePanel />`, and the
+panel read its data from `useApp()`. `AppShell` hard-refuses to hydrate
+the private contract on anything under the `/league` prefix:
+
+```js
+// components/AppShell.jsx
+const PUBLIC_ONLY_ROUTE_PREFIXES = ["/league"];
+...
+function PublicAppShell({ children, authenticated }) {
+  return <InnerAppShell loading={false} rows={[]} rawData={null} ... />;
+}
+```
+
+So on `/league/phases`, `useApp()` is permanently `{loading: false,
+rows: [], rawData: null}`. `analyzeLeaguePhases(null, [])` returns zero
+teams, and the panel hit `if (!analysis.teams.length) return null`. The
+page could never render its content — it was not slow, not
+data-dependent, not a config problem. It was dead.
+
+The fix follows an existing in-repo pattern rather than inventing one:
+the sibling route `/league/franchise/[owner]` has the identical problem
+and already solves it — `RosterComparePanel` calls `useDynastyData()`
+directly instead of `useApp()`, and renders an explicit message for
+every state instead of returning `null`. `TeamPhasePanel` now does the
+same.
+
+Privacy: `/api/data` is auth-gated, so an anonymous visitor gets a 401
+and the explicit "unavailable" message, not leaked data — the same
+posture `RosterComparePanel` already has on the public franchise route.
+The e2e privacy-isolation assertion in
+`tests/e2e/specs/public-league.spec.js` scopes its no-private-endpoints
+check to `/league?tab=...`, not to `/league/phases`, so this does not
+cross it.
+
+Test: `frontend/__tests__/components/team-phase-panel.test.jsx`
+— 3 of 3 fail before (`AssertionError: expected '' not to be ''`,
+literally proving the empty render), 3 pass after. The suite pins
+`useApp()` to the values AppShell really supplies under `/league/*`, so
+a regression back onto `useApp()` fails loudly instead of silently
+blanking the page again.
+
+Verified in the browser after rebuilding — signed in, the route now
+renders all 12 franchises with real classifications:
+
+```
+##### /league/phases (signed in)
+  len: 759  rows: 12  pageerrors: 0
+  teams:  ["Jason","Joey","Brent","Eric","MaKayla","Collin",
+           "Ed","Ty","Kich","Roy","Blaine","jstuedle"]
+  phases: ["Win-now","Win-now","Contender","Contender","Contender",
+           "Contender","Mixed","Mixed","Mixed","Mixed","Mixed","Mixed"]
+  ... "against the league medians (91,362 value · 25.0 age)"
+      Jason  Win-now  118,636  23.0
+      Brent  Contender 139,097 27.0   ...
+```
+
+And anonymous — no leak, no redirect off the public route, explicit
+message instead of a blank body:
+
+```
+##### /league/phases (anonymous)
+  rows: 0 | still on: /league/phases
+  "League phases unavailable — no Sleeper rosters in the active
+   league's data. Sign in and pick your team on the league page."
+```
+
+---
+
+## Reported, not fixed
+
+### F-1 — the documented one-command E2E recipe fails on a clean checkout
+
+**Severity: high.** `tests/e2e/README.md` opens with:
+
+> ```bash
+> npm ci && npm --prefix frontend ci && npm run e2e
+> ```
+> That is the whole recipe. It works offline, needs no credentials, and
+> if anything is missing it tells you exactly what to fix.
+
+It does not work, and it does not tell you what to fix. On a clean
+checkout:
+
+```
+$ python3 tests/e2e/preflight.py
+[preflight] Python compile checks passed
+Traceback (most recent call last):
+  File ".../scripts/validate_api_contract.py", line 92, in <module>
+    raise SystemExit(main())
+  File ".../scripts/validate_api_contract.py", line 45, in main
+    payload, source_file = _load_latest_payload(repo_root)
+  File ".../scripts/validate_api_contract.py", line 26, in _load_latest_payload
+    raise FileNotFoundError(
+FileNotFoundError: No dynasty_data_YYYY-MM-DD.json files found in
+repo/data or repo root.
+```
+
+Root cause — `tests/e2e/preflight.py::main` runs the steps in the wrong
+order:
+
+```python
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    _compile_python(repo_root)
+    _run_contract_validation(repo_root)   # <-- needs data/
+    _seed_data_cache(repo_root)           # <-- creates data/
+    _check_node_deps(repo_root)
+```
+
+`_seed_data_cache` is the step that copies `exports/latest/` into
+`data/`, and it runs *after* the validation that requires it.
+`scripts/validate_api_contract.py::_load_latest_payload` searches only
+`repo_root/data` and `repo_root` — never `exports/latest/` — and
+`git ls-files` confirms the only committed snapshot is
+`exports/latest/dynasty_data_2026-07-26.json`. Nothing under
+`data/dynasty_data_*.json` is tracked.
+
+This is very likely what the README's own "two agents in a row
+concluded the stack was broken" note is describing: the first command
+in the documented recipe dies with a raw traceback about missing data,
+which reads exactly like the "no data" symptom the README then spends a
+table telling you to ignore.
+
+Fix: swap two lines so `_seed_data_cache(repo_root)` runs before
+`_run_contract_validation(repo_root)`. Optionally also teach
+`_load_latest_payload` to fall back to `exports/latest/`.
+
+Not fixed here because `tests/e2e/**` is owned by another agent this
+session. Worked around by seeding `data/` by hand before booting.
+
+### F-2 — `/league/activity` can never show trades, but offers a Trades filter
+
+Same root cause as FIX-3, different blast radius, and the fix is a
+product decision rather than a mechanical one.
+
+`/league/activity` calls `useApp()` and builds its feed with
+`buildActivityEvents(rawData, newsItems)`. Under `/league/*`, `rawData`
+is `null`, so the trade and waiver half of the feed is always empty.
+Observed:
+
+```
+"League activity — Trades + news in one chronological feed. Scope to
+ your roster to see only events involving your players.
+ Scope [League] [My roster]   Type [All] [Trades] [News]
+ 88 events · newest first
+ NEWS  4m ago  Isaiah Davis added in 10,701 leagues (last 24h)
+ NEWS  4m ago  Zavion Thomas added in 7,749 leagues (last 24h)
+ ..."
+```
+
+All 88 events are `NEWS`. The contract for the same league carries 109
+trades and 785 waivers. So:
+
+* the page's own description ("Trades + news in one chronological
+  feed") is false;
+* the **Trades** type filter is a dead control — it can only ever
+  produce an empty feed;
+* the **My roster** scope filter is a dead control — it filters on
+  `myTeam.players`, and `myTeam` resolves from `rawData.sleeper.teams`,
+  which is `null` here.
+
+Why this is not fixed with the FIX-3 one-liner: `/league/phases` is
+unambiguously a private feature that was misfiled under a public
+prefix, and its whole body was dead. `/league/activity` genuinely
+serves both audiences — it renders a real, useful public news feed
+today, and switching it to `useDynastyData()` would start pulling the
+private contract on a page anonymous visitors actually use. Someone has
+to decide whether this route is public-with-news or private-with-
+everything. Options:
+
+1. Follow FIX-3 — `useDynastyData()`, private contract, full feed. Cost:
+   a 401 round-trip for every anonymous visitor and a private fetch on
+   a public-prefix route that is more heavily trafficked than
+   `/league/phases`.
+2. Keep it public and hide the Trades/My-roster controls when
+   `rawData` is null, so the page stops advertising capability it does
+   not have. Cheapest honest option.
+3. Move the private view to its own prefix and leave a public news
+   feed here.
+
+### F-3 — `/api/chat` is dead code
+
+`frontend/app/api/chat/route.js` proxies `POST /api/chat` to
+`${BACKEND}/api/chat`. The backend has no `/api/chat` route (72 `/api/*`
+routes registered in `server.py`; this is the only Next handler with no
+backend counterpart). Nothing in `frontend/app`, `frontend/components`,
+or `frontend/lib` calls it. And because nginx routes `/api/` to the
+backend, the handler is unreachable in production even if something
+did.
+
+Safe to delete. Left alone because deleting it is not a usability fix
+and it touches nothing a user can reach.
+
+### F-4 — time-to-usable is the real user-facing problem
+
+Not a correctness defect, but the thing most likely to make the owner
+distrust a page that is actually working. Settle times from the clean
+sweep, measured as "text length stops growing and no skeletons remain":
+
+| Route | Settled | Final |
+|---|---|---|
+| `/rankings` | **28.8s** | 18,113 chars, 231 rows |
+| `/finder` | 34.9s | 4,036 chars, 59 rows |
+| `/idptc-rookies` | 33.2s | 41,628 chars, 114 rows |
+| `/angle` | 24.5s | 1,916 chars |
+| `/draft-capital` | 24.2s | 5,571 chars, 78 rows |
+| `/draft` | 18.5s | 7,545 chars, 72 rows |
+| `/edge` | 15.4s | 3,392 chars, 36 rows |
+| `/rosters` | 12.3s | 6,389 chars, 12 rows |
+| `/league` | 4.5s | 2,784 chars |
+| `/more` | 1.6s | 1,230 chars |
+
+`/trade`, `/trades` and `/trending` did not finish inside the 40s
+window on the loaded run; re-measured on a quiet backend they settle at
+18.3s, ~20s (22 rows) and 5.1s respectively.
+
+Contributors, in rough order:
+
+* `GET /api/data?view=app` is **5,602,258 bytes** uncompressed and is
+  fetched per page load.
+* `server.py` runs a single uvicorn worker (`uvicorn.run("server:app",
+  host=HOST, port=PORT, log_level="info", reload=False)` — no
+  `workers`), so concurrent page loads serialise behind one process.
+* **Duplicate in-flight fetches.** `/trade` on a quiet backend, with
+  timings relative to navigation:
+
+  ```
+     529ms 200 /api/leagues
+     530ms 200 /api/user/state
+   10544ms 200 /api/draft-capital
+   12534ms 200 /api/draft-capital?leagueKey=dynasty_main   <-- 2nd
+   12543ms 200 /api/dynasty-data
+   12543ms 200 /api/dynasty-data                            <-- 2nd
+   15400ms 200 /api/rankings/overrides?view=delta
+   15401ms 200 /api/rankings/overrides?view=delta           <-- 2nd
+   15908ms 200 /api/ros/player-values?limit=2000
+   16392ms 200 /api/trade/suggestions
+  ```
+
+  The 5.6MB contract is fetched **twice**, the override delta twice,
+  and draft-capital twice (once before the league key resolves, once
+  after). First paint of real content is at 16.3s. De-duplicating
+  these three pairs is the cheapest available win on the heaviest page
+  in the app.
+* `/api/draft-capital` alone took 10.5s to first byte on an idle
+  backend.
+* `/tools/trade-coverage` issues **12 sequential** `/api/terminal`
+  calls, one per team, after the contract lands (39.3s to settle).
+
+CLAUDE.md lists page-load speed as an explicit priority, so this is
+worth a dedicated pass. Cheapest first look: why the base contract is
+5.6MB when the delta path already proved ~1.25MB is enough for the
+override-sensitive fields.
+
+### F-5 — `/favicon.ico` 404s on every page load
+
+`GET /favicon.ico -> 404`. There is no `frontend/app/favicon.ico`, no
+`app/icon.*`, and no `icons` entry in the root layout's `metadata`.
+`public/icons/` does ship `icon-192.png`, `icon-512.png`, and
+`icon-maskable-512.png`, but those are referenced only by
+`app/manifest.js` (the PWA manifest), not as the browser favicon. nginx
+routes `location = /favicon.ico` to the frontend, so production 404s
+identically.
+
+Cosmetic — browsers degrade gracefully — but it is the only unexplained
+console error left in the whole sweep, so it costs a few seconds every
+time someone reads the console looking for something real.
+
+Fix is one line: add an `icons` block to the root layout's `metadata`
+pointing at the already-shipping `/icons/icon-192.png`, or drop an
+`app/icon.png` in. Not done here because `app/layout.jsx` is being
+edited on the design branch this session and this is not worth a
+conflict.
+
+### F-6 — invisible controls (styling; handed back to the design agent)
+
+The design agent reported an invisible `/login` submit button — a
+hardcoded navy fill on near-black that its brand sweep missed because
+the colour is not a brand hex. Confirmed the markup side: `login/page.jsx`
+carries no inline colours at all, only `className="button login-button"`,
+so the fix belongs entirely in the CSS layer (`globals.css`), which is
+off-limits to this branch tonight.
+
+A contrast auditor was built for this
+(`scratchpad/route-sweep/contrast.js`: composites every ancestor
+background, then computes WCAG text-vs-surface, fill-vs-page, and
+border-vs-page ratios for every `button`, `a[href]`, `input`, `select`,
+`[role=button|tab|menuitem|option]`). It did not get a clean run across
+all 38 routes before time ran out — the sweep and the auditor cannot
+share the backend (M-3). Recommend running it after the token rewrite
+lands; it is the cheap way to catch the whole class rather than the one
+button someone happened to look at.
+
+---
+
+## Error inventory — the whole sweep, 38 routes
+
+**Uncaught exceptions / React error boundaries / blank white pages: zero.**
+`page.on('pageerror')` fired exactly 0 times across all 38 routes.
+
+Every console error, deduplicated:
+
+| Count | Error | Verdict |
+|---|---|---|
+| 37 | `503 (Service Unavailable)` on `/api/health` | Expected offline (M-1) |
+| 9 | `net::ERR_CONNECTION_RESET` | `https://sleepercdn.com/avatars/thumbs/*` — external CDN, unreachable offline. Not a defect. |
+| 1 | `404 (Not Found)` | `/favicon.ico` — F-5 |
+
+Every response with status >= 400, excluding `/api/health`:
+
+| Count | Request | Verdict |
+|---|---|---|
+| 1 | `503 GET /api/intel/summary?limit=200&leagueKey=dynasty_main` | Honest — backend returns `{"error":"data_not_ready", "message":"No intel snapshot for league 'dynasty_main' yet…"}` and `/intel` renders exactly that. |
+
+`net::ERR_ABORTED` on `…?_rsc=` URLs also appears; that is Next.js
+cancelling a route prefetch on navigation, not an error.
+
+---
+
+## Route-by-route
+
+Console-error counts exclude the `/api/health` 503 (M-1). Settle times
+are from the loaded sequential sweep and are upper bounds — see M-3.
+
+| Route | Verdict | Evidence |
+|---|---|---|
+| `/` | PASS | 4,317 chars, settled 4.6s; team/portfolio/signal panels render |
+| `/admin` | PASS | 1,149 chars, 10 rows, settled 3.0s |
+| `/angle` | PASS | 1,916 chars, settled 5.3s clean / 24.5s loaded; roster picker + market routing |
+| `/design` | PASS | 3,872 chars, 5 rows; skeleton specimens are intentional (M-4) |
+| `/draft` | PASS | 7,545 chars, 72 rows, settled 2.1s clean / 18.5s loaded |
+| `/draft-capital` | PASS | redirects to `/league?tab=draft-capital`; 5,571 chars, 78 rows |
+| `/edge` | PASS | 3,392 chars, 36 rows; delta columns need multi-day data (M-5) |
+| `/finder` | PASS | 4,036 chars, 59 rows |
+| `/idptc-rookies` | PASS | 41,628 chars, 114 rows |
+| `/intel` | PASS (honest empty) | `/api/intel/summary` 503 `data_not_ready`; UI says "No intel snapshot yet — the first crawl hasn't run", matching the API's own message |
+| `/league` | PASS | 2,784 chars, settled 4.5s — resolves fine on a warm backend; 3 seasons / 12 managers / 190 trades / 1,092 waivers / defending champion all render |
+| `/league-comparison` | PASS | 2,399 chars; not caught by the `/league` prefix gate (`"/league-comparison".startsWith("/league/")` is false) |
+| `/league/activity` | **DEFECT** (empty-state lie + 2 dead controls) | F-2 — 88 events, all NEWS, 0 trades against 109 in the contract |
+| `/league/phases` | **FIXED** | FIX-3 — was 282 chars / empty body / structurally dead; now 759 chars, 12 rows, all 12 franchises classified |
+| `/login` | PASS (markup) | form + submit render; invisible-button issue is CSS-layer, F-5 |
+| `/more` | PASS | 1,230 chars, settled 1.6s |
+| `/news` | PASS | 2,436 chars |
+| `/players/compare` | PASS | 402 chars with no `?p1=`/`?p2=`; correctly shows two "No player matched" prompts |
+| `/rankings` | PASS (slow) | 18,113 chars, **231 rows**; settled 28.8s — F-4 |
+| `/rosters` | PASS | 6,389 chars, 12 rows |
+| `/settings` | PASS | 4,504 chars, 21 rows; source registry lists every registered source |
+| `/trade` | PASS (slow) | 3,768 chars, settled 18.3s quiet; first real content at 16.3s, with 3 duplicated fetches — F-4 |
+| `/trades` | **FIXED** (header) + slow | FIX-1; 22 rows, header now reads "109 trades in the last 365 days" |
+| `/trending` | PASS (honest empty) | settled 5.1s; "No movers in this window" — 0/1,095 players carry `rankHistory` or non-zero `rankChange` in a single-day snapshot (M-5) |
+| `/waivers` | PASS | 9,686 chars, 93 rows, 4 tables |
+| `/tools/ros-data-health` | PASS | 1,219 chars, 17 rows; 5 ROS sources + per-team unmapped counts |
+| `/tools/source-health` | **FIXED** | FIX-2; healthy path renders "Sources · 4 · 2h ago · 2 issues" |
+| `/tools/trade-coverage` | PASS (slow) | renders after 12 sequential `/api/terminal` calls — F-4 |
+| `/rankings/qb` | PASS | redirect to `?pos=QB`; 7,963 chars, 116 rows, settled 35.2s |
+| `/rankings/idp` | PASS | redirect to `?pos=idp`; 34,233 chars, **485 rows**, settled 35.3s |
+| `/rankings/picks` | PASS | redirect to `?pos=pick`; 5,974 chars, **82 rows**, settled 13.6s (2026 slot picks are deliberately hidden post-draft — `rankings/page.jsx` line 365) |
+| `/league/player/[playerId]` | PASS | Rashee Rice: ownership arc, per-manager impact table, transaction timeline |
+| `/league/franchise/[owner]` | PASS | cumulative stats, season results, roster-compare panel |
+| `/league/rivalry/[pair]` | PASS | head-to-head, memorable meetings, season splits |
+| `/league/week/[season]/[week]` | PASS | 2025 wk17 recap headline, superlatives, 4 matchups |
+| `/league/weekly/[…]/[matchup]` | PASS | 1,404 chars, 34 rows |
+| `/league/articles/[season]/[week]` | PASS | slate renders; preview/recap cards link through |
+| `/league/articles/…/[mode]` | PASS | 4,582 chars, full generated article |
+
+No route produced an uncaught `pageerror`, a React error boundary, a
+500, or a blank white page. The only genuinely non-functional surface
+was `/league/phases`, now fixed.
+
+---
+
+## Reproducing
+
+```bash
+# 1. seed + boot (see F-1 — seed BEFORE preflight)
+python3 -c "import shutil;shutil.copy2('exports/latest/dynasty_data_2026-07-26.json','data/')"
+UPTIME_CHECK_ENABLED=false ALLOW_DEFAULT_LOGIN_DEV=1 E2E_TEST_MODE=1 \
+  E2E_TEST_SECRET=e2e-local-insecure-secret RATE_LIMIT_BYPASS_IPS=127.0.0.1 \
+  PLAYWRIGHT_BROWSERS_PATH=$(pwd)/tests/e2e/.no-browsers python3 server.py &
+npm --prefix frontend run build:nocheck && npm --prefix frontend run start &
+
+# 2. nginx-equivalent split on :8080 — without this the audit is invalid
+node scratchpad/route-sweep/nginx-sim.js &
+
+# 3. walk (sequential only — see M-3)
+MAX_WAIT=40000 node scratchpad/route-sweep/walk2.js
+```
+
+The walker, reverse proxy, contrast auditor, and network capture live
+in the session scratchpad under `route-sweep/`; they are throwaway
+instruments, deliberately not committed to `tests/e2e/`.

--- a/frontend/__tests__/components/source-health-strip.test.jsx
+++ b/frontend/__tests__/components/source-health-strip.test.jsx
@@ -1,0 +1,106 @@
+// SourceHealthStrip must not fail silently on the page it *is*.
+//
+// Observed by driving /tools/source-health with /api/status forced to
+// 500 (fresh browser context, so no warm HTTP cache):
+//
+//   strip rendered: false | alerts: 0
+//   "Source Health / Scraper status for every ranking source in the
+//    pipeline. / Auto-refreshes every 60 seconds.  Green dot = last
+//    run OK and recent (<4h)…"
+//
+// i.e. a page whose entire purpose is scraper health rendered a legend
+// for dots that were not there, and gave the reader no way to tell
+// "every source is fine" from "the status endpoint is down".
+//
+// The hide-on-failure behaviour is deliberate for the *inline* variant
+// (a broken status card should not clutter an otherwise-functional
+// page) and is kept.  The page variant is the whole surface, so a
+// failure there has to be visible — CLAUDE.md's fail-fast convention.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import SourceHealthStrip from "@/components/SourceHealthStrip";
+
+const HEALTHY = {
+  source_health: {
+    source_runtime: {
+      overall_status: "partial",
+      enabled_sources: ["KTC", "IDPTradeCalc"],
+      failed_sources: [],
+      partial_sources: ["KTC"],
+      finished_at: new Date().toISOString(),
+    },
+    source_counts: { ktc: 500, idpTradeCalc: 900 },
+    sources: {},
+    source_failures: [],
+    missing_sources: [],
+  },
+};
+
+const NO_SOURCES = {
+  source_health: {
+    source_runtime: { overall_status: "unknown", enabled_sources: [] },
+    source_counts: {},
+    sources: {},
+    source_failures: [],
+    missing_sources: [],
+  },
+};
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function mockStatus({ ok = true, body = HEALTHY, reject = false } = {}) {
+  globalThis.fetch.mockImplementation(() =>
+    reject
+      ? Promise.reject(new Error("network down"))
+      : Promise.resolve({ ok, status: ok ? 200 : 500, json: () => Promise.resolve(body) }),
+  );
+}
+
+describe("SourceHealthStrip", () => {
+  it("page variant surfaces an explicit failure when /api/status errors", async () => {
+    mockStatus({ ok: false });
+    render(<SourceHealthStrip variant="page" />);
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent(/source health unavailable/i);
+    });
+  });
+
+  it("page variant surfaces a failure when the status fetch throws", async () => {
+    mockStatus({ reject: true });
+    render(<SourceHealthStrip variant="page" />);
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent(/source health unavailable/i);
+    });
+  });
+
+  it("page variant says so when status loads but reports no enabled sources", async () => {
+    mockStatus({ body: NO_SOURCES });
+    render(<SourceHealthStrip variant="page" />);
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent(/no sources/i);
+    });
+  });
+
+  it("inline variant still hides itself on failure (deliberate)", async () => {
+    mockStatus({ ok: false });
+    const { container } = render(<SourceHealthStrip variant="inline" />);
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(container.querySelector(".source-health-strip")).toBeNull();
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders the real summary when status is healthy", async () => {
+    mockStatus({});
+    render(<SourceHealthStrip variant="page" />);
+    await waitFor(() => {
+      expect(screen.getByRole("region", { name: /scrape source health/i })).toBeInTheDocument();
+    });
+    expect(document.body.textContent).toMatch(/Sources · 2/);
+  });
+});

--- a/frontend/__tests__/components/team-phase-panel.test.jsx
+++ b/frontend/__tests__/components/team-phase-panel.test.jsx
@@ -1,0 +1,86 @@
+// /league/phases is structurally dead, and TeamPhasePanel is why.
+//
+// The route's entire body is <TeamPhasePanel />.  The panel read its
+// data from `useApp()` — but AppShell hard-refuses to hydrate the
+// private contract on anything under the `/league` prefix
+// (PUBLIC_ONLY_ROUTE_PREFIXES in components/AppShell.jsx), so on this
+// route `useApp()` always yields `{loading: false, rows: [], rawData:
+// null}`.  `analyzeLeaguePhases(null, [])` returns zero teams, the
+// panel hit `if (!analysis.teams.length) return null`, and the page
+// rendered a title, a subtitle, and nothing else — forever, for
+// everyone.  Walked signed-in against a warm backend, every run:
+//
+//   /league/phases  http=200 settled=3071ms len=282 rows=0
+//
+// (282 chars = global nav + heading + subtitle.)
+//
+// The sibling route /league/franchise/[owner] has the identical
+// problem and already solves it: RosterComparePanel calls
+// `useDynastyData()` directly instead of `useApp()`, and renders an
+// explicit message for every state rather than returning null.  This
+// pins that same contract for TeamPhasePanel.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const mockUseDynastyData = vi.fn();
+const mockUseUserState = vi.fn();
+
+// AppShell's useApp is what the panel used to read.  Pin it to the
+// values AppShell really supplies under /league/* so a regression back
+// onto useApp() fails this suite instead of silently blanking the page.
+vi.mock("@/components/AppShell", () => ({
+  useApp: () => ({ rows: [], rawData: null, loading: false, error: "" }),
+}));
+vi.mock("@/components/useDynastyData", () => ({
+  useDynastyData: () => mockUseDynastyData(),
+}));
+vi.mock("@/components/useUserState", () => ({
+  useUserState: () => mockUseUserState(),
+}));
+
+import TeamPhasePanel from "@/components/TeamPhasePanel";
+
+const ROWS = [
+  { name: "Young Star", rankDerivedValue: 9000, age: 23 },
+  { name: "Old Star", rankDerivedValue: 8500, age: 31 },
+  { name: "Young Depth", rankDerivedValue: 2000, age: 22 },
+  { name: "Old Depth", rankDerivedValue: 1500, age: 32 },
+];
+
+const RAW = {
+  sleeper: {
+    teams: [
+      { ownerId: "own-a", rosterId: 1, name: "Alpha", players: ["Young Star", "Young Depth"] },
+      { ownerId: "own-b", rosterId: 2, name: "Bravo", players: ["Old Star", "Old Depth"] },
+    ],
+  },
+};
+
+beforeEach(() => {
+  mockUseUserState.mockReturnValue({ state: {} });
+});
+
+describe("TeamPhasePanel (the whole body of /league/phases)", () => {
+  it("renders league phases from the private contract, not from useApp", () => {
+    mockUseDynastyData.mockReturnValue({ rows: ROWS, rawData: RAW, loading: false });
+    render(<TeamPhasePanel />);
+    // Both teams classified and listed.
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Bravo")).toBeInTheDocument();
+    expect(document.querySelectorAll("tbody tr").length).toBe(2);
+  });
+
+  it("shows a loading state instead of rendering nothing", () => {
+    mockUseDynastyData.mockReturnValue({ rows: [], rawData: null, loading: true });
+    const { container } = render(<TeamPhasePanel />);
+    expect(container.textContent.trim()).not.toBe("");
+    expect(container.textContent).toMatch(/loading/i);
+  });
+
+  it("explains itself instead of rendering nothing when there is no league data", () => {
+    mockUseDynastyData.mockReturnValue({ rows: [], rawData: null, loading: false });
+    const { container } = render(<TeamPhasePanel />);
+    expect(container.textContent.trim()).not.toBe("");
+    expect(container.textContent).toMatch(/unavailable|sign in|no league/i);
+  });
+});

--- a/frontend/__tests__/components/trades-header-honesty.test.jsx
+++ b/frontend/__tests__/components/trades-header-honesty.test.jsx
@@ -1,0 +1,80 @@
+// The /trades page header must not assert a trade count it does not
+// have yet.
+//
+// Observed on a real signed-in walk of the route: while the contract
+// was still in flight the page rendered
+//
+//   "0 trades in the last 365 days, graded at alpha=1.65."
+//
+// directly above a loading skeleton, and the same line renders above
+// the red "Couldn't load trade data" banner on the error path.  The
+// count comes from ``analyzeSleeperTradeHistory(rawData, ...)``, which
+// returns an empty analysis for an absent contract — so "0" means
+// "nothing loaded", not "no trades exist".  The league snapshot used
+// for this audit carries 109 Sleeper trades, so the line was simply
+// false.
+//
+// CLAUDE.md's fail-fast convention: a failure (or a pending load) must
+// be visible, never dressed up as a real, settled result.
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const mockUseApp = vi.fn();
+
+vi.mock("@/components/AppShell", () => ({
+  useApp: () => mockUseApp(),
+}));
+vi.mock("@/components/useSettings", () => ({
+  useSettings: () => ({ settings: {} }),
+}));
+vi.mock("@/components/useRankHistory", () => ({
+  useRankHistory: () => ({ history: null }),
+}));
+
+import TradesPage from "@/app/trades/page";
+
+// One real trade so the loaded-state assertion has something to count.
+const RAW_WITH_TRADES = {
+  sleeper: {
+    teams: [
+      { ownerId: "a", rosterId: 1, name: "Team A", players: [] },
+      { ownerId: "b", rosterId: 2, name: "Team B", players: [] },
+    ],
+    trades: [],
+    positions: {},
+  },
+};
+
+describe("/trades header honesty", () => {
+  it("does not claim a trade count while the contract is still loading", () => {
+    mockUseApp.mockReturnValue({ rows: [], rawData: null, loading: true, error: null });
+    const { container } = render(<TradesPage />);
+    // The skeleton is up...
+    expect(container.querySelector('[class*="keleton"]')).not.toBeNull();
+    // ...so the header must not assert "0 trades".
+    expect(document.body.textContent).not.toMatch(/0 trades in the last/);
+  });
+
+  it("does not claim a trade count when the contract failed to load", () => {
+    mockUseApp.mockReturnValue({
+      rows: [],
+      rawData: null,
+      loading: false,
+      error: "network exploded",
+    });
+    render(<TradesPage />);
+    expect(document.body.textContent).toMatch(/Couldn't load trade data/);
+    expect(document.body.textContent).not.toMatch(/0 trades in the last/);
+  });
+
+  it("still reports the real count once the contract has loaded", () => {
+    mockUseApp.mockReturnValue({
+      rows: [],
+      rawData: RAW_WITH_TRADES,
+      loading: false,
+      error: null,
+    });
+    render(<TradesPage />);
+    expect(document.body.textContent).toMatch(/0 trades in the last 365 days/);
+  });
+});

--- a/frontend/app/trades/page.jsx
+++ b/frontend/app/trades/page.jsx
@@ -471,9 +471,21 @@ export default function TradesPage() {
         eyebrow="Ledger"
         title="Trade History"
         description={
-          combineMode
-            ? `Combined head-to-head: ${teamFilter} ↔ ${teamFilterB} — assets that bounced back cancel out.`
-            : `${analysis.analyzed.length} trades in the last ${windowDays} days, graded at alpha=${alpha}.`
+          // The count comes from the contract, so it is only true once
+          // the contract is actually here.  While loading (or after a
+          // failed load) ``analysis.analyzed`` is empty for want of
+          // data, and printing "0 trades in the last N days" states a
+          // settled fact we do not have — the snapshot behind this page
+          // routinely carries 100+ trades.  Say what is actually
+          // happening instead; the skeleton / error banner below
+          // carries the detail.
+          loading
+            ? `Grading trades from the last ${windowDays} days…`
+            : error
+              ? "Trade history unavailable — the board data failed to load."
+              : combineMode
+                ? `Combined head-to-head: ${teamFilter} ↔ ${teamFilterB} — assets that bounced back cancel out.`
+                : `${analysis.analyzed.length} trades in the last ${windowDays} days, graded at alpha=${alpha}.`
         }
       />
 

--- a/frontend/components/SourceHealthStrip.jsx
+++ b/frontend/components/SourceHealthStrip.jsx
@@ -25,10 +25,10 @@ async function fetchStatus() {
       credentials: "same-origin",
       headers: { "Cache-Control": "no-store" },
     });
-    if (!res.ok) return null;
-    return await res.json();
-  } catch {
-    return null;
+    if (!res.ok) return { ok: false, reason: `HTTP ${res.status}`, data: null };
+    return { ok: true, reason: null, data: await res.json() };
+  } catch (err) {
+    return { ok: false, reason: err?.message || "network error", data: null };
   }
 }
 
@@ -59,15 +59,24 @@ function toneFor(source, runtime, ageHours) {
 
 export default function SourceHealthStrip({ variant = "inline" }) {
   const [status, setStatus] = useState(null);
+  const [fetchError, setFetchError] = useState(null);
   const [loading, setLoading] = useState(true);
   const [expanded, setExpanded] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     async function pull() {
-      const data = await fetchStatus();
+      const result = await fetchStatus();
       if (cancelled) return;
-      setStatus(data);
+      // Keep the last good payload on a transient blip so a 60s poll
+      // failure doesn't blank a working strip; only report the error
+      // when we have nothing to show.
+      if (result.ok) {
+        setStatus(result.data);
+        setFetchError(null);
+      } else {
+        setFetchError(result.reason);
+      }
       setLoading(false);
     }
     pull();
@@ -127,8 +136,34 @@ export default function SourceHealthStrip({ variant = "inline" }) {
   }, [status]);
 
   if (loading) return null;
-  if (!summary) return null;
-  if (summary.entries.length === 0) return null;
+
+  // ── Nothing to show ───────────────────────────────────────────────
+  // Inline: stay hidden.  A broken status card must not clutter an
+  // otherwise-functional page — that is the documented intent.
+  //
+  // Page: this component IS /tools/source-health.  Returning null there
+  // left the route rendering a legend for dots that weren't present,
+  // with no way to distinguish "all sources healthy" from "the status
+  // endpoint is down".  A failure the reader can't see is exactly what
+  // CLAUDE.md's fail-fast convention forbids.
+  const isPage = variant === "page";
+  if (!summary || summary.entries.length === 0) {
+    if (!isPage) return null;
+    const detail = !summary
+      ? `Couldn't reach /api/status${fetchError ? ` (${fetchError})` : ""}.`
+      : "The scrape runtime reports no enabled sources.";
+    return (
+      <div
+        className={`source-health-strip source-health-strip--${variant} source-health-strip--down`}
+        role="status"
+      >
+        <span className="source-health-dot source-health-dot--down" aria-hidden="true" />
+        <span className="source-health-summary">
+          {summary ? "No sources reported" : "Source health unavailable"} — {detail}
+        </span>
+      </div>
+    );
+  }
 
   const overallTone =
     summary.overall === "complete"

--- a/frontend/components/TeamPhasePanel.jsx
+++ b/frontend/components/TeamPhasePanel.jsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import Link from "next/link";
-import { useApp } from "@/components/AppShell";
+import { useDynastyData } from "@/components/useDynastyData";
 import { useUserState } from "@/components/useUserState";
 import { analyzeLeaguePhases } from "@/lib/team-phase";
 
@@ -23,7 +23,18 @@ function fmtValue(v) {
 }
 
 export default function TeamPhasePanel() {
-  const { rows, rawData, loading } = useApp();
+  // Deliberately NOT ``useApp()``.  This panel is the entire body of
+  // /league/phases, and AppShell refuses to hydrate the private
+  // contract anywhere under the ``/league`` prefix
+  // (PUBLIC_ONLY_ROUTE_PREFIXES) — so useApp() there is permanently
+  // ``{loading: false, rows: [], rawData: null}`` and the page could
+  // never render.  Reading the private contract directly is the
+  // established pattern for a private panel hosted under the public
+  // prefix; RosterComparePanel does the same thing on
+  // /league/franchise/[owner].  ``/api/data`` is auth-gated, so an
+  // anonymous visitor gets a 401 and the explicit message below
+  // rather than any leaked data.
+  const { rows, rawData, loading } = useDynastyData();
   const { state: userState } = useUserState();
 
   const myOwnerId = userState?.selectedTeam?.ownerId
@@ -35,8 +46,23 @@ export default function TeamPhasePanel() {
     [rawData, rows],
   );
 
-  if (loading) return null;
-  if (!analysis.teams.length) return null;
+  // Never render nothing: this component owns a whole route, so a
+  // silent null is indistinguishable from a broken page.
+  if (loading) {
+    return (
+      <p className="muted" style={{ fontSize: "0.72rem", margin: "8px 0" }}>
+        Loading league rosters…
+      </p>
+    );
+  }
+  if (!analysis.teams.length) {
+    return (
+      <p className="muted" style={{ fontSize: "0.72rem", margin: "8px 0" }}>
+        League phases unavailable — no Sleeper rosters in the active league&apos;s
+        data. Sign in and pick your team on the league page.
+      </p>
+    );
+  }
 
   const myRow = myOwnerId
     ? analysis.teams.find((t) => t.ownerId === myOwnerId)


### PR DESCRIPTION
Walked all 38 Next.js routes as a signed-in user against a warm backend. Three defects fixed, each with a test that fails before and passes after; everything else is written up in `docs/route-usability-audit.md`.

**Headline: `/league/phases` has never worked.** Not slow, not data-dependent — structurally incapable of rendering, for everyone, since it shipped.

## The topology thing, first

Production nginx splits by prefix (`deploy/nginx/chaseupside-proxy.conf`):

```
location /api/     -> dynasty_backend  (:8000)
location /         -> dynasty_frontend (:3000)
```

`/api/` is the longer prefix match, so **every** `/api/*` browser request goes to the backend and the 22 route handlers under `frontend/app/api/**` are unreachable in production. The frontend references 48 distinct `/api/*` paths; only 22 have a Next handler. Point a browser at `:3000` directly and you get 404s on `/api/health`, `/api/leagues`, `/api/user/state`, `/api/terminal`, `/api/data` — endpoints that answer perfectly well on the backend, where nginx actually sends them.

The first pass of this audit did exactly that and produced a dozen phantom defects. The real sweep ran through a small reverse proxy reproducing the nginx split, so the browser saw one origin and production's routing.

## Fixed

### 1. `/league/phases` was dead — `frontend/components/TeamPhasePanel.jsx`

```
/league/phases  http=200  settled=3071ms  len=282  rows=0
```

282 chars is the global nav plus two lines of copy. The body was empty on every run.

The route's whole body is `<TeamPhasePanel />`, and the panel read from `useApp()`. AppShell hard-refuses to hydrate the private contract under the `/league` prefix (`PUBLIC_ONLY_ROUTE_PREFIXES`), so `useApp()` there is permanently `{loading:false, rows:[], rawData:null}`. `analyzeLeaguePhases(null, [])` returns zero teams and the panel hit `if (!analysis.teams.length) return null`.

Fixed by following the pattern the sibling route already uses rather than inventing one: `RosterComparePanel` on `/league/franchise/[owner]` has the identical problem and solves it with `useDynastyData()` plus an explicit message for every state. Verified in a browser against a rebuilt bundle:

```
signed in -> 759 chars, 12 rows, 0 pageerrors
  teams  [Jason, Joey, Brent, Eric, MaKayla, Collin, Ed, Ty, Kich, Roy, Blaine, jstuedle]
  phases [Win-now, Win-now, Contender x4, Mixed x6]
  "against the league medians (91,362 value · 25.0 age)"
anonymous -> 0 rows, still on /league/phases, no redirect,
  "League phases unavailable — no Sleeper rosters in the active league's data."
```

`/api/data` is auth-gated, so anonymous visitors get the message, not data. The e2e privacy assertion in `public-league.spec.js` scopes its no-private-endpoints check to `/league?tab=...`, which this doesn't touch.

### 2. `/trades` claimed a count it didn't have — `frontend/app/trades/page.jsx`

The header rendered `0 trades in the last 365 days, graded at alpha=1.65.` while the contract was in flight, and again above the red error banner:

```
"LedgerTrade History0 trades in the last 365 days, graded at
 alpha=1.65.Couldn't load trade datanetwork exploded"
```

"0" meant "nothing loaded". The snapshot holds **109 trades**. After the fix, sampled every 700ms with 28 skeletons still on screen:

```
early samples (skeleton up -> claims "0 trades"?): [{"skel":28,"claims0":false}, x6]
final header: "109 trades in the last 365 days, graded at alpha=1.65."
```

### 3. `/tools/source-health` failed silently — `frontend/components/SourceHealthStrip.jsx`

The component returned `null` when `/api/status` failed. It *is* the whole page, so the route rendered a legend explaining dot colours for dots that weren't there — nothing distinguished "all sources healthy" from "status endpoint down". Reproduced by forcing a 500 in a fresh context (a warm cache masks it):

```
before, status-500: strip rendered: false | alerts: 0
after,  status-500: role="status" — "Source health unavailable — Couldn't reach /api/status (HTTP 500)."
after,  healthy:    role="region" — "Sources · 4 · 2h ago · 2 issues"
```

The `inline` variant still hides itself on failure — documented, deliberate, unchanged. Reuses existing `.source-health-strip--down` styles; **no CSS touched.**

## Reported, not fixed — see `docs/route-usability-audit.md`

- **F-1 (high): the documented one-command E2E recipe fails on a clean checkout.** `tests/e2e/preflight.py::main` runs `_run_contract_validation()` before `_seed_data_cache()`, and validation is what needs `data/`. Result is a raw `FileNotFoundError` traceback — which reads exactly like the "no data" symptom the README then spends a table telling you to ignore. Very likely what burned the two prior agents. Fix is swapping two lines; left alone because `tests/e2e/**` is owned elsewhere tonight.
- **F-2: `/league/activity` offers a Trades filter that can never return a row.** Same root cause as fix 1, but the resolution is a product call. Measured: 88 events, 80 `NEWS`, **0 `TRADE`**, against 109 trades in the contract. Clicking Trades gives "No activity in this view — try widening the scope", and no scope can help. Three options laid out in the doc.
- **F-3: `/api/chat` is dead code** — Next handler proxying to a backend route that doesn't exist, called by nobody, unreachable through nginx anyway.
- **F-4: time-to-usable.** `/rankings` 28.8s to 231 rows; `/trade` 16.3s to first real content with the **5.6MB contract fetched twice**, the override delta twice, and draft-capital twice. Single uvicorn worker, no `workers` arg.
- **F-5:** `/favicon.ico` 404s on every page load.
- **F-6:** invisible-control contrast auditor built and handed back to the design agent (couldn't share the backend with the sweep).

## Health of everything else

**Zero uncaught exceptions, zero error boundaries, zero blank pages across all 38 routes.** Every console error accounted for: 37× the `/api/health` 503 (expected offline), 9× `ERR_CONNECTION_RESET` on `sleepercdn.com` avatars (external CDN, offline), 1× the favicon 404. Only non-health 4xx/5xx was `/api/intel/summary` 503, which the UI reports honestly.

`/trending`'s "No movers in this window" and the `/edge` delta columns are honest — the snapshot is a single day, so `rank-history` is `{}` and no player carries `rankHistory`. Needs a multi-day environment to verify, flagged as such rather than passed off as working.

The doc also records the measurement caveats that made three earlier passes of this audit wrong — most importantly that waiting for the string "Loading" misses every page using `SkeletonTable`, which is most of them, and that a settle heuristic false-positives on a mid-load pause. `/angle` read as a 72-char blank page until measured properly; it's fine at 5.3s.

## Suite

```
python3 -m pytest tests/ -q -m "not livedata"
  3927 passed, 325 deselected, 4 subtests passed in 1084.20s (0:18:04)

npx vitest run    (frontend, both projects)
  Test Files  63 passed (63)
       Tests  1219 passed (1219)

python3 -m ruff format --check .
  538 files already formatted
```

No `.py` files changed, so `pr-validation.yml`'s changed-files ruff gate has nothing to lint.

## Coordination

No overlap with `claude/redesign-r5-polish` — none of the four touched source files appear on its list. No CSS custom properties or token-layer edits. Nothing under `tests/e2e/**`, `src/trade/angle.py`, `src/roster_intel/**`, or new `server.py` endpoints. Walker, reverse proxy, and contrast auditor stayed in the session scratchpad.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_