### PR TITLE
Source-data reliability: D-1 range guard + unfreeze three dead sources

### DIFF
--- a/.github/workflows/scheduled-refresh.yml
+++ b/.github/workflows/scheduled-refresh.yml
@@ -233,9 +233,14 @@ jobs:
           stamp_if_present ktc                CSVs/site_raw/ktc.csv               100
           stamp_if_present ktcSfTep           CSVs/site_raw/ktcSfTep.csv          100
           stamp_if_present idpTradeCalc       CSVs/site_raw/idpTradeCalc.csv       50
-          stamp_if_present dynastyNerdsSfTep  CSVs/site_raw/dynastyNerdsSfTep.csv  50
-          stamp_if_present fantasyProsSf      CSVs/site_raw/fantasyProsSf.csv      50
-          stamp_if_present fantasyProsIdp     CSVs/site_raw/fantasyProsIdp.csv     50
+          # NOTE: dynastyNerdsSfTep / fantasyProsSf / fantasyProsIdp used
+          # to be stamped here too.  They are now fetched below instead —
+          # see "Three sources were frozen" further down.  Leaving the
+          # stamps here would be actively harmful: ``stamp_if_present``
+          # only fires for a CSV the scraper rewrote this run, and the
+          # scraper no longer produces these at all, so the stamps could
+          # never fire and their presence implied a producer that does
+          # not exist.
 
           # Fetch Dynasty Daddy SF rankings
           run_fetcher dynastyDaddy:dynastyDaddySf "Dynasty Daddy" python scripts/fetch_dynasty_daddy.py --mirror-data-dir
@@ -308,6 +313,40 @@ jobs:
           # stays byte-identical between drops — the stamp is what
           # tracks that the fetcher itself succeeded each cycle.
           run_fetcher fantasyProsFitzmaurice "FP Fitzmaurice" python scripts/fetch_fantasypros_fitzmaurice.py
+
+          # ── Three sources were frozen. This unfreezes them. ─────────
+          #
+          # ``dynastyNerdsSfTep``, ``fantasyProsSf`` and ``fantasyProsIdp``
+          # had NO producer at all:
+          #
+          #   * ``Dynasty Scraper.py`` sets DynastyNerds / FantasyPros /
+          #     FantasyPros_IDP to ``False`` in its ``SITES`` dict
+          #     ("disabled in scope reduction") — only KTC and
+          #     IDPTradeCalc remain ``True``.
+          #   * Replacement fetchers were WRITTEN but never wired:
+          #     ``fetch_dynasty_nerds.py``, ``fetch_fantasypros_offense.py``
+          #     and ``fetch_fantasypros_idp.py`` had zero references in
+          #     .github/workflows/ before this change.
+          #
+          # So the only thing touching them was ``stamp_if_present``,
+          # which correctly declined to stamp a CSV nothing rewrote.
+          # Their last real fetch was 2026-07-25; the checked-in
+          # ``dynastyNerdsSfTep.csv`` dates from 2026-07-20. Measured
+          # 2026-07-27 against a live fetch: 131 of 269 shared players
+          # had moved >=10 ranks, 25 players were missing entirely, and
+          # the #2 overall asset was wrong (frozen said Drake Maye, live
+          # says Bijan Robinson). All three kept voting in every
+          # player's blend the whole time — 420 + 169 + 293 served rows
+          # of week-old data.
+          #
+          # All three fetchers were validated live before wiring:
+          # FantasyPros offense 540 players (QB 72 / RB 137 / TE 99 /
+          # WR 232), FantasyPros IDP 183, Dynasty Nerds 294 rows. Each
+          # is a plain ``requests.get`` against a public page — no auth,
+          # no paywall bypass — exactly like the fetchers above.
+          run_fetcher dynastyNerdsSfTep "Dynasty Nerds SF-TEP" python scripts/fetch_dynasty_nerds.py --mirror-data-dir
+          run_fetcher fantasyProsSf "FantasyPros Dynasty SF" python scripts/fetch_fantasypros_offense.py --mirror-data-dir
+          run_fetcher fantasyProsIdp "FantasyPros Dynasty IDP" python scripts/fetch_fantasypros_idp.py --mirror-data-dir
 
           # Fetch Justin Boone's Yahoo Sports dynasty trade value charts
           # (QB / RB / WR / TE).  Public web pages, no auth, so the

--- a/docs/python-coverage-audit.md
+++ b/docs/python-coverage-audit.md
@@ -177,7 +177,42 @@ copies, which remain useful as live-board checks.
 
 ## 4. Defects
 
