### PR TITLE
fix(te-premium): cap the TE++ uplift curve at the observed maximum

### DIFF
--- a/config/weights/te_premium_curve.json
+++ b/config/weights/te_premium_curve.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "KTC's own TE-premium (TE++, level 2) uplift curve, measured from CSVs/site_raw/ktc.csv vs ktcSfTep.csv. ratio(v) = 1 + a * v^-k, monotone and >= 1 by construction. Regenerate with scripts/audit/fit_ktc_tep_curve.py --write-config.",
+  "_comment": "KTC's own TE-premium (TE++, level 2) uplift curve, measured from CSVs/site_raw/ktc.csv vs ktcSfTep.csv. ratio(v) = 1 + a * v^-k, monotone and >= 1 by construction, clamped live to [floor, observed_ratio_range max] - the range maximum is read at runtime as the uplift cap, not documentation. Regenerate with scripts/audit/fit_ktc_tep_curve.py --write-config.",
   "_limitation": "Measured within KTC's board. Applying it to another publisher's TE values assumes that board's TEs sit at a comparable base. Nothing here validates that, and nothing here says KTC's TE premium is correct - only that this is what KTC does.",
   "form": "1 + a * value^(-k)",
   "a": 43.555794,

--- a/scripts/audit/fit_ktc_tep_curve.py
+++ b/scripts/audit/fit_ktc_tep_curve.py
@@ -138,18 +138,27 @@ def fit_power(obs: list[tuple[str, int, int]]) -> dict[str, float]:
     }
 
 
-def uplift(value: float, *, a: float, k: float, floor: float = 1.0) -> float:
-    """TE++ uplift ratio for a base-board value.  Always >= ``floor``.
+def uplift(
+    value: float, *, a: float, k: float, floor: float = 1.0, ceiling: float = math.inf
+) -> float:
+    """TE++ uplift ratio for a base-board value.  Clamped to
+    ``[floor, ceiling]``.
 
     The floor is the smallest uplift KTC actually applies to any TE.  The
     unconstrained fit reads ~1.146 at the most valuable TE against an
     observed 1.209, because a smooth curve through 73 points cannot also
     honour its own endpoint.  Clamping to the observed minimum is a
     measured bound, not a fudge: no tight end on the board receives less.
