### PR TITLE
LI-9: the valuation toggle works — one ranker, an overlay that composes, three controls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -354,6 +354,52 @@ Registry lockstep:
 
 **Fail-fast on missing stamps**: The prior `computeUnifiedRanks` fallback (~280 lines of coverage-aware blend code) has been **removed**. `buildRows` now fails fast when a non-empty payload has zero backend rank stamps: it logs an error and returns an empty rows array, letting the `useDynastyData` error state surface a "no players" banner. There is no silent recompute. If you see the fail-fast error in production logs, the scrape pipeline is not stamping — investigate upstream, do not add a client-side blend.
 
+### Two overlays, and why neither one relaxes the no-frontend-ranker rule
+
+There are **two** delta-shaped overlays on the contract. They differ in the
+one way that matters most in this codebase — their scope:
+
+| overlay | scope | driven by | endpoint |
+|---|---|---|---|
+| rankings override delta | **scoring profile** — shared across leagues | user source weights | `POST /api/rankings/overrides?view=delta` |
+| league-adjusted valuation | **leagueKey** — roster-derived, never shared | positional scarcity from this league's 12 rosters | `GET /api/valuation/league-adjusted` |
+
+The valuation overlay is league-scoped *by necessity, not convention*.
+`lineupScarcity` is measured from one league's rosters, so two leagues sharing a
+scoring profile get different adjusted values. Stamping it onto the contract
+would let one league's roster shape silently reprice another's board — the exact
+collapse the scoring-profile/leagueKey split exists to prevent. Hence an overlay
+the client applies, never contract fields.
+
+**Ranks are backend-computed in both cases.** The valuation overlay ships dense
+`ranks` + `tiers` alongside sparse `factors`, produced by
+`data_contract.py::compact_ranks_and_tiers` — the *same* function the pipeline
+uses, called on shallow copies because `latest_contract_data` is a shared mutable
+global. `buildRows` still consumes stamps verbatim. This feature **conformed to**
+the "no frontend ranking engine, period" rule rather than being excepted from it:
+the rule is what forced the composing design instead of a client-side re-sort.
+
+Two consequences worth knowing before touching this:
+
+- **`factors`, not absolute values.** The adjustment factor is a function of
+  position alone and never reads the consensus value, so it composes exactly
+  against any board — including one the user re-weighted. Absolute values would
+  carry the default board's numbers into a board the server never computed.
+- **The two overlays are NOT composed on the client.** With source overrides
+  active the valuation overlay's ranks are the ranks of
+  `default_consensus × factor`, but the correct answer is
+  `overridden_consensus × factor`, which the server never computed. Composing
+  them yields a board where neither values nor ranks correspond to anything, so
+  `fetchDynastyData` serves the overridden market board and warns instead.
+  Threading `valuation_mode` through the overrides pipeline server-side is the
+  fix; until then the combination is deliberately blocked, not silently wrong.
+
+Regression tests: `frontend/__tests__/valuation-overlay.test.js` (both
+materializer key sets — the legacy dict uses `_canonicalConsensusRank` but
+`rankDerivedValue`, and the legacy path is the default one), and
+`tests/league_intel/test_publish.py` (caller-row isolation, dense contiguous
+ranks, anchor-slot-pick exclusion).
+
 ### Rankings Override Payload Size Optimization
 The `POST /api/rankings/overrides` endpoint supports two response views:
 