-### D-1 — one out-of-range source value rescales the entire board *(UNRESOLVED — documented, not fixed)*
+### D-1 — one out-of-range source value rescales the entire board *(**RESOLVED 2026-07-27**)*
+
+> **Resolution.** Fixed in `src/api/data_contract.py` by
+> `_partition_value_source_ranges` + `_value_is_in_declared_range`.
+> Operator decision was **"B with a C escalation"**:
+>
+> * **B** — an out-of-range row is dropped from the value-direct path
+>   for that source only and falls through to the existing rank→Hill
+>   fallback, exactly as a missing value already does. Every other
+>   player is untouched.
+> * **C** — above `_VALUE_RANGE_ESCALATION_FRACTION` (2%) out-of-range
+>   rows the vendor has changed their scale rather than glitched, so
+>   the whole source is suppressed from the value-direct path (it still
+>   votes via rank→Hill) and the run logs an ERROR.
+> * **Minimum sample** — `_VALUE_RANGE_ESCALATION_MIN_ROWS` (50). Below
+>   that we always take policy B. Escalation C is a claim about the
+>   *source*, and a fraction over a handful of rows cannot support it:
+>   on a 4-row fixture one glitch is 25%. This was caught by a test,
+>   not by review.
+> * The ceiling is **per source**, not a global 9999 — `dynastyNerdsSfTep`
+>   publishes up to 10256, so a hardcoded ceiling would be wrong the
+>   moment a differently-scaled board joins `_VALUE_BASED_SOURCES`.
+>
+> **It changed no live number.** Verified against the real board on the
+> day of the fix: `ktcSfTep` 464 rows / 0 out of range / max 9999;
+> `idpTradeCalc` 814 rows / 0 out of range / max 9999; nothing
+> suppressed. A tripwire, not a repricing.
+>
+> The characterisation test below
+> (`test_out_of_range_finite_value_rescales_the_board`) has been
+> converted to the no-contamination assertion it asked for and renamed
+> `test_out_of_range_finite_value_does_not_rescale_the_board`.
+> `tests/api/test_value_range_guard.py` adds 15 more.
+>
+> The original write-up is retained below because the measurement and
+> the policy reasoning are the load-bearing part.
 
 **Where** `src/api/data_contract.py::_compute_unified_rankings`, the
 `value_source_max` construction (~line 6597) feeding the value-direct

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -5053,6 +5053,142 @@ _VALUE_BASED_SOURCES: frozenset[str] = frozenset(
 )
 
 
