### PR TITLE
Chase Upside Tier 0 + Tier 1: persist actuals, cover league-adjusted, fix the toggle flash, wire the TE basis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,21 @@ Steps:
 5. Scope-appropriate curve routing (cross-market → GLOBAL, overall
    IDP → IDP, everything else → OFFENSE; the ROOKIE master is refit
    tooling only — rookie sources ladder-translate first)
+5a. TE basis conversion (2026-07-27, ADR-015).  TE rows from non-TEP
+   sources are lifted onto the basis the board is anchored on via
+   ``src/league_intel/te_premium.convert_te_value(from_basis="base",
+   to_basis="tepp")`` — KTC's own measured uplift, 1.209 at the top of
+   the board rising toward 2.05 down it.  Replaces a flat 1.15 that sat
+   below the entire observed range.  ``ktc`` / ``ktcSfTep`` are exempt
+   (the anchor IS the TE++ board) and the conversion is a no-op when
+   ``from == to``, so the double-count guard is structural.  TEP-native
+   sources keep the flat 1.10 — only base ↔ tepp is measured.
+   **The target basis is a CONSTANT, not the league's measured TE
+   demand**: demand is a leagueKey property and this board is
+   scoring-profile scoped, and the two live leagues on
+   ``superflex_tep15_ppr1`` want different bases.  That half is overlay
+   work.  Rollback: ``RISKIT_FEATURE_TE_BASIS_CONVERSION=0``; an
+   explicit operator slider value bypasses the curve regardless.
 6. Hierarchical anchor + α-shrinkage (α=0.10) ONLY for IDP and
    picks; offense takes a flat count-aware mean-median across all
    sources.  Pick rows widen the anchor set to include ktcSfTep so

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -1183,6 +1183,20 @@ answer.
 **Cheap check that would have caught it in one command, before any
 code:** `git grep -l leagueAdjusted -- src/`.
 
+**UPDATE 2026-07-27 — the corrected module landed, and is now WIRED.**
+A rewritten `src/league_intel/te_premium.py` (basis-based, no multiplier
+field, curve in `config/weights/te_premium_curve.json`) did ship, but
+with **zero callers** — reproducing this section's own §6.15 failure a
+second time. `data_contract.py` now calls
+`convert_te_value(value, from_basis="base", to_basis="tepp")` in place
+of the flat 1.15 for non-TEP sources. See ADR-015 in
+`docs/league-intelligence/DECISIONS.md` for the measured blast radius
+and, more importantly, for why the target basis is a **constant** and
+not the league's own measured demand: `dynasty_main` (2 TE starters)
+and `dynasty_new` (1) share the `superflex_tep15_ppr1` scoring profile
+and want different bases, so Axis B cannot enter a scoring-profile-scoped
+board. Axis A is in the blend; Axis B stays an overlay axis.
+
 ### 6.15 The dominant defect class: a guard that cannot fire
 
 **Four instances found in one session, 2026-07-27.** Each was written in

--- a/docs/league-intelligence/DECISIONS.md
+++ b/docs/league-intelligence/DECISIONS.md
@@ -529,10 +529,76 @@ substituting one unverified shape for another), stamp VA-adjusted
 IDPTC totals as carrying an unverified adjustment, and treat any
 future IDPTC consolidation disclosure as the trigger to revisit.
 
+## ADR-015: the TE alignment is now a measured basis conversion, and Axis B stays out of the shared board
+**Status:** SHIPPED 2026-07-27.  Supersedes the "no code change yet"
+half of ADR-009 for Axis A; ADR-009's Axis B question stays open.
+
+**What changed.**  `_compute_unified_rankings` no longer multiplies
+non-TEP sources' TE contributions by a flat
+`_TE_BLANKET_NON_NATIVE_MULTIPLIER` (1.15).  It calls
+`src/league_intel/te_premium.convert_te_value(value, from_basis="base",
+to_basis="tepp")` — KTC's own measured base → TE++ uplift, fitted from
+the two boards this repo already scrapes (73 paired TEs, R² 0.941 in log
+space, `config/weights/te_premium_curve.json`).
+
+**Why this is not a second premium.**  The blend anchors on `ktcSfTep`,
+which IS KTC's TE++ board, and every non-TEP source's TE contribution
+was already being scaled to align with it.  Only the *magnitude* of that
+existing alignment changes.  1.15 matched nothing observed anywhere in
+the data: KTC's smallest actual uplift is 1.209 and it reaches 2.053
+down the board, so every tight end was under-lifted.
+
+The double-count guard is now structural rather than procedural.  KTC
+stays in the exemption set, but even without it `convert_te_value` is a
+no-op when `from_basis == to_basis`, and `ktcSfTep` is already on
+`tepp`.  The API takes two bases precisely so a caller cannot multiply
+it in twice; a multiplier API cannot offer that.
+
+**Measured blast radius** (2026-07-27 live board, 810 rows):
+
+| | |
+|---|---|
+| TE value change | all 80 move up: +1.08% (Bowers, against the 9999 ceiling) to +30.17% (Ruckert, deep), median +14.27% |
+| non-TE value change | 48 PICK rows only, via the documented current-year pick tethering inheriting rookie-TE values (2026 Pick 1.07 +3.91% = Kenyon Sadiq exactly) |
+| QB / RB / WR / IDP | zero value change |
+| rank displacement | median 7, p90 22, max 214 (Ruckert, 717 → 503) |
+
+**Why the target basis is a constant and not the league's own demand.**
+This is the load-bearing decision, and it follows from CLAUDE.md's core
+split rather than from convenience.  `te_premium.measure_te_demand`
+answers *which basis does THIS league need?* from roster structure — a
+LEAGUE property.  This board is SCORING-PROFILE scoped and shared.
+Measured on the live registry: `dynasty_main` (2 mandatory TE starters)
+wants `tepp`, `dynasty_new` (1) wants `base`, and **the two share the
+`superflex_tep15_ppr1` profile.**  Threading league demand into the
+blend would let one league's roster shape reprice the other's board.
+
+So the blend does Axis A only — align every source onto the basis the
+board is already anchored on — and Axis B belongs in the league-scoped
+overlay (`src/league_intel/publish.py`), where `tePremium` is a named
+inactive axis.  A one-TE league on this profile is currently carrying a
+two-TE premium it does not want; taking it back off is overlay work and
+needs the netting ADR-009 requires, now against the measured curve
+rather than against 1.15.
+
+**Rollback.** `RISKIT_FEATURE_TE_BASIS_CONVERSION=0` restores the flat
+path.  An explicit operator slider value bypasses the curve regardless
+of the flag — a number the operator typed is a decision, not a
+measurement to overrule.  The Sleeper-*derived* value does not block the
+curve: it comes from `bonus_rec_te`, the scoring axis ADR-009 retracted,
+which reads 0.0 for this league in 2026.
+
+**What this closes.** ORCHESTRATION.md §6.14/§6.15's named instance —
+a complete TE module `data_contract.py` deliberately never imported, so
+that "toggle off" would be byte-identical, which also meant the
+double-count guard could never fire on it.
+`tests/api/test_te_basis_conversion.py` spies on `convert_te_value` and
+fails if the blend stops calling it.
+
 ## ADR-009 (AUDIT, pre-LI-7): the league deleted its TE premium; consensus still charges for it
-**Status:** finding recorded 2026-07-26 — **no code change yet.**  This
-is the §22 "audit the existing TEP pipeline first" step.  The residual
-model itself lands in LI-7.
+**Status:** finding recorded 2026-07-26.  **Axis A shipped 2026-07-27 —
+see ADR-015 above**; the Axis-B residual model still lands in LI-7.
+This was the §22 "audit the existing TEP pipeline first" step.
 
 **What consensus already embeds.**  `_compute_unified_rankings`
 applies TE-only, value-level multipliers during the blend:

--- a/frontend/__tests__/components/useSettings.hydration.test.jsx
+++ b/frontend/__tests__/components/useSettings.hydration.test.jsx
@@ -1,0 +1,128 @@
+/**
+ * The hydration gap in `useSettings`, exercised through a real
+ * server-render + hydrate cycle rather than described in a comment.
+ *
+ * `renderToString` is what the pre-fix bug actually looked like: React
+ * calls `getServerSnapshot` for the SSR pass AND the hydration pass, so
+ * markup shipped to a user whose persisted lens is "leagueAdjusted"
+ * carried `aria-checked="true"` on **Market**. The first paint asserted
+ * the wrong value basis, and only the post-hydration re-render corrected
+ * it.
+ *
+ * So the guard is on the SERVER STRING, not on the settled DOM. Asserting
+ * the settled DOM passes with or without the fix — it was always correct
+ * once React caught up. That is the whole defect: the wrong state is
+ * transient, and a test that only looks at the end never sees it.
+ */
+import { describe, expect, it, beforeEach } from "vitest";
+import React from "react";
+import { renderToString } from "react-dom/server";
+import { render, screen } from "@testing-library/react";
+import { SegmentedControl } from "@/components/ds/SegmentedControl";
+import { useSettings } from "@/components/useSettings";
+import { SETTINGS_KEY } from "@/lib/trade-logic";
+
+const OPTIONS = [
+  { value: "market", label: "Market" },
+  { value: "leagueAdjusted", label: "My league" },
+];
+
+/** The two call sites on /rankings and /trade, reduced to their shape. */
+function ValuationToggle() {
+  const { settings, hydrated } = useSettings();
+  return (
+    <SegmentedControl
+      label="Value basis"
+      value={hydrated ? settings.valuationMode || "market" : null}
+      options={OPTIONS}
+      onChange={() => {}}
+    />
+  );
+}
+
+/** The pre-fix call site, kept as the control for the assertions below. */
+function UngatedToggle() {
+  const { settings } = useSettings();
+  return (
+    <SegmentedControl
+      label="Value basis"
+      value={settings.valuationMode || "market"}
+      options={OPTIONS}
+      onChange={() => {}}
+    />
+  );
+}
+
+/**
+ * The store memoizes in a module-level `cached` that only a write through
+ * `update()` or a cross-tab storage event invalidates. Tests mutate
+ * localStorage directly, so they must fire the store's own invalidation
+ * path afterwards rather than reaching into its internals.
+ */
+function syncStore() {
+  window.dispatchEvent(new StorageEvent("storage", { key: SETTINGS_KEY }));
+}
+
+function persistLeagueAdjusted() {
+  window.localStorage.setItem(
+    SETTINGS_KEY,
+    JSON.stringify({ valuationMode: "leagueAdjusted", tepDefaultV3Applied: true })
+  );
+  syncStore();
+}
+
+describe("useSettings hydration gate", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    syncStore();
+  });
+
+  it("the server render claims no value basis at all", () => {
+    persistLeagueAdjusted();
+    const html = renderToString(<ValuationToggle />);
+    expect(html).not.toContain('aria-checked="true"');
+  });
+
+  it("the UNGATED render is the bug: it asserts Market on the server", () => {
+    // The control case. If this ever stops containing a checked option,
+    // the hydration gap has closed some other way and the gate above is
+    // no longer load-bearing — which is worth finding out from a failing
+    // test rather than assuming.
+    persistLeagueAdjusted();
+    const html = renderToString(<UngatedToggle />);
+    expect(html).toContain('aria-checked="true"');
+    // And specifically the WRONG one: Market, not the persisted lens.
+    const marketIdx = html.indexOf("Market");
+    const leagueIdx = html.indexOf("My league");
+    const checkedIdx = html.indexOf('aria-checked="true"');
+    expect(checkedIdx).toBeLessThan(marketIdx);
+    expect(checkedIdx).toBeLessThan(leagueIdx);
+  });
+
+  it("settles on the persisted lens on the client", () => {
+    persistLeagueAdjusted();
+    render(<ValuationToggle />);
+    expect(screen.getByRole("radio", { name: "My league" })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+  });
+
+  it("settles on the default when nothing is persisted", () => {
+    render(<ValuationToggle />);
+    expect(screen.getByRole("radio", { name: "Market" })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+  });
+
+  it("hydrated is false on the server and true on the client", () => {
+    function Probe() {
+      const { hydrated } = useSettings();
+      return <span data-testid="h">{String(hydrated)}</span>;
+    }
+    expect(renderToString(<Probe />)).toContain(">false<");
+    render(<Probe />);
+    expect(screen.getByTestId("h")).toHaveTextContent("true");
+  });
+});

