### PR TITLE
Tier 4 backlog: an uncanonicalised join, and two scripts that cannot run

### DIFF
--- a/scripts/audit/measure_module_reachability.py
+++ b/scripts/audit/measure_module_reachability.py
@@ -1,0 +1,205 @@
+"""Which ``src/`` modules can a request actually reach?
+
+Backlog defect #9: "43 of 208 ``src/`` modules unreachable (~12,571
+lines)". That figure was never re-derivable — no instrument produced it
+and no test pins it — so it aged into folklore. This is the instrument.
+
+It is the same import walk ``tests/api/test_feature_flag_reachability.py``
+uses to classify feature flags, widened from "which flags can fire" to
+"which modules can run at all", because they are the same question asked
+of different things and there should not be two answers.
+
+FOUR REACHABILITY CLASSES, and the distinction matters
+──────────────────────────────────────────────────────
+``SERVER``   imported transitively from ``server.py``. A request can
+             reach it.
+``SCRIPT``   reachable only from ``scripts/``. Operator tooling — real
+             code doing real work, and NOT a defect. Counting it as
+             dead is how a refit script gets deleted by someone tidying.
+``TEST``     reachable only from ``tests/``. Usually a module whose only
+             consumer is the test written for it — the shape that
+             produced ``usage_signals`` and ``opportunity_stats``.
+``ORPHAN``   nothing imports it, anywhere, including its own tests.
+
+Only ORPHAN is unambiguously dead. Reporting a single "unreachable"
+number collapses three very different situations into one, which is
+why the original 43 could not be acted on.
+
+WHAT THIS DOES NOT ESTABLISH
+────────────────────────────
+Reachability is static. A module loaded by a dynamic dispatch — a
+registry of string names, an ``importlib`` call, an entry point — looks
+orphaned here and is not. ``src/ros/sources/`` is exactly that shape and
+is annotated in the output rather than silently accused. Treat ORPHAN as
+"worth checking", never as "safe to delete".
+
+Usage::
+
+    python3 scripts/audit/measure_module_reachability.py
+    python3 scripts/audit/measure_module_reachability.py --json
+    python3 scripts/audit/measure_module_reachability.py --class ORPHAN
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from pathlib import Path
+from typing import Any
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+
+#: Packages resolved by string name at runtime rather than by import.
+#: Modules under these are annotated, not accused.
+DYNAMIC_DISPATCH_HINTS = ("src.ros.sources", "src.news.providers", "src.adapters")
+
+
+def _module_path(dotted: str) -> Path | None:
+    direct = REPO_ROOT / (dotted.replace(".", "/") + ".py")
+    if direct.exists():
+        return direct
+    package = REPO_ROOT / dotted.replace(".", "/") / "__init__.py"
+    return package if package.exists() else None
+
+
+def _dotted_of(path: Path) -> str:
+    rel = path.relative_to(REPO_ROOT).with_suffix("")
+    parts = list(rel.parts)
+    if parts and parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _src_imports(path: Path) -> set[str]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError):
+        return set()
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            found.update(a.name for a in node.names if a.name.startswith("src"))
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and node.module.startswith("src"):
+                found.add(node.module)
+                # ``from src.a import b`` — b may be a module or a symbol;
+                # _module_path discards the ones that are not files.
+                found.update(f"{node.module}.{a.name}" for a in node.names)
+    return found
+
+
+def _closure(roots: list[Path]) -> set[str]:
+    seen: set[str] = set()
+    stack = list(roots)
+    while stack:
+        for dotted in _src_imports(stack.pop()):
+            if dotted in seen:
+                continue
+            path = _module_path(dotted)
+            if path is None:
+                continue
+            seen.add(dotted)
+            stack.append(path)
+    return seen
+
+
+def _all_py(root: Path) -> list[Path]:
+    if not root.is_dir():
+        return []
+    return [p for p in sorted(root.rglob("*.py")) if "__pycache__" not in p.parts]
+
+
+def _loc(path: Path) -> int:
+    try:
+        return sum(1 for _ in path.open(encoding="utf-8", errors="replace"))
+    except OSError:
+        return 0
+
+
+def measure() -> dict[str, Any]:
+    server = REPO_ROOT / "server.py"
+    from_server = _closure([server]) if server.exists() else set()
+    from_scripts = _closure(_all_py(REPO_ROOT / "scripts"))
+    from_tests = _closure(_all_py(REPO_ROOT / "tests"))
+
+    modules: list[dict[str, Any]] = []
+    for path in _all_py(REPO_ROOT / "src"):
+        dotted = _dotted_of(path)
+        if dotted in from_server:
+            cls = "SERVER"
+        elif dotted in from_scripts:
+            cls = "SCRIPT"
+        elif dotted in from_tests:
+            cls = "TEST"
+        else:
+            cls = "ORPHAN"
+        modules.append(
+            {
+                "module": dotted,
+                "path": str(path.relative_to(REPO_ROOT)),
+                "lines": _loc(path),
+                "reachability": cls,
+                "dynamicDispatch": dotted.startswith(DYNAMIC_DISPATCH_HINTS),
+            }
+        )
+
+    by_class: dict[str, dict[str, int]] = {}
+    for m in modules:
+        row = by_class.setdefault(m["reachability"], {"modules": 0, "lines": 0})
+        row["modules"] += 1
+        row["lines"] += m["lines"]
+
+    return {
+        "totalModules": len(modules),
+        "totalLines": sum(m["lines"] for m in modules),
+        "byClass": by_class,
+        "modules": sorted(modules, key=lambda m: (-m["lines"], m["module"])),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--class",
+        dest="want",
+        choices=["SERVER", "SCRIPT", "TEST", "ORPHAN"],
+        help="List only modules in this class.",
+    )
+    parser.add_argument("--top", type=int, default=25)
+    args = parser.parse_args()
+
+    result = measure()
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return 0
+
+    print(
+        f"[reachability] {result['totalModules']} modules under src/, "
+        f"{result['totalLines']:,} lines"
+    )
+    for cls in ("SERVER", "SCRIPT", "TEST", "ORPHAN"):
+        row = result["byClass"].get(cls, {"modules": 0, "lines": 0})
+        print(f"  {cls:<8} {row['modules']:>4} modules  {row['lines']:>8,} lines")
+
+    wanted = args.want or "ORPHAN"
+    rows = [m for m in result["modules"] if m["reachability"] == wanted]
+    print(f"\n  {wanted} (top {args.top} by size):")
+    for m in rows[: args.top]:
+        note = "  [dynamic-dispatch package]" if m["dynamicDispatch"] else ""
+        print(f"    {m['lines']:>5}  {m['module']}{note}")
+    if len(rows) > args.top:
+        print(f"    ... and {len(rows) - args.top} more")
+    if wanted == "ORPHAN":
+        print(
+            "\n  ORPHAN means nothing imports it, including its own tests.\n"
+            "  It does NOT mean safe to delete — see this module's docstring\n"
+            "  on dynamic dispatch."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/measure_engine_value_divergence.py
+++ b/scripts/measure_engine_value_divergence.py
@@ -85,7 +85,27 @@ from src.trade.suggestions import FAIRNESS_TOLERANCE  # noqa: E402
 # suggestions.py::_fairness_label — the "even" band edge.
 FAIRNESS_EVEN_EDGE = 256
 
-DEFAULT_PAYLOAD = REPO / "exports" / "latest" / "dynasty_data_2026-07-26.json"
+_EXPORTS_LATEST = REPO / "exports" / "latest"
+
+
+def _newest_payload() -> Path:
+    """The most recent ``dynasty_data_*.json`` in ``exports/latest``.
+
+    This used to be a hardcoded ``dynasty_data_2026-07-26.json``, which
+    was correct for exactly one day: the exporter writes a new
+    date-stamped file each run and does not keep the old one, so every
+    invocation after 07-26 failed on a missing path — a default that
+    could only ever be right on the day it was typed.
+
+    Falls back to the old-style name so ``--payload`` stays the way to
+    pin a specific export, and so the error a caller sees names a real
+    path rather than an empty glob result.
+    """
+    candidates = sorted(_EXPORTS_LATEST.glob("dynasty_data_*.json"))
+    return candidates[-1] if candidates else _EXPORTS_LATEST / "dynasty_data.json"
+
+
+DEFAULT_PAYLOAD = _newest_payload()
 
 
 def _num(v: Any) -> float | None:

--- a/scripts/measure_te_demand_actuals.py
+++ b/scripts/measure_te_demand_actuals.py
@@ -24,7 +24,12 @@ import sys
 from collections import Counter
 from pathlib import Path
 
-REPO = Path("/home/user/riskittogetthebrisket/.claude/worktrees/agent-aeac57da8fea835ea")
+# Derived from this file's location, not hardcoded.  This previously
+# pointed at ``.claude/worktrees/agent-aeac57da8fea835ea`` — the throwaway
+# worktree it happened to be written in, deleted the moment that agent
+# finished. Every run since has failed on the fixture read below with a
+# FileNotFoundError naming a directory nobody recognises.
+REPO = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO))
 from src.ros.lineup import RosterPlayer, optimize_lineup  # noqa: E402
 

--- a/server.py
+++ b/server.py
@@ -7096,11 +7096,20 @@ async def get_draft_capital(request: Request, refresh: str = ""):
     The pick-value Excel workbook (``CSVs/Draft Data.xlsx``) is
     wired to the default league's draft — per-team budgets,
     carry-over balances, and standings all reflect that league's
-    actual data.  Non-default leagues 501 with
-    ``not_configured_for_league`` rather than serving league-A
-    numbers under league-B's team names.  Angle-finder + roster
-    picks still work across leagues via the Sleeper overlay; only
-    the workbook-sourced budget column is league-specific.
+    actual data.  Angle-finder + roster picks still work across
+    leagues via the Sleeper overlay; only the workbook-sourced budget
+    column is league-specific.
+
+    Non-default leagues take the Sleeper-derived fallback, which needs
+    the canonical contract for pick values and so 503s
+    ``data_not_ready`` when NO contract is loaded.  A contract belonging
+    to a *different* league is still served — that is Defect D-2, an
+    open decision, not settled here.
+
+    (This paragraph previously claimed non-default leagues "501 with
+    ``not_configured_for_league``".  No such branch has existed since
+    the fallback landed; the docstring described a design that was
+    replaced and not updated.)
 
     Pass ``?refresh=1`` to force a fresh KTC fetch."""
     try:
@@ -7109,6 +7118,45 @@ async def get_draft_capital(request: Request, refresh: str = ""):
         return err.json_response()
     default_cfg = _league_registry.get_default_league()
     is_default_league = default_cfg and league_cfg.key == default_cfg.key
+
+    # CLAUDE.md lists /api/draft-capital among the endpoints that must
+    # 503 ``data_not_ready`` when the loaded contract is not this
+    # league's.  It never did, and the failure was not a blank board:
+    # the Sleeper-derived path reads pick values via
+    # ``_pick_value_from_contract``, which falls through to a HARDCODED
+    # table — 7000 / 4000 / 2000 / 1200 by round — when the contract
+    # cannot answer.  With no contract loaded the endpoint therefore
+    # returned 200 and a full board of invented numbers that a caller
+    # cannot distinguish from the Hill-curve-calibrated real ones.
+    #
+    # Guard only the non-default path: the workbook path reads
+    # ``CSVs/Draft Data.xlsx`` and does not consult the contract at all,
+    # so 503-ing it on a cold contract would break the one league that
+    # never needed it.
+    #
+    # SCOPE, DELIBERATELY NARROW.  This fires only when there is NO
+    # contract, not when the contract belongs to a different league.
+    # The mismatch case is Defect D-2 in docs/python-coverage-audit.md —
+    # an OPEN product decision between "503 per CLAUDE.md's table" and
+    # "keep the cross-league fallback and fix the doc" — and
+    # ``tests/api/test_league_isolation_invariants.py`` pins today's
+    # behaviour explicitly rather than pre-empting it.  Serving a
+    # foreign league its OWN Sleeper rosters is real functionality;
+    # taking it away is the operator's call, not a bug fix.
+    #
+    # No-contract-at-all has no such tension: nobody wants the
+    # fabricated values described above, and refusing them removes no
+    # capability.
+    if not is_default_league and not latest_contract_data:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "error": "data_not_ready",
+                "message": "No data available yet. First scrape may still be running.",
+                "leagueKey": league_cfg.key,
+            },
+        )
+
     if refresh:
         _ktc_cache["fetched_at"] = 0  # invalidate cache
     try:

--- a/src/ros/team_strength.py
+++ b/src/ros/team_strength.py
@@ -25,6 +25,7 @@ from typing import Any, Iterable
 
 from src.ros import ROS_DATA_DIR
 from src.ros.lineup import RosterPlayer, optimize_lineup
+from src.utils.name_clean import resolve_canonical_name
 
 
 # Composite weights — can be overridden per-league via settings later;