+
+    The ceiling is the largest observed uplift, and matters BELOW the
+    measured range (KTC's board bottoms out around base ~480), where the
+    power form extrapolates unbounded.  ``te_premium.tep_uplift`` applies
+    the same clamp live, reading ``observed_ratio_range`` max from the
+    config this script writes.
     """
     if value <= 0:
-        return max(1.0, floor)
-    return max(floor, 1.0 + a * float(value) ** -k)
+        return min(ceiling, max(1.0, floor))
+    return min(ceiling, max(floor, 1.0 + a * float(value) ** -k))
 
 
 def main() -> int:
@@ -166,7 +175,9 @@ def main() -> int:
         "_comment": (
             "KTC's own TE-premium (TE++, level 2) uplift curve, measured from "
             "CSVs/site_raw/ktc.csv vs ktcSfTep.csv. ratio(v) = 1 + a * v^-k, "
-            "monotone and >= 1 by construction. Regenerate with "
+            "monotone and >= 1 by construction, clamped live to "
+            "[floor, observed_ratio_range max] - the range maximum is read at "
+            "runtime as the uplift cap, not documentation. Regenerate with "
             "scripts/audit/fit_ktc_tep_curve.py --write-config."
         ),
         "_limitation": (
@@ -221,8 +232,11 @@ def main() -> int:
     print()
     print("  value    fitted ratio")
     floor = payload["floor"]
-    for v in (9999, 8000, 5000, 3000, 2000, 1000, 500):
-        print(f"  {v:5d}    {uplift(v, a=a, k=k, floor=floor):.4f}")
+    ceiling = payload["observed_ratio_range"][1]
+    # 200 and 100 sit below KTC's own board (bottoms out ~480) and show
+    # the observed-maximum cap doing its job on out-of-range reads.
+    for v in (9999, 8000, 5000, 3000, 2000, 1000, 500, 200, 100):
+        print(f"  {v:5d}    {uplift(v, a=a, k=k, floor=floor, ceiling=ceiling):.4f}")
     print()
     print("live constants for comparison:")
     print("  _TE_BLANKET_NON_NATIVE_MULTIPLIER = 1.15")

--- a/src/league_intel/te_premium.py
+++ b/src/league_intel/te_premium.py
@@ -90,6 +90,14 @@ _FALLBACK_K = 0.632839
 # its own endpoint.  Clamping to the observed minimum is a measured
 # bound, not a fudge: no tight end receives less than this.
 _FALLBACK_FLOOR = 1.2092
+# The largest uplift KTC actually applies, and the cap on the curve.
+# KTC's own board bottoms out around base value ~480, but non-KTC
+# sources produce TE contributions below that, where the power form
+# extrapolates unbounded (3.36x at base 100 against an observed max of
+# ~2.05).  No tight end was ever observed to receive more than this, so
+# reading the curve past it below the measured range would be exactly
+# the kind of unmeasured number this module exists to remove.
+_FALLBACK_CEILING = 2.0531
 
 # KTC's TE-premium ladder, in the order its own payload names them.
 # ``Dynasty Scraper.py`` reads ``superflexValues.tepp`` (level 2) and
@@ -270,8 +278,16 @@ def measure_te_demand(
 
 
 @lru_cache(maxsize=1)
-def load_tep_curve() -> tuple[float, float, float]:
-    """``(a, k, floor)`` for ``ratio(v) = max(floor, 1 + a * v**-k)``.
+def load_tep_curve() -> tuple[float, float, float, float]:
+    """``(a, k, floor, ceiling)`` for
+    ``ratio(v) = min(ceiling, max(floor, 1 + a * v**-k))``.
+
+    The ceiling is the config's ``observed_ratio_range`` maximum — the
+    largest uplift KTC was ever measured to apply.  It exists for values
+    BELOW the measured range: KTC's board bottoms out around base ~480,
+    and the power form extrapolates unbounded past it, so a deep TE from
+    a non-KTC source would otherwise be lifted harder than any tight end
+    KTC has ever lifted.
 
     Falls back to the measured 2026-07-27 constants when the config file
     is absent, so a fresh checkout behaves identically rather than
@@ -289,10 +305,15 @@ def load_tep_curve() -> tuple[float, float, float]:
         k = _as_float(payload.get("k"))
         floor = _as_float(payload.get("floor"))
         if a is not None and k is not None and a > 0 and k > 0:
-            return a, k, floor if (floor is not None and floor >= 1.0) else 1.0
+            floor = floor if (floor is not None and floor >= 1.0) else 1.0
+            observed = payload.get("observed_ratio_range")
+            ceiling = _as_float(observed[1]) if isinstance(observed, (list, tuple)) and len(observed) == 2 else None
+            if ceiling is None or ceiling < floor:
+                ceiling = max(_FALLBACK_CEILING, floor)
+            return a, k, floor, ceiling
     except (OSError, ValueError):
         pass
-    return _FALLBACK_A, _FALLBACK_K, _FALLBACK_FLOOR
+    return _FALLBACK_A, _FALLBACK_K, _FALLBACK_FLOOR, _FALLBACK_CEILING
 
 
 def tep_uplift(
@@ -301,22 +322,30 @@ def tep_uplift(
     a: float | None = None,
     k: float | None = None,
     floor: float | None = None,
+    ceiling: float | None = None,
 ) -> float:
     """KTC's measured TE++ uplift ratio for a base-board TE value.
 
     Monotone non-increasing in ``value`` and ``>= 1.0`` by construction: a
     TE premium can never lower a tight end's value, and a functional form
     that permits it is wrong regardless of its fit statistic.
+
+    Clamped to the observed ratio range on BOTH ends.  The floor is the
+    smallest uplift KTC actually applies; the ceiling is the largest.
+    Both are measured bounds, and the ceiling matters below the measured
+    range, where the power form would otherwise extrapolate a deep TE's
+    uplift past anything KTC has ever done.
     """
-    if a is None or k is None or floor is None:
-        _a, _k, _floor = load_tep_curve()
+    if a is None or k is None or floor is None or ceiling is None:
+        _a, _k, _floor, _ceiling = load_tep_curve()
         a = _a if a is None else a
         k = _k if k is None else k
         floor = _floor if floor is None else floor
+        ceiling = _ceiling if ceiling is None else ceiling
     v = _as_float(value)
     if v is None or v <= 0:
-        return max(1.0, floor)
-    return max(floor, 1.0 + a * v**-k)
+        return min(ceiling, max(1.0, floor))
+    return min(ceiling, max(floor, 1.0 + a * v**-k))
 
 
 def convert_te_value(value: float, *, from_basis: str, to_basis: str) -> float:

--- a/src/league_intel/te_premium.py
+++ b/src/league_intel/te_premium.py
@@ -307,7 +307,11 @@ def load_tep_curve() -> tuple[float, float, float, float]:
         if a is not None and k is not None and a > 0 and k > 0:
             floor = floor if (floor is not None and floor >= 1.0) else 1.0
             observed = payload.get("observed_ratio_range")
-            ceiling = _as_float(observed[1]) if isinstance(observed, (list, tuple)) and len(observed) == 2 else None
+            ceiling = (
+                _as_float(observed[1])
+                if isinstance(observed, (list, tuple)) and len(observed) == 2
+                else None
+            )
             if ceiling is None or ceiling < floor:
                 ceiling = max(_FALLBACK_CEILING, floor)
             return a, k, floor, ceiling

--- a/tests/league_intel/test_te_premium_measurement.py
+++ b/tests/league_intel/test_te_premium_measurement.py
@@ -135,7 +135,9 @@ class TestDoubleCountIsStructurallyImpossible:
         assert once == twice
 
     def test_round_trip_returns_the_original(self):
-        for v in (490, 1000, 3000, 8169):
+        # 200 sits below KTC's measured range, where the uplift is the
+        # flat observed-maximum cap — the inversion must hold there too.
+        for v in (200, 490, 1000, 3000, 8169):
             up = convert_te_value(v, from_basis="base", to_basis="tepp")
             back = convert_te_value(up, from_basis="tepp", to_basis="base")
             assert back == pytest.approx(v, rel=1e-3)
@@ -175,6 +177,21 @@ class TestAxisATheKtcUpliftCurve:
         for v in (1, 500, 3000, 8169, 9999, 10**6):
             assert tep_uplift(v) >= curve["floor"] - 1e-9
 
+    def test_curve_never_reads_above_the_observed_maximum(self):
+        """The other end of the same argument.  KTC's board bottoms out
+        around base ~480; below that the power form extrapolates
+        unbounded (3.36x at base 100, 43x at base 1), and non-KTC
+        sources DO produce TE contributions down there.  No tight end
+        was ever observed above the config's ratio maximum, so the curve
+        must not read past it — an extrapolated uplift is exactly the
+        unmeasured number this module exists to remove."""
+        curve = json.loads(
+            (REPO / "config" / "weights" / "te_premium_curve.json").read_text(encoding="utf-8")
+        )
+        ceiling = curve["observed_ratio_range"][1]
+        for v in (0, 1, 50, 100, 400, 482, 3000, 9999):
+            assert tep_uplift(v) <= ceiling + 1e-9
+
     def test_live_blanket_constant_under_corrects_every_tight_end(self):
         """The finding that SURVIVES the Axis-B correction, and gets
         stronger under it.
@@ -194,10 +211,11 @@ class TestAxisATheKtcUpliftCurve:
     def test_config_and_fallback_agree(self):
         from src.league_intel import te_premium as tp
 
-        a, k, floor = load_tep_curve()
+        a, k, floor, ceiling = load_tep_curve()
         assert a == pytest.approx(tp._FALLBACK_A, rel=1e-6)
         assert k == pytest.approx(tp._FALLBACK_K, rel=1e-6)
         assert floor == pytest.approx(tp._FALLBACK_FLOOR, rel=1e-4)
+        assert ceiling == pytest.approx(tp._FALLBACK_CEILING, rel=1e-4)
 
 
 class TestTheTwoAxesStaySeparate:


### PR DESCRIPTION
## What

The measured base→tepp TE uplift curve (ADR-015) has a floor at KTC's smallest observed uplift (1.209) but had no ceiling, so it extrapolated unbounded below the measured range. KTC's own board bottoms out around base value ~480 (uplift 1.87), but non-KTC sources produce deep-TE post-Hill contributions well below that, where the power form read 1.98x at base 400 and **3.36x at base 100** — past the largest uplift KTC was ever observed to apply (2.053).

`tep_uplift` is now clamped to `[floor, ceiling]`, with the ceiling read from the config's `observed_ratio_range` maximum (fallback 2.0531 matching the fitted config — same pattern as the floor). Below the measured range the uplift is now the flat observed maximum instead of an unmeasured extrapolation.

## What doesn't change

- **Within the measured range the curve is byte-identical.** Validated against today's fresh scrape (74 TE pairs): measured ratios 1.209–2.071, curve median abs err 1.6%, max 9.5% at the deepest 3 TEs (where it under-states, per the fit notes).
- The tepp→base bisection inversion is unaffected — `v * uplift(v)` stays strictly increasing through the capped region, and the existing `v/3` lower bound already contains `v/2.053`. Round trip pinned at base 200 in the tests.
- `load_tep_curve()` now returns `(a, k, floor, ceiling)`; its only non-test caller (`data_contract.py`) uses it as a cache warmer and ignores the tuple.

## Changes

- `src/league_intel/te_premium.py` — ceiling in `load_tep_curve()` + clamp in `tep_uplift()`, with `_FALLBACK_CEILING = 2.0531`
- `scripts/audit/fit_ktc_tep_curve.py` — mirror the clamp in the script's printout helper; note in the written config that `observed_ratio_range` max is now load-bearing
- `config/weights/te_premium_curve.json` — `_comment` updated to match (fitted constants untouched, no refit)
- `tests/league_intel/test_te_premium_measurement.py` — new observed-maximum invariant test, capped-region round-trip value, 4-tuple unpack

## Testing

- TE-specific suites: 50 passed
- `tests/league_intel/` + `tests/api/` full run: **1,971 passed, 14 skipped, 366 subtests passed**

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nPSdAJhWup5MPJZCYnLPn

---
_Generated by [Claude Code](https://claude.ai/code/session_019nPSdAJhWup5MPJZCYnLPn)_