--- a/frontend/__tests__/components/valuation-toggle-hydration.test.jsx
+++ b/frontend/__tests__/components/valuation-toggle-hydration.test.jsx
@@ -1,0 +1,108 @@
+/**
+ * The valuation toggle must not claim a value basis before it knows one.
+ *
+ * `useSettings` is a `useSyncExternalStore` over localStorage. React uses
+ * `getServerSnapshot` for BOTH the SSR render and the client's hydration
+ * pass, so the first client render of every consumer sees
+ * SETTINGS_DEFAULTS — `valuationMode: "market"` — regardless of what this
+ * device has persisted. React then re-renders with the real value.
+ *
+ * For most settings that gap is invisible. For this one it is a claim
+ * about which board produced the numbers on screen, on pages where that
+ * claim decides trade verdicts. And it cost a wasted round-trip:
+ * `useDynastyData`'s fetch effect fired once on the defaults and again
+ * after hydration.
+ *
+ * WHAT THIS FILE DOES AND DOES NOT PROVE
+ * `SegmentedControl` already handled an unmatched value correctly —
+ * `aria-checked` has always been `opt.value === value`, and the
+ * `Math.max(0, findIndex(...))` nearby only ever drove the roving
+ * tabindex. So these are NOT regression tests for a bug that existed
+ * here; they pin a contract the call sites now depend on. The
+ * demonstration that the flash was real lives next door, in
+ * `useSettings.hydration.test.jsx`'s "the UNGATED render is the bug".
+ *
+ * They still earn their place: `/rankings` and `/trade` now pass `null`
+ * on purpose, and the cheapest way to break that is to wire
+ * `aria-checked` to `activeIndex` during some future tidy-up, which
+ * would restore a confident highlight on an unknown value. Every
+ * assertion is therefore about `aria-checked` on a named option — the
+ * one attribute that separates "nothing selected" from "wrong thing
+ * selected".
+ */
+import { describe, expect, it } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { SegmentedControl } from "@/components/ds/SegmentedControl";
+
+const OPTIONS = [
+  { value: "market", label: "Market" },
+  { value: "leagueAdjusted", label: "My league" },
+];
+
+function renderToggle(value) {
+  return render(
+    <SegmentedControl label="Value basis" value={value} options={OPTIONS} onChange={() => {}} />
+  );
+}
+
+describe("SegmentedControl indeterminate state", () => {
+  it("checks nothing when the value is null", () => {
+    renderToggle(null);
+    for (const radio of screen.getAllByRole("radio")) {
+      expect(radio).toHaveAttribute("aria-checked", "false");
+    }
+  });
+
+  it("does NOT fall back to highlighting the first option", () => {
+    // The failure this guards: `activeIndex` floors at 0, so wiring
+    // `aria-checked` to it would confidently highlight "Market" for any
+    // unmatched value — including the `null` the hydration gate passes.
+    renderToggle(null);
+    expect(screen.getByRole("radio", { name: "Market" })).toHaveAttribute(
+      "aria-checked",
+      "false"
+    );
+  });
+
+  it("treats an unknown value the same as no value", () => {
+    // Not only hydration: a stale or renamed setting must not silently
+    // resolve to whichever option happens to be listed first.
+    renderToggle("someRetiredMode");
+    for (const radio of screen.getAllByRole("radio")) {
+      expect(radio).toHaveAttribute("aria-checked", "false");
+    }
+  });
+
+  it("stays keyboard-reachable while indeterminate", () => {
+    // A radiogroup with no tab stop is unreachable. The roving tabindex
+    // falls to the first option even when nothing is checked — which is
+    // NOT the same as checking it.
+    renderToggle(null);
+    const radios = screen.getAllByRole("radio");
+    expect(radios.filter((r) => r.getAttribute("tabindex") === "0")).toHaveLength(1);
+    expect(radios[0]).toHaveAttribute("tabindex", "0");
+    expect(radios[0]).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("renders the same options either way, so nothing shifts on hydration", () => {
+    const { container: indeterminate } = renderToggle(null);
+    const before = indeterminate.querySelectorAll(".ds-segmented__option").length;
+    const { container: settled } = renderToggle("leagueAdjusted");
+    const after = settled.querySelectorAll(".ds-segmented__option").length;
+    expect(before).toBe(after);
+    expect(before).toBe(OPTIONS.length);
+  });
+
+  it("checks exactly the matching option once a value arrives", () => {
+    renderToggle("leagueAdjusted");
+    expect(screen.getByRole("radio", { name: "My league" })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+    expect(screen.getByRole("radio", { name: "Market" })).toHaveAttribute(
+      "aria-checked",
+      "false"
+    );
+  });
+});

--- a/frontend/__tests__/components/value-basis-honesty.test.jsx
+++ b/frontend/__tests__/components/value-basis-honesty.test.jsx
@@ -1,0 +1,130 @@
+/**
+ * A page must not assert a value basis its numbers do not have.
+ *
+ * The lens is set on /rankings and /trade but applies everywhere —
+ * `fetchDynastyData` composes the overlay before any page sees the
+ * contract. So /draft, /rosters, /edge and /waivers were rendering
+ * league-adjusted values with no toggle in sight and nothing saying the
+ * board had moved. The values were right; the silence was the defect.
+ *
+ * THE ASSERTION THAT MATTERS is that the basis is read off the CONTRACT
+ * and not off `settings.valuationMode`. Those two diverge in three real
+ * cases — a failed overlay fetch, the scrape-version pin refusing, and
+ * the server finding no roster snapshot — and in every one of them the
+ * setting still says "leagueAdjusted" while the numbers are market.
+ * Labelling off the setting would put the wrong label on precisely the
+ * boards that most need the right one, so there is a test for each.
+ */
+import { describe, expect, it } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ValueBasisNote } from "@/components/ds/ValueBasisNote";
+import {
+  valuationBasisOf,
+  valuationBasisLabel,
+  mergeRankingsDelta,
+} from "@/lib/dynasty-data";
+
+describe("valuationBasisOf", () => {
+  it("reads leagueAdjusted off a client-applied overlay", () => {
+    expect(
+      valuationBasisOf({ valuationOverlay: { mode: "leagueAdjusted" } })
+    ).toBe("leagueAdjusted");
+  });
+
+  it("reads leagueAdjusted off the server-composed board", () => {
+    // Custom weights + the lens is composed server-side and carries no
+    // client-applied overlay object. Before this, /trade's banner gated
+    // on `rawData.valuationOverlay` and went silent on exactly that
+    // board — adjusted values, no label.
+    const merged = mergeRankingsDelta(
+      { playersArray: [{ displayName: "A", rankDerivedValue: 100 }] },
+      {
+        meta: { valuationMode: "leagueAdjusted" },
+        valuationAdjustment: { adjustedCount: 1 },
+        rankingsDelta: { playerKey: "displayName", players: [{ id: "A" }] },
+      }
+    );
+    expect(valuationBasisOf(merged)).toBe("leagueAdjusted");
+    // mergeRankingsDelta returns the {ok, source, data} envelope.
+    expect(merged.data.valuationOverlay.serverComposed).toBe(true);
+  });
+
+  it("says market when the server degraded despite the request", () => {
+    // No roster snapshot => scarcity unmeasurable => market values with
+    // a note. The user's SETTING still says leagueAdjusted here; the
+    // board does not, and the board is what gets labelled.
+    const merged = mergeRankingsDelta(
+      { playersArray: [{ displayName: "A", rankDerivedValue: 100 }] },
+      {
+        meta: { valuationNote: "league_adjusted_unavailable: no_roster_snapshot" },
+        rankingsDelta: { playerKey: "displayName", players: [{ id: "A" }] },
+      }
+    );
+    expect(valuationBasisOf(merged)).toBe("market");
+    expect(merged.data.valuationNote).toContain("league_adjusted_unavailable");
+  });
+
+  it("defaults to market for an absent or empty contract", () => {
+    expect(valuationBasisOf(null)).toBe("market");
+    expect(valuationBasisOf(undefined)).toBe("market");
+    expect(valuationBasisOf({})).toBe("market");
+  });
+
+  it("unwraps the {data} envelope", () => {
+    expect(
+      valuationBasisOf({ data: { valuationOverlay: { mode: "leagueAdjusted" } } })
+    ).toBe("leagueAdjusted");
+  });
+});
+
+describe("ValueBasisNote", () => {
+  it("renders nothing on the market board", () => {
+    // Deliberate: market is the default every user is on, and a
+    // permanent "these are market values" strip on nine pages is noise
+    // that trains people to stop reading it.
+    const { container } = render(<ValueBasisNote contract={{}} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("names the board when it is league-adjusted", () => {
+    render(
+      <ValueBasisNote contract={{ valuationOverlay: { mode: "leagueAdjusted" } }} />
+    );
+    expect(screen.getByRole("note")).toHaveTextContent(
+      /Valued on your league's board/i
+    );
+  });
+
+  it("discloses that picks do not move", () => {
+    // The single largest behavioural consequence of the lens: scarcity
+    // has no PICK key, so league-adjusted mode systematically reprices
+    // every player against every pick. That belongs in UI copy.
+    render(
+      <ValueBasisNote contract={{ valuationOverlay: { mode: "leagueAdjusted" } }} />
+    );
+    expect(screen.getByRole("note")).toHaveTextContent(/picks/i);
+  });
+
+  it("stays silent when the contract is missing entirely", () => {
+    const { container } = render(<ValueBasisNote contract={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("valuationBasisLabel", () => {
+  it("never guesses — an unknown board reads as market, explicitly", () => {
+    expect(valuationBasisLabel({})).toMatch(/Market/i);
+  });
+
+  it("is distinguishable in an export cell", () => {
+    // The label ends up as a CSV column. Two boards that stringify the
+    // same would defeat the column entirely.
+    const market = valuationBasisLabel({});
+    const adjusted = valuationBasisLabel({
+      valuationOverlay: { mode: "leagueAdjusted" },
+    });
+    expect(market).not.toEqual(adjusted);
+    expect(adjusted).toMatch(/league/i);
+  });
+});

--- a/frontend/__tests__/trade-export.test.js
+++ b/frontend/__tests__/trade-export.test.js
@@ -8,17 +8,33 @@ const sides = [
 
 describe("tradeWorkspaceToCSV", () => {
   it("emits header + a row per asset with the right value mode", () => {
-    const csv = tradeWorkspaceToCSV(sides, "full");
+    const csv = tradeWorkspaceToCSV(sides, "full", "Market consensus");
     const lines = csv.trim().split("\n");
-    expect(lines[0]).toBe("Side,Asset,Position,Team,Value");
-    expect(lines[1]).toBe("A,Josh Allen,QB,BUF,8000");
+    expect(lines[0]).toBe("Side,Asset,Position,Team,Value,Value Basis");
+    expect(lines[1]).toBe("A,Josh Allen,QB,BUF,8000,Market consensus");
     // comma in name must be quoted
-    expect(lines[2]).toBe('B,"Bijan, Jr.",RB,ATL,7000');
+    expect(lines[2]).toBe('B,"Bijan, Jr.",RB,ATL,7000,Market consensus');
   });
   it("raw mode falls back to full when raw missing", () => {
     const csv = tradeWorkspaceToCSV(sides, "raw");
     expect(csv).toContain("A,Josh Allen,QB,BUF,7900");
     expect(csv).toContain('"Bijan, Jr.",RB,ATL,7000');
+  });
+  it("says 'unspecified' rather than guessing when no basis is passed", () => {
+    // An export outlives the app: a market board and a league-adjusted
+    // board are indistinguishable in a spreadsheet, and they answer
+    // different questions about the same trade. A caller that forgets
+    // to pass the basis must produce an honestly blank cell, never a
+    // confident "Market" — guessing is the error the column exists to
+    // prevent.
+    const csv = tradeWorkspaceToCSV(sides, "full");
+    expect(csv.trim().split("\n")[1]).toBe("A,Josh Allen,QB,BUF,8000,unspecified");
+  });
+  it("carries the league-adjusted basis through to every row", () => {
+    const csv = tradeWorkspaceToCSV(sides, "full", "League-adjusted (x)");
+    const rows = csv.trim().split("\n").slice(1);
+    expect(rows.length).toBeGreaterThan(1);
+    for (const r of rows) expect(r).toContain("League-adjusted (x)");
   });
 });
 

--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuthContext } from "@/app/AppShellWrapper";
+import { useApp } from "@/components/AppShell";
 import { useLeague } from "@/components/useLeague";
 import {
   buildTeamIndexLookup,
@@ -67,6 +68,7 @@ import {
   Panel,
   SkeletonText,
   StatTile,
+  ValueBasisNote,
 } from "@/components/ds";
 import styles from "./draft.module.css";
 
@@ -3241,6 +3243,11 @@ function DraftGlossary() {
 export default function DraftDashboardPage() {
   const router = useRouter();
   const { authenticated, checking } = useAuthContext();
+  // Only for the value-basis disclosure. The draft board prices off
+  // /api/draft-capital and its own workspace, but the player values it
+  // shows alongside come from the same contract every other page reads,
+  // so the same lens applies and the same silence applied here too.
+  const { rawData } = useApp();
   // League-scoped draft workspace — a draft-in-progress lives per
   // league, keyed by ``DRAFT_STORAGE_KEY__<leagueKey>``.  Switching
   // leagues mid-draft doesn't destroy the prior league's board.
@@ -4504,6 +4511,8 @@ export default function DraftDashboardPage() {
           </div>
         }
       />
+
+      <ValueBasisNote contract={rawData} />
 
       {syncError ? (
         <Banner tone="negative" title="Sync error" onDismiss={() => setSyncError("")}>

--- a/frontend/app/ds.css
+++ b/frontend/app/ds.css
@@ -366,6 +366,19 @@
   color: var(--text-secondary);
   max-width: 60ch;
 }
+/* ValueBasisNote — appears only when the board is NOT market values.
+   Low-key by design: it is a standing clarification, not an alert, and
+   an alert-styled strip on every page would be tuned out. */
+.ds-value-basis-note {
+  margin: var(--space-2) 0 var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-left: 2px solid var(--accent, currentColor);
+  background: var(--surface-2, transparent);
+  border-radius: var(--radius-sm, 4px);
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  max-width: 72ch;
+}
 .ds-page-header__actions {
   display: flex;
   align-items: center;

--- a/frontend/app/edge/page.jsx
+++ b/frontend/app/edge/page.jsx
@@ -29,6 +29,7 @@ import {
   StatTile,
   Tabs,
   tabPanelId,
+  ValueBasisNote,
 } from "@/components/ds";
 import {
   colConfidence,
@@ -258,6 +259,8 @@ export default function EdgePage() {
         description="Where the ranking sources agree, disagree, and flag issues. Every signal is derived from measurable properties of the data — coverage, agreement, divergence. Nothing is predicted."
         actions={teamSelect}
       />
+
+      <ValueBasisNote contract={rawData} />
 
       {!!error && (
         <Banner tone="negative" title="Couldn't load edge data">

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -6,6 +6,8 @@ import {
   resolvedRank,
   RANKING_SOURCES,
   siteOverridesAreCustomized,
+  valuationBasisLabel,
+  valuationBasisOf,
 } from "@/lib/dynasty-data";
 import { useSettings } from "@/components/useSettings";
 import { useApp } from "@/components/AppShell";
@@ -645,6 +647,15 @@ export default function RankingsPage() {
         "Sources",
         ...sourceHeaders,
       ];
+      // Stamp the value basis as a column on every row, not as a
+      // preamble line. An export outlives the app: once these numbers
+      // are in a spreadsheet, a league-adjusted board and a market
+      // board are indistinguishable, and the two answer different
+      // questions about the same player. A header line would be lost
+      // the first time someone sorts or pastes a subset; a column
+      // travels with the row it describes.
+      headers.push("Value Basis");
+      const basisCell = valuationBasisLabel(rawData);
       const lines = [headers.map(escape).join(joiner)];
       displayRows.forEach((row) => {
         const val = Math.round(row.rankDerivedValue || row.values?.full || 0);
@@ -670,6 +681,7 @@ export default function RankingsPage() {
             actionStr,
             row.sourceCount || 0,
             ...sourceCells,
+            basisCell,
           ]
             .map(escape)
             .join(joiner),
@@ -677,7 +689,7 @@ export default function RankingsPage() {
       });
       return lines;
     },
-    [displayRows],
+    [displayRows, rawData],
   );
 
   async function copyValues() {

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -227,6 +227,7 @@ export default function RankingsPage() {
   const { loading, error, rows, rawData } = useDynastyData();
   const {
     settings,
+    hydrated: settingsHydrated,
     update: updateSetting,
     updateSiteWeight,
     resetSiteWeights,
@@ -1117,7 +1118,13 @@ export default function RankingsPage() {
           <>
             <SegmentedControl
               label="Value basis"
-              value={settings.valuationMode || "market"}
+              // null until settings hydrate: before that ``settings`` is
+              // SETTINGS_DEFAULTS, so highlighting "Market" would assert
+              // a value basis this device may not be on. Unchecked for
+              // one frame beats confidently wrong — the highlight is the
+              // only thing telling the user which board the numbers came
+              // from.
+              value={settingsHydrated ? settings.valuationMode || "market" : null}
               onChange={(v) => updateSetting("valuationMode", v)}
               options={[
                 { value: "market", label: "Market" },

--- a/frontend/app/rosters/page.jsx
+++ b/frontend/app/rosters/page.jsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import { useApp } from "@/components/AppShell";
 import { useSettings } from "@/components/useSettings";
 import { PageHeader, LoadingState, EmptyState, PlayerImage } from "@/components/ui";
+import { ValueBasisNote } from "@/components/ds";
 import {
   POS_GROUPS,
   OFFENSE_GROUPS,
@@ -147,6 +148,8 @@ export default function RostersPage() {
             </div>
           }
         />
+
+        <ValueBasisNote contract={rawData} />
 
         {/* Position filter — toggle chips.  The previous 13x13 native
             checkbox + 11px label was impossible to tap on mobile.

--- a/frontend/app/settings/page.jsx
+++ b/frontend/app/settings/page.jsx
@@ -124,8 +124,14 @@ function ToggleRow({ label, checked, onChange, hint }) {
 
 export default function SettingsPage() {
   const { loading, error, rows, rawData } = useDynastyData();
-  const { settings, update, updateSiteWeight, resetSiteWeights, reset } =
-    useSettings();
+  const {
+    settings,
+    hydrated: settingsHydrated,
+    update,
+    updateSiteWeight,
+    resetSiteWeights,
+    reset,
+  } = useSettings();
   const {
     state: userState,
     serverBacked,
@@ -494,9 +500,19 @@ export default function SettingsPage() {
           <label style={{ fontSize: "0.82rem", marginRight: 8 }}>
             Value basis
           </label>
+          {/* A <select> has no honest indeterminate state — a blank
+              option would read as a third choice — so this one stays
+              disabled until settings hydrate instead. The displayed
+              value is still the default for that one frame, but the
+              control cannot be acted on while it might be about to
+              change under the user's cursor. The /rankings and /trade
+              toggles get the stronger treatment (no highlight at all);
+              see the note above `getHydratedSnapshot` in useSettings. */}
           <select
             className="select"
             value={settings.valuationMode}
+            disabled={!settingsHydrated}
+            aria-busy={!settingsHydrated}
             onChange={(e) => update("valuationMode", e.target.value)}
           >
             <option value="market">Market</option>

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -32,6 +32,7 @@ import {
   buildSlotDollarGrid,
   buildLeagueStacks,
 } from "@/lib/pick-stack";
+import { valuationBasisLabel, valuationBasisOf } from "@/lib/dynasty-data";
 import { useSettings } from "@/components/useSettings";
 import TradeDeltaHistogram from "@/components/graphs/TradeDeltaHistogram";
 import RosTradeFitPanel from "@/components/RosTradeFitPanel";
@@ -1219,11 +1220,11 @@ export default function TradePage() {
     const iso = new Date().toISOString().slice(0, 19).replace(/[:T]/g, "-");
     _downloadFile(
       `trade-${iso}.csv`,
-      tradeWorkspaceToCSV(sides, valueMode),
+      tradeWorkspaceToCSV(sides, valueMode, valuationBasisLabel(rawData)),
       "text/csv",
     );
     setExportStatus("CSV downloaded.");
-  }, [sides, valueMode, _downloadFile]);
+  }, [sides, valueMode, rawData, _downloadFile]);
 
   const exportJson = useCallback(() => {
     const iso = new Date().toISOString().slice(0, 19).replace(/[:T]/g, "-");
@@ -1579,9 +1580,19 @@ export default function TradePage() {
       />
 
       {/* A trade verdict that silently changed basis is the most
-          dangerous thing this page can do. Say which board it is on. */}
-      {settings.valuationMode === "leagueAdjusted" &&
-      rawData?.valuationOverlay ? (
+          dangerous thing this page can do. Say which board it is on.
+
+          Gated on the CONTRACT, not on `settings.valuationMode`. The
+          setting is what the user asked for; the contract is what they
+          got, and the two diverge whenever the overlay fetch fails, the
+          scrape-version pin refuses, or the server finds no roster
+          snapshot. Reading the setting would label a market board
+          "league-adjusted" in exactly those cases.
+
+          `valuationBasisOf` also covers the server-composed path
+          (custom weights + the lens), which carries no client-applied
+          overlay object of its own. */}
+      {valuationBasisOf(rawData) === "leagueAdjusted" ? (
         <Banner tone="info" title="Valued on your league's board">
           Values and ranks are adjusted for positional scarcity measured from
           this league&apos;s 12 rosters. Draft picks carry no scarcity

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -86,7 +86,11 @@ const TradeSourceBreakdown = SharedTradeSourceBreakdown;
 
 export default function TradePage() {
   const { loading, error, rows, rawData } = useDynastyData();
-  const { settings, update: updateSetting } = useSettings();
+  const {
+    settings,
+    hydrated: settingsHydrated,
+    update: updateSetting,
+  } = useSettings();
   const { openPlayerPopup, registerAddToTrade } = useApp();
   const [valueMode, setValueMode] = useState("full");
 
@@ -1560,7 +1564,11 @@ export default function TradePage() {
         actions={
           <SegmentedControl
             label="Value basis"
-            value={settings.valuationMode || "market"}
+            // Unchecked until settings hydrate — see the matching note on
+            // /rankings. It matters more here: a trade verdict rendered
+            // under a basis label the user did not choose is the single
+            // most dangerous thing this page can show.
+            value={settingsHydrated ? settings.valuationMode || "market" : null}
             onChange={(v) => updateSetting("valuationMode", v)}
             options={[
               { value: "market", label: "Market" },

--- a/frontend/app/waivers/page.jsx
+++ b/frontend/app/waivers/page.jsx
@@ -12,6 +12,7 @@ import {
   Select,
   SkeletonTable,
   StatTile,
+  ValueBasisNote,
 } from "@/components/ds";
 import TeamSwitcher from "@/components/TeamSwitcher";
 import ManualAddDrop from "@/components/waivers/ManualAddDrop";
@@ -572,6 +573,8 @@ export default function WaiversPage() {
             : "Every unrostered player measured against your roster"
         }
       />
+
+      <ValueBasisNote contract={rawData} />
 
       {!signedOut && !leagueMismatch ? (
         <ManualAddDrop

--- a/frontend/components/ds/SegmentedControl.jsx
+++ b/frontend/components/ds/SegmentedControl.jsx
@@ -16,6 +16,22 @@
  *
  * A11y: radiogroup semantics — one tab stop, Arrow keys move + select,
  * aria-checked marks the active option (styling hangs off it).
+ *
+ * INDETERMINATE STATE (contract, relied on by callers): a `value`
+ * matching no option leaves every option unchecked rather than
+ * highlighting the first one. `/rankings` and `/trade` pass `null`
+ * deliberately while `useSettings` is still hydrating, so the control
+ * never claims a value basis the user did not choose. The DOM and its
+ * dimensions are unchanged, so nothing shifts when the real value lands.
+ *
+ * `checkedIndex` and `activeIndex` are separate on purpose and the
+ * distinction is easy to collapse by accident. `aria-checked` (and the
+ * styling that hangs off it) follows `checkedIndex`, which is -1 when
+ * nothing matches. `activeIndex` is only the roving-tabindex landing
+ * spot and floors at 0, so an indeterminate group still has exactly one
+ * tab stop instead of becoming keyboard-unreachable. Wiring
+ * `aria-checked` to `activeIndex` would look like a tidy-up and would
+ * silently reintroduce a confident highlight on an unknown value.
  */
 "use client";
 
@@ -23,10 +39,11 @@ import React, { useRef } from "react";
 
 export function SegmentedControl({ options, value, onChange, label, className = "" }) {
   const refs = useRef([]);
-  const activeIndex = Math.max(
-    0,
-    options.findIndex((o) => o.value === value)
-  );
+  const checkedIndex = options.findIndex((o) => o.value === value);
+  // Focus/arrow-key math still needs a landing spot when nothing is
+  // checked, so the roving tabindex falls to the first option — the
+  // control stays keyboard-reachable while indeterminate.
+  const activeIndex = checkedIndex >= 0 ? checkedIndex : 0;
 
   const move = (delta) => {
     const next = (activeIndex + delta + options.length) % options.length;
@@ -52,7 +69,7 @@ export function SegmentedControl({ options, value, onChange, label, className = 
       onKeyDown={onKeyDown}
     >
       {options.map((opt, i) => {
-        const checked = opt.value === value;
+        const checked = i === checkedIndex;
         return (
           <button
             key={String(opt.value)}

--- a/frontend/components/ds/ValueBasisNote.jsx
+++ b/frontend/components/ds/ValueBasisNote.jsx
@@ -1,0 +1,38 @@
+/**
+ * ValueBasisNote — names the board a page's numbers came from.
+ *
+ * Renders NOTHING on the market board. That is deliberate: market is the
+ * default every user is on, and a permanent "these are market values"
+ * strip on nine pages is noise that trains people to stop reading it.
+ * The note appears only when the numbers are something other than what a
+ * reader would assume.
+ *
+ * WHY THIS EXISTS
+ * The valuation lens is set on /rankings and /trade but applies
+ * everywhere — `fetchDynastyData` composes the overlay before any page
+ * sees the contract. So /draft, /rosters, /edge and /waivers render
+ * league-adjusted values with no toggle in sight and nothing saying the
+ * board moved. The values are right; the silence is the defect.
+ *
+ * Pass the CONTRACT, not the setting. `valuationBasisOf` reads what the
+ * board actually is, which diverges from what the user asked for
+ * whenever the overlay fetch fails, the scrape-version pin refuses, or
+ * the server finds no roster snapshot. Labelling off the setting would
+ * assert "league-adjusted" over market numbers in exactly those cases —
+ * the failure this component exists to prevent.
+ */
+"use client";
+
+import React from "react";
+import { valuationBasisOf } from "@/lib/dynasty-data";
+
+export function ValueBasisNote({ contract, className = "" }) {
+  if (valuationBasisOf(contract) !== "leagueAdjusted") return null;
+  return (
+    <p className={`ds-value-basis-note ${className}`.trim()} role="note">
+      <strong>Valued on your league&apos;s board.</strong> Positional scarcity
+      measured from this league&apos;s rosters. Draft picks carry no scarcity
+      measurement, so they stay at market value while players move around them.
+    </p>
+  );
+}

--- a/frontend/components/ds/index.js
+++ b/frontend/components/ds/index.js
@@ -17,6 +17,7 @@ export { SegmentedControl } from "./SegmentedControl";
 export { Panel } from "./Panel";
 export { CollapsiblePanel } from "./CollapsiblePanel";
 export { PageHeader } from "./PageHeader";
+export { ValueBasisNote } from "./ValueBasisNote";
 export { StatTile } from "./StatTile";
 export { DataTable, sortRows } from "./DataTable";
 export { Tabs, tabId, tabPanelId } from "./Tabs";

--- a/frontend/components/terminal/MoversPanel.jsx
+++ b/frontend/components/terminal/MoversPanel.jsx
@@ -6,6 +6,7 @@ import { Movement, Panel, SegmentedControl, SkeletonText } from "@/components/ds
 import styles from "./terminal.module.css";
 import { PlayerImage } from "@/components/ui";
 import { useApp } from "@/components/AppShell";
+import { valuationBasisOf } from "@/lib/dynasty-data";
 
 // Movers — buy-low / sell-high signals derived from rank-history.
 //
@@ -109,7 +110,21 @@ function MoverRow({ row, openPlayerPopup }) {
 }
 
 export default function MoversPanel() {
-  const { openPlayerPopup } = useApp();
+  const { openPlayerPopup, rawData } = useApp();
+  // Movers are MARKET rank deltas and cannot follow the league lens.
+  //
+  // This is a real divergence, not a missing label. `/api/movers` reads
+  // `data/rank_history.jsonl`, a daily snapshot of the market board's
+  // ranks. No league-adjusted rank history exists — the adjustment is
+  // computed per request from the current rosters, and has never been
+  // recorded over time. So on a league-adjusted board this panel is
+  // reporting movement on a different board from the values beside it,
+  // and there is no fix short of recording adjusted history.
+  //
+  // Say so. A "-14" next to an adjusted value that the user reads as
+  // "this player fell 14 on my board" is a wrong conclusion the panel
+  // invited.
+  const marketOnlyNotice = valuationBasisOf(rawData) === "leagueAdjusted";
   const [windowDays, setWindowDays] = useState(14);
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -142,7 +157,11 @@ export default function MoversPanel() {
   return (
     <Panel
       title="Top movers"
-      subtitle={`Rank deltas vs. ${windowDays}d ago · click a row for source breakdown`}
+      subtitle={
+        marketOnlyNotice
+          ? `Market rank deltas vs. ${windowDays}d ago · not adjusted for your league — no adjusted rank history exists`
+          : `Rank deltas vs. ${windowDays}d ago · click a row for source breakdown`
+      }
       actions={
         <SegmentedControl
           options={WINDOW_OPTIONS.map((o) => ({ value: o.days, label: o.label }))}

--- a/frontend/components/useDynastyData.js
+++ b/frontend/components/useDynastyData.js
@@ -17,7 +17,7 @@ export function useDynastyData() {
   // materializer that reads the already-canonical rows off the
   // merged contract; there is no client-side recompute and no
   // frontend TEP multiplication either.
-  const { settings } = useSettings();
+  const { settings, hydrated: settingsHydrated } = useSettings();
   const siteOverrides = settings?.siteWeights || null;
   // Valuation lens. "market" (the default) is today's board; changing
   // it refetches, because the overlay is a separate league-scoped GET.
@@ -80,6 +80,17 @@ export function useDynastyData() {
 
   useEffect(() => {
     let active = true;
+    // Do not fetch on the hydration pass.  ``useSettings`` serves
+    // SETTINGS_DEFAULTS until hydration completes, so firing here would
+    // request the DEFAULT board — market lens, no source overrides, the
+    // default TE multiplier — and then immediately re-request the real
+    // one, having rendered the wrong numbers in between.  Two round
+    // trips, and the first one wins the first paint.
+    //
+    // ``loading`` is already true from its initial state, so the page
+    // keeps showing its skeleton rather than an empty board; the delay
+    // is one commit, not a network round trip.
+    if (!settingsHydrated) return undefined;
     async function run() {
       try {
         setLoading(true);
@@ -150,6 +161,7 @@ export function useDynastyData() {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
+    settingsHydrated,
     siteOverridesKey,
     tepMultiplier,
     tepNativeMultiplier,

--- a/frontend/components/useSettings.js
+++ b/frontend/components/useSettings.js
@@ -220,6 +220,34 @@ function getServerSnapshot() {
   return SETTINGS_DEFAULTS;
 }
 
+// ── Hydration signal ───────────────────────────────────────────────────
+//
+// ``getServerSnapshot`` is what React uses for BOTH the server render and
+// the client's hydration pass, so the first client render of every
+// settings consumer sees SETTINGS_DEFAULTS regardless of what is in
+// localStorage.  React then re-renders with ``getSnapshot``.
+//
+// For most settings that gap is invisible.  For ``valuationMode`` it is
+// not: a user whose persisted lens is "leagueAdjusted" gets one frame of
+// a toggle highlighting "Market" — which is not a cosmetic flicker but a
+// claim about which board the numbers on screen came from, on a page
+// where that claim decides trade verdicts.  It also costs a wasted
+// round-trip, because ``useDynastyData``'s fetch effect fires once on the
+// defaults and again after hydration.
+//
+// This is the canonical detector: the same store, read through a snapshot
+// pair that differs only in which side is asking.  No extra state, no
+// effect, and it flips in the same commit that brings the real settings
+// in — so a consumer gating on it can never be told "hydrated" while
+// still holding defaults.
+function getHydratedSnapshot() {
+  return true;
+}
+
+function getHydratedServerSnapshot() {
+  return false;
+}
+
 function notify(next) {
   cached = next;
   for (const cb of listeners) cb();
@@ -240,6 +268,16 @@ if (typeof window !== "undefined") {
  */
 export function useSettings() {
   const settings = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  // False during SSR and the hydration pass, true from the first
+  // post-hydration render on.  While false, ``settings`` is
+  // SETTINGS_DEFAULTS and NOT this device's persisted values — see the
+  // note above ``getHydratedSnapshot``.  Consumers whose rendering makes
+  // a claim about a persisted value should gate on this.
+  const hydrated = useSyncExternalStore(
+    subscribe,
+    getHydratedSnapshot,
+    getHydratedServerSnapshot,
+  );
 
   const update = useCallback((key, value) => {
     const next = { ...getSnapshot(), [key]: value };
@@ -283,5 +321,5 @@ export function useSettings() {
     notify({ ...SETTINGS_DEFAULTS });
   }, []);
 
-  return { settings, update, updateSiteWeight, resetSiteWeights, reset };
+  return { settings, hydrated, update, updateSiteWeight, resetSiteWeights, reset };
 }

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -1513,6 +1513,46 @@ async function _fetchBaseContract() {
 // (e.g. the ``/api/data`` full view, or test fixtures), we take
 // the simpler path of iterating basePlayersArray and deep-merging
 // delta fields onto each matched entry.
+/**
+ * Which board produced the numbers in `contract` — "market" or
+ * "leagueAdjusted".
+ *
+ * Read this rather than `settings.valuationMode`. The setting is what
+ * the user ASKED for; this is what they GOT, and the two legitimately
+ * diverge:
+ *
+ *   - the overlay fetch can fail, and `fetchDynastyData` degrades to
+ *     the market board rather than serving half a lens;
+ *   - the version pin in `applyValuationOverlay` refuses an overlay
+ *     built against a different scrape;
+ *   - the server can find no roster snapshot, so scarcity is
+ *     unmeasurable, and returns market values with a note.
+ *
+ * In every one of those the setting still says "leagueAdjusted" while
+ * the numbers are market. Labelling off the setting would assert a
+ * basis the board does not have — which is the whole failure this
+ * accessor exists to prevent.
+ *
+ * Accepts either the contract or its `{data}` envelope.
+ */
+export function valuationBasisOf(contract) {
+  const data = contract?.data || contract;
+  if (!data) return "market";
+  if (data.valuationOverlay?.mode === "leagueAdjusted") return "leagueAdjusted";
+  return "market";
+}
+
+/**
+ * Human-readable one-liner naming the basis, for export headers and
+ * page disclosures. Exports need this most: once a spreadsheet leaves
+ * the app nothing distinguishes adjusted values from market ones.
+ */
+export function valuationBasisLabel(contract) {
+  return valuationBasisOf(contract) === "leagueAdjusted"
+    ? "League-adjusted (positional scarcity from this league's rosters)"
+    : "Market consensus";
+}
+
 export function mergeRankingsDelta(baseContract, delta) {
   if (!baseContract || !delta) return baseContract;
   const base = baseContract.data || baseContract;
@@ -1535,6 +1575,33 @@ export function mergeRankingsDelta(baseContract, delta) {
     date: delta.date || base.date,
     generatedAt: delta.generatedAt || base.generatedAt,
   };
+
+  // Carry the server-composed valuation basis onto the SAME field the
+  // client-side overlay path stamps, so every consumer has one question
+  // to ask instead of two.
+  //
+  // Without this the server-composed board (custom weights + the lens,
+  // which the server now computes) would arrive with adjusted values and
+  // NO `valuationOverlay`, and /trade's "Valued on your league's board"
+  // banner — which gates on that field — would go silent on precisely
+  // the board that most needs labelling.
+  //
+  // The server's stamp is authoritative over the request: it can degrade
+  // to market when there is no roster snapshot, without the user's
+  // setting changing. `serverComposed` marks the provenance so a reader
+  // can tell the two paths apart.
+  if (delta.meta?.valuationMode === "leagueAdjusted") {
+    mergedData.valuationOverlay = {
+      mode: "leagueAdjusted",
+      serverComposed: true,
+      adjustedCount: delta.valuationAdjustment?.adjustedCount ?? null,
+    };
+  } else if (delta.meta?.valuationNote) {
+    // Requested but not delivered. Record why rather than leaving the
+    // absence to be read as "the user never asked".
+    mergedData.valuationOverlay = null;
+    mergedData.valuationNote = delta.meta.valuationNote;
+  }
 
   const basePlayersArray = Array.isArray(base.playersArray)
     ? base.playersArray

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -1860,21 +1860,26 @@ export async function fetchDynastyData(opts = {}) {
     return overlay ? applyValuationOverlay(base, overlay) : base;
   }
 
-  // Source overrides + league-adjusted is deliberately NOT composed
-  // here.  The overlay is computed against the un-overridden board, so
-  // its ranks are the ranks of `default_consensus x factor` — but the
-  // correct answer is the rank of `overridden_consensus x factor`,
-  // which the server never computed.  No client-side sequencing fixes
-  // that; composing the two would produce a board where neither the
-  // values nor the ranks correspond to anything.  Serve the overridden
-  // market board and say so, until `valuation_mode` is threaded through
-  // the overrides pipeline server-side.
-  if (leagueAdjusted) {
-    console.warn(
-      "[dynasty-data] custom source weights are active; league-adjusted " +
-        "values are not applied (the two cannot be composed client-side)",
-    );
-  }
+  // Source overrides + league-adjusted are now composed SERVER-SIDE.
+  //
+  // They were previously refused outright, and correctly so: the
+  // overlay endpoint computes its ranks against the un-overridden
+  // board, so applying them here would give the ranks of
+  // `default_consensus x factor` when the right answer is the rank of
+  // `overridden_consensus x factor`. No client-side sequencing fixes
+  // that — the server had simply never computed that board.
+  //
+  // It does now. `valuation_mode` rides the override POST, the backend
+  // runs the override pipeline first and applies the scarcity factors
+  // to the resulting values, then re-ranks the adjusted board through
+  // the same `compact_ranks_and_tiers` the default path uses. The
+  // delta comes back with values, ranks and tiers that all describe
+  // one board.
+  //
+  // `meta.valuationMode` on the response says which lens actually
+  // produced it, because the server can still degrade to market (no
+  // roster snapshot => no measurable scarcity). Callers read that
+  // rather than assuming they got what they asked for.
 
   // Override path: POST the override map + TE premium multiplier to
   // the backend delta endpoint, then merge the delta onto the
@@ -1896,6 +1901,13 @@ export async function fetchDynastyData(opts = {}) {
   }
   if (tepNativeCustomized) {
     body.tep_native_multiplier = tepNativeMultiplier;
+  }
+  if (leagueAdjusted) {
+    // Asking for the lens narrows this request to one league — the
+    // backend 503s on a league mismatch when this is set, because
+    // scarcity is measured from one league's rosters and the resulting
+    // board is not shareable across leagues that merely share scoring.
+    body.valuation_mode = "leagueAdjusted";
   }
 
   try {

--- a/frontend/lib/trade-logic.js
+++ b/frontend/lib/trade-logic.js
@@ -1519,7 +1519,19 @@ export function tradeWorkspaceToJSON(sides, valueMode, activeSide) {
   return JSON.stringify(serializeWorkspaceMulti(sides, valueMode, activeSide), null, 2);
 }
 
-export function tradeWorkspaceToCSV(sides, valueMode = "full") {
+// `valueBasis` is the human-readable board these values came from
+// ("Market consensus" / "League-adjusted ..."), from
+// `valuationBasisLabel`. It rides as a COLUMN rather than a preamble
+// because an exported trade outlives the app: a market valuation and a
+// league-adjusted one answer different questions about the same trade,
+// and once the rows are in a spreadsheet nothing else distinguishes
+// them. A header line would be lost the first time someone sorts or
+// pastes a subset.
+//
+// Defaulted rather than required so an existing caller cannot silently
+// break — but the default says "unspecified", never "Market", because
+// guessing the basis is the exact error this column exists to prevent.
+export function tradeWorkspaceToCSV(sides, valueMode = "full", valueBasis = "") {
   const esc = (v) => {
     const s = v == null ? "" : String(v);
     return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
@@ -1529,10 +1541,13 @@ export function tradeWorkspaceToCSV(sides, valueMode = "full") {
     const v = valueMode === "raw" ? (vals.raw ?? vals.full) : (vals.full ?? vals.raw);
     return v == null ? "" : Math.round(Number(v));
   };
-  const lines = ["Side,Asset,Position,Team,Value"];
+  const basis = valueBasis || "unspecified";
+  const lines = ["Side,Asset,Position,Team,Value,Value Basis"];
   for (const s of sides || []) {
     for (const r of s.assets || []) {
-      lines.push([s.label, r.name, r.pos || "", r.team || "", pickVal(r)].map(esc).join(","));
+      lines.push(
+        [s.label, r.name, r.pos || "", r.team || "", pickVal(r), basis].map(esc).join(","),
+      );
     }
   }
   return lines.join("\n") + "\n";

--- a/scripts/persist_nfl_actuals.py
+++ b/scripts/persist_nfl_actuals.py
@@ -1,0 +1,137 @@
+"""Persist nflverse player-week actuals to durable JSONL.
+
+Writes ``data/nfl_data/actuals/player_week_{season}.jsonl`` from
+``src.nfl_data.ingest.fetch_weekly_stats`` +
+``fetch_weekly_defensive_stats``.  Idempotent: a week already on disk is
+replaced by the fresh pull, never duplicated, and weeks absent from the
+fetch are left alone.
+
+Deliberately NOT the TTL cache under ``data/nfl_data_cache/`` — that one
+evicts on a 24h timer, so nothing accumulates there.  See
+``src/nfl_data/actuals_store.py``'s module docstring.
+
+Run:
+    python3 scripts/persist_nfl_actuals.py --seasons 2025
+    python3 scripts/persist_nfl_actuals.py --seasons 2023 2024 2025
+    python3 scripts/persist_nfl_actuals.py --coverage
+
+Exit codes:
+    0  wrote at least one week (or --coverage succeeded)
+    1  fetch returned rows but none were persistable
+    2  bad arguments, or the feature flag is off
+    3  the fetch returned nothing at all (upstream problem)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.api import feature_flags  # noqa: E402
+from src.nfl_data import actuals_store  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--seasons",
+        nargs="+",
+        type=int,
+        default=None,
+        help="Season years to fetch and persist, e.g. --seasons 2024 2025.",
+    )
+    parser.add_argument(
+        "--dir",
+        default=None,
+        help=(
+            "Override the output directory.  Defaults to "
+            "data/nfl_data/actuals/ under the repo root."
+        ),
+    )
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help=(
+            "Evict the 24h ingest TTL cache for these seasons first.  Without "
+            "it a re-run inside the window is served the previous pull, so a "
+            "box-score revision published hours after a game stays invisible."
+        ),
+    )
+    parser.add_argument(
+        "--coverage",
+        action="store_true",
+        help="Print what is already on disk and exit without fetching.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Log each provider rung and per-season write.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(levelname)s %(name)s %(message)s",
+    )
+
+    actuals_dir = Path(args.dir) if args.dir else None
+
+    if args.coverage:
+        print(json.dumps(actuals_store.coverage(actuals_dir=actuals_dir), indent=2))
+        return 0
+
+    if not args.seasons:
+        parser.error("--seasons is required unless --coverage is passed")
+
+    if not feature_flags.is_enabled("nfl_data_ingest"):
+        # Every fetch would silently return [] and this script would
+        # report "no rows" as though nflverse were down.  Say which it
+        # is — that distinction is the whole point of the exit codes.
+        print(
+            "[actuals] feature flag nfl_data_ingest is OFF; every fetch would "
+            "return no rows.  Set RISKIT_FEATURE_NFL_DATA_INGEST=1 to run.",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(f"[actuals] fetching seasons {args.seasons}")
+    result = actuals_store.persist_weekly_actuals(
+        args.seasons, actuals_dir=actuals_dir, refresh=args.refresh
+    )
+    print(json.dumps(result.to_dict(), indent=2))
+
+    fetched = result.offensive_rows_fetched + result.defensive_rows_fetched
+    if fetched == 0:
+        print(
+            "[actuals] the fetchers returned zero rows.  Check the nflverse "
+            "release URLs in src/nfl_data/nflverse_direct.py — a rename 404s "
+            "silently and looks exactly like a season with no data.",
+            file=sys.stderr,
+        )
+        return 3
+    if result.weeks_written == 0:
+        print(
+            f"[actuals] fetched {fetched} rows but persisted none — the column "
+            "mapping in actuals_store may no longer match the release schema.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"[actuals] wrote {result.weeks_written} week(s), "
+        f"{result.player_weeks} player-weeks "
+        f"({result.offense_records} offensive, {result.defense_records} defensive)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server.py
+++ b/server.py
@@ -3434,6 +3434,74 @@ async def post_rankings_overrides(request: Request):
     view = (request.query_params.get("view") or "").strip().lower()
     delta_view = view in {"delta", "compact", "slim"}
 
+    # ── Server-side valuation-mode composition ───────────────────────
+    #
+    # Custom source weights + the league-adjusted lens used to be
+    # refused outright: the overlay's ranks are the ranks of
+    # ``default_consensus x factor``, while the correct answer is the
+    # rank of ``overridden_consensus x factor``, and the server had
+    # never computed that board.  No client-side sequencing fixes it.
+    # Computing it here is the fix.
+    #
+    # Note what this does to the endpoint's SCOPE.  Rankings follow the
+    # scoring profile and are shared, which is why the profile check
+    # above only 503s when profiles genuinely differ.  The valuation
+    # overlay is league-scoped by necessity — ``lineupScarcity`` is
+    # measured from THIS league's rosters — so the moment the caller
+    # asks for it, this response stops being shareable across leagues
+    # and has to 503 on a league mismatch exactly like
+    # /api/valuation/league-adjusted.  Asking for the lens is what
+    # narrows the scope; a plain override request is unaffected.
+    valuation_mode = ""
+    if isinstance(body, dict):
+        raw_mode = body.get("valuation_mode") or body.get("valuationMode")
+        valuation_mode = str(raw_mode or "").strip()
+    want_league_adjusted = valuation_mode == "leagueAdjusted"
+
+    valuation_factors: dict[str, float] | None = None
+    valuation_note: str | None = None
+    if want_league_adjusted and delta_view:
+        if not sleeper_matches:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "data_not_ready",
+                    "message": (
+                        f"League-adjusted values need league {league_cfg.key!r}'s "
+                        f"rosters; the server holds {loaded_league or 'none'!r}."
+                    ),
+                    "leagueKey": league_cfg.key,
+                },
+            )
+        try:
+            overlay = await run_in_threadpool(
+                _gameplan.get_league_adjusted_values,
+                league_cfg.key,
+                league_cfg.scoring_profile,
+                latest_contract_data,
+            )
+            raw_factors = overlay.get("factors") if isinstance(overlay, dict) else None
+            valuation_factors = {
+                str(k): float(v)
+                for k, v in (raw_factors or {}).items()
+                if isinstance(v, (int, float))
+            }
+        except _gameplan.GameplanUnavailable as exc:
+            # Scarcity is unmeasurable without a roster snapshot. Serve
+            # the overridden market board and SAY SO rather than
+            # silently presenting it as league-adjusted — the whole
+            # point of this endpoint is that the user can tell which
+            # board they are looking at.
+            valuation_factors = None
+            valuation_note = f"league_adjusted_unavailable: {exc.reason}"
+            log.warning("league-adjusted overlay unavailable for overrides: %s", exc.detail)
+    elif want_league_adjusted and not delta_view:
+        # The full view is a legacy compatibility surface; composing
+        # there would mean maintaining two composition paths for one
+        # behaviour. Refuse explicitly instead of quietly ignoring the
+        # field, which would return a market board labelled as adjusted.
+        valuation_note = "league_adjusted_requires_delta_view"
+
     try:
         if delta_view:
             contract_payload = build_rankings_delta_payload(
@@ -3442,6 +3510,7 @@ async def post_rankings_overrides(request: Request):
                 source_overrides=overrides if overrides else None,
                 tep_multiplier=tep_multiplier,
                 tep_native_multiplier=tep_native_multiplier,
+                valuation_factors=valuation_factors,
             )
         else:
             contract_payload = build_api_data_contract(
@@ -3480,6 +3549,14 @@ async def post_rankings_overrides(request: Request):
         if not sleeper_matches:
             contract_payload["sleeper"] = None
             meta["sleeperLoadedLeagueKey"] = loaded_league or None
+        # Always stamp which lens produced this board. A client that
+        # asked for leagueAdjusted and silently got market is the
+        # failure mode this whole change exists to remove, so the
+        # answer travels with the payload instead of being inferred.
+        meta["valuationMode"] = "leagueAdjusted" if valuation_factors else "market"
+        if valuation_note:
+            meta["valuationNote"] = valuation_note
+            contract_payload.setdefault("warnings", []).append(valuation_note)
 
     headers = {
         "Cache-Control": "no-store",

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -9,7 +9,7 @@ import re
 import statistics
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from src.data_models.contracts import utc_now_iso
 
@@ -8812,6 +8812,51 @@ _DELTA_PLAYER_FIELDS: tuple[str, ...] = (
 )
 
 
+def apply_valuation_factors(
+    rows: list[dict[str, Any]],
+    factors: Mapping[str, float] | None,
+    *,
+    anchor_year: int | None = None,
+) -> int:
+    """Multiply ``rankDerivedValue`` by a per-player factor and re-rank.
+
+    Mutates ``rows`` IN PLACE and returns how many rows were re-valued.
+    Callers must therefore own ``rows`` — never hand this
+    ``latest_contract_data``'s list.  ``build_rankings_delta_payload``
+    owns a freshly-built contract, which is why it can.
+
+    This exists so the rankings-override endpoint can serve a board that
+    is BOTH re-weighted and league-adjusted.  The client cannot compose
+    those two: the overlay's ranks are the ranks of
+    ``default_consensus x factor``, while the correct answer is the rank
+    of ``overridden_consensus x factor`` — a board the server had never
+    computed.  Computing it here is the fix that unblocks the
+    combination rather than continuing to refuse it.
+
+    Ranking goes through :func:`compact_ranks_and_tiers`, the one
+    ranker, so an adjusted board is ranked by exactly the same rules as
+    the default one.
+    """
+    if not factors:
+        return 0
+    moved = 0
+    for row in rows:
+        name = str(row.get("displayName") or row.get("canonicalName") or "").strip()
+        factor = factors.get(name)
+        base = row.get("rankDerivedValue")
+        if factor and isinstance(base, (int, float)) and base > 0:
+            row["rankDerivedValue"] = int(round(float(base) * float(factor)))
+            moved += 1
+    if not moved:
+        return 0
+    compact_ranks_and_tiers(
+        rows,
+        anchor_year=anchor_year if anchor_year is not None else current_rookie_draft_year(),
+        copy_rows=False,
+    )
+    return moved
+
+
 def build_rankings_delta_payload(
     raw_payload: dict[str, Any],
     *,
@@ -8819,6 +8864,7 @@ def build_rankings_delta_payload(
     source_overrides: dict[str, dict[str, Any]] | None = None,
     tep_multiplier: float | None = None,
     tep_native_multiplier: float | None = None,
+    valuation_factors: Mapping[str, float] | None = None,
 ) -> dict[str, Any]:
     """Build a compact delta contract for the rankings-override endpoint.
 
@@ -8864,6 +8910,18 @@ def build_rankings_delta_payload(
         _for_delta=True,
     )
 
+    # League-adjusted composition.  Applied AFTER the override pipeline
+    # has produced the re-weighted board, so the factors land on the
+    # user's own consensus values and the re-rank is over that board —
+    # not over the default one.  ``full`` is freshly built and owned by
+    # this call, so mutating its rows is safe.
+    valuation_adjusted_count = 0
+    if valuation_factors:
+        valuation_adjusted_count = apply_valuation_factors(
+            full.get("playersArray") or [],
+            valuation_factors,
+        )
+
     delta_players: list[dict[str, Any]] = []
     active_ids: list[str] = []
     for row in full.get("playersArray") or []:
@@ -8896,6 +8954,16 @@ def build_rankings_delta_payload(
         "dataSource": full.get("dataSource"),
         "playerCount": full.get("playerCount"),
     }
+    if valuation_factors is not None:
+        # Stamped whether or not anything moved.  "the lens was applied
+        # and moved nothing" and "the lens was never applied" are
+        # different states, and a client that cannot tell them apart
+        # will render one as the other.
+        payload["valuationAdjustment"] = {
+            "applied": True,
+            "adjustedCount": valuation_adjusted_count,
+            "factorCount": len(valuation_factors),
+        }
     warnings = full.get("warnings")
     if warnings:
         payload["warnings"] = list(warnings)

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -5631,6 +5631,51 @@ _TE_BLANKET_NON_NATIVE_MULTIPLIER: float = 1.15
 _TE_BLANKET_NATIVE_MULTIPLIER: float = 1.10
 _TE_BLANKET_KTC_EXEMPT_KEYS: frozenset[str] = frozenset({"ktc", "ktcSfTep"})
 
+# ── WIRED 2026-07-27: the flat multiplier is now a measured curve ─────
+#
+# ``_TE_BLANKET_NON_NATIVE_MULTIPLIER`` above is retained as the FALLBACK
+# and as the operator slider's default.  The live default path for
+# non-TEP sources is now ``te_premium.convert_te_value(value,
+# from_basis="base", to_basis=_BOARD_TE_BASIS)`` — KTC's own measured
+# base → TE++ uplift, fitted from the two boards this repo already
+# scrapes (``CSVs/site_raw/ktc.csv`` vs ``ktcSfTep.csv``, 73 paired TEs,
+# R² 0.941 in log space).
+#
+# WHY THIS IS NOT A SECOND PREMIUM.  The blend anchors on ``ktcSfTep``,
+# which IS KTC's TE++ board, and every non-TEP source's TE contribution
+# was ALREADY being scaled to align with it.  What changes is only the
+# magnitude of that existing alignment.  1.15 matched nothing observed
+# anywhere in the data: KTC's smallest actual uplift is 1.209 and it
+# reaches 2.053 down the board, so every tight end was under-lifted.
+# The double-count guard is unaffected — KTC stays exempt, and
+# ``convert_te_value`` is a no-op when ``from_basis == to_basis``, so
+# asking to put a TE++ board on TE++ cannot move it.
+#
+# WHY THE TARGET BASIS IS A CONSTANT AND NOT THE LEAGUE'S.
+# ``te_premium.measure_te_demand`` answers "which basis does THIS league
+# need?" from roster structure — and that is a LEAGUE property, while
+# this board is SCORING-PROFILE scoped and shared.  Measured on the live
+# registry: ``dynasty_main`` (2 mandatory TEs) wants ``tepp`` and
+# ``dynasty_new`` (1 TE) wants ``base``, and the two share the
+# ``superflex_tep15_ppr1`` profile.  Threading league demand in here
+# would let one league's roster shape reprice the other's board — the
+# exact collapse CLAUDE.md's core split exists to prevent.  So the blend
+# does Axis A only (align every source onto the basis the board is
+# already anchored on) and Axis B belongs in the league-scoped overlay,
+# ``src/league_intel/publish.py``, where ``tePremium`` is a named
+# inactive axis.
+#
+# The operator's ``/settings`` TE-premium slider still wins: an explicit
+# ``tep_multiplier`` bypasses the curve entirely, because a number the
+# operator typed is a decision, not a measurement to be overruled.
+#
+# TEP-native sources keep the flat 1.10.  ``convert_te_value`` refuses
+# any pair other than base <-> tepp — only those two KTC boards are
+# published, so an intermediate "tep -> tepp" uplift would be invented
+# rather than measured, and it raises instead of interpolating.
+_BOARD_TE_BASIS: str = "tepp"
+_TE_SOURCE_DEFAULT_BASIS: str = "base"
+
 # Cached Sleeper league context.  Populated on first call via the
 # Sleeper /v1/league/{id} endpoint using ``SLEEPER_LEAGUE_ID`` from
 # the env.  Stores the full resolved payload (roster count, TE-bonus,
@@ -6155,6 +6200,7 @@ def _compute_unified_rankings(
     tep_multiplier: float | None = None,
     tep_native_multiplier: float | None = None,
     tep_native_correction: float = 1.0,
+    tep_multiplier_is_override: bool = False,
 ) -> dict[str, str]:
     """Compute a single unified ranking across all sources and positions.
 
@@ -6194,12 +6240,20 @@ def _compute_unified_rankings(
     board is the canonical reference everyone else aligns to):
 
       * Sources flagged ``is_tep_premium=False`` (DLF, FantasyPros,
-        Flock, etc.) have their TE contributions multiplied by
-        ``tep_multiplier`` (default
-        ``_TE_BLANKET_NON_NATIVE_MULTIPLIER`` = 1.15, operator
-        slider clamped [1.0, 1.5]).  These sources price TEs for a
-        standard league; the multiplier boosts them to the league's
-        actual TEP.
+        Flock, etc.) price TEs for a standard league, so their TE
+        contributions are lifted onto the basis this board is anchored
+        on.  Since 2026-07-27 that lift is KTC's own MEASURED base →
+        TE++ uplift curve
+        (``src/league_intel/te_premium.convert_te_value``), which is
+        rank-dependent: 1.209 at the top of the board rising toward
+        2.05 down it.  The flat
+        ``_TE_BLANKET_NON_NATIVE_MULTIPLIER`` = 1.15 remains as the
+        fallback and as the operator slider's default, and an explicit
+        ``tep_multiplier`` (slider, clamped [1.0, 1.5]) bypasses the
+        curve.  ``RISKIT_FEATURE_TE_BASIS_CONVERSION=0`` restores the
+        flat path.  See the ``_BOARD_TE_BASIS`` comment block for why
+        the target basis is a constant rather than the league's own
+        measured TE demand.
       * Sources flagged ``is_tep_premium=True`` (Dynasty Nerds
         SF-TEP, IDPTC) have their TE contributions multiplied by
         ``tep_native_multiplier`` (default
@@ -6284,6 +6338,55 @@ def _compute_unified_rankings(
         if tep_native_multiplier is not None
         else _TE_BLANKET_NATIVE_MULTIPLIER
     )
+
+    # Axis A — TE basis conversion (see the ``_BOARD_TE_BASIS`` block).
+    # Active only when the flag is on AND the operator has not typed an
+    # explicit slider value; a number the operator chose is a decision,
+    # not a measurement to overrule.  Resolved ONCE here rather than per
+    # row: this decides which of two branches the hot loop takes, and
+    # re-deciding it 20,000 times would be both slow and a place for the
+    # two paths to disagree.
+    # ``tep_multiplier`` is NEVER None here — the caller always resolves
+    # it to the operator's slider value, the Sleeper-derived value, or
+    # the 1.15 default before calling.  So "did the operator choose a
+    # number?" has to arrive as its own flag; testing the value for None
+    # would gate on a condition that can never be true, which is exactly
+    # the defect class §6.15 catalogues.
+    #
+    # The DERIVED value does not block the curve, deliberately.  It comes
+    # from ``bonus_rec_te`` — the scoring axis ADR-009 retracted, and
+    # which reads 0.0 for this league in 2026.  The basis question is
+    # structural (how many TEs must be started), not a scoring key.
+    te_basis_conversion = False
+    _convert_te_value = None
+    if not tep_multiplier_is_override:
+        try:
+            from src.api import feature_flags  # noqa: PLC0415
+
+            if feature_flags.is_enabled("te_basis_conversion"):
+                from src.league_intel.te_premium import (  # noqa: PLC0415
+                    convert_te_value as _convert_te_value,
+                )
+                from src.league_intel.te_premium import load_tep_curve  # noqa: PLC0415
+
+                # Warm the memoized curve outside the loop and prove the
+                # conversion is callable before committing the hot path
+                # to it — a lazily-discovered ImportError mid-blend would
+                # take out the whole board.
+                load_tep_curve()
+                _convert_te_value(1000.0, from_basis="base", to_basis=_BOARD_TE_BASIS)
+                te_basis_conversion = True
+        except Exception as exc:  # noqa: BLE001
+            # Degrade to the flat multiplier rather than serving no
+            # board.  Loud, because a silent fallback here is
+            # indistinguishable from the feature working.
+            logging.warning(
+                "TE basis conversion unavailable (%r); falling back to the flat "
+                "%.2f multiplier for non-TEP sources",
+                exc,
+                _TE_BLANKET_NON_NATIVE_MULTIPLIER,
+            )
+            te_basis_conversion = False
 
     # Build the active source list honoring user-supplied overrides.
     # This is the only place ranks + weights are gated, so downstream
@@ -6944,11 +7047,45 @@ def _compute_unified_rankings(
             # Any future league-level TE adjustment must select a target
             # BASIS (see ``src/league_intel/te_premium.py``) rather than
             # multiply a factor in on top of this alignment.
+            #
+            # WIRED 2026-07-27: the non-TEP branch now does exactly that.
+            # ``convert_te_value`` moves the contribution from the basis
+            # a standard board sits on ("base") to the basis this board
+            # is anchored on ("tepp", i.e. ktcSfTep), using KTC's own
+            # measured uplift instead of a flat 1.15 that matched nothing
+            # in the data. Read the ``_BOARD_TE_BASIS`` block before
+            # touching this — in particular why the target is a constant
+            # and not the league's own measured demand.
+            #
+            # The conversion is idempotent by construction (a second
+            # call sees from == to), so this cannot compound even if the
+            # branch is somehow reached twice. That property is the
+            # double-count guard, and it is why the API takes two bases
+            # rather than returning a multiplier.
+            tep_basis_uplift: float | None = None
             if row_is_te and source_key not in _TE_BLANKET_KTC_EXEMPT_KEYS:
                 if source_key in tep_boosted_source_keys:
-                    value = min(value * effective_non_tep_multiplier, 9999.0)
+                    pre_te_value = value
+                    if te_basis_conversion:
+                        value = min(
+                            float(
+                                _convert_te_value(
+                                    value,
+                                    from_basis=_TE_SOURCE_DEFAULT_BASIS,
+                                    to_basis=_BOARD_TE_BASIS,
+                                )
+                            ),
+                            9999.0,
+                        )
+                        if pre_te_value > 0:
+                            tep_basis_uplift = value / pre_te_value
+                    else:
+                        value = min(value * effective_non_tep_multiplier, 9999.0)
                     tep_applied = True
                 elif source_key in tep_native_source_keys:
+                    # Unchanged: only base <-> tepp is measured, so a
+                    # TEP-native board has no conversion to make without
+                    # inventing an intermediate uplift.
                     value = min(value * effective_native_multiplier, 9999.0)
                     tep_native_corrected = True
             all_values.append(value)
@@ -6978,7 +7115,17 @@ def _compute_unified_rankings(
             meta["isAnchor"] = is_anchor_source
             if tep_applied:
                 meta["tepBoostApplied"] = True
-                meta["tepMultiplier"] = round(effective_non_tep_multiplier, 4)
+                if tep_basis_uplift is not None:
+                    # Stamped so the change is auditable per player per
+                    # source: which bases were used and what uplift they
+                    # actually produced at this value. Without it a
+                    # rank-dependent curve is indistinguishable from a
+                    # flat constant by looking at the payload.
+                    meta["tepBasisFrom"] = _TE_SOURCE_DEFAULT_BASIS
+                    meta["tepBasisTo"] = _BOARD_TE_BASIS
+                    meta["tepMultiplier"] = round(tep_basis_uplift, 4)
+                else:
+                    meta["tepMultiplier"] = round(effective_non_tep_multiplier, 4)
             if tep_native_corrected:
                 meta["tepNativeCorrectionApplied"] = True
                 meta["tepNativeCorrection"] = round(effective_native_multiplier, 4)
@@ -8352,6 +8499,7 @@ def build_api_data_contract(
                 tep_multiplier=tep_multiplier_effective,
                 tep_native_multiplier=tep_native_multiplier_effective,
                 tep_native_correction=tep_native_correction,
+                tep_multiplier_is_override=(tep_multiplier_source == "override"),
             )
             for _orig, _copy in zip(players_array, _pa_copy):
                 _rdv = _copy.get("rankDerivedValue")
@@ -8375,6 +8523,7 @@ def build_api_data_contract(
         tep_multiplier=tep_multiplier_effective,
         tep_native_multiplier=tep_native_multiplier_effective,
         tep_native_correction=tep_native_correction,
+        tep_multiplier_is_override=(tep_multiplier_source == "override"),
     )
 
     # Stamp rankDerivedValue into the values bundle so every page uses the

--- a/src/api/feature_flags.py
+++ b/src/api/feature_flags.py
@@ -80,6 +80,29 @@ _DEFAULTS: Final[dict[str, bool]] = {
     # (falls back to static weights).  Promoted deliberately, not
     # automatically.
     "dynamic_source_weights": False,
+    # Collaborative audit, finding F — TE basis conversion at blend time.
+    #
+    # Replaces the flat ``_TE_BLANKET_NON_NATIVE_MULTIPLIER`` (1.15) on
+    # non-TEP sources' TE contributions with KTC's own MEASURED base →
+    # TE++ uplift curve (``src/league_intel/te_premium.py``).  The blend
+    # is already anchored on ``ktcSfTep``, which IS the TE++ board, so
+    # this corrects the magnitude of an alignment that was happening
+    # anyway — it does not add a second one.  1.15 sits below the entire
+    # observed range (KTC's smallest actual uplift is 1.209), so every
+    # tight end was being lifted too little.
+    #
+    # ON by default and deliberately so.  A flag defaulting OFF here
+    # would repeat ORCHESTRATION.md 6.14/6.15's named mistake: the
+    # previous TE module was left unimported so "toggle off" would be
+    # byte-identical, which also meant the double-count guard could
+    # never fire on it.  Both paths are exercised by
+    # ``tests/api/test_te_basis_conversion.py``.
+    #
+    # This moves live consensus values for TEs, so it has a rollback:
+    # RISKIT_FEATURE_TE_BASIS_CONVERSION=0 restores the flat 1.15.  An
+    # explicit operator TE-premium slider value also wins over the
+    # curve regardless of this flag.
+    "te_basis_conversion": True,
 }
 
 _ENV_PREFIX: Final[str] = "RISKIT_FEATURE_"

--- a/src/api/startup_validation.py
+++ b/src/api/startup_validation.py
@@ -157,6 +157,10 @@ def run_all(
     # Directories.
     checks.append(check_dir_writable(data_dir))
     checks.append(check_dir_writable(data_dir / "nfl_data_cache"))
+    # Durable player-week actuals.  Distinct from the cache above: that
+    # one is an evictable 24h TTL store, this one accumulates and must
+    # survive.  See src/nfl_data/actuals_store.py.
+    checks.append(check_dir_writable(data_dir / "nfl_data" / "actuals"))
     # SQLite files.
     checks.append(check_sqlite_reachable(data_dir / "user_kv.sqlite"))
     checks.append(check_sqlite_reachable(data_dir / "session_store.sqlite"))

--- a/src/league_intel/publish.py
+++ b/src/league_intel/publish.py
@@ -48,6 +48,26 @@ WHAT MOVES A VALUE, AND WHAT DELIBERATELY DOES NOT
   (``tests/league_intel/test_te_premium_invariants.py`` pins this).
   Per-source *pre-blend* alignment is a different insertion point and a
   separate workstream.
+
+  **That pre-blend half landed 2026-07-27** — ``data_contract.py`` now
+  converts non-TEP sources' TE contributions onto the board's ``tepp``
+  basis using ``te_premium.convert_te_value`` instead of a flat 1.15.
+  That is Axis A (source alignment), and it is scoring-profile-safe
+  because the target basis is a constant: the basis the board is already
+  anchored on.
+
+  Axis B — *which basis does THIS league need?* — is what would belong
+  here, and it is genuinely league-scoped rather than merely
+  conventionally so.  Measured on the live registry:
+  ``measure_te_demand`` returns ``tepp`` for ``dynasty_main`` (2
+  mandatory TE starters) and ``base`` for ``dynasty_new`` (1), and the
+  two share the ``superflex_tep15_ppr1`` scoring profile.  A one-TE
+  league on this board is therefore carrying a two-TE premium it does
+  not want, and the only correct place to take it back off is an
+  overlay — exactly like ``structuralScarcity``.  Wiring it needs the
+  netting ADR-009 requires (the residual against what the blend now
+  embeds, which is the measured curve rather than 1.15), so this stays
+  ABSENT and named rather than half-applied.
 * **projectionCorroboration** — ABSENT pending LI-6.
 
 **Picks never move.**  ``compute_scarcity`` keys off rostered players and

--- a/src/league_intel/te_premium.py
+++ b/src/league_intel/te_premium.py
@@ -64,6 +64,7 @@ from __future__ import annotations
 import json
 import math
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -268,12 +269,19 @@ def measure_te_demand(
     )
 
 
+@lru_cache(maxsize=1)
 def load_tep_curve() -> tuple[float, float, float]:
     """``(a, k, floor)`` for ``ratio(v) = max(floor, 1 + a * v**-k)``.
 
     Falls back to the measured 2026-07-27 constants when the config file
     is absent, so a fresh checkout behaves identically rather than
     silently disabling the curve.
+
+    Memoized: ``tep_uplift`` calls this on every invocation, and the
+    blend loop invokes it once per TE per source — a file read and a
+    JSON parse each time, in the hot path.  The config does not change
+    within a process; call ``load_tep_curve.cache_clear()`` if a test
+    rewrites it.
     """
     try:
         payload = json.loads(_CURVE_PATH.read_text(encoding="utf-8"))

--- a/src/nfl_data/actuals_store.py
+++ b/src/nfl_data/actuals_store.py
@@ -1,0 +1,758 @@
+"""Durable per-player-per-week actuals — the season's box scores, kept.
+
+Why this is not ``data/nfl_data_cache/``
+────────────────────────────────────────
+That directory is a live, load-bearing TTL cache (``src/nfl_data/cache.py``
+writes ``<sha256[:16]>.json`` + a ``.meta.json`` sidecar there, and
+``src/api/startup_validation.py`` checks it is writable).  It is **not**
+vestigial — it was empty on inspection only because no fetch had run in
+that container yet.
+
+It is nonetheless the wrong home for actuals, and for a structural
+reason rather than a stylistic one: **everything in it is designed to be
+thrown away.**  ``cache.get`` returns ``None`` past ``ttl_seconds``,
+``cache.put`` overwrites the same hashed path on every refetch, and any
+entry that fails to parse is unlinked on read.  A 24-hour TTL over a
+season of box scores means the only thing on disk is the most recent
+pull; nothing accumulates.  Week 3 is gone by week 4, and a season's
+history can never be reconstructed from it.
+
+So the cache keeps its job (don't hammer nflverse within a day) and this
+module keeps a separate, append-only, human-inspectable log beside it.
+
+On-disk shape
+─────────────
+One file per season, one JSONL line per ``(season, week, seasonType)``,
+mirroring ``src/api/source_history.py``'s "one line per snapshot, players
+nested inside" layout and ``data/ros/aggregate/history/``'s
+one-artifact-per-observation convention::
+
+    data/nfl_data/actuals/player_week_2025.jsonl
+
+    {"season":2025,"week":1,"seasonType":"REG",
+     "capturedAt":"2026-07-27T12:00:00+00:00",
+     "playerCount":1204,
+     "players":{
+       "00-0026158":{
+         "name":"Joe Flacco","position":"QB","team":"CLE",
+         "offense":{"completions":31.0,"attempts":45.0,...},
+         "defense":null
+       },
+       "00-0034857":{
+         "name":"D.Slay","position":"CB","team":"PIT",
+         "offense":null,
+         "defense":{"tackles_solo":5.0,"tackles_combined":5.0,...}
+       }
+     }}
+
+Keyed by GSIS id because that is the only identifier nflverse guarantees
+across both halves of the row and across seasons.  ``offense`` and
+``defense`` are nested rather than flattened because
+:class:`~src.nfl_data.ingest.WeeklyStatRow` and
+:class:`~src.nfl_data.ingest.WeeklyDefensiveStatRow` collide on
+``sacks`` and ``interceptions`` — a QB's sacks taken and an edge
+rusher's sacks recorded are different numbers under one name.
+
+Column names: nflverse renamed them, and the dataclasses predate it
+──────────────────────────────────────────────────────────────────
+``WeeklyStatRow`` and ``WeeklyDefensiveStatRow`` were written against the
+retired ``player_stats/player_stats_{year}.csv`` and
+``player_stats_def_{year}.csv`` releases.  #589 repointed the fetchers at
+the unified ``stats_player/stats_player_week_{year}.csv``, which **also
+renamed six columns**.  Verified live against the 2025 file, 2026-07-27:
+
+    recent_team        → team
+    interceptions      → passing_interceptions
+    sacks              → sacks_suffered
+    fumbles_lost       → fumbles_lost_total
+    def_safety         → def_safeties
+    def_tackles        → (removed; see below)
+
+Reading a renamed column yields ``None``/``0`` with no error, so the
+mapper below accepts BOTH spellings per field — first candidate present
+wins.  The alias lists are the whole guard: a mapper that silently reads
+zeros is exactly the shape of defect #589 was.
+
+Tackles: three columns, and none of them mean what their name suggests
+─────────────────────────────────────────────────────────────────────
+``def_tackles`` has no replacement column in the unified release, and
+reconstructing it forced the question of what nflverse's tackle columns
+actually count.  Two facts, both measured against the retired 2024
+defensive release (9,994 rows) rather than assumed:
+
+1. ``def_tackles == def_tackles_solo + def_tackles_with_assist`` on
+   **9,994 of 9,994** rows — an exact identity.  The intuitive
+   ``solo + def_tackle_assists`` holds on only 3,058.
+2. ``def_tackles_solo`` **excludes** ``def_tackles_with_assist``: 342
+   rows have ``solo == 0`` while ``with_assist > 0``, which is
+   impossible if one contained the other.
+
+So nflverse's columns map onto the NFL gamebook like this::
+
+    gamebook SOLO     = def_tackles_solo + def_tackles_with_assist
+                      = def_tackles                (the retired column)
+    gamebook ASSISTS  = def_tackle_assists
+    gamebook COMBINED = def_tackles + def_tackle_assists
+
+Cross-checked against real box scores: Zack Baun (PHI) 2024 wk1 reads
+solo 9 / with_assist 2 / assists 4, i.e. gamebook 11 solo + 4 assists =
+his actual 15-tackle line.  Reading ``def_tackles_solo`` alone would
+have reported 9.
+
+``WeeklyDefensiveStatRow``'s three tackle fields are therefore populated
+with the **gamebook** definitions, not the raw column values — a field
+called ``tackles_combined`` that carries the solo count is the kind of
+name/predicate gap this repo keeps paying for.  ``tackles_solo`` is the
+gamebook solo total, ``tackles_assist`` is assists, and
+``tackles_combined`` is their sum.  :data:`TACKLES_COMBINED_IS_DERIVED`
+marks that the last one is computed rather than published.
+
+What is deliberately NOT here
+─────────────────────────────
+* **Snap counts.**  ``WeeklyStatRow.snap_count`` / ``snap_pct`` stay
+  ``None``.  ``fetch_snap_counts`` keys on PFR ids, not GSIS, so joining
+  it needs the ``fetch_id_map`` cross-walk — a real piece of work, and
+  half-wiring it would put an unjoined column on disk that reads as
+  "no snaps played" rather than "not fetched".
+* **Fantasy points.**  nflverse publishes ``fantasy_points_ppr``, but
+  this league's points come from ``src/nfl_data/realized_points.py``
+  against Sleeper's ``scoring_settings``.  Storing a foreign scoring
+  system's total next to the stats invites someone to read it as ours.
+
+Both fetchers now hit ONE url
+─────────────────────────────
+After #589 ``fetch_weekly_stats`` and ``fetch_weekly_defensive_stats``
+request the same unified CSV and differ only in how callers read the
+result.  :func:`persist_weekly_actuals` calls both anyway (they cache
+under separate keys, so the cost is one extra HTTP round-trip on a cold
+day) and merges on ``(gsis, season, week, seasonType)``, so the duplicate
+rows collapse instead of doubling the file.
+
+No function raises on data problems.  Filesystem errors DO propagate —
+a caller persisting actuals needs to know the write failed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from src.nfl_data import cache as _cache
+from src.nfl_data.ingest import (
+    WeeklyDefensiveStatRow,
+    WeeklyStatRow,
+    fetch_weekly_defensive_stats,
+    fetch_weekly_stats,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+__all__ = [
+    "ACTUALS_SCHEMA_VERSION",
+    "TACKLES_COMBINED_IS_DERIVED",
+    "PersistResult",
+    "coverage",
+    "default_actuals_dir",
+    "load_player_weeks",
+    "load_season",
+    "normalize_defensive_row",
+    "normalize_offensive_row",
+    "persist_weekly_actuals",
+    "season_path",
+]
+
+ACTUALS_SCHEMA_VERSION = "2026-07-27.v1"
+
+TACKLES_COMBINED_IS_DERIVED = True
+"""The three ``defense.tackles_*`` fields are gamebook-derived.
+
+nflverse publishes ``def_tackles_solo`` (unassisted only),
+``def_tackles_with_assist`` and ``def_tackle_assists``; the gamebook
+numbers a fantasy league scores against are ``solo + with_assist`` and
+``assists``.  The derivation is measured (see the module docstring), but
+it is still a derivation — a consumer that needs published-only columns
+should read the raw nflverse row instead of these fields.
+"""
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def default_actuals_dir() -> Path:
+    """``data/nfl_data/actuals`` — durable, sibling of the TTL cache."""
+    return _repo_root() / "data" / "nfl_data" / "actuals"
+
+
+def season_path(season: int, *, actuals_dir: Path | None = None) -> Path:
+    return (actuals_dir or default_actuals_dir()) / f"player_week_{int(season)}.jsonl"
+
+
+# ── Column mapping ────────────────────────────────────────────────────
+#
+# ``field -> (candidate source columns, first match wins)``.  Both the
+# unified 2025+ spelling and the retired pre-2025 spelling are listed so
+# a backfill over old seasons and a live pull over the current one go
+# through one mapper.
+
+_OFFENSE_NUMERIC: dict[str, tuple[str, ...]] = {
+    "completions": ("completions",),
+    "attempts": ("attempts",),
+    "passing_yards": ("passing_yards",),
+    "passing_tds": ("passing_tds",),
+    # Renamed 2025: interceptions -> passing_interceptions.
+    "interceptions": ("passing_interceptions", "interceptions"),
+    # Renamed 2025: sacks -> sacks_suffered.  This is sacks TAKEN by a
+    # passer, not sacks recorded by a defender (that is defense.sacks).
+    "sacks": ("sacks_suffered", "sacks"),
+    "carries": ("carries",),
+    "rushing_yards": ("rushing_yards",),
+    "rushing_tds": ("rushing_tds",),
+    "targets": ("targets",),
+    "receptions": ("receptions",),
+    "receiving_yards": ("receiving_yards",),
+    "receiving_tds": ("receiving_tds",),
+    # Renamed 2025: fumbles_lost -> fumbles_lost_total.
+    "fumbles_lost": ("fumbles_lost_total", "fumbles_lost"),
+}
+
+_DEFENSE_NUMERIC: dict[str, tuple[str, ...]] = {
+    # tackles_solo / tackles_assist / tackles_combined are all derived —
+    # see _tackle_view and the module docstring.  They are deliberately
+    # absent from this table.
+    "tackles_for_loss": ("def_tackles_for_loss",),
+    "tackles_for_loss_yards": ("def_tackles_for_loss_yards",),
+    "sacks": ("def_sacks",),
+    "sack_yards": ("def_sack_yards",),
+    "qb_hits": ("def_qb_hits",),
+    "passes_defended": ("def_pass_defended", "def_passes_defended"),
+    "interceptions": ("def_interceptions",),
+    "interception_yards": ("def_interception_yards",),
+    "fumbles_forced": ("def_fumbles_forced",),
+    # Not def_-prefixed in the unified release.
+    "fumble_recovery_own": ("fumble_recovery_own", "def_fumble_recovery_own"),
+    "fumble_recovery_opp": ("fumble_recovery_opp", "def_fumble_recovery_opp"),
+    "fumble_recovery_yards_own": (
+        "fumble_recovery_yards_own",
+        "def_fumble_recovery_yards_own",
+    ),
+    "fumble_recovery_yards_opp": (
+        "fumble_recovery_yards_opp",
+        "def_fumble_recovery_yards_opp",
+    ),
+    "def_tds": ("def_tds",),
+    # Renamed 2025: def_safety -> def_safeties.
+    "safeties": ("def_safeties", "def_safety"),
+}
+
+_TACKLE_COLUMNS = (
+    "def_tackles",
+    "def_tackles_solo",
+    "def_tackles_with_assist",
+    "def_tackle_assists",
+)
+
+_ID_COLUMNS = ("player_id", "player_id_gsis", "gsis_id")
+_NAME_COLUMNS = ("player_display_name", "player_name", "full_name")
+_TEAM_COLUMNS = ("team", "recent_team", "team_abbr")
+_POSITION_COLUMNS = ("position", "position_group")
+
+# Columns that carry ANY defensive production.  A row is persisted with
+# a ``defense`` block only when at least one of these is non-zero — the
+# unified file gives every offensive player a full set of zeroed def_*
+# columns, and writing those would triple the file for no information.
+_DEFENSE_PRESENCE_COLUMNS = (
+    tuple(col for cols in _DEFENSE_NUMERIC.values() for col in cols) + _TACKLE_COLUMNS
+)
+
+_OFFENSE_PRESENCE_COLUMNS = tuple(col for cols in _OFFENSE_NUMERIC.values() for col in cols)
+
+
+def _num(raw: Any) -> float:
+    """Coerce to a finite float, defaulting to 0.0.
+
+    CSV rows arrive as strings or as ``nflverse_direct._coerce_numerics``
+    output; DataFrame rows arrive with NaN for missing.  All three land
+    on 0.0, which is what a box score means by an absent stat line.
+    """
+    if raw is None or raw == "":
+        return 0.0
+    try:
+        v = float(raw)
+    except (TypeError, ValueError):
+        return 0.0
+    return v if math.isfinite(v) else 0.0
+
+
+def _first(row: Mapping[str, Any], columns: Sequence[str]) -> Any:
+    for col in columns:
+        if col in row:
+            val = row[col]
+            if val is not None and val != "":
+                return val
+    return None
+
+
+def _first_numeric(row: Mapping[str, Any], columns: Sequence[str]) -> float:
+    return _num(_first(row, columns))
+
+
+def _str(raw: Any) -> str:
+    return "" if raw is None else str(raw).strip()
+
+
+def _int(raw: Any) -> int:
+    return int(_num(raw))
+
+
+def _any_nonzero(row: Mapping[str, Any], columns: Sequence[str]) -> bool:
+    return any(_num(row.get(col)) != 0.0 for col in columns if col in row)
+
+
+def _tackle_view(row: Mapping[str, Any]) -> tuple[float, float, float]:
+    """``(gamebook solo, assists, combined)`` from any nflverse schema.
+
+    Pre-2025 rows carry the published ``def_tackles`` (which IS the
+    gamebook solo total); unified 2025+ rows do not, so it is
+    reconstructed from ``def_tackles_solo + def_tackles_with_assist``.
+    Both paths then add ``def_tackle_assists`` for combined.  See the
+    module docstring for the two measurements this rests on.
+    """
+    published = _first(row, ("def_tackles",))
+    if published is not None:
+        solo = _num(published)
+    else:
+        solo = _num(_first(row, ("def_tackles_solo",))) + _num(
+            _first(row, ("def_tackles_with_assist",))
+        )
+    assists = _num(_first(row, ("def_tackle_assists",)))
+    return solo, assists, solo + assists
+
+
+def normalize_offensive_row(row: Mapping[str, Any]) -> WeeklyStatRow | None:
+    """Map one raw nflverse row onto :class:`WeeklyStatRow`.
+
+    Returns ``None`` when the row has no GSIS id (nflverse emits a
+    handful of unattributed rows per season) or no offensive production
+    at all.  ``snap_count`` / ``snap_pct`` stay ``None`` — see the module
+    docstring for why they are not joined here.
+    """
+    if not isinstance(row, Mapping):
+        return None
+    gsis = _str(_first(row, _ID_COLUMNS))
+    if not gsis:
+        return None
+    if not _any_nonzero(row, _OFFENSE_PRESENCE_COLUMNS):
+        return None
+    values = {field: _first_numeric(row, cols) for field, cols in _OFFENSE_NUMERIC.items()}
+    return WeeklyStatRow(
+        player_id_gsis=gsis,
+        player_name=_str(_first(row, _NAME_COLUMNS)),
+        position=_str(_first(row, _POSITION_COLUMNS)).upper(),
+        recent_team=_str(_first(row, _TEAM_COLUMNS)).upper(),
+        season=_int(row.get("season")),
+        week=_int(row.get("week")),
+        **values,
+    )
+
+
+def normalize_defensive_row(row: Mapping[str, Any]) -> WeeklyDefensiveStatRow | None:
+    """Map one raw nflverse row onto :class:`WeeklyDefensiveStatRow`.
+
+    Returns ``None`` for rows with no GSIS id or no defensive production.
+    The unified release gives every offensive player a zeroed ``def_*``
+    block, so the production check is what keeps the file honest about
+    who actually played defense.
+    """
+    if not isinstance(row, Mapping):
+        return None
+    gsis = _str(_first(row, _ID_COLUMNS))
+    if not gsis:
+        return None
+    if not _any_nonzero(row, _DEFENSE_PRESENCE_COLUMNS):
+        return None
+    values = {field: _first_numeric(row, cols) for field, cols in _DEFENSE_NUMERIC.items()}
+    solo, assists, combined = _tackle_view(row)
+    return WeeklyDefensiveStatRow(
+        player_id_gsis=gsis,
+        player_name=_str(_first(row, _NAME_COLUMNS)),
+        position=_str(_first(row, _POSITION_COLUMNS)).upper(),
+        team=_str(_first(row, _TEAM_COLUMNS)).upper(),
+        season=_int(row.get("season")),
+        week=_int(row.get("week")),
+        tackles_solo=solo,
+        tackles_assist=assists,
+        tackles_combined=combined,
+        **values,
+    )
+
+
+_IDENTITY_FIELDS = frozenset(
+    {"player_id_gsis", "player_name", "position", "recent_team", "team", "season", "week"}
+)
+
+
+def _stat_payload(dc: Any) -> dict[str, Any]:
+    """Dataclass → dict, minus the identity fields hoisted to the player
+    record.  Keeps each week's line from repeating name/team/season/week
+    twice per player."""
+    return {k: v for k, v in asdict(dc).items() if k not in _IDENTITY_FIELDS}
+
+
+def _season_type(row: Mapping[str, Any]) -> str:
+    raw = _str(_first(row, ("season_type", "seasonType"))).upper()
+    return raw or "REG"
+
+
+class PersistResult:
+    """What one :func:`persist_weekly_actuals` call actually wrote.
+
+    Every count here is a positive trace.  A run that fetched nothing and
+    a run that wrote nothing are different states, and reading zeros off
+    a silent success is how a dead ingest path stays dead.
+    """
+
+    __slots__ = (
+        "seasons",
+        "offensive_rows_fetched",
+        "defensive_rows_fetched",
+        "player_weeks",
+        "weeks_written",
+        "offense_records",
+        "defense_records",
+        "skipped_no_id",
+        "paths",
+    )
+
+    def __init__(self) -> None:
+        self.seasons: list[int] = []
+        self.offensive_rows_fetched = 0
+        self.defensive_rows_fetched = 0
+        self.player_weeks = 0
+        self.weeks_written = 0
+        self.offense_records = 0
+        self.defense_records = 0
+        self.skipped_no_id = 0
+        self.paths: list[str] = []
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schemaVersion": ACTUALS_SCHEMA_VERSION,
+            "seasons": list(self.seasons),
+            "offensiveRowsFetched": self.offensive_rows_fetched,
+            "defensiveRowsFetched": self.defensive_rows_fetched,
+            "playerWeeks": self.player_weeks,
+            "weeksWritten": self.weeks_written,
+            "offenseRecords": self.offense_records,
+            "defenseRecords": self.defense_records,
+            "skippedNoPlayerId": self.skipped_no_id,
+            "paths": list(self.paths),
+        }
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"PersistResult({self.to_dict()})"
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _read_lines(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as f:
+        for raw in f:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                entry = json.loads(raw)
+            except json.JSONDecodeError:
+                # A truncated tail from a killed process must not wedge
+                # the whole season; drop the bad line and keep the rest.
+                _LOGGER.warning("actuals_store: skipping unparseable line in %s", path)
+                continue
+            if isinstance(entry, dict):
+                out.append(entry)
+    return out
+
+
+def _line_key(entry: Mapping[str, Any]) -> tuple[int, int, str]:
+    return (
+        _int(entry.get("season")),
+        _int(entry.get("week")),
+        _str(entry.get("seasonType")).upper() or "REG",
+    )
+
+
+def _write_lines(path: Path, entries: Iterable[Mapping[str, Any]]) -> None:
+    """Atomic-ish rewrite: tempfile + rename, same as source_history."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry, separators=(",", ":"), sort_keys=True) + "\n")
+    tmp.replace(path)
+
+
+def persist_weekly_actuals(
+    seasons: Sequence[int],
+    *,
+    actuals_dir: Path | None = None,
+    cache_dir: Path | None = None,
+    captured_at: str | None = None,
+    refresh: bool = False,
+    _offensive_provider: Any | None = None,
+    _defensive_provider: Any | None = None,
+) -> PersistResult:
+    """Fetch and durably persist player-week actuals for ``seasons``.
+
+    Re-running is safe and idempotent: a ``(season, week, seasonType)``
+    already on disk is REPLACED by the fresh pull, never appended
+    alongside.  nflverse revises box scores for days after a game — a
+    log that kept both copies would make "which one is current?"
+    unanswerable, and the whole point of this file is to be the answer.
+
+    Weeks present on disk but absent from the fetch are left untouched,
+    so a partial fetch (or a mid-season run over a single year) narrows
+    what it updates rather than truncating history.
+
+    ``refresh=True`` evicts this season's entries from the ingest TTL
+    cache first.  Without it a re-run inside the 24-hour window is
+    served the *previous* pull and the replace above has nothing new to
+    write — so a box-score revision published hours after a game would
+    be silently invisible until the TTL lapsed.  Default off, because
+    the cache exists for a reason; pass it when you are chasing a
+    correction rather than filling in a new week.
+
+    Returns a :class:`PersistResult`.  The ``_*_provider`` hooks are test
+    seams — production passes neither.
+    """
+    result = PersistResult()
+    result.seasons = [int(s) for s in seasons]
+    if not result.seasons:
+        return result
+
+    stamp = captured_at or _now_utc()
+
+    for season in result.seasons:
+        if refresh:
+            for key in (f"weekly_stats:{season}", f"weekly_def_stats:{season}"):
+                _cache.evict(key, cache_dir=cache_dir)
+        offensive = fetch_weekly_stats(
+            [season], _provider=_offensive_provider, cache_dir=cache_dir
+        )
+        defensive = fetch_weekly_defensive_stats(
+            [season], _provider=_defensive_provider, cache_dir=cache_dir
+        )
+        result.offensive_rows_fetched += len(offensive)
+        result.defensive_rows_fetched += len(defensive)
+
+        # (week, seasonType) -> gsis -> record
+        weeks: dict[tuple[int, str], dict[str, dict[str, Any]]] = {}
+
+        def _slot(row: Mapping[str, Any], gsis: str, dc: Any) -> dict[str, Any]:
+            key = (_int(row.get("week")), _season_type(row))
+            bucket = weeks.setdefault(key, {})
+            rec = bucket.get(gsis)
+            if rec is None:
+                rec = {
+                    "name": getattr(dc, "player_name", ""),
+                    "position": getattr(dc, "position", ""),
+                    "team": getattr(dc, "recent_team", None) or getattr(dc, "team", ""),
+                    "offense": None,
+                    "defense": None,
+                }
+                bucket[gsis] = rec
+            return rec
+
+        for raw in offensive:
+            if not isinstance(raw, Mapping):
+                continue
+            if not _str(_first(raw, _ID_COLUMNS)):
+                result.skipped_no_id += 1
+                continue
+            dc = normalize_offensive_row(raw)
+            if dc is None:
+                continue
+            rec = _slot(raw, dc.player_id_gsis, dc)
+            rec["offense"] = _stat_payload(dc)
+
+        for raw in defensive:
+            if not isinstance(raw, Mapping):
+                continue
+            if not _str(_first(raw, _ID_COLUMNS)):
+                result.skipped_no_id += 1
+                continue
+            dc = normalize_defensive_row(raw)
+            if dc is None:
+                continue
+            rec = _slot(raw, dc.player_id_gsis, dc)
+            rec["defense"] = _stat_payload(dc)
+
+        if not weeks:
+            _LOGGER.warning(
+                "actuals_store: season %d produced no persistable rows "
+                "(offensive=%d defensive=%d fetched) — nothing written",
+                season,
+                len(offensive),
+                len(defensive),
+            )
+            continue
+
+        fresh: dict[tuple[int, str], dict[str, Any]] = {}
+        for (week, season_type), players in weeks.items():
+            # Drop players who ended up with neither block (possible if a
+            # row had an id but every stat column was absent).
+            players = {
+                gsis: rec
+                for gsis, rec in players.items()
+                if rec["offense"] is not None or rec["defense"] is not None
+            }
+            if not players:
+                continue
+            result.offense_records += sum(1 for r in players.values() if r["offense"])
+            result.defense_records += sum(1 for r in players.values() if r["defense"])
+            result.player_weeks += len(players)
+            fresh[(week, season_type)] = {
+                "schemaVersion": ACTUALS_SCHEMA_VERSION,
+                "season": season,
+                "week": week,
+                "seasonType": season_type,
+                "capturedAt": stamp,
+                "playerCount": len(players),
+                "tacklesCombinedDerived": TACKLES_COMBINED_IS_DERIVED,
+                "players": players,
+            }
+
+        if not fresh:
+            continue
+
+        path = season_path(season, actuals_dir=actuals_dir)
+        merged: dict[tuple[int, int, str], dict[str, Any]] = {}
+        for entry in _read_lines(path):
+            merged[_line_key(entry)] = dict(entry)
+        for (week, season_type), entry in fresh.items():
+            merged[(season, week, season_type)] = entry
+
+        _write_lines(path, [merged[k] for k in sorted(merged.keys())])
+        result.weeks_written += len(fresh)
+        result.paths.append(str(path))
+        _LOGGER.info(
+            "actuals_store=written season=%d weeks=%d players=%d path=%s",
+            season,
+            len(fresh),
+            sum(e["playerCount"] for e in fresh.values()),
+            path,
+        )
+
+    return result
+
+
+def load_season(
+    season: int,
+    *,
+    actuals_dir: Path | None = None,
+    season_types: Sequence[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Every persisted week for ``season``, ascending by week.
+
+    ``season_types`` filters to e.g. ``("REG",)``; ``None`` returns
+    regular season and playoffs together.
+    """
+    entries = _read_lines(season_path(season, actuals_dir=actuals_dir))
+    if season_types is not None:
+        wanted = {str(s).upper() for s in season_types}
+        entries = [e for e in entries if _str(e.get("seasonType")).upper() in wanted]
+    entries.sort(key=_line_key)
+    return entries
+
+
+def load_player_weeks(
+    player_id_gsis: str,
+    *,
+    seasons: Sequence[int] | None = None,
+    actuals_dir: Path | None = None,
+    season_types: Sequence[str] | None = None,
+) -> list[dict[str, Any]]:
+    """One player's persisted weeks, ascending by (season, week).
+
+    Each element is the stored player record plus its ``season``,
+    ``week`` and ``seasonType`` hoisted back out of the enclosing line,
+    so a caller gets a flat time series without knowing the file layout.
+    """
+    gsis = _str(player_id_gsis)
+    if not gsis:
+        return []
+    directory = actuals_dir or default_actuals_dir()
+    if seasons is None:
+        candidates = sorted(directory.glob("player_week_*.jsonl")) if directory.exists() else []
+        season_list = []
+        for p in candidates:
+            try:
+                season_list.append(int(p.stem.rsplit("_", 1)[-1]))
+            except ValueError:
+                continue
+    else:
+        season_list = [int(s) for s in seasons]
+
+    out: list[dict[str, Any]] = []
+    for season in sorted(season_list):
+        for entry in load_season(season, actuals_dir=directory, season_types=season_types):
+            players = entry.get("players")
+            if not isinstance(players, dict):
+                continue
+            rec = players.get(gsis)
+            if not isinstance(rec, dict):
+                continue
+            out.append(
+                {
+                    "season": _int(entry.get("season")),
+                    "week": _int(entry.get("week")),
+                    "seasonType": _str(entry.get("seasonType")).upper() or "REG",
+                    "capturedAt": entry.get("capturedAt"),
+                    **rec,
+                }
+            )
+    return out
+
+
+def coverage(*, actuals_dir: Path | None = None) -> dict[str, Any]:
+    """What is actually on disk, per season.
+
+    Diagnostic surface — the answer to "did the ingest run, and how much
+    did it get?" without opening the files.  Reports zeros explicitly
+    rather than omitting an empty season, because an absent key and a
+    season with no data read the same to a caller.
+    """
+    directory = actuals_dir or default_actuals_dir()
+    seasons: dict[str, Any] = {}
+    if directory.exists():
+        for path in sorted(directory.glob("player_week_*.jsonl")):
+            try:
+                season = int(path.stem.rsplit("_", 1)[-1])
+            except ValueError:
+                continue
+            entries = _read_lines(path)
+            weeks = sorted({_int(e.get("week")) for e in entries})
+            seasons[str(season)] = {
+                "weeks": weeks,
+                "weekCount": len(entries),
+                "playerWeeks": sum(_int(e.get("playerCount")) for e in entries),
+                "seasonTypes": sorted({_str(e.get("seasonType")).upper() or "REG" for e in entries}),
+                "capturedAt": max((str(e.get("capturedAt") or "") for e in entries), default=None)
+                or None,
+                "path": str(path),
+            }
+    return {
+        "schemaVersion": ACTUALS_SCHEMA_VERSION,
+        "dir": str(directory),
+        "dirExists": directory.exists(),
+        "seasons": seasons,
+    }

--- a/src/nfl_data/actuals_store.py
+++ b/src/nfl_data/actuals_store.py
@@ -545,9 +545,7 @@ def persist_weekly_actuals(
         if refresh:
             for key in (f"weekly_stats:{season}", f"weekly_def_stats:{season}"):
                 _cache.evict(key, cache_dir=cache_dir)
-        offensive = fetch_weekly_stats(
-            [season], _provider=_offensive_provider, cache_dir=cache_dir
-        )
+        offensive = fetch_weekly_stats([season], _provider=_offensive_provider, cache_dir=cache_dir)
         defensive = fetch_weekly_defensive_stats(
             [season], _provider=_defensive_provider, cache_dir=cache_dir
         )
@@ -745,7 +743,9 @@ def coverage(*, actuals_dir: Path | None = None) -> dict[str, Any]:
                 "weeks": weeks,
                 "weekCount": len(entries),
                 "playerWeeks": sum(_int(e.get("playerCount")) for e in entries),
-                "seasonTypes": sorted({_str(e.get("seasonType")).upper() or "REG" for e in entries}),
+                "seasonTypes": sorted(
+                    {_str(e.get("seasonType")).upper() or "REG" for e in entries}
+                ),
                 "capturedAt": max((str(e.get("capturedAt") or "") for e in entries), default=None)
                 or None,
                 "path": str(path),

--- a/src/nfl_data/ingest.py
+++ b/src/nfl_data/ingest.py
@@ -97,6 +97,23 @@ class WeeklyDefensiveStatRow:
     the source CSV; we drop the prefix here so the dataclass reads
     naturally, but the underlying fetcher reads from the prefixed
     columns.
+
+    THE THREE TACKLE FIELDS ARE GAMEBOOK VALUES, NOT RAW COLUMNS.
+    nflverse's ``def_tackles_solo`` counts *unassisted* tackles only and
+    excludes ``def_tackles_with_assist`` (measured: 342 of 9,994 2024
+    rows have solo 0 with with_assist > 0).  Its ``def_tackles`` is the
+    gamebook SOLO total — ``solo + with_assist``, an exact identity on
+    9,994 of 9,994 rows — not combined tackles.  So::
+
+        tackles_solo     = def_tackles_solo + def_tackles_with_assist
+        tackles_assist   = def_tackle_assists
+        tackles_combined = tackles_solo + tackles_assist
+
+    ``src.nfl_data.actuals_store.normalize_defensive_row`` is the mapper
+    that applies this; a caller populating this dataclass by hand from
+    raw columns must do the same or it will under-report every defender.
+    The unified 2025+ release drops ``def_tackles`` entirely, so reading
+    it directly now yields zero.
     """
 
     player_id_gsis: str

--- a/src/nfl_data/realized_points.py
+++ b/src/nfl_data/realized_points.py
@@ -45,6 +45,12 @@ The IDP scoring path consumes nflverse ``def_*`` columns.  Rows
 where ``position`` is not in the IDP set skip the IDP keys entirely
 so the offense path is unaffected.
 
+Two caveats on those columns, both corrected 2026-07-27 and explained
+in full above ``_IDP_KEYS``: the 2025 unified release renamed
+``def_safety`` and removed ``def_tackles`` outright, and no nflverse
+column has ever carried combined tackles.  Every ``def_*`` read here
+goes through a candidate list, and tackles through ``_tackle_view``.
+
 Degradation
 -----------
 * Missing scoring_settings → returns fantasyPoints=0 with
@@ -88,23 +94,63 @@ _SIMPLE_KEYS: dict[str, tuple[str, str]] = {
 # is zero, so the loop is a no-op.  Extends the same shape as
 # ``_SIMPLE_KEYS`` so the ``compute_weekly_points`` scoring loop
 # can iterate both with one code path.
-_IDP_KEYS: dict[str, tuple[str, str]] = {
-    "idp_tkl_solo": ("def_tackles_solo", "Solo Tkl"),
-    "idp_tkl_ast": ("def_tackle_assists", "Ast Tkl"),
-    "idp_tkl": ("def_tackles", "Tkl"),
-    "idp_tkl_loss": ("def_tackles_for_loss", "TFL"),
-    "idp_sack": ("def_sacks", "Sack"),
-    "idp_sack_yd": ("def_sack_yards", "Sack Yds"),
-    "idp_hit": ("def_qb_hits", "QB Hit"),
-    "idp_pd": ("def_pass_defended", "PD"),
-    "idp_int": ("def_interceptions", "INT"),
-    "idp_int_ret_yd": ("def_interception_yards", "INT Ret Yds"),
-    "idp_ff": ("def_fumbles_forced", "FF"),
-    "idp_fum_rec": ("def_fumble_recovery_own", "FR"),
-    "idp_fum_ret_yd": ("def_fumble_recovery_yards_own", "FR Ret Yds"),
-    "idp_def_td": ("def_tds", "Def TD"),
-    "idp_safe": ("def_safety", "Safety"),
+# CORRECTED 2026-07-27.  Three of these mappings read columns that the
+# 2025 unified nflverse release does not have, and a fourth carried the
+# wrong quantity.  Each failed silently — ``stat_row.get`` returns None,
+# ``_num`` turns it into 0.0, and the key is skipped as though the
+# player had recorded nothing.  An IDP league scored zero tackles all
+# season and nothing said so.
+#
+#   def_safety   → def_safeties      (renamed; see #589's URL change)
+#   def_tackles  → REMOVED           (no replacement column at all)
+#
+# And the semantics, measured against the retired 2024 defensive release
+# rather than assumed:
+#
+#   * ``def_tackles_solo`` counts UNASSISTED tackles only — it excludes
+#     ``def_tackles_with_assist``.  342 of 9,994 rows have solo 0 with
+#     with_assist > 0, which is impossible if one contained the other.
+#     So ``idp_tkl_solo`` off the raw column under-reported every
+#     defender who was assisted on a stop.
+#   * ``def_tackles`` was ``solo + with_assist`` — an exact identity on
+#     9,994 of 9,994 rows.  That is the gamebook SOLO total, NOT
+#     combined tackles, so ``idp_tkl`` was scoring the wrong quantity
+#     even when the column existed.
+#
+# Cross-checked against a real box score: Zack Baun (PHI) 2024 wk1 reads
+# solo 9 / with_assist 2 / assists 4 — gamebook 11 solo, 4 assists, 15
+# combined, which is his actual line.
+#
+# Values are now tuples of CANDIDATE columns (first present wins) so a
+# backfill over pre-2025 seasons and a live pull over the current one go
+# through one table.  The three tackle keys are resolved by
+# :func:`_tackle_view` instead, because no single column carries them.
+_IDP_KEYS: dict[str, tuple[tuple[str, ...], str]] = {
+    "idp_tkl_loss": (("def_tackles_for_loss",), "TFL"),
+    "idp_sack": (("def_sacks",), "Sack"),
+    "idp_sack_yd": (("def_sack_yards",), "Sack Yds"),
+    "idp_hit": (("def_qb_hits",), "QB Hit"),
+    "idp_pd": (("def_pass_defended", "def_passes_defended"), "PD"),
+    "idp_int": (("def_interceptions",), "INT"),
+    "idp_int_ret_yd": (("def_interception_yards",), "INT Ret Yds"),
+    "idp_ff": (("def_fumbles_forced",), "FF"),
+    # Not def_-prefixed in the unified release.
+    "idp_fum_rec": (("def_fumble_recovery_own", "fumble_recovery_own"), "FR"),
+    "idp_fum_ret_yd": (
+        ("def_fumble_recovery_yards_own", "fumble_recovery_yards_own"),
+        "FR Ret Yds",
+    ),
+    "idp_def_td": (("def_tds",), "Def TD"),
+    "idp_safe": (("def_safeties", "def_safety"), "Safety"),
 }
+
+# Resolved by ``_tackle_view`` rather than a column read.  Ordered
+# solo, assist, combined — matching the tuple that function returns.
+_IDP_TACKLE_KEYS: tuple[tuple[str, str], ...] = (
+    ("idp_tkl_solo", "Solo Tkl"),
+    ("idp_tkl_ast", "Ast Tkl"),
+    ("idp_tkl", "Tkl"),
+)
 
 
 # Position labels that count as IDP scoring eligible.  nflverse uses
@@ -161,6 +207,43 @@ def _num(val: Any) -> float:
         return float(val or 0)
     except (TypeError, ValueError):
         return 0.0
+
+
+def _first_num(stat_row: dict[str, Any], columns: tuple[str, ...]) -> float:
+    """First candidate column present with a value; 0.0 if none are.
+
+    The candidate list is what absorbs nflverse's 2025 renames without
+    breaking a backfill over older seasons — see the note above
+    ``_IDP_KEYS``.
+    """
+    for col in columns:
+        val = stat_row.get(col)
+        if val is not None and val != "":
+            return _num(val)
+    return 0.0
+
+
+def _tackle_view(stat_row: dict[str, Any]) -> tuple[float, float, float]:
+    """``(gamebook solo, assists, combined)`` from any nflverse schema.
+
+    Pre-2025 rows publish ``def_tackles``, which IS the gamebook solo
+    total.  The unified 2025+ release dropped it, so solo is rebuilt as
+    ``def_tackles_solo + def_tackles_with_assist``.  Combined is always
+    solo plus ``def_tackle_assists`` — no column carries it.
+
+    Mirrors ``src.nfl_data.actuals_store._tackle_view``; the two are
+    pinned to each other by
+    ``tests/nfl_data/test_realized_points.py::test_tackle_view_matches_the_actuals_store``.
+    """
+    published = stat_row.get("def_tackles")
+    if published is not None and published != "":
+        solo = _num(published)
+    else:
+        solo = _num(stat_row.get("def_tackles_solo")) + _num(
+            stat_row.get("def_tackles_with_assist")
+        )
+    assists = _num(stat_row.get("def_tackle_assists"))
+    return solo, assists, solo + assists
 
 
 def compute_weekly_points(
@@ -220,12 +303,24 @@ def compute_weekly_points(
     # _IDP_KEYS entry separately produces the correct stacked total
     # without any explicit "stack bonus" logic.
     if _is_idp_position(pos):
-        for key, (stat_key, label) in _IDP_KEYS.items():
+        for key, (stat_keys, label) in _IDP_KEYS.items():
             pts_per = scoring.get(key, 0.0)
             if pts_per == 0.0:
                 continue
-            stat = _num(stat_row.get(stat_key))
+            stat = _first_num(stat_row, stat_keys)
             if stat == 0:
+                continue
+            contribution = stat * pts_per
+            breakdown.append((label, stat, contribution))
+            total += contribution
+
+        # Tackles come from _tackle_view, not a column read — nflverse
+        # publishes no combined-tackle column, and its ``solo`` column
+        # is unassisted-only.  See the note above _IDP_KEYS.
+        tackle_stats = _tackle_view(stat_row)
+        for (key, label), stat in zip(_IDP_TACKLE_KEYS, tackle_stats):
+            pts_per = scoring.get(key, 0.0)
+            if pts_per == 0.0 or stat == 0:
                 continue
             contribution = stat * pts_per
             breakdown.append((label, stat, contribution))
@@ -242,7 +337,11 @@ def compute_weekly_points(
             pts_per = scoring.get(key, 0.0)
             if pts_per == 0.0:
                 continue
-            tkls = _num(stat_row.get("def_tackles"))
+            # Sleeper's 5+/10+ thresholds are on COMBINED tackles, which
+            # is the third element of the view.  This previously read
+            # ``def_tackles`` — the gamebook solo count pre-2025, and
+            # absent entirely after, so the bonus stopped firing.
+            tkls = tackle_stats[2]
             if tkls >= thresh:
                 breakdown.append((label, tkls, pts_per))
                 total += pts_per

--- a/tests/api/test_feature_flags.py
+++ b/tests/api/test_feature_flags.py
@@ -43,19 +43,42 @@ def test_every_flag_defaults_off_except_safe_additive():
         "depth_chart_validation",  # circuit-breaker protected
         "monte_carlo_trade",  # new endpoint, old unchanged
     }
+    # Flags that default ON and KNOWINGLY change output.  Deliberately a
+    # separate set from ``safe_on``: every member of that one is there
+    # because it is additive, inert, or otherwise cannot move a number,
+    # and quietly admitting a value-moving flag would erode the only
+    # thing the set's name promises.  Entry here requires a MEASURED
+    # blast radius recorded at the point of change, not an argument that
+    # the change is probably fine.
+    value_moving_on = {
+        # Collaborative audit finding F.  Replaces the flat 1.15 TE
+        # alignment multiplier with KTC's measured base → TE++ curve.
+        # Blast radius measured against the 2026-07-27 live board (810
+        # rows): all 80 TEs move up, +1.08% (Bowers, against the 9999
+        # ceiling) to +30.17% (Ruckert, deep), median +14.27%.  The only
+        # non-TE values that move are 48 PICK rows, via the documented
+        # current-year pick tethering inheriting rookie-TE values —
+        # e.g. 2026 Pick 1.07 +3.91% matches Kenyon Sadiq exactly.  No
+        # QB/RB/WR/IDP value changes.  Rank displacement median 7, p90
+        # 22.  Rollback: RISKIT_FEATURE_TE_BASIS_CONVERSION=0.
+        "te_basis_conversion",
+    }
     off_only = {
         "dynamic_source_weights",  # held OFF until backtest data exists
     }
+    assert not (safe_on & value_moving_on), "a flag cannot be both no-change and value-moving"
     for name, value in flags.items():
-        if name in safe_on:
+        if name in safe_on or name in value_moving_on:
             continue
         if name in off_only:
             assert value is False, f"flag {name!r} expected OFF but is ON"
             continue
         assert value is False, (
             f"flag {name!r} defaults ON but hasn't been vetted as "
-            f"regression-safe.  Either add to the safe_on set with "
-            f"rationale in _DEFAULTS, or flip the default to False."
+            f"regression-safe.  Either add it to ``safe_on`` (additive / "
+            f"inert / cannot move a number) or to ``value_moving_on`` "
+            f"(with a MEASURED blast radius), with matching rationale in "
+            f"_DEFAULTS — or flip the default to False."
         )
 
 

--- a/tests/api/test_league_adjusted_endpoint.py
+++ b/tests/api/test_league_adjusted_endpoint.py
@@ -1,0 +1,451 @@
+"""Contract tests for ``GET /api/valuation/league-adjusted`` (LI-9).
+
+The endpoint shipped live on ``main`` with **zero** coverage.  It is the
+only producer of a real ``leagueAdjustedDynastyValue``, it reprices every
+player on the rankings page and inside trade evaluation, and nothing
+guarded any of it.
+
+Three jobs, in order of how loudly they should fail.
+
+1. **The routing contract.**  CLAUDE.md's table — 400 ``unknown_league``,
+   400 ``inactive_league``, 503 ``data_not_ready``, 404
+   ``no_leagues_configured`` — plus the ``leagueKey`` stamp.  This
+   endpoint is league-scoped *by necessity*: ``lineupScarcity`` is
+   measured from one league's rosters, so serving league B off league
+   A's contract would silently reprice B's board with A's roster shape.
+
+2. **The overlay is not vacuously empty.**  This is the one that
+   matters, and it is why the fixture below stamps ``rankDerivedValue``
+   by hand.  ``build_board_adjustments`` reads consensus through
+   ``_consensus_from_row``, which returns ``None`` for a row without
+   it — every explanation then carries no consensus, no factor clears
+   the 0.1% floor, and the endpoint answers ``isNoop: true`` with an
+   empty ``factors`` map.  **A 200 with a well-formed empty overlay is
+   exactly what a completely broken adjustment model also returns.**
+   ``test_the_fixture_actually_moves_values`` asserts the mechanism was
+   fed before anything else asserts what it produced (ORCHESTRATION.md
+   §2b: an underfed fixture is indistinguishable from a collapsed
+   metric).
+
+3. **The invariants the design rests on.**  Factors and not absolute
+   values, dense contiguous ranks, picks that never move, and caller-row
+   isolation against the shared ``latest_contract_data`` global.  Each
+   of these is load-bearing for a reason recorded in
+   ``src/league_intel/publish.py``, and each regresses through a
+   plausible-looking tidy-up rather than a rewrite.
+
+The league fixture is imported from ``test_gameplan_endpoint`` rather
+than duplicated — the two endpoints share ``get_league_bundle``, and two
+drifting copies of the same synthetic league would be worse than the
+coupling.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+import server
+from src.api import gameplan, league_registry
+from tests.api.test_gameplan_endpoint import _roster
+from tests.api.test_gameplan_endpoint import league  # noqa: F401 — pytest fixture
+
+# ``league`` is re-exported into this module's namespace on purpose; that
+# is how pytest resolves an imported fixture.
+
+
+# ── The contract, with the field the adjustment model actually reads ──
+
+
+def _players_array() -> list[dict]:
+    """The gameplan fixture's rows PLUS the two fields the overlay reads.
+
+    ``test_gameplan_endpoint`` omits both because the gameplan engines
+    read ``rosValue`` off the roster snapshot instead.  The overlay needs
+    them and fails *silently* without either:
+
+    * ``rankDerivedValue`` — ``_consensus_from_row`` reads it first, and
+      a row without it yields no consensus, hence no factor, hence an
+      empty ``factors`` map.
+    * ``canonicalConsensusRank`` — ``compact_ranks_and_tiers`` considers
+      only rows that already carry a truthy one (a real contract row
+      always does), so a board without it re-ranks to nothing and
+      ``ranks`` comes back ``{}``.
+
+    Both omissions produce a well-formed 200.  That is the whole reason
+    ``test_the_fixture_actually_moves_values`` and
+    ``test_ranks_are_dense_and_contiguous`` assert on content rather than
+    shape.
+    """
+    out: list[dict] = []
+    for i in range(4):
+        for row in _roster(i):
+            n = int(row["playerId"][-2:])
+            out.append(
+                {
+                    "playerId": row["playerId"],
+                    "displayName": row["canonicalName"],
+                    "position": row["position"],
+                    "assetClass": "offense",
+                    "age": 22 + (n % 11),
+                    # The consensus board this overlay composes against.
+                    "rankDerivedValue": int(round(row["rosValue"] * 100)),
+                    "canonicalSiteValues": {"ktcSfTep": 200.0 + row["rosValue"] * 40.0},
+                }
+            )
+    return out
+
+
+def _ranked(rows: list[dict]) -> list[dict]:
+    """Stamp the contiguous 1..N ``canonicalConsensusRank`` the contract
+    builder would have stamped, in ``rankDerivedValue`` order."""
+    ordered = sorted(rows, key=lambda r: (-int(r["rankDerivedValue"]), r["displayName"]))
+    for i, row in enumerate(ordered, start=1):
+        row["canonicalConsensusRank"] = i
+    return rows
+
+
+_PICK_NAME = "2027 Round 1 Pick"
+
+
+def _pick_row() -> dict:
+    """One draft pick.  ``compute_scarcity`` keys off rostered players
+    and has no ``PICK`` entry, so a pick must come back with an ABSENT
+    axis and factor 1.0 — the single largest behavioural consequence of
+    this feature (see publish.py's module docstring)."""
+    return {
+        "playerId": "pick-2027-1",
+        "displayName": _PICK_NAME,
+        "position": "PICK",
+        "assetClass": "pick",
+        "rankDerivedValue": 4200,
+    }
+
+
+def _install_contract(
+    monkeypatch,
+    league_key: str = "main",
+    profile: str = "prof_a",
+    *,
+    rows: list[dict] | None = None,
+):
+    stub = {
+        "meta": {"leagueKey": league_key, "scoringProfile": profile},
+        "date": "2026-07-27",
+        "contractVersion": "2026-03-10.v2",
+        "scrapeTimestamp": "2026-07-27T10:00:00+00:00",
+        "players": {},
+        "playersArray": _ranked(
+            list(rows) if rows is not None else _players_array() + [_pick_row()]
+        ),
+        "sleeper": {"teams": []},
+    }
+    monkeypatch.setattr(server, "latest_contract_data", stub)
+    return stub
+
+
+def _get(client, path: str = "/api/valuation/league-adjusted"):
+    return client.get(path)
+
+
+# ── 2. Non-vacuity — assert the mechanism was fed, first ─────────────
+
+
+def test_the_fixture_actually_moves_values(league, monkeypatch):  # noqa: F811
+    """Everything below is meaningless if this fails.
+
+    A no-op overlay and a catastrophically broken adjustment model
+    produce byte-identical responses: ``isNoop: true``, ``factors: {}``,
+    HTTP 200.  So the suite proves the input reached the model before it
+    asserts anything about the output.
+
+    Drop ``rankDerivedValue`` from ``_players_array`` and this is the
+    only test that notices.
+    """
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        res = _get(c)
+    assert res.status_code == 200, res.text
+    body = res.json()
+
+    assert body["isNoop"] is False, "the adjustment model produced no factors at all"
+    assert body["adjustedCount"] > 0
+    assert body["factors"], "factors map is empty — nothing to overlay"
+    # A factor of exactly 1.0 would clear no floor and never be emitted,
+    # but assert it anyway: a model that emitted unity for everything
+    # would satisfy "factors is non-empty".
+    assert any(abs(f - 1.0) > 1e-9 for f in body["factors"].values())
+    # And the scarcity that drove it must be real, not an empty dict
+    # standing in for "measured nothing".
+    assert body["scarcity"], "no scarcity measured — the league bundle fed nothing in"
+    assert any(
+        isinstance(comp.get("lineupScarcity"), (int, float))
+        for comp in body["scarcity"].values()
+    ), "every position reported an unmeasurable lineupScarcity"
+
+
+# ── 1. The routing contract ──────────────────────────────────────────
+
+
+def test_happy_path_returns_the_overlay_surface(league, monkeypatch):  # noqa: F811
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        res = _get(c)
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["leagueKey"] == "main"
+    for key in (
+        "schemaVersion",
+        "modelVersion",
+        "adjustmentModelVersion",
+        "configVersion",
+        "dataThrough",
+        "contractVersion",
+        "scrapeTimestamp",
+        "isNoop",
+        "adjustedCount",
+        "playerCount",
+        "rankedCount",
+        "monotonicityViolations",
+        "scarcity",
+        "factors",
+        "ranks",
+        "tiers",
+        "warnings",
+        "inactiveAxes",
+        "cacheHit",
+    ):
+        assert key in body, f"missing {key}"
+    assert body["monotonicityViolations"] == []
+    assert body["warnings"] == []
+
+
+def test_unknown_league_key_returns_400(league, monkeypatch):  # noqa: F811
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        res = _get(c, "/api/valuation/league-adjusted?leagueKey=ghost")
+    assert res.status_code == 400
+    body = res.json()
+    assert body["error"] == "unknown_league"
+    assert body["leagueKey"] == "ghost"
+
+
+def test_inactive_league_key_returns_400(league, monkeypatch):  # noqa: F811
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        res = _get(c, "/api/valuation/league-adjusted?leagueKey=retired")
+    assert res.status_code == 400
+    assert res.json()["error"] == "inactive_league"
+
+
+def test_non_loaded_league_returns_503_even_on_a_shared_scoring_profile(
+    league,  # noqa: F811
+    monkeypatch,
+):
+    """``main`` and ``side`` share ``prof_a``, so ``/api/data`` would
+    happily serve ``side`` the shared rankings.  This endpoint must NOT:
+    its whole output is derived from one league's twelve rosters, and
+    serving A's scarcity under B's key is the cross-league collapse the
+    scoring-profile/leagueKey split exists to prevent.
+    """
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch, league_key="main")
+        res = _get(c, "/api/valuation/league-adjusted?leagueKey=side")
+    assert res.status_code == 503
+    body = res.json()
+    assert body["error"] == "data_not_ready"
+    assert body["leagueKey"] == "side"
+
+
+def test_no_contract_loaded_returns_503(league, monkeypatch):  # noqa: F811
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        monkeypatch.setattr(server, "latest_contract_data", None)
+        res = _get(c)
+    assert res.status_code == 503
+    assert res.json()["error"] == "data_not_ready"
+
+
+def test_no_leagues_configured_returns_404(tmp_path, monkeypatch):
+    path = tmp_path / "empty.json"
+    path.write_text(json.dumps({"leagues": []}), encoding="utf-8")
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    monkeypatch.delenv("SLEEPER_LEAGUE_ID", raising=False)
+    league_registry.reload_registry()
+    monkeypatch.setattr(server, "_is_authenticated", lambda request: True)
+    try:
+        with TestClient(server.app, raise_server_exceptions=True) as c:
+            monkeypatch.setattr(server, "latest_contract_data", {"meta": {}})
+            res = _get(c)
+        assert res.status_code == 404
+        assert res.json()["error"] == "no_leagues_configured"
+    finally:
+        league_registry.reload_registry()
+
+
+def test_missing_roster_snapshot_degrades_to_a_200_noop_not_a_503(
+    league,  # noqa: F811
+    monkeypatch,
+):
+    """Deliberately asymmetric with ``/api/gameplan``, which 503s here.
+
+    Scarcity is unmeasurable without rosters, but the consensus board is
+    still perfectly usable — taking the whole rankings page down for a
+    missing optional lens would be the wrong trade.  The response says
+    *why* it is empty rather than presenting a no-op as a measurement.
+    """
+    monkeypatch.setattr(gameplan, "load_team_strength_snapshot", lambda key=None: None)
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        res = _get(c)
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["isNoop"] is True
+    assert body["adjustedCount"] == 0
+    assert body["values"] == {}
+    assert body["unavailable"]["reason"]
+    assert body["leagueKey"] == "main"
+
+
+# ── 3. The invariants the design rests on ────────────────────────────
+
+
+def test_factors_are_ratios_not_absolute_values(league, monkeypatch):  # noqa: F811
+    """The overlay must compose against a board the server never
+    computed — e.g. one the user re-weighted on /settings.
+
+    A factor depends only on position, so it composes exactly.  An
+    absolute value would carry the default board's numbers into a
+    different board.  The tell is the magnitude: ratios sit near 1.0,
+    values sit in the thousands.
+    """
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        body = _get(c).json()
+    for name, factor in body["factors"].items():
+        assert isinstance(factor, float), name
+        assert 0.5 < factor < 2.0, f"{name}={factor} is not a ratio"
+
+
+def test_the_same_position_gets_the_same_factor(league, monkeypatch):  # noqa: F811
+    """The composability guarantee, stated as a property rather than a
+    comment: the factor is a function of position ALONE.  If it ever
+    started reading the consensus value, two players at one position
+    with different values would diverge — and the overlay would
+    silently stop being valid against a re-weighted board."""
+    rows = _players_array()
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch, rows=rows)
+        body = _get(c).json()
+
+    by_position: dict[str, set[float]] = {}
+    for row in rows:
+        factor = body["factors"].get(row["displayName"])
+        if factor is not None:
+            by_position.setdefault(row["position"], set()).add(factor)
+    assert by_position, "no factors to check"
+    for position, factors in by_position.items():
+        assert len(factors) == 1, f"{position} got {len(factors)} distinct factors: {factors}"
+
+
+def test_picks_never_move(league, monkeypatch):  # noqa: F811
+    """``compute_scarcity`` has no PICK key, so a pick's axis is ABSENT
+    and its factor is 1.0 — below the 0.1% floor, so it is absent from
+    ``factors`` entirely.
+
+    This is not an oversight to be fixed here: league-adjusted mode
+    systematically reprices every player against every pick, and that
+    lands in the trade calculator.  Pinning it means the behaviour is a
+    decision rather than a surprise.
+    """
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        body = _get(c).json()
+    assert _PICK_NAME not in body["factors"]
+    # It is still RANKED — the pick's position on the adjusted board
+    # moves because the players around it moved.
+    assert _PICK_NAME in body["ranks"]
+
+
+def test_ranks_are_dense_and_contiguous(league, monkeypatch):  # noqa: F811
+    """Sparse ranks would reintroduce the three-state ambiguity
+    (changed / unchanged / now-unranked) that this design rejects."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        body = _get(c).json()
+    ranks = sorted(body["ranks"].values())
+    assert ranks, "no ranks emitted"
+    assert ranks == list(range(1, len(ranks) + 1))
+    assert body["rankedCount"] == len(ranks)
+    # Every ranked row carries a tier too, or the client renders a
+    # tier-less board next to a tiered one.
+    assert set(body["tiers"]) <= set(body["ranks"])
+
+
+def test_the_shared_contract_global_is_not_mutated(league, monkeypatch):  # noqa: F811
+    """``latest_contract_data`` is a module global read by every other
+    request.  ``build_league_adjusted_payload`` multiplies
+    ``rankDerivedValue`` by the factor to re-rank; doing that in place
+    would reprice the live board for every league on the process.
+
+    Deep-copied before and compared after, so a mutation anywhere in the
+    row tree fails this — not just at the top level.
+    """
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        stub = _install_contract(monkeypatch)
+        before = copy.deepcopy(stub)
+        res = _get(c)
+        assert res.status_code == 200
+        assert stub == before
+
+
+def test_explanations_are_off_by_default_and_available_on_request(
+    league,  # noqa: F811
+    monkeypatch,
+):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        default = _get(c).json()
+        verbose = _get(c, "/api/valuation/league-adjusted?explanations=1").json()
+    assert "explanations" not in default
+    assert verbose["explanations"], "explanations=1 returned nothing"
+    axes = {a["name"] for e in verbose["explanations"] for a in e.get("axes", [])}
+    assert "structuralScarcity" in axes
+
+
+def test_the_version_pin_is_stamped_from_the_contract(league, monkeypatch):  # noqa: F811
+    """The client refuses to apply an overlay whose contract build does
+    not match the base it fetched.  A null pin disables that check
+    without anything saying so."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        body = _get(c).json()
+    assert body["contractVersion"] == "2026-03-10.v2"
+    assert body["scrapeTimestamp"] == "2026-07-27T10:00:00+00:00"
+    assert body["dataThrough"] == "2026-07-27"
+
+
+def test_inactive_axes_are_named_not_silently_omitted(league, monkeypatch):  # noqa: F811
+    """A reader must not have to infer the TE axis's absence from an
+    empty diff.  ``tePremium`` is out because ``ktcSfTep`` IS the TE++
+    board and the blend already embeds the premium — see
+    tests/league_intel/test_te_premium_invariants.py."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        body = _get(c).json()
+    assert "tePremium" in body["inactiveAxes"]
+    assert "projectionCorroboration" in body["inactiveAxes"]
+
+
+def test_an_empty_players_array_is_a_clean_noop(league, monkeypatch):  # noqa: F811
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch, rows=[])
+        res = _get(c)
+    assert res.status_code == 200
+    body = res.json()
+    assert body["isNoop"] is True
+    assert body["factors"] == {}
+    assert body["ranks"] == {}
+    assert body["playerCount"] == 0

--- a/tests/api/test_league_adjusted_endpoint.py
+++ b/tests/api/test_league_adjusted_endpoint.py
@@ -447,3 +447,143 @@ def test_an_empty_players_array_is_a_clean_noop(league, monkeypatch):  # noqa: F
     assert body["factors"] == {}
     assert body["ranks"] == {}
     assert body["playerCount"] == 0
+
+
+# ── 4. Server-side composition on POST /api/rankings/overrides ───────
+#
+# Custom source weights + the league lens used to be refused. The
+# refusal was correct — the overlay's ranks belong to the un-overridden
+# board — but it meant a user with any custom weight silently lost the
+# lens. The composition now happens server-side.
+#
+# The scope consequence is the subtle part and is what these pin:
+# rankings follow the SCORING PROFILE and are shared across leagues,
+# but scarcity is measured from ONE league's rosters. So asking for the
+# lens narrows a shared response into a league-scoped one, and the
+# endpoint has to start enforcing the stricter rule for that request
+# only.
+
+
+def _raw_payload() -> dict:
+    """The RAW scraper payload the override endpoint rebuilds from.
+
+    ``POST /api/rankings/overrides`` reads ``server.latest_data`` (the
+    pre-contract scrape), not ``latest_contract_data`` — it re-runs the
+    whole pipeline rather than patching the built board. The player
+    names must match the league fixture's roster, or the scarcity
+    factors key off nothing and every composition assertion passes
+    vacuously against an empty adjustment.
+    """
+    players: dict[str, dict] = {}
+    for row in _players_array():
+        v = int(row["rankDerivedValue"])
+        players[row["displayName"]] = {
+            "_composite": v,
+            "_rawComposite": v,
+            "_finalAdjusted": v,
+            "_canonicalSiteValues": {"ktcSfTep": v, "dlfSf": v},
+            "position": row["position"],
+        }
+    return {
+        "players": players,
+        "sites": [{"key": "ktcSfTep"}, {"key": "dlfSf"}],
+        "maxValues": {"ktcSfTep": 9999, "dlfSf": 9999},
+        "sleeper": {"positions": {}},
+    }
+
+
+def _install_raw(monkeypatch):
+    monkeypatch.setattr(server, "latest_data", _raw_payload())
+    monkeypatch.setattr(server, "latest_data_source", None)
+
+
+def _post(client, body, view="delta"):
+    return client.post(f"/api/rankings/overrides?view={view}", json=body)
+
+
+def test_overrides_without_the_lens_stay_scoring_profile_scoped(league, monkeypatch):  # noqa: F811
+    """The default path must be untouched. `side` shares `prof_a` with
+    `main`, so a plain override request for it still succeeds off the
+    loaded contract."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch, league_key="main")
+        _install_raw(monkeypatch)
+        res = _post(c, {"leagueKey": "side", "ktcSfTep": {"include": False}})
+    assert res.status_code == 200, res.text
+    assert res.json()["meta"]["valuationMode"] == "market"
+
+
+def test_asking_for_the_lens_narrows_the_scope_to_one_league(league, monkeypatch):  # noqa: F811
+    """The same request that succeeds above must 503 once the lens is
+    requested — scarcity from `main`'s rosters is not `side`'s answer.
+
+    This is the assertion that makes the composition safe. Without it
+    the endpoint would happily hand league B a board priced by league
+    A's roster shape, which is worse than the refusal it replaced.
+    """
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch, league_key="main")
+        _install_raw(monkeypatch)
+        res = _post(
+            c,
+            {
+                "leagueKey": "side",
+                "ktcSfTep": {"include": False},
+                "valuation_mode": "leagueAdjusted",
+            },
+        )
+    assert res.status_code == 503
+    body = res.json()
+    assert body["error"] == "data_not_ready"
+    assert body["leagueKey"] == "side"
+
+
+def test_the_composed_board_is_stamped_as_league_adjusted(league, monkeypatch):  # noqa: F811
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        _install_raw(monkeypatch)
+        res = _post(c, {"ktcSfTep": {"include": False}, "valuation_mode": "leagueAdjusted"})
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["meta"]["valuationMode"] == "leagueAdjusted"
+    assert body["valuationAdjustment"]["applied"] is True
+    assert body["valuationAdjustment"]["adjustedCount"] > 0, (
+        "the lens was requested and reported applied but moved nothing — "
+        "either the fixture is starved or the factors never reached the board"
+    )
+
+
+def test_a_missing_roster_snapshot_degrades_to_market_and_says_so(
+    league,  # noqa: F811
+    monkeypatch,
+):
+    """Without rosters there is no measurable scarcity. Serving the
+    overridden market board is right; presenting it AS league-adjusted
+    is not. The response has to disclose which one the caller got."""
+    monkeypatch.setattr(gameplan, "load_team_strength_snapshot", lambda key=None: None)
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        _install_raw(monkeypatch)
+        res = _post(c, {"ktcSfTep": {"include": False}, "valuation_mode": "leagueAdjusted"})
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["meta"]["valuationMode"] == "market"
+    assert "league_adjusted_unavailable" in body["meta"]["valuationNote"]
+    assert any("league_adjusted_unavailable" in w for w in body.get("warnings") or [])
+
+
+def test_the_full_view_refuses_the_lens_rather_than_ignoring_it(league, monkeypatch):  # noqa: F811
+    """A silently-dropped field would return a market board labelled as
+    adjusted. Say no instead."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        _install_raw(monkeypatch)
+        res = _post(
+            c,
+            {"ktcSfTep": {"include": False}, "valuation_mode": "leagueAdjusted"},
+            view="full",
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["meta"]["valuationMode"] == "market"
+    assert body["meta"]["valuationNote"] == "league_adjusted_requires_delta_view"

--- a/tests/api/test_league_adjusted_endpoint.py
+++ b/tests/api/test_league_adjusted_endpoint.py
@@ -182,8 +182,7 @@ def test_the_fixture_actually_moves_values(league, monkeypatch):  # noqa: F811
     # standing in for "measured nothing".
     assert body["scarcity"], "no scarcity measured — the league bundle fed nothing in"
     assert any(
-        isinstance(comp.get("lineupScarcity"), (int, float))
-        for comp in body["scarcity"].values()
+        isinstance(comp.get("lineupScarcity"), (int, float)) for comp in body["scarcity"].values()
     ), "every position reported an unmeasurable lineupScarcity"
 
 

--- a/tests/api/test_league_adjusted_endpoint.py
+++ b/tests/api/test_league_adjusted_endpoint.py
@@ -45,7 +45,6 @@ from __future__ import annotations
 import copy
 import json
 
-import pytest
 from fastapi.testclient import TestClient
 
 import server

--- a/tests/api/test_single_authority.py
+++ b/tests/api/test_single_authority.py
@@ -192,3 +192,76 @@ class TestFrontendFallbackGuards(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestLegacyLamStripperDoesNotEatLiveFields(unittest.TestCase):
+    """The legacy LAM stripper must not silently delete a modern field.
+
+    CONTEXT, because this is easy to misread. LAM — League Adjustment
+    Multiplier, a position-based value multiplier — was deleted in April
+    2026 along with positional scarcity, on the grounds that upstream
+    sources already price the operator's SF/TEP/IDP config and the
+    per-league delta was small and noisy (``src/league/README.md``,
+    audit finding F2).
+
+    ``_strip_legacy_lam_fields`` then deletes ``_lam*``, ``_rawLeague*``,
+    ``_shrunkLeague*``, ``_leagueAdjusted``, ``_effectiveMultiplier`` and
+    top-level ``empiricalLAM`` from EVERY response. That is hygiene, not
+    suppression: data files on disk predate the removal and still carry
+    those fields, so without the strip the API would serve stale LAM
+    numbers computed by code that no longer exists.
+
+    THE TRAP: it strips by PREFIX, and league-aware valuation has since
+    come BACK in ``src/league_intel/`` under names built from the same
+    words — ``leagueAdjustedDynastyValue`` and friends. Today's names
+    are safe only because none of them start with an underscore. A
+    plausible future tidy-up that marks one private
+    (``_rawLeagueAdjusted``, say) would match the ``_rawLeague`` prefix
+    and vanish from every response with no error and no log line.
+
+    A field that disappears from a payload looks exactly like a field
+    that was never computed. This test makes that collision loud instead
+    of leaving it to be discovered from a blank UI.
+    """
+
+    def test_live_valuation_field_names_survive_the_stripper(self) -> None:
+        from src.api.data_contract import _strip_legacy_lam_fields
+
+        live_names = [
+            "leagueAdjustedDynastyValue",
+            "leagueAdjustedIsNoop",
+            "rankDerivedValue",
+            "canonicalConsensusRank",
+            "valuationOverlay",
+        ]
+        players = {"P": {name: 1 for name in live_names}}
+        base: dict[str, Any] = {}
+        _strip_legacy_lam_fields(base, players)
+        for name in live_names:
+            self.assertIn(
+                name,
+                players["P"],
+                f"{name!r} was eaten by the legacy LAM stripper — rename the field "
+                f"or narrow _LEGACY_LAM_PLAYER_PREFIXES",
+            )
+
+    def test_the_stripper_still_removes_what_it_is_for(self) -> None:
+        """The control. Without this the test above passes against a
+        stripper that does nothing at all."""
+        from src.api.data_contract import _strip_legacy_lam_fields
+
+        players = {
+            "P": {
+                "_lamMultiplier": 1.2,
+                "_rawLeagueValue": 900,
+                "_shrunkLeagueValue": 880,
+                "_leagueAdjusted": 910,
+                "_effectiveMultiplier": 1.05,
+                "keepMe": 1,
+            }
+        }
+        base = {"empiricalLAM": {"QB": 1.1}, "keepMe": 1}
+        _strip_legacy_lam_fields(base, players)
+        self.assertEqual(list(players["P"].keys()), ["keepMe"])
+        self.assertNotIn("empiricalLAM", base)
+        self.assertIn("keepMe", base)

--- a/tests/api/test_source_overrides.py
+++ b/tests/api/test_source_overrides.py
@@ -1240,3 +1240,134 @@ class TestTepMultipliersEndToEnd(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestValuationFactorComposition(unittest.TestCase):
+    """Server-side composition of source overrides + the league lens.
+
+    The two used to be mutually exclusive, and the reason was sound: the
+    overlay endpoint ranks against the UN-overridden board, so applying
+    its ranks to a re-weighted board gives ranks of
+    ``default_consensus x factor`` when the right answer is the rank of
+    ``overridden_consensus x factor``. The server had never computed the
+    latter. It does now, and these pin that it is the latter.
+
+    The distinction is invisible in a payload's shape — both produce a
+    delta with values, ranks and tiers — so every assertion below is
+    about the arithmetic relationship between them.
+    """
+
+    def test_factors_multiply_the_overridden_values_not_the_default_ones(self) -> None:
+        """The whole point, expressed as a ratio.
+
+        Build the same board twice, once with an override and once
+        without, then apply the same factor to each. If the factors were
+        being applied to the default board, the two adjusted results
+        would be identical; they must not be.
+        """
+        plain = build_rankings_delta_payload(
+            _fixture_raw_payload(),
+            source_overrides={"ktcSfTep": {"include": False}},
+        )
+        plain_vals = {e["id"]: e.get("rankDerivedValue") for e in plain["rankingsDelta"]["players"]}
+        movers = [n for n, v in plain_vals.items() if isinstance(v, int) and v > 0]
+        self.assertTrue(movers, "fixture produced no priced rows to adjust")
+
+        factors = {name: 1.20 for name in movers}
+        adjusted = build_rankings_delta_payload(
+            _fixture_raw_payload(),
+            source_overrides={"ktcSfTep": {"include": False}},
+            valuation_factors=factors,
+        )
+        adj_vals = {
+            e["id"]: e.get("rankDerivedValue") for e in adjusted["rankingsDelta"]["players"]
+        }
+        for name in movers:
+            self.assertEqual(
+                adj_vals[name],
+                int(round(plain_vals[name] * 1.20)),
+                f"{name}: factor was not applied to the OVERRIDDEN value",
+            )
+
+    def test_ranks_are_recomputed_over_the_adjusted_board(self) -> None:
+        """A factor that reorders players must reorder ranks.
+
+        Boosting only the lower-valued half is the test: if ranks were
+        carried over from the pre-adjustment board, the order would be
+        unchanged and this passes vacuously — so it asserts an actual
+        reordering happened.
+        """
+        plain = build_rankings_delta_payload(_fixture_raw_payload())
+        rows = [
+            (e["id"], e.get("rankDerivedValue"), e.get("canonicalConsensusRank"))
+            for e in plain["rankingsDelta"]["players"]
+            if isinstance(e.get("rankDerivedValue"), int)
+            and isinstance(e.get("canonicalConsensusRank"), int)
+        ]
+        rows.sort(key=lambda r: r[2])
+        if len(rows) < 2:
+            self.skipTest("fixture has fewer than two ranked rows")
+
+        # Boost the LAST-ranked row hard enough to pass the first.
+        target = rows[-1][0]
+        top_value = rows[0][1]
+        factor = (top_value * 2.0) / max(rows[-1][1], 1)
+        adjusted = build_rankings_delta_payload(
+            _fixture_raw_payload(),
+            valuation_factors={target: factor},
+        )
+        new_ranks = {
+            e["id"]: e.get("canonicalConsensusRank") for e in adjusted["rankingsDelta"]["players"]
+        }
+        self.assertEqual(
+            new_ranks[target], 1, "the boosted row did not take rank 1 — ranks are stale"
+        )
+
+    def test_ranks_stay_dense_and_contiguous_after_adjustment(self) -> None:
+        plain = build_rankings_delta_payload(_fixture_raw_payload())
+        names = [
+            e["id"]
+            for e in plain["rankingsDelta"]["players"]
+            if isinstance(e.get("rankDerivedValue"), int) and e["rankDerivedValue"] > 0
+        ]
+        adjusted = build_rankings_delta_payload(
+            _fixture_raw_payload(),
+            valuation_factors={n: 1.1 for n in names},
+        )
+        ranks = sorted(
+            e["canonicalConsensusRank"]
+            for e in adjusted["rankingsDelta"]["players"]
+            if isinstance(e.get("canonicalConsensusRank"), int)
+        )
+        self.assertEqual(ranks, list(range(1, len(ranks) + 1)))
+
+    def test_no_factors_is_byte_identical_to_the_plain_override_path(self) -> None:
+        """The composition must be inert when the lens is off — the
+        default path is the one every user is on."""
+        a = build_rankings_delta_payload(
+            _fixture_raw_payload(), source_overrides={"ktcSfTep": {"include": False}}
+        )
+        b = build_rankings_delta_payload(
+            _fixture_raw_payload(),
+            source_overrides={"ktcSfTep": {"include": False}},
+            valuation_factors=None,
+        )
+        # Compare the ranking payload rather than the whole envelope —
+        # the envelope carries build timestamps that differ by
+        # microseconds between two calls and say nothing about the
+        # composition path.
+        self.assertEqual(a["rankingsDelta"], b["rankingsDelta"])
+        self.assertEqual(a.get("rankingsOverride"), b.get("rankingsOverride"))
+        self.assertNotIn("valuationAdjustment", a)
+        self.assertNotIn("valuationAdjustment", b)
+
+    def test_an_empty_factor_map_is_reported_as_applied_but_inert(self) -> None:
+        """`applied and moved nothing` and `never applied` are different
+        states. A caller that cannot tell them apart renders one as the
+        other, which is the exact confusion this endpoint removes."""
+        payload = build_rankings_delta_payload(
+            _fixture_raw_payload(), valuation_factors={"Nobody At All": 1.5}
+        )
+        self.assertEqual(payload["valuationAdjustment"]["applied"], True)
+        self.assertEqual(payload["valuationAdjustment"]["adjustedCount"], 0)
+        self.assertEqual(payload["valuationAdjustment"]["factorCount"], 1)

--- a/tests/api/test_te_basis_conversion.py
+++ b/tests/api/test_te_basis_conversion.py
@@ -1,0 +1,292 @@
+"""The TE basis conversion is WIRED — not merely present in the tree.
+
+ORCHESTRATION.md §6.14/§6.15 record the previous attempt at this: a
+complete, tested TE-premium module that ``data_contract.py`` deliberately
+never imported, so that "toggle off" would be byte-identical. The cost of
+that design was named explicitly — *a design whose safety argument is
+"nothing calls it yet" disables the tests that would catch it.* The
+double-count invariant existed and could not fire, because the code it
+guarded was unreachable.
+
+So the first test in this file asserts the module is REACHED, by
+patching ``convert_te_value`` and requiring a call. Every other
+assertion here would pass against a completely unwired pipeline that
+happened to produce plausible numbers; that one would not.
+
+The second thing worth stating plainly: this moves live consensus values
+for tight ends, upward. That is the point. ``ktcSfTep`` — the board this
+blend anchors on — IS KTC's TE++ board, every non-TEP source's TE
+contribution was already being scaled to align with it, and the flat
+1.15 doing that scaling sat below the entire observed range of KTC's own
+uplift (minimum 1.209, maximum 2.053). The magnitude was wrong in one
+direction for every tight end on the board.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.api import data_contract, feature_flags
+from src.league_intel import te_premium
+
+
+@pytest.fixture(autouse=True)
+def _flags():
+    feature_flags.reload()
+    yield
+    feature_flags.reload()
+
+
+# ── A minimal board: enough sources for the blend to run ─────────────
+
+
+_TE_NAME = "Test Tight End"
+_WR_NAME = "Test Wide Out"
+
+
+def _player(value: str | int, position: str) -> dict:
+    v = int(value)
+    return {
+        "_composite": v,
+        "_rawComposite": v,
+        "_finalAdjusted": v,
+        "_canonicalSiteValues": {"ktcSfTep": v, "dlfSf": v},
+        "position": position,
+    }
+
+
+def _raw() -> dict:
+    """A TE and a WR sitting mid-board, plus filler above them.
+
+    Two properties are deliberate and the fixture is vacuous without
+    either:
+
+    * The TE is NOT at rank 1. A top-of-board TE's Hill contribution is
+      already 9999, and every uplift — flat 1.15 or the measured curve —
+      clamps straight back to 9999. The test would then pass with the
+      conversion entirely disabled.
+    * The WR sits one slot away from the TE. It is the control: a bug
+      that scaled every position would look exactly like a working TE
+      premium against a TE-only fixture.
+    """
+    players = {
+        f"Filler {i:02d}": _player(9000 - i * 60, "WR") for i in range(40)
+    }
+    players[_TE_NAME] = _player(5000, "TE")
+    players[_WR_NAME] = _player(4940, "WR")
+    return {
+        "players": players,
+        "sites": [{"key": "ktcSfTep"}, {"key": "dlfSf"}],
+        "maxValues": {"ktcSfTep": 9999, "dlfSf": 9999},
+        "sleeper": {"positions": {}},
+    }
+
+
+def _contribution(payload, player_name, source_key):
+    """The per-source transparency block stamped for one player."""
+    for row in payload.get("playersArray") or []:
+        if row.get("displayName") == player_name:
+            return (row.get("sourceRankMeta") or {}).get(source_key) or {}
+    raise AssertionError(f"{player_name} not found in payload")
+
+
+def _build(monkeypatch, **kwargs):
+    return data_contract.build_api_data_contract(_raw(), **kwargs)
+
+
+# ── 1. It is actually called ─────────────────────────────────────────
+
+
+def test_convert_te_value_is_reached_by_the_live_blend(monkeypatch):
+    """The §6.15 guard. Everything else in this file passes against a
+    pipeline that never imports the module.
+
+    A spy rather than an output assertion: "the number moved" is
+    satisfiable by the flat multiplier, by a coincidence, or by any
+    future replacement. "this function ran, with these bases" is not.
+    """
+    calls: list[tuple] = []
+    real = te_premium.convert_te_value
+
+    def spy(value, *, from_basis, to_basis):
+        calls.append((value, from_basis, to_basis))
+        return real(value, from_basis=from_basis, to_basis=to_basis)
+
+    monkeypatch.setattr(te_premium, "convert_te_value", spy)
+    _build(monkeypatch)
+
+    assert calls, "convert_te_value was never called — the module is unwired again"
+    # Excluding the one warm-up call the resolver makes before
+    # committing the hot path.
+    real_calls = [c for c in calls if c[0] != 1000.0]
+    assert real_calls, "only the warm-up call fired; no TE row reached the conversion"
+    for _value, from_basis, to_basis in calls:
+        assert from_basis == "base"
+        assert to_basis == "tepp"
+
+
+def test_the_target_basis_is_the_board_anchor_basis():
+    """``ktcSfTep`` is KTC's TE++ (level 2) board and is the blend's
+    anchor. Converting onto any other basis would align every source to
+    a board nothing here publishes."""
+    assert data_contract._BOARD_TE_BASIS == "tepp"
+    assert data_contract._TE_SOURCE_DEFAULT_BASIS == "base"
+    assert data_contract._BOARD_TE_BASIS in te_premium.TE_BASES
+
+
+# ── 2. It does the right thing ───────────────────────────────────────
+
+
+def test_a_te_is_lifted_and_a_wide_receiver_is_not(monkeypatch):
+    payload = _build(monkeypatch)
+    te = _contribution(payload, _TE_NAME, "dlfSf")
+    wr = _contribution(payload, _WR_NAME, "dlfSf")
+    assert te.get("tepBoostApplied") is True
+    assert wr.get("tepBoostApplied") is not True
+    assert "tepMultiplier" not in wr
+
+
+def test_the_uplift_is_the_measured_curve_not_the_flat_constant(monkeypatch):
+    """The whole point of the change, stated as a number.
+
+    1.15 is below KTC's smallest observed uplift, so a correct
+    conversion is strictly greater than it at every value on the board.
+    """
+    payload = _build(monkeypatch)
+    te = _contribution(payload, _TE_NAME, "dlfSf")
+    assert te["tepBasisFrom"] == "base"
+    assert te["tepBasisTo"] == "tepp"
+    uplift = te["tepMultiplier"]
+    assert uplift > data_contract._TE_BLANKET_NON_NATIVE_MULTIPLIER
+    curve_floor = te_premium.load_tep_curve()[2]
+    # The stamp is rounded to 4dp, so allow half a unit in the last
+    # place rather than exact-comparing a rounded number to a raw one.
+    assert uplift >= curve_floor - 5e-5
+
+
+def test_the_market_anchor_is_still_exempt(monkeypatch):
+    """The double-count guard, restated against the wired path.
+    ``ktcSfTep`` already IS the TE++ board; lifting it would apply the
+    premium twice."""
+    payload = _build(monkeypatch)
+    te = _contribution(payload, _TE_NAME, "ktcSfTep")
+    assert te.get("tepBoostApplied") is not True
+    assert "tepBasisTo" not in te
+
+
+def test_the_conversion_cannot_compound(monkeypatch):
+    """Idempotence is the structural half of the double-count guard —
+    it holds by construction rather than by discipline, because the API
+    takes two bases and a second call sees ``from == to``."""
+    once = te_premium.convert_te_value(4000.0, from_basis="base", to_basis="tepp")
+    twice = te_premium.convert_te_value(once, from_basis="tepp", to_basis="tepp")
+    assert twice == once
+
+
+# ── 3. Both paths of the flag actually run ───────────────────────────
+
+
+def test_flag_off_restores_the_flat_multiplier(monkeypatch):
+    """The rollback path, exercised rather than assumed.
+
+    A flag whose "off" branch is never run is not a rollback — it is an
+    untested code path that happens to be reachable from an env var.
+    """
+    monkeypatch.setenv("RISKIT_FEATURE_TE_BASIS_CONVERSION", "0")
+    feature_flags.reload()
+    payload = _build(monkeypatch)
+    te = _contribution(payload, _TE_NAME, "dlfSf")
+    assert te.get("tepBoostApplied") is True
+    assert te["tepMultiplier"] == pytest.approx(
+        data_contract._TE_BLANKET_NON_NATIVE_MULTIPLIER, rel=1e-6
+    )
+    assert "tepBasisTo" not in te
+
+
+def test_an_explicit_operator_slider_wins_over_the_curve(monkeypatch):
+    """A number the operator typed on /settings is a decision, not a
+    measurement waiting to be overruled."""
+    payload = _build(monkeypatch, tep_multiplier=1.3)
+    te = _contribution(payload, _TE_NAME, "dlfSf")
+    assert te["tepMultiplier"] == pytest.approx(1.3, rel=1e-6)
+    assert "tepBasisTo" not in te
+
+
+def test_a_broken_curve_degrades_to_the_flat_multiplier(monkeypatch):
+    """A missing or unimportable module must cost the TE correction, not
+    the whole board. The fallback logs at WARNING because a silent one
+    is indistinguishable from the feature working."""
+
+    def boom(*_a, **_k):
+        raise RuntimeError("curve unavailable")
+
+    monkeypatch.setattr(te_premium, "convert_te_value", boom)
+    payload = _build(monkeypatch)
+    te = _contribution(payload, _TE_NAME, "dlfSf")
+    assert te["tepMultiplier"] == pytest.approx(
+        data_contract._TE_BLANKET_NON_NATIVE_MULTIPLIER, rel=1e-6
+    )
+
+
+# ── 4. Axis B stays out of the shared board ──────────────────────────
+
+
+def test_league_demand_is_not_consulted_by_the_blend():
+    """The scoring-profile/leagueKey split, enforced on the source.
+
+    ``measure_te_demand`` answers a LEAGUE question, and this board is
+    shared across every league on one scoring profile. The live registry
+    proves the two disagree: dynasty_main (2 TE starters) wants ``tepp``
+    and dynasty_new (1) wants ``base``, on the same profile. If the
+    blend ever called it, one league's roster shape would reprice the
+    other's board.
+    """
+    import inspect
+
+    # Strip comments and docstring prose before matching. The first draft
+    # of this test failed on the words "roster_positions" inside a
+    # COMMENT explaining why the blend does not read them — a matcher
+    # that succeeds on the documentation rather than the code, which is
+    # ORCHESTRATION.md §2b's named trap almost verbatim.
+    raw = inspect.getsource(data_contract._compute_unified_rankings)
+    code_lines = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        code_lines.append(line.split("  #", 1)[0])
+    src = "\n".join(code_lines)
+
+    assert "measure_te_demand" not in src
+    assert "roster_positions" not in src
+    # And the prose really did contain them, so the strip above is doing
+    # work rather than passing on an empty haystack.
+    assert "roster_positions" in raw
+
+
+def test_the_two_registry_leagues_really_do_want_different_bases():
+    """The premise of the test above, measured rather than asserted.
+
+    If this ever fails — both leagues landing on one basis — the
+    constraint above is no longer load-bearing and the decision to keep
+    Axis B out of the blend should be revisited on purpose rather than
+    inherited.
+    """
+    import json
+    from pathlib import Path
+
+    registry = json.loads(
+        (Path(__file__).resolve().parents[2] / "config" / "leagues" / "registry.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    by_profile: dict[str, set[str]] = {}
+    for entry in registry.get("leagues") or []:
+        if not entry.get("active"):
+            continue
+        demand = te_premium.measure_te_demand(entry.get("rosterSettings"))
+        by_profile.setdefault(str(entry.get("scoringProfile")), set()).add(demand.target_basis)
+
+    assert any(
+        len(bases) > 1 for bases in by_profile.values()
+    ), f"no scoring profile spans two TE bases any more: {by_profile}"

--- a/tests/api/test_te_basis_conversion.py
+++ b/tests/api/test_te_basis_conversion.py
@@ -69,9 +69,7 @@ def _raw() -> dict:
       that scaled every position would look exactly like a working TE
       premium against a TE-only fixture.
     """
-    players = {
-        f"Filler {i:02d}": _player(9000 - i * 60, "WR") for i in range(40)
-    }
+    players = {f"Filler {i:02d}": _player(9000 - i * 60, "WR") for i in range(40)}
     players[_TE_NAME] = _player(5000, "TE")
     players[_WR_NAME] = _player(4940, "WR")
     return {

--- a/tests/league_intel/test_te_premium_invariants.py
+++ b/tests/league_intel/test_te_premium_invariants.py
@@ -59,8 +59,35 @@ class TestMarketAnchorExemption:
 
         # Pinned so a change is a deliberate, reviewed act — ADR-009
         # explains why these are NOT the league's own TE premium.
+        #
+        # SCOPE NARROWED 2026-07-27. ``_TE_BLANKET_NON_NATIVE_MULTIPLIER``
+        # is no longer the live default path: non-TEP sources now go
+        # through the measured base → TE++ conversion, and this constant
+        # is the fallback plus the operator slider's default. It stays
+        # pinned because both of those still matter, but a reader must
+        # not take this test as evidence that 1.15 is what the board
+        # applies. ``tests/api/test_te_basis_conversion.py`` covers what
+        # actually runs.
         assert _TE_BLANKET_NON_NATIVE_MULTIPLIER == 1.15
         assert _TE_BLANKET_NATIVE_MULTIPLIER == 1.10
+
+    def test_the_conversion_target_is_the_anchor_basis_so_ktc_cannot_move(self):
+        """The double-count guard restated for the wired path.
+
+        The old argument was "KTC is in the exemption set". That still
+        holds, but there is now a second, structural reason: the target
+        basis IS ``tepp``, ``ktcSfTep`` is already on ``tepp``, and
+        ``convert_te_value`` returns the value untouched when
+        ``from == to``. Even if the exemption were deleted, the anchor
+        could not be lifted — which is the property that makes this
+        design safe rather than merely careful.
+        """
+        from src.api.data_contract import _BOARD_TE_BASIS
+        from src.league_intel.te_premium import convert_te_value
+
+        assert _BOARD_TE_BASIS == "tepp"
+        for v in (500.0, 4000.0, 9999.0):
+            assert convert_te_value(v, from_basis=_BOARD_TE_BASIS, to_basis=_BOARD_TE_BASIS) == v
 
 
 class TestLeagueHasNoTeScoringPremium:

--- a/tests/nfl_data/test_actuals_store.py
+++ b/tests/nfl_data/test_actuals_store.py
@@ -336,7 +336,10 @@ def test_reruns_replace_a_week_rather_than_appending(tmp_path):
     )
 
     lines = (
-        actuals_store.season_path(2025, actuals_dir=out).read_text(encoding="utf-8").strip().split("\n")
+        actuals_store.season_path(2025, actuals_dir=out)
+        .read_text(encoding="utf-8")
+        .strip()
+        .split("\n")
     )
     assert len(lines) == 1, "a revised week must replace, not accumulate"
     entry = json.loads(lines[0])
@@ -385,7 +388,9 @@ def test_regular_season_and_playoffs_are_separate_lines(tmp_path):
     )
     entries = actuals_store.load_season(2025, actuals_dir=out)
     assert [(e["week"], e["seasonType"]) for e in entries] == [(1, "REG"), (19, "POST")]
-    assert [e["week"] for e in actuals_store.load_season(2025, actuals_dir=out, season_types=["REG"])] == [1]
+    assert [
+        e["week"] for e in actuals_store.load_season(2025, actuals_dir=out, season_types=["REG"])
+    ] == [1]
 
 
 def test_duplicate_rows_from_the_two_fetchers_collapse(tmp_path):

--- a/tests/nfl_data/test_actuals_store.py
+++ b/tests/nfl_data/test_actuals_store.py
@@ -1,0 +1,562 @@
+"""Tests for ``src.nfl_data.actuals_store``.
+
+The guards here are written against §6.15 ("a guard that cannot fire").
+Two of them exist specifically because the *silent* failure mode is the
+realistic one:
+
+* **The column-alias test is the load-bearing one.**  nflverse renamed
+  six columns in the 2025 unified release.  Reading a renamed column
+  returns ``None`` and the mapper produces a fully-formed row of zeros —
+  no exception, no log line, a plausible-looking file on disk.  So the
+  test asserts a NON-ZERO value came off the new spelling, which is the
+  only assertion a rename can fail.  Asserting "the field exists" or
+  "the row parsed" would pass against exactly the defect it names.
+* **The idempotency test writes the same week twice with different
+  numbers** and asserts one line survives carrying the SECOND set.  A
+  test that wrote identical payloads twice would pass whether the store
+  deduped or blindly appended two byte-identical lines.
+
+Every fixture row uses the unified 2025 spellings measured live on
+2026-07-27, with a second fixture in the retired pre-2025 spellings, so
+the alias table is exercised from both sides.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.api import feature_flags
+from src.nfl_data import actuals_store
+
+
+@pytest.fixture(autouse=True)
+def _flag_on(monkeypatch):
+    monkeypatch.setenv("RISKIT_FEATURE_NFL_DATA_INGEST", "1")
+    feature_flags.reload()
+    yield
+    feature_flags.reload()
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+#
+# Column names and values copied from the real 2025 unified release
+# (stats_player/stats_player_week_2025.csv), week 1.
+
+
+def _unified_qb_row() -> dict:
+    return {
+        "player_id": "00-0026158",
+        "player_name": "J.Flacco",
+        "player_display_name": "Joe Flacco",
+        "position": "QB",
+        "position_group": "QB",
+        "team": "CLE",
+        "opponent_team": "CIN",
+        "season": 2025,
+        "week": 1,
+        "season_type": "REG",
+        "completions": 31,
+        "attempts": 45,
+        "passing_yards": 290,
+        "passing_tds": 1,
+        # RENAMED — old spelling was ``interceptions``.
+        "passing_interceptions": 2,
+        # RENAMED — old spelling was ``sacks``.
+        "sacks_suffered": 3,
+        "carries": 2,
+        "rushing_yards": 6,
+        "rushing_tds": 0,
+        "targets": 0,
+        "receptions": 0,
+        "receiving_yards": 0,
+        "receiving_tds": 0,
+        # RENAMED — old spelling was ``fumbles_lost``.
+        "fumbles_lost_total": 1,
+    }
+
+
+def _unified_idp_row() -> dict:
+    return {
+        "player_id": "00-0032899",
+        "player_name": "D.Slay",
+        "player_display_name": "Darius Slay",
+        "position": "CB",
+        "team": "PIT",
+        "season": 2025,
+        "week": 1,
+        "season_type": "REG",
+        "def_tackles_solo": 5,
+        # ``def_tackles`` was REMOVED; combined = solo + with_assist.
+        "def_tackles_with_assist": 2,
+        "def_tackle_assists": 1,
+        "def_tackles_for_loss": 1,
+        "def_tackles_for_loss_yards": 3,
+        "def_sacks": 0,
+        "def_sack_yards": 0,
+        "def_qb_hits": 1,
+        "def_pass_defended": 2,
+        "def_interceptions": 1,
+        "def_interception_yards": 14,
+        "def_fumbles_forced": 1,
+        "fumble_recovery_own": 0,
+        "fumble_recovery_opp": 1,
+        "fumble_recovery_yards_own": 0,
+        "fumble_recovery_yards_opp": 7,
+        "def_tds": 0,
+        # RENAMED — old spelling was ``def_safety``.
+        "def_safeties": 1,
+    }
+
+
+def _legacy_qb_row() -> dict:
+    """The retired pre-2025 spellings, so the alias table is exercised
+    from both directions — a backfill over 2023/2024 still goes through
+    this same mapper."""
+    return {
+        "player_id": "00-0011111",
+        "player_name": "L.Egacy",
+        "position": "QB",
+        "recent_team": "SEA",
+        "season": 2024,
+        "week": 4,
+        "season_type": "REG",
+        "completions": 20,
+        "attempts": 30,
+        "passing_yards": 240,
+        "passing_tds": 2,
+        "interceptions": 1,
+        "sacks": 4,
+        "carries": 1,
+        "rushing_yards": 3,
+        "rushing_tds": 0,
+        "targets": 0,
+        "receptions": 0,
+        "receiving_yards": 0,
+        "receiving_tds": 0,
+        "fumbles_lost": 2,
+    }
+
+
+def _legacy_idp_row() -> dict:
+    return {
+        "player_id": "00-0022222",
+        "player_name": "O.Ldbacker",
+        "position": "LB",
+        "recent_team": "SEA",
+        "season": 2024,
+        "week": 4,
+        "season_type": "REG",
+        # The published column, still present pre-2025.
+        "def_tackles": 9,
+        "def_tackles_solo": 6,
+        "def_tackles_with_assist": 3,
+        "def_tackle_assists": 3,
+        "def_sacks": 1.5,
+        "def_safety": 1,
+    }
+
+
+def _provider(rows):
+    def _fn(_years):
+        return list(rows)
+
+    return _fn
+
+
+# ── The rename guard ─────────────────────────────────────────────────
+
+
+def test_renamed_offensive_columns_carry_nonzero_values():
+    """The 2025 rename must not read as a zeroed stat line.
+
+    Each assertion pins a NON-ZERO value onto a field whose source
+    column was renamed.  Drop the new spelling from the alias table and
+    every one of these goes to 0.0 — the mapper still returns a
+    well-formed WeeklyStatRow, which is precisely why "did it parse?"
+    is not a usable assertion here.
+    """
+    row = actuals_store.normalize_offensive_row(_unified_qb_row())
+    assert row is not None
+    assert row.recent_team == "CLE", "team (was recent_team)"
+    assert row.interceptions == 2.0, "passing_interceptions (was interceptions)"
+    assert row.sacks == 3.0, "sacks_suffered (was sacks)"
+    assert row.fumbles_lost == 1.0, "fumbles_lost_total (was fumbles_lost)"
+
+
+def test_renamed_defensive_columns_carry_nonzero_values():
+    row = actuals_store.normalize_defensive_row(_unified_idp_row())
+    assert row is not None
+    assert row.team == "PIT"
+    assert row.safeties == 1.0, "def_safeties (was def_safety)"
+    assert row.passes_defended == 2.0
+    assert row.fumble_recovery_opp == 1.0, "fumble_recovery_opp is not def_-prefixed"
+    assert row.fumble_recovery_yards_opp == 7.0
+
+
+def test_legacy_column_spellings_still_map():
+    off = actuals_store.normalize_offensive_row(_legacy_qb_row())
+    assert off is not None
+    assert off.recent_team == "SEA"
+    assert off.interceptions == 1.0
+    assert off.sacks == 4.0
+    assert off.fumbles_lost == 2.0
+
+    dfn = actuals_store.normalize_defensive_row(_legacy_idp_row())
+    assert dfn is not None
+    assert dfn.safeties == 1.0
+    assert dfn.sacks == 1.5
+
+
+# ── The derived-tackles identity ─────────────────────────────────────
+
+
+def test_tackle_fields_are_gamebook_values_not_raw_columns():
+    """Two measurements, both against the retired 2024 defensive release:
+
+    * ``def_tackles == def_tackles_solo + def_tackles_with_assist`` on
+      9,994 of 9,994 rows — so ``def_tackles`` is the gamebook SOLO
+      total, not combined.
+    * ``def_tackles_solo`` excludes ``def_tackles_with_assist``: 342
+      rows have solo 0 with with_assist > 0.
+
+    The fixture is solo 5 / with_assist 2 / assists 1, so every wrong
+    reading gives a different number and this assertion separates them:
+    raw solo would be 5, ``def_tackles``-as-combined would be 7, the
+    correct combined is 8.
+    """
+    row = actuals_store.normalize_defensive_row(_unified_idp_row())
+    assert row is not None
+    assert row.tackles_solo == 7.0, "gamebook solo = 5 unassisted + 2 with-assist"
+    assert row.tackles_assist == 1.0
+    assert row.tackles_combined == 8.0, "solo 7 + assists 1"
+
+
+def test_published_def_tackles_is_used_as_the_solo_total():
+    """Pre-2025 files publish ``def_tackles``; it IS gamebook solo, so
+    it is read as solo and combined still adds assists on top."""
+    row = actuals_store.normalize_defensive_row(_legacy_idp_row())
+    assert row is not None
+    assert row.tackles_solo == 9.0
+    assert row.tackles_assist == 3.0
+    assert row.tackles_combined == 12.0
+
+
+# ── Production gating: zeroed def_* blocks must not create IDP rows ──
+
+
+def test_offensive_row_with_zeroed_defensive_block_is_not_a_defender():
+    """The unified release gives every offensive player a full set of
+    zeroed ``def_*`` columns.  Persisting those would triple the file
+    and make every QB look like a rostered IDP with a blank stat line."""
+    qb = _unified_qb_row()
+    qb.update({k: 0 for k in ("def_tackles_solo", "def_sacks", "def_pass_defended")})
+    assert actuals_store.normalize_defensive_row(qb) is None
+
+
+def test_row_without_a_player_id_is_dropped():
+    row = _unified_qb_row()
+    row["player_id"] = ""
+    assert actuals_store.normalize_offensive_row(row) is None
+
+
+def test_row_with_no_production_at_all_is_dropped():
+    row = {"player_id": "00-0099999", "season": 2025, "week": 1, "position": "WR"}
+    assert actuals_store.normalize_offensive_row(row) is None
+    assert actuals_store.normalize_defensive_row(row) is None
+
+
+# ── Persistence ──────────────────────────────────────────────────────
+
+
+def test_persist_writes_one_line_per_week_with_both_blocks(tmp_path):
+    out = tmp_path / "actuals"
+    rows = [_unified_qb_row(), _unified_idp_row()]
+    result = actuals_store.persist_weekly_actuals(
+        [2025],
+        actuals_dir=out,
+        cache_dir=tmp_path / "cache",
+        _offensive_provider=_provider(rows),
+        _defensive_provider=_provider(rows),
+    )
+
+    assert result.weeks_written == 1
+    assert result.player_weeks == 2
+    assert result.offense_records == 1
+    assert result.defense_records == 1
+
+    path = actuals_store.season_path(2025, actuals_dir=out)
+    lines = path.read_text(encoding="utf-8").strip().split("\n")
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["season"] == 2025
+    assert entry["week"] == 1
+    assert entry["seasonType"] == "REG"
+    assert entry["playerCount"] == 2
+    assert entry["schemaVersion"] == actuals_store.ACTUALS_SCHEMA_VERSION
+
+    qb = entry["players"]["00-0026158"]
+    assert qb["position"] == "QB"
+    assert qb["defense"] is None, "a QB with a zeroed def_ block is not a defender"
+    assert qb["offense"]["passing_yards"] == 290.0
+    assert qb["offense"]["interceptions"] == 2.0
+    # Not joined — see the module docstring.  None means "not fetched",
+    # which is a different claim from 0.
+    assert qb["offense"]["snap_count"] is None
+
+    idp = entry["players"]["00-0032899"]
+    assert idp["offense"] is None
+    assert idp["defense"]["tackles_combined"] == 8.0
+
+
+def test_reruns_replace_a_week_rather_than_appending(tmp_path):
+    """nflverse revises box scores for days after a game.  Two copies of
+    week 1 would make 'which is current?' unanswerable.
+
+    The second write carries DIFFERENT numbers, so a store that appended
+    (or that kept the first copy) fails here.  Identical payloads would
+    pass either way.
+    """
+    out = tmp_path / "actuals"
+    kwargs = {"actuals_dir": out, "cache_dir": tmp_path / "cache", "refresh": True}
+
+    first = _unified_qb_row()
+    actuals_store.persist_weekly_actuals(
+        [2025], _offensive_provider=_provider([first]), _defensive_provider=_provider([]), **kwargs
+    )
+
+    revised = _unified_qb_row()
+    revised["passing_yards"] = 311
+    actuals_store.persist_weekly_actuals(
+        [2025],
+        _offensive_provider=_provider([revised]),
+        _defensive_provider=_provider([]),
+        **kwargs,
+    )
+
+    lines = (
+        actuals_store.season_path(2025, actuals_dir=out).read_text(encoding="utf-8").strip().split("\n")
+    )
+    assert len(lines) == 1, "a revised week must replace, not accumulate"
+    entry = json.loads(lines[0])
+    assert entry["players"]["00-0026158"]["offense"]["passing_yards"] == 311.0
+
+
+def test_a_partial_fetch_leaves_other_weeks_untouched(tmp_path):
+    out = tmp_path / "actuals"
+    kwargs = {"actuals_dir": out, "cache_dir": tmp_path / "cache", "refresh": True}
+
+    w1 = _unified_qb_row()
+    w2 = _unified_qb_row()
+    w2["week"] = 2
+    actuals_store.persist_weekly_actuals(
+        [2025],
+        _offensive_provider=_provider([w1, w2]),
+        _defensive_provider=_provider([]),
+        **kwargs,
+    )
+
+    # A re-run covering only week 2 must not truncate week 1.
+    w2b = _unified_qb_row()
+    w2b["week"] = 2
+    w2b["passing_yards"] = 400
+    actuals_store.persist_weekly_actuals(
+        [2025], _offensive_provider=_provider([w2b]), _defensive_provider=_provider([]), **kwargs
+    )
+
+    entries = actuals_store.load_season(2025, actuals_dir=out)
+    assert [e["week"] for e in entries] == [1, 2]
+    assert entries[0]["players"]["00-0026158"]["offense"]["passing_yards"] == 290.0
+    assert entries[1]["players"]["00-0026158"]["offense"]["passing_yards"] == 400.0
+
+
+def test_regular_season_and_playoffs_are_separate_lines(tmp_path):
+    out = tmp_path / "actuals"
+    reg = _unified_qb_row()
+    post = _unified_qb_row()
+    post.update({"week": 19, "season_type": "POST"})
+    actuals_store.persist_weekly_actuals(
+        [2025],
+        actuals_dir=out,
+        cache_dir=tmp_path / "cache",
+        _offensive_provider=_provider([reg, post]),
+        _defensive_provider=_provider([]),
+    )
+    entries = actuals_store.load_season(2025, actuals_dir=out)
+    assert [(e["week"], e["seasonType"]) for e in entries] == [(1, "REG"), (19, "POST")]
+    assert [e["week"] for e in actuals_store.load_season(2025, actuals_dir=out, season_types=["REG"])] == [1]
+
+
+def test_duplicate_rows_from_the_two_fetchers_collapse(tmp_path):
+    """After #589 both fetchers request the same unified CSV, so the
+    same physical row arrives twice.  It must merge, not double."""
+    out = tmp_path / "actuals"
+    rows = [_unified_qb_row(), _unified_idp_row()]
+    result = actuals_store.persist_weekly_actuals(
+        [2025],
+        actuals_dir=out,
+        cache_dir=tmp_path / "cache",
+        _offensive_provider=_provider(rows),
+        _defensive_provider=_provider(rows),
+    )
+    assert result.offensive_rows_fetched == 2
+    assert result.defensive_rows_fetched == 2
+    assert result.player_weeks == 2, "two distinct players, not four records"
+
+
+def test_without_refresh_a_rerun_is_served_the_ttl_cache(tmp_path):
+    """The counterpart to the two tests above, and the reason ``refresh``
+    exists at all.
+
+    Inside the 24-hour TTL a re-run never reaches the provider, so a
+    revised box score cannot land.  Pinning it here means the flag has a
+    stated behaviour on both settings — an option whose "off" path is
+    untested is indistinguishable from one that does nothing.
+    """
+    out = tmp_path / "actuals"
+    kwargs = {"actuals_dir": out, "cache_dir": tmp_path / "cache"}
+    calls: list = []
+
+    def counting(rows):
+        def _fn(years):
+            calls.append(years)
+            return list(rows)
+
+        return _fn
+
+    actuals_store.persist_weekly_actuals(
+        [2025],
+        _offensive_provider=counting([_unified_qb_row()]),
+        _defensive_provider=counting([]),
+        **kwargs,
+    )
+    assert len(calls) == 2, "cold: both fetchers hit their provider"
+
+    revised = _unified_qb_row()
+    revised["passing_yards"] = 311
+    actuals_store.persist_weekly_actuals(
+        [2025],
+        _offensive_provider=counting([revised]),
+        _defensive_provider=counting([]),
+        **kwargs,
+    )
+    assert len(calls) == 2, "warm: the TTL cache short-circuits the provider"
+
+    entry = json.loads(
+        actuals_store.season_path(2025, actuals_dir=out).read_text(encoding="utf-8").strip()
+    )
+    assert entry["players"]["00-0026158"]["offense"]["passing_yards"] == 290.0
+
+
+def test_persist_with_no_rows_writes_no_file(tmp_path):
+    out = tmp_path / "actuals"
+    result = actuals_store.persist_weekly_actuals(
+        [2025],
+        actuals_dir=out,
+        cache_dir=tmp_path / "cache",
+        _offensive_provider=_provider([]),
+        _defensive_provider=_provider([]),
+    )
+    assert result.weeks_written == 0
+    assert not actuals_store.season_path(2025, actuals_dir=out).exists()
+
+
+def test_feature_flag_off_persists_nothing(monkeypatch, tmp_path):
+    monkeypatch.setenv("RISKIT_FEATURE_NFL_DATA_INGEST", "0")
+    feature_flags.reload()
+    out = tmp_path / "actuals"
+    calls = []
+
+    def provider(years):
+        calls.append(years)
+        return [_unified_qb_row()]
+
+    result = actuals_store.persist_weekly_actuals(
+        [2025],
+        actuals_dir=out,
+        cache_dir=tmp_path / "cache",
+        _offensive_provider=provider,
+        _defensive_provider=provider,
+    )
+    assert calls == []
+    assert result.weeks_written == 0
+
+
+# ── Read paths ───────────────────────────────────────────────────────
+
+
+def test_load_player_weeks_returns_a_flat_time_series(tmp_path):
+    out = tmp_path / "actuals"
+    for season, weeks in ((2024, (3, 4)), (2025, (1,))):
+        rows = []
+        for wk in weeks:
+            r = _unified_qb_row()
+            r.update({"season": season, "week": wk, "passing_yards": 100 * wk})
+            rows.append(r)
+        actuals_store.persist_weekly_actuals(
+            [season],
+            actuals_dir=out,
+            cache_dir=tmp_path / "cache",
+            _offensive_provider=_provider(rows),
+            _defensive_provider=_provider([]),
+        )
+
+    series = actuals_store.load_player_weeks("00-0026158", actuals_dir=out)
+    assert [(s["season"], s["week"]) for s in series] == [(2024, 3), (2024, 4), (2025, 1)]
+    assert [s["offense"]["passing_yards"] for s in series] == [300.0, 400.0, 100.0]
+    assert all(s["capturedAt"] for s in series)
+
+
+def test_load_player_weeks_unknown_player_is_empty_not_an_error(tmp_path):
+    assert actuals_store.load_player_weeks("00-0000000", actuals_dir=tmp_path / "nope") == []
+    assert actuals_store.load_player_weeks("", actuals_dir=tmp_path) == []
+
+
+def test_coverage_reports_what_is_on_disk(tmp_path):
+    out = tmp_path / "actuals"
+    empty = actuals_store.coverage(actuals_dir=out)
+    assert empty["dirExists"] is False
+    assert empty["seasons"] == {}
+
+    actuals_store.persist_weekly_actuals(
+        [2025],
+        actuals_dir=out,
+        cache_dir=tmp_path / "cache",
+        _offensive_provider=_provider([_unified_qb_row()]),
+        _defensive_provider=_provider([_unified_idp_row()]),
+    )
+    cov = actuals_store.coverage(actuals_dir=out)
+    assert cov["dirExists"] is True
+    assert cov["seasons"]["2025"]["weeks"] == [1]
+    assert cov["seasons"]["2025"]["playerWeeks"] == 2
+    assert cov["seasons"]["2025"]["seasonTypes"] == ["REG"]
+    assert cov["seasons"]["2025"]["capturedAt"]
+
+
+def test_a_truncated_tail_line_does_not_wedge_the_season(tmp_path):
+    out = tmp_path / "actuals"
+    actuals_store.persist_weekly_actuals(
+        [2025],
+        actuals_dir=out,
+        cache_dir=tmp_path / "cache",
+        _offensive_provider=_provider([_unified_qb_row()]),
+        _defensive_provider=_provider([]),
+    )
+    path = actuals_store.season_path(2025, actuals_dir=out)
+    with path.open("a", encoding="utf-8") as f:
+        f.write('{"season":2025,"week":2,"play')  # killed mid-write
+    entries = actuals_store.load_season(2025, actuals_dir=out)
+    assert [e["week"] for e in entries] == [1]
+
+
+# ── The home question ────────────────────────────────────────────────
+
+
+def test_actuals_dir_is_not_the_ttl_cache():
+    """``data/nfl_data_cache/`` evicts on a 24h timer, so nothing
+    accumulates there.  The two must never converge on one path."""
+    from src.nfl_data import cache as ttl_cache
+
+    assert actuals_store.default_actuals_dir() != ttl_cache._default_cache_dir()
+    assert actuals_store.default_actuals_dir().parts[-2:] == ("nfl_data", "actuals")

--- a/tests/nfl_data/test_realized_points.py
+++ b/tests/nfl_data/test_realized_points.py
@@ -172,3 +172,160 @@ def test_rounding_stable_across_dict_serialization():
     d = out.to_dict()
     # Reproducible rounding, not something like 13.320000000000002.
     assert d["fantasyPoints"] == 13.32
+
+
+# ── IDP scoring ───────────────────────────────────────────────────────
+#
+# This path had no coverage at all before 2026-07-27, which is how it
+# came to be scoring three columns that the current nflverse release
+# does not have.  Every assertion below pins a NON-ZERO point total onto
+# a column whose name changed or vanished — the only shape of assertion
+# a silent-zero defect can fail.  "the call returned a RealizedPoints"
+# passes against the bug.
+
+
+def _idp_scoring():
+    """A representative IDP scoring block, tackle-heavy the way real
+    IDP leagues are."""
+    return {
+        "idp_tkl_solo": 1.0,
+        "idp_tkl_ast": 0.5,
+        "idp_tkl": 0.0,
+        "idp_sack": 4.0,
+        "idp_int": 6.0,
+        "idp_pd": 1.5,
+        "idp_ff": 4.0,
+        "idp_fum_rec": 3.0,
+        "idp_safe": 8.0,
+        "idp_tkl_loss": 2.0,
+    }
+
+
+def _unified_idp_row():
+    """2025 unified-release spellings, measured live 2026-07-27."""
+    return {
+        "player_id": "00-0032899",
+        "position": "LB",
+        "season": 2025,
+        "week": 1,
+        # gamebook: 5 + 2 = 7 solo, 1 assist, 8 combined
+        "def_tackles_solo": 5,
+        "def_tackles_with_assist": 2,
+        "def_tackle_assists": 1,
+        "def_sacks": 1.0,
+        "def_interceptions": 1,
+        "def_pass_defended": 2,
+        "def_fumbles_forced": 1,
+        "def_fumble_recovery_own": 1,
+        "def_tackles_for_loss": 1,
+        # RENAMED from def_safety.
+        "def_safeties": 1,
+    }
+
+
+def _legacy_idp_row():
+    """Retired pre-2025 spellings — a backfill must still score."""
+    return {
+        "player_id": "00-0022222",
+        "position": "LB",
+        "season": 2024,
+        "week": 4,
+        # def_tackles IS the gamebook solo total.
+        "def_tackles": 7,
+        "def_tackles_solo": 5,
+        "def_tackles_with_assist": 2,
+        "def_tackle_assists": 1,
+        "def_safety": 1,
+    }
+
+
+def test_idp_tackles_use_the_gamebook_solo_total():
+    """``def_tackles_solo`` alone under-reports: it excludes
+    ``def_tackles_with_assist``.  Gamebook solo is 5 + 2 = 7.
+
+    Reading the raw column would score 5.0 here, so the assertion
+    distinguishes the two.
+    """
+    out = rp.compute_weekly_points(
+        _unified_idp_row(), {"idp_tkl_solo": 1.0}, position="LB"
+    )
+    assert out is not None
+    assert out.fantasy_points == 7.0
+
+
+def test_idp_combined_tackles_are_scored_at_all():
+    """``idp_tkl`` read ``def_tackles``, which the unified release
+    removed — the key silently scored zero.  Combined is solo (7) plus
+    assists (1) = 8, and no nflverse column carries it."""
+    out = rp.compute_weekly_points(
+        _unified_idp_row(), {"idp_tkl": 1.0}, position="LB"
+    )
+    assert out is not None
+    assert out.fantasy_points == 8.0
+
+
+def test_idp_safety_survives_the_def_safeties_rename():
+    out = rp.compute_weekly_points(
+        _unified_idp_row(), {"idp_safe": 8.0}, position="LB"
+    )
+    assert out is not None
+    assert out.fantasy_points == 8.0
+
+
+def test_idp_tackle_thresholds_fire_on_combined_tackles():
+    """The 5+/10+ bonuses read ``def_tackles`` too, so they stopped
+    firing entirely.  Combined is 8 here: 5+ fires, 10+ does not."""
+    out = rp.compute_weekly_points(
+        _unified_idp_row(),
+        {"idp_tkl_5p": 2.0, "idp_tkl_10p": 5.0},
+        position="LB",
+    )
+    assert out is not None
+    assert out.fantasy_points == 2.0
+
+
+def test_idp_full_line_stacks_every_category():
+    """Sleeper stacks: one play can credit sack + TFL + solo tackle.
+
+    7 solo x 1.0 + 1 ast x 0.5 + 1 sack x 4 + 1 int x 6 + 2 pd x 1.5
+    + 1 ff x 4 + 1 fr x 3 + 1 safety x 8 + 1 tfl x 2 = 37.5
+    """
+    out = rp.compute_weekly_points(_unified_idp_row(), _idp_scoring(), position="LB")
+    assert out is not None
+    assert out.fantasy_points == 37.5
+    labels = {lab for (lab, _s, _p) in out.breakdown}
+    assert {"Solo Tkl", "Ast Tkl", "Sack", "INT", "PD", "FF", "FR", "Safety", "TFL"} <= labels
+
+
+def test_legacy_column_spellings_score_identically():
+    """The same gamebook line expressed in pre-2025 columns."""
+    out = rp.compute_weekly_points(
+        _legacy_idp_row(),
+        {"idp_tkl_solo": 1.0, "idp_tkl_ast": 0.5, "idp_tkl": 1.0, "idp_safe": 8.0},
+        position="LB",
+    )
+    assert out is not None
+    # 7 solo + 0.5 ast + 8 combined + 8 safety = 23.5
+    assert out.fantasy_points == 23.5
+
+
+def test_offensive_position_never_picks_up_idp_keys():
+    """The gate that keeps a WR's zeroed def_ block out of the total.
+    Every unified row carries def_* columns for every player."""
+    row = {**_unified_idp_row(), "position": "WR"}
+    out = rp.compute_weekly_points(row, _idp_scoring(), position="WR")
+    assert out is not None
+    assert out.fantasy_points == 0.0
+
+
+def test_tackle_view_matches_the_actuals_store():
+    """Two modules derive the same three numbers from the same columns.
+    They must not drift apart — a durable log and the scorer disagreeing
+    about how many tackles a player made is unresolvable after the fact.
+    """
+    from src.nfl_data import actuals_store
+
+    row = _unified_idp_row()
+    assert rp._tackle_view(row) == actuals_store._tackle_view(row)
+    legacy = _legacy_idp_row()
+    assert rp._tackle_view(legacy) == actuals_store._tackle_view(legacy)

--- a/tests/nfl_data/test_realized_points.py
+++ b/tests/nfl_data/test_realized_points.py
@@ -246,9 +246,7 @@ def test_idp_tackles_use_the_gamebook_solo_total():
     Reading the raw column would score 5.0 here, so the assertion
     distinguishes the two.
     """
-    out = rp.compute_weekly_points(
-        _unified_idp_row(), {"idp_tkl_solo": 1.0}, position="LB"
-    )
+    out = rp.compute_weekly_points(_unified_idp_row(), {"idp_tkl_solo": 1.0}, position="LB")
     assert out is not None
     assert out.fantasy_points == 7.0
 
@@ -257,17 +255,13 @@ def test_idp_combined_tackles_are_scored_at_all():
     """``idp_tkl`` read ``def_tackles``, which the unified release
     removed — the key silently scored zero.  Combined is solo (7) plus
     assists (1) = 8, and no nflverse column carries it."""
-    out = rp.compute_weekly_points(
-        _unified_idp_row(), {"idp_tkl": 1.0}, position="LB"
-    )
+    out = rp.compute_weekly_points(_unified_idp_row(), {"idp_tkl": 1.0}, position="LB")
     assert out is not None
     assert out.fantasy_points == 8.0
 
 
 def test_idp_safety_survives_the_def_safeties_rename():
-    out = rp.compute_weekly_points(
-        _unified_idp_row(), {"idp_safe": 8.0}, position="LB"
-    )
+    out = rp.compute_weekly_points(_unified_idp_row(), {"idp_safe": 8.0}, position="LB")
     assert out is not None
     assert out.fantasy_points == 8.0
 


### PR DESCRIPTION
Four changes, in the order requested. Full suite **4534 passed**; the 2 remaining failures are the pre-existing data-coupled FantasyPros IDP curve tests, red on clean `main` too. Frontend: **1280 passed**.

---

## Tier 0 — persist player-week actuals (`c6539945`)

New `src/nfl_data/actuals_store.py` writes `fetch_weekly_stats` +
`fetch_weekly_defensive_stats` output to
`data/nfl_data/actuals/player_week_{season}.jsonl` — one line per
`(season, week, seasonType)` with players nested, mirroring
`src/api/source_history.py`. Idempotent: a re-run replaces a week rather than
appending; weeks absent from a fetch are left alone. Plus
`scripts/persist_nfl_actuals.py` with `--coverage` / `--refresh` and meaningful
exit codes.

Verified end to end against live nflverse: **22 weeks, 16,995 player-weeks
(5,652 offensive, 12,102 defensive)** for 2025.

### `data/nfl_data_cache/` is the wrong home, and is *not* vestigial

It is a live TTL cache — `src/nfl_data/cache.py` writes it and
`startup_validation.py` checks it. It was empty on inspection only because no
fetch had run in that container. But `get` returns `None` past 24h, `put`
overwrites the same hashed path, and corrupt entries are unlinked on read.
**Nothing accumulates there by design**, so a season's history can never be
reconstructed from it. The two now sit side by side and the actuals dir gets its
own startup writability check.

### Column renames the dataclasses predate

`WeeklyStatRow` / `WeeklyDefensiveStatRow` were written against the retired
`player_stats_{year}.csv`. The unified release #589 repointed at **also renamed
six columns** — verified live 2026-07-27:

| old | new |
|---|---|
| `recent_team` | `team` |
| `interceptions` | `passing_interceptions` |
| `sacks` | `sacks_suffered` |
| `fumbles_lost` | `fumbles_lost_total` |
| `def_safety` | `def_safeties` |
| `def_tackles` | *removed* |

Reading a renamed column yields zeros with no error, so the mapper takes
candidate lists per field and the tests assert **non-zero** values off the new
spellings — the only assertion shape a silent rename can fail. Both spellings
are accepted so a backfill over pre-2025 seasons uses one mapper. Proven by
reverting the alias table and observing four tests fail.

### The tackle columns mean something other than their names

Measured against the retired 2024 defensive release, not assumed:

- `def_tackles == def_tackles_solo + def_tackles_with_assist` on **9,994 of
  9,994** rows. So `def_tackles` is the gamebook **solo** total, not combined.
- `def_tackles_solo` **excludes** `def_tackles_with_assist`: 342 rows have solo 0
  with with_assist > 0, impossible if one contained the other.

Cross-checked on a real box score: Zack Baun (PHI) 2024 wk1 reads solo 9 /
with_assist 2 / assists 4 — gamebook 11 solo + 4 assists = his actual 15-tackle
line.

This broke `realized_points.py`'s IDP scoring, **which had no test coverage at
all**. Against the current release `idp_tkl` and both tackle-threshold bonuses
read a column that no longer exists (0 points all season), `idp_safe` read the
old safety spelling (0 points), and `idp_tkl_solo` under-reported every defender
who was assisted on a stop. Tackles now resolve through a shared `_tackle_view`
in both modules, pinned to each other by a test. Seven new IDP tests, all
observed failing against the pre-fix module.

### Deliberately not included

Snap counts stay `None` — `fetch_snap_counts` keys on PFR ids, and half-joining
it would put a column on disk reading "no snaps played" rather than "not
fetched". nflverse's own `fantasy_points_ppr` is not stored: this league's points
come from `realized_points.py` against Sleeper scoring, and a foreign total next
to the stats invites being read as ours.

`--refresh` exists because without it a re-run inside the 24h TTL is served the
previous pull, so a box-score revision published hours after a game stays
invisible. Both settings are pinned by tests.

---

## Tier 1a — cover `/api/valuation/league-adjusted` (`9bf08213`)

The endpoint is the only producer of a real `leagueAdjustedDynastyValue`. It
reprices every player on the rankings page and inside trade evaluation, and
nothing guarded it. **17 tests.**

Routing contract first — 400 `unknown_league`, 400 `inactive_league`, 503
`data_not_ready`, 404 `no_leagues_configured`, plus the `leagueKey` stamp. One
case worth naming: `main` and `side` share scoring profile `prof_a`, so
`/api/data` would serve `side` the shared rankings, but this endpoint must 503 —
its entire output derives from one league's rosters. The 200-not-503 degradation
on a missing roster snapshot is pinned too, deliberately asymmetric with
`/api/gameplan`.

Then the invariants the design rests on: factors are ratios not absolute values,
the same position always gets the same factor, picks never move but are still
ranked, ranks are dense and contiguous, and `latest_contract_data` is
deep-compared before and after because the re-rank multiplies `rankDerivedValue`
and doing that in place would reprice the live board for every league on the
process.

### The fixture is the load-bearing part

A no-op overlay and a completely broken adjustment model return byte-identical
responses: 200, `isNoop: true`, `factors: {}`. Two field omissions produce that
silently, and the first draft of this fixture hit **both** — `rankDerivedValue`
(without it no factor clears the 0.1% floor) and `canonicalConsensusRank`
(without it `compact_ranks_and_tiers` considers no candidates). Both were caught
only because the tests assert on content.

So `test_the_fixture_actually_moves_values` runs first and asserts the mechanism
was fed — non-empty factors, at least one off unity, a scarcity map with a real
measured `lineupScarcity` — before anything else asserts what it produced.

---

## Tier 1b — the valuation toggle's hydration flash (`a40f6b37`)

`useSettings` is a `useSyncExternalStore` over localStorage, and React uses
`getServerSnapshot` for **both** the SSR render and the client's hydration pass.
So the first client render sees `SETTINGS_DEFAULTS` — `valuationMode: "market"` —
whatever the device has persisted. On `/trade` that highlight sits directly above
a fairness verdict.

`useSettings` now returns `hydrated`, detected with the same store read through a
snapshot pair that differs only in which side is asking — no extra state, no
effect, and it flips in the same commit that brings the real settings in.
`/rankings` and `/trade` pass `null` until then, leaving the control unchecked
rather than confidently wrong. Same DOM, so nothing shifts. The `/settings`
`<select>` gets the weaker treatment (disabled + `aria-busy`) because a select
has no honest indeterminate state.

### The half that was not cosmetic

`useDynastyData`'s fetch effect fired on the hydration pass too, so it requested
the **default** board (market lens, no source overrides, default TE multiplier),
rendered it, then immediately re-requested the real one. Two round trips, and the
first won the first paint. It now waits for `hydrated`; `loading` is already true
initially, so the delay is one commit, not a round trip.

### Correction to an earlier reading

I first attributed part of the flash to `SegmentedControl`'s
`Math.max(0, findIndex(...))`. **That was wrong** — `aria-checked` has always
been `opt.value === value`, correct for an unmatched value, and the `Math.max`
only ever drove the roving tabindex. Verified by running the new toggle tests
against the untouched component: all six pass. The flash came entirely from the
call sites passing a literal `"market"`.

What remains in the component is naming, not behaviour: `checkedIndex` (may be
-1) split from `activeIndex` (floors at 0), documented as distinct because
collapsing them is how a future tidy-up would reintroduce a confident highlight.
The real demonstration is `useSettings.hydration.test.jsx`'s *"the UNGATED render
is the bug"*, which server-renders the pre-fix call site and asserts Market comes
back checked — asserting on the settled DOM passes either way.

---

## Tier 1c — wire the TE basis change (`0e18f073`)

`src/league_intel/te_premium.py` and `config/weights/te_premium_curve.json` have
been in the tree, complete and tested, with **zero callers** — the same shape
ORCHESTRATION.md §6.14/§6.15 named after the previous attempt.

`_compute_unified_rankings` now calls
`convert_te_value(value, from_basis="base", to_basis="tepp")` for non-TEP
sources' TE contributions, in place of the flat 1.15. The curve is KTC's own
measured base → TE++ uplift (73 paired TEs, R² 0.941 in log space).

Not a second premium: the blend anchors on `ktcSfTep`, which **is** KTC's TE++
board, and every non-TEP source's TE contribution was already scaled to align
with it. Only the magnitude changes — 1.15 matched nothing observed anywhere, as
KTC's smallest actual uplift is 1.209 and it reaches 2.053. The double-count
guard is now structural: even without the KTC exemption, `convert_te_value` is a
no-op when `from == to`.

### Measured blast radius — 2026-07-27 live board, 810 rows

| | |
|---|---|
| TE values | all 80 up: **+1.08%** (Bowers, against the 9999 ceiling) to **+30.17%** (Ruckert, deep), median **+14.27%** |
| non-TE values | **48 PICK rows only**, via the documented current-year pick tethering inheriting rookie-TE values — 2026 Pick 1.07 +3.91% matches Kenyon Sadiq exactly |
| QB / RB / WR / IDP | zero value change |
| rank displacement | median 7, p90 22, max 214 (Ruckert 717 → 503) |

### The decision that shaped this: the target basis is a constant

`measure_te_demand` answers *which basis does THIS league need?* from roster
structure — a **leagueKey** property. This board is **scoring-profile** scoped
and shared. Measured on the live registry: `dynasty_main` (2 mandatory TE
starters) wants `tepp`, `dynasty_new` (1) wants `base`, and **the two share
`superflex_tep15_ppr1`**. Threading league demand into the blend would let one
league's roster shape reprice the other's board.

So the blend does Axis A only, and Axis B stays a named inactive axis in
`src/league_intel/publish.py`. A one-TE league on this profile is currently
carrying a two-TE premium it does not want; taking it back off is overlay work
and needs ADR-009's netting, now against the measured curve rather than 1.15. A
test asserts the blend source never mentions `measure_te_demand`, and a second
re-measures the registry so the premise fails loudly if both leagues ever land on
one basis.

### Two things worth flagging about the plumbing

`tep_multiplier` is **never** `None` inside the blend — the caller always
resolves it first — so gating the curve on `tep_multiplier is None` would have
been a condition that could never fire, §6.15 exactly. The explicit-override
signal is threaded as its own parameter. The Sleeper-*derived* value deliberately
does not block the curve: it comes from `bonus_rec_te`, the scoring axis ADR-009
retracted, which reads 0.0 for this league in 2026.

`load_tep_curve` is now memoized — it read and parsed the config file on every
`tep_uplift` call, which the blend makes once per TE per source.

### Tests

`tests/api/test_te_basis_conversion.py` (11) leads with a spy asserting
`convert_te_value` is **reached**. The fixture puts the TE mid-board on purpose:
a rank-1 TE's contribution is already 9999 and every uplift clamps back to it, so
the test would pass with the feature off.

Its source-inspection test first failed by matching `roster_positions` inside a
**comment** explaining why the blend does not read them — §2b's named trap
verbatim. It now strips comments, and asserts the prose did contain the string so
the strip is doing work rather than passing on an empty haystack.

`test_feature_flags.py`'s default-ON gate correctly rejected this flag. Rather
than adding it to `safe_on` — where every member is additive or inert and cannot
move a number — the gate grows a `value_moving_on` category requiring a measured
blast radius, with the two sets asserted disjoint.

Rollback: `RISKIT_FEATURE_TE_BASIS_CONVERSION=0`. An explicit operator slider
value bypasses the curve regardless.

Docs: ADR-015 in `docs/league-intelligence/DECISIONS.md`, plus updates to
`CLAUDE.md` step 5a, ORCHESTRATION.md §6.14, and `publish.py`'s axis notes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeqwBFmFak84h3h7RaCZqa

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeqwBFmFak84h3h7RaCZqa)_