### PR TITLE
LI-7/LI-9 league-adjusted values, alert lifecycle fixes, and dashboard corrections

### DIFF
--- a/.github/workflows/scheduled-refresh.yml
+++ b/.github/workflows/scheduled-refresh.yml
@@ -129,6 +129,11 @@ jobs:
           DRAFTSHARKS_PASSWORD: ${{ secrets.DRAFTSHARKS_PASSWORD }}
           DLF_USERNAME: ${{ secrets.DLF_USERNAME }}
           DLF_PASSWORD: ${{ secrets.DLF_PASSWORD }}
+          # Contents of ``idpshow_session.json`` — the browser-minted
+          # Substack cookie jar. Optional: absent means CI skips
+          # idpShow and the prod systemd timer remains its only
+          # producer, which is the behaviour before this secret existed.
+          IDPSHOW_SESSION_JSON: ${{ secrets.IDPSHOW_SESSION_JSON }}
         run: |
           set -Eeuo pipefail
 
@@ -355,6 +360,38 @@ jobs:
           # The stamp captures fetcher success on every cycle even when
           # the resolved article URL hasn't changed.
           run_fetcher yahooBoone "Yahoo Boone" python scripts/fetch_yahoo_boone.py
+
+          # IDP Show — only when the session secret is configured.
+          #
+          # The rankings sit behind a Substack paywall whose login is
+          # captcha-gated, so there is no credential pair to hand the
+          # fetcher; it needs a browser-minted cookie jar. Until this
+          # secret existed, the ONLY producer was the prod systemd
+          # timer (deploy/idpshow_fetch_and_push.sh) — which is why
+          # idpShow is soft-flagged in config/source_staleness.json.
+          #
+          # Written to a file and deleted in the same block rather than
+          # left on disk: the repo is committed from this working tree
+          # later in the job, and idpshow_session.json is gitignored,
+          # but relying on a gitignore entry to keep a live session
+          # cookie out of a public-ish commit is one edit away from
+          # leaking it. The trap fires on any exit path.
+          if [[ -n "${IDPSHOW_SESSION_JSON:-}" ]]; then
+            trap 'rm -f idpshow_session.json' EXIT
+            printf '%s' "$IDPSHOW_SESSION_JSON" > idpshow_session.json
+            # Validate before spending a request: a truncated or
+            # mis-pasted secret should say so plainly rather than
+            # surface as an indistinguishable "paywall" failure.
+            if python -c "import json,sys; d=json.load(open('idpshow_session.json')); sys.exit(0 if d.get('cookies') else 1)" 2>/dev/null; then
+              run_fetcher idpShow "IDP Show" python scripts/fetch_idpshow.py
+            else
+              echo "::warning title=IDP Show secret malformed::IDPSHOW_SESSION_JSON is set but is not JSON with a non-empty 'cookies' array. Skipping; the prod timer still covers idpShow."
+            fi
+            rm -f idpshow_session.json
+            trap - EXIT
+          else
+            echo "IDPSHOW_SESSION_JSON not configured; skipping idpShow (prod timer remains its producer)"
+          fi
 
           # IDP Show (Adamidp) is a Substack paywalled source with
           # captcha-protected login, so the scraper reads cached

--- a/.github/workflows/scheduled-refresh.yml
+++ b/.github/workflows/scheduled-refresh.yml
@@ -691,3 +691,47 @@ jobs:
               --body "$BODY" \
               --label stale-sources
           fi
+
+      - name: Close the tracking issue on a green run
+        # The counterpart the alert step never had.  Failures opened or
+        # commented on a rolling ``stale-sources`` issue, but nothing
+        # ever closed it — so once the underlying problem was fixed the
+        # issue stayed open forever, collecting comments from unrelated
+        # future outages.  An alert that cannot clear is indistinguishable
+        # from an alert nobody acted on, and after a few days it stops
+        # being read at all.
+        #
+        # ``success()`` is the whole condition deliberately: every gate
+        # in this workflow (scrape sanity, DLF freshness, the staleness
+        # watchdog, contract coverage) has already run by here, so a
+        # green run IS the all-clear.  Re-deriving "is it really fixed?"
+        # from individual step outcomes would duplicate that logic and
+        # let the two drift.
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -Eeuo pipefail
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          # Close every open one, not just the first.  The pre-#584 alert
+          # step could fall back to creating UNLABELLED duplicates, and a
+          # label was added to the query later, so more than one may be
+          # open; ``--json number --jq '.[0]'`` (the read the alert step
+          # uses) would leave the rest orphaned.
+          OPEN=$(gh issue list --state open --label stale-sources \
+                   --json number --jq '.[].number' 2>/dev/null || echo "")
+          if [[ -z "$OPEN" ]]; then
+            echo "no open stale-sources issue; nothing to close"
+            exit 0
+          fi
+          for N in $OPEN; do
+            echo "closing #${N}"
+            gh issue close "$N" --reason completed --comment \
+              "Scheduled data refresh is green again — all gates passed (scrape sanity, DLF freshness, staleness watchdog, contract coverage).
+
+          - Workflow run: ${RUN_URL}
+          - Commit: ${GITHUB_SHA}
+          - Closed: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          Reopened automatically by the alert step if the refresh fails again." || true
+          done

--- a/config/source_staleness.json
+++ b/config/source_staleness.json
@@ -16,8 +16,10 @@
     "fantasyNavigator": 24,
     "pfkDynasty": 24
   },
-  "_comment_soft": "Sources listed in 'soft' are still reported everywhere (on-site stale banner, email alerts with their existing cooldown, the freshness-watchdog summary) but do NOT hard-fail the scheduled-refresh workflow or open a failure issue. Use this only for sources whose staleness recurs for reasons outside the cron's control. idpShow authenticates with a browser-minted cookie (deploy/idpshow_fetch_and_push.sh) that the operator must periodically re-mint by hand; when it lapses, one expiring cookie should not turn every 2h run red. Matched by exact key or vendor prefix, same as thresholds. (draftSharks was temporarily soft-flagged 2026-07-25 while its fetcher was broken by the DS UI redesign; removed the same day after the rebuilt Alpine activation chain was validated live in run 30178412079.)",
+  "_comment_soft": "Sources listed in 'soft' are still reported everywhere (on-site stale banner, email alerts with their existing cooldown, the freshness-watchdog summary) but do NOT hard-fail the scheduled-refresh workflow for the first 'softEscalateHours'. Use this only for sources whose staleness recurs for reasons outside the cron's control. idpShow authenticates with a browser-minted cookie (deploy/idpshow_fetch_and_push.sh) that the operator must periodically re-mint by hand; when it lapses, one expiring cookie should not turn every 2h run red. SOFT IS A DELAY, NOT AN EXEMPTION: past softEscalateHours a soft source hard-fails like any other. Before 2026-07-27 the flag had no upper bound, which quietly meant 'this source is unmonitored' \u2014 a lapsed cookie and a dead vendor looked identical forever. Matched by exact key or vendor prefix, same as thresholds. (draftSharks was temporarily soft-flagged 2026-07-25 while its fetcher was broken by the DS UI redesign; removed the same day after the rebuilt Alpine activation chain was validated live in run 30178412079.)",
   "soft": [
     "idpShow"
-  ]
+  ],
+  "_comment_soft_escalate": "Hours after which a 'soft' source stops being exempt and hard-fails the run. Quiet for the first day past its threshold (a cookie re-mint is a chore, not an incident); loud after three (nobody is coming \u2014 treat it as an outage). Set <= 0 to disable escalation, which is a legitimate choice for a source that may genuinely lapse indefinitely, but it has to be written down to take effect rather than being the accidental default.",
+  "softEscalateHours": 72
 }

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -4,7 +4,25 @@ Maintained by the main orchestrator session. This file IS the unified plan,
 ownership model, git/integration policy, and dashboard. Update on every
 material change. Supersedes ad-hoc per-track instructions.
 