+# ── D-1: out-of-range guard for the value-direct path ──────────────────
+#
+# The value-direct branch computes ``raw / site_max * 9999`` where
+# ``site_max`` was an UNBOUNDED ``max()`` across every player.  One
+# corrupt row therefore rescaled the entire board: a single
+# ``ktcSfTep=99990`` (an extra digit — the most plausible scrape glitch
+# on a 4-digit board) deflates EVERY other player by 45.3%, measured
+# through ``build_api_data_contract`` on a 120-player board.  ``950000``
+# gives 49.5%.  Ordering is preserved, so the damage is invisible:
+# the board still looks correctly sorted, at roughly half value.
+#
+# ``_safe_num`` already blocks inf/nan/strings.  Nothing validated the
+# declared numeric RANGE, which is the gap this closes.
+#
+# Policy (operator decision, 2026-07-27) — "B with a C escalation":
+#
+#   B. A single out-of-range row is dropped from the value-direct path
+#      for that source only.  It falls through to the existing Hill
+#      fallback, exactly as a missing value already does, so the player
+#      keeps a vote and every other player is untouched.
+#
+#   C. If more than ``_VALUE_RANGE_ESCALATION_FRACTION`` of a source's
+#      rows are out of range, that is not a glitch — it means the
+#      vendor changed their scale.  Silently dropping most of a source
+#      would be worse than either failing or passing, so the whole
+#      source is suppressed from the value-direct path (it still votes
+#      via rank→Hill) and the run is stamped for the operator.
+#
+# The ceiling is PER SOURCE, deliberately, not a global 9999.  Sources
+# publish on their own native scales — ``dynastyNerdsSfTep`` tops out at
+# 10256 today — so a hardcoded 9999 would be wrong the moment a
+# differently-scaled board joins ``_VALUE_BASED_SOURCES``.  Only sources
+# listed here are range-checked; anything else keeps prior behaviour.
+_VALUE_SOURCE_DECLARED_MAX: dict[str, float] = {
+    # KTC's TE+ sub-board and IDPTradeCalc both publish a native 0-9999
+    # scale whose top asset is exactly 9999.  Verified against the live
+    # board 2026-07-27: ktcSfTep max 9999 (Josh Allen), idpTradeCalc max
+    # 9999 (Bijan Robinson), zero out-of-range rows on either.
+    "ktcSfTep": 9999.0,
+    "idpTradeCalc": 9999.0,
+}
+
+# Above this fraction of out-of-range rows, treat it as a scale change
+# rather than a glitch and suppress the source (escalation C).
+_VALUE_RANGE_ESCALATION_FRACTION: float = 0.02
+
+# ...but never escalate on an underpowered sample.  Escalation C is a
+# claim about the SOURCE ("its scale changed"), and a fraction computed
+# over a handful of rows cannot support that claim: on a 4-row fixture a
+# single glitch is 25% and would suppress a healthy source outright.
+# Real boards carry 400-900 rows, where one bad row is ~0.2%.  Below
+# this count we always take policy B (drop the row) regardless of the
+# fraction.  Same discipline as ORCHESTRATION.md §2b — do not conclude
+# from a sample that cannot distinguish the hypotheses.
+_VALUE_RANGE_ESCALATION_MIN_ROWS: int = 50
+
+
+def _partition_value_source_ranges(
+    players_array: list[dict[str, Any]],
+) -> tuple[dict[str, float], set[str], dict[str, dict[str, int]]]:
+    """Compute per-source max over IN-RANGE values only, plus the D-1 verdicts.
+
+    Returns ``(value_source_max, suppressed_sources, diagnostics)``:
+
+    * ``value_source_max`` — max observed value per source, computed
+      **excluding** out-of-range rows so one bad row cannot inflate the
+      divisor and deflate the board.
+    * ``suppressed_sources`` — sources whose out-of-range fraction
+      exceeded ``_VALUE_RANGE_ESCALATION_FRACTION`` (escalation C).
+    * ``diagnostics`` — per-source ``{"total", "outOfRange"}`` counts so
+      the condition is observable rather than silent.
+    """
+    totals: dict[str, int] = {}
+    out_of_range: dict[str, int] = {}
+    value_source_max: dict[str, float] = {}
+
+    for row in players_array:
+        canonical_site_values = row.get("canonicalSiteValues") or {}
+        if not isinstance(canonical_site_values, dict):
+            continue
+        for key in _VALUE_BASED_SOURCES:
+            raw = canonical_site_values.get(key)
+            if raw is None:
+                continue
+            try:
+                raw_f = float(raw)
+            except (TypeError, ValueError):
+                continue
+            totals[key] = totals.get(key, 0) + 1
+            ceiling = _VALUE_SOURCE_DECLARED_MAX.get(key)
+            if ceiling is not None and (raw_f < 0.0 or raw_f > ceiling):
+                out_of_range[key] = out_of_range.get(key, 0) + 1
+                continue
+            if raw_f > value_source_max.get(key, 0.0):
+                value_source_max[key] = raw_f
+
+    suppressed: set[str] = set()
+    diagnostics: dict[str, dict[str, int]] = {}
+    for key, total in totals.items():
+        bad = out_of_range.get(key, 0)
+        diagnostics[key] = {"total": total, "outOfRange": bad}
+        if (
+            bad
+            and total >= _VALUE_RANGE_ESCALATION_MIN_ROWS
+            and (bad / total) > _VALUE_RANGE_ESCALATION_FRACTION
+        ):
+            suppressed.add(key)
+            logging.error(
+                "D-1 escalation: %s has %d/%d values outside its declared "
+                "0-%s range (>%.0f%%) — suppressing its value-direct vote "
+                "for this build; the source's scale has likely changed.",
+                key,
+                bad,
+                total,
+                _VALUE_SOURCE_DECLARED_MAX.get(key),
+                _VALUE_RANGE_ESCALATION_FRACTION * 100.0,
+            )
+        elif bad:
+            logging.warning(
+                "D-1: dropped %d/%d out-of-range %s value(s) from the "
+                "value-direct path; those rows fall back to rank->Hill.",
+                bad,
+                total,
+                key,
+            )
+    return value_source_max, suppressed, diagnostics
+
+
+def _value_is_in_declared_range(source_key: str, raw_f: float) -> bool:
+    """True when ``raw_f`` sits inside ``source_key``'s declared range."""
+    ceiling = _VALUE_SOURCE_DECLARED_MAX.get(source_key)
+    if ceiling is None:
+        return True
+    return 0.0 <= raw_f <= ceiling
+
+
 def _validate_value_based_sources_invariant() -> None:
     """Module-import safety rail: every source registered for VOTING
     in ``_RANKING_SOURCES`` whose CSV signal is ``value`` must either
@@ -6594,19 +6730,23 @@ def _compute_unified_rankings(
     # ``maxValues`` dict only tracks ktc + idpTradeCalc today; the other
     # value-based sources (dynastyDaddySf, draftSharks, draftSharksIdp)
     # carry their real values only inside the per-player dict.
-    value_source_max: dict[str, float] = {}
-    for row in players_array:
-        canonical_site_values = row.get("canonicalSiteValues") or {}
-        if not isinstance(canonical_site_values, dict):
-            continue
-        for key in _VALUE_BASED_SOURCES:
-            raw = canonical_site_values.get(key)
-            try:
-                raw_f = float(raw) if raw is not None else 0.0
-            except (TypeError, ValueError):
-                continue
-            if raw_f > value_source_max.get(key, 0.0):
-                value_source_max[key] = raw_f
+    #
+    # D-1: the max is computed over IN-RANGE values only, and a source
+    # whose out-of-range fraction exceeds the escalation threshold is
+    # suppressed from the value-direct path entirely.  See
+    # ``_partition_value_source_ranges`` for the policy and the measured
+    # failure it prevents.
+    # ``_value_range_diagnostics`` is intentionally unused here: the
+    # per-source counts reach operators through the WARNING/ERROR logs
+    # emitted inside the helper, and reach CI through direct unit tests
+    # on ``_partition_value_source_ranges``.  Threading them into the
+    # return would change this function's published contract
+    # (``dict[str, str]``) for a diagnostic, which is not worth it.
+    (
+        value_source_max,
+        value_range_suppressed,
+        _value_range_diagnostics,
+    ) = _partition_value_source_ranges(players_array)
 
     _trimmed_mean_median = count_aware_mean_median_blend
 
@@ -6671,7 +6811,15 @@ def _compute_unified_rankings(
                 except (TypeError, ValueError):
                     raw_f = 0.0
                 site_max = value_source_max.get(source_key, 0.0)
-                if raw_f > 0.0 and site_max > 0.0:
+                # D-1 (policy B): an out-of-range value is not trustworthy
+                # for THIS row, so it takes the same fallback a missing
+                # value already takes.  D-1 (policy C): if the whole
+                # source was suppressed, no row uses the value-direct
+                # path for it.
+                in_range = _value_is_in_declared_range(source_key, raw_f)
+                if source_key in value_range_suppressed or not in_range:
+                    value = float(percentile_to_value(p, midpoint=hill_c, slope=hill_s))
+                elif raw_f > 0.0 and site_max > 0.0:
                     value = raw_f / site_max * 9999.0
                 else:
                     # Fall back to the Hill path if the raw value is

--- a/tests/api/test_valuation_degraded_inputs.py
+++ b/tests/api/test_valuation_degraded_inputs.py
@@ -242,9 +242,7 @@ class TestSiteMaxContamination:
         clean = _contract_values(dc.build_api_data_contract(_payload()))
         poisoned = _contract_values(dc.build_api_data_contract(_payload(corrupt=99990)))
 
-        ratios = [
-            poisoned[n] / clean[n] for n in clean if clean[n] and poisoned.get(n) is not None
-        ]
+        ratios = [poisoned[n] / clean[n] for n in clean if clean[n] and poisoned.get(n) is not None]
         assert ratios, "fixture produced no comparable players"
 
         worst = min(ratios)

--- a/tests/api/test_valuation_degraded_inputs.py
+++ b/tests/api/test_valuation_degraded_inputs.py
@@ -14,9 +14,11 @@ bearing and invisible*:
     formula divides by it.  See ``TestSiteMaxContamination``.
   * negative / zero source values being dropped rather than voted.
 
-A known **unfixed** gap is characterised (not asserted as correct) in
-``TestSiteMaxContamination.test_out_of_range_finite_value_rescales_the_board``
-— see ``docs/python-coverage-audit.md``.
+The out-of-range gap that was characterised here as *unfixed* (D-1) was
+closed 2026-07-27 — see
+``TestSiteMaxContamination.test_out_of_range_finite_value_does_not_rescale_the_board``,
+``_partition_value_source_ranges`` in ``src/api/data_contract.py``, and
+``docs/python-coverage-audit.md`` D-1.
 """
 
 from __future__ import annotations
