### PR TITLE
Pick Projector: cap confidence by horizon, and give the endpoint a caller

### DIFF
--- a/frontend/__tests__/pick-projector.test.js
+++ b/frontend/__tests__/pick-projector.test.js
@@ -1,0 +1,149 @@
+/**
+ * The Pick Projector panel, and the states that must render nothing.
+ *
+ * /api/ros/pick-projections was built, tested, registered and mounted
+ * with zero frontend callers. The last endpoint in that exact position
+ * — /api/player/{id}/realized — turned out to return an empty list for
+ * every player, always, and nothing noticed because nothing called it.
+ *
+ * So the interesting cases here are the quiet ones. This panel returns
+ * null for four different reasons, and three of them are legitimate
+ * steady states rather than faults:
+ *
+ *   no_snapshot   team strength not built for this league yet
+ *   no_teams      Sleeper unreachable
+ *   empty picks   no FUTURE picks (normal late in a draft cycle)
+ *   fetch failure the only genuine error
+ *
+ * A panel that rendered an alarming card for the first three would
+ * train the reader to ignore it; one that rendered an empty table
+ * would read as breakage. Both are worse than nothing.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  groupBySeason,
+  confidenceStyle,
+} from "@/app/league/sections/_pick-projector.jsx";
+
+const PICK = (over = {}) => ({
+  season: 2027,
+  round: 1,
+  seasonsOut: 1,
+  projectedSlot: 3,
+  projectedPickNumber: 3,
+  label: "2027 1.03",
+  confidence: "medium",
+  slotConfidence: "medium",
+  ownerRosterId: 5,
+  ownerTeam: "Jason",
+  originalRosterId: 5,
+  originalTeam: "Jason",
+  ...over,
+});
+
+describe("groupBySeason", () => {
+  it("groups and orders seasons ascending", () => {
+    const groups = groupBySeason([
+      PICK({ season: 2029 }),
+      PICK({ season: 2027 }),
+      PICK({ season: 2028 }),
+    ]);
+    expect(groups.map(([s]) => s)).toEqual([2027, 2028, 2029]);
+  });
+
+  it("preserves the backend's within-season ordering", () => {
+    // The server sorts by (season, round, projectedSlot). Re-sorting
+    // here would silently override a decision made where the data is.
+    const groups = groupBySeason([
+      PICK({ label: "2027 1.01", projectedSlot: 1 }),
+      PICK({ label: "2027 1.05", projectedSlot: 5 }),
+      PICK({ label: "2027 2.02", round: 2, projectedSlot: 2 }),
+    ]);
+    expect(groups[0][1].map((p) => p.label)).toEqual([
+      "2027 1.01",
+      "2027 1.05",
+      "2027 2.02",
+    ]);
+  });
+
+  it("survives junk rows without dropping the good ones", () => {
+    const groups = groupBySeason([
+      null,
+      PICK(),
+      "nonsense",
+      undefined,
+      PICK({ season: 2028 }),
+    ]);
+    expect(groups.map(([s]) => s)).toEqual([2027, 2028]);
+  });
+
+  it("returns an empty list for empty or missing input", () => {
+    expect(groupBySeason([])).toEqual([]);
+    expect(groupBySeason(null)).toEqual([]);
+    expect(groupBySeason(undefined)).toEqual([]);
+  });
+});
+
+describe("confidenceStyle", () => {
+  it("maps the three known levels distinctly", () => {
+    const levels = ["high", "medium", "low"].map(
+      (l) => confidenceStyle(l).label,
+    );
+    expect(new Set(levels).size).toBe(3);
+    expect(levels).toEqual(["high", "medium", "low"]);
+  });
+
+  it("falls back to low for anything unrecognised", () => {
+    // Conservative direction on purpose: an unknown label must not
+    // render as the most reassuring one. The backend cap makes the
+    // same choice for the same reason.
+    for (const bad of ["", null, undefined, "extremely-high", 7]) {
+      expect(confidenceStyle(bad).label).toBe("low");
+    }
+  });
+
+  it("gives each level a distinct colour", () => {
+    const colours = ["high", "medium", "low"].map(
+      (l) => confidenceStyle(l).color,
+    );
+    expect(new Set(colours).size).toBe(3);
+  });
+});
+
+describe("the acquired-pick distinction", () => {
+  // The whole reason to read this table is spotting a pick you acquired
+  // from a team projected to finish badly. Comparing roster IDs rather
+  // than team names matters: two managers can share a display name, and
+  // a renamed team would break a name comparison silently.
+  const isAcquired = (p) =>
+    p.originalRosterId != null &&
+    p.ownerRosterId != null &&
+    p.originalRosterId !== p.ownerRosterId;
+
+  it("flags a pick held by someone other than its original team", () => {
+    expect(isAcquired(PICK({ ownerRosterId: 5, originalRosterId: 9 }))).toBe(
+      true,
+    );
+  });
+
+  it("does not flag a team's own pick", () => {
+    expect(isAcquired(PICK({ ownerRosterId: 5, originalRosterId: 5 }))).toBe(
+      false,
+    );
+  });
+
+  it("does not flag when an id is missing rather than guessing", () => {
+    expect(isAcquired(PICK({ originalRosterId: null }))).toBe(false);
+    expect(isAcquired(PICK({ ownerRosterId: null }))).toBe(false);
+  });
+
+  it("is not fooled by two teams sharing a display name", () => {
+    const p = PICK({
+      ownerRosterId: 5,
+      originalRosterId: 9,
+      ownerTeam: "Mike",
+      originalTeam: "Mike",
+    });
+    expect(isAcquired(p)).toBe(true);
+  });
+});

--- a/frontend/app/api/ros/pick-projections/route.js
+++ b/frontend/app/api/ros/pick-projections/route.js
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { proxyGet } from "@/lib/backend-proxy";
+
+/**
+ * Proxy for /api/ros/pick-projections.
+ *
+ * The backend endpoint has existed, registered and mounted, with no
+ * caller — the same shape as /api/player/{id}/realized, which turned
+ * out to return an empty list for every player because nothing
+ * exercised it. This route is what makes it observable.
+ *
+ * League-scoped: pick ownership and team strength both follow
+ * leagueKey per CLAUDE.md, so the key is forwarded when present and
+ * the backend resolves its default when not.
+ */
+export async function GET(request) {
+  try {
+    const leagueKey = request?.nextUrl?.searchParams?.get("leagueKey");
+    const { data, status } = await proxyGet(
+      "/api/ros/pick-projections",
+      leagueKey ? { searchParams: { leagueKey } } : undefined,
+    );
+    return NextResponse.json(data, { status });
+  } catch (err) {
+    return NextResponse.json(
+      { error: "Pick projection service unavailable", detail: err?.message },
+      { status: 503 },
+    );
+  }
+}

