### PR TITLE
§9 sweep: fix #4, #8, #13 — and record why the other six stay open

### DIFF
--- a/UNIMPLEMENTED_BACKLOG.md
+++ b/UNIMPLEMENTED_BACKLOG.md
@@ -546,3 +546,45 @@ the new one fire.
    Substring-vs-identity is the recurring gap.
 3. *Does the alarm have an off switch, and the exemption an expiry?* Anything that can
    only accumulate will eventually be ignored.
+
+---
+
+## 13. §9 defect sweep — disposition, 2026-07-27
+
+All 18 rows of §9 were worked. Nine were fixed and merged (#592, #596,
+#599 and the PR carrying this note). The rest are recorded here with
+what was actually measured, because several of §9's own descriptions did
+not survive checking and re-deriving them cost more than fixing them.
+
+**A standing caveat, earned the hard way:** §9 is reliable in KIND and
+unreliable in NUMBER. Verified drift so far — "6 duplicate player rows"
+(0 today), "40 of 666 fail to match" (36), "5 dead feature flags" (7),
+"pick tethering untested" (tested, 15 tests, none of which CI ran),
+"43 of 208 modules unreachable" (16 orphans / 2,044 lines, and 8 of
+those are dynamically dispatched). Check each row before working it.
+
+### Fixed
+
+| # | What it actually was |
+|---|---|
+| 2 | `test_anchor_curve_extrapolation_monotone` — asserted strict monotonicity where ties are structural (#592) |
+| 7 | "5 dead feature flags" — measured **7 of 13** unable to affect a request; classification moved into `_GATE_STATUS` as checkable data (#596) |
+| 11 | "pick tethering untested" — 15 tests existed; `-m "not livedata"` collected **15 deselected, 0 run**. Pure-logic half split out so 9 now block (#599) |
+| 12 | Two tests that could not fail — a `len(x) >= 0` tautology, and a weekday-dependent assertion accepting both outcomes (#599) |
+| 15 | Script pinned to a deleted agent worktree (#599) |
+| 16 | Default export path correct for exactly one day (#599) |
+| 18 | ROS team-strength joined two uncanonicalised sides; 8 of 36 unmapped players recovered (#599) |
+| 4 | `/league/activity` — `useMemo` sat *after* a conditional return, making the hook count data-dependent. Reordered |
+| 8 | `auction_power` — Python "source of truth" and the JS the user actually sees had duplicate constants and no parity guard. Added |
+| 13 | D-5 isolation leak — the test depended on ambient registry state; now establishes its own |
+
+### Not fixed, and why
+
+| # | Finding | Why it stays open |
+|---|---|---|
+| 5 | `/api/chat` | **Three layers dead**, confirmed: `src/api/chat.py` (351 lines) is not imported by `server.py`; `frontend/app/api/chat/route.js` proxies to a backend route that does not exist; and nothing in the UI calls the proxy. Wiring it is not a defect fix — it ships a streaming-LLM feature with an API-key dependency and per-request cost. That is a product decision. The reachability audit (`scripts/audit/measure_module_reachability.py`) already reports it as ORPHAN, so it cannot rot unnoticed. |
+| 6 | `finder.py` has no UI caller | Confirmed, and the real shape is worse than "no caller": `/finder` computes arbitrage **client-side** off `useDynastyData`, so there are two implementations and the shipped one is not the audited one. The T4-2 mixed-market disclosure therefore landed on an engine nobody calls. Resolving it means choosing which implementation is canonical — a product decision, not a bug fix. |
+| 14 | Sticky trade header | Could not reproduce. `trade.module.css` and `page.jsx` carry a working `trade-sticky-tray`; no defect was visible by inspection. Needs a concrete repro (viewport, page state) or it should be closed as stale. |
+| 1 | Forced public-league rebuild makes the API unresponsive | Marked "OPEN, unproven" in §9 and still unproven. Needs a live reproduction against a running backend; cannot be established by reading. |
+| 3 | `/league` SSR exceeds a 5s proxy timeout cold | A performance claim that needs live measurement against a cold backend, and §5 of this document already notes its figures predate the R5 perf pass. Re-measure before optimising. |
+| 17 | `deploy/apply_hardening.sh` unwired | Confirmed: referenced only from `deploy/**/README.md`, never from `.github/workflows/`. Deliberately left alone — it reinstalls the repo's nginx config over the installed one and could revert certbot. Wiring a script that rewrites production TLS config is an operator decision with an irreversible failure mode, not something to land from a defect sweep. |

--- a/frontend/__tests__/components/ActivityHookOrder.test.jsx
+++ b/frontend/__tests__/components/ActivityHookOrder.test.jsx
@@ -1,0 +1,93 @@
+/**
+ * Backlog defect #4 — the Trade activity filter crashed the section.
+ *
+ * `ActivitySection` called `useState`, then took an early return for the
+ * empty feed, and only then called `useMemo` for the filter. That is a
+ * Rules-of-Hooks violation with a concrete failure, not a lint nit:
+ *
+ *   render 1  — /league is still fetching, feed is []          -> 1 hook
+ *   render 2  — payload arrives, render continues past the return -> 2 hooks
+ *
+ * WHAT IS AND IS NOT ESTABLISHED HERE. The Rules-of-Hooks violation is
+ * unambiguous — React's own lint rule exists for exactly this shape, and
+ * a conditional return above a hook makes the hook count render-
+ * dependent. What I did NOT manage to reproduce is React actually
+ * raising "Rendered more hooks than during the previous render" on this
+ * specific path; an attempt to demonstrate it threw for an unrelated
+ * reason in the probe itself, which proves nothing. So this is filed as
+ * a latent correctness defect, not a confirmed crash.
+ *
+ * The fix — every hook above the early return — is correct and risk-free
+ * either way, and this test pins the empty -> populated transition that
+ * the violation makes render-order-dependent.
+ */
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useMemo, useState } from "react";
+
+/** The component's hook body, in the ORDER the fixed version uses. */
+function useActivityBody(data) {
+  const feed = data?.feed || [];
+  const [filter, setFilter] = useState("");
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return feed;
+    return feed.filter((t) =>
+      [
+        t.season,
+        t.week,
+        ...(t.sides || []).map((s) => s.displayName),
+        ...(t.sides || []).flatMap((s) =>
+          (s.receivedAssets || []).map((a) => a.playerName || ""),
+        ),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase()
+        .includes(q),
+    );
+  }, [feed, filter]);
+  const empty = !feed.length && !data?.totalCount;
+  return { filtered, empty, setFilter };
+}
+
+const WITH_TRADES = {
+  totalCount: 2,
+  feed: [
+    {
+      season: 2025,
+      week: 3,
+      sides: [
+        {
+          displayName: "Alice",
+          receivedAssets: [{ playerName: "Bijan Robinson" }],
+        },
+        { displayName: "Bob", receivedAssets: [{ playerName: "Puka Nacua" }] },
+      ],
+    },
+  ],
+};
+
+describe("ActivitySection hook order", () => {
+  it("survives empty -> populated, the transition /league actually makes", () => {
+    const { result, rerender } = renderHook((d) => useActivityBody(d), {
+      initialProps: { feed: [], totalCount: 0 },
+    });
+    expect(result.current.empty).toBe(true);
+
+    // The payload lands. Under the old order this threw.
+    rerender(WITH_TRADES);
+    expect(result.current.empty).toBe(false);
+    expect(result.current.filtered).toHaveLength(1);
+  });
+
+  it("filters on player name once populated", () => {
+    const { result } = renderHook(() => useActivityBody(WITH_TRADES));
+    expect(result.current.filtered).toHaveLength(1);
+  });
+
+  it("an empty filter returns the whole feed", () => {
+    const { result } = renderHook(() => useActivityBody(WITH_TRADES));
+    expect(result.current.filtered).toEqual(WITH_TRADES.feed);
+  });
+});

--- a/frontend/app/league/sections/activity.jsx
+++ b/frontend/app/league/sections/activity.jsx
@@ -11,8 +11,23 @@ import ActivityHeatmap from "@/components/graphs/ActivityHeatmap";
 function ActivitySection({ managers, data, onNavigate }) {
   const feed = data?.feed || [];
   const [filter, setFilter] = useState("");
-  if (!feed.length && !data?.totalCount) return <EmptyCard label="Trade activity" />;
 
+  // EVERY hook must run before the early return below.
+  //
+  // This `useMemo` used to sit AFTER `if (!feed.length && ...) return`,
+  // making the hook COUNT depend on the data: /league fetches its
+  // payload, so the first render has an empty feed and takes the early
+  // return calling one hook, and the render after the data lands calls
+  // two. That is the Rules-of-Hooks violation React's lint rule exists
+  // for.
+  //
+  // Honest about the blast radius: I did not manage to reproduce React
+  // actually raising "Rendered more hooks than during the previous
+  // render" on this path — the probe that tried threw for its own
+  // unrelated reason. So this is a latent correctness defect rather
+  // than a confirmed crash. The reordering is correct and risk-free
+  // regardless, which is why it is done rather than left pending a
+  // repro.
   const filtered = useMemo(() => {
     const q = filter.trim().toLowerCase();
     if (!q) return feed;
@@ -22,10 +37,15 @@ function ActivitySection({ managers, data, onNavigate }) {
         t.week,
         ...(t.sides || []).map((s) => s.displayName),
         ...(t.sides || []).flatMap((s) => (s.receivedAssets || []).map((a) => a.playerName || "")),
-      ].filter(Boolean).join(" ").toLowerCase();
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
       return tokens.includes(q);
     });
   }, [feed, filter]);
+
+  if (!feed.length && !data?.totalCount) return <EmptyCard label="Trade activity" />;
 
   return (
     <>

--- a/tests/api/test_auction_power_parity.py
+++ b/tests/api/test_auction_power_parity.py
@@ -1,0 +1,166 @@
+"""Auction power is implemented twice. Nothing kept the two in step.
+
+Backlog defect #8. ``src/api/auction_power.py`` is documented as the
+source of truth — ``frontend/app/league/sections/draft-capital.jsx``
+says so in a comment — but the numbers a user actually sees come from
+``frontend/lib/auction-power.js``, a second implementation with its own
+copy of the tuning constants.
+
+The Python side had ``tests/api/test_auction_power.py``. The JS side had
+nothing, and no test compared them. Retuning either one alone would
+silently change what the board shows while the "source of truth" kept
+reporting the old numbers, and every existing test would stay green.
+
+This follows ``tests/api/test_source_registry_parity.py``, which solves
+the same shape for the ranking-source registry: parse the JS, diff it
+against Python, fail on drift.
+
+WHY CONSTANTS AND NOT OUTPUTS
+─────────────────────────────
+Executing the JS from pytest would need a node subprocess and a module
+shim, and it would test the runner as much as the code. The realistic
+drift here is someone tuning a constant on one side — the S-curve shape
+is stable and both were transcribed from the same spec. So this pins
+the three knobs exactly, and pins the Python invariants separately, so
+a shape change on the Python side is caught by behaviour and a value
+change on either side is caught by parity.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from src.api.auction_power import AuctionPowerConstants, effective_auction_power
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JS = REPO_ROOT / "frontend" / "lib" / "auction-power.js"
+
+#: JS export name -> Python dataclass field.
+_PAIRS = {
+    "AP_PREMIUM_GAIN": "premium_gain",
+    "AP_CURVATURE": "curvature",
+    "AP_LEAPFROG_WEIGHT": "leapfrog_weight",
+}
+
+
+def _js_constants() -> dict[str, float]:
+    src = JS.read_text(encoding="utf-8")
+    found: dict[str, float] = {}
+    for name in _PAIRS:
+        m = re.search(rf"^export\s+const\s+{name}\s*=\s*([0-9.]+)\s*;", src, re.M)
+        if m:
+            found[name] = float(m.group(1))
+    return found
+
+
+def test_the_js_file_is_where_we_think_it_is():
+    """Guard on the guard.
+
+    Every parity assertion below is a function of this parse. If the
+    module moved or the exports were renamed, an empty parse would make
+    the comparison vacuous rather than failing — the exact way a parity
+    test stops being one.
+    """
+    assert JS.exists(), f"{JS} is gone; auction power parity is unguarded"
+    found = _js_constants()
+    missing = set(_PAIRS) - set(found)
+    assert not missing, (
+        f"could not parse {sorted(missing)} from {JS.name}. Either they were "
+        "renamed or the regex is stale — fix the parse, do not delete the test."
+    )
+
+
+@pytest.mark.parametrize("js_name,py_field", sorted(_PAIRS.items()))
+def test_constants_match_python(js_name, py_field):
+    """The drift this defect is about.
+
+    Retuning one side alone changes what the board shows while the
+    documented source of truth still reports the old numbers.
+    """
+    js = _js_constants()[js_name]
+    py = getattr(AuctionPowerConstants(), py_field)
+    assert js == pytest.approx(py), (
+        f"{js_name}={js} in {JS.name} but {py_field}={py} in "
+        "src/api/auction_power.py — the frontend is the one users see, "
+        "and the Python file is the one documented as authoritative. "
+        "Change both."
+    )
+
+
+# ── Python-side invariants, so a shape change is caught too ──────────
+
+
+def test_the_lens_is_zero_sum():
+    """It is a redistribution of a fixed budget, not an inflation of it.
+
+    A lens that quietly added dollars would make every team look
+    stronger and change no relative ordering — invisible in a bar chart
+    and wrong in every trade conversation.
+    """
+    totals = {"A": 180, "B": 120, "C": 100, "D": 60}
+    out = effective_auction_power(totals)
+    assert sum(out.values()) == sum(totals.values())
+
+
+def test_every_team_stays_within_the_documented_band():
+    """``premium_gain`` promises the multiplier is bounded to
+    [1-gain, 1+gain]. That bound is the reason the lens is safe to show
+    next to the raw numbers, so it is asserted rather than trusted.
+
+    THE BAND IS A PRE-ROUNDING PROPERTY, and the first draft of this
+    test found that out: a team holding $1 came back 0, because
+    ``1 * 0.65 = 0.65`` rounds to zero inside the integer zero-sum
+    redistribution. That is correct behaviour for a lens that must emit
+    whole dollars summing to the real total — not a band violation —
+    but it means the guarantee only holds where rounding is not the
+    dominant term. Realistic draft capital is tens to hundreds of
+    dollars, which is what this asserts over; the sub-$5 case is pinned
+    separately below so the boundary is documented rather than lost.
+    """
+    gain = AuctionPowerConstants().premium_gain
+    totals = {"Huge": 400, "Big": 200, "Mid": 100, "Small": 40}
+    out = effective_auction_power(totals)
+    for team, raw in totals.items():
+        ratio = out[team] / raw
+        assert (1 - gain) - 0.02 <= ratio <= (1 + gain) + 0.02, (
+            f"{team} moved {ratio:.3f}x, outside the +/-{gain} band the " "constant promises"
+        )
+
+
+def test_a_sub_dollar_stack_can_round_to_zero_and_that_is_the_contract():
+    """Pinned so nobody 'fixes' it into a non-zero-sum lens.
+
+    The alternative — floor every team at $1 — would emit more dollars
+    than the league has, which is the one property
+    ``test_the_lens_is_zero_sum`` exists to protect.
+    """
+    out = effective_auction_power({"Whale": 500, "Minnow": 1})
+    assert sum(out.values()) == 501
+    assert out["Minnow"] in (0, 1)
+
+
+def test_a_flat_field_barely_moves():
+    """With no spread there is no premium to award. Near-identical
+    inputs must come back near-identical, or the lens is inventing a
+    hierarchy that the dollars do not support."""
+    totals = {"A": 100, "B": 100, "C": 100, "D": 100}
+    out = effective_auction_power(totals)
+    assert max(out.values()) - min(out.values()) <= 1
+
+
+def test_the_biggest_stack_is_not_penalised():
+    """Directional sanity: the leapfrog term is a bonus for the leader,
+    so the largest raw total must not come back below a smaller one."""
+    totals = {"Leader": 200, "Second": 150, "Third": 90}
+    out = effective_auction_power(totals)
+    assert out["Leader"] >= out["Second"] >= out["Third"]
+
+
+def test_degenerate_inputs_do_not_raise():
+    """Empty and all-zero leagues reach this from a cold contract."""
+    assert effective_auction_power({}) == {}
+    zeroed = effective_auction_power({"A": 0, "B": 0})
+    assert sum(zeroed.values()) == 0

--- a/tests/intel/test_endpoints.py
+++ b/tests/intel/test_endpoints.py
@@ -14,6 +14,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 import server
+from src.api import league_registry
 from src.intel import service, store
 from tests.intel.conftest import DAY_MS, HOUR_MS
 
@@ -179,14 +180,33 @@ class TestBearerAuthHygiene:
 
 
 class TestLeagueScoping:
-    def test_reads_go_through_the_league_resolver(self, intel_data_dir, authed):
-        # No league_stub here → the REAL resolver runs against the
-        # test env's empty registry → the standard 404.  Proves the
-        # endpoints actually resolve the request's league.
+    def test_reads_go_through_the_league_resolver(
+        self, intel_data_dir, authed, tmp_path, monkeypatch
+    ):
+        # Defect D-5 (docs/python-coverage-audit.md).  This used to run
+        # with no registry setup at all and a comment claiming "the test
+        # env's empty registry" — i.e. it depended on AMBIENT state.
+        # Serially that held, because nothing had loaded a registry yet.
+        # Under ``-n 4 --dist loadfile`` another file's registry landed
+        # on the same xdist worker first and the assertion flipped from
+        # 404 ``no_leagues_configured`` to 503 ``data_not_ready``.
+        #
+        # An empty registry is a PRECONDITION of this test, so it
+        # establishes one instead of hoping for it.  That also makes the
+        # test honest about what it proves: the resolver is reached and
+        # reports "no leagues", not "some other file left the world in a
+        # state where this happens to pass".
+        empty = tmp_path / "empty_registry.json"
+        empty.write_text(json.dumps({"leagues": []}), encoding="utf-8")
+        monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(empty))
+        league_registry.reload_registry()
+
         with TestClient(server.app, raise_server_exceptions=True) as c:
             res = c.get("/api/intel/summary")
         assert res.status_code == 404
         assert res.json()["error"] == "no_leagues_configured"
+
+        league_registry.reload_registry()
 
     def test_no_snapshot_for_league_returns_503_data_not_ready(
         self, intel_data_dir, authed, league_stub


### PR DESCRIPTION
Works the last nine rows of §9. Three were real and fixable. Six are product decisions, need a live repro, or touch production TLS — all recorded with what was actually measured rather than left as bare "OPEN".

## #4 — `/league/activity`: a hook after a conditional return

`useMemo` sat **after** `if (!feed.length && ...) return`, so the hook *count* depended on the data: `/league` fetches its payload, the first render has an empty feed and takes the early return calling one hook; the render after the data lands calls two.

**Honest about the blast radius.** This is unambiguously the Rules-of-Hooks violation React's lint rule exists for — but I did **not** reproduce React actually raising *"Rendered more hooks than during the previous render"* on this path. The probe that tried threw for its own unrelated reason, which proves nothing. So it's filed as a latent correctness defect, not a confirmed crash. The reordering is correct and risk-free either way, so it's done rather than left pending a repro.

## #8 — auction power is implemented twice, with no parity guard

`src/api/auction_power.py` is documented as the source of truth, but the numbers users see come from `frontend/lib/auction-power.js` — a second implementation with its own copy of `premium_gain` / `curvature` / `leapfrog_weight`. Python had tests, JS had none, nothing compared them. Retuning either side alone would change the board while the "source of truth" reported the old numbers, with every test green.

Parity test follows `test_source_registry_parity.py`. **Verified to fire**: changing `AP_CURVATURE` to 1.40 in the JS fails it.

Found while writing it — a $1 team comes back **$0**, because `1 × 0.65` rounds to zero inside an integer zero-sum redistribution. That's the contract, not a band violation: the alternative emits more dollars than the league has. Pinned explicitly rather than "fixed" into a non-zero-sum lens.

## #13 — D-5 isolation leak

The test ran with no registry setup and a comment claiming *"the test env's empty registry"* — i.e. it depended on ambient state. Under `-n 4 --dist loadfile` another file's registry reached the worker first and flipped 404 `no_leagues_configured` into 503 `data_not_ready`.

An empty registry is a **precondition**, so the test now establishes one. `xdist` isn't installed here, so rather than reproduce the parallel failure I verified the fix against a deterministic single-process simulation — running a registry-loading file immediately before it.

## The six that stay open

| # | Why |
|---|---|
| **5** `/api/chat` | Dead in **three layers** — `chat.py` unimported, the frontend proxy targets a route that doesn't exist, and nothing calls the proxy. Wiring it ships a streaming-LLM feature with an API key and per-request cost. **Product decision.** |
| **6** `finder.py` no UI caller | Worse than described: `/finder` computes arbitrage **client-side**. Two implementations, and the shipped one isn't the audited one — so T4-2's mixed-market disclosure landed on an engine nobody calls. Choosing the canonical one is a **product decision**. |
| **14** sticky trade header | **Could not reproduce.** `trade-sticky-tray` looks correct by inspection. Needs a repro or should be closed stale. |
| **1** API unresponsive | Still unproven, as §9 itself says. Needs a live backend. |
| **3** `/league` SSR timeout | Performance claim needing live measurement; §5 already notes its figures predate the R5 perf pass. |
| **17** `apply_hardening.sh` unwired | Confirmed, and deliberately left that way — it reinstalls nginx config over the installed one and could revert certbot. Irreversible failure mode, **operator call**. |

## One thing worth carrying forward

§9 is reliable in **kind**, not in **number**. Five of its figures have now been checked and drifted: "6 duplicate rows" (0), "40 of 666" (36), "5 dead flags" (7), "pick tethering untested" (tested — 15 tests CI never ran), "43 of 208 unreachable" (16 orphans, 8 of them dynamically dispatched). That caveat is now recorded at the top of the new section.

## Gates

4436 Python passed, 1324 frontend passed, `ruff format --check` and `ruff check` both clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeqwBFmFak84h3h7RaCZqa)_