@@ -185,8 +187,18 @@ class TestNonPositiveAndNonFiniteValues:
 class TestSiteMaxContamination:
     """The value-direct branch is ``raw / site_max × 9999``.
 
-    ``site_max`` is an unbounded max over the pool, so one bad cell in
-    a value-based source rescales *every* player in that source.
+    ``site_max`` USED to be an unbounded max over the pool, so one bad
+    cell in a value-based source rescaled *every* player in that source.
+    Two independent guards now stand there, and both are load-bearing:
+
+      * ``_safe_num`` rejects non-finite values before they can reach
+        the max at all;
+      * ``_partition_value_source_ranges`` (D-1, 2026-07-27) computes
+        the max over in-range values only, and drops out-of-range rows
+        to the rank→Hill fallback.
+
+    Neither subsumes the other — ``inf`` is caught by coercion, an
+    extra digit is caught by the range check.
     """
 
     def test_non_finite_values_never_become_the_site_max(self):

--- a/tests/api/test_valuation_degraded_inputs.py
+++ b/tests/api/test_valuation_degraded_inputs.py
@@ -217,32 +217,41 @@ class TestSiteMaxContamination:
                 poisoned_vals[name] == value
             ), f"{name} was repriced by a non-finite cell in another row"
 
-    def test_out_of_range_finite_value_rescales_the_board(self):
-        """CHARACTERISATION of a known, unfixed gap — not an endorsement.
+    def test_out_of_range_finite_value_does_not_rescale_the_board(self):
+        """D-1 CLOSED — this was a characterisation test; it is now a guard.
 
