### PR TITLE
rebrand: the product is Chase Upside, the league is still the Brisket

### DIFF
--- a/frontend/__tests__/nav-model.test.js
+++ b/frontend/__tests__/nav-model.test.js
@@ -143,7 +143,7 @@ describe("pageTitleFor", () => {
   });
 
   it("falls back to the brand for unknown routes", () => {
-    expect(pageTitleFor("/nonexistent")).toBe("Brisket");
+    expect(pageTitleFor("/nonexistent")).toBe("Chase Upside");
   });
 });
 

--- a/frontend/app/design/page.jsx
+++ b/frontend/app/design/page.jsx
@@ -9,7 +9,7 @@
 import DesignGallery from "./DesignGallery";
 
 export const metadata = {
-  title: "Design System — Brisket",
+  title: "Design System — Chase Upside",
   robots: { index: false, follow: false },
 };
 

--- a/frontend/app/layout.jsx
+++ b/frontend/app/layout.jsx
@@ -43,7 +43,7 @@ export const metadata = {
   appleWebApp: {
     capable: true,
     statusBarStyle: "black-translucent",
-    title: "Brisket",
+    title: "Chase Upside",
   },
   // Theme color matches the manifest's ``theme_color`` — drives
   // the Android Chrome URL bar tint when the user is on the site.

--- a/frontend/app/league/articles/[season]/[week]/page.jsx
+++ b/frontend/app/league/articles/[season]/[week]/page.jsx
@@ -36,7 +36,7 @@ async function fetchSlate(season, week) {
 export async function generateMetadata({ params }) {
   const { season, week } = await params;
   return {
-    title: `Articles · ${season} Week ${week} — Brisket League`,
+    title: `Articles · ${season} Week ${week} — Chase Upside`,
     description: `AI-generated previews and recaps for the ${season} Week ${week} matchup slate.`,
   };
 }

--- a/frontend/app/league/franchise/[owner]/opengraph-image.js
+++ b/frontend/app/league/franchise/[owner]/opengraph-image.js
@@ -63,7 +63,7 @@ export default async function FranchiseOGImage({ params }) {
       >
         <div style={{ display: "flex", alignItems: "center", gap: 16, color: "#FFC704", fontSize: 28 }}>
           <span style={{ letterSpacing: "0.15em", textTransform: "uppercase", fontWeight: 700 }}>
-            Brisket League · Franchise
+            Chase Upside · Franchise
           </span>
         </div>
         <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>

--- a/frontend/app/league/page.jsx
+++ b/frontend/app/league/page.jsx
@@ -44,12 +44,12 @@ export async function generateMetadata() {
   if (!data) {
     return {
       title: "Risk It To Get The Brisket — public league",
-      description: "Public league home for the Brisket dynasty league.",
+      description: "Public league home for the dynasty league.",
     };
   }
   const league = data.league || {};
   const overview = data.sections?.overview || {};
-  const name = league.leagueName || "Brisket League";
+  const name = league.leagueName || "Chase Upside";
   const range = overview.seasonRangeLabel || (league.seasonsCovered || []).join("–");
   const champ = overview.currentChampion;
   const decorated = overview.mostDecoratedFranchise;

--- a/frontend/app/league/player/[playerId]/opengraph-image.js
+++ b/frontend/app/league/player/[playerId]/opengraph-image.js
@@ -52,7 +52,7 @@ export default async function PlayerOGImage({ params }) {
       >
         <div style={{ display: "flex", gap: 16, color: "#FFC704", fontSize: 28 }}>
           <span style={{ letterSpacing: "0.15em", textTransform: "uppercase", fontWeight: 700 }}>
-            Brisket League · Player Journey
+            Chase Upside · Player Journey
           </span>
         </div>
 

--- a/frontend/app/league/player/[playerId]/page.jsx
+++ b/frontend/app/league/player/[playerId]/page.jsx
@@ -80,8 +80,8 @@ export async function generateMetadata({ params }) {
   const payload = await fetchPlayer(playerId);
   if (!payload || !payload.player) {
     return {
-      title: `Player journey · Brisket League`,
-      description: "Public player transaction + scoring history across the Brisket dynasty league.",
+      title: `Player journey · Chase Upside`,
+      description: "Public player transaction + scoring history across the dynasty league.",
     };
   }
   const p = payload.player.identity;
@@ -90,7 +90,7 @@ export async function generateMetadata({ params }) {
   const title = `${p.playerName} (${p.position}) — league journey`;
   const description = top
     ? `${p.playerName} scored ${top.pointsTotal} pts for ${top.displayName} across ${top.weeksRostered} weeks.`
-    : `${p.playerName}'s transaction history in the Brisket dynasty league.`;
+    : `${p.playerName}'s transaction history in the dynasty league.`;
   return {
     title,
     description,

--- a/frontend/app/league/rivalry/[pair]/opengraph-image.js
+++ b/frontend/app/league/rivalry/[pair]/opengraph-image.js
@@ -79,7 +79,7 @@ export default async function RivalryOGImage({ params }) {
       >
         <div style={{ display: "flex", gap: 16, color: "#f87171", fontSize: 28 }}>
           <span style={{ letterSpacing: "0.15em", textTransform: "uppercase", fontWeight: 700 }}>
-            Brisket League · Rivalry
+            Chase Upside · Rivalry
           </span>
         </div>
 

--- a/frontend/app/league/rivalry/[pair]/page.jsx
+++ b/frontend/app/league/rivalry/[pair]/page.jsx
@@ -58,8 +58,8 @@ export async function generateMetadata({ params }) {
   const detail = findDetail(data, a, b);
   if (!detail) {
     return {
-      title: "Rivalry · Brisket League",
-      description: "Public head-to-head record for two managers in the Brisket dynasty league.",
+      title: "Rivalry · Chase Upside",
+      description: "Public head-to-head record for two managers in the dynasty league.",
     };
   }
   const [idA, idB] = detail.ownerIds;
@@ -73,7 +73,7 @@ export async function generateMetadata({ params }) {
   return {
     title,
     description,
-    openGraph: { title, description, type: "article", siteName: "Risk It To Get The Brisket" },
+    openGraph: { title, description, type: "article", siteName: "Chase Upside" },
     twitter: { card: "summary", title, description },
   };
 }

--- a/frontend/app/league/weekly/[season]/[week]/[matchup]/opengraph-image.js
+++ b/frontend/app/league/weekly/[season]/[week]/[matchup]/opengraph-image.js
@@ -61,7 +61,7 @@ export default async function MatchupOGImage({ params }) {
         }}
       >
         <div style={{ display: "flex", color: "#FFC704", fontSize: 28, letterSpacing: "0.15em", textTransform: "uppercase", fontWeight: 700 }}>
-          {`Brisket League · ${season} Week ${week}${m?.isPlayoff ? " · Playoffs" : ""}`}
+          {`Chase Upside · ${season} Week ${week}${m?.isPlayoff ? " · Playoffs" : ""}`}
         </div>
 
         <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 40 }}>

--- a/frontend/app/login/page.jsx
+++ b/frontend/app/login/page.jsx
@@ -12,7 +12,7 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  // Default landing post-login is the Brisket Home dashboard at "/" —
+  // Default landing post-login is the Chase Upside home dashboard at "/" —
   // Team Value + Top Movers + Risers/Fallers — which gives a more
   // useful daily-checkin view than the raw rankings table.  Users
   // who deep-linked to a specific page before being bounced to login

--- a/frontend/app/manifest.js
+++ b/frontend/app/manifest.js
@@ -10,16 +10,16 @@
  */
 export default function manifest() {
   return {
-    name: "Risk It To Get The Brisket",
-    short_name: "Brisket",
+    name: "Chase Upside",
+    short_name: "Chase Upside",
     description:
       "Dynasty fantasy football terminal — rankings, trade calculator, league analysis.",
     start_url: "/",
     id: "/",
     display: "standalone",
     orientation: "portrait",
-    background_color: "#0f0a1a",
-    theme_color: "#4F2185",
+    background_color: "#0b0d10",
+    theme_color: "#0b0d10",
     categories: ["sports", "productivity"],
     icons: [
       {

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -18,7 +18,7 @@ function LandingHome() {
   return (
     <section className="login-shell">
       <div className="login-panel" style={{ textAlign: "center" }}>
-        <h1 style={{ margin: "0 0 8px", fontSize: "1.4rem" }}>Risk It To Get The Brisket</h1>
+        <h1 style={{ margin: "0 0 8px", fontSize: "1.4rem" }}>Chase Upside</h1>
         <p className="muted" style={{ marginBottom: "var(--space-lg)" }}>Choose where you want to go.</p>
         <div className="grid-responsive" style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
           <Link href="/league" className="button" style={{ textAlign: "center", padding: "14px 12px" }}>

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -622,7 +622,7 @@ export default function RankingsPage() {
     const iso = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
     const a = document.createElement("a");
     a.href = url;
-    a.download = `brisket-rankings-${iso}.csv`;
+    a.download = `chaseupside-rankings-${iso}.csv`;
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);

--- a/frontend/components/ScreenshotFab.jsx
+++ b/frontend/components/ScreenshotFab.jsx
@@ -67,14 +67,14 @@ export default function ScreenshotFab() {
         );
       });
 
-      const filename = `brisket-${new Date().toISOString().slice(0, 10)}.png`;
+      const filename = `chaseupside-${new Date().toISOString().slice(0, 10)}.png`;
       const file = new File([blob], filename, { type: "image/png" });
 
       // Prefer Web Share API with files (iOS 15+ / Android — share sheet
       // includes "Save Image" → camera roll).
       if (canShareFiles(file)) {
         try {
-          await navigator.share({ files: [file], title: "Brisket Rankings" });
+          await navigator.share({ files: [file], title: "Chase Upside Rankings" });
           return;
         } catch (err) {
           if (err?.name === "AbortError") return; // user dismissed

--- a/frontend/components/shell/TopBar.jsx
+++ b/frontend/components/shell/TopBar.jsx
@@ -48,7 +48,7 @@ export default function TopBar({ authenticated, isPublic, onSearch, onLogout }) 
           <span className="shell-brand-mark" aria-hidden="true">
             ▪
           </span>
-          Brisket
+          Chase Upside
         </Link>
         <nav className="shell-nav" aria-label="Primary">
           {groups.map((group) =>

--- a/frontend/lib/nav-model.js
+++ b/frontend/lib/nav-model.js
@@ -209,5 +209,5 @@ export function pageTitleFor(pathname) {
     if (!isNavActive(item.href, pathname)) continue;
     if (!best || item.href.length > best.href.length) best = item;
   }
-  return best ? best.label : "Brisket";
+  return best ? best.label : "Chase Upside";
 }

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,5 +1,5 @@
 /**
- * Service worker — minimal "offline-first shell" for Brisket.
+ * Service worker — minimal "offline-first shell" for Chase Upside.
  *
  * What this does:
  *   - Cache-first for static assets (``/_next/static/*``, icons,
@@ -53,7 +53,7 @@
 // v3: push + notificationclick handlers added.  Cache layout is
 // otherwise unchanged; the bump just forces an SW activation cycle so
 // existing tabs pick up the new event listeners.
-const CACHE_VERSION = "brisket-v5";
+const CACHE_VERSION = "chaseupside-v6";
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const RUNTIME_CACHE = `${CACHE_VERSION}-runtime`;
 const PUBLIC_LEAGUE_CACHE = `${CACHE_VERSION}-public-league`;
@@ -204,13 +204,13 @@ self.addEventListener("push", (event) => {
       payload = event.data.json();
     } catch {
       try {
-        payload = { title: "Brisket", body: event.data.text() };
+        payload = { title: "Chase Upside", body: event.data.text() };
       } catch {
         payload = {};
       }
     }
   }
-  const title = String(payload.title || "Brisket").slice(0, 120);
+  const title = String(payload.title || "Chase Upside").slice(0, 120);
   const body = String(payload.body || "").slice(0, 300);
   const url = typeof payload.url === "string" ? payload.url : "/";
   const tag = typeof payload.tag === "string" ? payload.tag : undefined;

--- a/tests/e2e/specs/critical-smoke.spec.js
+++ b/tests/e2e/specs/critical-smoke.spec.js
@@ -13,13 +13,14 @@
 const { test, expect } = require("@playwright/test");
 
 const PUBLIC_ROUTES = [
-  // Anonymous "/" no longer shows the "Risk It To Get The Brisket"
-  // wordmark: the R1 shell brands the chrome "Brisket", and an
-  // unauthenticated visit now lands on the sign-in surface.  Assert on
-  // the brand, which is present in the shell on every route and every
-  // auth state — this check exists to prove the route renders at all,
-  // not to pin the marketing copy.
-  { path: "/", mustHave: /Brisket/i },
+  // The shell brands the chrome "Chase Upside" (renamed from "Brisket"
+  // 2026-07-27; the Sleeper LEAGUE is still called "Risk It To Get The
+  // Brisket" and that name is deliberately untouched).  An
+  // unauthenticated visit lands on the sign-in surface.  Assert on the
+  // brand, which is present in the shell on every route and every auth
+  // state — this check exists to prove the route renders at all, not to
+  // pin the marketing copy.
+  { path: "/", mustHave: /Chase Upside/i },
   // ``/league`` removed from this list: the backend's ``_proxy_next``
   // helper is hit by these tests (baseURL = backend port) but the
   // /league SSR pass is consistently slower than even a 5s proxy


### PR DESCRIPTION
The domain cutover landed a week ago — nginx, `robots.js`, `sitemap.js` all on chaseupside.com — but the **product rename never reached the UI**. The wordmark, page title, PWA manifest, service worker and export filenames all still said "Brisket".

## The trap this avoids

"Brisket" is **two different things** in this repo:

| | |
|---|---|
| the **product** name | renamed → "Chase Upside" |
| the **Sleeper league** name, `"Risk It To Get The Brisket"` | **untouched** |

A blanket find-and-replace would have broken data ingestion: `scripts/fetch_draftsharks.py` **matches that literal string in fetched HTML** to locate the league. Verified after the rename rather than assumed:

```
scripts/fetch_draftsharks.py     3 occurrences  ✓ intact
config/leagues/registry.json     1 occurrence   ✓ intact
frontend/app/league/page.jsx     1 occurrence   ✓ intact (names the league)
```

## What changed

**Renamed** — user-visible product identity: shell wordmark, `nav-model` page-title fallback, `layout.jsx` appleWebApp title, PWA manifest `name`/`short_name`, service-worker name + push titles, landing `<h1>`, screenshot and CSV export filenames, OpenGraph `siteName`, and `"Brisket League"` where it was acting as site branding.

**Kept** — the literal league name on `/league` public pages and in league OG images. Those pages are *about* that league; using its real name is correct.

**Kept** — test fixtures (`"Brisket Bros"`, `"Brisket Bidders"` team names, arbitrary `"brisket"` keyboard input in `Dialog.test.jsx`). Renaming those is churn with no user-visible effect.

## Two things found while doing this

**1. The PWA manifest still carried the old Vikings purple.** `theme_color: "#4F2185"`, `background_color: "#0f0a1a"`. R5 changes `layout.jsx`'s `themeColor` but **does not touch `manifest.js`** — so the PWA splash screen and Android URL bar would have stayed purple after the redesign shipped. Both now `#0b0d10`, matching R5's `layout.jsx` exactly.

**2. An e2e assertion pinned the old brand.** `critical-smoke.spec.js` used `/Brisket/i` on `/` as its render marker. Updated to `/Chase Upside/i`, and the product-vs-league distinction is now recorded in the comment so the next reader doesn't "fix" it back.

`CACHE_VERSION` bumped `brisket-v5` → `chaseupside-v6` — correct on an asset change, and it forces clients off the old cached shell.

## Verification

```
npx vitest run    63 files, 1219 tests passed
```

Sequencing note: this branches from `main`, so if **#582 (R5)** lands first there may be a trivial `layout.jsx` conflict — R5 touches `themeColor`, this touches `appleWebApp.title`, different lines.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_