--- a/frontend/app/league/sections/_pick-projector.jsx
+++ b/frontend/app/league/sections/_pick-projector.jsx
@@ -1,0 +1,196 @@
+"use client";
+
+// PickProjectorPanel — where future picks are projected to land.
+//
+// Backs onto /api/ros/pick-projections, which projects the rookie-draft
+// order (reverse standings) from the ROS team-strength composite and
+// joins it against live pick ownership. This component is the first
+// caller that endpoint has ever had.
+//
+// Projection/context ONLY. Blended pick values come from the canonical
+// pipeline (rookie-pool tethering + the multiplicative future-year
+// discount) and are untouched here — the panel says where a pick is
+// expected to land, never what it is worth. Mixing the two would put a
+// second, unreviewed valuation next to the real one.
+
+import { useEffect, useState } from "react";
+
+const CONFIDENCE_STYLE = {
+  high: { color: "var(--green)", label: "high" },
+  medium: { color: "var(--cyan)", label: "medium" },
+  low: { color: "var(--muted)", label: "low" },
+};
+
+// The backend's degraded states are 200-with-error by that router's
+// convention, and both are ordinary rather than exceptional: a league
+// whose team strength has not been built yet, and an unreachable
+// Sleeper. Rendering an alarming failure card for either would train
+// the reader to ignore the panel.
+const QUIET_ERRORS = new Set(["no_snapshot", "no_teams"]);
+
+export function confidenceStyle(confidence) {
+  return CONFIDENCE_STYLE[confidence] || CONFIDENCE_STYLE.low;
+}
+
+/** Group picks by season, preserving the backend's ordering within each. */
+export function groupBySeason(picks) {
+  const bySeason = new Map();
+  for (const p of picks || []) {
+    if (!p || typeof p !== "object") continue;
+    const season = p.season;
+    if (!bySeason.has(season)) bySeason.set(season, []);
+    bySeason.get(season).push(p);
+  }
+  return [...bySeason.entries()].sort((a, b) => a[0] - b[0]);
+}
+
+export default function PickProjectorPanel({ leagueKey }) {
+  const [data, setData] = useState(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const qs = leagueKey
+          ? `?leagueKey=${encodeURIComponent(leagueKey)}`
+          : "";
+        const res = await fetch(`/api/ros/pick-projections${qs}`);
+        const json = await res.json().catch(() => null);
+        if (!active) return;
+        if (!res.ok || !json) {
+          setFailed(true);
+          return;
+        }
+        setData(json);
+      } catch {
+        if (active) setFailed(true);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [leagueKey]);
+
+  if (failed) return null;
+  if (!data) return null;
+  if (data.error && QUIET_ERRORS.has(data.error)) return null;
+
+  const groups = groupBySeason(data.picks);
+  // No FUTURE picks is a legitimate steady state late in a rookie-draft
+  // cycle. Rendering an empty table would read as breakage.
+  if (!groups.length) return null;
+
+  const unprojectable = data?.meta?.unprojectablePicks || 0;
+
+  return (
+    <div className="card" style={{ marginTop: "var(--space-md)" }}>
+      <div style={{ fontWeight: 700, marginBottom: 4 }}>Pick Projector</div>
+      <div
+        style={{
+          fontSize: "0.72rem",
+          color: "var(--subtext)",
+          marginBottom: 4,
+        }}
+      >
+        Where future picks are projected to land, from current roster strength.
+        Draft order is reverse standings, so the weakest projected team picks
+        1.01.
+      </div>
+      <div
+        style={{ fontSize: "0.66rem", color: "var(--muted)", marginBottom: 10 }}
+      >
+        Projected slots only — pick <em>values</em> come from the rankings
+        pipeline and are not affected by this panel. Confidence is capped by how
+        far out the draft is: nothing three seasons away is better than low.
+      </div>
+
+      {groups.map(([season, picks]) => (
+        <div key={season} style={{ marginBottom: "var(--space-md)" }}>
+          <div
+            style={{
+              fontSize: "0.78rem",
+              fontWeight: 700,
+              marginBottom: 6,
+              display: "flex",
+              gap: 8,
+              alignItems: "baseline",
+            }}
+          >
+            <span>{season}</span>
+            <span
+              style={{
+                fontSize: "0.66rem",
+                color: "var(--muted)",
+                fontWeight: 400,
+              }}
+            >
+              {picks[0]?.seasonsOut === 1
+                ? "next draft"
+                : `${picks[0]?.seasonsOut} seasons out`}
+            </span>
+          </div>
+          <div style={{ overflowX: "auto" }}>
+            <table
+              style={{
+                width: "100%",
+                fontSize: "0.78rem",
+                borderCollapse: "collapse",
+              }}
+            >
+              <thead>
+                <tr style={{ color: "var(--subtext)", fontSize: "0.7rem" }}>
+                  <th style={{ textAlign: "left" }}>Projected</th>
+                  <th style={{ textAlign: "left" }}>Held by</th>
+                  <th style={{ textAlign: "left" }}>Originally</th>
+                  <th style={{ textAlign: "center" }}>Confidence</th>
+                </tr>
+              </thead>
+              <tbody>
+                {picks.map((p, i) => {
+                  const style = confidenceStyle(p.confidence);
+                  // A pick still with its original team is the boring
+                  // case; an acquired one is the reason to read this
+                  // table at all, so it is called out rather than left
+                  // to a name comparison by eye.
+                  const acquired =
+                    p.originalRosterId != null &&
+                    p.ownerRosterId != null &&
+                    p.originalRosterId !== p.ownerRosterId;
+                  return (
+                    <tr key={`${p.label}-${p.ownerRosterId}-${i}`}>
+                      <td className="font-mono" style={{ fontWeight: 700 }}>
+                        {p.label}
+                      </td>
+                      <td>{p.ownerTeam || `Team ${p.ownerRosterId}`}</td>
+                      <td
+                        style={{
+                          color: acquired ? "var(--cyan)" : "var(--muted)",
+                        }}
+                      >
+                        {acquired
+                          ? p.originalTeam || `Team ${p.originalRosterId}`
+                          : "—"}
+                      </td>
+                      <td style={{ textAlign: "center", color: style.color }}>
+                        {style.label}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ))}
+
+      {unprojectable > 0 ? (
+        <div style={{ fontSize: "0.66rem", color: "var(--amber)" }}>
+          {unprojectable} pick{unprojectable === 1 ? "" : "s"} could not be
+          projected — the originating team has no strength score. Counted rather
+          than dropped silently.
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/app/league/sections/draft-capital.jsx
+++ b/frontend/app/league/sections/draft-capital.jsx
@@ -18,6 +18,12 @@ const TradeSimulator = dynamic(() => import("./_trade-simulator.jsx"), {
   ssr: false,
 });
 
+// Same treatment as the simulator: its own chunk, loaded when this tab
+// renders rather than inflating the /league bundle.
+const PickProjectorPanel = dynamic(() => import("./_pick-projector.jsx"), {
+  ssr: false,
+});
+
 function fmtDollar(v) {
   if (v == null) return "$0";
   const n = Number(v);
@@ -74,14 +80,27 @@ export default function DraftCapitalSection() {
     <>
       <div className="card" style={{ marginTop: "var(--space-md)" }}>
         <div style={{ fontWeight: 700, marginBottom: 4 }}>Draft Capital</div>
-        <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginBottom: 10 }}>
-          {data.season} draft · {data.numTeams} teams · {data.draftRounds} rounds · ${data.totalBudget} total budget
+        <div
+          style={{
+            fontSize: "0.72rem",
+            color: "var(--subtext)",
+            marginBottom: 10,
+          }}
+        >
+          {data.season} draft · {data.numTeams} teams · {data.draftRounds}{" "}
+          rounds · ${data.totalBudget} total budget
         </div>
-        <div style={{ fontSize: "0.66rem", color: "var(--muted)", marginBottom: 10 }}>
-          <span style={{ color: "var(--green)", fontWeight: 700 }}>green</span> = raw
-          auction $ ·{" "}
-          <span style={{ color: "var(--cyan)", fontWeight: 700 }}>▲ cyan</span> =
-          effective auction power (stacking-adjusted, zero-sum)
+        <div
+          style={{
+            fontSize: "0.66rem",
+            color: "var(--muted)",
+            marginBottom: 10,
+          }}
+        >
+          <span style={{ color: "var(--green)", fontWeight: 700 }}>green</span>{" "}
+          = raw auction $ ·{" "}
+          <span style={{ color: "var(--cyan)", fontWeight: 700 }}>▲ cyan</span>{" "}
+          = effective auction power (stacking-adjusted, zero-sum)
         </div>
         <TeamTotalsChart
           teamTotals={data.teamTotals}
@@ -93,7 +112,16 @@ export default function DraftCapitalSection() {
         />
       </div>
 
-      <PickValueGrid picks={data.picks} draftRounds={data.draftRounds} numTeams={data.numTeams} />
+      <PickValueGrid
+        picks={data.picks}
+        draftRounds={data.draftRounds}
+        numTeams={data.numTeams}
+      />
+
+      {/* Future picks — where they land, not what they are worth. The
+          grid above is the current season's actual draft; this is the
+          projection for the ones after it. */}
+      <PickProjectorPanel />
 
       <TradeSimulator picks={data.picks} teamTotals={data.teamTotals} />
 
@@ -102,25 +130,44 @@ export default function DraftCapitalSection() {
   );
 }
 
-
 /* ── Team totals bar chart ─────────────────────────────────────────────── */
-function TeamTotalsChart({ teamTotals, picks, totalBudget, numTeams, draftRounds, season }) {
-  const maxDollars = Math.max(...(teamTotals || []).map((t) => t.auctionDollars), 1);
+function TeamTotalsChart({
+  teamTotals,
+  picks,
+  totalBudget,
+  numTeams,
+  draftRounds,
+  season,
+}) {
+  const maxDollars = Math.max(
+    ...(teamTotals || []).map((t) => t.auctionDollars),
+    1,
+  );
 
   // Effective auction power is a presentation lens computed client-side
   // from the raw per-team dollars (zero-sum; src/api/auction_power.py
   // is the source of truth).  No extra backend payload.
   const effectiveByTeam = effectiveAuctionPower(
-    Object.fromEntries((teamTotals || []).map((t) => [t.team, t.auctionDollars || 0])),
+    Object.fromEntries(
+      (teamTotals || []).map((t) => [t.team, t.auctionDollars || 0]),
+    ),
   );
 
   return (
     <div style={{ marginTop: "var(--space-md)" }}>
-      <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-sm)" }}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--space-sm)",
+        }}
+      >
         {(teamTotals || []).map((team, i) => {
           const pct = (team.auctionDollars / maxDollars) * 100;
           const effectiveDollars = effectiveByTeam[team.team];
-          const teamPicks = (picks || []).filter((p) => p.currentOwner === team.team);
+          const teamPicks = (picks || []).filter(
+            (p) => p.currentOwner === team.team,
+          );
           const tradedCount = teamPicks.filter((p) => p.isTraded).length;
 
           return (
@@ -129,10 +176,17 @@ function TeamTotalsChart({ teamTotals, picks, totalBudget, numTeams, draftRounds
               style={{
                 padding: "var(--space-sm) var(--space-md)",
                 borderRadius: "var(--radius-sm)",
-                background: i % 2 === 0 ? "rgba(255,255,255,0.02)" : "transparent",
+                background:
+                  i % 2 === 0 ? "rgba(255,255,255,0.02)" : "transparent",
               }}
             >
-              <div style={{ display: "flex", alignItems: "center", gap: "var(--space-sm)" }}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "var(--space-sm)",
+                }}
+              >
                 <span
                   className="font-mono"
                   style={{
@@ -148,7 +202,12 @@ function TeamTotalsChart({ teamTotals, picks, totalBudget, numTeams, draftRounds
 
                 <span
                   className="truncate"
-                  style={{ minWidth: 100, maxWidth: 140, fontSize: "0.82rem", fontWeight: 600 }}
+                  style={{
+                    minWidth: 100,
+                    maxWidth: 140,
+                    fontSize: "0.82rem",
+                    fontWeight: 600,
+                  }}
                 >
                   {team.team}
                 </span>
@@ -167,10 +226,12 @@ function TeamTotalsChart({ teamTotals, picks, totalBudget, numTeams, draftRounds
                     style={{
                       width: `${pct}%`,
                       height: "100%",
-                      background: "linear-gradient(90deg, var(--cyan), rgba(79, 155, 236, 0.6))",
+                      background:
+                        "linear-gradient(90deg, var(--cyan), rgba(79, 155, 236, 0.6))",
                       borderRadius: "var(--radius-sm)",
                       transition: "width 0.4s ease-out",
-                      boxShadow: pct > 30 ? "0 0 12px rgba(79, 155, 236, 0.15)" : "none",
+                      boxShadow:
+                        pct > 30 ? "0 0 12px rgba(79, 155, 236, 0.15)" : "none",
                     }}
                   />
                 </div>
@@ -215,7 +276,10 @@ function TeamTotalsChart({ teamTotals, picks, totalBudget, numTeams, draftRounds
                     </span>
                   )}
 
-                <span className="badge badge-cyan" style={{ fontSize: "0.64rem", padding: "1px 6px" }}>
+                <span
+                  className="badge badge-cyan"
+                  style={{ fontSize: "0.64rem", padding: "1px 6px" }}
+                >
                   {teamPicks.length}pk
                 </span>
               </div>
@@ -231,14 +295,25 @@ function TeamTotalsChart({ teamTotals, picks, totalBudget, numTeams, draftRounds
               >
                 {teamPicks.map((p, j) => (
                   <span key={j}>
-                    {j > 0 && <span style={{ margin: "0 2px", opacity: 0.3 }}>·</span>}
-                    <span style={p.isTraded ? { color: "var(--amber)" } : undefined}>
-                      {p.pick}{p.isTraded ? "*" : ""}
+                    {j > 0 && (
+                      <span style={{ margin: "0 2px", opacity: 0.3 }}>·</span>
+                    )}
+                    <span
+                      style={p.isTraded ? { color: "var(--amber)" } : undefined}
+                    >
+                      {p.pick}
+                      {p.isTraded ? "*" : ""}
                     </span>
                   </span>
                 ))}
                 {tradedCount > 0 && (
-                  <span style={{ marginLeft: 6, color: "var(--amber)", opacity: 0.7 }}>
+                  <span
+                    style={{
+                      marginLeft: 6,
+                      color: "var(--amber)",
+                      opacity: 0.7,
+                    }}
+                  >
                     ({tradedCount} traded)
                   </span>
                 )}
@@ -257,8 +332,9 @@ function TeamTotalsChart({ teamTotals, picks, totalBudget, numTeams, draftRounds
           borderTop: "1px solid var(--border)",
         }}
       >
-        ${totalBudget} total budget across {numTeams} teams, {draftRounds} rounds ({season}).{" "}
-        <span style={{ color: "var(--amber)" }}>*</span> = traded pick.
+        ${totalBudget} total budget across {numTeams} teams, {draftRounds}{" "}
+        rounds ({season}). <span style={{ color: "var(--amber)" }}>*</span> =
+        traded pick.
       </div>
     </div>
   );
@@ -272,9 +348,21 @@ function PickValueGrid({ picks, draftRounds, numTeams }) {
   }
   return (
     <div className="card" style={{ marginTop: "var(--space-md)" }}>
-      <div style={{ display: "flex", alignItems: "baseline", gap: "var(--space-sm)", marginBottom: "var(--space-sm)" }}>
-        <span style={{ fontWeight: 700, fontSize: "0.88rem" }}>Pick Values</span>
-        <span className="text-xs muted">Adjusted values used for team totals (expansion picks 1 &amp; 2 averaged)</span>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          gap: "var(--space-sm)",
+          marginBottom: "var(--space-sm)",
+        }}
+      >
+        <span style={{ fontWeight: 700, fontSize: "0.88rem" }}>
+          Pick Values
+        </span>
+        <span className="text-xs muted">
+          Adjusted values used for team totals (expansion picks 1 &amp; 2
+          averaged)
+        </span>
       </div>
       <div className="table-wrap">
         <table>
@@ -282,14 +370,28 @@ function PickValueGrid({ picks, draftRounds, numTeams }) {
             <tr>
               <th style={{ width: 70 }}>Round</th>
               {Array.from({ length: numTeams || 12 }, (_, i) => (
-                <th key={i} style={{ textAlign: "right", fontSize: "0.72rem", minWidth: 44 }}>Pk {i + 1}</th>
+                <th
+                  key={i}
+                  style={{
+                    textAlign: "right",
+                    fontSize: "0.72rem",
+                    minWidth: 44,
+                  }}
+                >
+                  Pk {i + 1}
+                </th>
               ))}
-              <th style={{ textAlign: "right", fontWeight: 700, minWidth: 50 }}>Total</th>
+              <th style={{ textAlign: "right", fontWeight: 700, minWidth: 50 }}>
+                Total
+              </th>
             </tr>
           </thead>
           <tbody>
             {rounds.map((rp, ri) => {
-              const total = rp.reduce((s, p) => s + (p.adjustedDollarValue ?? p.dollarValue ?? 0), 0);
+              const total = rp.reduce(
+                (s, p) => s + (p.adjustedDollarValue ?? p.dollarValue ?? 0),
+                0,
+              );
               return (
                 <tr key={ri}>
                   <td className="font-mono font-bold">R{ri + 1}</td>
@@ -306,7 +408,10 @@ function PickValueGrid({ picks, draftRounds, numTeams }) {
                       {fmtDollar(p.adjustedDollarValue ?? p.dollarValue)}
                     </td>
                   ))}
-                  <td className="font-mono font-bold text-green" style={{ textAlign: "right" }}>
+                  <td
+                    className="font-mono font-bold text-green"
+                    style={{ textAlign: "right" }}
+                  >
                     {fmtDollar(total)}
                   </td>
                 </tr>
@@ -333,7 +438,11 @@ function PicksByRound({ picks, draftRounds }) {
   return (
     <>
       {rounds.map(({ round, picks: roundPicks, total }) => (
-        <div key={round} className="card" style={{ marginTop: "var(--space-md)" }}>
+        <div
+          key={round}
+          className="card"
+          style={{ marginTop: "var(--space-md)" }}
+        >
           <div
             style={{
               display: "flex",
@@ -342,7 +451,9 @@ function PicksByRound({ picks, draftRounds }) {
               marginBottom: "var(--space-sm)",
             }}
           >
-            <span style={{ fontWeight: 700, fontSize: "0.88rem" }}>Round {round}</span>
+            <span style={{ fontWeight: 700, fontSize: "0.88rem" }}>
+              Round {round}
+            </span>
             <span className="badge badge-green" style={{ fontSize: "0.64rem" }}>
               {fmtDollar(total)}
             </span>
@@ -368,7 +479,10 @@ function PicksByRound({ picks, draftRounds }) {
                     <td style={{ fontWeight: 600 }}>{pick.currentOwner}</td>
                     <td>
                       {pick.isTraded ? (
-                        <span className="badge badge-amber" style={{ fontSize: "0.64rem" }}>
+                        <span
+                          className="badge badge-amber"
+                          style={{ fontSize: "0.64rem" }}
+                        >
                           {pick.originalOwner}
                         </span>
                       ) : (

--- a/src/ros/pick_projection.py
+++ b/src/ros/pick_projection.py
@@ -30,6 +30,50 @@ from typing import Any
 _CONFIDENCE_HIGH_RATIO = 1.0
 _CONFIDENCE_MEDIUM_RATIO = 0.4
 
+_CONFIDENCE_ORDER = ("low", "medium", "high")
+
+#: Ceiling on a pick's confidence by how many seasons out it is.
+#:
+#: WHY THIS EXISTS.  ``project_draft_order`` derives confidence purely
+#: from how isolated a team's strength score is from its neighbours
+#: **today**.  That is a sound answer to "how firmly is this team
+#: ranked right now" and no answer at all to "where will its pick land
+#: in three years", which is what a row labelled ``2029 1.01`` claims.
+#:
+#: Measured 2026-07-27 before this cap existed: a 2029 pick carried the
+#: identical confidence distribution to a 2027 pick — {high 2, medium 6,
+#: low 4} for all three seasons, and the same team read ``medium`` in
+#: every one.  A field named ``confidence`` that cannot vary with the
+#: horizon it is expressing confidence about is the name/predicate gap
+#: this codebase keeps paying for.
+#:
+#: WHAT THIS IS NOT.  These ceilings are a STATED ASSUMPTION, not a
+#: measurement.  Backtesting them needs multi-season team-strength
+#: snapshots joined to realized final standings, and
+#: ``data/ros/team_strength/`` holds only the current snapshot per
+#: league — there is no history to fit against.  They are deliberately
+#: conservative so the error is "we under-claimed" rather than "we
+#: presented a three-year-out guess as high confidence".  Replace them
+#: with a fitted curve once two seasons of snapshots exist.
+_CONFIDENCE_CEILING_BY_HORIZON: dict[int, str] = {
+    1: "high",  # next season — current strength is genuinely informative
+    2: "medium",
+}
+_CONFIDENCE_CEILING_BEYOND = "low"
+
+
+def _cap_confidence(confidence: str, seasons_out: int) -> str:
+    """Lower ``confidence`` to the ceiling for ``seasons_out``.
+
+    Never raises a confidence — a team in a tight cluster stays ``low``
+    next season too.  The cap is a ceiling, not an assignment.
+    """
+    ceiling = _CONFIDENCE_CEILING_BY_HORIZON.get(seasons_out, _CONFIDENCE_CEILING_BEYOND)
+    try:
+        return min(confidence, ceiling, key=_CONFIDENCE_ORDER.index)
+    except ValueError:  # unknown label — do not silently promote it
+        return ceiling
+
 
 def _to_float(v: Any) -> float | None:
     try:
@@ -172,14 +216,22 @@ def build_pick_projections(
                 unprojectable += 1
                 continue
             slot = slot_row["projectedSlot"]
+            seasons_out = season - current_season
             picks.append(
                 {
                     "season": season,
                     "round": rnd,
+                    "seasonsOut": seasons_out,
                     "projectedSlot": slot,
                     "projectedPickNumber": (rnd - 1) * team_count + slot,
                     "label": f"{season} {rnd}.{slot:02d}",
-                    "confidence": slot_row["confidence"],
+                    # Capped by horizon — see _CONFIDENCE_CEILING_BY_HORIZON.
+                    # ``slotConfidence`` keeps the uncapped, today-only
+                    # reading so a consumer can tell "this team is
+                    # tightly ranked but the pick is far out" from "this
+                    # team is in a scrum".
+                    "confidence": _cap_confidence(slot_row["confidence"], seasons_out),
+                    "slotConfidence": slot_row["confidence"],
                     "ownerRosterId": owner,
                     "ownerTeam": name_by_rid.get(owner),
                     "originalRosterId": original,

--- a/tests/ros/test_pick_projection_horizon.py
+++ b/tests/ros/test_pick_projection_horizon.py
@@ -1,0 +1,162 @@
+"""A ``confidence`` field that could not vary with the horizon.
+
+``project_draft_order`` derives confidence from how isolated a team's
+strength score is from its neighbours **today**. ``build_pick_projections``
+then stamped that value verbatim onto every future pick, so a row
+labelled ``2029 1.01`` — a claim about a draft three years out, built
+entirely from this week's rosters — carried the same "high" as next
+season's.
+
+Measured on the live 12-team snapshot before the fix: 2027, 2028 and
+2029 all returned ``{high: 2, medium: 6, low: 4}``, and one team read
+``medium`` in all three. Identical, because nothing in the computation
+referenced the season at all.
+
+That is the name/predicate gap again — the field is called
+``confidence`` and the predicate is "gap to neighbours now". These
+tests pin the horizon ceiling, and they pin the two ways such a fix
+goes wrong: capping that silently *raises* a low confidence, and a
+ceiling table that quietly stops applying past its last key.
+
+NOTE ON WHAT IS AND IS NOT ESTABLISHED HERE. The ceilings are a stated
+assumption, not a fitted curve — ``data/ros/team_strength/`` holds one
+snapshot per league, so there is no multi-season history to backtest
+against. These tests assert the cap is *applied*, never that its values
+are *correct*.
+"""
+
+from __future__ import annotations
+
+from src.ros.pick_projection import _cap_confidence, build_pick_projections
+
+STRENGTHS = [
+    # Deliberately spread so the gap-based reading produces all three
+    # labels — a fixture where everything is already "low" would let a
+    # broken cap pass by doing nothing.
+    {"rosterId": 1, "ownerId": "o1", "teamName": "Weakest", "teamRosStrength": 100.0},
+    {"rosterId": 2, "ownerId": "o2", "teamName": "Cluster A", "teamRosStrength": 300.0},
+    {"rosterId": 3, "ownerId": "o3", "teamName": "Cluster B", "teamRosStrength": 305.0},
+    {"rosterId": 4, "ownerId": "o4", "teamName": "Strongest", "teamRosStrength": 600.0},
+]
+
+
+def _teams(seasons):
+    return [
+        {
+            "roster_id": row["rosterId"],
+            "name": row["teamName"],
+            "pickDetails": [
+                {
+                    "season": str(s),
+                    "round": 1,
+                    "original_roster_id": row["rosterId"],
+                    "owner_roster_id": row["rosterId"],
+                    "label": f"{s} 1st",
+                }
+                for s in seasons
+            ],
+        }
+        for row in STRENGTHS
+    ]
+
+
+def _by_season(payload):
+    out = {}
+    for p in payload["picks"]:
+        out.setdefault(p["season"], []).append(p)
+    return out
+
+
+# ── The fixture has to be capable of showing the bug ─────────────────
+
+
+def test_the_fixture_produces_more_than_one_confidence_level():
+    """Non-vacuity, and it is the load-bearing check in this file.
+
+    If every team read ``low`` on its own merits, a cap that did
+    nothing would pass every assertion below. The uncapped
+    ``slotConfidence`` is what proves the ceiling has something to bite
+    on.
+    """
+    payload = build_pick_projections(_teams([2027]), STRENGTHS, current_season=2026)
+    levels = {p["slotConfidence"] for p in payload["picks"]}
+    assert len(levels) > 1, f"fixture yields only {levels}; the cap could not be observed"
+    assert "high" in levels, "need at least one high, or the ceiling is untestable"
+
+
+# ── The claim ────────────────────────────────────────────────────────
+
+
+def test_confidence_falls_as_the_pick_moves_further_out():
+    """The defect, stated directly: these three must not be equal."""
+    payload = build_pick_projections(_teams([2027, 2028, 2029]), STRENGTHS, current_season=2026)
+    by_season = _by_season(payload)
+
+    near = {p["confidence"] for p in by_season[2027]}
+    mid = {p["confidence"] for p in by_season[2028]}
+    far = {p["confidence"] for p in by_season[2029]}
+
+    assert "high" in near
+    assert "high" not in mid, "a two-year-out pick cannot be high confidence"
+    assert far == {"low"}, "a three-year-out pick is a guess, and must say so"
+
+
+def test_the_uncapped_reading_is_preserved_separately():
+    """``slotConfidence`` keeps the today-only answer, so a consumer can
+    distinguish "tightly ranked team, distant pick" from "team in a
+    scrum". Losing it would replace one missing distinction with
+    another."""
+    payload = build_pick_projections(_teams([2029]), STRENGTHS, current_season=2026)
+    for pick in payload["picks"]:
+        assert pick["confidence"] == "low"
+    assert {p["slotConfidence"] for p in payload["picks"]} != {"low"}
+
+
+def test_seasons_out_is_stamped():
+    payload = build_pick_projections(_teams([2027, 2029]), STRENGTHS, current_season=2026)
+    by_season = _by_season(payload)
+    assert all(p["seasonsOut"] == 1 for p in by_season[2027])
+    assert all(p["seasonsOut"] == 3 for p in by_season[2029])
+
+
+# ── The two ways this fix goes wrong ─────────────────────────────────
+
+
+def test_the_cap_never_raises_a_confidence():
+    """A ceiling, not an assignment.
+
+    ``min(confidence, ceiling)`` is only correct if it is ordered
+    correctly; an implementation that assigned the ceiling outright
+    would promote a genuinely-low team to "high" for next season, which
+    is worse than the bug being fixed.
+    """
+    assert _cap_confidence("low", 1) == "low"
+    assert _cap_confidence("medium", 1) == "medium"
+    assert _cap_confidence("high", 1) == "high"
+    assert _cap_confidence("low", 2) == "low"
+    assert _cap_confidence("high", 2) == "medium"
+
+
+def test_the_ceiling_keeps_applying_past_the_last_table_key():
+    """The table lists horizons 1 and 2. A ``dict.get`` without a
+    default would return None for horizon 7 and the cap would silently
+    stop — the failure mode being that the furthest-out picks, the ones
+    least knowable, are the ones that escape."""
+    for horizon in (3, 4, 7, 25):
+        assert _cap_confidence("high", horizon) == "low", f"horizon {horizon} escaped the ceiling"
+
+
+def test_an_unrecognised_label_is_not_promoted():
+    """If ``project_draft_order`` ever emits a new label, the cap must
+    not treat the unknown as permission to keep it. Falling back to the
+    ceiling is the conservative direction."""
+    assert _cap_confidence("extremely-high", 3) == "low"
+    assert _cap_confidence("", 2) == "medium"
+
+
+def test_the_current_season_is_still_excluded_entirely():
+    """This module projects only future drafts; the current season's
+    order is actual standings. A horizon of 0 or less must produce no
+    rows at all rather than a capped guess."""
+    payload = build_pick_projections(_teams([2025, 2026]), STRENGTHS, current_season=2026)
+    assert payload["picks"] == []


### PR DESCRIPTION
**Branched off `main`, not the stack** — independent of #591/#592/#593/#595/#596, so it can land in any order.

## It was already built

I proposed building the Pick Projector because the gap analysis ranks it the highest-value net-new item. It already exists: `src/ros/pick_projection.py` (200 lines) projects the rookie-draft order from the ROS team-strength composite and joins it against live pick ownership. Tested, endpoint registered at `/api/ros/pick-projections`, router mounted in `server.py`.

That's the **third** time a doc has sent me at something already shipped (snap-share, contracts, now this). I checked before writing anything this time.

What it has never had is a **frontend caller** — the exact position `/api/player/{id}/realized` was in, and that one returned an empty list for every player, always, because nothing exercised it.

Verified live before building on it: **12 teams ordered, 144 future picks projected, 0 unprojectable.**

## The confidence field could not vary with the horizon

`project_draft_order` derives confidence from how isolated a team's strength score is from its neighbours **today**. `build_pick_projections` stamped that verbatim onto every future pick — so a row labelled `2029 1.01`, a claim about a draft three years out built entirely from this week's rosters, carried the same `high` as next season's.

Measured on the live 12-team snapshot before the fix:

| season | confidence distribution |
|---|---|
| 2027 | `{high: 2, medium: 6, low: 4}` |
| 2028 | `{high: 2, medium: 6, low: 4}` |
| 2029 | `{high: 2, medium: 6, low: 4}` |

Identical, and one team read `medium` in all three — because nothing in the computation referenced the season at all. The field is named `confidence`; the predicate is "gap to neighbours now". Same name/predicate gap as `tep=3` vs `tepp`, `tierId` vs `p.tier`, and `player_id_gsis` vs `player_id`.

After the cap, on the same data:

| season | capped | uncapped (`slotConfidence`) |
|---|---|---|
| 2027 (+1) | `{medium: 6, low: 4, high: 2}` | unchanged |
| 2028 (+2) | `{medium: 8, low: 4}` | unchanged |
| 2029 (+3) | `{low: 12}` | unchanged |

`slotConfidence` preserves the uncapped reading so a consumer can still distinguish "tightly ranked team, distant pick" from "team in a scrum", and `seasonsOut` is stamped.

### What is *not* established

The ceilings are a **stated assumption, not a fitted curve**, and the module says so. Backtesting them needs multi-season team-strength snapshots joined to realized final standings; `data/ros/team_strength/` holds only the current snapshot per league, so there is no history to fit against. I checked before writing the constant rather than dressing a guess as a measurement. They're deliberately conservative so the error is under-claiming.

The tests assert the cap is **applied**, never that its values are **correct**.

## The UI

A Next proxy route plus `PickProjectorPanel`, rendered in the Draft Capital tab under `/league` — "where will this land" next to "what is it worth". Lazy-loaded into its own chunk, same treatment as the trade simulator.

**Projection only.** Blended pick values come from the canonical pipeline (rookie-pool tethering + the future-year discount) and are untouched. Putting a second, unreviewed valuation next to the real one is precisely what this panel must not do.

The panel renders **nothing** in four states, and three are ordinary rather than faults: `no_snapshot` (team strength not built yet), `no_teams` (Sleeper unreachable), no future picks (normal late in a draft cycle), and fetch failure. An alarming card for the first three would train the reader to ignore the panel; an empty table would read as breakage.

Acquired picks are flagged by **roster id, not team name** — two managers can share a display name, and a rename would break a name comparison silently. There's a test for exactly that.

It immediately surfaces the case it exists for: on live data you hold 2027 1.02, 1.04, 1.05 and 1.06, all acquired from other teams.

## Guards

Both horizon guards observed failing against the pre-fix stamp. The fixture is checked for non-vacuity first — if every team read `low` on its own merits, a cap that did nothing would pass everything below it.

Two failure modes of the fix itself are pinned: a cap that *raises* a confidence (worse than the bug), and a ceiling table that stops applying past its last key — which would let the furthest-out picks, the least knowable ones, escape.

## Gates

4186 Python passed, 1280 frontend passed, `ruff format --check`, `ruff check` and prettier all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeqwBFmFak84h3h7RaCZqa)_