-        ``_safe_num`` only rejects non-finite values.  A finite but
-        out-of-scale cell (e.g. an extra digit: 99990 on a board that
-        tops out at 9999) is accepted, becomes ``site_max``, and
-        deflates every player's contribution from that source.
+        Until 2026-07-27 this asserted the *defect*: ``_safe_num`` only
+        rejected non-finite values, so a finite but out-of-scale cell
+        (an extra digit — 99990 on a board topping out at 9999) was
+        accepted, became ``site_max``, and deflated every player's
+        contribution from that source by ~45%.  The original docstring
+        instructed the next reader to "turn this into a no-contamination
+        assertion" once a range guard landed.  It has, so this is it.
 
-        This test pins the CURRENT behaviour so that whenever a range
-        guard is added the change is deliberate and visible, rather
-        than landing silently.  See ``docs/python-coverage-audit.md``
-        (Defect D-1) for the numbers and the open policy question.
+        The guard is policy "B with a C escalation" (operator decision):
+        the out-of-range row is dropped from the value-direct path for
+        that source and falls through to rank->Hill, exactly as a
+        missing value already does.  Everyone else is untouched — which
+        is what this now asserts.
+
+        Note the fixture is 120 players, above
+        ``_VALUE_RANGE_ESCALATION_MIN_ROWS`` (50), and one bad row is
+        ~0.8% — below the 2% escalation threshold.  So this exercises
+        policy B specifically, not the source-level suppression.
         """
         clean = _contract_values(dc.build_api_data_contract(_payload()))
         poisoned = _contract_values(dc.build_api_data_contract(_payload(corrupt=99990)))
 
-        # Today: every player is deflated, and by the same proportion.
-        deflated = [
+        ratios = [
             poisoned[n] / clean[n] for n in clean if clean[n] and poisoned.get(n) is not None
         ]
-        assert deflated, "fixture produced no comparable players"
-        assert all(r < 0.75 for r in deflated), (
-            "expected the documented board-wide deflation; if this now "
-            "passes at ~1.0 a range guard has been added — update "
-            "docs/python-coverage-audit.md D-1 and turn this into a "
-            "no-contamination assertion"
+        assert ratios, "fixture produced no comparable players"
+
+        worst = min(ratios)
+        assert worst > 0.99, (
+            f"a single out-of-range cell repriced the board (worst ratio "
+            f"{worst:.4f}); the D-1 range guard is not holding — see "
+            f"_partition_value_source_ranges in src/api/data_contract.py"
         )
 
 

--- a/tests/api/test_value_range_guard.py
+++ b/tests/api/test_value_range_guard.py
@@ -1,0 +1,189 @@
+"""D-1: one out-of-range source value must not rescale the whole board.
+
+Operator decision 2026-07-27 — "B with a C escalation":
+
+  B. A single out-of-range row is dropped from the value-direct path for
+     that source only, falling through to the existing rank->Hill
+     fallback.  Every other player is untouched.
+  C. Above ``_VALUE_RANGE_ESCALATION_FRACTION`` out-of-range rows, the
+     source's scale has changed rather than one row being corrupt, so
+     the whole source is suppressed from the value-direct path.
+
+The defect these pin: ``site_max`` was an unbounded ``max()`` and the
+value-direct branch computes ``raw / site_max * 9999``.  One row at
+``ktcSfTep=99990`` therefore deflated EVERY other player by ~45%, with
+ordering preserved so the board still looked correctly sorted.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.api.data_contract import (
+    _VALUE_RANGE_ESCALATION_FRACTION,
+    _VALUE_SOURCE_DECLARED_MAX,
+    _partition_value_source_ranges,
+    _value_is_in_declared_range,
+)
+
+
+def _rows(source: str, values: list[float]) -> list[dict]:
+    return [
+        {"displayName": f"P{i}", "canonicalSiteValues": {source: v}} for i, v in enumerate(values)
+    ]
+
+
+class TestDeclaredRangeCheck:
+    def test_in_range_values_accepted(self):
+        assert _value_is_in_declared_range("ktcSfTep", 0.0)
+        assert _value_is_in_declared_range("ktcSfTep", 5000.0)
+        assert _value_is_in_declared_range("ktcSfTep", 9999.0)
+
+    def test_out_of_range_values_rejected(self):
+        assert not _value_is_in_declared_range("ktcSfTep", 10000.0)
+        assert not _value_is_in_declared_range("ktcSfTep", 99990.0)
+        assert not _value_is_in_declared_range("ktcSfTep", -1.0)
+
+    def test_unlisted_source_is_not_range_checked(self):
+        """Sources publish on their own scales — dynastyNerdsSfTep tops
+        out at 10256 today.  A source with no declared ceiling must keep
+        prior behaviour rather than being clamped to someone else's."""
+        assert "dynastyNerdsSfTep" not in _VALUE_SOURCE_DECLARED_MAX
+        assert _value_is_in_declared_range("dynastyNerdsSfTep", 10256.0)
+        assert _value_is_in_declared_range("someFutureSource", 1e9)
+
+
+class TestPolicyB_SingleBadRowDropped:
+    def test_site_max_ignores_the_out_of_range_row(self):
+        """The whole defect in one assertion: the divisor must come from
+        the legitimate rows, not from the corrupt one."""
+        # Realistic board size: one glitch in 101 rows is ~1%, below the
+        # escalation threshold, so policy B applies.
+        rows = _rows("ktcSfTep", [9999.0] + [5000.0] * 99 + [99990.0])
+        value_source_max, suppressed, diags = _partition_value_source_ranges(rows)
+
+        assert value_source_max["ktcSfTep"] == 9999.0, (
+            "site_max must exclude the out-of-range row; "
+            "pre-fix this was 99990 and deflated every player ~45%"
+        )
+        assert "ktcSfTep" not in suppressed
+        assert diags["ktcSfTep"] == {"total": 101, "outOfRange": 1}
+
+    def test_negative_value_is_also_out_of_range(self):
+        rows = _rows("idpTradeCalc", [9999.0] + [5000.0] * 99 + [-50.0])
+        _, _, diags = _partition_value_source_ranges(rows)
+        assert diags["idpTradeCalc"]["outOfRange"] == 1
+
+    def test_one_bad_row_does_not_suppress_the_source(self):
+        """Policy B, not C: a lone glitch keeps the source in play."""
+        rows = _rows("ktcSfTep", [9999.0] + [5000.0] * 199 + [99990.0])
+        _, suppressed, diags = _partition_value_source_ranges(rows)
+        assert diags["ktcSfTep"]["outOfRange"] == 1
+        assert diags["ktcSfTep"]["total"] == 201
+        assert "ktcSfTep" not in suppressed
+
+
+class TestPolicyC_ScaleChangeSuppresses:
+    def test_many_out_of_range_rows_suppress_the_source(self):
+        """A vendor rescaling their board is not a glitch. Silently
+        dropping most of a source would be worse than failing."""
+        rows = _rows("ktcSfTep", [50000.0] * 30 + [5000.0] * 70)
+        _, suppressed, diags = _partition_value_source_ranges(rows)
+        assert diags["ktcSfTep"]["outOfRange"] == 30
+        assert "ktcSfTep" in suppressed
+
+    def test_threshold_boundary_does_not_suppress(self):
+        """At exactly the threshold we stay in policy B — suppression
+        requires strictly exceeding it."""
+        total = 100
+        bad = int(_VALUE_RANGE_ESCALATION_FRACTION * total)  # 2
+        rows = _rows("ktcSfTep", [50000.0] * bad + [5000.0] * (total - bad))
+        _, suppressed, _ = _partition_value_source_ranges(rows)
+        assert "ktcSfTep" not in suppressed
+
+    def test_just_over_threshold_suppresses(self):
+        total = 100
+        bad = int(_VALUE_RANGE_ESCALATION_FRACTION * total) + 1  # 3
+        rows = _rows("ktcSfTep", [50000.0] * bad + [5000.0] * (total - bad))
+        _, suppressed, _ = _partition_value_source_ranges(rows)
+        assert "ktcSfTep" in suppressed
+
+
+class TestCleanBoardUnaffected:
+    def test_healthy_board_produces_no_drops_and_no_suppression(self):
+        """The guard must be a no-op on good data. Measured against the
+        live board 2026-07-27: both value sources max at exactly 9999
+        with zero out-of-range rows, so this reflects production."""
+        rows = _rows("ktcSfTep", [9999.0, 7000.0, 4000.0, 1.0, 0.0])
+        value_source_max, suppressed, diags = _partition_value_source_ranges(rows)
+        assert value_source_max["ktcSfTep"] == 9999.0
+        assert suppressed == set()
+        assert diags["ktcSfTep"]["outOfRange"] == 0
+
+    def test_non_numeric_and_missing_values_are_skipped_not_counted(self):
+        rows = [
+            {"canonicalSiteValues": {"ktcSfTep": 9999.0}},
+            {"canonicalSiteValues": {"ktcSfTep": None}},
+            {"canonicalSiteValues": {"ktcSfTep": "not-a-number"}},
+            {"canonicalSiteValues": None},
+            {},
+        ]
+        value_source_max, suppressed, diags = _partition_value_source_ranges(rows)
+        assert value_source_max["ktcSfTep"] == 9999.0
+        assert diags["ktcSfTep"]["total"] == 1
+        assert suppressed == set()
+
+
+class TestEndToEndDeflation:
+    """The measured failure, driven through the partition step.
+
+    Pre-fix, ``site_max`` would be 99990 and a legitimate 9999 player
+    would normalise to ``9999/99990*9999 = 1000`` — a 90% haircut on the
+    top asset, and proportionally on everyone else.
+    """
+
+    @pytest.mark.parametrize("bad_value", [99990.0, 950000.0])
+    def test_top_asset_keeps_full_value_despite_a_corrupt_row(self, bad_value):
+        rows = _rows("ktcSfTep", [9999.0] + [5000.0] * 99 + [bad_value])
+        value_source_max, suppressed, _ = _partition_value_source_ranges(rows)
+        site_max = value_source_max["ktcSfTep"]
+
+        normalized_top = 9999.0 / site_max * 9999.0
+        assert normalized_top == pytest.approx(9999.0), (
+            f"top asset must stay at 9999; with the unbounded max it "
+            f"would be {9999.0 / bad_value * 9999.0:.0f}"
+        )
+        assert "ktcSfTep" not in suppressed
+
+
+class TestEscalationNeedsAdequateSample:
+    """Escalation C claims the SOURCE's scale changed. That claim cannot
+    be made from a handful of rows — on a 4-row fixture one glitch is
+    25%, which would suppress a healthy source outright. Below
+    ``_VALUE_RANGE_ESCALATION_MIN_ROWS`` we always take policy B.
+
+    This was found by a test, not by review: the first version of the
+    guard suppressed ktcSfTep on a 4-row fixture holding a single bad
+    value.
+    """
+
+    def test_tiny_sample_never_escalates_even_at_high_fraction(self):
+        from src.api.data_contract import _VALUE_RANGE_ESCALATION_MIN_ROWS
+
+        rows = _rows("ktcSfTep", [9999.0, 8000.0, 5000.0, 99990.0])
+        assert len(rows) < _VALUE_RANGE_ESCALATION_MIN_ROWS
+        value_source_max, suppressed, diags = _partition_value_source_ranges(rows)
+
+        assert diags["ktcSfTep"]["outOfRange"] == 1
+        assert diags["ktcSfTep"]["total"] == 4  # 25%, far above the 2% fraction
+        assert "ktcSfTep" not in suppressed, "one bad row in four is not evidence of a scale change"
+        assert value_source_max["ktcSfTep"] == 9999.0
+
+    def test_adequate_sample_still_escalates(self):
+        from src.api.data_contract import _VALUE_RANGE_ESCALATION_MIN_ROWS
+
+        n = _VALUE_RANGE_ESCALATION_MIN_ROWS
+        bad = int(n * 0.5)
+        rows = _rows("ktcSfTep", [50000.0] * bad + [5000.0] * (n - bad))
+        _, suppressed, _ = _partition_value_source_ranges(rows)
+        assert "ktcSfTep" in suppressed


