### PR TITLE
fix(health-check): inline the freshness probe — .gitignore ate the last one

### DIFF
--- a/.claude/health-check.sh
+++ b/.claude/health-check.sh
@@ -50,9 +50,79 @@ fi
 # and means the same thing everywhere. Per-source health is reported as
 # coverage — how many players actually carry a value — which is what a dead
 # source would change, and a line count would not.
+#
+# The probe is INLINE, not a sibling file, and that is deliberate. It first
+# shipped as `.claude/freshness.py` — which `.gitignore:28` ignores, so
+# `git add -A` silently skipped it and `main` got a hook invoking a file that
+# did not exist. `health-check.sh` is a force-added exception to that ignore
+# rule; anything new beside it is dropped without a word. A heredoc cannot be
+# left behind by the next commit.
 echo ""
 echo "--- Data Freshness ---"
-python .claude/freshness.py 2>/dev/null || echo "  UNKNOWN: freshness probe failed to run."
+python - <<'PY' 2>&1 || echo "  UNKNOWN: freshness probe errored (see above)."
+"""Read the artifact CONSUMERS read, not the raw-source mirror.
+
+`scrapeTimestamp` is an internal content stamp, so unlike file mtime or
+commit dates it survives cloning and means the same thing everywhere.
+
+Every degraded input must land on UNKNOWN rather than a confident "0h" —
+a probe that reports fresh when it cannot tell is the bug this replaced.
+"""
+
+import datetime as dt
+import glob
+import json
+
+
+def threshold():
+    try:
+        with open("config/source_staleness.json", encoding="utf-8") as fh:
+            return int(json.load(fh)["thresholds"].get("ktc", 24))
+    except Exception:
+        return 24
+
+
+paths = sorted(glob.glob("exports/latest/dynasty_data_*.json"))
+if not paths:
+    print("  UNKNOWN: no exports/latest/dynasty_data_*.json — cannot measure.")
+    raise SystemExit(0)
+
+try:
+    with open(paths[-1], encoding="utf-8") as fh:
+        data = json.load(fh)
+except Exception as exc:
+    print(f"  UNKNOWN: could not read {paths[-1]}: {exc}")
+    raise SystemExit(0)
+
+stamp = data.get("scrapeTimestamp")
+if not stamp:
+    print("  UNKNOWN: contract carries no scrapeTimestamp — cannot measure.")
+    raise SystemExit(0)
+
+try:
+    scraped = dt.datetime.fromisoformat(stamp)
+except ValueError:
+    print(f"  UNKNOWN: unparseable scrapeTimestamp {stamp!r}.")
+    raise SystemExit(0)
+
+now = dt.datetime.now(scraped.tzinfo) if scraped.tzinfo else dt.datetime.now()
+age_h = (now - scraped).total_seconds() / 3600.0
+limit = threshold()
+
+print(f"  Contract: scraped {age_h:.0f}h ago (threshold {limit}h)")
+if age_h > limit:
+    print(f"  WARNING: no successful scrape in {age_h:.0f}h. Check scheduled-refresh workflow.")
+
+players = data.get("players") or {}
+stats = data.get("siteStats") or {}
+for key in ("ktc", "idpTradeCalc"):
+    entry = stats.get(key)
+    if not entry:
+        print(f"  {key}: ABSENT from siteStats — source produced nothing this run.")
+        continue
+    carried = sum(1 for p in players.values() if isinstance(p, dict) and p.get(key) is not None)
+    print(f"  {key}: {entry.get('count')} values, carried by {carried} of {len(players)} players")
+PY
 
 # 3. Git status
 echo ""

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -1042,9 +1042,12 @@ any KV read, so it says nothing about whether `user_kv` works for a
 signed-in user. Verifying that needs a session cookie the orchestrator
 does not hold. Unverified, not fine.
 
-### 6.12 The startup staleness check fires on a file nothing consumes — FIXED 2026-07-27 ~19:00
+### 6.12 The startup staleness check fires on a file nothing consumes — FIXED 2026-07-27 ~19:00, landed ~19:30
 