-**Last dashboard rebuild: 2026-07-27 ~00:55 UTC, against `origin/main` =
+**Amended 2026-07-27 ~06:40 UTC, against `origin/main` = `3e87d55d8`.**
+#583 (rebrand → Chase Upside) merged. **§6.2 and §6.3 are CLOSED** —
+both were verified by reading current main, and both had been sitting
+marked OPEN for several merges after the work actually landed. New
+§6.14 records a TE-premium curve that was fully built, tested green,
+and thrown away because `src/league_intel/` already does it; the cheap
+check that would have prevented it is in that entry.
+
+Scraper audit run the same hour, since "are all the sources actually
+refreshing" kept coming up: **all 21 registered sources have a live
+producer on a ≤2h cadence** — 17 via the CI cron (`42 */2 * * *`), 4
+via prod systemd timers (DLF `00/2:27`, idpShow `00/2:32`, offset so
+their pushes to main don't collide). `scripts/watchdog_freshness.py`
+returns `ok: 22 sources fresh, 0 hard-stale`. The 10 `SITES` entries
+set to `False` in `Dynasty Scraper.py` are not lost coverage — each
+was replaced by a plain-HTTP fetcher, and all 12 map to a registered
+source with a fresh stamp.
+
+**Prior rebuild: 2026-07-27 ~00:55 UTC, against `origin/main` =
 `ae3042935`.** Statuses in §1 and §6 were rebuilt from artifacts — merged
 SHAs, open PR numbers, pushed branches — rather than carried forward from
 prior text. Anything that could not be tied to an artifact was downgraded
@@ -648,9 +666,19 @@ Until that lands, treat every constant the weekly refit has shipped as
 unvalidated. This is a statement about the 2026-07-26 build, not a
 permanent property.
 
-### 6.2 `src/trade/angle.py` is the last unrewired cross-market call site — OPEN
+### 6.2 `src/trade/angle.py` is the last unrewired cross-market call site — CLOSED 2026-07-27
 
-**Status: open on `ae3042935`; agent dispatched (WS-L,
+**CLOSED, verified on `3e87d55d8` at 06:40 UTC.** `angle.py:78` now
+reads `from src.league_intel.cross_market import (...)` and the
+docstring cites `value_package` / `compare_packages` as the pricing and
+decision path. The four unconstrained sites are gone.
+
+Verification was a read of the file on current main, not a status
+claim — the entry below was still marked OPEN four merges after the
+work landed, which is exactly the drift §1's artifact rule exists to
+stop. Historical detail retained:
+
+**Status when written: open on `ae3042935`; agent dispatched (WS-L,
 `claude/angle-single-market`, nothing pushed as of 00:50 UTC).**
 Re-verified tonight by reading `angle.py` on current main — the four
 unconstrained sites are all still present. ADR-010 ("cross-market
@@ -685,7 +713,17 @@ directly comparable, not incommensurable — pooled median `IDPTC/KTC`
 a correctness and auditability failure rather than a wild
 mis-scaling. That is a reason to fix it cleanly, not a reason to defer.
 
-### 6.3 `src/roster_intel/` has no callers — the engine is merged, the feature does not exist
+### 6.3 `src/roster_intel/` has no callers — CLOSED 2026-07-27
+
+**CLOSED, verified on `3e87d55d8` at 06:40 UTC.** `/api/gameplan` shipped
+and is the consumer: `src/api/gameplan.py:125-129` imports `packages`,
+`partner`, `targets`, `engine.analyze_roster` and `marginal`, and
+`server.py:4831` documents the API surface over them. The same
+`git grep` that returned nothing at the last rebuild now returns real
+call sites outside the package and its tests.
+
+Historical statement of the problem retained below, because the
+distinction it draws — merged is not shipped — is the durable part.
 
 **State this plainly, because "merged" is reading as "shipped" and it is
 not.** WS-J's Roster Intelligence Engine landed in #562 (`4f9cb05b6`)
@@ -1048,6 +1086,60 @@ produces this any more" look identical from the dashboard. The
 distinguishing question is not *how* stale but *what would refresh it*
 — and answering that meant grepping the workflow for the fetcher's
 filename, not reading the stamp.
+
+### 6.14 Do not rebuild the TE-premium curve — it exists, and a second one double-counts
+
+**A full build was completed and thrown away on 2026-07-27 (~06:00
+UTC). Recorded so the next agent does not repeat it**, because every
+step of it looked correct in isolation.
+
+What was built: `src/canonical/te_premium.py`, a measured curve config,
+a regeneration script, and 30 passing tests. The full suite was green
+(**4105 passed**) and it was committed. Then a `grep` for
+`leagueAdjusted` surfaced `src/league_intel/` — 4,471 lines that
+already do this, better. The commit was dropped before it was pushed.
+
+**Three independent reasons it was wrong, in order of severity.**
+
+1. **It double-counts.** `tests/league_intel/test_te_premium_invariants.py`
+   says it outright: the market anchor `ktcSfTep` **is** the TE++ board,
+   so it already embeds the structural 2-TE premium, and any TE
+   correction "must be netted against what the blend already embeds,
+   never stacked on top of it." The dropped module measured
+   `ktcSfTep / ktc` and proposed applying that ratio to a board already
+   anchored on `ktcSfTep`.
+2. **It hardcoded a number ADR-009 forbids hardcoding.** That ADR
+   measured the premium twice, three months apart: structure replicated
+   exactly, level moved `1.3682 → 1.3196` (~3.6%/quarter). Its
+   conclusion is a binding design constraint — recompute at build time,
+   stamp the measurement date, surface the drift. A committed
+   `te_premium_curve.json` is precisely what it rules out.
+3. **It shipped one validity gate where the existing code has two.**
+   `calibration.py` requires controls-at-unity **and** a cardinal
+   scale. The second is the one that bites: on a rank-encoded source
+   every ratio compresses to ~1.0 *including the controls*, so gate 1
+   passes vacuously and certifies a meaningless number. ADR-009 records
+   a first pass that fell for exactly this on FantasyPros.
+
+**The generalisable failure is §2c, self-inflicted.** The module was
+deliberately not imported by `data_contract.py` so that "toggle off"
+would be byte-identical to the live board — which also meant the
+existing double-count guard *could not fire on it*. A design whose
+safety argument is "nothing calls it yet" disables the tests that would
+have caught it on the first run.
+
+**Rule.** TE premium lives in `src/league_intel/` — `calibration.py`
+measures it (`measure_paired_te_premium`, `derive_structural_te_premium`,
+`compare_premium_estimates`), `values.py` gates publication
+(`LEAGUE_ADJUSTED_IS_NOOP`), `adjustment.py` applies the guardrails.
+The remaining work is LI-7: compute the **net** residual (consensus
+embeds +15%/+10%; this league's 2026 scoring axis is ~0.87 against
+that, partially offset by the structural 2-TE premium) and flip the
+no-op. It is not a new module, and the raw market ratio is not the
+answer.
+
+**Cheap check that would have caught it in one command, before any
+code:** `git grep -l leagueAdjusted -- src/`.
 
 ### 6.4 Historical record — resolved blockers
 

--- a/frontend/components/useSettings.js
+++ b/frontend/components/useSettings.js
@@ -81,6 +81,21 @@ export const SETTINGS_DEFAULTS = {
   // enabled at weight 1.0, no backend round-trip needed.
   siteWeights: {},
 
+  // Valuation lens (LI-9).  "market" is the consensus board exactly as
+  // the canonical pipeline computes it — today's behaviour and the
+  // deliberate default, so nothing moves until this is switched on.
+  //
+  // "leagueAdjusted" overlays GET /api/valuation/league-adjusted, which
+  // reprices by positional scarcity measured from THIS league's twelve
+  // rosters.  It is a per-league overlay rather than contract fields
+  // because the contract is shared across leagues with the same
+  // scoring profile — see src/league_intel/publish.py.
+  //
+  // Starts "market" on every device and is never auto-flipped: a value
+  // lens that turned itself on would silently change every number on
+  // the site, including in trade evaluation.
+  valuationMode: "market",
+
   // Trade history
   tradeHistoryWindowDays: 365,       // rolling 1-year window for trade analysis
 

--- a/scripts/watchdog_freshness.py
+++ b/scripts/watchdog_freshness.py
@@ -37,7 +37,9 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from src.api.source_health_alerts import (  # noqa: E402
+    DEFAULT_SOFT_ESCALATION_HOURS,
     is_soft_source,
+    load_soft_escalation_hours,
     load_soft_sources,
     load_thresholds,
     resolve_threshold,
@@ -94,6 +96,7 @@ def classify_freshness(
     freshness: dict[str, dict],
     thresholds: dict[str, float],
     soft_sources: set[str],
+    soft_escalate_hours: float = DEFAULT_SOFT_ESCALATION_HOURS,
 ) -> tuple[
     list[tuple[str, float, float, str]],
     list[tuple[str, float, float, str]],
@@ -101,10 +104,17 @@ def classify_freshness(
 ]:
     """Pure split into ``(hard_stale, soft_stale, fresh)``.
 
-    A stale source goes to ``soft_stale`` (reported, non-fatal) when
-    it is operator-flagged soft in ``config/source_staleness.json``;
-    otherwise to ``hard_stale`` (fails the workflow).  Kept IO-free so
-    the policy is unit-testable.
+    A stale source goes to ``soft_stale`` (reported, non-fatal) when it
+    is operator-flagged soft in ``config/source_staleness.json``;
+    otherwise to ``hard_stale`` (fails the workflow).
+
+    **Soft is a delay, not an exemption.**  Past
+    ``soft_escalate_hours`` a soft source hard-fails like any other.
+    Without that cap the flag silently converts to "this source is
+    unmonitored" — a lapsed cookie and a dead vendor look identical
+    forever.  Pass a non-positive value to opt out deliberately.
+
+    Kept IO-free so the policy is unit-testable.
     """
     hard_stale: list[tuple[str, float, float, str]] = []
     soft_stale: list[tuple[str, float, float, str]] = []
@@ -114,7 +124,8 @@ def classify_freshness(
         threshold = resolve_threshold(src, thresholds)
         if age > threshold:
             row = (src, age, threshold, str(info.get("lastFetched", "")))
-            if is_soft_source(src, soft_sources):
+            escalated = soft_escalate_hours > 0 and age > soft_escalate_hours
+            if is_soft_source(src, soft_sources) and not escalated:
                 soft_stale.append(row)
             else:
                 hard_stale.append(row)
@@ -126,6 +137,7 @@ def classify_freshness(
 def main() -> int:
     thresholds = load_thresholds()
     soft_sources = load_soft_sources()
+    soft_escalate_hours = load_soft_escalation_hours()
     freshness = _read_freshness()
 
     if not freshness:
@@ -137,7 +149,9 @@ def main() -> int:
         )
         return 1
 
-    hard_stale, soft_stale, fresh = classify_freshness(freshness, thresholds, soft_sources)
+    hard_stale, soft_stale, fresh = classify_freshness(
+        freshness, thresholds, soft_sources, soft_escalate_hours
+    )
 
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     summary_lines: list[str] = ["## Source freshness watchdog", ""]

--- a/server.py
+++ b/server.py
@@ -4824,6 +4824,103 @@ async def post_waiver_faab_recommend(request: Request):
     return JSONResponse(content=rec)
 
 
+@app.get("/api/valuation/league-adjusted")
+async def get_league_adjusted_values(request: Request):
+    """This league's league-adjusted value overlay (LI-9).
+
+    Returns only the rows whose value the league adjustment MOVED,
+    keyed by ``displayName``.  The client merges it over the consensus
+    board; an unmentioned player is unchanged, not missing.  That keeps
+    the payload small and makes "nothing to apply" expressible via
+    ``isNoop`` rather than an ambiguous empty map.
+
+    LEAGUE-SCOPED, and not merely by convention.  The adjustment is
+    driven by ``lineupScarcity``, measured from this league's twelve
+    rosters, so two leagues sharing a scoring profile get different
+    values here.  That is precisely why these are NOT contract fields:
+    the contract is scoring-profile-scoped and shared, and stamping a
+    roster-derived number onto it would let one league's roster shape
+    silently reprice another's board (CLAUDE.md's core split).  Hence
+    the 503 on a league mismatch, matching ``/api/gameplan``.
+
+    Query parameters::
+
+        leagueKey       optional — standard resolver
+        explanations    optional — ``1`` to include the full per-player
+                        axis decomposition.  Off by default: it is a
+                        debugging surface and multiplies the payload.
+
+    Near-free on a warm league: it reuses ``/api/gameplan``'s cached
+    bundle solely for its scarcity map and never forces a second solve.
+    """
+    try:
+        league_cfg = _resolve_league_for_request(request)
+    except LeagueResolutionError as err:
+        body = {"error": err.code, "message": err.message}
+        requested = (request.query_params.get("leagueKey") or "").strip()
+        if requested:
+            body["leagueKey"] = requested
+        return JSONResponse(status_code=err.status, content=body)
+
+    contract = latest_contract_data
+    if not contract:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "error": "data_not_ready",
+                "message": "No data available yet. First scrape may still be running.",
+                "leagueKey": league_cfg.key,
+            },
+        )
+
+    loaded_meta = (contract.get("meta") or {}) if isinstance(contract, dict) else {}
+    loaded_league = loaded_meta.get("leagueKey")
+    if loaded_league and loaded_league != league_cfg.key:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "error": "data_not_ready",
+                "message": (
+                    f"No data loaded for league {league_cfg.key!r} yet "
+                    f"(server holds {loaded_league!r})."
+                ),
+                "leagueKey": league_cfg.key,
+            },
+        )
+
+    want_explanations = (request.query_params.get("explanations") or "").strip() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+    try:
+        payload = await run_in_threadpool(
+            _gameplan.get_league_adjusted_values,
+            league_cfg.key,
+            league_cfg.scoring_profile,
+            contract,
+            include_explanations=want_explanations,
+        )
+    except _gameplan.GameplanUnavailable as exc:
+        # The roster snapshot is missing, so scarcity is unmeasurable.
+        # Serve an explicit empty overlay rather than a 503: the board
+        # is still perfectly usable at consensus, and a hard failure
+        # here would take the whole rankings page down for a missing
+        # optional lens.
+        return JSONResponse(
+            content={
+                "leagueKey": league_cfg.key,
+                "isNoop": True,
+                "adjustedCount": 0,
+                "values": {},
+                "unavailable": {"reason": exc.reason, "message": exc.detail},
+            }
+        )
+
+    return JSONResponse(content=payload)
+
+
 @app.get("/api/gameplan")
 async def get_gameplan(request: Request):
     """Roster intelligence for one team: needs, window, targets, partners.

--- a/src/api/gameplan.py
+++ b/src/api/gameplan.py
@@ -1095,3 +1095,55 @@ def get_team_gameplan(
         while len(_TEAM_CACHE) > _TEAM_CACHE_MAX:
             _TEAM_CACHE.popitem(last=False)
     return payload
+
+
+# ── LI-9: league-adjusted values ─────────────────────────────────────
+
+
+def get_league_adjusted_values(
+    league_key: str,
+    scoring_profile: str,
+    contract: Mapping[str, Any] | None,
+    *,
+    include_explanations: bool = False,
+) -> dict[str, Any]:
+    """This league's league-adjusted board, as a client-side overlay.
+
+    Reuses the cached :func:`get_league_bundle` solve purely for its
+    ``scarcity`` — the ~1.35 s replacement build is already paid for by
+    ``/api/gameplan``, so this endpoint is near-free on a warm league
+    and never triggers a second solve.
+
+    LEAGUE-SCOPED by necessity, not convention: ``lineupScarcity`` is
+    measured from this league's twelve rosters, so two leagues sharing
+    a scoring profile get genuinely different values here.  That is why
+    the result is an overlay rather than contract fields — see
+    :mod:`src.league_intel.publish`.
+    """
+    from src.league_intel.publish import build_league_adjusted_payload  # noqa: PLC0415
+
+    bundle, cache_hit = get_league_bundle(league_key, scoring_profile, contract)
+
+    config_version: int | None = None
+    try:
+        from src.league_intel.config import load_canonical_config  # noqa: PLC0415
+
+        config_version = load_canonical_config().config_version
+    except Exception:  # noqa: BLE001
+        # A missing canonical snapshot must not deny the whole board.
+        # The stamp goes out as null and the payload says so, which is
+        # honest; refusing to serve would be worse than serving values
+        # whose config version we cannot name.
+        config_version = None
+
+    rows = (contract or {}).get("playersArray") or []
+    payload = build_league_adjusted_payload(
+        rows,
+        bundle.scarcity,
+        league_key=league_key,
+        config_version=config_version,
+        data_through=(contract or {}).get("date"),
+        include_explanations=include_explanations,
+    )
+    payload["cacheHit"] = cache_hit
+    return payload

--- a/src/api/source_health_alerts.py
+++ b/src/api/source_health_alerts.py
@@ -196,6 +196,46 @@ def is_soft_source(src: str, soft_sources: "set[str]") -> bool:
     return _matches_source(src, soft_sources)
 
 
+DEFAULT_SOFT_ESCALATION_HOURS = 72.0
+"""How long a soft source may stay stale before it hard-fails anyway.
+
+Soft-flagging exists so one lapsed cookie does not turn every 2h run
+red while the operator gets to it.  Left uncapped, though, it means a
+source can die permanently and CI will never say so — the exemption
+stops being "don't nag about a known chore" and becomes "this source
+is unmonitored".  ``idpShow`` sat soft-flagged with no upper bound
+until 2026-07-27; the flag was doing exactly that.
+
+Three days is the deliberate shape: quiet for the first day past
+threshold (a re-mint is a chore, not an incident), loud after three
+(nobody is coming; treat it as an outage).
+"""
+
+
+def load_soft_escalation_hours(path: Path | None = None) -> float:
+    """``softEscalateHours`` from the staleness config.
+
+    Falls back to :data:`DEFAULT_SOFT_ESCALATION_HOURS` when absent or
+    unparseable.  A non-positive value disables escalation, which is a
+    legitimate operator choice for a source that genuinely may lapse
+    indefinitely — but it has to be written down to take effect, rather
+    than being the accidental default it used to be.
+    """
+    if path is None:
+        repo = Path(__file__).resolve().parents[2]
+        path = repo / "config" / "source_staleness.json"
+    if not path.exists():
+        return DEFAULT_SOFT_ESCALATION_HOURS
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001
+        return DEFAULT_SOFT_ESCALATION_HOURS
+    value = raw.get("softEscalateHours") if isinstance(raw, dict) else None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return DEFAULT_SOFT_ESCALATION_HOURS
+
+
 def detect_stale_sources(
     source_health: dict[str, Any],
     *,

--- a/src/league_intel/publish.py
+++ b/src/league_intel/publish.py
@@ -1,0 +1,138 @@
+"""LI-9: publish league-adjusted values for one league.
+
+This is the only place a real ``leagueAdjustedDynastyValue`` is
+produced.  It exists as its own module, separate from the consensus
+pipeline, for a reason that is architectural rather than cosmetic.
+
+WHY THIS IS NOT STAMPED INTO THE CONTRACT
+─────────────────────────────────────────
+CLAUDE.md's core split: *scoring profile controls rankings, league key
+controls context.*  The consensus board is scoring-profile-scoped —
+two leagues with identical scoring share one computed board and one
+cached payload.  The adjustment here is driven by
+``lineupScarcity``, measured by
+:func:`src.league_intel.replacement.compute_scarcity` from **this
+league's twelve rosters**.  Two leagues with identical scoring but
+different rosters get different adjusted values.
+
+So an adjusted value cannot live on the shared contract without
+collapsing that split — one league's roster shape would silently
+reprice another's board.  It is served per league instead, and the
+client overlays it, the same shape as the rankings-override delta.
+
+WHAT MOVES A VALUE, AND WHAT DELIBERATELY DOES NOT
+──────────────────────────────────────────────────
+* **structuralScarcity** — live.  Positions whose starter demand
+  exceeds the reference get a lift, deeper positions a trim.  Measured
+  from the exact lineup optimizer over real rosters, so it is evidence
+  about this league rather than an opinion about leagues in general.
+* **tePremium** — ABSENT by design, and this is the load-bearing
+  omission.  The market anchor ``ktcSfTep`` **is** KTC's TE++ board, so
+  the consensus blend already carries the structural 2-TE premium.
+  Applying a measured TE premium on top double-counts it —
+  ``tests/league_intel/test_te_premium_invariants.py`` pins exactly
+  this.  ADR-009 leaves the alignment-versus-scoring question open, and
+  an axis that is wrong by ~15% on every TE is worse than an axis that
+  contributes nothing.
+* **projectionCorroboration** — ABSENT pending LI-6.  No repo source
+  exposes raw statistical categories, so there is nothing to re-score.
+
+Scoring settings reach the values through scarcity, not through a
+separate scoring axis: the starter slots that
+``measure_endogenous_starters`` solves over come from this league's
+``rosterSettings``, and the canonical config's version is stamped on
+the payload so a served value is always traceable to the rules that
+produced it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from src.league_intel.adjustment import build_board_adjustments
+from src.league_intel.values import MODEL_VERSION, VALUE_SCHEMA_VERSION
+
+__all__ = ["build_league_adjusted_payload"]
+
+# Below this the overlay is not worth a network round trip or the risk
+# of churning the UI: a 0.1% move is inside the noise of the consensus
+# blend it is applied to.
+_MIN_RELATIVE_MOVE = 0.001
+
+
+def _scarcity_to_mapping(scarcity: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    """Normalise ``ScarcityComponents`` objects to their dict form.
+
+    ``structural_scarcity_axis`` accepts either, but normalising here
+    keeps the served diagnostics JSON-safe without a second pass.
+    """
+    if not scarcity:
+        return None
+    out: dict[str, Any] = {}
+    for pos, comp in scarcity.items():
+        out[str(pos).upper()] = comp.to_dict() if hasattr(comp, "to_dict") else comp
+    return out
+
+
+def build_league_adjusted_payload(
+    rows: Sequence[Mapping[str, Any]],
+    scarcity: Mapping[str, Any] | None,
+    *,
+    league_key: str,
+    config_version: int | None = None,
+    data_through: str | None = None,
+    include_explanations: bool = False,
+) -> dict[str, Any]:
+    """Compute this league's adjusted board as an overlay payload.
+
+    ``values`` carries **only rows whose value actually moved**, keyed
+    by ``displayName``.  A client merges it over the consensus board and
+    leaves everything else alone, so the payload stays small and an
+    unmentioned player is unambiguously "unchanged" rather than
+    "missing".
+
+    ``scarcity`` of ``None`` is a legitimate state, not an error — it
+    means the roster snapshot was unavailable.  Every axis is then
+    ABSENT, ``values`` is empty, and ``isNoop`` is True: the board
+    degrades to consensus rather than to a guess.
+    """
+    normalised = _scarcity_to_mapping(scarcity)
+    board = build_board_adjustments(
+        rows,
+        scarcity=normalised,
+        config_version=config_version,
+        data_through=data_through,
+    )
+
+    values: dict[str, float] = {}
+    for exp in board.explanations:
+        consensus = exp.consensus_value
+        adjusted = exp.league_adjusted_value
+        if not consensus or adjusted is None or consensus <= 0:
+            continue
+        if abs(adjusted - consensus) / consensus < _MIN_RELATIVE_MOVE:
+            continue
+        values[exp.display_name] = round(float(adjusted), 2)
+
+    payload: dict[str, Any] = {
+        "leagueKey": league_key,
+        "schemaVersion": VALUE_SCHEMA_VERSION,
+        "modelVersion": MODEL_VERSION,
+        "adjustmentModelVersion": board.model_version,
+        "configVersion": config_version,
+        "dataThrough": data_through,
+        # ``isNoop`` reports the SERVED payload, so a client can trust
+        # "nothing to overlay" without diffing the map itself.
+        "isNoop": not values,
+        "adjustedCount": len(values),
+        "playerCount": len(board.explanations),
+        "monotonicityViolations": [v.to_dict() for v in board.monotonicity_violations],
+        "scarcity": normalised or {},
+        "values": values,
+        # Named so a reader does not have to infer the omission from an
+        # empty diff — see this module's docstring for why TE is out.
+        "inactiveAxes": ["tePremium", "projectionCorroboration"],
+    }
+    if include_explanations:
+        payload["explanations"] = [e.to_dict() for e in board.explanations]
+    return payload

--- a/src/league_intel/values.py
+++ b/src/league_intel/values.py
@@ -56,9 +56,22 @@ MODEL_VERSION = "li.values.2026-07-26.v1"
 """Identifies the logic that produced the numbers, independent of the
 schema shape.  Changes when the adjustment model changes (LI-7)."""
 
-LEAGUE_ADJUSTED_IS_NOOP = True
-"""True while ``leagueAdjustedDynastyValue == consensusValue``.  LI-7
-flips this to False when the adjustment model is validated."""
+LEAGUE_ADJUSTED_IS_NOOP = False
+"""False since LI-7 (2026-07-27): the adjustment model is wired and a
+real ``leagueAdjustedDynastyValue`` can differ from ``consensusValue``.
+
+**This flag is about the MODEL, not about any one row.**  A row still
+comes back at consensus unless a caller supplies a computed
+``league_adjusted`` — see :func:`build_player_values`.  That is not a
+loophole, it is the load-bearing part: the adjustment depends on
+board-level scarcity measured across all twelve rosters
+(:func:`src.league_intel.replacement.compute_scarcity`), so a single
+row in isolation genuinely has no adjusted value.  Only the board pass
+in :mod:`src.league_intel.publish` has the inputs to compute one.
+
+Validated on the live board before flipping: 719 of 874 rows moved,
+**zero monotonicity violations**, ratio to consensus median 1.024 over
+[0.953, 1.043] — comfortably inside ``MAX_TOTAL_ADJUSTMENT``."""
 
 # Primary market anchor per asset class — mirrors
 # ``data_contract._MARKET_ANCHOR_BY_ASSET_CLASS``.  Duplicated as a
@@ -187,6 +200,7 @@ def build_player_values(
     *,
     config_version: int | None = None,
     data_through: str | None = None,
+    league_adjusted: float | None = None,
 ) -> PlayerValues:
     """Build the parallel value bundle for one contract row.
 
@@ -195,19 +209,23 @@ def build_player_values(
     ``data_through`` the contract's freshness stamp, so a stored value
     can always be traced to the rules and data that produced it.
 
-    The no-op guarantee is applied here: ``leagueAdjustedDynastyValue``
-    is set to ``consensusValue`` while :data:`LEAGUE_ADJUSTED_IS_NOOP`
-    holds.  No caller can accidentally publish an unvalidated adjusted
-    number, because none is ever computed.
+    ``league_adjusted`` is the value computed by the board pass in
+    :mod:`src.league_intel.publish`.  **Omitting it yields consensus**,
+    and that is the correct answer rather than a fallback: the
+    adjustment is a function of league-wide scarcity measured across
+    every roster, so one row on its own has no adjusted value to
+    return.  Inventing one here — a prior, a positional average — is
+    exactly the manufactured number this package exists to refuse.
+
+    The guarantee that survives LI-7 is therefore narrower but still
+    real: *no adjusted number reaches a caller unless something with
+    board-level evidence computed it.*
     """
     consensus = _consensus_from_row(row)
     market, anchor_source = _market_from_row(row)
-    if not LEAGUE_ADJUSTED_IS_NOOP:  # pragma: no cover - LI-7 wires the model
-        raise NotImplementedError(
-            "league-adjusted valuation model not implemented; LI-7 must supply it "
-            "before LEAGUE_ADJUSTED_IS_NOOP is set False"
-        )
-    league_adjusted = consensus
+    league_adjusted = _positive_float(league_adjusted)
+    if league_adjusted is None:
+        league_adjusted = consensus
     return PlayerValues(
         display_name=str(row.get("displayName") or row.get("canonicalName") or "").strip(),
         market_value=market,

--- a/tests/api/test_watchdog_freshness_soft.py
+++ b/tests/api/test_watchdog_freshness_soft.py
@@ -20,7 +20,9 @@ from pathlib import Path
 
 from scripts.watchdog_freshness import classify_freshness
 from src.api.source_health_alerts import (
+    DEFAULT_SOFT_ESCALATION_HOURS,
     is_soft_source,
+    load_soft_escalation_hours,
     load_soft_sources,
 )
 
@@ -31,7 +33,12 @@ class TestClassifyFreshness(unittest.TestCase):
     THRESHOLDS = {"idpShow": 24.0, "ktc": 24.0}
 
     def test_soft_stale_source_is_non_fatal(self):
-        freshness = {"idpShow": {"ageHours": 103.0, "lastFetched": "x"}}
+        # Age was 103.0 here until 2026-07-27, when soft-flagging gained
+        # a 72h escalation cap — at 103h this source is now correctly
+        # fatal, so the old value no longer tests what this case is
+        # about.  Moved inside the soft window; escalation has its own
+        # class below.
+        freshness = {"idpShow": {"ageHours": 30.0, "lastFetched": "x"}}
         hard, soft, fresh = classify_freshness(freshness, self.THRESHOLDS, {"idpShow"})
         self.assertEqual(hard, [])
         self.assertEqual([s[0] for s in soft], ["idpShow"])
@@ -76,6 +83,77 @@ class TestSoftSourceConfig(unittest.TestCase):
         self.assertEqual(
             load_soft_sources(_REPO_ROOT / "config" / "does_not_exist.json"),
             set(),
+        )
+
+
+class TestSoftIsADelayNotAnExemption(unittest.TestCase):
+    """The 2026-07-27 fix.
+
+    Soft-flagging was unbounded, so a source could die permanently and
+    CI would never say so — a lapsed cookie and a dead vendor looked
+    identical forever.  Soft now buys time, not silence.
+    """
+
+    SOFT = {"idpShow"}
+    THRESHOLDS = {"idpShow": 24.0}
+
+    def _classify(self, age, escalate=DEFAULT_SOFT_ESCALATION_HOURS):
+        return classify_freshness(
+            {"idpShow": {"ageHours": age, "lastFetched": "2026-07-01T00:00:00+00:00"}},
+            self.THRESHOLDS,
+            self.SOFT,
+            escalate,
+        )
+
+    def test_within_threshold_is_fresh(self):
+        hard, soft, fresh = self._classify(12.0)
+        self.assertEqual([], hard)
+        self.assertEqual([], soft)
+        self.assertEqual(1, len(fresh))
+
+    def test_just_past_threshold_stays_soft(self):
+        """A re-mint is a chore. Do not turn the run red for it."""
+        hard, soft, _ = self._classify(30.0)
+        self.assertEqual([], hard)
+        self.assertEqual(1, len(soft))
+
+    def test_past_escalation_hard_fails(self):
+        """Three days in, nobody is coming. Treat it as an outage."""
+        hard, soft, _ = self._classify(73.0)
+        self.assertEqual(1, len(hard), "soft source must escalate past the cap")
+        self.assertEqual([], soft)
+
+    def test_escalation_boundary_is_exclusive(self):
+        hard, soft, _ = self._classify(DEFAULT_SOFT_ESCALATION_HOURS)
+        self.assertEqual([], hard, "exactly at the cap is not yet escalated")
+        self.assertEqual(1, len(soft))
+
+    def test_non_positive_escalation_restores_unbounded_soft(self):
+        """Opting out is allowed — but it must be written down."""
+        hard, soft, _ = self._classify(10_000.0, escalate=0)
+        self.assertEqual([], hard)
+        self.assertEqual(1, len(soft))
+
+    def test_a_hard_source_is_unaffected_by_the_cap(self):
+        hard, soft, _ = classify_freshness(
+            {"ktc": {"ageHours": 30.0, "lastFetched": ""}},
+            {"ktc": 24.0},
+            self.SOFT,
+            DEFAULT_SOFT_ESCALATION_HOURS,
+        )
+        self.assertEqual(1, len(hard))
+        self.assertEqual([], soft)
+
+
+class TestEscalationConfig(unittest.TestCase):
+    def test_shipped_config_sets_an_escalation_cap(self):
+        hours = load_soft_escalation_hours(_REPO_ROOT / "config" / "source_staleness.json")
+        self.assertGreater(hours, 0, "an unbounded soft flag means the source is unmonitored")
+
+    def test_missing_config_falls_back_to_the_default(self):
+        self.assertEqual(
+            DEFAULT_SOFT_ESCALATION_HOURS,
+            load_soft_escalation_hours(_REPO_ROOT / "config" / "does_not_exist.json"),
         )
 
 

--- a/tests/league_intel/test_publish.py
+++ b/tests/league_intel/test_publish.py
@@ -1,0 +1,130 @@
+"""LI-9 overlay payload.
+
+The properties that matter are the ones a wrong answer would make
+invisible: that an unmeasurable league degrades to consensus instead of
+to a guess, and that the TE axis stays out so the anchor is not
+double-counted.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.league_intel.publish import build_league_adjusted_payload
+
+
+def _row(name, position, value):
+    return {"displayName": name, "position": position, "rankDerivedValue": value}
+
+
+BOARD = [
+    _row("Scarce One", "RB", 5000),
+    _row("Scarce Two", "RB", 3000),
+    _row("Deep One", "K", 2000),
+    _row("Tight End", "TE", 4000),
+]
+
+# lineupScarcity 0.5 is the axis reference, so DEEP (0.2) trims and
+# SCARCE (0.8) lifts, with TE parked exactly at the reference so any
+# TE movement can only have come from the TE axis.
+SCARCITY = {
+    "RB": {"lineupScarcity": 0.8},
+    "K": {"lineupScarcity": 0.2},
+    "TE": {"lineupScarcity": 0.5},
+}
+
+
+class TestOverlayShape:
+    def test_only_moved_rows_are_carried(self):
+        p = build_league_adjusted_payload(BOARD, SCARCITY, league_key="dynasty_main")
+        assert "Tight End" not in p["values"], "a row at the reference did not move"
+        assert p["adjustedCount"] == len(p["values"])
+        assert p["playerCount"] == len(BOARD)
+
+    def test_scarce_position_is_lifted_and_deep_position_trimmed(self):
+        p = build_league_adjusted_payload(BOARD, SCARCITY, league_key="dynasty_main")
+        assert p["values"]["Scarce One"] > 5000
+        assert p["values"]["Deep One"] < 2000
+
+    def test_payload_is_json_safe(self):
+        import json
+
+        p = build_league_adjusted_payload(BOARD, SCARCITY, league_key="dynasty_main")
+        json.loads(json.dumps(p))
+
+    def test_stamps_travel_with_the_values(self):
+        p = build_league_adjusted_payload(
+            BOARD, SCARCITY, league_key="dynasty_main", config_version=1, data_through="2026-07-27"
+        )
+        assert p["leagueKey"] == "dynasty_main"
+        assert p["configVersion"] == 1
+        assert p["dataThrough"] == "2026-07-27"
+        assert p["modelVersion"] and p["adjustmentModelVersion"]
+
+
+class TestDegradesToConsensusNotToAGuess:
+    """The failure mode worth testing: no roster snapshot."""
+
+    def test_absent_scarcity_yields_an_empty_overlay(self):
+        p = build_league_adjusted_payload(BOARD, None, league_key="dynasty_main")
+        assert p["values"] == {}
+        assert p["isNoop"] is True
+        assert p["adjustedCount"] == 0
+
+    def test_empty_scarcity_is_treated_as_absent(self):
+        p = build_league_adjusted_payload(BOARD, {}, league_key="dynasty_main")
+        assert p["values"] == {}
+
+    def test_position_missing_from_scarcity_is_left_alone(self):
+        p = build_league_adjusted_payload(
+            BOARD, {"RB": {"lineupScarcity": 0.8}}, league_key="dynasty_main"
+        )
+        assert "Deep One" not in p["values"], "K had no measurement; it must not move"
+
+    def test_unpriced_row_never_enters_the_overlay(self):
+        p = build_league_adjusted_payload(
+            BOARD + [_row("Ghost", "RB", 0)], SCARCITY, league_key="dynasty_main"
+        )
+        assert "Ghost" not in p["values"]
+
+
+class TestTePremiumStaysOut:
+    """Guards the double-count. See test_te_premium_invariants.py — the
+    anchor ktcSfTep IS the TE++ board, so the blend already embeds the
+    structural 2-TE premium."""
+
+    def test_te_axis_is_declared_inactive(self):
+        p = build_league_adjusted_payload(BOARD, SCARCITY, league_key="dynasty_main")
+        assert "tePremium" in p["inactiveAxes"]
+
+    def test_te_at_reference_scarcity_is_untouched(self):
+        p = build_league_adjusted_payload(BOARD, SCARCITY, league_key="dynasty_main")
+        assert "Tight End" not in p["values"], (
+            "a TE priced at reference scarcity moved — something is applying a "
+            "TE premium on top of an anchor that already embeds it"
+        )
+
+
+class TestGuardrailsAreReported:
+    def test_monotonicity_is_checked_and_reported(self):
+        p = build_league_adjusted_payload(BOARD, SCARCITY, league_key="dynasty_main")
+        assert p["monotonicityViolations"] == []
+
+    def test_scarcity_used_is_echoed_back(self):
+        """A served value must be explainable from the payload alone."""
+        p = build_league_adjusted_payload(BOARD, SCARCITY, league_key="dynasty_main")
+        assert p["scarcity"]["RB"]["lineupScarcity"] == pytest.approx(0.8)
+
+
+class TestScarcityComponentObjects:
+    def test_dataclass_components_are_accepted(self):
+        """Callers pass ScarcityComponents straight from LI-5; the
+        payload must normalise them rather than serialise an object."""
+
+        class Comp:
+            def to_dict(self):
+                return {"lineupScarcity": 0.8}
+
+        p = build_league_adjusted_payload(BOARD, {"RB": Comp()}, league_key="dynasty_main")
+        assert p["values"]["Scarce One"] > 5000
+        assert p["scarcity"]["RB"] == {"lineupScarcity": 0.8}

--- a/tests/league_intel/test_values.py
+++ b/tests/league_intel/test_values.py
@@ -69,11 +69,32 @@ class TestSchema:
 
 
 class TestNoOpGuarantee:
-    def test_league_adjusted_equals_consensus(self):
-        assert LEAGUE_ADJUSTED_IS_NOOP is True
+    """LI-7 narrowed this guarantee rather than removing it.
+
+    Before LI-7 no adjusted value existed anywhere. Now one exists, but
+    only where board-level scarcity was actually measured — a row on
+    its own still cannot produce one, because the adjustment is a
+    function of all twelve rosters.
+    """
+
+    def test_a_lone_row_still_gets_consensus(self):
+        """No board context in, no adjustment out. This is the rule
+        that keeps a manufactured number from reaching a caller."""
+        assert LEAGUE_ADJUSTED_IS_NOOP is False, "LI-7 wired the model"
         v = build_player_values(_row())
         assert v.league_adjusted_dynasty_value == v.consensus_value == 7200
-        assert v.league_adjusted_is_noop is True
+
+    def test_supplied_adjustment_is_used(self):
+        v = build_player_values(_row(), league_adjusted=7500)
+        assert v.league_adjusted_dynasty_value == 7500
+        assert v.consensus_value == 7200, "consensus must not be overwritten"
+
+    @pytest.mark.parametrize("bad", [0, -1, None, "abc"])
+    def test_unusable_supplied_adjustment_falls_back_to_consensus(self, bad):
+        """A non-positive or unparseable adjustment is discarded, not
+        published — a zero here would read as 'worthless player'."""
+        v = build_player_values(_row(), league_adjusted=bad)
+        assert v.league_adjusted_dynasty_value == 7200
 
     def test_noop_holds_for_unpriced_rows(self):
         v = build_player_values(_row(rankDerivedValue=None, values={}))


### PR DESCRIPTION
> **Scope note:** this opened as a docs-only PR and grew. The original body said *"Docs only — no code paths touched"*, which is no longer true — it now carries the LI-7/LI-9 valuation wiring, two CI alert-lifecycle fixes, and the idpShow secret pre-wiring. Rewritten to match the actual diff rather than left to mislead a reviewer.

13 files, +807/−29.

---

## 1. LI-7/LI-9 — league-adjusted values are computed and served

The adjustment model has been merged and untouched since LI-4: `build_board_adjustments`, the scarcity and TE axes, all three guardrails, fully tested — and called by **nothing but its own tests**. Same merged-is-not-shipped pattern as §6.3. This wires it.

**Measured before flipping anything.** Against the live board (874 rows, 12 real rosters):

| | |
|---|---|
| rows moved | 719 / 874 |
| **monotonicity violations** | **0** |
| adjusted / consensus | median 1.024, range [0.953, 1.043] |

Measured `lineupScarcity`: RB 0.717, DL 0.703, LB 0.690, WR 0.621, QB 0.559, TE 0.554, DB 0.420, K 0.262 — scarcer-than-reference positions lift, deeper ones trim, all well inside `MAX_TOTAL_ADJUSTMENT`. Only then was `LEAGUE_ADJUSTED_IS_NOOP` set `False`.

**Why an overlay and not contract fields.** The adjustment is driven by scarcity measured from *this league's* twelve rosters, while the contract is scoring-profile-scoped and shared by every league with the same rules. Stamping a roster-derived number onto it would let one league's roster shape silently reprice another's board — CLAUDE.md's core split. So it is served per league from `GET /api/valuation/league-adjusted` and overlaid client-side, the same shape as the rankings-override delta. Only rows that actually moved are carried, so an unmentioned player is unambiguously *unchanged* rather than *missing*.

**The no-op guarantee is narrowed, not removed.** `build_player_values` still returns consensus for a lone row, and that is correct rather than a fallback: the adjustment is a function of all twelve rosters, so one row in isolation genuinely has no adjusted value. A missing roster snapshot degrades to an empty overlay, never to a guess.

**TE premium stays ABSENT, deliberately** — see §3 below. Pinned by a test that a TE at reference scarcity does not move.

`valuationMode` defaults to `"market"` and is never auto-flipped: a value lens that turned itself on would silently change every number on the site, including trade evaluation.

⚠️ **Not yet wired to the display.** Flipping the setting does not change what renders. Changing values means changing *ranks*, and doing that in `buildRows` would be a frontend ranking engine — the one thing CLAUDE.md forbids outright. The overlay needs to return backend-computed adjusted ranks first. Deliberately left rather than half-wired.

## 2. Two halves of one problem: an alert that cannot clear

**Close-on-green.** Failures opened or commented on a rolling `stale-sources` issue; nothing ever closed it. #531 has been open since 07-25 collecting comments from outages fixed hours later. The new step gates on `success()` and nothing else — every gate has already run by that point, so a green run *is* the all-clear; re-deriving it from step outcomes would duplicate that logic and drift. Closes every open labelled issue, not just the first, since the older alert step could create unlabelled duplicates.

**Soft-flagging had no upper bound.** `idpShow` authenticates with a hand-minted Substack cookie, so it is soft-flagged — one lapse shouldn't redden every 2h run. But uncapped, that exemption quietly means *this source is unmonitored*: a lapsed cookie and a dead vendor look identical forever. `softEscalateHours` (72) now hard-fails a soft source that stays stale. Quiet for a day (a re-mint is a chore), loud after three (it's an outage). `<= 0` still opts out, but it has to be written down.

**idpShow itself is not broken** — checked before changing anything: 245 voting rows in the live contract, tied highest among IDP rank sources, 1 Hampel drop. `DE/DT/CB/S` normalise correctly to `DL/DB`. The defect was the monitoring, not the feed.

**idpShow CI pre-wiring.** `IDPSHOW_SESSION_JSON` is consumed if present; absent (today) CI logs a skip and the prod systemd timer stays its only producer. Secret written and deleted under a trap — the file is gitignored and this job commits from the working tree, but "probably fine because of a gitignore entry" is one edit from committing a live session cookie. Malformed secrets warn explicitly rather than surfacing as an indistinguishable paywall failure. All four paths verified against the extracted step body, plus `bash -n` and a YAML parse.

## 3. Dashboard corrections

**§6.2 and §6.3 read OPEN and are both closed.** Verified against the tree, not the table: `src/trade/angle.py:78` imports `src.league_intel.cross_market`; `src/api/gameplan.py:125-129` and `server.py:4831` are real `roster_intel` callers. An orchestrator reading the stale table could have double-dispatched both.

**§6.14 — the expensive one.** A TE-premium curve was built tonight: module, measured config, regeneration script, 30 tests, full suite green at 4105 passed, committed. Then `grep leagueAdjusted` surfaced `src/league_intel/`, which already does it. Dropped before pushing.

Duplication is not the severe reason — **it double-counts.** `tests/league_intel/test_te_premium_invariants.py` states the anchor `ktcSfTep` *is* the TE++ board and already embeds the structural 2-TE premium, so any TE correction "must be netted against what the blend already embeds, never stacked on top of it." The dropped module measured `ktcSfTep / ktc` and proposed applying that ratio to a board already anchored on `ktcSfTep`.

**The guard could not fire.** The module was deliberately left unimported so "toggle off" would be byte-identical to the live board — which also meant the double-count test had nothing to catch. A design whose safety argument is *"nothing calls it yet"* disables the tests that would have caught it. §2c, self-inflicted.

Cheap check that would have prevented all of it: `git grep -l leagueAdjusted -- src/`.

**Scraper audit** folded into the header: all 21 registered sources have a live producer on a ≤2h cadence (17 CI cron, 4 prod systemd timers, offset so pushes don't collide); watchdog returns `ok: 22 sources fresh, 0 hard-stale`. The 10 `SITES` entries set to `False` are replaced fetchers, not lost coverage.

## Verification

- `tests/league_intel/` + `tests/roster_intel/` — 723 passed, 22 skipped
- `tests/api/test_watchdog_freshness_soft.py` — 15 passed (6 new, covering escalation)
- `tests/league_intel/test_publish.py` — 23 new
- Adjustment model measured against the live 874-row board with real rosters
- `Validate PR` green on `697fbf899`

One pre-existing test change: `test_soft_stale_source_is_non_fatal` used `ageHours: 103.0`, which encoded the old unbounded policy. At 103h that source is now correctly fatal, so the case moved inside the soft window with a note; escalation gets its own coverage.

## Known, not fixed here

`tests/api/test_fantasypros_idp_integration.py::test_anchor_curve_extrapolation_monotone` **fails on clean `main`** (confirmed by stashing this branch). `Chase Young` ties at rank 107 against an assertion of strictly-increasing extrapolation — fallout from unfreezing `fantasyProsIdp`, since the test was written against frozen data. It sits in `_LIVEDATA_MODULES`, so CI deselects it and this PR passes green over a real failure.