### PR DESCRIPTION
Two independent fixes, kept as two commits so either can be reverted alone.

## 1. D-1 — one bad value no longer rescales the board

**Operator decision: "B with a C escalation."**

The value-direct branch computes `raw / site_max * 9999`, where `site_max` was an **unbounded `max()`** across every player. One corrupt row rescaled everyone: a single `ktcSfTep=99990` — an extra digit, the most plausible glitch on a 4-digit board — deflates every other player by **45.3%**. `950000` gives 49.5%. Ordering is preserved, so the board still looks correctly sorted at roughly half value. `_safe_num` blocked `inf`/`nan`/strings; nothing checked the declared numeric *range*.

- **B**: an out-of-range row is dropped from the value-direct path for that source only, falling through to the existing rank→Hill fallback exactly as a missing value already does. The player keeps a vote; everyone else is untouched.
- **C**: above 2% out-of-range rows, the vendor changed their scale rather than glitching. Silently dropping most of a source is worse than failing, so it's suppressed from the value-direct path (still votes via rank→Hill) and the run logs an ERROR.

**A minimum-sample rule the tests forced.** My first version escalated on a 4-row fixture holding one bad value, because 1-in-4 is 25%. Escalation C is a claim about *the source* — four observations cannot support it. Below 50 rows we always take policy B. Same discipline as §2b: don't conclude from a sample that can't distinguish the hypotheses. I'd have shipped that without the test.

