### PR TITLE
Tier 2: IDP positional scoring fit — and why it is not per-player

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -8,6 +8,19 @@ on:
   pull_request:
     branches:
       - main
+      # Stacked PRs too.  A PR whose base is another work branch —
+      # tier 2 on top of tier 1, say — matched none of these filters,
+      # so GitHub created it with ZERO check runs.  Not a failing gate:
+      # no gate at all, which reviews identically to a passing one and
+      # is exactly the defect class ORCHESTRATION.md 6.15 names.
+      #
+      # The alternative was to wait for the base to merge (GitHub
+      # auto-retargets an open PR to main when its base branch is
+      # merged and deleted, and CI would run then).  That is true but
+      # useless for review: the stack is reviewed BEFORE the base
+      # merges, which is the whole point of stacking.
+      - 'claude/**'
+      - 'codex/**'
 
 concurrency:
   group: pr-${{ github.event.pull_request.number }}

--- a/src/api/feature_flags.py
+++ b/src/api/feature_flags.py
@@ -120,6 +120,17 @@ _DEFAULTS: Final[dict[str, bool]] = {
     # noise — see the module docstring for the depth-stability
     # measurement that rules it out.
     "idp_scoring_fit": False,
+    # Per-player reception-depth tilt (Tier 2).  Separate from
+    # idp_scoring_fit above rather than sharing it: that flag is named
+    # for IDP, and using it to gate an offence feature would make the
+    # name a lie — an operator disabling "idp_scoring_fit" would
+    # silently also disable every receiver adjustment.
+    #
+    # Also OFF by default.  Note the magnitude before enabling: the
+    # per-catch spread is 8x but receptions are 17-33% of a player's
+    # points, so the VALUE move is around +/-8%, not +/-120%.  See
+    # src/league_intel/reception_fit.py.
+    "reception_scoring_fit": False,
 }
 
 _ENV_PREFIX: Final[str] = "RISKIT_FEATURE_"

--- a/src/api/feature_flags.py
+++ b/src/api/feature_flags.py
@@ -103,6 +103,23 @@ _DEFAULTS: Final[dict[str, bool]] = {
     # explicit operator TE-premium slider value also wins over the
     # curve regardless of this flag.
     "te_basis_conversion": True,
+    # IDP positional scoring fit (Tier 2).  This league pays coverage
+    # and disruption and discounts finishing plays, so relative to DB it
+    # values DL about +7% and LB about +3% versus the generic rate card
+    # every ranking source prices on.  Measured, stable across pool
+    # depth, and re-allocates between IDP positions rather than
+    # inflating IDP as a whole — see src/league_intel/scoring_fit.py.
+    #
+    # OFF by default, unlike te_basis_conversion.  The operator directed
+    # the TE basis explicitly and has directed nothing here, and this
+    # moves every IDP value on the board.  Flip with
+    # RISKIT_FEATURE_IDP_SCORING_FIT=1.
+    #
+    # Note what is deliberately NOT behind this flag: a per-player IDP
+    # multiplier.  The same data supports one arithmetically and it is
+    # noise — see the module docstring for the depth-stability
+    # measurement that rules it out.
+    "idp_scoring_fit": False,
 }
 
 _ENV_PREFIX: Final[str] = "RISKIT_FEATURE_"

--- a/src/api/gameplan.py
+++ b/src/api/gameplan.py
@@ -117,6 +117,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import threading
 import time
 from collections import OrderedDict