-**Closed.** The check now reads `scrapeTimestamp` from
+**Closed**, though the first attempt (#597) shipped a hook calling a
+probe that `.gitignore` had silently dropped — see §6.15, instance 5,
+for that and the fourth cheap check it produced. The check now reads
+`scrapeTimestamp` from
 `dynasty_data_*.json` and reports per-source coverage, exactly as
 prescribed below. Both defects named here are gone: the hardcoded 12h is
 replaced by `config/source_staleness.json`, and the mirror is no longer
@@ -1294,6 +1297,46 @@ nothing until the new guard has been watched firing:
 This closes §6.12, which left the fix deliberately undone as "worth ten
 minutes at the window".
 
+**The fix shipped broken, in the same defect class it was fixing.**
+Recorded in full because a pattern this section claims is *dominant*
+catching its own author, twice in one evening, is the strongest evidence
+for it available.
+
+The probe first shipped as a sibling file, `.claude/freshness.py`, with
+the hook invoking it as `python .claude/freshness.py 2>/dev/null || echo
+"UNKNOWN: …"`. But `.gitignore:28` ignores `.claude/` wholesale —
+`health-check.sh` survives only as a force-added exception. So `git
+add -A` skipped the probe **without a word**, the commit looked clean,
+CI was green, and #597 merged a hook that called a file `main` does not
+contain. Verified after the merge with `git cat-file -e
+origin/main:.claude/freshness.py` → absent.
+
+The result on every fresh clone: `UNKNOWN: freshness probe failed to
+run.` A check that cannot report anything, anywhere — which is precisely
+what the mtime version was, in a new costume. And the `2>/dev/null ||`
+was what hid it: a missing file and a genuine unknown were rendered
+identically, so the failure read as a data condition rather than a repo
+defect. **That is the same substitution the section is about**, made
+inside the fix for it.
+
+Two things this changes going forward:
+
+- **The probe is now inline in `health-check.sh`** as a heredoc, not a
+  sibling file. Not a style preference — a heredoc cannot be silently
+  dropped by the next `git add`, and `.claude/` will keep swallowing
+  anything placed beside the hook.
+- **Add a fourth cheap check** (below): *does the thing I just committed
+  actually exist where it will run?* `git add -A` reports success for
+  files it ignored. For anything under an ignored path, confirm with
+  `git cat-file -e <ref>:<path>` rather than trusting a clean status.
+
+Re-verified after inlining, with the sibling file **deleted** so the
+heredoc is genuinely what ran: healthy, contract 99h (**WARNING fires**),
+source dropped from `siteStats` (`ABSENT`), stamp missing (`UNKNOWN`),
+no contract (`UNKNOWN`), unparseable stamp (`UNKNOWN`), corrupt JSON
+(`UNKNOWN` naming the parse error). Six degraded paths, none reaching a
+confident "0h".
+
 **Cheap checks, in order of value:**
 1. *Can I make this test fail right now, deliberately?* If not, it is not
    a test. The house standard already requires observing a regression
@@ -1302,6 +1345,12 @@ minutes at the window".
    docstring claim?* Substring-vs-identity is the recurring gap.
 3. *Does the alarm have an off switch, and the exemption an expiry?*
    Anything that can only accumulate will eventually be ignored.
+4. *Does what I just committed exist where it will actually run?*
+   `git add -A` succeeds silently on ignored paths. For anything under
+   one — `.claude/` above all — verify with
+   `git cat-file -e <ref>:<path>`, not a clean `git status`. And never
+   let a swallowed error (`2>/dev/null ||`) render "the file is missing"
+   and "the data is unknown" as the same message.
 
 ### 6.4 Historical record — resolved blockers
 


### PR DESCRIPTION
Follow-up to #597 (merged). It shipped a hook that invokes a file `main` does not contain.

## The defect

```
git cat-file -e origin/main:.claude/freshness.py   ->  absent
```

`.gitignore:28` ignores `.claude/` wholesale; `health-check.sh` survives only as a force-added exception. So `git add -A` skipped the probe **without a word** — the commit read clean, CI was green, #597 merged, and every fresh clone since has printed:

```
UNKNOWN: freshness probe failed to run.
```

A check that cannot report anything, anywhere. Which is exactly what the mtime version it replaced was, in a new costume — shipped inside the fix for that very defect class.

The `2>/dev/null ||` is what hid it: a missing file and a genuine unknown rendered as the same line, so a repo defect read as a data condition. That is the same name/predicate substitution ORCHESTRATION.md §6.15 is about.

## The fix

The probe is now a **heredoc inside `health-check.sh`**. Not a style preference — a heredoc cannot be silently dropped by the next `git add`, and `.claude/` will keep swallowing anything placed beside the hook.

Re-verified with the sibling file **deleted**, so the heredoc is genuinely what ran. Six degraded paths, none reaching a confident `0h`:

| path | result |
|---|---|
| healthy | `scraped 0h ago (threshold 24h)`, silent |
| contract 99h old | **`WARNING: no successful scrape in 99h`** |
| source dropped from `siteStats` | `ABSENT — source produced nothing this run` |
| `scrapeTimestamp` missing | `UNKNOWN`, not 0h |
| no contract file | `UNKNOWN` |
| unparseable stamp | `UNKNOWN: unparseable scrapeTimestamp 'not-a-date'` |
| corrupt JSON | `UNKNOWN`, naming the parse error |

## Docs

§6.15 instance 5 gains the full account, and the section gets a **fourth cheap check**:

> *Does what I just committed exist where it will run?* `git add -A` succeeds silently on ignored paths — verify with `git cat-file -e <ref>:<path>`, not a clean `git status`. And never let a swallowed error (`2>/dev/null ||`) render "the file is missing" and "the data is unknown" as the same message.

§6.12's closure note is amended to point at it.

## Scope

Two files, operator tooling only. No `src/`, no `frontend/`, no test changes — nothing in the request path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_