**The ceiling is per-source, not a global 9999.** Sources publish on their own scales — `dynastyNerdsSfTep` tops out at **10256** today — so a hardcoded ceiling would be wrong the moment a differently-scaled board joins `_VALUE_BASED_SOURCES`. Unlisted sources keep prior behaviour.

**It changes nothing today.** Verified against the real board:

| source | rows | out of range | site_max |
|---|---|---|---|
| `ktcSfTep` | 464 | **0** | 9999 |
| `idpTradeCalc` | 814 | **0** | 9999 |

Nothing suppressed. This is a tripwire, not a repricing.

15 new tests. `tests/api/` → **1039 passed, 0 failed**.

## 2. Three sources were frozen, not stale

`dynastyNerdsSfTep`, `fantasyProsSf` and `fantasyProsIdp` had **no producer at all**:

- `Dynasty Scraper.py` sets DynastyNerds / FantasyPros / FantasyPros_IDP to `False` in `SITES` ("disabled in scope reduction") — only KTC and IDPTradeCalc remain `True`.
- Replacement fetchers were **written but never wired**: `fetch_dynasty_nerds.py`, `fetch_fantasypros_offense.py`, `fetch_fantasypros_idp.py` had **zero references** in `.github/workflows/`.
- The only thing touching them was `stamp_if_present`, which correctly declined to stamp a CSV nothing rewrote. **The stamping logic was right** — there was simply no producer.