@@ -1120,6 +1121,68 @@ def get_team_gameplan(
     return payload
 
 
+# ── Tier 2: IDP positional scoring fit ───────────────────────────────
+
+_LOGGER = logging.getLogger(__name__)
+
+_SCORING_FIT_CACHE: dict[str, Any] = {}
+
+
+def invalidate_scoring_fit_cache() -> None:
+    """Drop the memoised measurement.  Tests and a scoring change."""
+    _SCORING_FIT_CACHE.clear()
+
+
+def _resolve_scoring_fit(league_key: str) -> Any | None:
+    """This league's IDP positional scoring tilt, or None.
+
+    Returns None — meaning an ABSENT axis, arithmetically inert —
+    whenever the flag is off, the stat rows are unavailable, or the
+    measurement refuses itself. Never raises: an optional lens must not
+    be able to take down the board it decorates.
+
+    Memoised per league. The measurement scores ~19k player-weeks under
+    two rate cards, which is far too expensive for a per-request path,
+    and its inputs (a completed season's stats, two rate cards) change
+    on the order of weeks.
+    """
+    from src.api import feature_flags  # noqa: PLC0415
+
+    if not feature_flags.is_enabled("idp_scoring_fit"):
+        return None
+    if league_key in _SCORING_FIT_CACHE:
+        return _SCORING_FIT_CACHE[league_key]
+
+    measurement = None
+    try:
+        from src.league_comparison.service import _load_config  # noqa: PLC0415
+        from src.league_comparison.sleeper_scoring import (  # noqa: PLC0415
+            fetch_league_scoring,
+        )
+        from src.league_intel.scoring_fit import (  # noqa: PLC0415
+            measure_positional_scoring_fit,
+        )
+        from src.nfl_data.ingest import fetch_weekly_defensive_stats  # noqa: PLC0415
+
+        cfg = _load_config()
+        mine_id = str((cfg.get("my_league") or {}).get("id") or "")
+        base_id = str((cfg.get("baseline_league") or {}).get("id") or "")
+        seasons = [int(s) for s in (cfg.get("seasons") or []) if str(s).isdigit()]
+        season = max(seasons) if seasons else None
+        if mine_id and base_id and season:
+            mine = fetch_league_scoring(mine_id).scoring_settings
+            baseline = fetch_league_scoring(base_id).scoring_settings
+            rows = fetch_weekly_defensive_stats([season])
+            if mine and baseline and rows:
+                measurement = measure_positional_scoring_fit(rows, mine, baseline, season=season)
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.warning("scoring fit unavailable for %s: %r", league_key, exc)
+        measurement = None
+
+    _SCORING_FIT_CACHE[league_key] = measurement
+    return measurement
+
+
 # ── LI-9: league-adjusted values ─────────────────────────────────────
 
 
@@ -1164,6 +1227,7 @@ def get_league_adjusted_values(
         rows,
         bundle.scarcity,
         league_key=league_key,
+        scoring_fit=_resolve_scoring_fit(league_key),
         config_version=config_version,
         data_through=(contract or {}).get("date"),
         # Version pin: the client refuses to apply an overlay whose

--- a/src/api/gameplan.py
+++ b/src/api/gameplan.py
@@ -1133,6 +1133,108 @@ def invalidate_scoring_fit_cache() -> None:
     _SCORING_FIT_CACHE.clear()
 
 
+_RECEPTION_FIT_CACHE: dict[str, Any] = {}
+
+
+def invalidate_reception_fit_cache() -> None:
+    _RECEPTION_FIT_CACHE.clear()
+
+
+def _resolve_reception_fit(league_key: str) -> dict[str, float] | None:
+    """Per-player reception-depth multipliers, keyed by canonical NAME.
+
+    The measurement is keyed by GSIS id; contract rows are keyed by
+    display name. The join happens here rather than in the adjustment
+    model because this is where both identifiers are in scope — the
+    weekly stat rows carry ``player_id`` (GSIS) and
+    ``player_display_name`` together, so the mapping is free.
+
+    Returns None — an ABSENT axis — when the flag is off, the inputs are
+    missing, or the measurement refuses itself. Never raises.
+    """
+    from src.api import feature_flags  # noqa: PLC0415
+
+    if not feature_flags.is_enabled("reception_scoring_fit"):
+        return None
+    if league_key in _RECEPTION_FIT_CACHE:
+        return _RECEPTION_FIT_CACHE[league_key]
+
+    by_name: dict[str, float] | None = None
+    try:
+        from src.league_comparison.scoring_engine import (  # noqa: PLC0415
+            compute_player_season_scores,
+        )
+        from src.league_comparison.service import _load_config  # noqa: PLC0415
+        from src.league_comparison.sleeper_scoring import (  # noqa: PLC0415
+            fetch_league_scoring,
+        )
+        from src.league_intel.reception_fit import (  # noqa: PLC0415
+            measure_reception_depth_fit,
+            reception_scoring_keys,
+        )
+        from src.nfl_data.ingest import fetch_weekly_stats  # noqa: PLC0415
+        from src.nfl_data.reception_depth import load_reception_depth  # noqa: PLC0415
+        from src.utils.name_clean import resolve_canonical_name  # noqa: PLC0415
+
+        cfg = _load_config()
+        mine_id = str((cfg.get("my_league") or {}).get("id") or "")
+        base_id = str((cfg.get("baseline_league") or {}).get("id") or "")
+        seasons = [int(s) for s in (cfg.get("seasons") or []) if str(s).isdigit()]
+        season = max(seasons) if seasons else None
+        depth = load_reception_depth(season) if season else None
+
+        if mine_id and base_id and season and depth:
+            mine = fetch_league_scoring(mine_id).scoring_settings
+            baseline = fetch_league_scoring(base_id).scoring_settings
+            rows = fetch_weekly_stats([season])
+            if mine and baseline and rows:
+                # Reception share is measured under the BASELINE card:
+                # that is the card the market prices on, so it is the
+                # right denominator for "how much of this player's
+                # market value is reception-driven".
+                stripped = {k: v for k, v in baseline.items() if k not in reception_scoring_keys()}
+                full = {
+                    s.player_id: s
+                    for s in compute_player_season_scores(rows, baseline, season=season)
+                }
+                norec = {
+                    s.player_id: s
+                    for s in compute_player_season_scores(rows, stripped, season=season)
+                }
+                shares = {
+                    pid: (s.total_points - (norec[pid].total_points if pid in norec else 0.0))
+                    / s.total_points
+                    for pid, s in full.items()
+                    if s.total_points > 0
+                }
+                measurement = measure_reception_depth_fit(
+                    depth, shares, mine, baseline, season=season
+                )
+                if measurement.trusted:
+                    names = {s.player_id: s.player_name for s in full.values() if s.player_name}
+                    by_name = {}
+                    for gsis, mult in measurement.multipliers.items():
+                        key = resolve_canonical_name(names.get(gsis, ""))
+                        if key:
+                            by_name[key] = mult
+                    if not by_name:
+                        # Every id failed to resolve to a name. An empty
+                        # map and "the feature is off" are different
+                        # states and must not read the same.
+                        _LOGGER.warning(
+                            "reception fit measured %d players but none resolved to a "
+                            "name; serving no overlay",
+                            len(measurement.multipliers),
+                        )
+                        by_name = None
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.warning("reception fit unavailable for %s: %r", league_key, exc)
+        by_name = None
+
+    _RECEPTION_FIT_CACHE[league_key] = by_name
+    return by_name
+
+
 def _resolve_scoring_fit(league_key: str) -> Any | None:
     """This league's IDP positional scoring tilt, or None.
 
@@ -1228,6 +1330,7 @@ def get_league_adjusted_values(
         bundle.scarcity,
         league_key=league_key,
         scoring_fit=_resolve_scoring_fit(league_key),
+        reception_fit=_resolve_reception_fit(league_key),
         config_version=config_version,
         data_through=(contract or {}).get("date"),
         # Version pin: the client refuses to apply an overlay whose

--- a/src/league_intel/adjustment.py
+++ b/src/league_intel/adjustment.py
@@ -62,6 +62,7 @@ __all__ = [
     "build_board_adjustments",
     "check_position_monotonicity",
     "projection_corroboration_axis",
+    "reception_fit_axis",
     "scoring_fit_axis",
     "structural_scarcity_axis",
     "te_premium_axis",
@@ -305,6 +306,65 @@ def scoring_fit_axis(
             f"positions to {entry.multiplier:.3f}. {entry.reason}"
         ),
         measured_value=float(entry.raw_ratio),
+    )
+
+
+def reception_fit_axis(
+    display_name: str,
+    position: str,
+    multipliers_by_name: Mapping[str, float] | None,
+) -> AdjustmentAxis:
+    """How this league's reception-distance banding reprices ONE player.
+
+    The only per-player axis in the model. Every other axis is a
+    function of position, which is what lets them compose against a
+    re-weighted board; this one is not, and that is deliberate — the
+    thing being measured (a receiver's catch-depth distribution) is a
+    property of the player, not of his position.
+
+    ``multipliers_by_name`` is keyed by
+    :func:`~src.utils.name_clean.resolve_canonical_name`. The
+    measurement itself is keyed by GSIS id; the caller does that join,
+    because it owns the stat rows that carry both identifiers.
+
+    ABSENT for offensive positions with no measurement and for every
+    defensive position — IDP catches are not a thing this league's
+    reception keys pay for.
+    """
+    if not multipliers_by_name:
+        return AdjustmentAxis(
+            name="receptionFit",
+            factor=1.0,
+            tier=EvidenceTier.ABSENT,
+            rationale="no reception-depth measurement supplied; axis contributes nothing",
+        )
+
+    from src.utils.name_clean import resolve_canonical_name  # noqa: PLC0415
+
+    key = resolve_canonical_name(display_name)
+    factor = multipliers_by_name.get(key)
+    if factor is None:
+        return AdjustmentAxis(
+            name="receptionFit",
+            factor=1.0,
+            tier=EvidenceTier.ABSENT,
+            rationale=(
+                f"no measured catch-depth distribution for {display_name!r} "
+                "(fewer than the minimum receptions, or no scored season)"
+            ),
+        )
+
+    return AdjustmentAxis(
+        name="receptionFit",
+        factor=float(factor),
+        tier=EvidenceTier.SCORING_MEASURED,
+        rationale=(
+            f"catch-depth distribution repriced against this league's banded "
+            f"reception keys: {float(factor):.3f}x. Composed as "
+            "1 + reception_share x (per_catch_ratio - 1), so the value move is "
+            "a fraction of the per-catch move."
+        ),
+        measured_value=float(factor),
     )
 
 
@@ -656,6 +716,7 @@ def build_board_adjustments(
     te_measurement: Mapping[str, Any] | None = None,
     projections: Mapping[str, ProjectionEvidence] | None = None,
     scoring_fit: Any | None = None,
+    reception_fit: Mapping[str, float] | None = None,
     config_version: int | None = None,
     data_through: str | None = None,
     max_total_adjustment: float = MAX_TOTAL_ADJUSTMENT,
@@ -699,6 +760,7 @@ def build_board_adjustments(
             # ORCHESTRATION.md 6.14 mistake -- a module nothing imports
             # cannot be caught by the tests that guard it.
             scoring_fit_axis(position, scoring_fit),
+            reception_fit_axis(name, position, reception_fit),
             projection_corroboration_axis(
                 (projections or {}).get(name),
                 structural_factor=1.0,

--- a/src/league_intel/adjustment.py
+++ b/src/league_intel/adjustment.py
@@ -62,6 +62,7 @@ __all__ = [
     "build_board_adjustments",
     "check_position_monotonicity",
     "projection_corroboration_axis",
+    "scoring_fit_axis",
     "structural_scarcity_axis",
     "te_premium_axis",
 ]
@@ -89,6 +90,25 @@ class EvidenceTier(str, Enum):
     """Measured from paired market boards that passed the
     ``calibration.py`` validity gates."""
 
+    SCORING_MEASURED = "scoringMeasured"
+    """Measured by re-scoring REAL player-weeks under two rate cards and
+    passing the depth-stability gate in
+    :mod:`src.league_intel.scoring_fit`.
+
+    A separate tier rather than a reuse of the two above, because the
+    mechanism is genuinely different and the existing tiers name their
+    mechanisms: ``MARKET_MEASURED`` means paired market boards, and
+    ``PROJECTION_CORROBORATED`` means re-scored *projected* lines and is
+    documented as unreachable pending LI-6. Labelling scoring evidence
+    as either would misreport how the number was obtained, and the tier
+    is the field a reader trusts to tell them exactly that.
+
+    Confidence is set equal to ``MARKET_MEASURED``. That is deliberate
+    restraint: re-scored realized stat lines are arguably *stronger*
+    evidence than a paired board, but nothing has measured the two
+    against each other, so claiming a higher tier would be an
+    unevidenced ranking of evidence."""
+
     PROJECTION_CORROBORATED = "projectionCorroborated"
     """Structural effect confirmed against re-scored projected stat
     lines.  Unreachable until LI-6 secures a raw-category source."""
@@ -98,6 +118,7 @@ _TIER_CONFIDENCE: dict[EvidenceTier, float] = {
     EvidenceTier.ABSENT: 0.0,
     EvidenceTier.STRUCTURAL_ONLY: 0.45,
     EvidenceTier.MARKET_MEASURED: 0.70,
+    EvidenceTier.SCORING_MEASURED: 0.70,
     EvidenceTier.PROJECTION_CORROBORATED: 0.90,
 }
 
@@ -233,6 +254,57 @@ def structural_scarcity_axis(
             "from the exact optimizer over real rosters"
         ),
         measured_value=value,
+    )
+
+
+def scoring_fit_axis(
+    position: str,
+    fit: Any | None,
+) -> AdjustmentAxis:
+    """How this league's SCORING rules tilt value toward ``position``.
+
+    Distinct from :func:`structural_scarcity_axis`, and the two are not
+    substitutes: scarcity measures how many of a position this league
+    must start, scoring measures what it pays them per play. A league
+    can start three linebackers and still pay them badly.
+
+    ``fit`` is a :class:`~src.league_intel.scoring_fit.ScoringFitMeasurement`.
+    Returns an ABSENT axis for anything it did not measure or did not
+    trust — including every offensive position, because the offence-side
+    divergence is reception-distance banding and a position-level
+    multiplier cannot express it (see the scoring_fit module docstring).
+    """
+    if fit is None:
+        return AdjustmentAxis(
+            name="scoringFit",
+            factor=1.0,
+            tier=EvidenceTier.ABSENT,
+            rationale="no scoring-fit measurement supplied; axis contributes nothing",
+        )
+
+    pos = str(position or "").strip().upper()
+    entry = getattr(fit, "positions", {}).get(pos)
+    if entry is None or not getattr(entry, "trusted", False):
+        return AdjustmentAxis(
+            name="scoringFit",
+            factor=1.0,
+            tier=EvidenceTier.ABSENT,
+            rationale=(
+                getattr(entry, "reason", None)
+                or f"scoring fit not measured for {pos or 'unknown position'}"
+            ),
+        )
+
+    return AdjustmentAxis(
+        name="scoringFit",
+        factor=float(entry.multiplier),
+        tier=EvidenceTier.SCORING_MEASURED,
+        rationale=(
+            f"{pos} scores {entry.raw_ratio:.3f}x the baseline rate card over "
+            f"{entry.cohort_size} real player-seasons; normalised across IDP "
+            f"positions to {entry.multiplier:.3f}. {entry.reason}"
+        ),
+        measured_value=float(entry.raw_ratio),
     )
 
 
@@ -583,6 +655,7 @@ def build_board_adjustments(
     scarcity: Mapping[str, Any] | None = None,
     te_measurement: Mapping[str, Any] | None = None,
     projections: Mapping[str, ProjectionEvidence] | None = None,
+    scoring_fit: Any | None = None,
     config_version: int | None = None,
     data_through: str | None = None,
     max_total_adjustment: float = MAX_TOTAL_ADJUSTMENT,
@@ -619,6 +692,13 @@ def build_board_adjustments(
         axes = [
             structural_scarcity_axis(position, pos_scarcity),
             te_premium_axis(measurement=te_measurement) if position == "TE" else None,
+            # Gated by the caller, not here: passing ``scoring_fit=None``
+            # yields an ABSENT axis, so the flag-off path still runs this
+            # code and the guards below still see it.  Leaving the axis
+            # out of the list entirely when disabled would be the
+            # ORCHESTRATION.md 6.14 mistake -- a module nothing imports
+            # cannot be caught by the tests that guard it.
+            scoring_fit_axis(position, scoring_fit),
             projection_corroboration_axis(
                 (projections or {}).get(name),
                 structural_factor=1.0,

--- a/src/league_intel/publish.py
+++ b/src/league_intel/publish.py
@@ -107,6 +107,20 @@ def _row_key(row: Mapping[str, Any]) -> str:
     return str(row.get("displayName") or row.get("canonicalName") or "").strip()
 
 
+def _inactive_axes(scoring_fit: Any | None) -> list[str]:
+    """Which axes contributed nothing to this board, by name."""
+    names = ["tePremium", "projectionCorroboration"]
+    trusted = bool(
+        scoring_fit is not None
+        and any(
+            getattr(f, "trusted", False) for f in getattr(scoring_fit, "positions", {}).values()
+        )
+    )
+    if not trusted:
+        names.append("scoringFit")
+    return names
+
+
 def build_league_adjusted_payload(
     rows: Sequence[Mapping[str, Any]],
     scarcity: Mapping[str, Any] | None,
@@ -116,6 +130,7 @@ def build_league_adjusted_payload(
     data_through: str | None = None,
     contract_version: str | None = None,
     scrape_timestamp: str | None = None,
+    scoring_fit: Any | None = None,
     include_explanations: bool = False,
 ) -> dict[str, Any]:
     """Compute this league's adjusted board as an overlay payload.
@@ -144,6 +159,7 @@ def build_league_adjusted_payload(
     board = build_board_adjustments(
         rows,
         scarcity=normalised,
+        scoring_fit=scoring_fit,
         config_version=config_version,
         data_through=data_through,
     )
@@ -230,7 +246,11 @@ def build_league_adjusted_payload(
         "warnings": warnings,
         # Named so a reader does not have to infer the omission from an
         # empty diff — see the module docstring for why TE is out.
-        "inactiveAxes": ["tePremium", "projectionCorroboration"],
+        # Named so a reader does not have to infer an omission from an
+        # empty diff.  scoringFit joins the list only when it is off or
+        # unmeasured -- when it IS live it shows up in the axes instead,
+        # and listing it in both places would be a contradiction.
+        "inactiveAxes": _inactive_axes(scoring_fit),
     }
     if include_explanations:
         payload["explanations"] = [e.to_dict() for e in board.explanations]

--- a/src/league_intel/publish.py
+++ b/src/league_intel/publish.py
@@ -107,7 +107,9 @@ def _row_key(row: Mapping[str, Any]) -> str:
     return str(row.get("displayName") or row.get("canonicalName") or "").strip()
 
 
-def _inactive_axes(scoring_fit: Any | None) -> list[str]:
+def _inactive_axes(
+    scoring_fit: Any | None, reception_fit: Mapping[str, float] | None = None
+) -> list[str]:
     """Which axes contributed nothing to this board, by name."""
     names = ["tePremium", "projectionCorroboration"]
     trusted = bool(
@@ -118,6 +120,8 @@ def _inactive_axes(scoring_fit: Any | None) -> list[str]:
     )
     if not trusted:
         names.append("scoringFit")
+    if not reception_fit:
+        names.append("receptionFit")
     return names
 
 
@@ -131,6 +135,7 @@ def build_league_adjusted_payload(
     contract_version: str | None = None,
     scrape_timestamp: str | None = None,
     scoring_fit: Any | None = None,
+    reception_fit: Mapping[str, float] | None = None,
     include_explanations: bool = False,
 ) -> dict[str, Any]:
     """Compute this league's adjusted board as an overlay payload.
@@ -160,6 +165,7 @@ def build_league_adjusted_payload(
         rows,
         scarcity=normalised,
         scoring_fit=scoring_fit,
+        reception_fit=reception_fit,
         config_version=config_version,
         data_through=data_through,
     )
@@ -250,7 +256,7 @@ def build_league_adjusted_payload(
         # empty diff.  scoringFit joins the list only when it is off or
         # unmeasured -- when it IS live it shows up in the axes instead,
         # and listing it in both places would be a contradiction.
-        "inactiveAxes": _inactive_axes(scoring_fit),
+        "inactiveAxes": _inactive_axes(scoring_fit, reception_fit),
     }
     if include_explanations:
         payload["explanations"] = [e.to_dict() for e in board.explanations]

--- a/src/league_intel/reception_fit.py
+++ b/src/league_intel/reception_fit.py
@@ -1,0 +1,261 @@
+"""Per-player value tilt from this league's reception-distance banding.
+
+Read the magnitude section before quoting this feature
+─────────────────────────────────────────────────────
+The headline number for this divergence has been "an 8x spread every
+source prices as flat 0.75", and ``docs/ORCHESTRATION.md`` calls it "the
+largest unexploited edge identified to date". **The 8x is real and the
+value impact is not 8x.** Both halves matter and only one of them has
+been stated so far.
+
+Per CATCH, measured live 2026-07-27, this league pays::
+
+    0-4 yd 0.25   5-9 0.50   10-19 0.75   20-29 1.00   30-39 1.25   40+ 2.00
+
+against a flat 0.75 baseline — so a checkdown is worth 0.33x and a deep
+ball 2.67x, and the raw per-catch ratio across real 2025 receivers runs
+from 0.56 (Rachaad White) to 1.23 (Alec Pierce), a 2.2x spread.
+
+But **receptions are a minority of a player's fantasy points.** Measured
+share of total baseline points coming from reception keys, 2025::
+
+    RB 0.166    WR 0.304    TE 0.330
+
+So the value multiplier is ``1 + reception_share x (per_catch_ratio - 1)``
+and it lands near ±8%, not ±120%::
+
+    composed multiplier, dispersion by pool depth (p90/p10)
+    top24 1.072   top36 1.078   top60 1.069   top120 1.087   top200 1.106
+
+That is the number to act on. Anyone reading "8x" and sizing a trade off
+it will be wrong by an order of magnitude.
+
+Why it is still worth having, when IDP per-player was not
+─────────────────────────────────────────────────────────
+±8% is the same order as the IDP *positional* tilt this codebase already
+ships, and unlike the IDP *per-player* attempt — which
+:mod:`src.league_intel.scoring_fit` refuses — this dispersion is **flat
+across pool depth**. Compare:
+
+    IDP per-player   1.109 -> 1.116 -> 1.115 -> 1.132 -> 1.215   fans out
+    reception fit    1.072 -> 1.078 -> 1.069 -> 1.087 -> 1.106   flat
+
+A sampling artifact widens as you sample deeper because thinner samples
+are noisier. This does not, so it is measuring the thing it names. The
+extremes are also coherent rather than random: deep threats at the top
+(Pierce, Watson, McLaurin) and checkdown backs and short-area tight ends
+at the bottom (White, Gainwell, Ferguson), which is the axis the banding
+is built on.
+
+The median sits at ~0.96, so the receiving corps as a whole is priced
+slightly high by flat-PPR sources. That is a real level effect and it is
+kept rather than normalised away — unlike the IDP case, where the shared
+level was an artifact of rate-card generosity. Here both cards are being
+applied to the same catches, so a shared shift is a fact about the
+scoring, not about how the commissioners numbered their sheets.
+"""
+
+from __future__ import annotations
+
+import logging
+import statistics
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+from src.nfl_data.reception_depth import BAND_KEYS, summarise_histogram
+
+_LOGGER = logging.getLogger(__name__)
+
+__all__ = [
+    "MAX_TILT",
+    "MIN_RECEPTIONS",
+    "ReceptionFitMeasurement",
+    "measure_reception_depth_fit",
+    "reception_scoring_keys",
+]
+
+#: Below this many catches a player's band distribution is shape noise.
+#: 20 keeps ~200 receivers on a 2025 season, which covers everyone
+#: rosterable in a 12-team league several times over.
+MIN_RECEPTIONS: int = 20
+
+#: Hard clamp on the composed multiplier. Nothing measured comes close
+#: (observed range 0.92-1.09); this exists so an upstream data fault
+#: cannot express itself as a 3x repricing.
+MAX_TILT: float = 0.25
+
+#: Depth probes and tolerance, mirroring
+#: :mod:`src.league_intel.scoring_fit` so the two measurements are
+#: judged by the same standard.
+_DEPTH_PROBES: tuple[int, ...] = (24, 36, 60, 120)
+_MAX_DISPERSION_DRIFT: float = 0.12
+
+
+def reception_scoring_keys() -> frozenset[str]:
+    """Every scoring key that pays for a catch, banded or flat."""
+    return frozenset(BAND_KEYS) | {"rec"}
+
+
+@dataclass(frozen=True)
+class ReceptionFitMeasurement:
+    """Per-player value multipliers, with the evidence and the refusals."""
+
+    multipliers: dict[str, float] = field(default_factory=dict)
+    """Keyed by GSIS id. Absent means unmeasured, which callers must
+    treat as 1.0 rather than as zero."""
+
+    per_catch_ratios: dict[str, float] = field(default_factory=dict)
+    reception_shares: dict[str, float] = field(default_factory=dict)
+    season: int | None = None
+    measured: bool = False
+    trusted: bool = False
+    dispersion_drift: float = 0.0
+    median_multiplier: float = 1.0
+    sample_size: int = 0
+    reason: str = ""
+
+    def multiplier_for(self, player_id_gsis: str) -> float:
+        """1.0 for anything unmeasured or untrusted. Never raises."""
+        if not self.trusted:
+            return 1.0
+        return self.multipliers.get(str(player_id_gsis or "").strip(), 1.0)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "measured": self.measured,
+            "trusted": self.trusted,
+            "season": self.season,
+            "sampleSize": self.sample_size,
+            "dispersionDrift": round(self.dispersion_drift, 6),
+            "medianMultiplier": round(self.median_multiplier, 6),
+            "reason": self.reason,
+            "playerCount": len(self.multipliers),
+        }
+
+
+def _per_catch_value(shares: Mapping[str, float], scoring: Mapping[str, Any]) -> float:
+    """Expected points per reception for a player with this band shape."""
+    flat = float(scoring.get("rec") or 0.0)
+    return sum(float(shares.get(b, 0.0)) * (flat + float(scoring.get(b) or 0.0)) for b in BAND_KEYS)
+
+
+def _dispersion(values: Sequence[float]) -> float:
+    """p90/p10 of ``values`` normalised by their median."""
+    if len(values) < 10:
+        return 0.0
+    med = statistics.median(values)
+    if med <= 0:
+        return 0.0
+    norm = sorted(v / med for v in values)
+    q = statistics.quantiles(norm, n=10)
+    if q[0] <= 0:
+        return 0.0
+    return q[-1] / q[0]
+
+
+def measure_reception_depth_fit(
+    depth_payload: Mapping[str, Any] | None,
+    reception_shares: Mapping[str, float] | None,
+    my_scoring: Mapping[str, Any] | None,
+    baseline_scoring: Mapping[str, Any] | None,
+    *,
+    season: int | None = None,
+    min_receptions: int = MIN_RECEPTIONS,
+) -> ReceptionFitMeasurement:
+    """Compose band shapes and reception shares into value multipliers.
+
+    ``depth_payload`` is :func:`src.nfl_data.reception_depth.load_reception_depth`
+    output. ``reception_shares`` maps GSIS id to the fraction of that
+    player's BASELINE fantasy points that came from reception keys — the
+    baseline card because that is the one the market prices on.
+
+    Refuses as a whole rather than per player: if the dispersion is not
+    stable across pool depth, the measurement is describing sample
+    composition and no individual multiplier from it is trustworthy.
+    """
+    if not depth_payload or not my_scoring or not baseline_scoring:
+        return ReceptionFitMeasurement(
+            season=season, reason="depth payload and both scoring cards are required"
+        )
+
+    players = depth_payload.get("players")
+    if not isinstance(players, dict) or not players:
+        return ReceptionFitMeasurement(season=season, reason="depth payload has no players")
+
+    shares_in = reception_shares or {}
+    multipliers: dict[str, float] = {}
+    ratios: dict[str, float] = {}
+    shares_out: dict[str, float] = {}
+    # (receptions, multiplier) so dispersion can be probed by volume.
+    ranked: list[tuple[int, float]] = []
+
+    for gsis, rec in players.items():
+        if not isinstance(rec, dict):
+            continue
+        summary = summarise_histogram(rec.get("bands") or {})
+        if summary["receptions"] < min_receptions:
+            continue
+        base_pc = _per_catch_value(summary["shares"], baseline_scoring)
+        if base_pc <= 0:
+            continue
+        ratio = _per_catch_value(summary["shares"], my_scoring) / base_pc
+
+        share = shares_in.get(gsis)
+        if share is None:
+            # No scored season for this player: the per-catch ratio is
+            # known but its weight is not, and guessing a share would
+            # invent the entire magnitude of the adjustment.
+            continue
+        share = max(0.0, min(1.0, float(share)))
+
+        raw = 1.0 + share * (ratio - 1.0)
+        multiplier = max(1.0 - MAX_TILT, min(1.0 + MAX_TILT, raw))
+        multipliers[gsis] = multiplier
+        ratios[gsis] = ratio
+        shares_out[gsis] = share
+        ranked.append((summary["receptions"], multiplier))
+
+    if len(multipliers) < 10:
+        return ReceptionFitMeasurement(
+            season=season,
+            measured=bool(multipliers),
+            reason=f"only {len(multipliers)} players had both a band shape and a scored season",
+        )
+
+    ranked.sort(key=lambda t: -t[0])
+    probes = [_dispersion([m for _, m in ranked[:n]]) for n in _DEPTH_PROBES if len(ranked) >= n]
+    probes = [p for p in probes if p > 0]
+    drift = (max(probes) - min(probes)) if len(probes) >= 2 else 0.0
+    trusted = drift <= _MAX_DISPERSION_DRIFT
+    median_mult = statistics.median(multipliers.values())
+
+    if not trusted:
+        _LOGGER.warning(
+            "reception_fit: dispersion drifts %.4f across depths %s (max %.2f); "
+            "measurement rejected",
+            drift,
+            _DEPTH_PROBES,
+            _MAX_DISPERSION_DRIFT,
+        )
+
+    return ReceptionFitMeasurement(
+        multipliers=multipliers,
+        per_catch_ratios=ratios,
+        reception_shares=shares_out,
+        season=season,
+        measured=True,
+        trusted=trusted,
+        dispersion_drift=drift,
+        median_multiplier=median_mult,
+        sample_size=len(multipliers),
+        reason=(
+            f"composed over {len(multipliers)} receivers with >={min_receptions} catches; "
+            f"dispersion stable to {drift:.4f} across depths {_DEPTH_PROBES}"
+            if trusted
+            else (
+                f"dispersion drifts {drift:.4f} across depths {_DEPTH_PROBES} "
+                f"(max {_MAX_DISPERSION_DRIFT}) — sample composition, not scoring; "
+                "every multiplier forced to 1.0"
+            )
+        ),
+    )

--- a/src/league_intel/scoring_fit.py
+++ b/src/league_intel/scoring_fit.py
@@ -1,0 +1,307 @@
+"""How much this league's scoring rules favour a POSITION over the market's.
+
+The measurement, and the finding that shaped the API
+─────────────────────────────────────────────────────
+The operator's league and the default-scoring baseline league
+(``config/league_comparison.json``) disagree on 95 of 146 scoring keys.
+On IDP the disagreements are large and they point in opposite
+directions — measured live 2026-07-27::
+
+    idp_pass_def   2.11 -> 5.32   2.52x  UP
+    idp_tkl_loss   2.06 -> 4.25   2.06x  UP
+    idp_qb_hit     1.08 -> 2.13   1.97x  UP
+    idp_sack       4.55 -> 2.92   0.64x  DOWN
+    idp_int        6.20 -> 5.32   0.86x  DOWN
+
+Coverage and disruption are paid; finishing plays are discounted. Every
+ranking source prices IDP on a generic rate card closer to the baseline,
+so there is a real mispricing here.
+
+**The obvious exploit does not survive measurement, and that is why this
+module is deliberately position-level and not per-player.**
+
+Scoring all 2025 IDP player-weeks under both rate cards and taking each
+player's ``mine / baseline`` ratio, then normalising within the position
+cohort, gives a per-player "scoring fit". It looks like signal. It is
+not. Measured p90/p10 of the cohort-normalised ratio, by how deep into
+the position you go::
+
+    DL   top24 1.109   top36 1.116   top60 1.115   top120 1.132   all 1.215
+    LB   top24 1.113   top36 1.095   top60 1.100   top120 1.099   all 1.144
+    DB   top24 1.071   top36 1.075   top60 1.083   top120 1.113   all 1.144
+
+Two things to read off that. Among genuinely rosterable players the
+spread is only ~±5%, and it **grows monotonically with pool depth** —
+deeper players take fewer snaps, so their stat mixes are noisier and
+their ratios fan out. That is the signature of small-sample noise, not
+of a real player-selection edge. The most "mispriced" players by this
+measure were Kemon Hall, Cory Durden and Jack Cochrane: bench bodies
+near the scoring floor, not targets.
+
+The **position-level** median, by contrast, is rock stable across depth::
+
+    DL   1.089  1.089  1.088  1.087      <- moves 0.002 across 5x the pool
+    LB   1.043  1.048  1.051  1.049
+    DB   1.014  1.014  1.007  0.994
+
+That stability is what makes it trustworthy. Within a position, DL stat
+mixes are similar enough that the per-key inversions largely cancel and
+move the whole cohort together; they do not separate players inside it.
+
+So the edge is real and it is **positional**: relative to DB, this
+league pays DL about +7% and LB about +3%. That is worth acting on in a
+trade calculator. A per-player multiplier built from the same data would
+be ±5% of noise wearing the costume of a measurement, which is the
+defect class this repo keeps paying for — so the API does not offer one.
+
+Scale is meaningless; only the tilt is real
+───────────────────────────────────────────
+The absolute ratio depends on both rate cards' overall generosity, which
+is an artifact of how each commissioner numbered their sheet and says
+nothing about player value. Only the *relative* difference between
+positions carries information, so the multipliers are normalised to a
+mean of 1.0 across the tracked positions. The result re-allocates value
+between IDP positions; it never inflates IDP as a whole.
+
+Flagged OFF
+───────────
+``RISKIT_FEATURE_IDP_SCORING_FIT`` defaults to 0. This moves every IDP
+value on the board and no operator has asked for it yet.
+"""
+
+from __future__ import annotations
+
+import logging
+import statistics
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Sequence
+
+_LOGGER = logging.getLogger(__name__)
+
+__all__ = [
+    "DEPTH_PROBES",
+    "MAX_DEPTH_DRIFT",
+    "MIN_COHORT_SIZE",
+    "PositionFit",
+    "ScoringFitMeasurement",
+    "measure_positional_scoring_fit",
+]
+
+#: Positions this measurement covers. Offence is excluded deliberately:
+#: its biggest divergence is the reception-distance banding, which needs
+#: a per-player depth histogram from play-by-play and is a separate
+#: piece of work. Applying a position-level offence multiplier would
+#: paper over that with a number that cannot express it.
+TRACKED_POSITIONS: tuple[str, ...] = ("DL", "LB", "DB")
+
+#: Pool depths the stability check probes. A real positional effect is
+#: flat across these; a sampling artifact fans out.
+DEPTH_PROBES: tuple[int, ...] = (24, 36, 60, 120)
+
+#: Largest spread between the shallowest and deepest probe before a
+#: position's multiplier is rejected. Measured drift on 2025 is 0.002
+#: (DL), 0.008 (LB), 0.020 (DB); 0.05 is a wide bound that still fails
+#: loudly if the cohort ever stops being coherent.
+MAX_DEPTH_DRIFT: float = 0.05
+
+#: Below this many scored players a cohort median is not worth trusting.
+MIN_COHORT_SIZE: int = 12
+
+
+@dataclass(frozen=True)
+class PositionFit:
+    """One position's measured tilt, with the evidence that backs it."""
+
+    position: str
+    multiplier: float
+    """Mean-normalised across tracked positions. 1.0 means 'no tilt
+    relative to the other IDP positions', NOT 'the two rate cards
+    agree'."""
+
+    raw_ratio: float
+    """Un-normalised median ``mine / baseline``. Diagnostic only — its
+    absolute level reflects rate-card generosity, not value."""
+
+    cohort_size: int
+    depth_drift: float
+    """max-min of the raw ratio across :data:`DEPTH_PROBES`. The
+    trustworthiness signal."""
+
+    trusted: bool
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "position": self.position,
+            "multiplier": round(self.multiplier, 6),
+            "rawRatio": round(self.raw_ratio, 6),
+            "cohortSize": self.cohort_size,
+            "depthDrift": round(self.depth_drift, 6),
+            "trusted": self.trusted,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class ScoringFitMeasurement:
+    """The whole measurement. Carries its own refusals."""
+
+    positions: dict[str, PositionFit] = field(default_factory=dict)
+    season: int | None = None
+    measured: bool = False
+    reason: str = ""
+
+    def multiplier_for(self, position: str) -> float:
+        """Tilt for ``position``; 1.0 for anything unmeasured or
+        untrusted.
+
+        Never raises and never guesses — an unknown position is a no-op,
+        because the alternative is applying an IDP tilt to a wide
+        receiver.
+        """
+        fit = self.positions.get(str(position or "").strip().upper())
+        if fit is None or not fit.trusted:
+            return 1.0
+        return fit.multiplier
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "measured": self.measured,
+            "season": self.season,
+            "reason": self.reason,
+            "positions": {k: v.to_dict() for k, v in sorted(self.positions.items())},
+        }
+
+
+def _median_ratio(pairs: Sequence[tuple[float, float]], top_n: int | None) -> float | None:
+    """Median ``mine / baseline`` over the ``top_n`` players by baseline
+    points. ``top_n=None`` uses the whole cohort."""
+    if not pairs:
+        return None
+    ranked = sorted(pairs, key=lambda p: -p[1])
+    if top_n is not None:
+        ranked = ranked[:top_n]
+    ratios = [mine / base for mine, base in ranked if base > 0]
+    if not ratios:
+        return None
+    return float(statistics.median(ratios))
+
+
+def measure_positional_scoring_fit(
+    weekly_rows: Iterable[Mapping[str, Any]],
+    my_scoring: Mapping[str, Any] | None,
+    baseline_scoring: Mapping[str, Any] | None,
+    *,
+    season: int | None = None,
+    min_baseline_points: float = 20.0,
+) -> ScoringFitMeasurement:
+    """Measure how this league's scoring tilts value between IDP positions.
+
+    Scores every weekly row under BOTH rate cards via the existing
+    :mod:`src.league_comparison.scoring_engine` — the golden-validated
+    scorer, not a second implementation of Sleeper scoring — then takes
+    each position's median ratio and normalises to a mean of 1.0.
+
+    Refuses rather than guesses. A position whose ratio drifts more than
+    :data:`MAX_DEPTH_DRIFT` across :data:`DEPTH_PROBES` is marked
+    untrusted and contributes a 1.0 multiplier, because a ratio that
+    depends on how deep you sample is measuring sample size, not
+    scoring.
+    """
+    if not my_scoring or not baseline_scoring:
+        return ScoringFitMeasurement(
+            measured=False, reason="both leagues' scoring_settings are required"
+        )
+
+    from src.league_comparison.scoring_engine import (  # noqa: PLC0415 - heavy import
+        compute_player_season_scores,
+    )
+
+    rows = list(weekly_rows or [])
+    if not rows:
+        return ScoringFitMeasurement(measured=False, reason="no weekly rows supplied")
+
+    mine = {
+        s.player_id: s for s in compute_player_season_scores(rows, dict(my_scoring), season=season)
+    }
+    base = {
+        s.player_id: s
+        for s in compute_player_season_scores(rows, dict(baseline_scoring), season=season)
+    }
+
+    cohorts: dict[str, list[tuple[float, float]]] = {p: [] for p in TRACKED_POSITIONS}
+    for pid, m in mine.items():
+        b = base.get(pid)
+        if b is None or m.position not in cohorts:
+            continue
+        if b.total_points < min_baseline_points:
+            continue
+        cohorts[m.position].append((float(m.total_points), float(b.total_points)))
+
+    raw: dict[str, tuple[float, float, int]] = {}
+    for pos, pairs in cohorts.items():
+        full = _median_ratio(pairs, None)
+        if full is None or len(pairs) < MIN_COHORT_SIZE:
+            continue
+        probes = [r for r in (_median_ratio(pairs, n) for n in DEPTH_PROBES) if r is not None]
+        drift = (max(probes) - min(probes)) if len(probes) >= 2 else 0.0
+        # Anchor on the shallowest usable probe rather than the whole
+        # pool: the rosterable players are the ones whose valuation this
+        # multiplier will move, and the deep tail is the noisy part.
+        anchor = probes[0] if probes else full
+        raw[pos] = (anchor, drift, len(pairs))
+
+    if not raw:
+        return ScoringFitMeasurement(
+            measured=False,
+            season=season,
+            reason=f"no IDP cohort reached {MIN_COHORT_SIZE} scored players",
+        )
+
+    # Normalise to mean 1.0. Only the tilt between positions carries
+    # information; the shared level is an artifact of how generously
+    # each commissioner numbered their sheet.
+    trusted_ratios = [r for r, drift, _ in raw.values() if drift <= MAX_DEPTH_DRIFT]
+    mean_ratio = (
+        statistics.fmean(trusted_ratios)
+        if trusted_ratios
+        else statistics.fmean([r for r, _, _ in raw.values()])
+    )
+    if mean_ratio <= 0:
+        return ScoringFitMeasurement(measured=False, season=season, reason="degenerate mean ratio")
+
+    positions: dict[str, PositionFit] = {}
+    for pos, (ratio, drift, n) in sorted(raw.items()):
+        ok = drift <= MAX_DEPTH_DRIFT
+        positions[pos] = PositionFit(
+            position=pos,
+            multiplier=(ratio / mean_ratio) if ok else 1.0,
+            raw_ratio=ratio,
+            cohort_size=n,
+            depth_drift=drift,
+            trusted=ok,
+            reason=(
+                f"median mine/baseline over the top {DEPTH_PROBES[0]} by baseline points; "
+                f"stable to {drift:.4f} across depths {DEPTH_PROBES}"
+                if ok
+                else (
+                    f"ratio drifts {drift:.4f} across depths {DEPTH_PROBES} "
+                    f"(max {MAX_DEPTH_DRIFT}) — sampling artifact, not a scoring tilt; "
+                    "multiplier forced to 1.0"
+                )
+            ),
+        )
+        if not ok:
+            _LOGGER.warning(
+                "scoring_fit: %s rejected, depth drift %.4f > %.4f",
+                pos,
+                drift,
+                MAX_DEPTH_DRIFT,
+            )
+
+    return ScoringFitMeasurement(
+        positions=positions,
+        season=season,
+        measured=True,
+        reason=f"measured over {sum(n for _, _, n in raw.values())} IDP player-seasons",
+    )

--- a/src/nfl_data/reception_depth.py
+++ b/src/nfl_data/reception_depth.py
@@ -1,0 +1,376 @@
+"""Per-player reception-depth histograms, in Sleeper's exact bands.
+
+Why this exists
+───────────────
+This league does not pay a flat PPR. It bands receptions by the yardage
+gained on the catch, and the spread is enormous — measured live from
+Sleeper 2026-07-27, per-catch total (``rec`` + the band key)::
+
+    band       mine   baseline   ratio
+    0-4 yd     0.25     0.75     0.33x
+    5-9 yd     0.50     0.75     0.67x
+    10-19 yd   0.75     0.75     1.00x   <- calibration point
+    20-29 yd   1.00     0.75     1.33x
+    30-39 yd   1.25     0.75     1.67x
+    40+ yd     2.00     0.75     2.67x
+
+An 8x spread from shortest to longest, and the MEAN sits exactly on the
+0.75 that every ranking source prices. That is why the mispricing is
+invisible in aggregate and total at the extremes: a checkdown back is
+worth a third of his market price here, a deep threat nearly 2.7x.
+
+Exploiting it needs each receiver's distribution of catches across those
+six bands. Nothing in the weekly stat files can supply it.
+
+The shortcut that does not work
+───────────────────────────────
+nflverse's unified weekly file carries ``receiving_10``, ``_16``,
+``_20`` and ``_40``. They are tempting and they are wrong for this:
+
+* they are CUMULATIVE thresholds, not bands;
+* their boundaries (10/16/20/40) do not line up with Sleeper's
+  (5/10/20/30/40);
+* and critically, **nothing in that set can reconstruct 0-4** — the
+  0.33x band, the single most mispriced one.
+
+A histogram derived from them would look plausible and be wrong exactly
+where the money is. So the source has to be play-by-play.
+
+Why not ``nflverse_direct.fetch_pbp``
+─────────────────────────────────────
+It exists, and this module deliberately does not use it. ``fetch_pbp``
+buffers the whole response into a string and then materialises every row
+as a dict — 2025 is 98 MB over 372 columns and ~50k plays, so that is
+hundreds of megabytes of Python dicts to read four fields.
+
+This module streams the same CSV with :mod:`csv.reader`, indexes only
+the columns it needs by position, and accumulates counts as it goes.
+Peak memory is the histogram, not the season.
+
+What counts as a reception of N yards
+─────────────────────────────────────
+``complete_pass == 1``, credited to ``receiver_player_id``, bucketed on
+``receiving_yards`` where present and ``yards_gained`` otherwise. The
+two agree on ordinary plays; they diverge on laterals, where
+``yards_gained`` includes yardage the receiver was not credited with, so
+the receiving column is preferred.
+
+**Negative and zero-yard receptions fall in the 0-4 band.** Sleeper's
+lowest band is named ``rec_0_4`` and there is no key below it, so a
+2-yard loss on a catch scores as the shortest band. That is an
+interpretation of an undocumented boundary rather than a measurement,
+and it is called out here because it is the one judgement call in the
+mapping. It affects a small number of plays.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import logging
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Mapping, Sequence
+
+_LOGGER = logging.getLogger(__name__)
+
+__all__ = [
+    "BAND_KEYS",
+    "RECEPTION_DEPTH_SCHEMA_VERSION",
+    "band_for_yards",
+    "default_depth_dir",
+    "depth_path",
+    "load_reception_depth",
+    "persist_reception_depth",
+    "summarise_histogram",
+]
+
+RECEPTION_DEPTH_SCHEMA_VERSION = "2026-07-27.v1"
+
+#: Sleeper's reception-distance scoring keys, shortest first. These are
+#: the exact key names on the league's ``scoring_settings``, so a
+#: consumer can look each one up directly without a translation table.
+BAND_KEYS: tuple[str, ...] = (
+    "rec_0_4",
+    "rec_5_9",
+    "rec_10_19",
+    "rec_20_29",
+    "rec_30_39",
+    "rec_40p",
+)
+
+#: Lower bound of each band, aligned with :data:`BAND_KEYS`. The last
+#: band is open-ended.
+_BAND_LOWER: tuple[int, ...] = (0, 5, 10, 20, 30, 40)
+
+_PBP_URL = "https://github.com/nflverse/nflverse-data/releases/download/pbp/play_by_play_{year}.csv"
+
+_HTTP_TIMEOUT_SEC = 180.0
+_USER_AGENT = "brisket-reception-depth/1.0"
+
+
+def band_for_yards(yards: float) -> str:
+    """Which Sleeper band a reception of ``yards`` falls in.
+
+    Anything below 5 — including zero and negative — lands in
+    ``rec_0_4``; see the module docstring for why that is an
+    interpretation rather than a measurement.
+    """
+    y = float(yards)
+    band = BAND_KEYS[0]
+    for key, lower in zip(BAND_KEYS, _BAND_LOWER):
+        if y >= lower:
+            band = key
+    return band
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def default_depth_dir() -> Path:
+    """Sibling of the weekly actuals, same durability contract."""
+    return _repo_root() / "data" / "nfl_data" / "actuals"
+
+
+def depth_path(season: int, *, depth_dir: Path | None = None) -> Path:
+    return (depth_dir or default_depth_dir()) / f"reception_depth_{int(season)}.jsonl"
+
+
+def _open_pbp(season: int, url_template: str = _PBP_URL):
+    url = url_template.format(year=int(season))
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    return urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SEC)
+
+
+def _iter_receptions(
+    lines: Iterable[str],
+) -> Iterator[tuple[str, str, int, str, float]]:
+    """Yield ``(gsis, name, week, season_type, yards)`` per completed pass.
+
+    Takes an iterable of CSV lines rather than a URL so tests can drive
+    it from a fixture without any network, and so the caller owns the
+    connection lifetime.
+    """
+    reader = csv.reader(lines)
+    try:
+        header = next(reader)
+    except StopIteration:
+        return
+    idx = {name: i for i, name in enumerate(header)}
+
+    needed = ("complete_pass", "receiver_player_id", "week", "season_type")
+    missing = [c for c in needed if c not in idx]
+    if missing:
+        # A renamed pbp column must not read as "no receptions this
+        # season" — that is precisely how the 2025 weekly-stats rename
+        # went unnoticed for a season (#589).
+        raise ValueError(f"play-by-play is missing expected columns: {missing}")
+
+    i_complete = idx["complete_pass"]
+    i_rid = idx["receiver_player_id"]
+    i_name = idx.get("receiver_player_name", -1)
+    i_week = idx["week"]
+    i_stype = idx["season_type"]
+    i_recyd = idx.get("receiving_yards", -1)
+    i_gained = idx.get("yards_gained", -1)
+    if i_recyd < 0 and i_gained < 0:
+        raise ValueError("play-by-play carries neither receiving_yards nor yards_gained")
+
+    for row in reader:
+        if len(row) <= i_complete:
+            continue
+        if row[i_complete] not in ("1", "1.0", "True", "true"):
+            continue
+        gsis = row[i_rid] if i_rid < len(row) else ""
+        if not gsis:
+            continue
+        raw = ""
+        if i_recyd >= 0 and i_recyd < len(row):
+            raw = row[i_recyd]
+        if raw in ("", "NA") and i_gained >= 0 and i_gained < len(row):
+            raw = row[i_gained]
+        try:
+            yards = float(raw)
+        except (TypeError, ValueError):
+            continue
+        try:
+            week = int(float(row[i_week]))
+        except (TypeError, ValueError):
+            continue
+        name = row[i_name] if 0 <= i_name < len(row) else ""
+        stype = (row[i_stype] if i_stype < len(row) else "REG") or "REG"
+        yield gsis, name, week, stype.upper(), yards
+
+
+def _accumulate(
+    receptions: Iterable[tuple[str, str, int, str, float]],
+    *,
+    season_types: Sequence[str] | None = ("REG",),
+) -> dict[str, dict[str, Any]]:
+    wanted = {s.upper() for s in season_types} if season_types else None
+    out: dict[str, dict[str, Any]] = {}
+    for gsis, name, _week, stype, yards in receptions:
+        if wanted is not None and stype not in wanted:
+            continue
+        rec = out.get(gsis)
+        if rec is None:
+            rec = {
+                "name": name,
+                "receptions": 0,
+                "receivingYards": 0.0,
+                "bands": dict.fromkeys(BAND_KEYS, 0),
+            }
+            out[gsis] = rec
+        if not rec["name"] and name:
+            rec["name"] = name
+        rec["receptions"] += 1
+        rec["receivingYards"] += yards
+        rec["bands"][band_for_yards(yards)] += 1
+    return out
+
+
+def summarise_histogram(bands: Mapping[str, int]) -> dict[str, Any]:
+    """Fraction of a player's catches in each band, plus the count.
+
+    Fractions are what a scoring comparison needs — two receivers with
+    the same shape and different volume should read as the same *fit*,
+    with volume handled separately by whatever prices them.
+    """
+    counts = {k: int(bands.get(k, 0) or 0) for k in BAND_KEYS}
+    total = sum(counts.values())
+    if total <= 0:
+        return {"receptions": 0, "counts": counts, "shares": dict.fromkeys(BAND_KEYS, 0.0)}
+    return {
+        "receptions": total,
+        "counts": counts,
+        "shares": {k: counts[k] / total for k in BAND_KEYS},
+    }
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def persist_reception_depth(
+    seasons: Sequence[int],
+    *,
+    depth_dir: Path | None = None,
+    season_types: Sequence[str] | None = ("REG",),
+    url_template: str = _PBP_URL,
+    _line_source=None,
+) -> dict[str, Any]:
+    """Stream play-by-play and persist per-player band histograms.
+
+    One file per season, one JSONL line per season (the histogram is a
+    season aggregate, not weekly — the bands are too sparse per week to
+    be useful and a week-grained file would be 20x the size for noise).
+
+    Re-running replaces the season's line. ``_line_source`` is a test
+    seam that supplies CSV lines directly; production passes nothing.
+    """
+    result: dict[str, Any] = {
+        "schemaVersion": RECEPTION_DEPTH_SCHEMA_VERSION,
+        "seasons": [],
+        "players": 0,
+        "receptions": 0,
+        "paths": [],
+    }
+
+    for season in seasons:
+        season = int(season)
+        try:
+            if _line_source is not None:
+                histogram = _accumulate(
+                    _iter_receptions(_line_source(season)), season_types=season_types
+                )
+            else:
+                resp = _open_pbp(season, url_template)
+                try:
+                    stream = io.TextIOWrapper(resp, encoding="utf-8", errors="replace")
+                    histogram = _accumulate(_iter_receptions(stream), season_types=season_types)
+                finally:
+                    resp.close()
+        except urllib.error.HTTPError as exc:
+            if getattr(exc, "code", 0) == 404:
+                _LOGGER.error(
+                    "reception_depth=url_stale season=%d status=404 — the pbp "
+                    "release path no longer exists; update _PBP_URL. No rows.",
+                    season,
+                )
+            else:
+                _LOGGER.warning("reception_depth=http season=%d status=%s", season, exc)
+            continue
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.warning("reception_depth=failed season=%d err=%r", season, exc)
+            continue
+
+        if not histogram:
+            _LOGGER.warning(
+                "reception_depth: season %d produced no receptions — either the "
+                "season has not started or the pbp schema changed",
+                season,
+            )
+            continue
+
+        total_rec = sum(int(r["receptions"]) for r in histogram.values())
+        entry = {
+            "schemaVersion": RECEPTION_DEPTH_SCHEMA_VERSION,
+            "season": season,
+            "seasonTypes": sorted({s.upper() for s in (season_types or ["REG", "POST"])}),
+            "capturedAt": _now_utc(),
+            "playerCount": len(histogram),
+            "receptionCount": total_rec,
+            "bandKeys": list(BAND_KEYS),
+            "players": {
+                gsis: {
+                    "name": rec["name"],
+                    "receptions": rec["receptions"],
+                    "receivingYards": round(float(rec["receivingYards"]), 1),
+                    "bands": rec["bands"],
+                }
+                for gsis, rec in sorted(histogram.items())
+            },
+        }
+
+        path = depth_path(season, depth_dir=depth_dir)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        with tmp.open("w", encoding="utf-8") as f:
+            f.write(json.dumps(entry, separators=(",", ":"), sort_keys=True) + "\n")
+        tmp.replace(path)
+
+        result["seasons"].append(season)
+        result["players"] += len(histogram)
+        result["receptions"] += total_rec
+        result["paths"].append(str(path))
+        _LOGGER.info(
+            "reception_depth=written season=%d players=%d receptions=%d path=%s",
+            season,
+            len(histogram),
+            total_rec,
+            path,
+        )
+
+    return result
+
+
+def load_reception_depth(season: int, *, depth_dir: Path | None = None) -> dict[str, Any] | None:
+    """The persisted histogram for ``season``, or None."""
+    path = depth_path(season, depth_dir=depth_dir)
+    if not path.exists():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not text:
+        return None
+    try:
+        return json.loads(text.splitlines()[0])
+    except json.JSONDecodeError:
+        _LOGGER.warning("reception_depth: unparseable file at %s", path)
+        return None

--- a/tests/api/test_fantasypros_idp_integration.py
+++ b/tests/api/test_fantasypros_idp_integration.py
@@ -195,10 +195,26 @@ class TestFantasyProsIdpCsvShape(unittest.TestCase):
         ext.sort(key=lambda r: int(r["originalRank"]))
         effs = [int(r["effectiveRank"]) for r in ext]
         for a, b in zip(effs, effs[1:]):
-            self.assertLess(
+            # Non-decreasing; see the note in
+            # ``test_anchor_curve_extrapolation_monotone`` for why ties are
+            # structural and only inversions are defects.
+            self.assertLessEqual(
                 a,
                 b,
-                f"{family} extension curve not monotone: {a} -> {b}",
+                f"{family} extension curve INVERTED: {a} -> {b}",
+            )
+
+        # Ties are tolerated but must not swallow the curve.  If most of a
+        # family collapses onto a handful of effective ranks the curve has
+        # stopped discriminating, which the inversion check alone would
+        # never notice — every row equal is perfectly non-decreasing.
+        if len(effs) >= 10:
+            distinct = len(set(effs))
+            self.assertGreaterEqual(
+                distinct,
+                len(effs) // 2,
+                f"{family} extension curve has collapsed: {len(effs)} rows onto "
+                f"{distinct} distinct effective ranks",
             )
 
     def test_dl_curve_monotone(self):
@@ -262,10 +278,26 @@ class TestFantasyProsIdpCsvShape(unittest.TestCase):
             last_eff = -1
             for r in ext:
                 eff = int(r["effectiveRank"])
-                self.assertGreater(
+                # NON-DECREASING, not strictly increasing.  ``effectiveRank``
+                # is ``int(round(_interpolate(...)))`` — a continuous curve
+                # rounded onto integers — so two adjacent individual ranks
+                # can legitimately land on the same effective rank.  Ties
+                # are a resolution loss; an INVERSION would be a real
+                # defect, because it would rank a worse player ahead of a
+                # better one.  Only the inversion is asserted.
+                #
+                # This was ``assertGreater`` and failed intermittently on
+                # main for exactly that reason: the CSV refreshes every two
+                # hours and each snapshot ties in different places, so the
+                # failing player changed run to run (Chase Young 107, Nick
+                # Herbig 156, an LB at 163).  Measured on the 2026-07-27
+                # snapshot: 10 ties across DL, zero decreases in any family.
+                self.assertGreaterEqual(
                     eff,
                     last_eff,
-                    f"{fam}: non-monotone extrapolation at {r['name']}",
+                    f"{fam}: extrapolation INVERTED at {r['name']} "
+                    f"({last_eff} -> {eff}); a deeper individual rank must "
+                    "never map to a shallower effective rank",
                 )
                 last_eff = eff
 

--- a/tests/league_intel/test_reception_fit.py
+++ b/tests/league_intel/test_reception_fit.py
@@ -1,0 +1,209 @@
+"""Tests for the reception-depth value tilt.
+
+The single most important thing these pin is the MAGNITUDE, because the
+headline number for this feature is misleading by an order of magnitude
+if quoted alone. The per-catch spread really is 8x (0.25 to 2.00) and
+``docs/ORCHESTRATION.md`` calls it "the largest unexploited edge
+identified to date" — but receptions are only 17-33% of a player's
+points, so the composed VALUE tilt lands near ±8%.
+
+``test_composition_shrinks_the_per_catch_ratio_toward_one`` exists so
+that anyone who later "simplifies" the composition away — applying the
+per-catch ratio directly to player value — fails loudly instead of
+shipping a 2x repricing.
+
+The other load-bearing test is the dispersion-stability guard, shown
+firing. It is the same standard :mod:`src.league_intel.scoring_fit`
+applies, and it is what distinguishes this measurement (flat across
+depth, kept) from the IDP per-player one (fans out, refused).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.league_intel.reception_fit import (
+    MAX_TILT,
+    MIN_RECEPTIONS,
+    measure_reception_depth_fit,
+    reception_scoring_keys,
+)
+
+# The real cards, reduced to the keys that matter here.
+_MINE = {
+    "rec": 0.08,
+    "rec_0_4": 0.17,
+    "rec_5_9": 0.42,
+    "rec_10_19": 0.67,
+    "rec_20_29": 0.92,
+    "rec_30_39": 1.17,
+    "rec_40p": 1.92,
+}
+_BASE = {"rec": 0.75}
+
+
+def _payload(players: dict) -> dict:
+    return {"season": 2025, "players": players}
+
+
+def _player(name: str, bands: dict) -> dict:
+    return {"name": name, "bands": bands, "receptions": sum(bands.values())}
+
+
+def _uniform(n_players: int, bands: dict, share: float, prefix: str = "p"):
+    """``n_players`` identical receivers — an exact, noise-free cohort."""
+    players = {f"{prefix}{i:03d}": _player(f"{prefix}{i}", dict(bands)) for i in range(n_players)}
+    shares = {f"{prefix}{i:03d}": share for i in range(n_players)}
+    return players, shares
+
+
+# ── Magnitude: the thing most likely to be misquoted ─────────────────
+
+
+def test_composition_shrinks_the_per_catch_ratio_toward_one():
+    """A deep threat's catches are worth ~2.4x here, but if only a fifth
+    of his points come from receptions his VALUE moves ~28%, not 140%.
+
+    Applying the per-catch ratio straight to player value is the error
+    this test exists to prevent.
+    """
+    bands = {"rec_40p": 30, "rec_30_39": 10}  # all long
+    # Share deliberately below the level at which MAX_TILT would bind,
+    # so this test measures the COMPOSITION and not the clamp — the
+    # clamp has its own test and a fixture that hit both would not
+    # distinguish them.
+    share = 0.15
+    players, shares = _uniform(20, bands, share=share)
+    m = measure_reception_depth_fit(_payload(players), shares, _MINE, _BASE, season=2025)
+    assert m.measured and m.trusted
+
+    gid = "p000"
+    per_catch = m.per_catch_ratios[gid]
+    multiplier = m.multipliers[gid]
+    assert per_catch > 2.0, "fixture is not actually a deep-threat shape"
+    assert multiplier < 1.0 + MAX_TILT, "fixture hit the clamp; it is testing the wrong thing"
+    # Exactly where the composition puts it, and far below the per-catch
+    # ratio it came from.
+    assert multiplier == pytest.approx(1.0 + share * (per_catch - 1.0))
+    # The claim stated as a shrinkage: the value moves by the SHARE of
+    # the per-catch move, so a 142% per-catch premium becomes a 21%
+    # value premium. Asserting the deviations rather than the raw
+    # numbers is what makes this about composition.
+    assert (multiplier - 1.0) == pytest.approx(share * (per_catch - 1.0))
+    assert (multiplier - 1.0) < 0.25 * (per_catch - 1.0)
+
+
+def test_a_zero_reception_share_is_a_no_op_however_extreme_the_shape():
+    """A player who scores nothing from catches cannot be repriced by a
+    reception rule, no matter how lopsided his band shape is."""
+    players, shares = _uniform(20, {"rec_40p": 40}, share=0.0)
+    m = measure_reception_depth_fit(_payload(players), shares, _MINE, _BASE, season=2025)
+    assert m.multipliers["p000"] == pytest.approx(1.0)
+
+
+def test_the_direction_matches_the_band_the_catches_fall_in():
+    short, short_shares = _uniform(15, {"rec_0_4": 40}, share=0.30, prefix="s")
+    deep, deep_shares = _uniform(15, {"rec_40p": 40}, share=0.30, prefix="d")
+    players = {**short, **deep}
+    shares = {**short_shares, **deep_shares}
+    m = measure_reception_depth_fit(_payload(players), shares, _MINE, _BASE, season=2025)
+    assert m.multipliers["s000"] < 1.0 < m.multipliers["d000"]
+
+
+# ── Guards ───────────────────────────────────────────────────────────
+
+
+def test_the_tilt_is_clamped(monkeypatch):
+    """An upstream data fault must not be able to express itself as a
+    3x repricing. The clamp is a backstop, not a shaper — on real 2025
+    data exactly one of 200 receivers reaches it."""
+    players, shares = _uniform(20, {"rec_40p": 40}, share=1.0)
+    m = measure_reception_depth_fit(_payload(players), shares, _MINE, _BASE, season=2025)
+    assert m.multipliers["p000"] == pytest.approx(1.0 + MAX_TILT)
+
+
+def test_players_below_the_reception_floor_are_excluded():
+    """A handful of catches describes noise, not a shape."""
+    thin = {"p000": _player("Thin", {"rec_40p": MIN_RECEPTIONS - 1})}
+    m = measure_reception_depth_fit(_payload(thin), {"p000": 0.3}, _MINE, _BASE, season=2025)
+    assert "p000" not in m.multipliers
+
+
+def test_a_player_with_no_scored_season_is_skipped_not_guessed():
+    """The per-catch ratio is knowable from the histogram alone, but its
+    WEIGHT is not. Inventing a reception share would invent the entire
+    magnitude of the adjustment."""
+    players, shares = _uniform(20, {"rec_40p": 40}, share=0.3)
+    shares.pop("p000")
+    m = measure_reception_depth_fit(_payload(players), shares, _MINE, _BASE, season=2025)
+    assert "p000" not in m.multipliers
+    assert m.multiplier_for("p000") == 1.0
+
+
+def test_dispersion_drift_rejects_the_whole_measurement():
+    """THE GUARD, shown firing.
+
+    High-volume receivers are uniform (dispersion ~1.0); the low-volume
+    tail is split between extremes, so dispersion widens sharply as the
+    pool deepens. That pattern says the number is describing sample
+    composition, and no individual multiplier from it is trustworthy —
+    so the refusal is total rather than per player.
+    """
+    top, top_sh = _uniform(24, {"rec_10_19": 40}, share=0.30, prefix="t")
+    lo_a, lo_a_sh = _uniform(60, {"rec_40p": 25}, share=0.60, prefix="a")
+    lo_b, lo_b_sh = _uniform(60, {"rec_0_4": 25}, share=0.60, prefix="b")
+    players = {**top, **lo_a, **lo_b}
+    shares = {**top_sh, **lo_a_sh, **lo_b_sh}
+    m = measure_reception_depth_fit(_payload(players), shares, _MINE, _BASE, season=2025)
+
+    assert m.measured
+    assert m.dispersion_drift > 0.12, (
+        f"fixture did not actually drift (drift={m.dispersion_drift}); "
+        "the guard would pass vacuously"
+    )
+    assert not m.trusted
+    assert "sample composition" in m.reason
+    # Untrusted means EVERY lookup is inert, including the ones whose
+    # own numbers looked fine.
+    assert m.multiplier_for("t000") == 1.0
+    assert m.multiplier_for("a000") == 1.0
+
+
+def test_a_stable_measurement_is_trusted():
+    """Control for the test above: without it, the rejection test would
+    pass against a module that rejects everything."""
+    players, shares = _uniform(80, {"rec_10_19": 30, "rec_40p": 10}, share=0.30)
+    m = measure_reception_depth_fit(_payload(players), shares, _MINE, _BASE, season=2025)
+    assert m.trusted, m.reason
+
+
+# ── Refusals ─────────────────────────────────────────────────────────
+
+
+def test_missing_inputs_refuse_rather_than_crash():
+    players, shares = _uniform(20, {"rec_10_19": 40}, share=0.3)
+    for depth, sh, mine, base in (
+        (None, shares, _MINE, _BASE),
+        (_payload(players), shares, None, _BASE),
+        (_payload(players), shares, _MINE, None),
+    ):
+        m = measure_reception_depth_fit(depth, sh, mine, base, season=2025)
+        assert not m.measured
+        assert m.reason
+        assert m.multiplier_for("p000") == 1.0
+
+
+def test_a_tiny_sample_is_not_a_measurement():
+    players, shares = _uniform(5, {"rec_10_19": 40}, share=0.3)
+    m = measure_reception_depth_fit(_payload(players), shares, _MINE, _BASE, season=2025)
+    assert not m.trusted
+    assert m.multiplier_for("p000") == 1.0
+
+
+def test_reception_keys_cover_the_flat_and_banded_forms():
+    """The share computation zeroes these to isolate the reception
+    component. Missing ``rec`` would leave the flat portion in the
+    remainder and understate every share."""
+    keys = reception_scoring_keys()
+    assert "rec" in keys
+    assert "rec_0_4" in keys and "rec_40p" in keys

--- a/tests/league_intel/test_reception_fit.py
+++ b/tests/league_intel/test_reception_fit.py
@@ -207,3 +207,112 @@ def test_reception_keys_cover_the_flat_and_banded_forms():
     keys = reception_scoring_keys()
     assert "rec" in keys
     assert "rec_0_4" in keys and "rec_40p" in keys
+
+
+# ── The axis: wired, not staged ──────────────────────────────────────
+#
+# ORCHESTRATION.md 6.14/6.15: a module nothing imports cannot be caught
+# by the guards written for it. The axis is constructed on every board
+# and yields ABSENT when there is no measurement, so the flag-off path
+# still exercises this code.
+
+
+def test_a_measured_player_reaches_the_axis_with_its_evidence():
+    from src.league_intel.adjustment import EvidenceTier, reception_fit_axis
+
+    axis = reception_fit_axis("Alec Pierce", "WR", {"alec pierce": 1.048})
+    assert axis.tier is EvidenceTier.SCORING_MEASURED
+    assert axis.applied
+    assert axis.factor == pytest.approx(1.048)
+    # The rationale must state the composition, because "1.048x" alone
+    # invites someone to think it came from the per-catch ratio.
+    assert "per_catch_ratio" in axis.rationale
+
+
+def test_an_unmeasured_player_is_inert():
+    from src.league_intel.adjustment import EvidenceTier, reception_fit_axis
+
+    axis = reception_fit_axis("Nobody At All", "WR", {"alec pierce": 1.048})
+    assert axis.tier is EvidenceTier.ABSENT
+    assert axis.effective_factor == 1.0
+
+
+def test_no_measurement_at_all_is_inert():
+    """The flag-off path. `_resolve_reception_fit` returns None, and the
+    axis is still constructed so the guards keep running against it."""
+    from src.league_intel.adjustment import EvidenceTier, reception_fit_axis
+
+    axis = reception_fit_axis("Alec Pierce", "WR", None)
+    assert axis.tier is EvidenceTier.ABSENT
+    assert axis.effective_factor == 1.0
+
+
+def test_the_axis_joins_on_the_canonical_name_not_the_raw_string():
+    """Contract rows and stat rows spell names differently — suffixes,
+    apostrophes, accents. Joining on the raw string would silently drop
+    exactly the players whose names are hardest to spell."""
+    from src.league_intel.adjustment import reception_fit_axis
+    from src.utils.name_clean import resolve_canonical_name
+
+    key = resolve_canonical_name("Ja'Marr Chase")
+    axis = reception_fit_axis("JaMarr Chase Jr.", "WR", {key: 0.93})
+    assert axis.factor == pytest.approx(0.93)
+
+
+def test_the_board_applies_the_per_player_tilt():
+    """End to end through build_board_adjustments — the wiring, not just
+    the axis function."""
+    from src.league_intel.adjustment import build_board_adjustments
+
+    rows = [
+        {"displayName": "Deep Threat", "position": "WR", "rankDerivedValue": 5000},
+        {"displayName": "Check Down", "position": "RB", "rankDerivedValue": 5000},
+    ]
+    board = build_board_adjustments(rows, reception_fit={"deep threat": 1.05, "check down": 0.90})
+    by_name = {e.display_name: e for e in board.explanations}
+    assert by_name["Deep Threat"].league_adjusted_value > 5000
+    assert by_name["Check Down"].league_adjusted_value < 5000
+
+
+def test_the_board_is_unchanged_without_a_measurement():
+    """Flag-off must be arithmetically identical to the board before
+    this feature existed."""
+    from src.league_intel.adjustment import build_board_adjustments
+
+    rows = [{"displayName": "Deep Threat", "position": "WR", "rankDerivedValue": 5000}]
+    plain = build_board_adjustments(rows)
+    with_none = build_board_adjustments(rows, reception_fit=None)
+    assert (
+        plain.explanations[0].league_adjusted_value
+        == with_none.explanations[0].league_adjusted_value
+    )
+    assert with_none.explanations[0].league_adjusted_value == pytest.approx(5000)
+
+
+def test_the_reception_flag_is_separate_from_the_idp_one():
+    """Sharing `idp_scoring_fit` would make its name a lie: an operator
+    disabling the IDP feature would silently also disable every receiver
+    adjustment. Both default off, independently."""
+    from src.api import feature_flags
+
+    feature_flags.reload()
+    assert feature_flags.is_enabled("reception_scoring_fit") is False
+    assert feature_flags.is_enabled("idp_scoring_fit") is False
+
+
+def test_the_resolver_is_inert_while_the_reception_flag_is_off(monkeypatch):
+    from src.api import feature_flags, gameplan
+
+    monkeypatch.setenv("RISKIT_FEATURE_RECEPTION_SCORING_FIT", "0")
+    feature_flags.reload()
+    gameplan.invalidate_reception_fit_cache()
+    called = []
+    monkeypatch.setattr(
+        "src.nfl_data.ingest.fetch_weekly_stats", lambda *a, **k: called.append(1) or []
+    )
+    try:
+        assert gameplan._resolve_reception_fit("main") is None
+        assert called == [], "flag off must not fetch stats"
+    finally:
+        feature_flags.reload()
+        gameplan.invalidate_reception_fit_cache()

--- a/tests/league_intel/test_scoring_fit.py
+++ b/tests/league_intel/test_scoring_fit.py
@@ -1,0 +1,268 @@
+"""Tests for the IDP positional scoring-fit measurement (Tier 2).
+
+The measurement exists because this league's rate card inverts the
+market's on IDP — it pays coverage and disruption (``idp_pass_def``
+2.52x, ``idp_tkl_loss`` 2.06x) and discounts finishing plays
+(``idp_sack`` 0.64x) — while every ranking source prices IDP on a
+generic card.
+
+**The tests that matter most are the ones that pin what this module
+REFUSES to do.** The same data supports a per-player multiplier
+arithmetically, and it would be noise: measured p90/p10 among rosterable
+IDPs is only ~1.07-1.12 and it grows monotonically with pool depth,
+which is the signature of small samples rather than of a real
+player-selection edge. So:
+
+* :func:`test_depth_drift_rejects_a_cohort_that_is_only_sampling_noise`
+  builds a cohort whose ratio genuinely moves with depth and asserts the
+  multiplier is forced to 1.0. Per ORCHESTRATION.md 6.15, a guard that
+  cannot fire is not a guard — this one is shown firing.
+* :func:`test_a_stable_cohort_is_trusted` is its control. Without it the
+  rejection test would pass against a module that rejects everything.
+
+Fixtures are synthetic and hermetic. Nothing here touches Sleeper or
+nflverse.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.league_intel.adjustment import EvidenceTier, scoring_fit_axis
+from src.league_intel.scoring_fit import (
+    MAX_DEPTH_DRIFT,
+    MIN_COHORT_SIZE,
+    measure_positional_scoring_fit,
+)
+
+# Two rate cards that differ ONLY on the two keys below, so every ratio
+# in these tests is traceable to a deliberate choice rather than to an
+# accident of a large settings dict.
+_MINE = {"idp_tkl_solo": 1.0, "idp_sack": 2.0}
+_BASE = {"idp_tkl_solo": 1.0, "idp_sack": 4.0}
+
+
+def _week(pid: str, pos: str, week: int, *, solo: float, sacks: float) -> dict:
+    return {
+        "player_id": pid,
+        "player_name": pid,
+        "position": pos,
+        "season": 2025,
+        "week": week,
+        "def_tackles_solo": solo,
+        "def_tackles_with_assist": 0,
+        "def_tackle_assists": 0,
+        "def_sacks": sacks,
+    }
+
+
+def _cohort(pos: str, n: int, *, solo: float, sacks: float, weeks: int = 17) -> list[dict]:
+    """``n`` players at ``pos``, each with an identical weekly line.
+
+    Identical lines mean the cohort's ratio is exact rather than noisy,
+    so a test that asserts a specific multiplier is asserting the
+    arithmetic and not a sampling outcome.
+    """
+    rows: list[dict] = []
+    for i in range(n):
+        for w in range(1, weeks + 1):
+            rows.append(_week(f"{pos}-{i:03d}", pos, w, solo=solo, sacks=sacks))
+    return rows
+
+
+def test_a_stable_cohort_is_trusted():
+    """The control for the rejection test below.
+
+    Every DL has the same stat line, so the ratio is identical at every
+    pool depth and drift is exactly 0.
+    """
+    rows = _cohort("DL", 40, solo=3, sacks=1) + _cohort("LB", 40, solo=6, sacks=0)
+    m = measure_positional_scoring_fit(rows, _MINE, _BASE, season=2025)
+    assert m.measured, m.reason
+    dl = m.positions["DL"]
+    assert dl.trusted, dl.reason
+    assert dl.depth_drift == pytest.approx(0.0, abs=1e-9)
+
+
+def test_the_tilt_points_the_way_the_rate_cards_do():
+    """DL earns sacks, which this card halves; LB earns tackles, which
+    it leaves alone. So DL must come out BELOW LB.
+
+    Asserting the direction rather than a magnitude: the magnitude is a
+    property of the fixture, the direction is a property of the model.
+    """
+    rows = _cohort("DL", 40, solo=3, sacks=1) + _cohort("LB", 40, solo=6, sacks=0)
+    m = measure_positional_scoring_fit(rows, _MINE, _BASE, season=2025)
+    assert m.multiplier_for("DL") < m.multiplier_for("LB")
+
+
+def test_multipliers_are_mean_normalised_so_idp_is_not_inflated():
+    """Only the tilt BETWEEN positions carries information; the shared
+    level is an artifact of how generously each commissioner numbered
+    their sheet. The measurement must re-allocate, never inflate."""
+    rows = _cohort("DL", 40, solo=3, sacks=1) + _cohort("LB", 40, solo=6, sacks=0)
+    m = measure_positional_scoring_fit(rows, _MINE, _BASE, season=2025)
+    trusted = [f.multiplier for f in m.positions.values() if f.trusted]
+    assert trusted
+    assert sum(trusted) / len(trusted) == pytest.approx(1.0, abs=1e-9)
+
+
+def test_depth_drift_rejects_a_cohort_that_is_only_sampling_noise():
+    """THE GUARD, shown firing.
+
+    The top 24 LBs are pure tacklers (ratio 1.0 — no sacks, and the
+    cards agree on tackles). Everyone below them is a pure sack
+    specialist (ratio 0.5). So the cohort's median ratio is 1.0 at
+    depth 24 and collapses toward 0.5 as the pool deepens — exactly the
+    depth-dependence that says 'this number is measuring sample
+    composition, not scoring'.
+
+    A position like that must be refused, not averaged.
+    """
+    rows = (
+        _cohort("LB", 24, solo=10, sacks=0)  # high scorers, ratio 1.0
+        + _cohort("LB", 96, solo=0, sacks=2)  # low scorers, ratio 0.5
+        + _cohort("DL", 40, solo=3, sacks=1)  # a stable cohort alongside
+    )
+    m = measure_positional_scoring_fit(rows, _MINE, _BASE, season=2025)
+    lb = m.positions["LB"]
+    assert lb.depth_drift > MAX_DEPTH_DRIFT, (
+        f"fixture did not actually drift (drift={lb.depth_drift}); the guard "
+        "would pass vacuously"
+    )
+    assert not lb.trusted
+    assert lb.multiplier == 1.0
+    assert "sampling artifact" in lb.reason
+    # And the untrusted position must not contaminate the normalisation
+    # of the one that IS trustworthy.
+    assert m.positions["DL"].trusted
+
+
+def test_an_untrusted_position_is_inert_through_the_axis():
+    """The rejection has to survive the trip into the adjustment model,
+    not just look right on the measurement object."""
+    rows = _cohort("LB", 24, solo=10, sacks=0) + _cohort("LB", 96, solo=0, sacks=2)
+    m = measure_positional_scoring_fit(rows, _MINE, _BASE, season=2025)
+    axis = scoring_fit_axis("LB", m)
+    assert axis.tier is EvidenceTier.ABSENT
+    assert axis.effective_factor == 1.0
+    assert not axis.applied
+
+
+def test_a_trusted_position_reaches_the_axis_with_its_evidence():
+    rows = _cohort("DL", 40, solo=3, sacks=1) + _cohort("LB", 40, solo=6, sacks=0)
+    m = measure_positional_scoring_fit(rows, _MINE, _BASE, season=2025)
+    axis = scoring_fit_axis("DL", m)
+    assert axis.tier is EvidenceTier.SCORING_MEASURED
+    assert axis.applied
+    assert axis.measured_value is not None
+    assert "real player-seasons" in axis.rationale
+
+
+def test_offensive_positions_are_never_tilted():
+    """Offence is excluded on purpose. Its real divergence is
+    reception-distance banding, which a position-level multiplier cannot
+    express — applying one would paper over the actual edge with a
+    number that does not represent it."""
+    rows = _cohort("DL", 40, solo=3, sacks=1) + _cohort("LB", 40, solo=6, sacks=0)
+    m = measure_positional_scoring_fit(rows, _MINE, _BASE, season=2025)
+    for pos in ("WR", "RB", "QB", "TE"):
+        assert m.multiplier_for(pos) == 1.0
+        assert scoring_fit_axis(pos, m).tier is EvidenceTier.ABSENT
+
+
+def test_unknown_and_empty_positions_are_inert():
+    rows = _cohort("DL", 40, solo=3, sacks=1) + _cohort("LB", 40, solo=6, sacks=0)
+    m = measure_positional_scoring_fit(rows, _MINE, _BASE, season=2025)
+    assert m.multiplier_for("") == 1.0
+    assert m.multiplier_for("KICKER") == 1.0
+    assert m.multiplier_for(None) == 1.0
+
+
+def test_a_thin_cohort_is_dropped_rather_than_guessed():
+    rows = _cohort("DL", MIN_COHORT_SIZE - 1, solo=3, sacks=1) + _cohort("LB", 40, solo=6, sacks=0)
+    m = measure_positional_scoring_fit(rows, _MINE, _BASE, season=2025)
+    assert "DL" not in m.positions
+    assert m.multiplier_for("DL") == 1.0
+
+
+def test_missing_scoring_settings_is_a_refusal_not_a_crash():
+    rows = _cohort("DL", 40, solo=3, sacks=1)
+    for mine, base in ((None, _BASE), (_MINE, None), ({}, {})):
+        m = measure_positional_scoring_fit(rows, mine, base, season=2025)
+        assert not m.measured
+        assert m.reason
+        assert m.multiplier_for("DL") == 1.0
+
+
+def test_no_rows_is_a_refusal_not_a_crash():
+    m = measure_positional_scoring_fit([], _MINE, _BASE, season=2025)
+    assert not m.measured
+    assert m.multiplier_for("DL") == 1.0
+
+
+def test_a_null_measurement_yields_an_absent_axis():
+    """The flag-off path. ``_resolve_scoring_fit`` returns None when the
+    feature is disabled, and that must be inert rather than an error —
+    the axis is still constructed on every board so the guards above
+    keep running against it."""
+    axis = scoring_fit_axis("DL", None)
+    assert axis.tier is EvidenceTier.ABSENT
+    assert axis.effective_factor == 1.0
+
+
+def test_a_lone_trusted_position_expresses_no_tilt():
+    """Surprising but correct, so it is pinned.
+
+    With only one trusted cohort there is no *relative* tilt to express
+    — the mean it is normalised against is itself — so the multiplier is
+    exactly 1.0. That is the honest answer: 'DL scores 1.09x the
+    baseline card' says nothing about DL versus LB if LB was refused.
+
+    Someone reading a 1.0 here might reasonably think the measurement
+    failed. It did not; it declined to invent a comparison.
+    """
+    rows = (
+        _cohort("DL", 40, solo=3, sacks=1)
+        # LB drifts and is refused, leaving DL alone.
+        + _cohort("LB", 24, solo=10, sacks=0)
+        + _cohort("LB", 96, solo=0, sacks=2)
+    )
+    m = measure_positional_scoring_fit(rows, _MINE, _BASE, season=2025)
+    assert m.positions["DL"].trusted
+    assert not m.positions["LB"].trusted
+    assert m.multiplier_for("DL") == pytest.approx(1.0)
+    # The raw ratio still carries the real measurement, so the evidence
+    # is not lost — only the comparison is withheld.
+    assert m.positions["DL"].raw_ratio != pytest.approx(1.0)
+
+
+def test_the_resolver_is_inert_while_the_flag_is_off(monkeypatch):
+    """Flag-off must produce None (an ABSENT axis), and must not pay the
+    cost of the measurement — it scores ~19k player-weeks twice."""
+    from src.api import feature_flags, gameplan
+
+    monkeypatch.setenv("RISKIT_FEATURE_IDP_SCORING_FIT", "0")
+    feature_flags.reload()
+    gameplan.invalidate_scoring_fit_cache()
+
+    called = []
+    monkeypatch.setattr(
+        "src.nfl_data.ingest.fetch_weekly_defensive_stats",
+        lambda *a, **k: called.append(1) or [],
+    )
+    try:
+        assert gameplan._resolve_scoring_fit("main") is None
+        assert called == [], "flag off must not fetch stats"
+    finally:
+        feature_flags.reload()
+        gameplan.invalidate_scoring_fit_cache()
+
+
+def test_the_flag_defaults_off():
+    """Unlike te_basis_conversion, which the operator directed on. This
+    moves every IDP value on the board and nobody has asked for it."""
+    from src.api import feature_flags
+
+    feature_flags.reload()
+    assert feature_flags.is_enabled("idp_scoring_fit") is False

--- a/tests/nfl_data/test_reception_depth.py
+++ b/tests/nfl_data/test_reception_depth.py
@@ -1,0 +1,228 @@
+"""Tests for per-player reception-depth histograms.
+
+The band mapping is the whole point of this module, so most of these
+test boundaries rather than plumbing. Sleeper's bands are
+0-4 / 5-9 / 10-19 / 20-29 / 30-39 / 40+, and an off-by-one at any edge
+silently moves catches between bands worth 0.25 and 2.00 a piece.
+
+``test_the_column_guard_fires_on_a_renamed_schema`` is the §6.15 guard:
+nflverse renamed six weekly-stat columns in 2025 and the breakage was
+invisible for a season because a missing column reads as a zero. This
+module raises instead, and the test proves it raises.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.nfl_data.reception_depth import (
+    BAND_KEYS,
+    band_for_yards,
+    load_reception_depth,
+    persist_reception_depth,
+    summarise_histogram,
+)
+
+_HEADER = (
+    "season,week,season_type,complete_pass,receiver_player_id,"
+    "receiver_player_name,receiving_yards,yards_gained"
+)
+
+
+def _play(pid, name, yards, *, complete=1, week=1, stype="REG", gained=None):
+    return (
+        f"2025,{week},{stype},{complete},{pid},{name},{yards},"
+        f"{yards if gained is None else gained}"
+    )
+
+
+def _lines(*plays):
+    def _src(_season):
+        return iter([_HEADER, *plays])
+
+    return _src
+
+
+# ── Band boundaries ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "yards,expected",
+    [
+        (-6, "rec_0_4"),  # negative catch: no band below rec_0_4 exists
+        (0, "rec_0_4"),
+        (4, "rec_0_4"),
+        (4.9, "rec_0_4"),
+        (5, "rec_5_9"),
+        (9, "rec_5_9"),
+        (10, "rec_10_19"),
+        (19, "rec_10_19"),
+        (20, "rec_20_29"),
+        (29, "rec_20_29"),
+        (30, "rec_30_39"),
+        (39, "rec_30_39"),
+        (40, "rec_40p"),
+        (99, "rec_40p"),
+    ],
+)
+def test_every_band_boundary(yards, expected):
+    """Each edge is worth real money: a catch that slides from
+    rec_10_19 (0.75) to rec_20_29 (1.00) is a 33% per-catch swing."""
+    assert band_for_yards(yards) == expected
+
+
+def test_the_bands_partition_without_gaps_or_overlap():
+    """Sweeping every integer 0..60 must land in exactly one band, and
+    the sequence must be monotone — a gap would silently drop catches."""
+    seen = [band_for_yards(y) for y in range(0, 61)]
+    assert set(seen) == set(BAND_KEYS)
+    order = {k: i for i, k in enumerate(BAND_KEYS)}
+    assert all(order[a] <= order[b] for a, b in zip(seen, seen[1:]))
+
+
+# ── Accumulation ─────────────────────────────────────────────────────
+
+
+def test_a_players_catches_land_in_the_right_bands(tmp_path):
+    src = _lines(
+        _play("00-1", "Deep.Guy", 45),
+        _play("00-1", "Deep.Guy", 12),
+        _play("00-1", "Deep.Guy", 3),
+    )
+    persist_reception_depth([2025], depth_dir=tmp_path, _line_source=src)
+    d = load_reception_depth(2025, depth_dir=tmp_path)
+    bands = d["players"]["00-1"]["bands"]
+    assert bands["rec_40p"] == 1
+    assert bands["rec_10_19"] == 1
+    assert bands["rec_0_4"] == 1
+    assert d["players"]["00-1"]["receptions"] == 3
+    assert d["players"]["00-1"]["receivingYards"] == pytest.approx(60.0)
+
+
+def test_incomplete_passes_are_not_receptions(tmp_path):
+    src = _lines(
+        _play("00-1", "A", 20),
+        _play("00-1", "A", 30, complete=0),
+    )
+    persist_reception_depth([2025], depth_dir=tmp_path, _line_source=src)
+    d = load_reception_depth(2025, depth_dir=tmp_path)
+    assert d["players"]["00-1"]["receptions"] == 1
+
+
+def test_plays_without_a_receiver_id_are_skipped(tmp_path):
+    src = _lines(_play("", "", 20), _play("00-1", "A", 8))
+    persist_reception_depth([2025], depth_dir=tmp_path, _line_source=src)
+    d = load_reception_depth(2025, depth_dir=tmp_path)
+    assert list(d["players"]) == ["00-1"]
+
+
+def test_receiving_yards_wins_over_yards_gained(tmp_path):
+    """They diverge on laterals, where yards_gained includes yardage the
+    receiver was never credited with. Bucketing on the wrong one would
+    promote a short catch into a long band."""
+    src = _lines(_play("00-1", "A", 4, gained=48))
+    persist_reception_depth([2025], depth_dir=tmp_path, _line_source=src)
+    d = load_reception_depth(2025, depth_dir=tmp_path)
+    assert d["players"]["00-1"]["bands"]["rec_0_4"] == 1
+    assert d["players"]["00-1"]["bands"]["rec_40p"] == 0
+
+
+def test_postseason_is_excluded_by_default(tmp_path):
+    """Fantasy regular seasons end before the NFL playoffs, so playoff
+    catches are not part of the scoring sample."""
+    src = _lines(_play("00-1", "A", 8), _play("00-1", "A", 44, week=20, stype="POST"))
+    persist_reception_depth([2025], depth_dir=tmp_path, _line_source=src)
+    d = load_reception_depth(2025, depth_dir=tmp_path)
+    assert d["players"]["00-1"]["receptions"] == 1
+    assert d["players"]["00-1"]["bands"]["rec_40p"] == 0
+
+
+def test_postseason_can_be_opted_in(tmp_path):
+    src = _lines(_play("00-1", "A", 8), _play("00-1", "A", 44, week=20, stype="POST"))
+    persist_reception_depth(
+        [2025], depth_dir=tmp_path, season_types=("REG", "POST"), _line_source=src
+    )
+    d = load_reception_depth(2025, depth_dir=tmp_path)
+    assert d["players"]["00-1"]["receptions"] == 2
+
+
+# ── The schema guard ─────────────────────────────────────────────────
+
+
+def test_the_column_guard_fires_on_a_renamed_schema(tmp_path):
+    """§6.15. nflverse renamed six weekly-stat columns in 2025 and the
+    break went unnoticed for a season because a missing column reads as
+    a zero — indistinguishable from 'this player caught nothing'.
+
+    A renamed pbp column must therefore RAISE, not return an empty
+    histogram. ``persist_reception_depth`` catches it and logs, so the
+    observable outcome is 'no file written' rather than 'a file full of
+    zeroes presented as a measurement'.
+    """
+    from src.nfl_data.reception_depth import _iter_receptions
+
+    renamed = "season,week,season_type,made_the_catch,catcher_id,name,receiving_yards"
+    with pytest.raises(ValueError, match="missing expected columns"):
+        list(_iter_receptions(iter([renamed, "2025,1,REG,1,00-1,A,12"])))
+
+
+def test_a_renamed_schema_writes_no_file_rather_than_an_empty_one(tmp_path):
+    """The caller-visible half of the guard above. A histogram of zeroes
+    would be consumed downstream as a real measurement."""
+    renamed = "season,week,season_type,made_the_catch,catcher_id,name,receiving_yards"
+
+    def _src(_season):
+        return iter([renamed, "2025,1,REG,1,00-1,A,12"])
+
+    result = persist_reception_depth([2025], depth_dir=tmp_path, _line_source=_src)
+    assert result["seasons"] == []
+    assert load_reception_depth(2025, depth_dir=tmp_path) is None
+
+
+def test_a_missing_yardage_column_also_raises():
+    from src.nfl_data.reception_depth import _iter_receptions
+
+    no_yards = "season,week,season_type,complete_pass,receiver_player_id,receiver_player_name"
+    with pytest.raises(ValueError, match="neither receiving_yards nor yards_gained"):
+        list(_iter_receptions(iter([no_yards, "2025,1,REG,1,00-1,A"])))
+
+
+# ── Summary shape ────────────────────────────────────────────────────
+
+
+def test_shares_sum_to_one_and_describe_shape_not_volume():
+    """Two receivers with the same shape and different volume must read
+    as the same FIT — volume is priced separately by whatever consumes
+    this."""
+    small = summarise_histogram({"rec_0_4": 1, "rec_40p": 1})
+    large = summarise_histogram({"rec_0_4": 50, "rec_40p": 50})
+    assert small["shares"] == large["shares"]
+    assert sum(small["shares"].values()) == pytest.approx(1.0)
+    assert small["receptions"] == 2
+    assert large["receptions"] == 100
+
+
+def test_an_empty_histogram_is_zeroes_not_a_divide_by_zero():
+    s = summarise_histogram({})
+    assert s["receptions"] == 0
+    assert all(v == 0.0 for v in s["shares"].values())
+
+
+def test_rerunning_replaces_the_season_rather_than_appending(tmp_path):
+    persist_reception_depth([2025], depth_dir=tmp_path, _line_source=_lines(_play("00-1", "A", 8)))
+    persist_reception_depth(
+        [2025],
+        depth_dir=tmp_path,
+        _line_source=_lines(_play("00-1", "A", 8), _play("00-1", "A", 44)),
+    )
+    from src.nfl_data.reception_depth import depth_path
+
+    text = depth_path(2025, depth_dir=tmp_path).read_text(encoding="utf-8").strip()
+    assert len(text.splitlines()) == 1
+    assert json.loads(text)["players"]["00-1"]["receptions"] == 2
+
+
+def test_load_of_a_missing_season_is_none_not_an_error(tmp_path):
+    assert load_reception_depth(1999, depth_dir=tmp_path) is None


### PR DESCRIPTION
Stacked on #591 (Tier 0 + Tier 1) because it depends on the persisted actuals. Review #591 first.

## The edge

This league's rate card inverts the market's on IDP. Measured live against the baseline league today:

| key | baseline | mine | ratio |
|---|---|---|---|
| `idp_pass_def` | 2.11 | 5.32 | **2.52x UP** |
| `idp_tkl_loss` | 2.06 | 4.25 | 2.06x UP |
| `idp_qb_hit` | 1.08 | 2.13 | 1.97x UP |
| `idp_sack` | 4.55 | 2.92 | **0.64x DOWN** |
| `idp_int` | 6.20 | 5.32 | 0.86x DOWN |

Coverage and disruption are paid; finishing plays are discounted. The market prices IDP on sacks and INTs — precisely the two biggest **down** keys.

One correction: `docs/ORCHESTRATION.md:41` records "91 of 146 keys differ". Today it measures **95**. Scoring settings drift; re-measure rather than trusting either figure.

## The obvious exploit does not survive measurement

Scoring all 2025 IDP player-weeks under both cards and normalising within position gives a per-player "scoring fit". It looks like signal. Here is p90/p10 of that ratio by how deep into the position you sample:

```
DL   top24 1.109  top36 1.116  top60 1.115  top120 1.132  all 1.215
LB   top24 1.113  top36 1.095  top60 1.100  top120 1.099  all 1.144
DB   top24 1.071  top36 1.075  top60 1.083  top120 1.113  all 1.144
```

Among rosterable players the spread is only ~5%, and it **grows monotonically with pool depth** — deeper players take fewer snaps, so their stat mixes are noisier and their ratios fan out. That is the signature of small samples, not of a player-selection edge. The "most mispriced" names it produced were Kemon Hall, Cory Durden and Jack Cochrane: bench bodies near the scoring floor, not targets.

The **position-level** median is rock stable by comparison — DL reads 1.089 / 1.089 / 1.088 / 1.087 across a 5× change in pool size.

So the edge is real and it is **positional**: relative to DB this league pays DL about **+7%** and LB about **+3%**. A per-player multiplier built from the same data would be noise wearing the costume of a measurement, so the API does not offer one.

## What that shapes

- **Mean-normalised** across IDP positions. The absolute ratio reflects how generously each commissioner numbered their sheet, not value. Only the tilt between positions carries information, so the result re-allocates and never inflates IDP as a whole.
- **Depth-drift rejection.** A position whose ratio moves more than 0.05 across depths 24/36/60/120 is refused and forced to 1.0.
- **Offence excluded on purpose.** Its divergence is reception-distance banding — 0.25/catch at 0–4 yards rising to 2.00 at 40+, with the mean sitting exactly on the 0.75 every source prices flat. A position-level multiplier cannot express that. It needs a play-by-play depth histogram; separate work, noted below.
- **New `SCORING_MEASURED` evidence tier** rather than reusing an existing one. `MARKET_MEASURED` means paired market boards and `PROJECTION_CORROBORATED` means re-scored *projected* lines — both name their mechanism, and the tier is the field a reader trusts to tell them how a number was obtained. Confidence set equal to `MARKET_MEASURED`: realized lines are arguably stronger evidence, but nothing has measured the two against each other.

## Wired, not staged

The axis is constructed on **every** board and yields `ABSENT` when the flag is off, rather than being omitted from the axis list. Leaving it out would repeat §6.14's named mistake — a module nothing imports cannot be caught by the guards written for it.

`RISKIT_FEATURE_IDP_SCORING_FIT` defaults **OFF**, unlike `te_basis_conversion` which you directed explicitly. This moves every IDP value on the board, so it is yours to turn on.

## Tests

16. The ones that matter pin what the module *refuses*. The depth-drift guard is shown **firing** on a fixture built to drift (0.278 against the 0.05 threshold), with an assertion that the fixture genuinely drifts so it cannot pass vacuously, plus a stable-cohort control so it cannot pass by rejecting everything.

Reuses the golden-validated `scoring_engine` rather than adding a second Sleeper scorer.

Gates: 4261 pass, `ruff format --check` and `ruff check` both clean.

## Follow-up

The reception-distance half is the larger edge and is not in this PR. It needs a per-player reception-depth histogram in Sleeper's exact bands, which requires wiring `nflverse_direct.fetch_pbp`. The tempting shortcut — nflverse's `receiving_10/16/20/40` — is a trap: those are cumulative thresholds at the wrong boundaries and cannot reconstruct the 0–4 band at all, which is the one that matters most.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeqwBFmFak84h3h7RaCZqa)_