--- a/frontend/__tests__/valuation-overlay.test.js
+++ b/frontend/__tests__/valuation-overlay.test.js
@@ -1,0 +1,215 @@
+/**
+ * LI-9 league-adjusted overlay application.
+ *
+ * The dangerous cases, in order:
+ *  1. The DEFAULT path is the legacy `players` dict, not `playersArray`
+ *     (server.py pops it). That path reads `_canonicalConsensusRank`
+ *     with an underscore but `rankDerivedValue` without one — so an
+ *     applier that writes one key set moves the value and leaves the
+ *     rank stale, on the only path that ships.
+ *  2. Sparse `factors` mean "absent = unchanged". Reusing the override
+ *     delta's merge would delete every unmentioned player instead.
+ *  3. A version mismatch must refuse outright, not half-apply.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { applyValuationOverlay, buildRows } from "@/lib/dynasty-data";
+
+const STAMP = "2026-07-27T05:14:44";
+
+function baseArrayContract() {
+  return {
+    ok: true,
+    source: "backend",
+    data: {
+      scrapeTimestamp: STAMP,
+      playersArray: [
+        {
+          displayName: "Rise",
+          canonicalName: "rise",
+          position: "RB",
+          assetClass: "player",
+          rankDerivedValue: 5000,
+          canonicalConsensusRank: 2,
+          canonicalTierId: 1,
+          rankChange: 4,
+          values: { overall: 5000, finalAdjusted: 5000, displayValue: 5000, raw: 4200 },
+        },
+        {
+          displayName: "Fall",
+          canonicalName: "fall",
+          position: "TE",
+          assetClass: "player",
+          rankDerivedValue: 5200,
+          canonicalConsensusRank: 1,
+          canonicalTierId: 1,
+          rankChange: -2,
+          values: { overall: 5200, finalAdjusted: 5200, displayValue: 5200, raw: 4400 },
+        },
+        {
+          displayName: "Still",
+          canonicalName: "still",
+          position: "WR",
+          assetClass: "player",
+          rankDerivedValue: 3000,
+          canonicalConsensusRank: 3,
+          canonicalTierId: 2,
+          values: { overall: 3000, finalAdjusted: 3000, displayValue: 3000, raw: 2500 },
+        },
+      ],
+    },
+  };
+}
+
+function baseLegacyContract() {
+  return {
+    ok: true,
+    source: "backend",
+    data: {
+      scrapeTimestamp: STAMP,
+      players: {
+        Rise: {
+          rankDerivedValue: 5000,
+          _canonicalConsensusRank: 2,
+          _canonicalTierId: 1,
+          _finalAdjusted: 5000,
+          _rankChange: 4,
+        },
+        Fall: {
+          rankDerivedValue: 5200,
+          _canonicalConsensusRank: 1,
+          _canonicalTierId: 1,
+          _finalAdjusted: 5200,
+        },
+      },
+      sleeper: { positions: { Rise: "RB", Fall: "TE" } },
+    },
+  };
+}
+
+const OVERLAY = {
+  isNoop: false,
+  scrapeTimestamp: STAMP,
+  factors: { Rise: 1.06, Fall: 0.94 },
+  ranks: { Rise: 1, Fall: 2, Still: 3 },
+  tiers: { Rise: 1, Fall: 1, Still: 2 },
+};
+
+describe("applyValuationOverlay — playersArray path", () => {
+  it("scales value and every alias that mirrors it", () => {
+    const out = applyValuationOverlay(baseArrayContract(), OVERLAY);
+    const rise = out.data.playersArray.find((r) => r.displayName === "Rise");
+    expect(rise.rankDerivedValue).toBe(5300);
+    expect(rise.values.overall).toBe(5300);
+    expect(rise.values.finalAdjusted).toBe(5300);
+    expect(rise.values.displayValue).toBe(5300);
+  });
+
+  it("leaves values.raw alone — the toggle changes Our Value, never Raw", () => {
+    const out = applyValuationOverlay(baseArrayContract(), OVERLAY);
+    const rise = out.data.playersArray.find((r) => r.displayName === "Rise");
+    expect(rise.values.raw).toBe(4200);
+  });
+
+  it("applies the served ranks, not a locally derived order", () => {
+    const out = applyValuationOverlay(baseArrayContract(), OVERLAY);
+    const byName = Object.fromEntries(
+      out.data.playersArray.map((r) => [r.displayName, r.canonicalConsensusRank]),
+    );
+    expect(byName).toEqual({ Rise: 1, Fall: 2, Still: 3 });
+  });
+
+  it("a row with no factor still takes its served rank", () => {
+    const out = applyValuationOverlay(baseArrayContract(), OVERLAY);
+    const still = out.data.playersArray.find((r) => r.displayName === "Still");
+    expect(still.rankDerivedValue).toBe(3000);
+    expect(still.canonicalConsensusRank).toBe(3);
+  });
+
+  it("nulls rankChange — 'moved up N since the previous scrape' is about the market board", () => {
+    const out = applyValuationOverlay(baseArrayContract(), OVERLAY);
+    expect(out.data.playersArray.every((r) => r.rankChange === null)).toBe(true);
+  });
+
+  it("does not mutate the input contract", () => {
+    const base = baseArrayContract();
+    const snapshot = JSON.stringify(base);
+    applyValuationOverlay(base, OVERLAY);
+    expect(JSON.stringify(base)).toBe(snapshot);
+  });
+});
+
+describe("applyValuationOverlay — legacy dict path (THE DEFAULT)", () => {
+  it("writes the underscored rank key AND the un-underscored value key", () => {
+    const out = applyValuationOverlay(baseLegacyContract(), OVERLAY);
+    const rise = out.data.players.Rise;
+    // The asymmetry that makes this the highest-risk bug in the feature.
+    expect(rise.rankDerivedValue).toBe(5300);
+    expect(rise._canonicalConsensusRank).toBe(1);
+    expect(rise._canonicalTierId).toBe(1);
+  });
+
+  it("moves value and rank together", () => {
+    const out = applyValuationOverlay(baseLegacyContract(), OVERLAY);
+    const fall = out.data.players.Fall;
+    expect(fall.rankDerivedValue).toBe(4888);
+    expect(fall._canonicalConsensusRank).toBe(2);
+  });
+
+  it("does not drop players absent from the overlay", () => {
+    const base = baseLegacyContract();
+    base.data.players.Unmentioned = { rankDerivedValue: 100, _canonicalConsensusRank: 9 };
+    const out = applyValuationOverlay(base, { ...OVERLAY, ranks: { Rise: 1 } });
+    expect(out.data.players.Unmentioned).toBeDefined();
+    expect(out.data.players.Unmentioned.rankDerivedValue).toBe(100);
+  });
+});
+
+describe("applyValuationOverlay — refuses rather than half-applies", () => {
+  let warn;
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => warn.mockRestore());
+
+  it("returns the base contract on a scrape-timestamp mismatch", () => {
+    const base = baseArrayContract();
+    const out = applyValuationOverlay(base, { ...OVERLAY, scrapeTimestamp: "2026-07-27T09:00:00" });
+    expect(out).toBe(base);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("returns the base contract when the overlay has no factors", () => {
+    const base = baseArrayContract();
+    expect(applyValuationOverlay(base, { ...OVERLAY, factors: {} })).toBe(base);
+  });
+
+  it("returns the base contract for a null overlay", () => {
+    const base = baseArrayContract();
+    expect(applyValuationOverlay(base, null)).toBe(base);
+  });
+});
+
+describe("buildRows with an overlay applied", () => {
+  it("orders by served rank and never invents one", () => {
+    const out = applyValuationOverlay(baseArrayContract(), OVERLAY);
+    const rows = buildRows(out.data);
+    expect(rows.map((r) => r.name)).toEqual(["Rise", "Fall", "Still"]);
+    expect(rows.map((r) => r.rank)).toEqual([1, 2, 3]);
+  });
+
+  it("an unranked row shows no rank rather than a client-derived ordinal", () => {
+    const base = baseArrayContract();
+    base.data.playersArray.push({
+      displayName: "Deep",
+      canonicalName: "deep",
+      position: "WR",
+      assetClass: "player",
+      rankDerivedValue: 50,
+      canonicalConsensusRank: null,
+      values: { overall: 50 },
+    });
+    const rows = buildRows(applyValuationOverlay(base, OVERLAY).data);
+    const deep = rows.find((r) => r.name === "Deep");
+    expect(deep.rank).toBeNull();
+  });
+});

--- a/frontend/app/api/valuation/league-adjusted/route.js
+++ b/frontend/app/api/valuation/league-adjusted/route.js
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+
+// Proxies the league-adjusted valuation overlay to the Python backend.
+//
+// In production nginx routes every `/api/*` path straight to the
+// backend, so this shim is never hit.  It exists for the dev flow,
+// where Next serves `/api/*` itself and the route would otherwise 404 —
+// the same reason `rankings/overrides/route.js` and
+// `dynasty-data/route.js` exist.
+//
+// LEAGUE-SCOPED.  The overlay is driven by positional scarcity measured
+// from one league's rosters, so `leagueKey` must be forwarded; two
+// leagues sharing a scoring profile get different overlays.
+//
+// Mirrored backend endpoint: server.py::get_league_adjusted_values()
+// Payload builder: src/league_intel/publish.py::build_league_adjusted_payload()
+
+const BACKEND_BASE = (
+  process.env.BACKEND_API_URL || "http://127.0.0.1:8000"
+).replace(/\/api\/data\/?$/, "");
+const OVERLAY_URL = `${BACKEND_BASE}/api/valuation/league-adjusted`;
+
+export async function GET(request) {
+  const incomingUrl = new URL(request.url);
+  const forwardedUrl = new URL(OVERLAY_URL);
+  for (const key of ["leagueKey", "explanations"]) {
+    const v = incomingUrl.searchParams.get(key);
+    if (v) forwardedUrl.searchParams.set(key, v);
+  }
+
+  const ctl = new AbortController();
+  // The overlay reuses /api/gameplan's cached league bundle, so it is
+  // near-free warm but pays the ~1.35 s replacement solve cold. 15 s
+  // matches the overrides proxy and leaves room for a cold league.
+  const timer = setTimeout(() => ctl.abort(), 15000);
+  try {
+    const cookie = request.headers.get("cookie") || "";
+    const headers = {};
+    if (cookie) headers.Cookie = cookie;
+    const res = await fetch(forwardedUrl.toString(), {
+      headers,
+      signal: ctl.signal,
+      cache: "no-store",
+    });
+    const text = await res.text();
+    return new Response(text, {
+      status: res.status,
+      headers: {
+        "Content-Type": "application/json",
+        // Private, league-scoped data. Never cache at the edge.
+        "Cache-Control": "no-store, private",
+      },
+    });
+  } catch (err) {
+    // A failed overlay is not a failed page: the caller degrades to the
+    // market board. Answer with a shape the client can read rather than
+    // an unhandled throw.
+    return NextResponse.json(
+      { error: "overlay_unavailable", message: String(err?.message || err) },
+      { status: 502, headers: { "Cache-Control": "no-store, private" } },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -2,7 +2,11 @@
 
 import { useMemo, useState, useCallback, useEffect } from "react";
 import { useDynastyData } from "@/components/useDynastyData";
-import { resolvedRank, RANKING_SOURCES, siteOverridesAreCustomized } from "@/lib/dynasty-data";
+import {
+  resolvedRank,
+  RANKING_SOURCES,
+  siteOverridesAreCustomized,
+} from "@/lib/dynasty-data";
 import { useSettings } from "@/components/useSettings";
 import { useApp } from "@/components/AppShell";
 import { useTeam } from "@/components/useTeam";
@@ -52,6 +56,7 @@ import {
   Movement,
   PageHeader,
   Panel,
+  SegmentedControl,
   Select,
   SkeletonTable,
   StatTile,
@@ -110,7 +115,8 @@ function posMatchesFilter(pos, assetClass, filter, row) {
   if (filter === "idp") return assetClass === "idp";
   if (filter === "pick") return assetClass === "pick";
   if (filter === "rookie") return !!row?.rookie;
-  if (filter.startsWith("rookie:")) return !!row?.rookie && pos === filter.split(":")[1];
+  if (filter.startsWith("rookie:"))
+    return !!row?.rookie && pos === filter.split(":")[1];
   return pos === filter;
 }
 
@@ -118,12 +124,14 @@ function posMatchesFilter(pos, assetClass, filter, row) {
 // the expanded audit panel.
 function confidenceExplain(row) {
   return (
-    row.confidenceLabel || (
-      row.confidenceBucket === "high" ? "2+ sources, tight agreement (spread ≤30)" :
-      row.confidenceBucket === "medium" ? "2+ sources, moderate spread (30-80)" :
-      row.confidenceBucket === "low" ? "Single source or wide disagreement (spread >80)" :
-      "Unranked"
-    )
+    row.confidenceLabel ||
+    (row.confidenceBucket === "high"
+      ? "2+ sources, tight agreement (spread ≤30)"
+      : row.confidenceBucket === "medium"
+        ? "2+ sources, moderate spread (30-80)"
+        : row.confidenceBucket === "low"
+          ? "Single source or wide disagreement (spread >80)"
+          : "Unranked")
   );
 }
 
@@ -172,7 +180,8 @@ export function describeCustomMix(rankingsOverride) {
 
 function CustomMixBadge({ rankingsOverride }) {
   const [open, setOpen] = useState(false);
-  const { active, disabled, reweighted, summary } = describeCustomMix(rankingsOverride);
+  const { active, disabled, reweighted, summary } =
+    describeCustomMix(rankingsOverride);
   if (!active) return null;
 
   return (
@@ -203,7 +212,9 @@ function CustomMixBadge({ rankingsOverride }) {
               <strong>Reweighted:</strong> {reweighted.join(", ")}
             </p>
           )}
-          <p className={styles.popoverHint}>Change these on the Settings page.</p>
+          <p className={styles.popoverHint}>
+            Change these on the Settings page.
+          </p>
         </div>
       )}
     </span>
@@ -214,7 +225,12 @@ function CustomMixBadge({ rankingsOverride }) {
 
 export default function RankingsPage() {
   const { loading, error, rows, rawData } = useDynastyData();
-  const { settings, update: updateSetting, updateSiteWeight, resetSiteWeights } = useSettings();
+  const {
+    settings,
+    update: updateSetting,
+    updateSiteWeight,
+    resetSiteWeights,
+  } = useSettings();
   const [colsMenuOpen, setColsMenuOpen] = useState(false);
   const [sourcesMenuOpen, setSourcesMenuOpen] = useState(false);
   // Per-source blend inclusion.  ``siteWeights[key].include === false``
@@ -227,12 +243,13 @@ export default function RankingsPage() {
   const siteWeights = settings.siteWeights || {};
   const includedSourceKeys = useMemo(
     () =>
-      RANKING_SOURCES.filter(
-        (s) => siteWeights[s.key]?.include !== false,
-      ).map((s) => s.key),
+      RANKING_SOURCES.filter((s) => siteWeights[s.key]?.include !== false).map(
+        (s) => s.key,
+      ),
     [siteWeights],
   );
-  const excludedSourceCount = RANKING_SOURCES.length - includedSourceKeys.length;
+  const excludedSourceCount =
+    RANKING_SOURCES.length - includedSourceKeys.length;
   // Reset clears BOTH exclusions and custom weights, so its enabled
   // state must track any override — not just excluded sources — or a
   // weights-only customization (set on /settings) can't be cleared
@@ -250,15 +267,18 @@ export default function RankingsPage() {
   const hiddenSiteCols = settings.hiddenSiteCols || {};
   const visibleSources = useMemo(
     () => RANKING_SOURCES.filter((s) => !hiddenSiteCols[s.key]),
-    [hiddenSiteCols]
+    [hiddenSiteCols],
   );
   const hiddenCount = RANKING_SOURCES.length - visibleSources.length;
-  const toggleSiteCol = useCallback((key) => {
-    const next = { ...(settings.hiddenSiteCols || {}) };
-    if (next[key]) delete next[key];
-    else next[key] = true;
-    updateSetting("hiddenSiteCols", next);
-  }, [settings.hiddenSiteCols, updateSetting]);
+  const toggleSiteCol = useCallback(
+    (key) => {
+      const next = { ...(settings.hiddenSiteCols || {}) };
+      if (next[key]) delete next[key];
+      else next[key] = true;
+      updateSetting("hiddenSiteCols", next);
+    },
+    [settings.hiddenSiteCols, updateSetting],
+  );
   const showAllSiteCols = useCallback(() => {
     updateSetting("hiddenSiteCols", {});
   }, [updateSetting]);
@@ -274,7 +294,8 @@ export default function RankingsPage() {
     serverBacked: watchlistServerBacked,
   } = useUserState();
   const watchlistLower = useMemo(
-    () => new Set((userState?.watchlist || []).map((n) => String(n).toLowerCase())),
+    () =>
+      new Set((userState?.watchlist || []).map((n) => String(n).toLowerCase())),
     [userState?.watchlist],
   );
   // Recent news → per-row news chip (lookupPlayerNews is O(1); the
@@ -312,7 +333,13 @@ export default function RankingsPage() {
   // a league that disables IDP, snap back to "all" so the board
   // doesn't render empty.
   useEffect(() => {
-    if (!idpEnabled && (posFilter === "idp" || posFilter === "DL" || posFilter === "LB" || posFilter === "DB")) {
+    if (
+      !idpEnabled &&
+      (posFilter === "idp" ||
+        posFilter === "DL" ||
+        posFilter === "LB" ||
+        posFilter === "DB")
+    ) {
       setPosFilter("all");
     }
   }, [idpEnabled, posFilter]);
@@ -327,7 +354,9 @@ export default function RankingsPage() {
     const params = new URLSearchParams(window.location.search);
     const requested = (params.get("pos") || "").trim();
     if (!requested) return;
-    const normalized = ["all", "offense", "idp", "pick", "rookie"].includes(requested.toLowerCase())
+    const normalized = ["all", "offense", "idp", "pick", "rookie"].includes(
+      requested.toLowerCase(),
+    )
       ? requested.toLowerCase()
       : requested.toUpperCase();
     setPosFilter(normalized);
@@ -361,7 +390,8 @@ export default function RankingsPage() {
     // 2026 rookie draft has passed — hide current-year slot picks from
     // the board.  Rows stay in buildRows so value resolution still
     // works for trade history; we filter only at display time.
-    let filtered = rows.filter(isEligibleForBoard)
+    let filtered = rows
+      .filter(isEligibleForBoard)
       .filter((r) => !(r.assetClass === "pick" && /^2026\b/.test(r.name)));
     if (!idpEnabled) {
       return filtered.filter((r) => r?.assetClass !== "idp");
@@ -384,7 +414,14 @@ export default function RankingsPage() {
       if (r.quarantined) quarantined++;
       if ((r.sourceCount || 0) >= 2) multiSource++;
     }
-    return { total: eligible.length, high, medium, low, quarantined, multiSource };
+    return {
+      total: eligible.length,
+      high,
+      medium,
+      low,
+      quarantined,
+      multiSource,
+    };
   }, [eligible]);
 
   // ── Edge summary ─────────────────────────────────────────────────
@@ -442,11 +479,14 @@ export default function RankingsPage() {
 
     // Additional filters layer on top of lens
     if (posFilter !== "all") {
-      list = list.filter((r) => posMatchesFilter(r.pos, r.assetClass, posFilter, r));
+      list = list.filter((r) =>
+        posMatchesFilter(r.pos, r.assetClass, posFilter, r),
+      );
     }
     if (confFilter !== "all") {
       list = list.filter((r) => {
-        if (confFilter === "low") return r.confidenceBucket === "low" || r.confidenceBucket === "none";
+        if (confFilter === "low")
+          return r.confidenceBucket === "low" || r.confidenceBucket === "none";
         return r.confidenceBucket === confFilter;
       });
     }
@@ -476,7 +516,10 @@ export default function RankingsPage() {
         case "name":
           return a.name.localeCompare(b.name) * dir;
         case "pos":
-          return a.pos.localeCompare(b.pos) * dir || resolvedRank(a) - resolvedRank(b);
+          return (
+            a.pos.localeCompare(b.pos) * dir ||
+            resolvedRank(a) - resolvedRank(b)
+          );
         case "score":
           va = a.blendedSourceRank ?? Infinity;
           vb = b.blendedSourceRank ?? Infinity;
@@ -523,12 +566,26 @@ export default function RankingsPage() {
       }
     });
     return sorted;
-  }, [eligible, activeLens, posFilter, confFilter, query, sortCol, sortAsc, advCriteria, advActiveCount, teamByPlayer]);
+  }, [
+    eligible,
+    activeLens,
+    posFilter,
+    confFilter,
+    query,
+    sortCol,
+    sortAsc,
+    advCriteria,
+    advActiveCount,
+    teamByPlayer,
+  ]);
 
   // ── Top movers (from the current filtered view — pre-R2 behavior) ──
   const movers = useMemo(() => {
     const withChange = ranked.filter(
-      (r) => typeof r?.rankChange === "number" && r.rankChange !== 0 && r.rank != null,
+      (r) =>
+        typeof r?.rankChange === "number" &&
+        r.rankChange !== 0 &&
+        r.rank != null,
     );
     const byDelta = [...withChange].sort(
       (a, b) => Math.abs(b.rankChange) - Math.abs(a.rankChange),
@@ -541,7 +598,11 @@ export default function RankingsPage() {
 
   // Apply row limit — search/filter bypasses the limit
   const hasActiveFilter =
-    query || posFilter !== "all" || confFilter !== "all" || activeLens !== "consensus" || advActiveCount > 0;
+    query ||
+    posFilter !== "all" ||
+    confFilter !== "all" ||
+    activeLens !== "consensus" ||
+    advActiveCount > 0;
   const displayRows = hasActiveFilter ? ranked : ranked.slice(0, rowLimit);
   const hasMore = !hasActiveFilter && ranked.length > rowLimit;
 
@@ -564,36 +625,59 @@ export default function RankingsPage() {
   }, [eligible]);
 
   // ── Copy/Export (unchanged columns + format) ────────────────────
-  const buildExportLines = useCallback((joiner, escape = (c) => c) => {
-    const sourceHeaders = RANKING_SOURCES.flatMap((src) => [
-      src.columnLabel,
-      `${src.columnLabel} Rank`,
-    ]);
-    const headers = [
-      "Rank", "Player", "Pos", "Team", "Tier", "Value", "Value Band",
-      "Confidence", "Action", "Sources",
-      ...sourceHeaders,
-    ];
-    const lines = [headers.map(escape).join(joiner)];
-    displayRows.forEach((row) => {
-      const val = Math.round(row.rankDerivedValue || row.values?.full || 0);
-      const band = valueBand(val);
-      const action = actionLabel(row);
-      const cautions = cautionLabels(row);
-      const actionStr = [action?.label, ...cautions.map((c) => c.label)]
-        .filter(Boolean).join("; ");
-      const sourceCells = RANKING_SOURCES.flatMap((src) => exportSourceCells(row, src));
-      lines.push(
-        [
-          row.rank, row.name, row.pos, row.team || "",
-          tierLabel(row), val, band.label,
-          row.confidenceBucket || "", actionStr, row.sourceCount || 0,
-          ...sourceCells,
-        ].map(escape).join(joiner)
-      );
-    });
-    return lines;
-  }, [displayRows]);
+  const buildExportLines = useCallback(
+    (joiner, escape = (c) => c) => {
+      const sourceHeaders = RANKING_SOURCES.flatMap((src) => [
+        src.columnLabel,
+        `${src.columnLabel} Rank`,
+      ]);
+      const headers = [
+        "Rank",
+        "Player",
+        "Pos",
+        "Team",
+        "Tier",
+        "Value",
+        "Value Band",
+        "Confidence",
+        "Action",
+        "Sources",
+        ...sourceHeaders,
+      ];
+      const lines = [headers.map(escape).join(joiner)];
+      displayRows.forEach((row) => {
+        const val = Math.round(row.rankDerivedValue || row.values?.full || 0);
+        const band = valueBand(val);
+        const action = actionLabel(row);
+        const cautions = cautionLabels(row);
+        const actionStr = [action?.label, ...cautions.map((c) => c.label)]
+          .filter(Boolean)
+          .join("; ");
+        const sourceCells = RANKING_SOURCES.flatMap((src) =>
+          exportSourceCells(row, src),
+        );
+        lines.push(
+          [
+            row.rank,
+            row.name,
+            row.pos,
+            row.team || "",
+            tierLabel(row),
+            val,
+            band.label,
+            row.confidenceBucket || "",
+            actionStr,
+            row.sourceCount || 0,
+            ...sourceCells,
+          ]
+            .map(escape)
+            .join(joiner),
+        );
+      });
+      return lines;
+    },
+    [displayRows],
+  );
 
   async function copyValues() {
     const lines = buildExportLines("\t");
@@ -652,7 +736,12 @@ export default function RankingsPage() {
   }, [timestamp]);
 
   // ── Tier separator logic ────────────────────────────────────────
-  const tierGroupingActive = showTiers && sortCol === "rank" && sortAsc && activeLens === "consensus" && !query;
+  const tierGroupingActive =
+    showTiers &&
+    sortCol === "rank" &&
+    sortAsc &&
+    activeLens === "consensus" &&
+    !query;
   const currentLens = getLens(activeLens);
 
   // ── DataTable wiring ────────────────────────────────────────────
@@ -660,7 +749,9 @@ export default function RankingsPage() {
   // source columns are page semantics); DataTable renders presorted
   // rows and owns only the header state machine + aria-sort stamps.
   const tableSort =
-    sortCol === "lens" ? null : { key: sortCol, direction: sortAsc ? "asc" : "desc" };
+    sortCol === "lens"
+      ? null
+      : { key: sortCol, direction: sortAsc ? "asc" : "desc" };
   const handleTableSort = useCallback((next) => {
     if (!next) return;
     setSortCol(next.key);
@@ -696,7 +787,9 @@ export default function RankingsPage() {
         render: (row) => {
           const tierId = effectiveTierId(row);
           return (
-            <span className={`rankings-tier-badge ${tierId != null ? `tier-${tierId}` : "tier-unknown"}`}>
+            <span
+              className={`rankings-tier-badge ${tierId != null ? `tier-${tierId}` : "tier-unknown"}`}
+            >
               {tierLabel(row)}
             </span>
           );
@@ -713,7 +806,9 @@ export default function RankingsPage() {
             playerMeta: newsPlayerMeta,
           })[0];
           const chips = rowChips(row, { newsItem });
-          const onWatch = watchlistLower.has(String(row.name || "").toLowerCase());
+          const onWatch = watchlistLower.has(
+            String(row.name || "").toLowerCase(),
+          );
           return (
             <div className={styles.playerCell}>
               <PlayerImage
@@ -754,7 +849,10 @@ export default function RankingsPage() {
                   {[row.team, row.age].filter(Boolean).join(" · ")}
                 </span>
               )}
-              <RankChangeGlyph history={row.rankHistory} change={row.rankChange} />
+              <RankChangeGlyph
+                history={row.rankHistory}
+                change={row.rankChange}
+              />
               {chips.length > 0 && (
                 <span className={styles.chips}>
                   {chips.map((c) =>
@@ -770,7 +868,11 @@ export default function RankingsPage() {
                         {c.label}
                       </a>
                     ) : (
-                      <span key={c.label} className={`badge ${c.css} rankings-chip`} title={c.title}>
+                      <span
+                        key={c.label}
+                        className={`badge ${c.css} rankings-chip`}
+                        title={c.title}
+                      >
                         {c.label}
                       </span>
                     ),
@@ -811,9 +913,15 @@ export default function RankingsPage() {
         render: (row) => (
           <span
             className={styles.consensusCell}
-            title={row.blendedSourceRank != null ? `Mean source rank ${row.blendedSourceRank.toFixed(2)}. Final rank is ${row.rank ? `#${row.rank}` : "— (unranked)"}. Gap = blend penalty/bonus for source disagreement.` : "No sources ranked this player"}
+            title={
+              row.blendedSourceRank != null
+                ? `Mean source rank ${row.blendedSourceRank.toFixed(2)}. Final rank is ${row.rank ? `#${row.rank}` : "— (unranked)"}. Gap = blend penalty/bonus for source disagreement.`
+                : "No sources ranked this player"
+            }
           >
-            {row.blendedSourceRank != null ? row.blendedSourceRank.toFixed(1) : "—"}
+            {row.blendedSourceRank != null
+              ? row.blendedSourceRank.toFixed(1)
+              : "—"}
           </span>
         ),
       },
@@ -835,7 +943,10 @@ export default function RankingsPage() {
               >
                 {val.toLocaleString()}
               </button>
-              <span className={`rankings-value-band ${band.css}`} title={band.title || "Value band"}>
+              <span
+                className={`rankings-value-band ${band.css}`}
+                title={band.title || "Value band"}
+              >
                 {band.label}
               </span>
             </span>
@@ -854,7 +965,9 @@ export default function RankingsPage() {
           hideBelow: "md",
           width: 96,
           headerTitle: `${src.displayName} — cell shows the source's 1–9,999 scale value (${
-            src.isRankSignal ? "Hill curve from this source's ordinal rank" : "linear rescale of this source's native trade value"
+            src.isRankSignal
+              ? "Hill curve from this source's ordinal rank"
+              : "linear rescale of this source's native trade value"
           }) with its effective rank on the shared board in parentheses.`,
           render: (row) => {
             const cell = formatSourceCell(row, src);
@@ -885,16 +998,23 @@ export default function RankingsPage() {
         headerTitle:
           "Sources that matched this player / sources structurally eligible to cover the player's position.",
         render: (row) => {
-          const srcCount = row.sourceCount ?? Object.keys(row.sourceRanks || {}).length;
+          const srcCount =
+            row.sourceCount ?? Object.keys(row.sourceRanks || {}).length;
           const eligibleCount =
             RANKING_SOURCES.filter((s) => {
               const pos = (row.pos || "").toUpperCase();
-              if (s.scope === "overall_offense") return ["QB", "RB", "WR", "TE", "PICK"].includes(pos);
-              if (s.scope === "overall_idp") return ["DL", "LB", "DB"].includes(pos);
+              if (s.scope === "overall_offense")
+                return ["QB", "RB", "WR", "TE", "PICK"].includes(pos);
+              if (s.scope === "overall_idp")
+                return ["DL", "LB", "DB"].includes(pos);
               return false;
             }).length || RANKING_SOURCES.length;
           return (
-            <span className={srcCount >= 2 ? styles.srcCountMulti : styles.srcCountSingle}>
+            <span
+              className={
+                srcCount >= 2 ? styles.srcCountMulti : styles.srcCountSingle
+              }
+            >
               {srcCount}/{eligibleCount}
             </span>
           );
@@ -946,16 +1066,25 @@ export default function RankingsPage() {
           return (
             <>
               {action && (
-                <span className={`action-label ${action.css}`} title={action.title}>
+                <span
+                  className={`action-label ${action.css}`}
+                  title={action.title}
+                >
                   {action.label}
                 </span>
               )}
               {cautions.map((c) => (
-                <span key={c.label} className={`action-label ${c.css}`} title={c.title}>
+                <span
+                  key={c.label}
+                  className={`action-label ${c.css}`}
+                  title={c.title}
+                >
                   {c.label}
                 </span>
               ))}
-              {!action && cautions.length === 0 && <span className="muted">—</span>}
+              {!action && cautions.length === 0 && (
+                <span className="muted">—</span>
+              )}
             </>
           );
         },
@@ -986,8 +1115,19 @@ export default function RankingsPage() {
         description="Unified dynasty board — offense + IDP blended by consensus rank."
         actions={
           <>
+            <SegmentedControl
+              label="Value basis"
+              value={settings.valuationMode || "market"}
+              onChange={(v) => updateSetting("valuationMode", v)}
+              options={[
+                { value: "market", label: "Market" },
+                { value: "leagueAdjusted", label: "My league" },
+              ]}
+            />
             <CustomMixBadge rankingsOverride={rawData?.rankingsOverride} />
-            {copyStatus && <span className={styles.resultCount}>{copyStatus}</span>}
+            {copyStatus && (
+              <span className={styles.resultCount}>{copyStatus}</span>
+            )}
             <Button
               size="sm"
               variant={showEdgeRail ? "secondary" : "ghost"}
@@ -1004,10 +1144,20 @@ export default function RankingsPage() {
             >
               Methodology
             </Button>
-            <Button size="sm" variant="secondary" onClick={copyValues} title="Copy the current rows as TSV for pasting into a spreadsheet">
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={copyValues}
+              title="Copy the current rows as TSV for pasting into a spreadsheet"
+            >
               Copy
             </Button>
-            <Button size="sm" variant="secondary" onClick={exportCsv} title="Download the current rows as a CSV file">
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={exportCsv}
+              title="Download the current rows as a CSV file"
+            >
               Export CSV
             </Button>
             {/* Sources popover — blend membership (math). Distinct from
@@ -1020,7 +1170,8 @@ export default function RankingsPage() {
                 onClick={() => setSourcesMenuOpen((v) => !v)}
                 title="Choose which sources are factored into the blended rankings"
               >
-                Sources{excludedSourceCount > 0 ? ` (${excludedSourceCount} off)` : ""}
+                Sources
+                {excludedSourceCount > 0 ? ` (${excludedSourceCount} off)` : ""}
               </Button>
               {sourcesMenuOpen && (
                 <div className={styles.popover}>
@@ -1043,21 +1194,30 @@ export default function RankingsPage() {
                     const included = siteWeights[src.key]?.include !== false;
                     // Never let the user disable the last source — the
                     // blend needs at least one.
-                    const isLastIncluded = included && includedSourceKeys.length === 1;
+                    const isLastIncluded =
+                      included && includedSourceKeys.length === 1;
                     return (
                       <label
                         key={src.key}
                         className={`${styles.popoverRow}${isLastIncluded ? ` ${styles.popoverRowDisabled}` : ""}`}
-                        title={isLastIncluded ? "At least one source must stay in the blend" : undefined}
+                        title={
+                          isLastIncluded
+                            ? "At least one source must stay in the blend"
+                            : undefined
+                        }
                       >
                         <input
                           type="checkbox"
                           checked={included}
                           disabled={isLastIncluded}
-                          onChange={(e) => toggleSourceIncluded(src.key, e.target.checked)}
+                          onChange={(e) =>
+                            toggleSourceIncluded(src.key, e.target.checked)
+                          }
                         />
                         <span>{src.columnLabel}</span>
-                        <span className={styles.popoverRowMeta}>{src.displayName}</span>
+                        <span className={styles.popoverRowMeta}>
+                          {src.displayName}
+                        </span>
                       </label>
                     );
                   })}
@@ -1094,11 +1254,15 @@ export default function RankingsPage() {
                       Show all
                     </Button>
                   </div>
-                  <label className={`${styles.popoverRow} ${styles.popoverRowMaster}`}>
+                  <label
+                    className={`${styles.popoverRow} ${styles.popoverRowMaster}`}
+                  >
                     <input
                       type="checkbox"
                       checked={Boolean(settings.showSiteCols)}
-                      onChange={(e) => updateSetting("showSiteCols", e.target.checked)}
+                      onChange={(e) =>
+                        updateSetting("showSiteCols", e.target.checked)
+                      }
                     />
                     <span>Show source columns</span>
                   </label>
@@ -1117,7 +1281,9 @@ export default function RankingsPage() {
                           disabled={rowDisabled}
                         />
                         <span>{src.columnLabel}</span>
-                        <span className={styles.popoverRowMeta}>{src.displayName}</span>
+                        <span className={styles.popoverRowMeta}>
+                          {src.displayName}
+                        </span>
                       </label>
                     );
                   })}
@@ -1139,14 +1305,24 @@ export default function RankingsPage() {
           />
           <StatTile label="Medium" value={trustStats.medium.toLocaleString()} />
           <StatTile label="Low" value={trustStats.low.toLocaleString()} />
-          <StatTile label="Multi-source" value={trustStats.multiSource.toLocaleString()} />
+          <StatTile
+            label="Multi-source"
+            value={trustStats.multiSource.toLocaleString()}
+          />
           <StatTile
             label="Quarantined"
             value={trustStats.quarantined.toLocaleString()}
-            meta={trustStats.quarantined > 0 ? <Badge tone="negative">check audit</Badge> : undefined}
+            meta={
+              trustStats.quarantined > 0 ? (
+                <Badge tone="negative">check audit</Badge>
+              ) : undefined
+            }
           />
           {timestamp && (
-            <span className={styles.trustFootnote} title={`Data generated at ${timestamp}`}>
+            <span
+              className={styles.trustFootnote}
+              title={`Data generated at ${timestamp}`}
+            >
               Last scraped {relativeUpdated || timestamp}
             </span>
           )}
@@ -1223,7 +1399,9 @@ export default function RankingsPage() {
               tabs={LENSES.map((lens) => ({ id: lens.key, label: lens.label }))}
             />
             {activeLens !== "consensus" && (
-              <p className={styles.lensDescription}>{currentLens.description}</p>
+              <p className={styles.lensDescription}>
+                {currentLens.description}
+              </p>
             )}
 
             {/* Filters — the "rankings-controls" literal class is the
@@ -1275,7 +1453,9 @@ export default function RankingsPage() {
                   aria-label="Confidence filter"
                 >
                   {CONFIDENCE_FILTERS.map((f) => (
-                    <option key={f.key} value={f.key}>{f.label}</option>
+                    <option key={f.key} value={f.key}>
+                      {f.label}
+                    </option>
                   ))}
                 </Select>
               </span>
@@ -1304,7 +1484,10 @@ export default function RankingsPage() {
                 joins league rosters at render time via buildTeamByPlayer
                 (rows are scoring-profile-scoped; owners are league-scoped). */}
             {advOpen && (
-              <div className={styles.advRail} style={{ marginTop: "var(--space-2)" }}>
+              <div
+                className={styles.advRail}
+                style={{ marginTop: "var(--space-2)" }}
+              >
                 <label className={styles.advField}>
                   Age
                   <Input
@@ -1334,7 +1517,9 @@ export default function RankingsPage() {
                 >
                   <option value="">Any experience</option>
                   {EXPERIENCE_BUCKETS.map((b) => (
-                    <option key={b.key} value={b.key}>{b.label}</option>
+                    <option key={b.key} value={b.key}>
+                      {b.label}
+                    </option>
                   ))}
                 </Select>
                 <Select
@@ -1344,7 +1529,9 @@ export default function RankingsPage() {
                 >
                   <option value="">Any NFL team</option>
                   {nflTeamOptions.map((t) => (
-                    <option key={t} value={t}>{t === "FA" ? "Free agent (NFL)" : t}</option>
+                    <option key={t} value={t}>
+                      {t === "FA" ? "Free agent (NFL)" : t}
+                    </option>
                   ))}
                 </Select>
                 {ownerOptions.length > 0 && (
@@ -1356,7 +1543,9 @@ export default function RankingsPage() {
                     <option value="">Any owner</option>
                     <option value={FREE_AGENT_OWNER}>Unrostered</option>
                     {ownerOptions.map((t) => (
-                      <option key={t} value={t}>{t}</option>
+                      <option key={t} value={t}>
+                        {t}
+                      </option>
                     ))}
                   </Select>
                 )}
@@ -1413,7 +1602,9 @@ export default function RankingsPage() {
                   <input
                     type="checkbox"
                     checked={!!adv.rookieOnly}
-                    onChange={(e) => setAdvField("rookieOnly", e.target.checked)}
+                    onChange={(e) =>
+                      setAdvField("rookieOnly", e.target.checked)
+                    }
                   />
                   Rookies
                 </label>
@@ -1421,20 +1612,31 @@ export default function RankingsPage() {
                   <input
                     type="checkbox"
                     checked={!!adv.watchlistOnly}
-                    onChange={(e) => setAdvField("watchlistOnly", e.target.checked)}
+                    onChange={(e) =>
+                      setAdvField("watchlistOnly", e.target.checked)
+                    }
                   />
                   Watchlist
                 </label>
                 {advActiveCount > 0 && (
-                  <Button size="sm" variant="ghost" onClick={clearAdv} title="Clear advanced filters">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={clearAdv}
+                    title="Clear advanced filters"
+                  >
                     Clear
                   </Button>
                 )}
               </div>
             )}
 
-            <p className={styles.resultCount} style={{ margin: "var(--space-2) 0 0" }}>
-              {displayRows.length.toLocaleString()}{hasMore ? ` of ${ranked.length.toLocaleString()}` : ""} shown
+            <p
+              className={styles.resultCount}
+              style={{ margin: "var(--space-2) 0 0" }}
+            >
+              {displayRows.length.toLocaleString()}
+              {hasMore ? ` of ${ranked.length.toLocaleString()}` : ""} shown
               {activeLens !== "consensus" && ` · ${currentLens.label} lens`}
               {confFilter !== "all" && ` · ${confFilter} confidence`}
               {tierGroupingActive && " · grouped by tier"}
@@ -1507,19 +1709,26 @@ export default function RankingsPage() {
                 return (
                   <tr className={styles.tierSeparator}>
                     <td colSpan={totalCols}>
-                      <span className={styles.tierSeparatorLabel}>{tierLabel(row)}</span>
+                      <span className={styles.tierSeparatorLabel}>
+                        {tierLabel(row)}
+                      </span>
                     </td>
                   </tr>
                 );
               }}
               renderAfterRow={(row) => {
                 if (expandedRow !== row.name) return null;
-                const val = Math.round(row.rankDerivedValue || row.values?.full || 0);
+                const val = Math.round(
+                  row.rankDerivedValue || row.values?.full || 0,
+                );
                 return (
                   <>
                     <tr className="rankings-mobile-source-row">
                       <td colSpan={totalCols}>
-                        <MobileSourceStrip row={row} formatSourceCell={formatSourceCell} />
+                        <MobileSourceStrip
+                          row={row}
+                          formatSourceCell={formatSourceCell}
+                        />
                       </td>
                     </tr>
                     {/* rankings-audit-row carries the panel's
@@ -1544,9 +1753,16 @@ export default function RankingsPage() {
 
           {/* ── Show more / show all ── */}
           {hasMore && (
-            <div className={styles.showMore} style={{ paddingBottom: "var(--space-4)" }}>
-              <Button variant="secondary" onClick={() => setRowLimit((l) => l + 200)}>
-                Show more ({(ranked.length - rowLimit).toLocaleString()} remaining)
+            <div
+              className={styles.showMore}
+              style={{ paddingBottom: "var(--space-4)" }}
+            >
+              <Button
+                variant="secondary"
+                onClick={() => setRowLimit((l) => l + 200)}
+              >
+                Show more ({(ranked.length - rowLimit).toLocaleString()}{" "}
+                remaining)
               </Button>
               <Button variant="ghost" onClick={() => setRowLimit(Infinity)}>
                 Show all

--- a/frontend/app/settings/page.jsx
+++ b/frontend/app/settings/page.jsx
@@ -2,7 +2,10 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useDynastyData } from "@/components/useDynastyData";
-import { useSettings, SETTINGS_DEFAULTS as DEFAULTS } from "@/components/useSettings";
+import {
+  useSettings,
+  SETTINGS_DEFAULTS as DEFAULTS,
+} from "@/components/useSettings";
 import { useUserState } from "@/components/useUserState";
 import {
   WEIGHT_PRESETS,
@@ -30,12 +33,22 @@ function Section({ title, defaultOpen = true, children }) {
         className="button-reset"
         onClick={() => setOpen(!open)}
         style={{
-          display: "flex", justifyContent: "space-between", alignItems: "center",
-          width: "100%", padding: "8px 0", minHeight: 44, cursor: "pointer",
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          width: "100%",
+          padding: "8px 0",
+          minHeight: 44,
+          cursor: "pointer",
         }}
       >
         <h3 style={{ margin: 0, fontSize: "0.92rem" }}>{title}</h3>
-        <span className="muted" style={{ fontSize: "1.2rem", width: 24, textAlign: "center" }}>{open ? "−" : "+"}</span>
+        <span
+          className="muted"
+          style={{ fontSize: "1.2rem", width: 24, textAlign: "center" }}
+        >
+          {open ? "−" : "+"}
+        </span>
       </button>
       {open && <div style={{ marginTop: 10 }}>{children}</div>}
     </div>
@@ -44,35 +57,81 @@ function Section({ title, defaultOpen = true, children }) {
 
 function SliderRow({ label, value, min, max, step, onChange, hint }) {
   return (
-    <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        marginBottom: 8,
+      }}
+    >
       <label style={{ minWidth: 100, fontSize: "0.82rem" }}>{label}</label>
       <input
-        type="range" min={min} max={max} step={step} value={value}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
         onChange={(e) => onChange(parseFloat(e.target.value))}
         style={{ flex: 1 }}
       />
-      <span className="badge" style={{ minWidth: 48, textAlign: "center" }}>{value}</span>
-      {hint && <span className="muted" style={{ fontSize: "0.66rem" }}>{hint}</span>}
+      <span className="badge" style={{ minWidth: 48, textAlign: "center" }}>
+        {value}
+      </span>
+      {hint && (
+        <span className="muted" style={{ fontSize: "0.66rem" }}>
+          {hint}
+        </span>
+      )}
     </div>
   );
 }
 
 function ToggleRow({ label, checked, onChange, hint }) {
   return (
-    <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 6 }}>
-      <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: "0.82rem", cursor: "pointer" }}>
-        <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} />
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        marginBottom: 6,
+      }}
+    >
+      <label
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          fontSize: "0.82rem",
+          cursor: "pointer",
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+        />
         {label}
       </label>
-      {hint && <span className="muted" style={{ fontSize: "0.66rem" }}>{hint}</span>}
+      {hint && (
+        <span className="muted" style={{ fontSize: "0.66rem" }}>
+          {hint}
+        </span>
+      )}
     </div>
   );
 }
 
 export default function SettingsPage() {
   const { loading, error, rows, rawData } = useDynastyData();
-  const { settings, update, updateSiteWeight, resetSiteWeights, reset } = useSettings();
-  const { state: userState, serverBacked, setNotifications, toggleWatchlist } = useUserState();
+  const { settings, update, updateSiteWeight, resetSiteWeights, reset } =
+    useSettings();
+  const {
+    state: userState,
+    serverBacked,
+    setNotifications,
+    toggleWatchlist,
+  } = useUserState();
   const [watchAddName, setWatchAddName] = useState("");
   const [hydrated, setHydrated] = useState(true);
   const [emailDraft, setEmailDraft] = useState("");
@@ -89,7 +148,10 @@ export default function SettingsPage() {
 
   const saveEmail = useCallback(() => {
     const clean = emailDraft.trim();
-    if (clean && (!clean.includes("@") || !clean.split("@")[1]?.includes("."))) {
+    if (
+      clean &&
+      (!clean.includes("@") || !clean.split("@")[1]?.includes("."))
+    ) {
       setEmailStatus("That doesn't look like a valid email address.");
       return;
     }
@@ -197,12 +259,12 @@ export default function SettingsPage() {
       };
     };
     return {
-      offense: RANKING_SOURCES
-        .filter((s) => s.scope === "overall_offense")
-        .map(decorate),
-      idp: RANKING_SOURCES
-        .filter((s) => s.scope === "overall_idp")
-        .map(decorate),
+      offense: RANKING_SOURCES.filter((s) => s.scope === "overall_offense").map(
+        decorate,
+      ),
+      idp: RANKING_SOURCES.filter((s) => s.scope === "overall_idp").map(
+        decorate,
+      ),
     };
   }, [rows, settings?.siteWeights]);
 
@@ -210,14 +272,25 @@ export default function SettingsPage() {
 
   return (
     <section className="card">
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
         <div>
           <h1 style={{ marginTop: 0 }}>Settings</h1>
           <p className="muted" style={{ marginTop: 4 }}>
-            Tuning controls that affect valuations, trade calculations, and rankings display.
+            Tuning controls that affect valuations, trade calculations, and
+            rankings display.
           </p>
         </div>
-        <button className="button" onClick={resetToDefaults} style={{ fontSize: "0.76rem" }}>
+        <button
+          className="button"
+          onClick={resetToDefaults}
+          style={{ fontSize: "0.76rem" }}
+        >
           Reset Defaults
         </button>
       </div>
@@ -236,8 +309,17 @@ export default function SettingsPage() {
             <option value="standard">Standard (1QB)</option>
           </select>
         </div>
-        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
-          <label style={{ minWidth: 140, fontSize: "0.82rem" }}>TEP — non-native</label>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 8,
+          }}
+        >
+          <label style={{ minWidth: 140, fontSize: "0.82rem" }}>
+            TEP — non-native
+          </label>
           <input
             type="number"
             min={1.0}
@@ -286,8 +368,17 @@ export default function SettingsPage() {
             </button>
           </div>
         )}
-        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
-          <label style={{ minWidth: 140, fontSize: "0.82rem" }}>TEP — native</label>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 8,
+          }}
+        >
+          <label style={{ minWidth: 140, fontSize: "0.82rem" }}>
+            TEP — native
+          </label>
           <input
             type="number"
             min={1.0}
@@ -332,12 +423,14 @@ export default function SettingsPage() {
             </button>
           </div>
         )}
-        <p className="muted" style={{ fontSize: "0.68rem", marginTop: 4, marginBottom: 0 }}>
-          Two parallel TE Premium multipliers, both applied at blend
-          time on TE rows only.  <strong>Non-native</strong> covers
-          sources whose published board doesn&apos;t already bake in
-          TE premium (DLF, FBG, FP consensus, Flock, DD, DraftSharks).{" "}
-          <strong>Native</strong> covers sources tagged{" "}
+        <p
+          className="muted"
+          style={{ fontSize: "0.68rem", marginTop: 4, marginBottom: 0 }}
+        >
+          Two parallel TE Premium multipliers, both applied at blend time on TE
+          rows only. <strong>Non-native</strong> covers sources whose published
+          board doesn&apos;t already bake in TE premium (DLF, FBG, FP consensus,
+          Flock, DD, DraftSharks). <strong>Native</strong> covers sources tagged{" "}
           <span
             style={{
               fontFamily: "var(--mono)",
@@ -350,13 +443,12 @@ export default function SettingsPage() {
           >
             TEP NATIVE
           </span>{" "}
-          (IDPTC, DN SfTep, Yahoo Boone, FP Fitzmaurice) — their
-          boards already publish some TE premium so the smaller
-          default (1.10×) is a calibration nudge, not a fresh boost.
-          KTC (standard SF and SF-TE++) is the canonical baseline
-          and passes through both knobs unchanged.  Changing either
-          value re-runs the canonical ranking pipeline so every page
-          (rankings, trade calculator, edge) sees the same values.
+          (IDPTC, DN SfTep, Yahoo Boone, FP Fitzmaurice) — their boards already
+          publish some TE premium so the smaller default (1.10×) is a
+          calibration nudge, not a fresh boost. KTC (standard SF and SF-TE++) is
+          the canonical baseline and passes through both knobs unchanged.
+          Changing either value re-runs the canonical ranking pipeline so every
+          page (rankings, trade calculator, edge) sees the same values.
         </p>
       </Section>
 
@@ -364,14 +456,18 @@ export default function SettingsPage() {
         <SliderRow
           label="Trade History Window"
           value={settings.tradeHistoryWindowDays}
-          min={30} max={730} step={30}
+          min={30}
+          max={730}
+          step={30}
           onChange={(v) => update("tradeHistoryWindowDays", v)}
           hint={`${settings.tradeHistoryWindowDays} days`}
         />
         <SliderRow
           label="Suggestion Pool Cap"
           value={settings.ktcSuggestionTopN ?? 150}
-          min={50} max={300} step={10}
+          min={50}
+          max={300}
+          step={10}
           onChange={(v) => update("ktcSuggestionTopN", v)}
           hint={`Top ${settings.ktcSuggestionTopN ?? 150} KTC offense players considered for trade suggestions`}
         />
@@ -379,16 +475,82 @@ export default function SettingsPage() {
           className="muted"
           style={{ fontSize: "0.7rem", marginTop: 4, marginBottom: 0 }}
         >
-          Default 150 fits a standard 12-team Superflex league.  Raise
-          for deeper formats (14-team 2QB, deep-IDP keeper) where the
-          bottom-50 of your roster pool sits below KTC #150 but is
-          genuinely traded.  Picks + IDP are unaffected by this cap.
+          Default 150 fits a standard 12-team Superflex league. Raise for deeper
+          formats (14-team 2QB, deep-IDP keeper) where the bottom-50 of your
+          roster pool sits below KTC #150 but is genuinely traded. Picks + IDP
+          are unaffected by this cap.
         </p>
+      </Section>
+
+      <Section title="Valuation" defaultOpen>
+        <div
+          style={{ fontSize: "0.72rem", marginBottom: 10 }}
+          className="muted"
+        >
+          This is the only setting that changes the numbers themselves. It
+          applies everywhere — rankings, the trade calculator, exports.
+        </div>
+        <div style={{ marginBottom: 8 }}>
+          <label style={{ fontSize: "0.82rem", marginRight: 8 }}>
+            Value basis
+          </label>
+          <select
+            className="select"
+            value={settings.valuationMode}
+            onChange={(e) => update("valuationMode", e.target.value)}
+          >
+            <option value="market">Market</option>
+            <option value="leagueAdjusted">My league</option>
+          </select>
+        </div>
+        <div
+          style={{ fontSize: "0.72rem", lineHeight: 1.55 }}
+          className="muted"
+        >
+          <p>
+            <strong>Market</strong> — the blended consensus board exactly as the
+            pipeline computes it. Shared by every league on the same scoring
+            settings.
+          </p>
+          <p>
+            <strong>My league</strong> — takes that board and re-prices it by
+            how scarce each position actually is here. We solve your exact
+            starting lineup against the 12 real rosters, measure the drop-off
+            from the best player at a position to the last startable one, and
+            scale every player at that position by up to ±10%. Thin positions
+            lift; deep positions trim. Ranks and tiers are recomputed on the
+            backend.
+          </p>
+          <p>
+            What it does <strong>not</strong> include, deliberately: no
+            tight-end premium — our market anchor is already KTC&apos;s TE++
+            board, so applying another would count the same premium twice. No
+            player projections — no source we can use publishes raw statistical
+            categories yet, so there is nothing to re-score under your rules.
+            And no per-player judgment: the adjustment is identical for every
+            player at a position, so it can never reorder your RBs against each
+            other.
+          </p>
+          <p>
+            What it <strong>does</strong> change is how positions — and{" "}
+            <strong>players versus draft picks</strong> — are priced against one
+            another. Picks carry no scarcity measurement, so they stay at market
+            value while players move around them. That is enough to shift most
+            ranks and to change trade verdicts.
+          </p>
+          <p>
+            Not applied while custom source weights are active: the two cannot
+            be combined correctly yet, so the board stays on your custom market
+            values.
+          </p>
+        </div>
       </Section>
 
       <Section title="Rankings Display" defaultOpen>
         <div style={{ marginBottom: 8 }}>
-          <label style={{ fontSize: "0.82rem", marginRight: 8 }}>Sort Basis</label>
+          <label style={{ fontSize: "0.82rem", marginRight: 8 }}>
+            Sort Basis
+          </label>
           <select
             className="select"
             value={settings.rankingsSortBasis}
@@ -407,19 +569,33 @@ export default function SettingsPage() {
       </Section>
 
       <Section title="Ranking Sources" defaultOpen>
-        <div style={{ fontSize: "0.72rem", marginBottom: 10 }} className="muted">
-          Every registered source contributes equally (default weight 1.0) to the
-          blended consensus rank.  Toggle a source off or adjust its weight to
-          recompute the board with your own mix.  Changing any knob flips the
+        <div
+          style={{ fontSize: "0.72rem", marginBottom: 10 }}
+          className="muted"
+        >
+          Every registered source contributes equally (default weight 1.0) to
+          the blended consensus rank. Toggle a source off or adjust its weight
+          to recompute the board with your own mix. Changing any knob flips the
           rankings page into override mode so your settings materially affect
           the displayed rank and value; clearing the overrides returns to the
-          canonical server blend.  IDP Trade Calculator is the IDP backbone and
-          also feeds offense via its secondary scope.  Backend registry:{" "}
-          <code style={{ fontFamily: "var(--mono)" }}>src/api/data_contract.py</code>.
+          canonical server blend. IDP Trade Calculator is the IDP backbone and
+          also feeds offense via its secondary scope. Backend registry:{" "}
+          <code style={{ fontFamily: "var(--mono)" }}>
+            src/api/data_contract.py
+          </code>
+          .
         </div>
-        <div style={{ display: "flex", gap: 8, marginBottom: 10, flexWrap: "wrap" }}>
+        <div
+          style={{
+            display: "flex",
+            gap: 8,
+            marginBottom: 10,
+            flexWrap: "wrap",
+          }}
+        >
           {Object.values(WEIGHT_PRESETS).map((preset) => {
-            const active = detectActivePreset(settings?.siteWeights) === preset.key;
+            const active =
+              detectActivePreset(settings?.siteWeights) === preset.key;
             return (
               <button
                 key={preset.key}
@@ -427,7 +603,9 @@ export default function SettingsPage() {
                 className={`button${active ? " button-primary" : ""}`}
                 style={{ fontSize: "0.72rem" }}
                 title={preset.description}
-                onClick={() => update("siteWeights", presetToWeights(preset.key))}
+                onClick={() =>
+                  update("siteWeights", presetToWeights(preset.key))
+                }
               >
                 {preset.label}
                 {active ? " ✓" : ""}
@@ -458,9 +636,14 @@ export default function SettingsPage() {
       </Section>
 
       <Section title="Rest-of-Season Engine" defaultOpen={false}>
-        <p className="muted" style={{ fontSize: "0.72rem", marginTop: 0, marginBottom: 10 }}>
+        <p
+          className="muted"
+          style={{ fontSize: "0.72rem", marginTop: 0, marginBottom: 10 }}
+        >
           The ROS engine is a separate short-term contender layer.{" "}
-          <strong>It never modifies dynasty rankings or trade-calculator math.</strong>{" "}
+          <strong>
+            It never modifies dynasty rankings or trade-calculator math.
+          </strong>{" "}
           These flags only control which surfaces show ROS context.
         </p>
         <ToggleRow
@@ -493,7 +676,14 @@ export default function SettingsPage() {
           onChange={(v) => update("showRosTags", v)}
           hint="Appends a Short-term context section to PlayerPopup with ROS value, rank, tier, and tags like Win-now target / Seller cash-out / Rebuilder hold."
         />
-        <div style={{ display: "flex", gap: 10, alignItems: "center", marginTop: 14 }}>
+        <div
+          style={{
+            display: "flex",
+            gap: 10,
+            alignItems: "center",
+            marginTop: 14,
+          }}
+        >
           <label style={{ fontSize: "0.82rem", minWidth: 200 }}>
             Monte Carlo simulations
           </label>
@@ -506,7 +696,10 @@ export default function SettingsPage() {
             onChange={(e) =>
               update(
                 "rosSimulationCount",
-                Math.max(1000, Math.min(100000, parseInt(e.target.value) || 10000)),
+                Math.max(
+                  1000,
+                  Math.min(100000, parseInt(e.target.value) || 10000),
+                ),
               )
             }
             className="input"
@@ -544,19 +737,18 @@ export default function SettingsPage() {
           <a href="/tools/ros-data-health" style={{ color: "var(--cyan)" }}>
             /tools/ros-data-health
           </a>
-          .  Overrides apply on the next admin Refresh — scheduled scrapes
-          run with registry defaults.
+          . Overrides apply on the next admin Refresh — scheduled scrapes run
+          with registry defaults.
         </p>
       </Section>
 
       <Section title="Pick Settings" defaultOpen={false}>
         <p className="muted" style={{ fontSize: "0.72rem", marginTop: 0 }}>
-          Future-year pick values are discounted automatically by the
-          ranking engine, and the &ldquo;current draft year&rdquo; now
-          rolls forward on its own from the live data — the next draft
-          carries no penalty, and further-out picks are discounted by
-          distance.  There is no longer a manual draft-year setting to
-          keep in sync.
+          Future-year pick values are discounted automatically by the ranking
+          engine, and the &ldquo;current draft year&rdquo; now rolls forward on
+          its own from the live data — the next draft carries no penalty, and
+          further-out picks are discounted by distance. There is no longer a
+          manual draft-year setting to keep in sync.
         </p>
       </Section>
 
@@ -569,8 +761,18 @@ export default function SettingsPage() {
               onChange={toggleEnabled}
               hint="Buy/sell/injury/roster digest, sent once per day when you have live signals."
             />
-            <div style={{ display: "flex", gap: 8, alignItems: "center", marginTop: 8, flexWrap: "wrap" }}>
-              <label style={{ fontSize: "0.82rem", minWidth: 100 }}>Email address</label>
+            <div
+              style={{
+                display: "flex",
+                gap: 8,
+                alignItems: "center",
+                marginTop: 8,
+                flexWrap: "wrap",
+              }}
+            >
+              <label style={{ fontSize: "0.82rem", minWidth: 100 }}>
+                Email address
+              </label>
               <input
                 type="email"
                 className="input"
@@ -582,7 +784,11 @@ export default function SettingsPage() {
                 }}
                 style={{ flex: "1 1 260px", maxWidth: 360 }}
               />
-              <button className="button" onClick={saveEmail} style={{ fontSize: "0.76rem" }}>
+              <button
+                className="button"
+                onClick={saveEmail}
+                style={{ fontSize: "0.76rem" }}
+              >
                 Save
               </button>
               {emailDraft && (
@@ -601,33 +807,65 @@ export default function SettingsPage() {
               )}
             </div>
             {emailStatus && (
-              <div className="muted" style={{ fontSize: "0.72rem", marginTop: 6, color: "var(--green)" }}>
+              <div
+                className="muted"
+                style={{
+                  fontSize: "0.72rem",
+                  marginTop: 6,
+                  color: "var(--green)",
+                }}
+              >
                 {emailStatus}
               </div>
             )}
-            <p className="muted" style={{ fontSize: "0.7rem", marginTop: 10, marginBottom: 0 }}>
-              Alerts fire once per day when the signal engine finds something notable on your
-              roster — buy-low / sell-high opportunities, injury news, rookie or pick movement.
-              We only email you when there&apos;s a change worth acting on.
+            <p
+              className="muted"
+              style={{ fontSize: "0.7rem", marginTop: 10, marginBottom: 0 }}
+            >
+              Alerts fire once per day when the signal engine finds something
+              notable on your roster — buy-low / sell-high opportunities, injury
+              news, rookie or pick movement. We only email you when there&apos;s
+              a change worth acting on.
             </p>
-            <div style={{ marginTop: 14, paddingTop: 12, borderTop: "1px solid var(--border)" }}>
+            <div
+              style={{
+                marginTop: 14,
+                paddingTop: 12,
+                borderTop: "1px solid var(--border)",
+              }}
+            >
               <PushNotificationToggle enabled={!!serverBacked} />
             </div>
           </>
         ) : (
           <p className="muted" style={{ fontSize: "0.78rem" }}>
-            Sign in to enable email notifications.  Your notification preferences
+            Sign in to enable email notifications. Your notification preferences
             are stored on the server and apply across devices.
           </p>
         )}
       </Section>
 
       <Section title="Watchlist" defaultOpen={false}>
-        <div style={{ fontSize: "0.78rem", color: "var(--subtext)", marginBottom: 8 }}>
+        <div
+          style={{
+            fontSize: "0.78rem",
+            color: "var(--subtext)",
+            marginBottom: 8,
+          }}
+        >
           Players you star (here or via the ☆ on Rankings / a player card).
-          {serverBacked ? " Synced across your devices." : " Saved on this device."}
+          {serverBacked
+            ? " Synced across your devices."
+            : " Saved on this device."}
         </div>
-        <div style={{ display: "flex", gap: 6, marginBottom: 10, flexWrap: "wrap" }}>
+        <div
+          style={{
+            display: "flex",
+            gap: 6,
+            marginBottom: 10,
+            flexWrap: "wrap",
+          }}
+        >
           <input
             className="input"
             value={watchAddName}
@@ -690,7 +928,11 @@ export default function SettingsPage() {
                   className="button-reset"
                   title="Remove from watchlist"
                   onClick={() => toggleWatchlist(name)}
-                  style={{ cursor: "pointer", color: "var(--subtext)", padding: "0 6px" }}
+                  style={{
+                    cursor: "pointer",
+                    color: "var(--subtext)",
+                    padding: "0 6px",
+                  }}
                 >
                   ☆ remove
                 </button>
@@ -712,8 +954,17 @@ export default function SettingsPage() {
         <GuestPassPanel />
       </Section>
 
-      <div className="muted" style={{ fontSize: "0.72rem", marginTop: 12, padding: "8px 0", borderTop: "1px solid var(--border)" }}>
-        Settings are saved automatically to your browser. They affect trade calculations, rankings display, and value composites.
+      <div
+        className="muted"
+        style={{
+          fontSize: "0.72rem",
+          marginTop: 12,
+          padding: "8px 0",
+          borderTop: "1px solid var(--border)",
+        }}
+      >
+        Settings are saved automatically to your browser. They affect trade
+        calculations, rankings display, and value composites.
       </div>
     </section>
   );
@@ -737,11 +988,36 @@ function SourceTable({ title, sources, onToggle, onWeight }) {
           <thead>
             <tr style={{ borderBottom: "1px solid var(--border)" }}>
               <th style={{ textAlign: "left", padding: "6px 8px" }}>Source</th>
-              <th className="settings-src-col-role" style={{ textAlign: "left", padding: "6px 8px" }}>Role</th>
-              <th style={{ textAlign: "center", padding: "6px 8px" }} title="Include this source in rank blending">On</th>
-              <th style={{ textAlign: "right", padding: "6px 8px" }} title="Weight applied to this source in the blend. Default 1.0">Weight</th>
-              <th className="settings-src-col-covered" style={{ textAlign: "right", padding: "6px 8px" }}>Covered</th>
-              <th className="settings-src-col-status" style={{ textAlign: "center", padding: "6px 8px" }}>Status</th>
+              <th
+                className="settings-src-col-role"
+                style={{ textAlign: "left", padding: "6px 8px" }}
+              >
+                Role
+              </th>
+              <th
+                style={{ textAlign: "center", padding: "6px 8px" }}
+                title="Include this source in rank blending"
+              >
+                On
+              </th>
+              <th
+                style={{ textAlign: "right", padding: "6px 8px" }}
+                title="Weight applied to this source in the blend. Default 1.0"
+              >
+                Weight
+              </th>
+              <th
+                className="settings-src-col-covered"
+                style={{ textAlign: "right", padding: "6px 8px" }}
+              >
+                Covered
+              </th>
+              <th
+                className="settings-src-col-status"
+                style={{ textAlign: "center", padding: "6px 8px" }}
+              >
+                Status
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -763,7 +1039,14 @@ function SourceTable({ title, sources, onToggle, onWeight }) {
                   }}
                 >
                   <td style={{ padding: "6px 8px" }}>
-                    <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 6,
+                        flexWrap: "wrap",
+                      }}
+                    >
                       <span style={{ fontWeight: 600 }}>{src.displayName}</span>
                       {/* Role badge — visible only on mobile where the
                           dedicated Role column is hidden to save horizontal
@@ -789,7 +1072,8 @@ function SourceTable({ title, sources, onToggle, onWeight }) {
                           style={{
                             fontSize: "0.58rem",
                             padding: "1px 5px",
-                            background: "var(--green-dim, rgba(80,200,120,0.18))",
+                            background:
+                              "var(--green-dim, rgba(80,200,120,0.18))",
                             color: "var(--green, #4ade80)",
                             border: "1px solid var(--green, #4ade80)",
                             borderRadius: 3,
@@ -812,7 +1096,10 @@ function SourceTable({ title, sources, onToggle, onWeight }) {
                       </span>
                     </div>
                   </td>
-                  <td className="settings-src-col-role" style={{ padding: "6px 8px", fontSize: "0.72rem" }}>
+                  <td
+                    className="settings-src-col-role"
+                    style={{ padding: "6px 8px", fontSize: "0.72rem" }}
+                  >
                     {role}
                   </td>
                   <td style={{ padding: "6px 8px", textAlign: "center" }}>
@@ -840,7 +1127,8 @@ function SourceTable({ title, sources, onToggle, onWeight }) {
                       value={Number(src.userWeight).toFixed(1)}
                       onChange={(e) => {
                         const v = Number(e.target.value);
-                        if (Number.isFinite(v) && v >= 0) onWeight?.(src.key, v);
+                        if (Number.isFinite(v) && v >= 0)
+                          onWeight?.(src.key, v);
                       }}
                       disabled={!enabled}
                       className="input weight-input"
@@ -884,8 +1172,6 @@ function SourceTable({ title, sources, onToggle, onWeight }) {
   );
 }
 
-
-
 function RosSourceTable({ overrides, onToggle, onWeight, onResetSource }) {
   // Triggers an admin scrape with the user's overrides in the body.
   // Falls back to plain "no-body" call if the user hasn't customized
@@ -911,13 +1197,15 @@ function RosSourceTable({ overrides, onToggle, onWeight, onResetSource }) {
         if (res.status === 401) {
           setFeedback("Admin session required.");
         } else {
-          setFeedback(`Refresh failed (HTTP ${res.status}): ${text.slice(0, 120)}`);
+          setFeedback(
+            `Refresh failed (HTTP ${res.status}): ${text.slice(0, 120)}`,
+          );
         }
       } else {
         const data = await res.json().catch(() => ({}));
         setFeedback(
           `Refreshed ${data.ranSources?.length ?? "?"} sources · ` +
-          `aggregate=${data.playerCount ?? "?"} players`,
+            `aggregate=${data.playerCount ?? "?"} players`,
         );
       }
     } catch (err) {
@@ -937,10 +1225,20 @@ function RosSourceTable({ overrides, onToggle, onWeight, onResetSource }) {
           <thead>
             <tr style={{ borderBottom: "1px solid var(--border)" }}>
               <th style={{ textAlign: "left", padding: "6px 8px" }}>Source</th>
-              <th className="settings-src-col-role" style={{ textAlign: "left", padding: "6px 8px" }}>Type</th>
+              <th
+                className="settings-src-col-role"
+                style={{ textAlign: "left", padding: "6px 8px" }}
+              >
+                Type
+              </th>
               <th style={{ textAlign: "center", padding: "6px 8px" }}>On</th>
               <th style={{ textAlign: "right", padding: "6px 8px" }}>Weight</th>
-              <th className="settings-src-col-status" style={{ textAlign: "center", padding: "6px 8px" }}>Default</th>
+              <th
+                className="settings-src-col-status"
+                style={{ textAlign: "center", padding: "6px 8px" }}
+              >
+                Default
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -953,7 +1251,8 @@ function RosSourceTable({ overrides, onToggle, onWeight, onResetSource }) {
               const customized =
                 ov.enabled === false ||
                 (Number.isFinite(Number(ov.weight)) &&
-                  Math.abs(Number(ov.weight) - Number(src.baseWeight ?? 1.0)) > 1e-6);
+                  Math.abs(Number(ov.weight) - Number(src.baseWeight ?? 1.0)) >
+                    1e-6);
               const sourceTypeLabel = src.isRos
                 ? "Real ROS"
                 : src.isDynasty
@@ -968,7 +1267,14 @@ function RosSourceTable({ overrides, onToggle, onWeight, onResetSource }) {
                   }}
                 >
                   <td style={{ padding: "6px 8px" }}>
-                    <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 6,
+                        flexWrap: "wrap",
+                      }}
+                    >
                       <span style={{ fontWeight: 600 }}>{src.displayName}</span>
                       {src.isIdp && (
                         <span
@@ -1000,11 +1306,24 @@ function RosSourceTable({ overrides, onToggle, onWeight, onResetSource }) {
                         </span>
                       )}
                     </div>
-                    <div style={{ fontSize: "0.66rem", color: "var(--subtext)", marginTop: 2 }}>
+                    <div
+                      style={{
+                        fontSize: "0.66rem",
+                        color: "var(--subtext)",
+                        marginTop: 2,
+                      }}
+                    >
                       {src.key}
                     </div>
                   </td>
-                  <td className="settings-src-col-role" style={{ padding: "6px 8px", fontSize: "0.74rem", color: "var(--subtext)" }}>
+                  <td
+                    className="settings-src-col-role"
+                    style={{
+                      padding: "6px 8px",
+                      fontSize: "0.74rem",
+                      color: "var(--subtext)",
+                    }}
+                  >
                     {sourceTypeLabel}
                   </td>
                   <td style={{ padding: "6px 8px", textAlign: "center" }}>
@@ -1016,7 +1335,13 @@ function RosSourceTable({ overrides, onToggle, onWeight, onResetSource }) {
                       style={{ cursor: "pointer" }}
                     />
                   </td>
-                  <td style={{ padding: "6px 8px", textAlign: "right", fontFamily: "var(--mono)" }}>
+                  <td
+                    style={{
+                      padding: "6px 8px",
+                      textAlign: "right",
+                      fontFamily: "var(--mono)",
+                    }}
+                  >
                     <input
                       type="number"
                       min={0}
@@ -1034,7 +1359,15 @@ function RosSourceTable({ overrides, onToggle, onWeight, onResetSource }) {
                       disabled={!enabled}
                     />
                   </td>
-                  <td className="settings-src-col-status" style={{ padding: "6px 8px", textAlign: "center", fontSize: "0.7rem", color: "var(--subtext)" }}>
+                  <td
+                    className="settings-src-col-status"
+                    style={{
+                      padding: "6px 8px",
+                      textAlign: "center",
+                      fontSize: "0.7rem",
+                      color: "var(--subtext)",
+                    }}
+                  >
                     {customized ? (
                       <button
                         type="button"
@@ -1062,7 +1395,14 @@ function RosSourceTable({ overrides, onToggle, onWeight, onResetSource }) {
           </tbody>
         </table>
       </div>
-      <div style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 10 }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          marginTop: 10,
+        }}
+      >
         <button
           type="button"
           className="button button-primary"
@@ -1072,13 +1412,13 @@ function RosSourceTable({ overrides, onToggle, onWeight, onResetSource }) {
           {submitting ? "Refreshing..." : "Apply now (admin refresh)"}
         </button>
         <span style={{ fontSize: "0.7rem", color: "var(--subtext)" }}>
-          {feedback || "Triggers POST /api/ros/refresh — re-runs the orchestrator with these overrides."}
+          {feedback ||
+            "Triggers POST /api/ros/refresh — re-runs the orchestrator with these overrides."}
         </span>
       </div>
     </div>
   );
 }
-
 
 function ServerStatusPanel() {
   const [status, setStatus] = useState(null);
@@ -1107,7 +1447,11 @@ function ServerStatusPanel() {
     try {
       const res = await fetch("/api/scrape", { method: "POST" });
       const data = await res.json().catch(() => ({}));
-      setScrapeMsg(data.error ? `Error: ${data.error}` : "Refresh triggered. Data will update shortly.");
+      setScrapeMsg(
+        data.error
+          ? `Error: ${data.error}`
+          : "Refresh triggered. Data will update shortly.",
+      );
       setTimeout(fetchStatus, 5000);
     } catch {
       setScrapeMsg("Failed to reach backend.");
@@ -1120,10 +1464,19 @@ function ServerStatusPanel() {
 
   return (
     <div>
-      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10 }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          marginBottom: 10,
+        }}
+      >
         <span
           style={{
-            width: 8, height: 8, borderRadius: "50%",
+            width: 8,
+            height: 8,
+            borderRadius: "50%",
             background: connected ? "var(--green)" : "var(--red)",
             display: "inline-block",
           }}
@@ -1134,11 +1487,21 @@ function ServerStatusPanel() {
       </div>
 
       {connected && (
-        <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginBottom: 10 }}>
-          {status.player_count != null && <div>Players: {status.player_count}</div>}
+        <div
+          style={{
+            fontSize: "0.72rem",
+            color: "var(--subtext)",
+            marginBottom: 10,
+          }}
+        >
+          {status.player_count != null && (
+            <div>Players: {status.player_count}</div>
+          )}
           {status.last_scrape && <div>Last update: {status.last_scrape}</div>}
           {status.next_scrape && <div>Next update: {status.next_scrape}</div>}
-          {status?.contract?.version && <div>Contract: {status.contract.version}</div>}
+          {status?.contract?.version && (
+            <div>Contract: {status.contract.version}</div>
+          )}
           {status?.uptime?.last_ok && (
             <div>
               Uptime monitor:{" "}
@@ -1151,7 +1514,9 @@ function ServerStatusPanel() {
       )}
 
       {status?.error && (
-        <div style={{ fontSize: "0.72rem", color: "var(--red)", marginBottom: 10 }}>
+        <div
+          style={{ fontSize: "0.72rem", color: "var(--red)", marginBottom: 10 }}
+        >
           {status.error}
         </div>
       )}
@@ -1175,7 +1540,15 @@ function ServerStatusPanel() {
       </div>
 
       {scrapeMsg && (
-        <div style={{ fontSize: "0.72rem", marginTop: 6, color: scrapeMsg.startsWith("Error") ? "var(--red)" : "var(--green)" }}>
+        <div
+          style={{
+            fontSize: "0.72rem",
+            marginTop: 6,
+            color: scrapeMsg.startsWith("Error")
+              ? "var(--red)"
+              : "var(--green)",
+          }}
+        >
           {scrapeMsg}
         </div>
       )}
@@ -1285,14 +1658,15 @@ function GuestPassPanel() {
   }
 
   async function revoke(id) {
-    if (!window.confirm("Revoke this guest pass? The recipient will lose access.")) {
+    if (
+      !window.confirm("Revoke this guest pass? The recipient will lose access.")
+    ) {
       return;
     }
     try {
-      const res = await fetch(
-        `/api/admin/guest-pass/${id}/revoke`,
-        { method: "POST" },
-      );
+      const res = await fetch(`/api/admin/guest-pass/${id}/revoke`, {
+        method: "POST",
+      });
       if (!res.ok) {
         setError(`Revoke failed (${res.status})`);
         return;
@@ -1306,11 +1680,10 @@ function GuestPassPanel() {
   return (
     <div>
       <p className="muted" style={{ fontSize: "0.76rem", margin: "0 0 12px" }}>
-        Generate a temporary password to share with someone you want to
-        give private-app access. They paste it into the login form's
-        password field; their session expires automatically when the
-        pass does. Plaintext tokens are shown ONCE — copy and share
-        immediately.
+        Generate a temporary password to share with someone you want to give
+        private-app access. They paste it into the login form's password field;
+        their session expires automatically when the pass does. Plaintext tokens
+        are shown ONCE — copy and share immediately.
       </p>
 
       {/* ── Generate form ─────────────────────────────────────── */}
@@ -1509,9 +1882,7 @@ function GuestPassPanel() {
                       {p.id}
                     </td>
                     <td style={{ padding: "4px 6px" }}>
-                      {p.note || (
-                        <span className="muted">— no note —</span>
-                      )}
+                      {p.note || <span className="muted">— no note —</span>}
                     </td>
                     <td
                       style={{ padding: "4px 6px", fontFamily: "var(--mono)" }}

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -37,10 +37,7 @@ import TradeDeltaHistogram from "@/components/graphs/TradeDeltaHistogram";
 import RosTradeFitPanel from "@/components/RosTradeFitPanel";
 import MultiTradeFlow from "@/components/graphs/MultiTradeFlow";
 import { useApp } from "@/components/AppShell";
-import {
-  buildShareUrl,
-  parseShareParam,
-} from "@/lib/trade-share";
+import { buildShareUrl, parseShareParam } from "@/lib/trade-share";
 import { useTradeSimulator } from "@/components/useTradeSimulator";
 import { useTeam } from "@/components/useTeam";
 import SharedTradeMeter from "@/components/trade/TradeMeter";
@@ -51,6 +48,7 @@ import {
   Button,
   Panel,
   PageHeader,
+  SegmentedControl,
   Select,
   SkeletonTable,
 } from "@/components/ds";
@@ -88,15 +86,12 @@ const TradeSourceBreakdown = SharedTradeSourceBreakdown;
 
 export default function TradePage() {
   const { loading, error, rows, rawData } = useDynastyData();
-  const { settings } = useSettings();
+  const { settings, update: updateSetting } = useSettings();
   const { openPlayerPopup, registerAddToTrade } = useApp();
   const [valueMode, setValueMode] = useState("full");
 
   // Multi-team state: array of { id, label, assets }
-  const [sides, setSides] = useState([
-    createSide(0),
-    createSide(1),
-  ]);
+  const [sides, setSides] = useState([createSide(0), createSide(1)]);
   const [activeSide, setActiveSide] = useState(0); // index into sides
   // Per-side inline search: each side renders its own search input, so
   // adding a player is one tap away — no overlay, no "+ Add" button.
@@ -136,19 +131,21 @@ export default function TradePage() {
   // Share + simulator state.
   const [shareStatus, setShareStatus] = useState("");
   const [shareHydrated, setShareHydrated] = useState(false);
-  const { simulate: simulateTrade, result: simResult, loading: simLoading, error: simError, reset: resetSim } = useTradeSimulator();
+  const {
+    simulate: simulateTrade,
+    result: simResult,
+    loading: simLoading,
+    error: simError,
+    reset: resetSim,
+  } = useTradeSimulator();
   // useTeam is already league-aware: ``selectedTeam`` resolves
   // against the active league, ``idpEnabled`` comes from the
   // league config, ``leagueMismatch`` flags the data-not-ready
   // state.  We use all three below to render the right picker
   // options, auto-attach the right league to trade suggestions,
   // and show a clear "data not ready" banner when needed.
-  const {
-    selectedTeam,
-    idpEnabled,
-    leagueMismatch,
-    selectedLeagueKey,
-  } = useTeam();
+  const { selectedTeam, idpEnabled, leagueMismatch, selectedLeagueKey } =
+    useTeam();
 
   // Extract Sleeper teams from dynasty data
   const sleeperTeams = useMemo(() => {
@@ -267,7 +264,8 @@ export default function TradePage() {
 
   const currentDraftYear = useMemo(() => {
     const fromContract = Number(rawData?.currentDraftYear);
-    if (Number.isFinite(fromContract) && fromContract > 2000) return fromContract;
+    if (Number.isFinite(fromContract) && fromContract > 2000)
+      return fromContract;
     const fromDC = parseInt(String(draftCapital?.season || ""), 10);
     return Number.isFinite(fromDC) ? fromDC : null;
   }, [rawData, draftCapital]);
@@ -287,13 +285,16 @@ export default function TradePage() {
   useEffect(() => {
     setSideTeamNames((prev) =>
       sides.map((s, i) =>
-        sideTeamLocked[i] ? (prev[i] ?? null) : (inferTeamForSide(s)?.name ?? null),
+        sideTeamLocked[i]
+          ? (prev[i] ?? null)
+          : (inferTeamForSide(s)?.name ?? null),
       ),
     );
   }, [sides, inferTeamForSide, sideTeamLocked]);
 
   const tradeHasPicks = useMemo(
-    () => sides.some((s) => (s.assets || []).some((a) => a.assetClass === "pick")),
+    () =>
+      sides.some((s) => (s.assets || []).some((a) => a.assetClass === "pick")),
     [sides],
   );
   // Gate: every side a pick is traded FROM *or* TO needs a resolved
@@ -331,11 +332,15 @@ export default function TradePage() {
     try {
       const saved = localStorage.getItem(ROSTER_KEY);
       if (saved) setRosterInput(saved);
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
     try {
       const savedTeam = localStorage.getItem(TEAM_KEY);
       if (savedTeam !== null) setSelectedTeamIdx(Number(savedTeam));
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }, []);
 
   // Sync trade-page team picker with the topbar's ``useTeam`` state.
@@ -356,16 +361,19 @@ export default function TradePage() {
     // stable; name is fallback for legacy contracts that don't
     // stamp ownerId.
     const ownerId = String(selectedTeam.ownerId || "");
-    const name = String(selectedTeam.name || "").trim().toLowerCase();
+    const name = String(selectedTeam.name || "")
+      .trim()
+      .toLowerCase();
     let idx = -1;
     if (ownerId) {
-      idx = sleeperTeams.findIndex(
-        (t) => String(t?.ownerId || "") === ownerId,
-      );
+      idx = sleeperTeams.findIndex((t) => String(t?.ownerId || "") === ownerId);
     }
     if (idx < 0 && name) {
       idx = sleeperTeams.findIndex(
-        (t) => String(t?.name || "").trim().toLowerCase() === name,
+        (t) =>
+          String(t?.name || "")
+            .trim()
+            .toLowerCase() === name,
       );
     }
     if (idx < 0) return;
@@ -388,13 +396,18 @@ export default function TradePage() {
         const restored = deserializeWorkspaceMulti(parsed, rowByName);
         if (restored) {
           const nextMode = String(restored.valueMode || "full");
-          if (VALUE_MODES.some((m) => m.key === nextMode)) setValueMode(nextMode);
+          if (VALUE_MODES.some((m) => m.key === nextMode))
+            setValueMode(nextMode);
           setActiveSide(restored.activeSide);
           setSides(restored.sides);
           setValueOverrides({});
         }
       }
-    } catch { /* ignore */ } finally { setHydrated(true); }
+    } catch {
+      /* ignore */
+    } finally {
+      setHydrated(true);
+    }
   }, [rows, hydrated, rowByName]);
 
   // Persist trade workspace to localStorage
@@ -425,7 +438,8 @@ export default function TradePage() {
       const neededSides = Math.max(2, state.sides.length);
       const ensureSides = (prev) => {
         let next = prev;
-        while (next.length < neededSides) next = [...next, createSide(next.length)];
+        while (next.length < neededSides)
+          next = [...next, createSide(next.length)];
         return next;
       };
       setSides((prev) => {
@@ -609,7 +623,8 @@ export default function TradePage() {
   // side).  In 3+-team trades each asset's destination drives the NET
   // flow, which is what the multi-team fairness bar renders.
   const sideFlows = useMemo(
-    () => computeSideFlows(sidesWithOverrides, valueMode, settings, stackContext),
+    () =>
+      computeSideFlows(sidesWithOverrides, valueMode, settings, stackContext),
     [sidesWithOverrides, valueMode, settings, stackContext],
   );
 
@@ -618,10 +633,7 @@ export default function TradePage() {
   // assets (and from whom) are arriving.  Rendered as a "Receiving"
   // section in 3+-team mode so the user doesn't have to mentally
   // reverse-lookup destinations across three separate side cards.
-  const sideFlowAssets = useMemo(
-    () => computeSideFlowAssets(sides),
-    [sides],
-  );
+  const sideFlowAssets = useMemo(() => computeSideFlowAssets(sides), [sides]);
 
   // Which side is the user's own roster?  Derived by counting how
   // many of each side's current assets match the user's selected
@@ -656,7 +668,10 @@ export default function TradePage() {
   const linTotalA = sideTotals[0]?.raw || 0;
   const linTotalB = sideTotals[1]?.raw || 0;
   const pwGap = pwTotalA - pwTotalB;
-  const pctGap = Math.max(pwTotalA, pwTotalB) > 0 ? Math.round(Math.abs(pwGap) / Math.max(pwTotalA, pwTotalB) * 100) : 0;
+  const pctGap =
+    Math.max(pwTotalA, pwTotalB) > 0
+      ? Math.round((Math.abs(pwGap) / Math.max(pwTotalA, pwTotalB)) * 100)
+      : 0;
 
   // Balancing suggestions (2-team mode only).
   //
@@ -671,7 +686,9 @@ export default function TradePage() {
   const balancers = useMemo(() => {
     if (sides.length !== 2) return { list: [], teamName: null };
     if (Math.abs(pwGap) < 350) return { list: [], teamName: null };
-    const allInTrade = new Set(sides.flatMap((s) => s.assets.map((a) => a.name)));
+    const allInTrade = new Set(
+      sides.flatMap((s) => s.assets.map((a) => a.name)),
+    );
     // Behind side = the one whose total is LOWER.
     const behindSideIdx = pwGap > 0 ? 1 : 0;
     const behindSide = sides[behindSideIdx];
@@ -681,7 +698,9 @@ export default function TradePage() {
     const is2026Pick = (r) => r.assetClass === "pick" && /^2026\b/.test(r.name);
     if (behindTeam) {
       const roster = teamRosterNames(behindTeam);
-      pool = rows.filter((r) => roster.has(r.name) && !allInTrade.has(r.name) && !is2026Pick(r));
+      pool = rows.filter(
+        (r) => roster.has(r.name) && !allInTrade.has(r.name) && !is2026Pick(r),
+      );
       teamName = behindTeam.name || null;
     }
     // Fallback when no team can be inferred (or the inferred team
@@ -707,10 +726,12 @@ export default function TradePage() {
     if (sides.length <= 2) return null;
     const nets = sideFlows.map((f) => f.net);
     const worstIdx = nets.indexOf(Math.min(...nets)); // most negative = overpaying
-    const bestIdx = nets.indexOf(Math.max(...nets));  // most positive = getting a deal
+    const bestIdx = nets.indexOf(Math.max(...nets)); // most positive = getting a deal
     const gap = nets[bestIdx] - nets[worstIdx];
     if (gap < 350) return null;
-    const allInTrade = new Set(sides.flatMap((s) => s.assets.map((a) => a.name)));
+    const allInTrade = new Set(
+      sides.flatMap((s) => s.assets.map((a) => a.name)),
+    );
     // Panel renders on the side that needs to GIVE more (the one with
     // the best deal right now).  Filter the suggestion pool to that
     // side's Sleeper team so the "add more" list is players they
@@ -722,7 +743,9 @@ export default function TradePage() {
     const is2026Pick = (r) => r.assetClass === "pick" && /^2026\b/.test(r.name);
     if (underpayingTeam) {
       const roster = teamRosterNames(underpayingTeam);
-      pool = rows.filter((r) => roster.has(r.name) && !allInTrade.has(r.name) && !is2026Pick(r));
+      pool = rows.filter(
+        (r) => roster.has(r.name) && !allInTrade.has(r.name) && !is2026Pick(r),
+      );
       teamName = underpayingTeam.name || null;
     }
     if (!pool || pool.length === 0) {
@@ -748,50 +771,61 @@ export default function TradePage() {
   // query, excluding anything already in the trade.  Sorted by
   // consensus rank ascending so the top hits are the most relevant
   // dynasty assets first — matches the KTC trade-calculator UX.
-  const searchAssets = useCallback((query) => {
-    const q = (query || "").trim().toLowerCase();
-    if (!q) return [];
-    const list = rows.filter(
-      (r) => !allTradeNames.has(r.name) &&
-        !(r.assetClass === "pick" && /^2026\b/.test(r.name)) &&
-        r.name.toLowerCase().includes(q),
-    );
-    list.sort((a, b) => (a.blendedSourceRank ?? Infinity) - (b.blendedSourceRank ?? Infinity));
-    return list.slice(0, 5);
-  }, [rows, allTradeNames]);
+  const searchAssets = useCallback(
+    (query) => {
+      const q = (query || "").trim().toLowerCase();
+      if (!q) return [];
+      const list = rows.filter(
+        (r) =>
+          !allTradeNames.has(r.name) &&
+          !(r.assetClass === "pick" && /^2026\b/.test(r.name)) &&
+          r.name.toLowerCase().includes(q),
+      );
+      list.sort(
+        (a, b) =>
+          (a.blendedSourceRank ?? Infinity) - (b.blendedSourceRank ?? Infinity),
+      );
+      return list.slice(0, 5);
+    },
+    [rows, allTradeNames],
+  );
 
   // ── Side management ─────────────────────────────────────────────────
   function addToSide(row, sideIdx) {
     if (!row) return;
     // Check all sides for duplicates
     if (allTradeNames.has(row.name)) return;
-    setSides((prev) => prev.map((s, i) => {
-      if (i !== sideIdx) return s;
-      if (s.assets.some((r) => r.name === row.name)) return s;
-      // 3+-team trades need an explicit destination per asset so the
-      // fairness bar can compute each side's NET flow.  Seed the
-      // default (next side, circular) whenever we're adding to a
-      // multi-side trade.  2-team trades leave destinations empty —
-      // ``computeSideFlows`` handles the implicit "other side" case.
-      const nextDestinations = { ...(s.destinations || {}) };
-      if (prev.length > 2) {
-        nextDestinations[row.name] = defaultDestination(i, prev.length);
-      }
-      return {
-        ...s,
-        assets: [...s.assets, row],
-        destinations: nextDestinations,
-      };
-    }));
+    setSides((prev) =>
+      prev.map((s, i) => {
+        if (i !== sideIdx) return s;
+        if (s.assets.some((r) => r.name === row.name)) return s;
+        // 3+-team trades need an explicit destination per asset so the
+        // fairness bar can compute each side's NET flow.  Seed the
+        // default (next side, circular) whenever we're adding to a
+        // multi-side trade.  2-team trades leave destinations empty —
+        // ``computeSideFlows`` handles the implicit "other side" case.
+        const nextDestinations = { ...(s.destinations || {}) };
+        if (prev.length > 2) {
+          nextDestinations[row.name] = defaultDestination(i, prev.length);
+        }
+        return {
+          ...s,
+          assets: [...s.assets, row],
+          destinations: nextDestinations,
+        };
+      }),
+    );
   }
 
   function setAssetDestination(sideIdx, assetName, destIdx) {
-    setSides((prev) => prev.map((s, i) => {
-      if (i !== sideIdx) return s;
-      const next = { ...(s.destinations || {}) };
-      next[assetName] = Number(destIdx);
-      return { ...s, destinations: next };
-    }));
+    setSides((prev) =>
+      prev.map((s, i) => {
+        if (i !== sideIdx) return s;
+        const next = { ...(s.destinations || {}) };
+        next[assetName] = Number(destIdx);
+        return { ...s, destinations: next };
+      }),
+    );
   }
 
   function addToActiveSide(row) {
@@ -838,21 +872,25 @@ export default function TradePage() {
   }
 
   function removeFromSide(name, sideIdx) {
-    setSides((prev) => prev.map((s, i) => {
-      if (i !== sideIdx) return s;
-      const nextDestinations = { ...(s.destinations || {}) };
-      delete nextDestinations[name];
-      return {
-        ...s,
-        assets: s.assets.filter((r) => r.name !== name),
-        destinations: nextDestinations,
-      };
-    }));
+    setSides((prev) =>
+      prev.map((s, i) => {
+        if (i !== sideIdx) return s;
+        const nextDestinations = { ...(s.destinations || {}) };
+        delete nextDestinations[name];
+        return {
+          ...s,
+          assets: s.assets.filter((r) => r.name !== name),
+          destinations: nextDestinations,
+        };
+      }),
+    );
     clearValueOverride(name);
   }
 
   function clearTrade() {
-    setSides((prev) => prev.map((s) => ({ ...s, assets: [], destinations: {} })));
+    setSides((prev) =>
+      prev.map((s) => ({ ...s, assets: [], destinations: {} })),
+    );
     setValueOverrides({});
   }
 
@@ -862,7 +900,7 @@ export default function TradePage() {
         { ...prev[1], id: 0, label: "A" },
         { ...prev[0], id: 1, label: "B" },
       ]);
-      setActiveSide((s) => s === 0 ? 1 : 0);
+      setActiveSide((s) => (s === 0 ? 1 : 0));
     } else {
       // Rotate: side i takes the previous side's assets.  Each asset
       // moves one slot forward, so its destination also rotates one
@@ -1030,7 +1068,8 @@ export default function TradePage() {
           // 1. Exact case match — fast path, covers 99%.
           let row = rowByName.get(entry.name);
           // 2. Case-insensitive match.
-          if (!row) row = lowerIndex.get(String(entry.name || "").toLowerCase());
+          if (!row)
+            row = lowerIndex.get(String(entry.name || "").toLowerCase());
           // 3. Normalized (punctuation / whitespace / suffix-stripped).
           if (!row) row = normIndex.get(_normalize(entry.name));
           // 4. Pick token fallback — KTC's pick labels ("2026 1.09",
@@ -1066,28 +1105,38 @@ export default function TradePage() {
       const cleanedOne = clean(one.found);
       const cleanedTwo = clean(two.found);
 
-      setSides((prev) => prev.map((s, i) => {
-        if (i !== 0 && i !== 1) return s; // leave 3rd+ sides alone
-        const replacement = i === 0 ? cleanedOne : cleanedTwo;
-        // Seed default destinations for the newly-loaded assets when
-        // we're in a 3+-team trade; 2-team trades ignore the map.
-        // Old destinations referencing assets that aren't in the new
-        // set are dropped so we don't accumulate stale routing.
-        const nextDestinations = {};
-        if (prev.length > 2) {
-          for (const asset of replacement) {
-            nextDestinations[asset.name] = defaultDestination(i, prev.length);
+      setSides((prev) =>
+        prev.map((s, i) => {
+          if (i !== 0 && i !== 1) return s; // leave 3rd+ sides alone
+          const replacement = i === 0 ? cleanedOne : cleanedTwo;
+          // Seed default destinations for the newly-loaded assets when
+          // we're in a 3+-team trade; 2-team trades ignore the map.
+          // Old destinations referencing assets that aren't in the new
+          // set are dropped so we don't accumulate stale routing.
+          const nextDestinations = {};
+          if (prev.length > 2) {
+            for (const asset of replacement) {
+              nextDestinations[asset.name] = defaultDestination(i, prev.length);
+            }
           }
-        }
-        return { ...s, assets: replacement, destinations: nextDestinations };
-      }));
+          return { ...s, assets: replacement, destinations: nextDestinations };
+        }),
+      );
       setValueOverrides({});
 
       const warnings = [];
-      if (unresolvedOne.length) warnings.push(`unknown KTC id(s) on side A: ${unresolvedOne.join(", ")}`);
-      if (unresolvedTwo.length) warnings.push(`unknown KTC id(s) on side B: ${unresolvedTwo.join(", ")}`);
-      if (one.missing.length) warnings.push(`no board match for: ${one.missing.join(", ")}`);
-      if (two.missing.length) warnings.push(`no board match for: ${two.missing.join(", ")}`);
+      if (unresolvedOne.length)
+        warnings.push(
+          `unknown KTC id(s) on side A: ${unresolvedOne.join(", ")}`,
+        );
+      if (unresolvedTwo.length)
+        warnings.push(
+          `unknown KTC id(s) on side B: ${unresolvedTwo.join(", ")}`,
+        );
+      if (one.missing.length)
+        warnings.push(`no board match for: ${one.missing.join(", ")}`);
+      if (two.missing.length)
+        warnings.push(`no board match for: ${two.missing.join(", ")}`);
       const totalLoaded = cleanedOne.length + cleanedTwo.length;
       const totalExpected = sideOneEntries.length + sideTwoEntries.length;
       if (totalLoaded === 0) {
@@ -1116,7 +1165,10 @@ export default function TradePage() {
     setExportStatus("");
     const sideOne = (sides[0]?.assets || []).map((r) => r.name);
     const sideTwo = (sides[1]?.assets || []).map((r) => r.name);
-    if (!sideOne.length && !sideTwo.length) { setExportStatus("Nothing to export."); return; }
+    if (!sideOne.length && !sideTwo.length) {
+      setExportStatus("Nothing to export.");
+      return;
+    }
     try {
       const res = await fetch("/api/trade/export-ktc", {
         method: "POST",
@@ -1125,10 +1177,23 @@ export default function TradePage() {
         cache: "no-store",
       });
       const data = await res.json();
-      if (!res.ok || !data.ok) { setExportStatus(data?.error || "KTC export failed."); return; }
-      try { await navigator.clipboard.writeText(data.url); } catch { /* clipboard blocked */ }
-      const miss = [...(data.unresolved?.sideOne || []), ...(data.unresolved?.sideTwo || [])];
-      setExportStatus("KTC URL copied" + (miss.length ? ` \u2014 unmatched: ${miss.join(", ")}` : ""));
+      if (!res.ok || !data.ok) {
+        setExportStatus(data?.error || "KTC export failed.");
+        return;
+      }
+      try {
+        await navigator.clipboard.writeText(data.url);
+      } catch {
+        /* clipboard blocked */
+      }
+      const miss = [
+        ...(data.unresolved?.sideOne || []),
+        ...(data.unresolved?.sideTwo || []),
+      ];
+      setExportStatus(
+        "KTC URL copied" +
+          (miss.length ? ` \u2014 unmatched: ${miss.join(", ")}` : ""),
+      );
     } catch (e) {
       setExportStatus("KTC export failed: " + (e?.message || e));
     }
@@ -1138,20 +1203,31 @@ export default function TradePage() {
     const blob = new Blob([text], { type: mime });
     const url = URL.createObjectURL(blob);
     const el = document.createElement("a");
-    el.href = url; el.download = filename;
-    document.body.appendChild(el); el.click(); el.remove();
+    el.href = url;
+    el.download = filename;
+    document.body.appendChild(el);
+    el.click();
+    el.remove();
     URL.revokeObjectURL(url);
   }, []);
 
   const exportCsv = useCallback(() => {
     const iso = new Date().toISOString().slice(0, 19).replace(/[:T]/g, "-");
-    _downloadFile(`trade-${iso}.csv`, tradeWorkspaceToCSV(sides, valueMode), "text/csv");
+    _downloadFile(
+      `trade-${iso}.csv`,
+      tradeWorkspaceToCSV(sides, valueMode),
+      "text/csv",
+    );
     setExportStatus("CSV downloaded.");
   }, [sides, valueMode, _downloadFile]);
 
   const exportJson = useCallback(() => {
     const iso = new Date().toISOString().slice(0, 19).replace(/[:T]/g, "-");
-    _downloadFile(`trade-${iso}.json`, tradeWorkspaceToJSON(sides, valueMode, activeSide), "application/json");
+    _downloadFile(
+      `trade-${iso}.json`,
+      tradeWorkspaceToJSON(sides, valueMode, activeSide),
+      "application/json",
+    );
     setExportStatus("JSON downloaded.");
   }, [sides, valueMode, activeSide, _downloadFile]);
 
@@ -1249,7 +1325,8 @@ export default function TradePage() {
     const picks = (team.picks || []).map((p) => {
       const m = p.match(/^(\d{4})\s+(\d)\./);
       if (m) {
-        const round = { "1": "1st", "2": "2nd", "3": "3rd", "4": "4th" }[m[2]] || `${m[2]}th`;
+        const round =
+          { 1: "1st", 2: "2nd", 3: "3rd", 4: "4th" }[m[2]] || `${m[2]}th`;
         return `${m[1]} ${round}`;
       }
       return p.replace(/\s*\(.*\)/, "").trim();
@@ -1398,7 +1475,9 @@ export default function TradePage() {
 
   function applySuggestion(s) {
     const giveRows = s.give.map((p) => rowByName.get(p.name)).filter(Boolean);
-    const recvRows = s.receive.map((p) => rowByName.get(p.name)).filter(Boolean);
+    const recvRows = s.receive
+      .map((p) => rowByName.get(p.name))
+      .filter(Boolean);
     // Apply to first two sides, reset others.  Suggestions are
     // inherently 2-team; wipe the 3rd+ side contents (and their
     // destination maps) so stale multi-team routing doesn't linger.
@@ -1413,8 +1492,18 @@ export default function TradePage() {
         return out;
       };
       return prev.map((side, i) => {
-        if (i === 0) return { ...side, assets: giveRows, destinations: seedDestinations(giveRows, 0) };
-        if (i === 1) return { ...side, assets: recvRows, destinations: seedDestinations(recvRows, 1) };
+        if (i === 0)
+          return {
+            ...side,
+            assets: giveRows,
+            destinations: seedDestinations(giveRows, 0),
+          };
+        if (i === 1)
+          return {
+            ...side,
+            assets: recvRows,
+            destinations: seedDestinations(recvRows, 1),
+          };
         return { ...side, assets: [], destinations: {} };
       });
     });
@@ -1424,18 +1513,16 @@ export default function TradePage() {
   // Count per category
   const suggestionCounts = useMemo(() => {
     if (!suggestions) return {};
-    return Object.fromEntries(SUGG_TYPES.map((t) => [t.key, (suggestions[t.key] || []).length]));
+    return Object.fromEntries(
+      SUGG_TYPES.map((t) => [t.key, (suggestions[t.key] || []).length]),
+    );
   }, [suggestions]);
 
   // Balancer payload for a given side — the label + list the SideCard
   // renders.  Returns null when that side has no balancer suggestion.
   function balancersForSide(sideIdx) {
     const isUnderpaying =
-      sides.length === 2
-        ? sideIdx === 0
-          ? pwGap < -350
-          : pwGap > 350
-        : false;
+      sides.length === 2 ? (sideIdx === 0 ? pwGap < -350 : pwGap > 350) : false;
     if (sides.length === 2 && isUnderpaying && balancers.list.length > 0) {
       return {
         label: balancers.teamName
@@ -1470,14 +1557,39 @@ export default function TradePage() {
         eyebrow="Terminal"
         title="Trade Builder"
         description="Multi-team trade calculator with live fairness visualization."
+        actions={
+          <SegmentedControl
+            label="Value basis"
+            value={settings.valuationMode || "market"}
+            onChange={(v) => updateSetting("valuationMode", v)}
+            options={[
+              { value: "market", label: "Market" },
+              { value: "leagueAdjusted", label: "My league" },
+            ]}
+          />
+        }
       />
+
+      {/* A trade verdict that silently changed basis is the most
+          dangerous thing this page can do. Say which board it is on. */}
+      {settings.valuationMode === "leagueAdjusted" &&
+      rawData?.valuationOverlay ? (
+        <Banner tone="info" title="Valued on your league's board">
+          Values and ranks are adjusted for positional scarcity measured from
+          this league&apos;s 12 rosters. Draft picks carry no scarcity
+          measurement, so they stay at market value while players move around
+          them.
+        </Banner>
+      ) : null}
 
       {loading ? (
         <Panel flush>
           <SkeletonTable rows={6} columns={4} />
         </Panel>
       ) : null}
-      {loading ? <span className="ds-visually-hidden">Loading player pool...</span> : null}
+      {loading ? (
+        <span className="ds-visually-hidden">Loading player pool...</span>
+      ) : null}
 
       {error ? (
         <Banner tone="negative" title="Couldn't load the player pool">
@@ -1489,8 +1601,8 @@ export default function TradePage() {
         <Banner tone="warning" title="Roster data not ready for this league">
           Rankings and values are available (scoring is shared), but
           team-specific features — Sleeper roster import, &quot;Simulate on my
-          team&quot;, and league-mate pickers — need this league&apos;s scrape to
-          finish. Switch back to the primary league to use them.
+          team&quot;, and league-mate pickers — need this league&apos;s scrape
+          to finish. Switch back to the primary league to use them.
         </Banner>
       ) : null}
 
@@ -1507,7 +1619,10 @@ export default function TradePage() {
         />
       ) : null}
 
-      {!loading && !error && !leagueMismatch && suggestions?.totalSuggestions > 0 ? (
+      {!loading &&
+      !error &&
+      !leagueMismatch &&
+      suggestions?.totalSuggestions > 0 ? (
         <ProactiveSuggestionsRail
           suggestions={suggestions}
           onApply={(s) => {
@@ -1709,7 +1824,9 @@ export default function TradePage() {
                 side={side}
                 sideIdx={sideIdx}
                 sides={sides}
-                total={sideTotals[sideIdx] || { raw: 0, adjustment: 0, adjusted: 0 }}
+                total={
+                  sideTotals[sideIdx] || { raw: 0, adjustment: 0, adjusted: 0 }
+                }
                 isMySide={sideIdx === mySideIdx}
                 selectedTeam={selectedTeam}
                 sideQuery={sideQueries[sideIdx]}
@@ -1787,7 +1904,9 @@ export default function TradePage() {
               <div className="trade-tray-main">
                 <div>
                   <div className="label">Side A</div>
-                  <div className="value">{Math.round(pwTotalA).toLocaleString()}</div>
+                  <div className="value">
+                    {Math.round(pwTotalA).toLocaleString()}
+                  </div>
                 </div>
                 <div style={{ flex: 1, maxWidth: 220 }}>
                   {/* Verdict bar: marker position is layout math from
@@ -1803,7 +1922,9 @@ export default function TradePage() {
                             ? styles.verdictMarkerNegative
                             : ""
                       }`}
-                      style={{ "--marker-pos": `${verdictBarPosition(pwGap)}%` }}
+                      style={{
+                        "--marker-pos": `${verdictBarPosition(pwGap)}%`,
+                      }}
                     />
                   </div>
                   <div className={`verdict ${colorFromGap(pwGap)}`}>
@@ -1816,7 +1937,9 @@ export default function TradePage() {
                 </div>
                 <div>
                   <div className="label">Side B</div>
-                  <div className="value">{Math.round(pwTotalB).toLocaleString()}</div>
+                  <div className="value">
+                    {Math.round(pwTotalB).toLocaleString()}
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/components/useDynastyData.js
+++ b/frontend/components/useDynastyData.js
@@ -19,6 +19,9 @@ export function useDynastyData() {
   // frontend TEP multiplication either.
   const { settings } = useSettings();
   const siteOverrides = settings?.siteWeights || null;
+  // Valuation lens. "market" (the default) is today's board; changing
+  // it refetches, because the overlay is a separate league-scoped GET.
+  const valuationMode = settings?.valuationMode || "market";
   // tepMultiplier: null means "auto from league" (derive on backend
   // from Sleeper's bonus_rec_te).  A finite number means the user
   // dragged the slider and wants that exact override.  Coercing null
@@ -85,6 +88,7 @@ export function useDynastyData() {
           siteOverrides,
           tepMultiplier,
           tepNativeMultiplier,
+          valuationMode,
         });
         if (!active) return;
 
@@ -95,9 +99,12 @@ export function useDynastyData() {
         // Detect structurally-valid but empty payloads that would silently render nothing.
         if (data && typeof data === "object") {
           const hasPlayers = Object.keys(data.players || {}).length > 0;
-          const hasPlayersArray = Array.isArray(data.playersArray) && data.playersArray.length > 0;
+          const hasPlayersArray =
+            Array.isArray(data.playersArray) && data.playersArray.length > 0;
           if (!hasPlayers && !hasPlayersArray) {
-            setError("Data loaded but contains no players. Backend may still be initializing.");
+            setError(
+              "Data loaded but contains no players. Backend may still be initializing.",
+            );
           }
         } else if (!data) {
           setError("No data received from server. Check backend status.");
@@ -142,7 +149,13 @@ export function useDynastyData() {
       active = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [siteOverridesKey, tepMultiplier, tepNativeMultiplier, leagueRefreshKey]);
+  }, [
+    siteOverridesKey,
+    tepMultiplier,
+    tepNativeMultiplier,
+    valuationMode,
+    leagueRefreshKey,
+  ]);
 
   const rows = useMemo(() => {
     try {

--- a/frontend/components/useLeague.js
+++ b/frontend/components/useLeague.js
@@ -3,7 +3,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useUserState } from "@/components/useUserState";
 import { invalidateTerminalCache } from "@/components/useTerminal";
-import { _resetBaseContractCache } from "@/lib/dynasty-data";
+import {
+  _resetBaseContractCache,
+  _resetValuationOverlayCache,
+} from "@/lib/dynasty-data";
 
 /**
  * useLeague — which dynasty league is the signed-in user looking at?
@@ -144,7 +147,8 @@ export function useLeague() {
   }, []);
 
   const leagues = useMemo(
-    () => (Array.isArray(leaguesPayload?.leagues) ? leaguesPayload.leagues : []),
+    () =>
+      Array.isArray(leaguesPayload?.leagues) ? leaguesPayload.leagues : [],
     [leaguesPayload],
   );
   const defaultLeagueKey = leaguesPayload?.defaultKey || "";
@@ -214,17 +218,27 @@ export function useLeague() {
       // frontend change.
       try {
         invalidateTerminalCache();
-      } catch { /* hook not mounted yet — safe to ignore */ }
+      } catch {
+        /* hook not mounted yet — safe to ignore */
+      }
       try {
         _resetBaseContractCache();
-      } catch { /* dynasty-data module not initialized — ignore */ }
+        // The valuation overlay is LEAGUE-scoped (scarcity comes from
+        // this league's rosters) while the base contract is
+        // scoring-profile-scoped. Switching leagues invalidates both.
+        _resetValuationOverlayCache();
+      } catch {
+        /* dynasty-data module not initialized — ignore */
+      }
 
       // Tell every other ``useUserState`` consumer that state changed.
       // The simplest signal is a storage event; since we already wrote
       // localStorage above, fire a synthetic event for same-tab
       // subscribers (native 'storage' only fires cross-tab).
       if (typeof window !== "undefined") {
-        window.dispatchEvent(new CustomEvent("league:changed", { detail: { key: clean } }));
+        window.dispatchEvent(
+          new CustomEvent("league:changed", { detail: { key: clean } }),
+        );
       }
     },
     [serverBacked],

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -95,9 +95,7 @@ export function normalizePlayerName(name) {
 // never disagrees with the backend on position assignment.
 export const IDP_PRIORITY = ["DL", "DB", "LB"];
 
-const _NON_IDP_ALIASES = new Set([
-  "QB", "RB", "WR", "TE", "K", "P", "PICK",
-]);
+const _NON_IDP_ALIASES = new Set(["QB", "RB", "WR", "TE", "K", "P", "PICK"]);
 
 function _collectIdpFamilies(raw, state) {
   const accept = (token) => {
@@ -169,10 +167,14 @@ export function classifyPos(pos) {
 // those stamps verbatim.
 
 export function inferValueBundle(player = {}) {
-  const raw = Number(player._rawComposite ?? player._rawMarketValue ?? player._composite ?? 0) || 0;
+  const raw =
+    Number(
+      player._rawComposite ?? player._rawMarketValue ?? player._composite ?? 0,
+    ) || 0;
   // Prefer 1–9999 display value; fall back to internal calibrated value
   const display = Number(player._canonicalDisplayValue ?? 0) || 0;
-  const internal = Number(player._finalAdjusted ?? player._composite ?? raw) || raw;
+  const internal =
+    Number(player._finalAdjusted ?? player._composite ?? raw) || raw;
   const full = display || internal;
   return {
     raw: Math.round(raw),
@@ -929,7 +931,8 @@ export function tepMultiplierIsCustomized(tepMultiplier) {
  * (1.10)" so ``fetchDynastyData`` skips posting the field.
  */
 export function tepNativeMultiplierIsCustomized(tepNativeMultiplier) {
-  if (tepNativeMultiplier === null || tepNativeMultiplier === undefined) return false;
+  if (tepNativeMultiplier === null || tepNativeMultiplier === undefined)
+    return false;
   const n = Number(tepNativeMultiplier);
   return Number.isFinite(n);
 }
@@ -972,9 +975,8 @@ function _materializePlayerArrayRow(player) {
 
   // Prefer 1–9999 display value; fall back to internal calibrated value
   const displayVal = Number(player?.values?.displayValue ?? 0) || 0;
-  const internalVal = Number(
-    player?.values?.finalAdjusted ?? player?.values?.overall ?? 0
-  ) || 0;
+  const internalVal =
+    Number(player?.values?.finalAdjusted ?? player?.values?.overall ?? 0) || 0;
   const rawValues = {
     raw: Number(player?.values?.rawComposite ?? 0) || 0,
     full: displayVal || internalVal,
@@ -1067,10 +1069,13 @@ function _materializePlayerArrayRow(player) {
     // confidence / anomaly flags, all of which are computed on the
     // post-Hampel set.  Falls back to `{}` for legacy payloads.
     effectiveSourceRanks:
-      player.effectiveSourceRanks && typeof player.effectiveSourceRanks === "object"
+      player.effectiveSourceRanks &&
+      typeof player.effectiveSourceRanks === "object"
         ? player.effectiveSourceRanks
         : {},
-    droppedSources: Array.isArray(player.droppedSources) ? player.droppedSources : [],
+    droppedSources: Array.isArray(player.droppedSources)
+      ? player.droppedSources
+      : [],
     sourceRankMeta: backendSourceRankMeta,
     blendedSourceRank: backendBlendedSourceRank,
     sourceCount: backendSourceCount,
@@ -1109,17 +1114,26 @@ function _materializePlayerArrayRow(player) {
     sourceRankSpread: player.sourceRankSpread ?? null,
     marketGapDirection: String(player.marketGapDirection || "none"),
     marketGapMagnitude: player.marketGapMagnitude ?? null,
-    sourceOriginalRanks: player.sourceOriginalRanks && typeof player.sourceOriginalRanks === "object"
-      ? player.sourceOriginalRanks : {},
+    sourceOriginalRanks:
+      player.sourceOriginalRanks &&
+      typeof player.sourceOriginalRanks === "object"
+        ? player.sourceOriginalRanks
+        : {},
     // Native vendor values for rank-signal sources — the real number
     // behind the synthetic encoding in canonicalSites (parallel map
     // to sourceOriginalRanks; keep both materializers in lockstep).
-    sourceNativeValues: player.sourceNativeValues && typeof player.sourceNativeValues === "object"
-      ? player.sourceNativeValues : {},
+    sourceNativeValues:
+      player.sourceNativeValues && typeof player.sourceNativeValues === "object"
+        ? player.sourceNativeValues
+        : {},
     // NFL years of experience (0 = rookie) — drives the experience
     // filter; null when the Sleeper blob never matched this player.
-    yearsExp: Number.isFinite(Number(player.yearsExp)) && player.yearsExp !== null
-      ? Number(player.yearsExp) : (Number.isFinite(Number(player._yearsExp)) && player._yearsExp !== null ? Number(player._yearsExp) : null),
+    yearsExp:
+      Number.isFinite(Number(player.yearsExp)) && player.yearsExp !== null
+        ? Number(player.yearsExp)
+        : Number.isFinite(Number(player._yearsExp)) && player._yearsExp !== null
+          ? Number(player._yearsExp)
+          : null,
     identityConfidence: Number(player.identityConfidence ?? 0.7),
     identityMethod: String(player.identityMethod || "name_only"),
     quarantined: Boolean(player.quarantined),
@@ -1134,12 +1148,21 @@ function _materializePlayerArrayRow(player) {
 
 function _materializeLegacyDictRow(name, player, posMap) {
   if (!player || typeof player !== "object") return null;
-  const isPick = /\b(20\d{2})\s+(early|mid|late)?\s*(1st|2nd|3rd|4th|5th|6th|round|r\d|pick)/i.test(name) || /^20\d{2}\s+pick/i.test(name);
-  const pos = isPick ? "PICK" : normalizePos(posMap[name] || player.position || "");
+  const isPick =
+    /\b(20\d{2})\s+(early|mid|late)?\s*(1st|2nd|3rd|4th|5th|6th|round|r\d|pick)/i.test(
+      name,
+    ) || /^20\d{2}\s+pick/i.test(name);
+  const pos = isPick
+    ? "PICK"
+    : normalizePos(posMap[name] || player.position || "");
   if (classifyPos(pos) === "excluded") return null;
 
   const rawValues = inferValueBundle(player);
-  const canonicalSites = player._canonicalSiteValues && typeof player._canonicalSiteValues === "object" ? player._canonicalSiteValues : {};
+  const canonicalSites =
+    player._canonicalSiteValues &&
+    typeof player._canonicalSiteValues === "object"
+      ? player._canonicalSiteValues
+      : {};
   // Legacy dict rows carry raw scrape values at the top level (e.g.
   // ``player.ktcSfTep``).  Mirror the playersArray materializer's
   // ``rawSourceValues`` field for the popup chip render — KTC TE++
@@ -1177,7 +1200,9 @@ function _materializeLegacyDictRow(name, player, posMap) {
     // carrying only _isRookie, so reading one signal alone made
     // rookie filters exclude every actual rookie on the view=app
     // path (Codex round 4 on PR #535).
-    rookie: Boolean(player._formatFitRookie || player._isRookie || player.rookie),
+    rookie: Boolean(
+      player._formatFitRookie || player._isRookie || player.rookie,
+    ),
     assetClass: classifyPos(pos || "?"),
     values,
     siteCount: Number(player.sourceCount || player._sites || 0),
@@ -1188,15 +1213,24 @@ function _materializeLegacyDictRow(name, player, posMap) {
     canonicalConsensusRank: backendRank,
     rankDerivedValue: backendValue,
     canonicalTierId: Number(player._canonicalTierId) || null,
-    sourceRanks: player.sourceRanks && typeof player.sourceRanks === "object" ? player.sourceRanks : {},
+    sourceRanks:
+      player.sourceRanks && typeof player.sourceRanks === "object"
+        ? player.sourceRanks
+        : {},
     // See ``_materializePlayerArrayRow`` for the rationale on these
     // two fields — keep both materializers in lockstep.
     effectiveSourceRanks:
-      player.effectiveSourceRanks && typeof player.effectiveSourceRanks === "object"
+      player.effectiveSourceRanks &&
+      typeof player.effectiveSourceRanks === "object"
         ? player.effectiveSourceRanks
         : {},
-    droppedSources: Array.isArray(player.droppedSources) ? player.droppedSources : [],
-    sourceRankMeta: player.sourceRankMeta && typeof player.sourceRankMeta === "object" ? player.sourceRankMeta : {},
+    droppedSources: Array.isArray(player.droppedSources)
+      ? player.droppedSources
+      : [],
+    sourceRankMeta:
+      player.sourceRankMeta && typeof player.sourceRankMeta === "object"
+        ? player.sourceRankMeta
+        : {},
     blendedSourceRank: player.blendedSourceRank ?? null,
     sourceCount: Number(player.sourceCount || 0),
     confidenceBucket: String(player.confidenceBucket || "none"),
@@ -1207,20 +1241,32 @@ function _materializeLegacyDictRow(name, player, posMap) {
     hasSourceDisagreement: Boolean(player.hasSourceDisagreement),
     sourceRankSpread: player.sourceRankSpread ?? null,
     sourceRankPercentileSpread: player.sourceRankPercentileSpread ?? null,
-    sourceAudit: player.sourceAudit && typeof player.sourceAudit === "object" ? player.sourceAudit : null,
+    sourceAudit:
+      player.sourceAudit && typeof player.sourceAudit === "object"
+        ? player.sourceAudit
+        : null,
     marketGapDirection: String(player.marketGapDirection || "none"),
     marketGapMagnitude: player.marketGapMagnitude ?? null,
-    sourceOriginalRanks: player.sourceOriginalRanks && typeof player.sourceOriginalRanks === "object"
-      ? player.sourceOriginalRanks : {},
+    sourceOriginalRanks:
+      player.sourceOriginalRanks &&
+      typeof player.sourceOriginalRanks === "object"
+        ? player.sourceOriginalRanks
+        : {},
     // Native vendor values for rank-signal sources — the real number
     // behind the synthetic encoding in canonicalSites (parallel map
     // to sourceOriginalRanks; keep both materializers in lockstep).
-    sourceNativeValues: player.sourceNativeValues && typeof player.sourceNativeValues === "object"
-      ? player.sourceNativeValues : {},
+    sourceNativeValues:
+      player.sourceNativeValues && typeof player.sourceNativeValues === "object"
+        ? player.sourceNativeValues
+        : {},
     // NFL years of experience (0 = rookie) — drives the experience
     // filter; null when the Sleeper blob never matched this player.
-    yearsExp: Number.isFinite(Number(player.yearsExp)) && player.yearsExp !== null
-      ? Number(player.yearsExp) : (Number.isFinite(Number(player._yearsExp)) && player._yearsExp !== null ? Number(player._yearsExp) : null),
+    yearsExp:
+      Number.isFinite(Number(player.yearsExp)) && player.yearsExp !== null
+        ? Number(player.yearsExp)
+        : Number.isFinite(Number(player._yearsExp)) && player._yearsExp !== null
+          ? Number(player._yearsExp)
+          : null,
     identityConfidence: Number(player.identityConfidence ?? 0.7),
     identityMethod: String(player.identityMethod || "name_only"),
     quarantined: Boolean(player.quarantined),
@@ -1239,7 +1285,11 @@ function _materializeLegacyDictRow(name, player, posMap) {
  */
 function _hasBackendRankStamps(rows) {
   for (const r of rows) {
-    if (r && Number.isInteger(r.canonicalConsensusRank) && r.canonicalConsensusRank > 0) {
+    if (
+      r &&
+      Number.isInteger(r.canonicalConsensusRank) &&
+      r.canonicalConsensusRank > 0
+    ) {
       return true;
     }
   }
@@ -1248,7 +1298,9 @@ function _hasBackendRankStamps(rows) {
 
 export function buildRows(data) {
   const players = data?.players || {};
-  const playersArray = Array.isArray(data?.playersArray) ? data.playersArray : [];
+  const playersArray = Array.isArray(data?.playersArray)
+    ? data.playersArray
+    : [];
   const posMap = data?.sleeper?.positions || {};
   const rows = [];
 
@@ -1288,7 +1340,19 @@ export function buildRows(data) {
   // end of the table. For ranked rows this ordering matches the
   // integer-rank order because the backend has already made value
   // monotonic with rank; the change only affects null-rank rows.
+  // When a valuation overlay is applied, ranked rows sort by the SERVED
+  // rank rather than by value.  Python rounds half-to-even and JS rounds
+  // half-up, so `consensus x factor` can differ by one unit between the
+  // two — enough to swap adjacent rows against the ranks the server
+  // sent, which renders as a `#100, #101, #100` stutter in the `#`
+  // column.  Null-rank rows still interleave by value.
+  const overlayActive = Boolean(data?.valuationOverlay);
   rows.sort((a, b) => {
+    if (overlayActive) {
+      const ra = a.canonicalConsensusRank ?? null;
+      const rb = b.canonicalConsensusRank ?? null;
+      if (ra != null && rb != null) return ra - rb;
+    }
     const va = Number(a.rankDerivedValue) || 0;
     const vb = Number(b.rankDerivedValue) || 0;
     if (vb !== va) return vb - va;
@@ -1305,7 +1369,10 @@ export function buildRows(data) {
     // local computed ordinal as before; picks show no rank number.
     if (r.canonicalConsensusRank != null) {
       r.rank = r.canonicalConsensusRank;
-    } else if (r.assetClass === "pick") {
+    } else if (r.assetClass === "pick" || overlayActive) {
+      // With an overlay active the local ordinal would be derived from
+      // ADJUSTED values — a client-computed rank in the `#` column,
+      // which is the one thing `buildRows` must never produce.
       r.rank = null;
     } else {
       r.rank = r.computedConsensusRank;
@@ -1392,7 +1459,12 @@ async function _fetchBaseContract() {
   // The Next.js API route wraps the payload: { ok, source, data: <contract> }
   // The Python backend alias returns the raw contract.  Normalize both.
   let wrapped;
-  if (json && typeof json === "object" && !json.data && (json.players || json.playersArray)) {
+  if (
+    json &&
+    typeof json === "object" &&
+    !json.data &&
+    (json.players || json.playersArray)
+  ) {
     wrapped = {
       ok: true,
       source: json.dataSource?.type
@@ -1445,7 +1517,8 @@ export function mergeRankingsDelta(baseContract, delta) {
   if (!baseContract || !delta) return baseContract;
   const base = baseContract.data || baseContract;
   const rankingsDelta = delta.rankingsDelta;
-  if (!rankingsDelta || !Array.isArray(rankingsDelta.players)) return baseContract;
+  if (!rankingsDelta || !Array.isArray(rankingsDelta.players))
+    return baseContract;
   const playerKey = rankingsDelta.playerKey || "displayName";
   const deltaByKey = new Map();
   for (const entry of rankingsDelta.players) {
@@ -1463,7 +1536,9 @@ export function mergeRankingsDelta(baseContract, delta) {
     generatedAt: delta.generatedAt || base.generatedAt,
   };
 
-  const basePlayersArray = Array.isArray(base.playersArray) ? base.playersArray : [];
+  const basePlayersArray = Array.isArray(base.playersArray)
+    ? base.playersArray
+    : [];
 
   if (basePlayersArray.length > 0) {
     // Fast path: base already has a fully-materialized playersArray,
@@ -1476,7 +1551,10 @@ export function mergeRankingsDelta(baseContract, delta) {
         continue;
       }
       const id = String(
-        basePlayer[playerKey] || basePlayer.displayName || basePlayer.canonicalName || "",
+        basePlayer[playerKey] ||
+          basePlayer.displayName ||
+          basePlayer.canonicalName ||
+          "",
       );
       const deltaEntry = deltaByKey.get(id);
       if (!deltaEntry) {
@@ -1504,9 +1582,9 @@ export function mergeRankingsDelta(baseContract, delta) {
     // override is actually reflected in the materialized rows.
     const legacyPlayers =
       base.players && typeof base.players === "object" ? base.players : {};
-    const posMap =
-      (base.sleeper && base.sleeper.positions) || {};
-    const PICK_RE = /\b(20\d{2})\s+(early|mid|late)?\s*(1st|2nd|3rd|4th|5th|6th|round|r\d|pick)/i;
+    const posMap = (base.sleeper && base.sleeper.positions) || {};
+    const PICK_RE =
+      /\b(20\d{2})\s+(early|mid|late)?\s*(1st|2nd|3rd|4th|5th|6th|round|r\d|pick)/i;
     const synthesizedArray = [];
     for (const deltaEntry of rankingsDelta.players) {
       if (!deltaEntry || !deltaEntry.id) continue;
@@ -1530,16 +1608,16 @@ export function mergeRankingsDelta(baseContract, delta) {
         // offense/IDP name twins can inherit each other's owner
         // (Codex round 3 on PR #535).
         playerId: String(legacy._sleeperId || "").trim() || null,
-        position: isPick
-          ? "PICK"
-          : String(posMap[id] || legacy.position || ""),
+        position: isPick ? "PICK" : String(posMap[id] || legacy.position || ""),
         team: legacy.team != null ? legacy.team : null,
         age: legacy.age != null ? legacy.age : null,
         // Override-invariant like team/age: without this copy the
         // experience filters return an empty board whenever a source
         // override is active (fail-closed predicate over null).
         yearsExp: legacy._yearsExp != null ? legacy._yearsExp : null,
-        rookie: Boolean(legacy._formatFitRookie || legacy._isRookie || legacy.rookie),
+        rookie: Boolean(
+          legacy._formatFitRookie || legacy._isRookie || legacy.rookie,
+        ),
         assetClass: String(legacy.assetClass || ""),
         identityConfidence: Number(legacy.identityConfidence ?? 0.7),
         identityMethod: String(legacy.identityMethod || "name_only"),
@@ -1547,7 +1625,8 @@ export function mergeRankingsDelta(baseContract, delta) {
         // the retail-vs-consensus gap column can fall back when the
         // delta dropped a source.
         canonicalSiteValues:
-          legacy._canonicalSiteValues && typeof legacy._canonicalSiteValues === "object"
+          legacy._canonicalSiteValues &&
+          typeof legacy._canonicalSiteValues === "object"
             ? legacy._canonicalSiteValues
             : {},
         // Vendor-native values are override-INVARIANT (toggling a
@@ -1556,7 +1635,8 @@ export function mergeRankingsDelta(baseContract, delta) {
         // mirror or the tooltips lose natives while an override is
         // active (Codex review on PR #532 round 8).
         sourceNativeValues:
-          legacy.sourceNativeValues && typeof legacy.sourceNativeValues === "object"
+          legacy.sourceNativeValues &&
+          typeof legacy.sourceNativeValues === "object"
             ? legacy.sourceNativeValues
             : {},
       };
@@ -1580,6 +1660,166 @@ export function mergeRankingsDelta(baseContract, delta) {
   };
 }
 
+// League-scoped, unlike ``_cachedBaseContract`` which is
+// scoring-profile-scoped. Reset together on a league switch.
+let _cachedValuationOverlay = null;
+
+export function _resetValuationOverlayCache() {
+  _cachedValuationOverlay = null;
+}
+
+async function _fetchValuationOverlay() {
+  if (_cachedValuationOverlay) return _cachedValuationOverlay;
+  try {
+    const leagueKey = _readActiveLeagueKey();
+    const qs = leagueKey ? `?leagueKey=${encodeURIComponent(leagueKey)}` : "";
+    const res = await fetch(`/api/valuation/league-adjusted${qs}`, {
+      cache: "no-store",
+    });
+    if (!res.ok) {
+      console.warn(
+        `[dynasty-data] valuation overlay ${res.status}; serving market values`,
+      );
+      return null;
+    }
+    const body = await res.json();
+    if (!body || body.isNoop) return null;
+    _cachedValuationOverlay = body;
+    return body;
+  } catch (err) {
+    console.warn(
+      "[dynasty-data] valuation overlay fetch failed; serving market values",
+      err,
+    );
+    return null;
+  }
+}
+
+/**
+ * Apply the league-adjusted valuation overlay to a contract.
+ *
+ * NOT ``mergeRankingsDelta``.  That function's runtime-view branch
+ * synthesizes ``playersArray`` from delta entries only, so a player the
+ * delta doesn't mention disappears; and its ``activePlayerIds`` branch
+ * nulls the rank of anything absent.  Both are correct for a dense
+ * override delta and catastrophic for this overlay, where ``factors``
+ * is sparse and absence means "unchanged".
+ *
+ * Writes TWO key sets, because the two materializers disagree:
+ *   - ``playersArray`` rows carry ``canonicalConsensusRank`` / ``canonicalTierId``
+ *   - the legacy ``players`` dict carries ``_canonicalConsensusRank`` /
+ *     ``_canonicalTierId`` — but ``rankDerivedValue`` with no underscore
+ *
+ * The legacy path is the DEFAULT one (``server.py`` pops ``playersArray``
+ * off the runtime payload), so an applier that writes only the first set
+ * moves the value and leaves the rank stale — on the path that actually
+ * ships, and nowhere else.
+ *
+ * Copy-on-write: untouched rows are returned by reference.
+ */
+export function applyValuationOverlay(baseContract, overlay) {
+  if (!baseContract || !overlay) return baseContract;
+  const factors = overlay.factors;
+  if (
+    !factors ||
+    typeof factors !== "object" ||
+    Object.keys(factors).length === 0
+  ) {
+    return baseContract;
+  }
+
+  const data = baseContract.data || baseContract;
+
+  // Version pin.  Overlay ranks are computed against one contract
+  // build; a scrape landing between the base fetch and the overlay
+  // fetch would apply board B's ranks to board A's values.  Refuse
+  // outright rather than half-apply — a board whose ranks disagree with
+  // its values is worse than the market board.
+  const baseStamp = data.scrapeTimestamp;
+  const overlayStamp = overlay.scrapeTimestamp;
+  if (baseStamp && overlayStamp && baseStamp !== overlayStamp) {
+    console.warn(
+      "[dynasty-data] valuation overlay is for a different scrape " +
+        `(base ${baseStamp} vs overlay ${overlayStamp}); serving market values`,
+    );
+    return baseContract;
+  }
+
+  const ranks = overlay.ranks || {};
+  const tiers = overlay.tiers || {};
+  const scale = (v, f) => {
+    const n = Number(v);
+    return Number.isFinite(n) && n > 0 ? Math.round(n * f) : v;
+  };
+
+  const nextData = {
+    ...data,
+    valuationOverlay: { mode: "leagueAdjusted", ...overlay },
+  };
+
+  if (Array.isArray(data.playersArray) && data.playersArray.length > 0) {
+    nextData.playersArray = data.playersArray.map((row) => {
+      const key = String(row?.displayName || row?.canonicalName || "").trim();
+      const f = factors[key];
+      const hasRank = Object.prototype.hasOwnProperty.call(ranks, key);
+      if (!f && !hasRank) return row;
+      const next = { ...row };
+      if (f) {
+        next.rankDerivedValue = scale(row.rankDerivedValue, f);
+        if (row.values && typeof row.values === "object") {
+          // All four aliases are identical on live rows; keep them so.
+          next.values = { ...row.values };
+          for (const k of ["overall", "finalAdjusted", "displayValue"]) {
+            if (row.values[k] != null) next.values[k] = scale(row.values[k], f);
+          }
+        }
+      }
+      if (hasRank) {
+        next.canonicalConsensusRank = ranks[key];
+        if (tiers[key] != null) next.canonicalTierId = tiers[key];
+      } else if (f) {
+        // Moved in value but not on the ranked board (past the cap, or
+        // an anchor slot pick). Leave the rank null rather than letting
+        // buildRows derive one from the adjusted sort order.
+        next.canonicalConsensusRank = null;
+      }
+      // "moved up N since the previous scrape" is a statement about the
+      // market board. Next to an adjusted rank it is simply false.
+      next.rankChange = null;
+      return next;
+    });
+  }
+
+  if (data.players && typeof data.players === "object") {
+    const nextPlayers = {};
+    for (const [name, row] of Object.entries(data.players)) {
+      const f = factors[name];
+      const hasRank = Object.prototype.hasOwnProperty.call(ranks, name);
+      if (!f && !hasRank) {
+        nextPlayers[name] = row;
+        continue;
+      }
+      const next = { ...row };
+      if (f) {
+        next.rankDerivedValue = scale(row.rankDerivedValue, f);
+        if (row._finalAdjusted != null)
+          next._finalAdjusted = scale(row._finalAdjusted, f);
+      }
+      if (hasRank) {
+        next._canonicalConsensusRank = ranks[name];
+        if (tiers[name] != null) next._canonicalTierId = tiers[name];
+      } else if (f) {
+        next._canonicalConsensusRank = null;
+      }
+      next._rankChange = null;
+      nextPlayers[name] = next;
+    }
+    nextData.players = nextPlayers;
+  }
+
+  return { ...baseContract, source: "backend:leagueAdjusted", data: nextData };
+}
+
 export async function fetchDynastyData(opts = {}) {
   const siteOverrides = opts.siteOverrides || null;
   // Preserve ``null`` / ``undefined`` as "inherit derived default"
@@ -1601,15 +1841,39 @@ export async function fetchDynastyData(opts = {}) {
         : null;
   const sitesCustomized = siteOverridesAreCustomized(siteOverrides);
   const tepCustomized = tepMultiplierIsCustomized(tepMultiplier);
-  const tepNativeCustomized = tepNativeMultiplierIsCustomized(tepNativeMultiplier);
+  const tepNativeCustomized =
+    tepNativeMultiplierIsCustomized(tepNativeMultiplier);
   const customized = sitesCustomized || tepCustomized || tepNativeCustomized;
+
+  const leagueAdjusted = opts.valuationMode === "leagueAdjusted";
 
   // Default path (no overrides): fetch + cache the base contract.
   // The backend will derive tep_multiplier from the operator's
   // Sleeper league ``bonus_rec_te`` and bake it into the blend for
   // us, so the frontend doesn't need to POST anything.
   if (!customized) {
-    return _fetchBaseContract();
+    const base = await _fetchBaseContract();
+    if (!leagueAdjusted) return base;
+    const overlay = await _fetchValuationOverlay();
+    // A failed overlay fetch degrades to the market board. Half a
+    // valuation lens is not a lens.
+    return overlay ? applyValuationOverlay(base, overlay) : base;
+  }
+
+  // Source overrides + league-adjusted is deliberately NOT composed
+  // here.  The overlay is computed against the un-overridden board, so
+  // its ranks are the ranks of `default_consensus x factor` — but the
+  // correct answer is the rank of `overridden_consensus x factor`,
+  // which the server never computed.  No client-side sequencing fixes
+  // that; composing the two would produce a board where neither the
+  // values nor the ranks correspond to anything.  Serve the overridden
+  // market board and say so, until `valuation_mode` is threaded through
+  // the overrides pipeline server-side.
+  if (leagueAdjusted) {
+    console.warn(
+      "[dynasty-data] custom source weights are active; league-adjusted " +
+        "values are not applied (the two cannot be composed client-side)",
+    );
   }
 
   // Override path: POST the override map + TE premium multiplier to
@@ -1643,7 +1907,11 @@ export async function fetchDynastyData(opts = {}) {
     });
     if (overrideRes.ok) {
       const deltaPayload = await overrideRes.json();
-      if (deltaPayload && deltaPayload.mode === "delta" && deltaPayload.rankingsDelta) {
+      if (
+        deltaPayload &&
+        deltaPayload.mode === "delta" &&
+        deltaPayload.rankingsDelta
+      ) {
         return mergeRankingsDelta(base, deltaPayload);
       }
       // Full-contract fallback: the backend may have returned a full

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -2053,6 +2053,85 @@ def _tier_id_from_rank(rank: int) -> int:
     return 10
 
 
+def compact_ranks_and_tiers(
+    rows: list[dict[str, Any]],
+    *,
+    anchor_year: int,
+    copy_rows: bool = False,
+) -> list[dict[str, Any]]:
+    """Assign contiguous ranks + gap-based tiers from ``rankDerivedValue``.
+
+    **The one ranker.** Extracted from the Phase 5 compact pass so the
+    league-adjusted overlay can re-rank an adjusted board without
+    reimplementing it.  A second ranker is exactly what the
+    "no secondary ranker anywhere in the stack" rule exists to prevent —
+    two implementations drift, and the one that drifts is the one nobody
+    is looking at.
+
+    Sorts by ``rankDerivedValue`` descending with the prior
+    ``canonicalConsensusRank`` as tiebreaker, so rows whose values were
+    not mutated keep their existing relative order.
+
+    Current-year slot picks (e.g. "2026 Pick 1.06") are deliberately
+    skipped: they carry a real value but must NOT consume a rank slot,
+    because they are a proxy for the corresponding rookie and would
+    otherwise push every player below them down one. Their rank and tier
+    are cleared; the row itself stays on the board. Tier-generic picks
+    ("2026 Early 1st") take ordinary slots.
+
+    Args:
+        rows: every candidate row. Only rows with a truthy
+            ``canonicalConsensusRank`` are considered — that set is
+            already the contiguous 1..N board, so a permutation of it is
+            automatically unique and contiguous.
+        anchor_year: current rookie draft year, for the slot-pick skip.
+        copy_rows: shallow-copy before mutating. **The overlay path must
+            pass True.** ``latest_contract_data`` is a shared module
+            global; mutating its rows to build one league's overlay would
+            permanently overwrite the board every other request reads.
+
+    Returns the ranked, compacted rows in rank order — i.e. exactly the
+    rows that received a tier, with anchor slot picks excluded.
+    """
+    candidates = [r for r in rows if r.get("canonicalConsensusRank")]
+    if copy_rows:
+        candidates = [dict(r) for r in candidates]
+
+    ranked_rows = sorted(
+        candidates,
+        key=lambda r: (
+            -int(r.get("rankDerivedValue") or 0),
+            int(r["canonicalConsensusRank"]),
+        ),
+    )
+
+    tiered_rows: list[dict[str, Any]] = []
+    new_rank = 0
+    for r in ranked_rows:
+        is_anchor_slot_pick = False
+        if r.get("assetClass") == "pick":
+            parsed = _parse_pick_slot(r.get("canonicalName") or "")
+            if parsed is not None and parsed[0] == anchor_year:
+                is_anchor_slot_pick = True
+        if is_anchor_slot_pick:
+            r["canonicalConsensusRank"] = None
+            r["canonicalTierId"] = None
+            continue
+        new_rank += 1
+        if r.get("canonicalConsensusRank") != new_rank:
+            r["canonicalConsensusRank"] = new_rank
+        tiered_rows.append(r)
+
+    # Gap-based tier detection on the blended value series.  Tiers land
+    # where the per-player value gap is unusually large relative to the
+    # local rolling-median gap: a 400-point drop from rank 12->13 is a
+    # boundary; a 3-point drop from 312->313 is not.
+    for r, tier_id in zip(tiered_rows, _compute_value_based_tier_ids(tiered_rows)):
+        r["canonicalTierId"] = tier_id
+
+    return tiered_rows
+
+
 def _retail_source_keys() -> frozenset[str]:
     """Return the set of ranking source keys marked `is_retail` in the registry.
 
@@ -7479,52 +7558,16 @@ def _compute_unified_rankings(
     #     for all rows whose values were not mutated.  Tier IDs are
     #     re-derived after compaction via gap-based detection on the
     #     blended ``rankDerivedValue`` series (see below).
-    ranked_rows = sorted(
-        [r for r in players_array if r.get("canonicalConsensusRank")],
-        key=lambda r: (
-            -int(r.get("rankDerivedValue") or 0),
-            int(r["canonicalConsensusRank"]),
-        ),
+    # Extracted to ``compact_ranks_and_tiers`` so the league-adjusted
+    # overlay re-ranks through the SAME code rather than a second
+    # implementation.  In-place here (copy_rows=False): these are the
+    # canonical board's own rows and the pipeline owns them.  The overlay
+    # passes copy_rows=True — see that function's docstring for why.
+    tiered_rows = compact_ranks_and_tiers(
+        players_array,
+        anchor_year=_anchor_year,
+        copy_rows=False,
     )
-    # Compact ranks, skipping current-year slot picks so picks don't
-    # consume merged-board rank slots. Picks still appear (the row is
-    # kept in the array) but their ``canonicalConsensusRank`` is
-    # cleared — they're a proxy for the corresponding rookie, so the
-    # user sees the value without the pick pushing every other player
-    # down one rank. Only applies to slot-specific current-year picks
-    # (e.g. "2026 Pick 1.06"); tier-generic picks ("2026 Early 1st")
-    # still take ordinary rank slots.
-    #
-    # Collect the ranked rows that actually receive a tier ID so the
-    # gap-detection pass below sees only the compacted board (no
-    # None-ranked anchor slot picks in the middle of its gap series).
-    tiered_rows: list[dict[str, Any]] = []
-    new_rank = 0
-    for r in ranked_rows:
-        is_anchor_slot_pick = False
-        if r.get("assetClass") == "pick":
-            parsed = _parse_pick_slot(r.get("canonicalName") or "")
-            if parsed is not None and parsed[0] == _anchor_year:
-                is_anchor_slot_pick = True
-        if is_anchor_slot_pick:
-            r["canonicalConsensusRank"] = None
-            r["canonicalTierId"] = None
-            continue
-        new_rank += 1
-        old_rank = r.get("canonicalConsensusRank")
-        if old_rank != new_rank:
-            r["canonicalConsensusRank"] = new_rank
-        tiered_rows.append(r)
-
-    # Gap-based tier detection on the blended value series.  Tiers
-    # land where the per-player value gap is unusually large relative
-    # to the local rolling-median gap: a 400-point drop from rank
-    # 12→13 registers as a new tier boundary; a 3-point drop from
-    # 312→313 does not.  The frontend renders the resulting tier IDs
-    # as generic "Tier N" labels, so every math-detected tier flows
-    # through uncapped.
-    for r, tier_id in zip(tiered_rows, _compute_value_based_tier_ids(tiered_rows)):
-        r["canonicalTierId"] = tier_id
 
     # Rank-change vs previous scrape.  Stamps ``rankChange`` on
     # each row from the persisted snapshot; writes the current ranks

--- a/src/api/gameplan.py
+++ b/src/api/gameplan.py
@@ -1143,6 +1143,11 @@ def get_league_adjusted_values(
         league_key=league_key,
         config_version=config_version,
         data_through=(contract or {}).get("date"),
+        # Version pin: the client refuses to apply an overlay whose
+        # contract build does not match the base it fetched, rather than
+        # applying board B's ranks to board A's values.
+        contract_version=(contract or {}).get("contractVersion"),
+        scrape_timestamp=(contract or {}).get("scrapeTimestamp"),
         include_explanations=include_explanations,
     )
     payload["cacheHit"] = cache_hit

--- a/src/league_intel/publish.py
+++ b/src/league_intel/publish.py
@@ -1,52 +1,66 @@
-"""LI-9: publish league-adjusted values for one league.
+"""LI-9: publish this league's adjusted board as a client-side overlay.
 
-This is the only place a real ``leagueAdjustedDynastyValue`` is
-produced.  It exists as its own module, separate from the consensus
-pipeline, for a reason that is architectural rather than cosmetic.
+This is the only place a real ``leagueAdjustedDynastyValue`` is produced.
 
-WHY THIS IS NOT STAMPED INTO THE CONTRACT
-─────────────────────────────────────────
+WHY AN OVERLAY AND NOT CONTRACT FIELDS
+──────────────────────────────────────
 CLAUDE.md's core split: *scoring profile controls rankings, league key
-controls context.*  The consensus board is scoring-profile-scoped —
-two leagues with identical scoring share one computed board and one
-cached payload.  The adjustment here is driven by
-``lineupScarcity``, measured by
-:func:`src.league_intel.replacement.compute_scarcity` from **this
+controls context.*  The consensus board is scoring-profile-scoped — two
+leagues with identical scoring share one computed board and one cached
+payload.  The adjustment here is driven by ``lineupScarcity``, measured
+by :func:`src.league_intel.replacement.compute_scarcity` from **this
 league's twelve rosters**.  Two leagues with identical scoring but
 different rosters get different adjusted values.
 
 So an adjusted value cannot live on the shared contract without
-collapsing that split — one league's roster shape would silently
-reprice another's board.  It is served per league instead, and the
-client overlays it, the same shape as the rankings-override delta.
+collapsing that split — one league's roster shape would silently reprice
+another's board.  It is served per league and overlaid client-side.
+
+WHY FACTORS, NOT ABSOLUTE VALUES
+────────────────────────────────
+``adjustment.build_adjustment`` computes ``adjusted = consensus ×
+combined`` where ``combined`` is a product of axis factors.  The factor
+depends only on **position** — it never reads the consensus value.  So a
+factor composes exactly against *any* consensus board, including one
+built with custom source weights.  An absolute value does not: it would
+carry the default board's numbers into a board the user has re-weighted,
+silently overwriting it.
+
+WHY RANKS ARE DENSE AND FACTORS ARE NOT
+───────────────────────────────────────
+A player whose own factor is 1.0 still moves rank when the players
+around him move.  Measured: a 4% relative shift displaces rank 500 by
+~63 slots.  So nearly every rank changes and a "changed ranks only" diff
+is the dense map minus a rounding error — while reintroducing the
+three-state ambiguity (changed / unchanged / now-unranked) that
+``activePlayerIds`` exists to paper over.  Dense ranks are ~7 KB gzip
+against a ~100 KB gzip override delta.  Not worth the ambiguity.
 
 WHAT MOVES A VALUE, AND WHAT DELIBERATELY DOES NOT
 ──────────────────────────────────────────────────
-* **structuralScarcity** — live.  Positions whose starter demand
-  exceeds the reference get a lift, deeper positions a trim.  Measured
-  from the exact lineup optimizer over real rosters, so it is evidence
-  about this league rather than an opinion about leagues in general.
-* **tePremium** — ABSENT by design, and this is the load-bearing
-  omission.  The market anchor ``ktcSfTep`` **is** KTC's TE++ board, so
-  the consensus blend already carries the structural 2-TE premium.
-  Applying a measured TE premium on top double-counts it —
-  ``tests/league_intel/test_te_premium_invariants.py`` pins exactly
-  this.  ADR-009 leaves the alignment-versus-scoring question open, and
-  an axis that is wrong by ~15% on every TE is worse than an axis that
-  contributes nothing.
-* **projectionCorroboration** — ABSENT pending LI-6.  No repo source
-  exposes raw statistical categories, so there is nothing to re-score.
+* **structuralScarcity** — live.  Positions whose starter demand exceeds
+  the reference lift; deeper positions trim.  Measured from the exact
+  lineup optimizer over real rosters, so it is evidence about this
+  league rather than an opinion about leagues in general.
+* **tePremium** — ABSENT.  The market anchor ``ktcSfTep`` **is** KTC's
+  TE++ board, so the blend already embeds the structural 2-TE premium; a
+  post-blend TE axis would double-count it
+  (``tests/league_intel/test_te_premium_invariants.py`` pins this).
+  Per-source *pre-blend* alignment is a different insertion point and a
+  separate workstream.
+* **projectionCorroboration** — ABSENT pending LI-6.
 
-Scoring settings reach the values through scarcity, not through a
-separate scoring axis: the starter slots that
-``measure_endogenous_starters`` solves over come from this league's
-``rosterSettings``, and the canonical config's version is stamped on
-the payload so a served value is always traceable to the rules that
-produced it.
+**Picks never move.**  ``compute_scarcity`` keys off rostered players and
+has no ``PICK`` key, so pick rows get an ABSENT axis and factor 1.0.
+League-adjusted mode therefore systematically re-prices every *player*
+against every *pick*.  That is the single largest behavioural
+consequence of this feature and it lands in the trade calculator, so it
+belongs in the UI copy rather than buried here.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Mapping, Sequence
 
 from src.league_intel.adjustment import build_board_adjustments
@@ -54,24 +68,23 @@ from src.league_intel.values import MODEL_VERSION, VALUE_SCHEMA_VERSION
 
 __all__ = ["build_league_adjusted_payload"]
 
-# Below this the overlay is not worth a network round trip or the risk
-# of churning the UI: a 0.1% move is inside the noise of the consensus
-# blend it is applied to.
+# Below this the overlay is not worth carrying: a 0.1% move is inside
+# the noise of the consensus blend it is applied to.
 _MIN_RELATIVE_MOVE = 0.001
 
 
 def _scarcity_to_mapping(scarcity: Mapping[str, Any] | None) -> dict[str, Any] | None:
-    """Normalise ``ScarcityComponents`` objects to their dict form.
-
-    ``structural_scarcity_axis`` accepts either, but normalising here
-    keeps the served diagnostics JSON-safe without a second pass.
-    """
+    """Normalise ``ScarcityComponents`` objects to their dict form."""
     if not scarcity:
         return None
     out: dict[str, Any] = {}
     for pos, comp in scarcity.items():
         out[str(pos).upper()] = comp.to_dict() if hasattr(comp, "to_dict") else comp
     return out
+
+
+def _row_key(row: Mapping[str, Any]) -> str:
+    return str(row.get("displayName") or row.get("canonicalName") or "").strip()
 
 
 def build_league_adjusted_payload(
@@ -81,21 +94,32 @@ def build_league_adjusted_payload(
     league_key: str,
     config_version: int | None = None,
     data_through: str | None = None,
+    contract_version: str | None = None,
+    scrape_timestamp: str | None = None,
     include_explanations: bool = False,
 ) -> dict[str, Any]:
     """Compute this league's adjusted board as an overlay payload.
 
-    ``values`` carries **only rows whose value actually moved**, keyed
-    by ``displayName``.  A client merges it over the consensus board and
-    leaves everything else alone, so the payload stays small and an
-    unmentioned player is unambiguously "unchanged" rather than
-    "missing".
+    ``factors`` is sparse — only rows the adjustment actually moved, so
+    absence means "unchanged".  ``ranks`` and ``tiers`` are dense over
+    the ranked board, for the reason in the module docstring.
 
-    ``scarcity`` of ``None`` is a legitimate state, not an error — it
-    means the roster snapshot was unavailable.  Every axis is then
-    ABSENT, ``values`` is empty, and ``isNoop`` is True: the board
-    degrades to consensus rather than to a guess.
+    ``scarcity`` of ``None`` is a legitimate state, not an error: the
+    roster snapshot was unavailable.  Every axis is then ABSENT and the
+    board degrades to consensus rather than to a guess.
+
+    The re-rank runs through
+    :func:`src.api.data_contract.compact_ranks_and_tiers` — the same
+    function the pipeline uses — on **shallow copies**.  Mutating the
+    caller's rows would corrupt ``latest_contract_data``, which is a
+    shared module global read by every other request.
     """
+    from src.api.data_contract import (  # noqa: PLC0415 - heavy import graph
+        assert_ranking_coherence,
+        compact_ranks_and_tiers,
+        current_rookie_draft_year,
+    )
+
     normalised = _scarcity_to_mapping(scarcity)
     board = build_board_adjustments(
         rows,
@@ -104,7 +128,7 @@ def build_league_adjusted_payload(
         data_through=data_through,
     )
 
-    values: dict[str, float] = {}
+    factors: dict[str, float] = {}
     for exp in board.explanations:
         consensus = exp.consensus_value
         adjusted = exp.league_adjusted_value
@@ -112,7 +136,54 @@ def build_league_adjusted_payload(
             continue
         if abs(adjusted - consensus) / consensus < _MIN_RELATIVE_MOVE:
             continue
-        values[exp.display_name] = round(float(adjusted), 2)
+        factors[exp.display_name] = round(float(adjusted) / float(consensus), 6)
+
+    ranks: dict[str, int] = {}
+    tiers: dict[str, int] = {}
+    warnings: list[str] = []
+
+    if factors:
+        # Adjusted copies. compact_ranks_and_tiers copies again
+        # (copy_rows=True) so the caller's rows are never touched; the
+        # multiply below therefore also has to land on a copy.
+        adjusted_rows: list[dict[str, Any]] = []
+        for row in rows:
+            copy = dict(row)
+            base = copy.get("rankDerivedValue")
+            factor = factors.get(_row_key(row))
+            if factor and isinstance(base, (int, float)) and base > 0:
+                copy["rankDerivedValue"] = int(round(float(base) * factor))
+            adjusted_rows.append(copy)
+
+        ranked = compact_ranks_and_tiers(
+            adjusted_rows,
+            anchor_year=current_rookie_draft_year(),
+            copy_rows=True,
+        )
+
+        errors = assert_ranking_coherence(ranked)
+        if errors:
+            # Serving an incoherent board is worse than serving none:
+            # the client would render ranks that contradict the values
+            # next to them. Degrade to consensus and say why.
+            logging.warning(
+                "league-adjusted overlay incoherent for %s (%d errors); serving no-op",
+                league_key,
+                len(errors),
+            )
+            warnings.append(f"ranking incoherent ({len(errors)} errors); overlay suppressed")
+            factors = {}
+        else:
+            for r in ranked:
+                name = _row_key(r)
+                if not name:
+                    continue
+                rank = r.get("canonicalConsensusRank")
+                tier = r.get("canonicalTierId")
+                if isinstance(rank, int):
+                    ranks[name] = rank
+                if isinstance(tier, int):
+                    tiers[name] = tier
 
     payload: dict[str, Any] = {
         "leagueKey": league_key,
@@ -121,16 +192,24 @@ def build_league_adjusted_payload(
         "adjustmentModelVersion": board.model_version,
         "configVersion": config_version,
         "dataThrough": data_through,
-        # ``isNoop`` reports the SERVED payload, so a client can trust
-        # "nothing to overlay" without diffing the map itself.
-        "isNoop": not values,
-        "adjustedCount": len(values),
+        # Version pin. Overlay ranks are only valid against the contract
+        # build they were computed from; a scrape landing between the
+        # base fetch and the overlay fetch would otherwise apply board
+        # B's ranks to board A's values. The client refuses on mismatch.
+        "contractVersion": contract_version,
+        "scrapeTimestamp": scrape_timestamp,
+        "isNoop": not factors,
+        "adjustedCount": len(factors),
         "playerCount": len(board.explanations),
+        "rankedCount": len(ranks),
         "monotonicityViolations": [v.to_dict() for v in board.monotonicity_violations],
         "scarcity": normalised or {},
-        "values": values,
+        "factors": factors,
+        "ranks": ranks,
+        "tiers": tiers,
+        "warnings": warnings,
         # Named so a reader does not have to infer the omission from an
-        # empty diff — see this module's docstring for why TE is out.
+        # empty diff — see the module docstring for why TE is out.
         "inactiveAxes": ["tePremium", "projectionCorroboration"],
     }
     if include_explanations:

--- a/tests/league_intel/test_publish.py
+++ b/tests/league_intel/test_publish.py
@@ -1,9 +1,10 @@
 """LI-9 overlay payload.
 
 The properties that matter are the ones a wrong answer would make
-invisible: that an unmeasurable league degrades to consensus instead of
-to a guess, and that the TE axis stays out so the anchor is not
-double-counted.
+invisible: that the caller's rows are never mutated (``latest_contract_data``
+is a shared global), that an unmeasurable league degrades to consensus
+instead of to a guess, and that the TE axis stays out so the market
+anchor is not double-counted.
 """
 
 from __future__ import annotations
@@ -13,20 +14,27 @@ import pytest
 from src.league_intel.publish import build_league_adjusted_payload
 
 
-def _row(name, position, value):
-    return {"displayName": name, "position": position, "rankDerivedValue": value}
+def _row(name, position, value, rank=None, asset_class="player", canonical=None):
+    return {
+        "displayName": name,
+        "canonicalName": canonical or name.lower(),
+        "position": position,
+        "rankDerivedValue": value,
+        "canonicalConsensusRank": rank,
+        "assetClass": asset_class,
+    }
 
 
 BOARD = [
-    _row("Scarce One", "RB", 5000),
-    _row("Scarce Two", "RB", 3000),
-    _row("Deep One", "K", 2000),
-    _row("Tight End", "TE", 4000),
+    _row("Scarce One", "RB", 5000, 1),
+    _row("Scarce Two", "RB", 3000, 3),
+    _row("Deep One", "K", 4000, 2),
+    _row("Tight End", "TE", 2000, 4),
 ]
 
 # lineupScarcity 0.5 is the axis reference, so DEEP (0.2) trims and
-# SCARCE (0.8) lifts, with TE parked exactly at the reference so any
-# TE movement can only have come from the TE axis.
+# SCARCE (0.8) lifts. TE sits exactly at the reference, so any TE
+# movement could only have come from a TE axis.
 SCARCITY = {
     "RB": {"lineupScarcity": 0.8},
     "K": {"lineupScarcity": 0.2},
@@ -34,97 +42,174 @@ SCARCITY = {
 }
 
 
-class TestOverlayShape:
-    def test_only_moved_rows_are_carried(self):
-        p = build_league_adjusted_payload(BOARD, SCARCITY, league_key="dynasty_main")
-        assert "Tight End" not in p["values"], "a row at the reference did not move"
-        assert p["adjustedCount"] == len(p["values"])
-        assert p["playerCount"] == len(BOARD)
+def _payload(board=None, scarcity=SCARCITY, **kw):
+    kw.setdefault("league_key", "dynasty_main")
+    return build_league_adjusted_payload(board if board is not None else BOARD, scarcity, **kw)
 
-    def test_scarce_position_is_lifted_and_deep_position_trimmed(self):
-        p = build_league_adjusted_payload(BOARD, SCARCITY, league_key="dynasty_main")
-        assert p["values"]["Scarce One"] > 5000
-        assert p["values"]["Deep One"] < 2000
 
-    def test_payload_is_json_safe(self):
-        import json
+class TestCallerRowsAreNeverMutated:
+    """The single most dangerous failure in this feature.
 
-        p = build_league_adjusted_payload(BOARD, SCARCITY, league_key="dynasty_main")
-        json.loads(json.dumps(p))
+    ``latest_contract_data`` is a shared module global and the compact
+    pass assigns ``canonicalConsensusRank`` in place. Building one
+    league's overlay must not touch the board every other request reads.
+    """
 
-    def test_stamps_travel_with_the_values(self):
-        p = build_league_adjusted_payload(
-            BOARD, SCARCITY, league_key="dynasty_main", config_version=1, data_through="2026-07-27"
-        )
-        assert p["leagueKey"] == "dynasty_main"
-        assert p["configVersion"] == 1
-        assert p["dataThrough"] == "2026-07-27"
-        assert p["modelVersion"] and p["adjustmentModelVersion"]
+    def test_rows_are_untouched(self):
+        board = [dict(r) for r in BOARD]
+        before = [dict(r) for r in board]
+        _payload(board)
+        assert board == before, "overlay mutated the caller's rows"
+
+    def test_nested_values_are_untouched(self):
+        board = [dict(r, values={"overall": r["rankDerivedValue"]}) for r in BOARD]
+        before = [r["values"]["overall"] for r in board]
+        _payload(board)
+        assert [r["values"]["overall"] for r in board] == before
+
+
+class TestFactorsCompose:
+    """Factors, not absolute values — so the overlay is correct against
+    a board built with custom source weights, which the server never
+    computed absolute numbers for."""
+
+    def test_factor_is_a_ratio_not_a_value(self):
+        p = _payload()
+        assert all(0.5 < f < 1.5 for f in p["factors"].values()), p["factors"]
+
+    def test_same_position_gets_the_same_factor(self):
+        """Position-uniform. This is what makes a global re-rank safe:
+        it can reorder across positions but never within one."""
+        p = _payload()
+        assert p["factors"]["Scarce One"] == pytest.approx(p["factors"]["Scarce Two"])
+
+    def test_scarce_lifts_and_deep_trims(self):
+        p = _payload()
+        assert p["factors"]["Scarce One"] > 1.0
+        assert p["factors"]["Deep One"] < 1.0
+
+
+class TestRanksAreDenseAndCoherent:
+    def test_ranks_are_contiguous_from_one(self):
+        p = _payload()
+        ranks = sorted(p["ranks"].values())
+        assert ranks == list(range(1, len(ranks) + 1))
+
+    def test_every_ranked_row_gets_a_tier(self):
+        p = _payload()
+        assert set(p["ranks"]) == set(p["tiers"])
+
+    def test_reorders_across_positions(self):
+        """Scarce One 5000x1.06 = 5300 stays top; Deep One 4000x0.94 =
+        3760 falls below Scarce Two 3000x1.06 = 3180? No — but the RB/K
+        gap must narrow. Assert the direction, not a brittle ordering."""
+        p = _payload()
+        assert p["ranks"]["Scarce One"] < p["ranks"]["Deep One"]
+
+    def test_rankedCount_matches_the_map(self):
+        p = _payload()
+        assert p["rankedCount"] == len(p["ranks"])
+
+
+class TestAnchorSlotPicks:
+    """They carry a real value but must not consume a rank slot."""
+
+    def test_anchor_year_slot_pick_is_priced_but_unranked(self):
+        """Derived, not hardcoded: the anchor year rolls over mid-season
+        (on 2026-07-27 it is already 2027, because the 2026 rookie draft
+        has happened), so a literal year here would rot silently."""
+        from src.api.data_contract import current_rookie_draft_year
+
+        name = f"{current_rookie_draft_year()} Pick 1.06"
+        board = BOARD + [_row(name, "PICK", 4500, 5, asset_class="pick", canonical=name.lower())]
+        p = _payload(board)
+        assert name not in p["ranks"], "anchor slot pick consumed a rank slot"
+        ranks = sorted(p["ranks"].values())
+        assert ranks == list(range(1, len(ranks) + 1)), "excluding it must leave ranks contiguous"
+
+    def test_non_anchor_year_slot_pick_still_takes_a_slot(self):
+        """Only CURRENT-year slot picks are excluded. A future-year pick
+        is an ordinary ranked asset."""
+        from src.api.data_contract import current_rookie_draft_year
+
+        name = f"{current_rookie_draft_year() + 1} Pick 1.06"
+        board = BOARD + [_row(name, "PICK", 4500, 5, asset_class="pick", canonical=name.lower())]
+        assert name in _payload(board)["ranks"]
+
+    def test_picks_do_not_move(self):
+        """No PICK key in scarcity -> ABSENT axis -> factor 1.0. This is
+        why league-adjusted mode re-prices every player against every
+        pick, which is the headline behavioural consequence."""
+        board = BOARD + [_row("2028 Early 1st", "PICK", 3500, 5, asset_class="pick")]
+        p = _payload(board)
+        assert "2028 Early 1st" not in p["factors"]
 
 
 class TestDegradesToConsensusNotToAGuess:
-    """The failure mode worth testing: no roster snapshot."""
-
     def test_absent_scarcity_yields_an_empty_overlay(self):
-        p = build_league_adjusted_payload(BOARD, None, league_key="dynasty_main")
-        assert p["values"] == {}
+        p = _payload(scarcity=None)
+        assert p["factors"] == {} and p["ranks"] == {}
         assert p["isNoop"] is True
-        assert p["adjustedCount"] == 0
 
     def test_empty_scarcity_is_treated_as_absent(self):
-        p = build_league_adjusted_payload(BOARD, {}, league_key="dynasty_main")
-        assert p["values"] == {}
+        assert _payload(scarcity={})["factors"] == {}
 
     def test_position_missing_from_scarcity_is_left_alone(self):
-        p = build_league_adjusted_payload(
-            BOARD, {"RB": {"lineupScarcity": 0.8}}, league_key="dynasty_main"
-        )
-        assert "Deep One" not in p["values"], "K had no measurement; it must not move"
+        p = _payload(scarcity={"RB": {"lineupScarcity": 0.8}})
+        assert "Deep One" not in p["factors"], "K had no measurement; it must not move"
 
     def test_unpriced_row_never_enters_the_overlay(self):
-        p = build_league_adjusted_payload(
-            BOARD + [_row("Ghost", "RB", 0)], SCARCITY, league_key="dynasty_main"
-        )
-        assert "Ghost" not in p["values"]
+        p = _payload(BOARD + [_row("Ghost", "RB", 0)])
+        assert "Ghost" not in p["factors"]
 
 
 class TestTePremiumStaysOut:
-    """Guards the double-count. See test_te_premium_invariants.py — the
-    anchor ktcSfTep IS the TE++ board, so the blend already embeds the
-    structural 2-TE premium."""
+    """The market anchor ktcSfTep IS the TE++ board, so the blend already
+    embeds the structural 2-TE premium. A post-blend TE axis double-counts."""
 
     def test_te_axis_is_declared_inactive(self):
-        p = build_league_adjusted_payload(BOARD, SCARCITY, league_key="dynasty_main")
-        assert "tePremium" in p["inactiveAxes"]
+        assert "tePremium" in _payload()["inactiveAxes"]
 
     def test_te_at_reference_scarcity_is_untouched(self):
-        p = build_league_adjusted_payload(BOARD, SCARCITY, league_key="dynasty_main")
-        assert "Tight End" not in p["values"], (
+        assert "Tight End" not in _payload()["factors"], (
             "a TE priced at reference scarcity moved — something is applying a "
             "TE premium on top of an anchor that already embeds it"
         )
 
 
-class TestGuardrailsAreReported:
-    def test_monotonicity_is_checked_and_reported(self):
-        p = build_league_adjusted_payload(BOARD, SCARCITY, league_key="dynasty_main")
-        assert p["monotonicityViolations"] == []
+class TestVersionPin:
+    """Overlay ranks are valid only against the contract build they came
+    from. A scrape landing mid-fetch would otherwise apply board B's
+    ranks to board A's values."""
+
+    def test_stamps_travel_with_the_payload(self):
+        p = _payload(contract_version="2026-03-10.v2", scrape_timestamp="2026-07-27T05:14:44")
+        assert p["contractVersion"] == "2026-03-10.v2"
+        assert p["scrapeTimestamp"] == "2026-07-27T05:14:44"
+
+    def test_absent_pin_is_explicit_null_not_missing(self):
+        p = _payload()
+        assert "contractVersion" in p and "scrapeTimestamp" in p
+
+
+class TestProvenance:
+    def test_payload_is_json_safe(self):
+        import json
+
+        json.loads(json.dumps(_payload()))
 
     def test_scarcity_used_is_echoed_back(self):
         """A served value must be explainable from the payload alone."""
-        p = build_league_adjusted_payload(BOARD, SCARCITY, league_key="dynasty_main")
-        assert p["scarcity"]["RB"]["lineupScarcity"] == pytest.approx(0.8)
+        assert _payload()["scarcity"]["RB"]["lineupScarcity"] == pytest.approx(0.8)
 
-
-class TestScarcityComponentObjects:
     def test_dataclass_components_are_accepted(self):
-        """Callers pass ScarcityComponents straight from LI-5; the
-        payload must normalise them rather than serialise an object."""
-
         class Comp:
             def to_dict(self):
                 return {"lineupScarcity": 0.8}
 
-        p = build_league_adjusted_payload(BOARD, {"RB": Comp()}, league_key="dynasty_main")
-        assert p["values"]["Scarce One"] > 5000
+        p = _payload(scarcity={"RB": Comp()})
+        assert p["factors"]["Scarce One"] > 1.0
         assert p["scarcity"]["RB"] == {"lineupScarcity": 0.8}
+
+    def test_monotonicity_is_reported(self):
+        assert _payload()["monotonicityViolations"] == []


### PR DESCRIPTION
`src/league_intel/` computed league-adjusted values and `GET /api/valuation/league-adjusted` served them, but **nothing consumed them** — `settings.valuationMode` existed with zero consumers. Flipping it did nothing. This wires it end to end.

13 files, +2150/−607.

## §1 — one ranker

Extracted the Phase 5 compact pass into `data_contract.py::compact_ranks_and_tiers`. The overlay has to re-rank an adjusted board; writing that inline would have created a second ranker, which `data_contract.py:8303` already forbids — two implementations drift, and the one that drifts is the one nobody is watching.

It takes `copy_rows` because the callers have opposite needs. The pipeline owns its rows and mutates in place. **The overlay must not**: `latest_contract_data` is a shared module global and the compact pass assigns `canonicalConsensusRank` directly, so building one league's overlay on live rows would permanently overwrite the board every other request reads.

Verified behaviour-preserving on the live board: **707 ranked, contiguous 1..707, zero coherence errors**, 72 anchor-year slot picks still carrying a value while consuming no rank slot.

## §2 — factors, not values; dense ranks, not a diff

**Factors** because `build_adjustment` computes `adjusted = consensus × combined`, and `combined` never reads the consensus value — it's a function of position alone. So a factor composes exactly against *any* board, including one re-weighted with custom source weights. An absolute value would carry the default board's numbers into a board the server never computed.

**Dense ranks** because a player whose own factor is 1.0 still moves when neighbours move — a 4% shift displaces rank 500 by ~63 slots. A "changed ranks only" diff is the dense map minus a rounding error, and it reintroduces the three-state ambiguity (`changed` / `unchanged` / `now-unranked`) that `activePlayerIds` exists to paper over. ~7 KB gzip against a ~100 KB gzip override delta.

Measured live: 719 factors over [0.9529, 1.0433], 707 dense ranks + tiers, caller rows provably untouched. Bijan Robinson (RB, scarcity 0.717) rises **3→1**; Brock Bowers (TE, 0.554) falls **2→4**. Positions moving against each other — the whole point.

## §4/§6 — applier and three controls

Applied at **contract level** inside `fetchDynastyData`, so one write to `rankDerivedValue` reaches the rankings board, the trade calculator's "Our Value", every sort comparator and the CSV exports with zero changes to `/trade`. `values.raw` untouched — the toggle changes Our Value, never Raw.

`applyValuationOverlay` is deliberately **not** `mergeRankingsDelta`: that function's runtime-view branch synthesizes `playersArray` from delta entries only (an unmentioned player disappears) and its `activePlayerIds` branch nulls absent ranks. Both correct for a dense delta, catastrophic for a sparse overlay where absence means unchanged.

It writes **two key sets**, because the materializers disagree: `playersArray` uses `canonicalConsensusRank`, the legacy dict uses `_canonicalConsensusRank` — but `rankDerivedValue` with no underscore in both. The legacy dict is the **default** path (`server.py` pops `playersArray` off the runtime payload), so writing one set would move the value and leave the rank stale *on the only path that ships*. Tested explicitly.

Two guards that refuse rather than half-apply:
- **Version pin** — a scrape landing between the base fetch and the overlay fetch would apply board B's ranks to board A's values. Mismatch → serve market, warn.
- **Sort by served rank** when active. Python rounds half-to-even, JS half-up; a one-unit divergence swaps adjacent rows against the served ranks and renders as `#100, #101, #100` stutter.

`buildRows`' `computedConsensusRank` fallback is suppressed while active — left alone it puts an adjusted-value-derived ordinal in the `#` column, which is the client-side ranking the rule forbids (an instance that predates this change). `rankChange` is nulled: *"moved up N since the previous scrape"* is false next to an adjusted rank.

Controls on `/settings` (authoritative, long-form copy), `/rankings` and `/trade` (`SegmentedControl`, as `a11y-tab-roles.test.js:141` requires), all writing one setting.

## Deliberately blocked, not silently wrong

**Source overrides + leagueAdjusted is not composed.** The overlay's ranks are the ranks of `default_consensus × factor`; the correct answer is `overridden_consensus × factor`, which the server never computed. No client-side sequencing fixes that — composing them yields a board where neither values nor ranks correspond to anything. `fetchDynastyData` serves the overridden market board and warns.

## What is NOT in this PR

Stated plainly rather than implied by omission:

- **§3 server-side composition** — threading `valuation_mode` through the overrides pipeline (the fix for the block above), and the precomputed warm cache (a perf optimisation, not correctness).
- **§5 partial** — `rankChange` is nulled, but the Movers panel isn't explicitly hidden, exports aren't stamped with the mode, the server-computed suggestions rail isn't labelled, and `/draft` (which reads values directly, bypassing `buildRows`) stays on market.
- **§7 TE alignment** — not started. Overlaps #585's `te_premium.py`.
- **§8 scoring spike** — partially answered. `data_contract.py:7738` shows LAM and positional scarcity were *deliberately removed and are actively stripped from all API responses*, which is a strong prior they were found unsound. The precise reason needs the consolidation commit history.

## Verification

- Python: `pytest -m "not livedata"` — running; will confirm before merge
- Frontend: **1269 passed** (14 new in `valuation-overlay.test.js`)
- Live board: isolation, contiguity, coherence, and the reorder all verified against real rosters

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_