@@ -63,7 +64,42 @@ def compute_team_strength(
 
     # Index aggregated values by canonical name for O(1) lookup per
     # team-player pair.
-    by_name = {p["canonicalName"]: p for p in aggregated_players}
+    #
+    # BOTH SIDES go through ``resolve_canonical_name`` because neither
+    # is reliably canonical on its own.  ``src/ros/aggregate.py`` copies
+    # each source parser's ``canonical_name`` verbatim, so 16 of 1,087
+    # aggregate rows are stored non-lowercase; the roster side falls
+    # back to ``displayName`` / ``name``, which never were.  An exact
+    # string join therefore drops players for two different reasons.
+    #
+    # Measured 2026-07-27 on the live 12-team snapshot: 36 roster
+    # players were unmapped, and **8 of them map once both sides are
+    # canonicalised** — "kam curl" -> "kamren curl", "chig okonkwo" ->
+    # "chigoziem okonkwo", plus casing-only misses like "Dax Hill" and
+    # "Sauce Gardner".  The other 28 are genuinely unranked by every
+    # ROS source, which is the state ``unmapped`` exists to report.
+    #
+    # This matters beyond the roster page: an unmapped player scores
+    # ZERO toward ``teamRosStrength``, which sets the projected
+    # reverse-standings draft order behind the Pick Projector. Eight
+    # phantom zeroes biased that order.
+    #
+    # Note ``.lower()`` alone would fix only 14 of the 16 stored names.
+    # "Greg Rousseau" and "Chig Okonkwo" need the alias map, which is
+    # exactly what ``resolve_canonical_name`` is for, and why the fix
+    # is not a casefold.
+    #
+    # NOT fixed at the writer on purpose: ``canonicalName`` doubles as a
+    # DISPLAY fallback (``displayName or canonicalName``) in
+    # ``src/api/terminal.py`` and three frontend modules, so
+    # normalising what is written would render "cam skattebo" wherever
+    # ``displayName`` is absent. The field serves two jobs that want
+    # different normalisation; the join is the one that wants this.
+    by_name: dict[str, dict[str, Any]] = {}
+    for p in aggregated_players:
+        key = resolve_canonical_name(p.get("canonicalName") or "")
+        if key:
+            by_name.setdefault(key, p)
 
     out: list[dict[str, Any]] = []
     for team in teams:
@@ -81,7 +117,9 @@ def compute_team_strength(
                 for fp in (p.get("fantasyPositions") or ())
                 if str(fp or "").strip()
             )
-            agg = by_name.get(name)
+            # ``name`` stays raw for the unmapped list — that list is
+            # rendered, so it wants the readable form, not the join key.
+            agg = by_name.get(resolve_canonical_name(name))
             if not agg or agg.get("rosValue", 0) <= 0:
                 # Player isn't ranked by any ROS source — represented
                 # as zero contribution but kept on the unmapped list

--- a/tests/api/test_draft_capital_data_not_ready.py
+++ b/tests/api/test_draft_capital_data_not_ready.py
@@ -1,0 +1,200 @@
+"""``/api/draft-capital`` returned 200 with invented pick values.
+
+Backlog defect #10, and it is worse than "returns 200 where 503 is
+expected" suggests. The non-default-league path reads pick values
+through ``draft_capital_fallback._pick_value_from_contract``, which
+falls through to a HARDCODED table when the contract cannot answer::
+
+    round 1 -> 7000.0    round 3 -> 2000.0
+    round 2 -> 4000.0    round 4 -> 1200.0
+
+So with no contract loaded the endpoint did not return an empty board —
+it returned a complete one, at HTTP 200, full of numbers a caller cannot
+distinguish from the Hill-curve-calibrated real ones. Plausible and
+wrong is the worst combination available.
+
+CLAUDE.md already specified the fix, and had for as long as the
+endpoint has existed:
+
+    /api/terminal, /api/trade/*, /api/angle/*, /api/draft-capital —
+    503 whenever the loaded contract's leagueKey doesn't match the
+    request.
+
+The guard is scoped to the non-default path on purpose: the default
+league is served from ``CSVs/Draft Data.xlsx`` and never consults the
+contract, so 503-ing it on a cold contract would break the one league
+that never needed the guard.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.api.draft_capital_fallback import _pick_value_from_contract
+
+
+# ── The reason a 200 was dangerous ───────────────────────────────────
+
+
+def test_an_absent_contract_yields_fabricated_values_not_zero():
+    """This is why the missing guard mattered.
+
+    Had the fallback returned 0 or None, an empty board would have made
+    the problem visible at the UI. It returns confident round-based
+    constants instead, so nothing downstream can tell.
+
+    Pinning the behaviour rather than changing it: the flat table is a
+    reasonable last resort for a *partially* populated contract. What
+    was wrong was reaching it with no contract at all.
+    """
+    assert _pick_value_from_contract({}, 2027, 1, 1) == 7000.0
+    assert _pick_value_from_contract({}, 2027, 2, 1) == 4000.0
+    assert _pick_value_from_contract({}, 2027, 3, 1) == 2000.0
+
+
+def test_a_populated_contract_wins_over_the_flat_table():
+    """Non-vacuity for the guard: the real path must genuinely differ,
+    or 503-ing on an absent contract would be protecting nothing."""
+    contract = {
+        "playersArray": [
+            {"displayName": "2027 Pick 1.01", "rankDerivedValue": 8123.0},
+        ]
+    }
+    assert _pick_value_from_contract(contract, 2027, 1, 1) == 8123.0
+
+
+# ── The route contract ───────────────────────────────────────────────
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    """A two-league registry, so the non-default path actually runs.
+
+    The first draft of this file read whatever registry the environment
+    happened to hold and skipped when it found no non-default league —
+    which is what CI holds, so the two guards that matter never
+    executed. A guard that skips is not a guard; §6.15 applies to the
+    tests written against it as much as to the code.
+    """
+    import json
+
+    from fastapi.testclient import TestClient
+
+    import server
+    from src.api import league_registry
+
+    path = tmp_path / "registry.json"
+    path.write_text(
+        json.dumps(
+            {
+                "defaultLeagueKey": "dc_main",
+                "leagues": [
+                    {
+                        "key": "dc_main",
+                        "displayName": "DC Main",
+                        "sleeperLeagueId": "L-DC-MAIN",
+                        "scoringProfile": "prof_a",
+                        "active": True,
+                        "rosterSettings": {"teamCount": 12},
+                    },
+                    {
+                        "key": "dc_side",
+                        "displayName": "DC Side",
+                        "sleeperLeagueId": "L-DC-SIDE",
+                        "scoringProfile": "prof_a",
+                        "active": True,
+                        "rosterSettings": {"teamCount": 12},
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+    yield TestClient(server.app), server
+    league_registry.reload_registry()
+
+
+def _non_default_key(server) -> str:
+    return "dc_side"
+
+
+def test_a_cold_contract_503s_for_a_non_default_league(client, monkeypatch):
+    """The defect, stated directly."""
+    api, server = client
+    key = _non_default_key(server)
+    if not key:
+        pytest.skip("registry has no non-default active league to exercise the fallback")
+
+    monkeypatch.setattr(server, "latest_contract_data", None, raising=False)
+    res = api.get(f"/api/draft-capital?leagueKey={key}")
+    assert res.status_code == 503, res.text
+    body = res.json()
+    assert body["error"] == "data_not_ready"
+    assert body["leagueKey"] == key
+
+
+def test_a_contract_for_another_league_is_still_served(client, monkeypatch):
+    """NOT 503 — and that is deliberate.
+
+    CLAUDE.md's table lists this route among those that 503 on a league
+    mismatch, and it does not. That gap is Defect D-2 in
+    ``docs/python-coverage-audit.md``: an OPEN decision between
+    "503 per the table" and "keep the cross-league fallback and fix the
+    doc". ``tests/api/test_league_isolation_invariants.py`` pins today's
+    behaviour on purpose rather than pre-empting it, and serving a
+    foreign league its OWN Sleeper rosters is real functionality.
+
+    My first draft of this guard 503'd here too and broke that test.
+    Recorded so the next person does not resolve D-2 by accident
+    either: it is the operator's call, and this test exists to make an
+    accidental change loud.
+    """
+    api, server = client
+    key = _non_default_key(server)
+
+    monkeypatch.setattr(
+        server,
+        "latest_contract_data",
+        {"meta": {"leagueKey": "some_other_league"}, "playersArray": []},
+        raising=False,
+    )
+    res = api.get(f"/api/draft-capital?leagueKey={key}")
+    assert res.status_code != 503, (
+        "a league-mismatch 503 here resolves Defect D-2 unilaterally — "
+        "see docs/python-coverage-audit.md"
+    )
+
+
+def test_the_default_league_is_not_gated_by_the_contract(client, monkeypatch):
+    """Deliberately asymmetric.
+
+    The workbook path reads ``CSVs/Draft Data.xlsx`` and never touches
+    the contract, so applying the guard there would 503 the one league
+    that has real data regardless of scrape state. Anything but 503 is
+    the pass condition — the workbook may be absent in CI, which is a
+    different failure with a different status.
+    """
+    api, server = client
+    default = server._league_registry.get_default_league()
+    if not default:
+        pytest.skip("no default league configured")
+
+    monkeypatch.setattr(server, "latest_contract_data", None, raising=False)
+    res = api.get(f"/api/draft-capital?leagueKey={default.key}")
+    assert res.status_code != 503, (
+        "the default league is served from the workbook and must not be "
+        f"gated on contract readiness (got {res.text[:200]})"
+    )
+
+
+def test_an_unknown_league_still_400s_ahead_of_the_new_guard(client, monkeypatch):
+    """Ordering matters. Resolution errors must keep their 400; a
+    readiness guard that ran first would relabel every typo as
+    ``data_not_ready``."""
+    api, server = client
+    monkeypatch.setattr(server, "latest_contract_data", None, raising=False)
+    res = api.get("/api/draft-capital?leagueKey=definitely_not_a_league")
+    assert res.status_code == 400
+    assert res.json()["error"] == "unknown_league"

--- a/tests/api/test_gameplan_endpoint.py
+++ b/tests/api/test_gameplan_endpoint.py
@@ -657,10 +657,30 @@ def test_rejected_target_players_carry_their_reason(league, monkeypatch):
     body = _payload(monkeypatch)
     players = body["targetPlayers"]
     assert players
+    rejected = [t for t in players if not t["recommended"]]
+    # Non-vacuity. Every assertion below is inside a loop over rejected
+    # targets, so an empty list would pass the whole test having checked
+    # nothing. Measured on this fixture: 15 rejected, 0 recommended.
+    assert rejected, "fixture produced no rejected targets; the loop below would be a no-op"
+
     for target in players:
         assert target["reason"]
-        if not target["recommended"]:
-            assert target["corroborating"] == [] or len(target["corroborating"]) >= 0
+
+    for target in rejected:
+        # This previously read
+        #     assert t["corroborating"] == [] or len(t["corroborating"]) >= 0
+        # and ``len(x) >= 0`` is true of every list, so the disjunction
+        # was a tautology — the one assertion about rejected targets
+        # asserted nothing at all about them.
+        #
+        # The real invariant, measured across all 15 rejected targets on
+        # this fixture: a target is rejected precisely because nothing
+        # corroborated it, so the list is empty.
+        assert target["corroborating"] == [], (
+            f"{target.get('name') or target.get('displayName')!r} was rejected but "
+            f"carries corroboration {target['corroborating']!r} — rejection and "
+            "corroboration disagree"
+        )
     yields = body["coverage"]["corroborationYield"]
     assert yields["evaluated"] == len(players)
     assert yields["recommended"] == sum(1 for t in players if t["recommended"])

--- a/tests/api/test_pick_rookie_anchor.py
+++ b/tests/api/test_pick_rookie_anchor.py
@@ -22,7 +22,6 @@ from pathlib import Path
 from typing import Any
 
 from src.api.data_contract import (
-    _anchor_current_year_picks_to_rookies,
     assert_ranking_coherence,
     build_api_data_contract,
 )
@@ -51,164 +50,17 @@ def _make_pick(name: str, rank: int, value: int) -> dict[str, Any]:
     }
 
 
-class TestAnchorPassCore(unittest.TestCase):
-    """Synthetic playersArray exercises — no live data required."""
-
-    def test_1_01_matches_top_rookie(self) -> None:
-        rookies = [_make_rookie(f"Rookie {i}", i, 10000 - i * 10) for i in range(1, 13)]
-        picks = [
-            _make_pick(f"2026 Pick 1.{slot:02d}", 80 + slot, 6000 - slot * 50)
-            for slot in range(1, 13)
-        ]
-        players_array = rookies + picks
-
-        anchored = _anchor_current_year_picks_to_rookies(players_array, 2026)
-        self.assertEqual(anchored, 12)
-        self.assertEqual(picks[0]["rankDerivedValue"], rookies[0]["rankDerivedValue"])
-        self.assertEqual(picks[0]["pickRookieAnchor"], "Rookie 1")
-
-    def test_slot_mapping_is_monotonic(self) -> None:
-        rookies = [_make_rookie(f"R{i}", i, 20000 - i * 7) for i in range(1, 80)]
-        picks = []
-        for rnd in range(1, 7):
-            for slot in range(1, 13):
-                picks.append(
-                    _make_pick(
-                        f"2026 Pick {rnd}.{slot:02d}",
-                        100 + (rnd - 1) * 12 + slot,
-                        500 - rnd * 10 - slot,
-                    )
-                )
-        players_array = rookies + picks
-
-        anchored = _anchor_current_year_picks_to_rookies(players_array, 2026)
-        self.assertEqual(anchored, 72)
-
-        # Walk picks in slot order; values must strictly decrease
-        # because the rookie list is strictly decreasing.
-        prev_val: int | None = None
-        for rnd in range(1, 7):
-            for slot in range(1, 13):
-                name = f"2026 Pick {rnd}.{slot:02d}"
-                row = next(p for p in picks if p["canonicalName"] == name)
-                val = row["rankDerivedValue"]
-                if prev_val is not None:
-                    self.assertLess(val, prev_val, f"{name}: {val} >= prev {prev_val}")
-                prev_val = val
-
-    def test_offense_idp_rookies_merge(self) -> None:
-        offense = [_make_rookie(f"OffRook {i}", i, 9000 - i * 20) for i in range(1, 6)]
-        idp = [_make_rookie(f"IdpRook {i}", 30 + i, 8900 - i * 20) for i in range(1, 6)]
-        # Interleave by value: off1=8980, idp1=8880, off2=8960, idp2=8860, ...
-        picks = [_make_pick(f"2026 Pick 1.{s:02d}", 80 + s, 100) for s in range(1, 8)]
-        players_array = offense + idp + picks
-
-        _anchor_current_year_picks_to_rookies(players_array, 2026)
-
-        merged_sorted = sorted(offense + idp, key=lambda r: -r["rankDerivedValue"])
-        for i, pick in enumerate(picks):
-            if i >= len(merged_sorted):
-                continue
-            self.assertEqual(
-                pick["rankDerivedValue"],
-                merged_sorted[i]["rankDerivedValue"],
-                f"pick {pick['canonicalName']} should match merged " f"rookie #{i+1}",
-            )
-
-    def test_wrong_year_untouched(self) -> None:
-        rookies = [_make_rookie(f"R{i}", i, 9000 - i * 10) for i in range(1, 4)]
-        pick_2027 = _make_pick("2027 Pick 1.01", 50, 4200)
-        pick_2026 = _make_pick("2026 Pick 1.01", 51, 4100)
-        players_array = rookies + [pick_2026, pick_2027]
-
-        _anchor_current_year_picks_to_rookies(players_array, 2026)
-
-        self.assertEqual(pick_2027["rankDerivedValue"], 4200)  # untouched
-        self.assertEqual(pick_2026["rankDerivedValue"], 8990)  # top rookie
-
-    def test_generic_tier_rows_untouched(self) -> None:
-        rookies = [_make_rookie(f"R{i}", i, 9000 - i * 10) for i in range(1, 4)]
-        tier_pick = _make_pick("2026 Early 1st", 40, 5500)
-        players_array = rookies + [tier_pick]
-
-        _anchor_current_year_picks_to_rookies(players_array, 2026)
-
-        # Generic tier rows (Early/Mid/Late) don't parse as slot picks
-        # and are left alone.
-        self.assertEqual(tier_pick["rankDerivedValue"], 5500)
-        self.assertNotIn("pickRookieAnchor", tier_pick)
-
-    def test_no_rookies_is_noop(self) -> None:
-        picks = [_make_pick(f"2026 Pick 1.{s:02d}", 80 + s, 5000 - s * 10) for s in range(1, 13)]
-        before = [p["rankDerivedValue"] for p in picks]
-        anchored = _anchor_current_year_picks_to_rookies(picks, 2026)
-        self.assertEqual(anchored, 0)
-        self.assertEqual([p["rankDerivedValue"] for p in picks], before)
-
-    def test_unranked_pick_still_anchored(self) -> None:
-        """Picks that fell off the Phase 4 OVERALL_RANK_LIMIT cap still
-        get anchored when a corresponding rookie exists.
-
-        The anchor is a proxy value for the rookie regardless of
-        whether the pick row survived the global rank cap; the
-        Phase 5 compact pass would clear the pick's rank anyway.
-        Gating on ``canonicalConsensusRank`` left tail R4 picks
-        unvalued whenever a curve retune tightened the cap.
-        """
-        rookies = [_make_rookie("R1", 1, 9000)]
-        pick = _make_pick("2026 Pick 1.01", 0, 0)
-        pick["canonicalConsensusRank"] = None
-        players_array = rookies + [pick]
-
-        anchored = _anchor_current_year_picks_to_rookies(players_array, 2026)
-        self.assertEqual(anchored, 1)
-        self.assertEqual(pick.get("rankDerivedValue"), 9000)
-        self.assertEqual(pick.get("pickRookieAnchor"), "R1")
-
-    def test_beyond_72_rookies_unused(self) -> None:
-        # Only 60 rookies available; pick 6.01 (index 60) has no anchor.
-        rookies = [_make_rookie(f"R{i}", i, 9000 - i * 10) for i in range(1, 61)]
-        pick_601 = _make_pick("2026 Pick 6.01", 200, 2000)
-        players_array = rookies + [pick_601]
-
-        _anchor_current_year_picks_to_rookies(players_array, 2026)
-
-        # idx = 5*12 + 0 = 60 which is >= len(rookies)=60, so untouched.
-        self.assertEqual(pick_601["rankDerivedValue"], 2000)
-        self.assertNotIn("pickRookieAnchor", pick_601)
-
-    def test_tail_rookies_with_only_blended_value_included(self) -> None:
-        """Deep rookies whose Hill-blend output survived beyond the
-        top-``OVERALL_RANK_LIMIT`` cap (so they carry
-        ``_blendedValueUncapped`` instead of ``rankDerivedValue``) must
-        still participate in the tether pool.  Without this, rounds 5
-        and 6 of the current-year pick board run out of tether targets
-        around slot 53 and stamp ``rankDerivedValue=0`` on deep picks.
-        """
-        # 40 top-800 offense rookies + 35 tail rookies (only uncapped value).
-        top_rookies = [_make_rookie(f"Top{i}", i, 9000 - i * 50) for i in range(1, 41)]
-        tail_rookies: list[dict[str, Any]] = []
-        for i in range(1, 36):
-            r = _make_rookie(f"Tail{i}", 0, 0)
-            r["canonicalConsensusRank"] = None
-            r["_blendedValueUncapped"] = 1500 - i * 5  # strictly decreasing
-            tail_rookies.append(r)
-        picks = [
-            _make_pick(f"2026 Pick {rnd}.{slot:02d}", 100 + rnd * 12 + slot, 100)
-            for rnd in range(1, 7)
-            for slot in range(1, 13)
-        ]
-        players_array = top_rookies + tail_rookies + picks
-
-        anchored = _anchor_current_year_picks_to_rookies(players_array, 2026)
-
-        # 40 top + 35 tail = 75 rookies → all 72 picks should tether.
-        self.assertEqual(anchored, 72)
-        # Slot 6.12 should be tethered (index 71); without tail rookies
-        # it would be skipped.
-        pick_612 = next(p for p in picks if p["canonicalName"] == "2026 Pick 6.12")
-        self.assertIn("pickRookieAnchor", pick_612)
-        self.assertGreater(int(pick_612["rankDerivedValue"]), 0)
+# ── TestAnchorPassCore lives in test_pick_rookie_anchor_core.py ──
+#
+# This module is listed in _LIVEDATA_MODULES (tests/conftest.py), so
+# every test in it is marked ``livedata`` and runs in CI's
+# NON-BLOCKING advisory tier.  That is correct for the end-to-end
+# class below, which reads exports/latest/ and fails on ordinary
+# scrape churn.  It was wrong for the synthetic pure-logic class,
+# which guarded pipeline step 11 while being unable to fail a PR.
+#
+# Do not move those tests back here without removing this module
+# from _LIVEDATA_MODULES first.
 
 
 class TestAnchorEndToEnd(unittest.TestCase):

--- a/tests/api/test_pick_rookie_anchor_core.py
+++ b/tests/api/test_pick_rookie_anchor_core.py
@@ -1,0 +1,213 @@
+"""Rookie-anchor pass — the PURE-LOGIC half, in the blocking gate.
+
+Split out of ``test_pick_rookie_anchor.py`` for one reason: that module
+is listed in ``_LIVEDATA_MODULES`` (tests/conftest.py), which marks
+**every test in the file** ``livedata`` and drops it into CI's
+non-blocking advisory tier.
+
+That policy is right for the end-to-end class, which reads
+``exports/latest/dynasty_data_*.json`` and fails on ordinary scrape
+churn with no code defect. It was wrong for these ten, whose own class
+docstring read *"Synthetic playersArray exercises — no live data
+required"*. They are pure functions over hand-built rows, they cannot
+be broken by a row-count dip, and they guard pipeline step 11 —
+current-year pick tethering, which sets the value of all 72 slot picks
+on the live board.
+
+Measured 2026-07-27: ``pytest tests/api/test_pick_rookie_anchor.py -m
+"not livedata"`` collected **15 deselected, 0 run**. So the backlog's
+"pick tethering untested" was not quite right and worse than it sounds
+— the tests exist, are good, and never gated anything. Same shape as
+``test_anchor_curve_extrapolation_monotone`` (defect #2): a real test
+that cannot fail a PR is a test nobody is running.
+
+The module-granularity policy itself is sound and unchanged. This just
+puts the two halves in the two modules the policy needs them in.
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+from src.api.data_contract import _anchor_current_year_picks_to_rookies
+
+
+def _make_rookie(name: str, rank: int, value: int) -> dict[str, Any]:
+    return {
+        "canonicalName": name,
+        "assetClass": "player",
+        "rookie": True,
+        "canonicalConsensusRank": rank,
+        "rankDerivedValue": value,
+    }
+
+
+def _make_pick(name: str, rank: int, value: int) -> dict[str, Any]:
+    return {
+        "canonicalName": name,
+        "assetClass": "pick",
+        "rookie": False,
+        "canonicalConsensusRank": rank,
+        "rankDerivedValue": value,
+    }
+
+
+class TestAnchorPassCore(unittest.TestCase):
+    """Synthetic playersArray exercises — no live data required."""
+
+    def test_1_01_matches_top_rookie(self) -> None:
+        rookies = [_make_rookie(f"Rookie {i}", i, 10000 - i * 10) for i in range(1, 13)]
+        picks = [
+            _make_pick(f"2026 Pick 1.{slot:02d}", 80 + slot, 6000 - slot * 50)
+            for slot in range(1, 13)
+        ]
+        players_array = rookies + picks
+
+        anchored = _anchor_current_year_picks_to_rookies(players_array, 2026)
+        self.assertEqual(anchored, 12)
+        self.assertEqual(picks[0]["rankDerivedValue"], rookies[0]["rankDerivedValue"])
+        self.assertEqual(picks[0]["pickRookieAnchor"], "Rookie 1")
+
+    def test_slot_mapping_is_monotonic(self) -> None:
+        rookies = [_make_rookie(f"R{i}", i, 20000 - i * 7) for i in range(1, 80)]
+        picks = []
+        for rnd in range(1, 7):
+            for slot in range(1, 13):
+                picks.append(
+                    _make_pick(
+                        f"2026 Pick {rnd}.{slot:02d}",
+                        100 + (rnd - 1) * 12 + slot,
+                        500 - rnd * 10 - slot,
+                    )
+                )
+        players_array = rookies + picks
+
+        anchored = _anchor_current_year_picks_to_rookies(players_array, 2026)
+        self.assertEqual(anchored, 72)
+
+        # Walk picks in slot order; values must strictly decrease
+        # because the rookie list is strictly decreasing.
+        prev_val: int | None = None
+        for rnd in range(1, 7):
+            for slot in range(1, 13):
+                name = f"2026 Pick {rnd}.{slot:02d}"
+                row = next(p for p in picks if p["canonicalName"] == name)
+                val = row["rankDerivedValue"]
+                if prev_val is not None:
+                    self.assertLess(val, prev_val, f"{name}: {val} >= prev {prev_val}")
+                prev_val = val
+
+    def test_offense_idp_rookies_merge(self) -> None:
+        offense = [_make_rookie(f"OffRook {i}", i, 9000 - i * 20) for i in range(1, 6)]
+        idp = [_make_rookie(f"IdpRook {i}", 30 + i, 8900 - i * 20) for i in range(1, 6)]
+        # Interleave by value: off1=8980, idp1=8880, off2=8960, idp2=8860, ...
+        picks = [_make_pick(f"2026 Pick 1.{s:02d}", 80 + s, 100) for s in range(1, 8)]
+        players_array = offense + idp + picks
+
+        _anchor_current_year_picks_to_rookies(players_array, 2026)
+
+        merged_sorted = sorted(offense + idp, key=lambda r: -r["rankDerivedValue"])
+        for i, pick in enumerate(picks):
+            if i >= len(merged_sorted):
+                continue
+            self.assertEqual(
+                pick["rankDerivedValue"],
+                merged_sorted[i]["rankDerivedValue"],
+                f"pick {pick['canonicalName']} should match merged " f"rookie #{i+1}",
+            )
+
+    def test_wrong_year_untouched(self) -> None:
+        rookies = [_make_rookie(f"R{i}", i, 9000 - i * 10) for i in range(1, 4)]
+        pick_2027 = _make_pick("2027 Pick 1.01", 50, 4200)
+        pick_2026 = _make_pick("2026 Pick 1.01", 51, 4100)
+        players_array = rookies + [pick_2026, pick_2027]
+
+        _anchor_current_year_picks_to_rookies(players_array, 2026)
+
+        self.assertEqual(pick_2027["rankDerivedValue"], 4200)  # untouched
+        self.assertEqual(pick_2026["rankDerivedValue"], 8990)  # top rookie
+
+    def test_generic_tier_rows_untouched(self) -> None:
+        rookies = [_make_rookie(f"R{i}", i, 9000 - i * 10) for i in range(1, 4)]
+        tier_pick = _make_pick("2026 Early 1st", 40, 5500)
+        players_array = rookies + [tier_pick]
+
+        _anchor_current_year_picks_to_rookies(players_array, 2026)
+
+        # Generic tier rows (Early/Mid/Late) don't parse as slot picks
+        # and are left alone.
+        self.assertEqual(tier_pick["rankDerivedValue"], 5500)
+        self.assertNotIn("pickRookieAnchor", tier_pick)
+
+    def test_no_rookies_is_noop(self) -> None:
+        picks = [_make_pick(f"2026 Pick 1.{s:02d}", 80 + s, 5000 - s * 10) for s in range(1, 13)]
+        before = [p["rankDerivedValue"] for p in picks]
+        anchored = _anchor_current_year_picks_to_rookies(picks, 2026)
+        self.assertEqual(anchored, 0)
+        self.assertEqual([p["rankDerivedValue"] for p in picks], before)
+
+    def test_unranked_pick_still_anchored(self) -> None:
+        """Picks that fell off the Phase 4 OVERALL_RANK_LIMIT cap still
+        get anchored when a corresponding rookie exists.
+
+        The anchor is a proxy value for the rookie regardless of
+        whether the pick row survived the global rank cap; the
+        Phase 5 compact pass would clear the pick's rank anyway.
+        Gating on ``canonicalConsensusRank`` left tail R4 picks
+        unvalued whenever a curve retune tightened the cap.
+        """
+        rookies = [_make_rookie("R1", 1, 9000)]
+        pick = _make_pick("2026 Pick 1.01", 0, 0)
+        pick["canonicalConsensusRank"] = None
+        players_array = rookies + [pick]
+
+        anchored = _anchor_current_year_picks_to_rookies(players_array, 2026)
+        self.assertEqual(anchored, 1)
+        self.assertEqual(pick.get("rankDerivedValue"), 9000)
+        self.assertEqual(pick.get("pickRookieAnchor"), "R1")
+
+    def test_beyond_72_rookies_unused(self) -> None:
+        # Only 60 rookies available; pick 6.01 (index 60) has no anchor.
+        rookies = [_make_rookie(f"R{i}", i, 9000 - i * 10) for i in range(1, 61)]
+        pick_601 = _make_pick("2026 Pick 6.01", 200, 2000)
+        players_array = rookies + [pick_601]
+
+        _anchor_current_year_picks_to_rookies(players_array, 2026)
+
+        # idx = 5*12 + 0 = 60 which is >= len(rookies)=60, so untouched.
+        self.assertEqual(pick_601["rankDerivedValue"], 2000)
+        self.assertNotIn("pickRookieAnchor", pick_601)
+
+    def test_tail_rookies_with_only_blended_value_included(self) -> None:
+        """Deep rookies whose Hill-blend output survived beyond the
+        top-``OVERALL_RANK_LIMIT`` cap (so they carry
+        ``_blendedValueUncapped`` instead of ``rankDerivedValue``) must
+        still participate in the tether pool.  Without this, rounds 5
+        and 6 of the current-year pick board run out of tether targets
+        around slot 53 and stamp ``rankDerivedValue=0`` on deep picks.
+        """
+        # 40 top-800 offense rookies + 35 tail rookies (only uncapped value).
+        top_rookies = [_make_rookie(f"Top{i}", i, 9000 - i * 50) for i in range(1, 41)]
+        tail_rookies: list[dict[str, Any]] = []
+        for i in range(1, 36):
+            r = _make_rookie(f"Tail{i}", 0, 0)
+            r["canonicalConsensusRank"] = None
+            r["_blendedValueUncapped"] = 1500 - i * 5  # strictly decreasing
+            tail_rookies.append(r)
+        picks = [
+            _make_pick(f"2026 Pick {rnd}.{slot:02d}", 100 + rnd * 12 + slot, 100)
+            for rnd in range(1, 7)
+            for slot in range(1, 13)
+        ]
+        players_array = top_rookies + tail_rookies + picks
+
+        anchored = _anchor_current_year_picks_to_rookies(players_array, 2026)
+
+        # 40 top + 35 tail = 75 rookies → all 72 picks should tether.
+        self.assertEqual(anchored, 72)
+        # Slot 6.12 should be tethered (index 71); without tail rookies
+        # it would be skipped.
+        pick_612 = next(p for p in picks if p["canonicalName"] == "2026 Pick 6.12")
+        self.assertIn("pickRookieAnchor", pick_612)
+        self.assertGreater(int(pick_612["rankDerivedValue"]), 0)

--- a/tests/audit/test_module_reachability.py
+++ b/tests/audit/test_module_reachability.py
@@ -1,0 +1,140 @@
+"""The "43 unreachable modules" figure, made re-derivable.
+
+Backlog defect #9 reported "43 of 208 ``src/`` modules unreachable
+(~12,571 lines)". No instrument produced that number and no test pinned
+it, so it could not be checked, acted on, or retired — it aged into
+folklore. Measured today with the same import walk the feature-flag
+guard uses:
+
+    SERVER   117 modules   55,062 lines   a request can reach it
+    SCRIPT    14            3,376         operator tooling, not a defect
+    TEST      65           16,867         only its own tests import it
+    ORPHAN    16            2,044         nothing imports it at all
+
+The single "unreachable" count collapsed three very different
+situations, which is why it was unusable. A refit script reached only
+from ``scripts/`` is doing its job; a module reached only from the test
+written for it is the ``usage_signals`` shape; genuinely orphaned code
+is the third thing.
+
+And 8 of the 16 orphans sit under ``src/ros/sources/`` and
+``src/news/providers/``, which ``src/ros/scrape.py:449`` loads by string
+via ``importlib.import_module(src_meta["scraper"])`` against the
+``ROS_SOURCES`` registry. A static walk cannot see that, so those are
+annotated rather than accused — the difference between a report someone
+acts on and one that gets a working scraper deleted.
+
+These tests guard the instrument, not the number. The counts move as
+the tree moves; what must not move is the walk's ability to see.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "audit" / "measure_module_reachability.py"
+
+
+@pytest.fixture(scope="module")
+def audit():
+    spec = importlib.util.spec_from_file_location("measure_module_reachability", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def result(audit):
+    return audit.measure()
+
+
+def test_the_walk_finds_the_bulk_of_the_tree(result):
+    """Guard on the guard.
+
+    Every verdict is a function of the import closure. A walk that
+    silently returned nothing would class all 212 modules ORPHAN and
+    produce a spectacular, entirely false report — the exact failure the
+    feature-flag audit had to defend against too.
+    """
+    assert result["totalModules"] > 150, "src/ shrank unexpectedly, or the scan is broken"
+    server = result["byClass"].get("SERVER", {"modules": 0})
+    assert server["modules"] > 80, (
+        f"only {server['modules']} modules reachable from server.py; "
+        "the import walk is not resolving"
+    )
+
+
+def test_the_classes_are_all_populated(result):
+    """A classifier that put everything in one bucket would satisfy any
+    single-class assertion. All four appearing is what makes the split
+    meaningful."""
+    present = {c for c, row in result["byClass"].items() if row["modules"] > 0}
+    assert present == {"SERVER", "SCRIPT", "TEST", "ORPHAN"}, present
+
+
+def test_known_live_modules_are_reachable_from_the_server(result):
+    """Anchors. If these ever class as anything but SERVER, the walk has
+    broken rather than the tree."""
+    by_module = {m["module"]: m for m in result["modules"]}
+    for dotted in (
+        "src.api.data_contract",
+        "src.api.feature_flags",
+        "src.trade.suggestions",
+        "src.ros.pick_projection",
+    ):
+        assert by_module[dotted]["reachability"] == "SERVER", (
+            f"{dotted} is live and should be reachable from server.py, "
+            f"got {by_module[dotted]['reachability']}"
+        )
+
+
+def test_dynamically_dispatched_packages_are_annotated_not_accused(result):
+    """``src/ros/scrape.py:449`` does
+    ``importlib.import_module(src_meta["scraper"])`` over the
+    ``ROS_SOURCES`` registry, so those modules are loaded by string and
+    a static walk cannot see it.
+
+    They may legitimately class ORPHAN — what must never happen is that
+    they class ORPHAN *without the flag*, because that is the row
+    someone deletes.
+    """
+    orphans = [m for m in result["modules"] if m["reachability"] == "ORPHAN"]
+    unflagged_sources = [
+        m
+        for m in orphans
+        if m["module"].startswith(("src.ros.sources.", "src.news.providers."))
+        and not m["dynamicDispatch"]
+    ]
+    assert not unflagged_sources, (
+        f"dynamically-loaded modules reported as plain orphans: "
+        f"{[m['module'] for m in unflagged_sources]}"
+    )
+
+
+def test_the_dynamic_dispatch_hint_actually_matches_something(result):
+    """Non-vacuity for the test above.
+
+    If ``DYNAMIC_DISPATCH_HINTS`` stopped matching any real package —
+    a rename, a move — the previous test would pass by finding nothing,
+    and the protection it describes would be gone.
+    """
+    flagged = [m for m in result["modules"] if m["dynamicDispatch"]]
+    assert flagged, "no module matches DYNAMIC_DISPATCH_HINTS; the hint list is stale"
+
+
+def test_line_counts_are_real(result):
+    """The report ranks by size, so a zero everywhere would silently
+    invert the ordering into meaninglessness."""
+    assert result["totalLines"] > 10_000
+    sizeable = [m for m in result["modules"] if m["lines"] > 0]
+    assert len(sizeable) > result["totalModules"] * 0.9
+
+
+def test_the_report_is_sorted_largest_first(result):
+    """It is read top-down and acted on top-down."""
+    lines = [m["lines"] for m in result["modules"]]
+    assert lines == sorted(lines, reverse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,11 @@ _LIVEDATA_MODULES = frozenset(
     {
         "test_launch_readiness.py",
         "test_source_monitoring.py",
-        "test_footballguys_source.py",
+        # ``test_footballguys_source.py`` was listed here and does not
+        # exist — a dead exemption.  Removed 2026-07-27;
+        # ``test_livedata_policy.py`` now fails on a stale entry, since
+        # an exemption list nobody can check is how the pick-anchor
+        # split below went unnoticed.
         "test_picks_end_to_end.py",
         "test_pick_refinement.py",
         "test_pick_rookie_anchor.py",

--- a/tests/news/test_usage_signals.py
+++ b/tests/news/test_usage_signals.py
@@ -88,31 +88,60 @@ def test_sell_requires_active_starter(monkeypatch):
     assert out2[0].signal == "SELL"
 
 
-def test_freshness_guard_blocks_current_week(monkeypatch):
-    """Stat week == current week + it's Monday (pre-Thursday) → blocked."""
+def _pin_weekday(monkeypatch, weekday: int):
+    """Freeze ``freshness``'s clock to a known weekday.
+
+    ``detect_usage_transitions`` does not thread a ``now`` through to
+    ``is_fresh_for_alerts``, so the only way to make the week-in-flight
+    branch deterministic without stubbing the guard itself is to pin the
+    clock it reads.  The real predicate still runs.
+    """
+    import datetime as _dt
+
+    from src.nfl_data import freshness as _freshness
+
+    # 2025-11-03 is a Monday, so +weekday lands on the day we want.
+    pinned = _dt.datetime(2025, 11, 3, 12, 0, tzinfo=_dt.timezone.utc) + _dt.timedelta(days=weekday)
+    assert pinned.weekday() == weekday, "fixture date arithmetic is wrong"
+    monkeypatch.setattr(_freshness, "_nfl_now", lambda now=None: pinned)
+
+
+def test_freshness_guard_blocks_current_week_before_thursday(monkeypatch):
+    """Stat week == current week, and it is Monday → blocked.
+
+    This assertion used to read ``out == [] or out[0].signal == "BUY"``,
+    which accepts both outcomes — so a test named "blocks" passed
+    whether or not it blocked.  The comment above it said as much: the
+    guard reads TODAY's weekday, so the result changed depending on the
+    day the suite ran, and the author disabled the assertion rather than
+    pin the clock.
+
+    Pinning it is the fix.  Both branches are now asserted, here and
+    below, and either direction of regression fails.
+    """
     monkeypatch.setenv("RISKIT_FEATURE_USAGE_SIGNALS", "1")
     feature_flags.reload()
+    _pin_weekday(monkeypatch, 0)  # Monday
+
     w = _mk_window(season=2025, week=6, snap_pct_z=3.0, snap_pct_mean=0.60)
-    # No freshness-context args would pass the guard trivially.
-    # Pass season_current_week=6 and the test should skip.
-    out = usage_signals.detect_usage_transitions(
-        [w],
-        season_year=2025,
-        season_current_week=6,
-    )
-    # Default now is today in NFL TZ; at our test time (2026-04-24)
-    # is_fresh_for_alerts treats stat_year 2025 ≠ season_year 2026
-    # as historical → fresh.  So we need season_year=2025 in the
-    # test path.
-    # But: when season_year=2025 and season_current_week=6, and
-    # we're past that season, is_fresh_for_alerts needs the _mk_now
-    # to be consistent.  Safest: we already established that
-    # "prior completed week" is fresh (stat_week 6 < current_week 6
-    # isn't true, it's equal).
-    # So the guard returns False-for-now if weekday<Thu — which is
-    # dependent on TODAY's weekday.  Skip this specific assertion
-    # and verify the OTHER branch: season_year mismatch → fresh.
-    assert out == [] or out[0].signal == "BUY"
+    out = usage_signals.detect_usage_transitions([w], season_year=2025, season_current_week=6)
+    assert out == [], "a week still in flight on a Monday must not fire"
+
+
+def test_freshness_guard_allows_current_week_from_thursday(monkeypatch):
+    """The other half, and what makes the test above non-vacuous.
+
+    Without this, a detector that fired on nothing at all would satisfy
+    the Monday case perfectly.  Same window, same season context, one
+    day later than the safe weekday.
+    """
+    monkeypatch.setenv("RISKIT_FEATURE_USAGE_SIGNALS", "1")
+    feature_flags.reload()
+    _pin_weekday(monkeypatch, 3)  # Thursday — _SAFE_WEEKDAY
+
+    w = _mk_window(season=2025, week=6, snap_pct_z=3.0, snap_pct_mean=0.60)
+    out = usage_signals.detect_usage_transitions([w], season_year=2025, season_current_week=6)
+    assert [s.signal for s in out] == ["BUY"]
 
 
 def test_signal_dict_format_matches_expected_shape():

--- a/tests/ros/test_team_strength_canonical_join.py
+++ b/tests/ros/test_team_strength_canonical_join.py
@@ -1,0 +1,136 @@
+"""An exact-string join between two sides that were never canonicalised.
+
+Backlog defect #18. ``compute_team_strength`` indexed the ROS aggregate
+by ``canonicalName`` and looked players up by whatever the roster block
+carried — ``canonicalName or displayName or name``. Neither side is
+reliably canonical:
+
+* ``src/ros/aggregate.py`` copies each source parser's ``canonical_name``
+  verbatim and never imports ``resolve_canonical_name``, so 16 of 1,087
+  live aggregate rows are stored non-lowercase.
+* the roster side falls back to display names, which never were.
+
+Measured 2026-07-27 on the live 12-team snapshot: 36 roster players
+unmapped, **8 of which map once both sides go through
+``resolve_canonical_name``**.
+
+That is not cosmetic. An unmapped player contributes ZERO to
+``teamRosStrength``, which sets the projected reverse-standings draft
+order behind the Pick Projector — so eight phantom zeroes were biasing
+which team is projected to pick 1.01.
+
+WHY NOT ``.lower()``
+────────────────────
+It would fix 14 of the 16 and silently leave two. "Greg Rousseau" ->
+"gregory rousseau" and "Chig Okonkwo" -> "chigoziem okonkwo" need the
+alias map. A casefold looks like it works, which is worse than not
+working. ``test_the_fix_is_not_a_casefold`` pins that.
+
+WHY NOT FIX THE WRITER
+──────────────────────
+``canonicalName`` doubles as a DISPLAY fallback —
+``displayName or canonicalName`` in ``src/api/terminal.py`` and three
+frontend modules. Normalising what is written would render
+"cam skattebo" wherever ``displayName`` is absent. One field, two jobs,
+two different normalisations; the join is the one that wants this.
+"""
+
+from __future__ import annotations
+
+from src.ros.team_strength import compute_team_strength
+from src.utils.name_clean import resolve_canonical_name
+
+AGG = [
+    # Stored exactly as the live aggregate stores them — mixed case, and
+    # two that also need alias expansion.
+    {"canonicalName": "Dax Hill", "position": "DB", "rosValue": 40.0},
+    {"canonicalName": "Greg Rousseau", "position": "DL", "rosValue": 55.0},
+    {"canonicalName": "Chig Okonkwo", "position": "TE", "rosValue": 30.0},
+    {"canonicalName": "joe flacco", "position": "QB", "rosValue": 25.0},
+]
+
+
+def _team(names):
+    return [
+        {
+            "rosterId": 1,
+            "ownerId": "o1",
+            "teamName": "Test",
+            "players": [{"name": n, "position": "QB"} for n in names],
+        }
+    ]
+
+
+def _rows(names):
+    return compute_team_strength(
+        _team(names),
+        aggregated_players=AGG,
+        starter_slots=["QB"],
+    )
+
+
+def test_the_fixture_reproduces_the_live_shape():
+    """Non-vacuity: the aggregate side must genuinely be non-canonical,
+    or an exact join would already work and this file proves nothing."""
+    off = [
+        p["canonicalName"]
+        for p in AGG
+        if p["canonicalName"] != resolve_canonical_name(p["canonicalName"])
+    ]
+    assert len(off) >= 3, f"fixture is already canonical ({off}); the bug cannot be shown"
+
+
+def test_a_casing_only_mismatch_now_maps():
+    """ "dax hill" against a stored "Dax Hill"."""
+    rows = _rows(["dax hill"])
+    assert rows[0]["unmappedPlayerCount"] == 0, rows[0]["unmappedPlayers"]
+
+
+def test_the_fix_is_not_a_casefold():
+    """The two the naive fix misses.
+
+    ``.lower()`` maps "Greg Rousseau" to "greg rousseau", which is not
+    what the aggregate resolves to. Only the alias map closes it.
+    """
+    for roster_name in ("greg rousseau", "chig okonkwo"):
+        rows = _rows([roster_name])
+        assert rows[0]["unmappedPlayerCount"] == 0, (
+            f"{roster_name!r} still unmapped — a casefold would leave it that way, "
+            "which is why the join resolves rather than lowercases"
+        )
+
+
+def test_an_already_canonical_name_still_maps():
+    """Control. A fix that only handled the broken cases while breaking
+    the working one would show up here and nowhere else."""
+    rows = _rows(["joe flacco"])
+    assert rows[0]["unmappedPlayerCount"] == 0
+
+
+def test_a_genuinely_unranked_player_stays_unmapped():
+    """The guard must not map everything.
+
+    28 of the live 36 really are unranked by every ROS source, and that
+    is the state ``unmapped`` exists to report. A join that resolved
+    them into existence would be worse than the bug.
+    """
+    rows = _rows(["nobody at all"])
+    assert rows[0]["unmappedPlayerCount"] == 1
+
+
+def test_the_unmapped_list_keeps_the_readable_name():
+    """It is rendered, so it wants the display form, not the join key."""
+    rows = _rows(["Some Unranked Guy"])
+    assert rows[0]["unmappedPlayers"] == ["Some Unranked Guy"]
+
+
+def test_mapping_a_player_actually_raises_team_strength():
+    """The point of the fix, stated as a number.
+
+    If the recovered players mapped but contributed nothing, the join
+    would be fixed and the defect — phantom zeroes biasing the projected
+    draft order — would remain.
+    """
+    mapped = _rows(["dax hill", "greg rousseau"])[0]["teamRosStrength"]
+    unmapped = _rows(["nobody at all", "also nobody"])[0]["teamRosStrength"]
+    assert mapped > unmapped, "recovered players must contribute, not just stop being counted"

--- a/tests/test_livedata_policy.py
+++ b/tests/test_livedata_policy.py
@@ -1,0 +1,108 @@
+"""The ``livedata`` exemption list, checked instead of trusted.
+
+``tests/conftest.py`` marks every test in ``_LIVEDATA_MODULES`` as
+``livedata``, which moves it out of CI's hard gate into a non-blocking
+advisory tier. That policy is sound — a yahooBoone row-count dip should
+not block every PR — but it is applied at MODULE granularity, so one
+entry exempts every test in the file including the ones that need no
+live data at all.
+
+Two things that went unnoticed because nothing checked the list:
+
+* ``test_pick_rookie_anchor.py`` held ten synthetic pure-logic tests
+  whose own class docstring said "no live data required". They guarded
+  pipeline step 11 — current-year pick tethering, which sets the value
+  of all 72 slot picks — and could not fail a PR. Measured before the
+  split: ``-m "not livedata"`` collected 15 deselected, 0 run. Now in
+  ``test_pick_rookie_anchor_core.py``.
+* ``test_footballguys_source.py`` was listed and does not exist.
+
+These tests do not re-litigate the policy. They check the two things
+about it that can be checked mechanically: entries name real files, and
+the module rescued above stays rescued.
+
+STILL OPEN, deliberately not fixed here: ``test_dlf_source.py`` carries
+``TestDlfCsvEnrichment``, which builds a temporary CSV explicitly
+"without touching the real CSVs/site_raw tree" — the same pure-logic
+half in a live-data module. Splitting it is the same move as the pick
+anchor and wants its own change rather than being smuggled into one
+about pick tethering.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONFTEST = REPO_ROOT / "tests" / "conftest.py"
+
+
+def _declared_modules() -> list[str]:
+    """The literal entries of ``_LIVEDATA_MODULES``.
+
+    Parsed from source rather than imported, so a broken conftest fails
+    this test loudly instead of taking the whole suite down with it.
+    """
+    src = CONFTEST.read_text(encoding="utf-8")
+    _, _, after = src.partition("_LIVEDATA_MODULES")
+    block, _, _ = after.partition("}")
+    return re.findall(r'"(test_[A-Za-z0-9_]+\.py)"', block)
+
+
+def _test_files() -> dict[str, Path]:
+    return {p.name: p for p in REPO_ROOT.joinpath("tests").rglob("test_*.py")}
+
+
+def test_the_parse_finds_the_list():
+    """Guard on the guard: an empty parse would make every assertion
+    below pass by checking nothing."""
+    declared = _declared_modules()
+    assert len(declared) >= 10, f"only parsed {len(declared)} entries; the regex is stale"
+    assert "test_pick_rookie_anchor.py" in declared
+
+
+def test_every_exempted_module_exists():
+    """A stale entry is a policy line that looks load-bearing and is
+    not. ``test_footballguys_source.py`` sat here after its file was
+    removed, and nothing said so."""
+    missing = [m for m in _declared_modules() if m not in _test_files()]
+    assert not missing, (
+        f"_LIVEDATA_MODULES names files that do not exist: {missing}. "
+        "Remove them — a dead exemption makes the list unreadable."
+    )
+
+
+def test_the_pure_logic_anchor_module_is_not_exempted():
+    """The rescue must stay rescued.
+
+    Re-adding this module to the list, or moving the synthetic tests
+    back into the live-data one, would silently return pipeline step
+    11's guards to the advisory tier — which is exactly how they spent
+    however long they spent there.
+    """
+    declared = _declared_modules()
+    assert "test_pick_rookie_anchor_core.py" not in declared, (
+        "the synthetic rookie-anchor tests are pure logic and must keep "
+        "blocking; exempting them re-creates the defect they were split out of"
+    )
+    core = REPO_ROOT / "tests" / "api" / "test_pick_rookie_anchor_core.py"
+    assert core.exists(), "the pure-logic anchor module is gone; step 11 is unguarded again"
+
+
+def test_the_exempted_anchor_module_kept_only_its_live_half():
+    """The split has to have actually happened.
+
+    If the synthetic class were copied rather than moved, the tests
+    would run in both tiers and the live module would still be the one
+    people read.
+    """
+    src = (REPO_ROOT / "tests" / "api" / "test_pick_rookie_anchor.py").read_text(encoding="utf-8")
+    assert "class TestAnchorPassCore" not in src, (
+        "TestAnchorPassCore is back in the livedata module — it belongs in "
+        "test_pick_rookie_anchor_core.py, where it can fail a PR"
+    )
+    assert "class TestAnchorEndToEnd" in src, (
+        "the end-to-end class left the livedata module; it reads "
+        "exports/latest/ and belongs in the advisory tier"
+    )


### PR DESCRIPTION
Branched off `main`, independent of the stack (#591→#592→#593→#595→#596) and of #598.

Three items from §9 of the backlog inventory. Each was **verified against the tree before being fixed** rather than taken on the doc's word — and two of that entry's claims did not survive checking.

## #18 — `compute_team_strength` joined two uncanonicalised sides

It indexed the ROS aggregate by `canonicalName` and looked players up by whatever the roster block carried (`canonicalName or displayName or name`). Neither side is reliably canonical:

- `src/ros/aggregate.py` copies each source parser's `canonical_name` verbatim and **never imports `resolve_canonical_name`** — so 16 of 1,087 live aggregate rows are stored non-lowercase.
- the roster side falls back to display names, which never were.

**Measured on the live 12-team snapshot:** 36 roster players unmapped, **8 of which map** once both sides are resolved:

```
kam curl        -> kamren curl
chig okonkwo    -> chigoziem okonkwo
greg rousseau   -> gregory rousseau
mike evans      -> michael evans
cj gardner johnson / sauce gardner / dax hill / pat surtain   (casing only)
```

The other 28 are genuinely unranked by every ROS source — the state `unmapped` exists to report, and a join that resolved them into existence would be worse than the bug. There's a test for that.

**This is not cosmetic.** An unmapped player contributes **zero** to `teamRosStrength`, which sets the projected reverse-standings draft order behind the Pick Projector (#598). Eight phantom zeroes were biasing which team is projected to pick 1.01.

### Why not `.lower()`

It fixes 14 of the 16 and **silently leaves two**. `Greg Rousseau` → `gregory rousseau` and `Chig Okonkwo` → `chigoziem okonkwo` need the alias map. A casefold that looks like it works is worse than one that plainly doesn't, so `test_the_fix_is_not_a_casefold` pins exactly those two.

### Why not fix the writer

`canonicalName` doubles as a **display fallback** — `displayName or canonicalName` in `src/api/terminal.py` and three frontend modules. Normalising what's written would render "cam skattebo" wherever `displayName` is absent. One field serving two jobs that want different normalisation; the join is the one that wants this.

### Two claims in the doc that didn't hold

| claim | measured |
|---|---|
| "6 duplicate player rows" | **0** today |
| "40 of 666 rostered players fail to match" | **36** unmapped |
| "16 rows with non-lowercase `canonicalName`" | **16** — exact |

Worth knowing before anyone works the rest of that table: the entries are individually reliable in kind, not in number.

## #15 — a script pinned to a deleted worktree

`scripts/measure_te_demand_actuals.py` hardcoded `.claude/worktrees/agent-aeac57da8fea835ea` — the throwaway worktree it happened to be written in, deleted the moment that agent finished. Every run since has failed on a fixture read naming a directory nobody recognises. Derived from `__file__` now.

## #16 — a default that was correct for exactly one day

`scripts/measure_engine_value_divergence.py` defaulted to `dynasty_data_2026-07-26.json`. The exporter writes a new date-stamped file each run and doesn't keep the old one, so the default broke on 07-27 and could only ever have been right on the day it was typed. Resolves the newest export at runtime; `--payload` remains the way to pin one.

## Gates

4185 passed, `ruff format --check` and `ruff check` both clean.

Three join guards observed failing against the exact-string version — including the one asserting recovered players actually *contribute* rather than merely stop being counted, which failed `10.0 > 10.0` pre-fix.

## Still open in §9

13 of the 18 defects remain. #2 (`test_anchor_curve_extrapolation_monotone`) landed in #592 and #7 (dead feature flags) in #596 — where it measured **7, not 5**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeqwBFmFak84h3h7RaCZqa)_