**Impact, measured against a live fetch:**

| | |
|---|---|
| Frozen `dynastyNerdsSfTep.csv` dated | **2026-07-20** |
| Shared players moved ≥10 ranks | **131 of 269** |
| Players missing from the frozen file | **25** |
| #2 overall asset | frozen: Drake Maye · live: **Bijan Robinson** |

All three kept voting in every player's blend the whole time — 420 + 169 + 293 served rows of week-old data.

**All three fetchers were validated live before wiring**, not assumed to work: FantasyPros offense **540** players (QB 72 / RB 137 / TE 99 / WR 232), FantasyPros IDP **183**, Dynasty Nerds **294** rows. Each is a plain `requests.get` against a public page — no auth, no paywall bypass — matching the fetchers already wired above them.

Their `stamp_if_present` lines are removed. Keeping them would be actively misleading: the stamp can only fire for a CSV the scraper rewrote, and the scraper no longer produces these, so the lines implied a producer that doesn't exist.

**This commit does move live numbers, by design** — three sources resume contributing current data instead of week-old data.

## Verification

- `python -m ruff check` clean; `ruff format --check` clean.
- `tests/api/` → 1039 passed, 0 failed, 234 deselected.
- `yaml.safe_load` on the workflow parses; all three fetchers now referenced.
- Guard proven a no-op on the real committed board (table above).

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_