### PR TITLE
fix(scoring): derive the Sleeper alias map — a second one was live and unread

### DIFF
--- a/UNIMPLEMENTED_BACKLOG.md
+++ b/UNIMPLEMENTED_BACKLOG.md
@@ -20,13 +20,13 @@ reason, so nobody re-litigates them from scratch.
 
 ---
 
-## Read this first: five items have open PRs
+## Read this first: much of this file is already superseded
 
-Added 2026-07-27 ~18:45, within an hour of compiling this file. A parallel
-session had work in flight that this document could not see, and **the statuses
-below are stale for five items**. They are still accurate against `main` — none
-of this is merged — but starting any of them from this file would duplicate
-finished work. Check the PR before picking one up.
+**Updated 2026-07-28 ~00:15.** This document was compiled against `main` at
+`d224e15de` and was stale within the hour — a parallel session had a large
+amount of work in flight that it could not see. Treat every status below as a
+claim about a `main` that no longer exists, and check the PR column before
+picking anything up.
 
 | item below | status here | actually |
 |---|---|---|
@@ -35,8 +35,14 @@ finished work. Check the PR before picking one up.
 | §2.1 TE basis wiring | BUILT, NOT WIRED | **#591** — wired pre-blend; measured blast radius, 80 TEs up, median +14.27% |
 | §4.2 persist player-week actuals | NOT STARTED · *the one open Tier-0 item* | **#591** — 22 weeks / 16,995 player-weeks persisted for 2025 |
 | §8.2 `tep=3` vs `tepp` | NOT STARTED · latent | **#593** — half of it *was* live via the DOM fallback; see below |
+| §6 ML / archetypes — "undecided" | NOT STARTED | largely **overtaken by BDVM v1** (#600, merged) — a projection-driven fundamental engine beside the market board, flag `bdvm_engine` OFF |
+| §12 guard-that-cannot-fire (4 instances) | — | **five**, and the fifth was this repo's own health check. See ORCHESTRATION.md §6.15 |
 
-Two of those carry findings that change what this file says, not just its status:
+One item the file **never contained at all**, because it was found after
+compiling: the realized-points scoring aliases — added as §13 at the end.
+
+Two entries carry findings that change what this file *says*, not just its
+status:
 
 - **§8.2 was not purely latent.** I recorded it as harmless-today because KTC
   returns every TEP level regardless of the parameter — which is true of the
@@ -588,3 +594,45 @@ those are dynamically dispatched). Check each row before working it.
 | 1 | Forced public-league rebuild makes the API unresponsive | Marked "OPEN, unproven" in §9 and still unproven. Needs a live reproduction against a running backend; cannot be established by reading. |
 | 3 | `/league` SSR exceeds a 5s proxy timeout cold | A performance claim that needs live measurement against a cold backend, and §5 of this document already notes its figures predate the R5 perf pass. Re-measure before optimising. |
 | 17 | `deploy/apply_hardening.sh` unwired | Confirmed: referenced only from `deploy/**/README.md`, never from `.github/workflows/`. Deliberately left alone — it reinstalls the repo's nginx config over the installed one and could revert certbot. Wiring a script that rewrites production TLS config is an operator decision with an irreversible failure mode, not something to land from a defect sweep. |
+
+---
+
+## 13. Realized-points scoring aliases — FOUND AFTER COMPILING, FIXED
+
+Not in the original file: found on 2026-07-28 while reviewing #600, and worth
+recording because the *shape* of the mistake generalises.
+
+Sleeper publishes some scoring rules under two key names. `realized_points.py`
+read only the canonical spelling, so any rule your league dumps under the alias
+scored **zero, silently** — the key is simply absent from the settings dict, so
+there is nothing to raise.
+
+Measured against live 2025 data, both aliases are live in this league:
+
+| alias in your dump | module read | value | 2025 points unscored | who it hits |
+|---|---|---|---|---|
+| `idp_pass_def` | `idp_pd` | 5.32 | **11,119** | cornerbacks |
+| `idp_qb_hit` | `idp_hit` | 2.13 | **6,545** | edge rushers |
+
+Top single players affected: Mike Jackson 23 PD (122 pts), Zach Allen 51 QB hits
+(109 pts). For a CB whose realized season lands near 150–200 points, that is not
+a rounding error.
+
+**The generalisable part.** #600 fixed the first one — the key someone happened
+to trip over — with a one-entry literal. `sleeper_ingest.KEY_ALIASES` already
+enumerated **eight**. Half-fixing was not half-right, it was *differently*
+wrong: PD is a corner stat and QB hits an edge stat, so correcting only PD tilts
+DB up against DL by 11k points while the linemen stay owed 6.5k. **A partial
+correction to a relative ranking introduces a bias that no correction does
+not** — the arithmetic gets closer to true while the ordering gets further from
+it.
+
+Fixed by deriving the map from `KEY_ALIASES` rather than restating it, so the
+ninth alias Sleeper adds is picked up by both layers at once. Six regression
+tests, all observed failing against the one-entry version first.
+
+Still open, and deliberately not guessed at: whether any of the other six
+aliases go live if you ever change scoring, and whether the same
+noticed-one-only pattern exists in the *offensive* keys. `KEY_ALIASES` shows no
+genuine offensive aliases today, but that was not measured against a second
+league's dump.

--- a/src/nfl_data/realized_points.py
+++ b/src/nfl_data/realized_points.py
@@ -65,6 +65,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from src.scoring.sleeper_ingest import KEY_ALIASES as _SLEEPER_KEY_ALIASES
+
 
 # ── Scoring-key mapping ───────────────────────────────────────────
 #
@@ -161,8 +163,26 @@ _IDP_TACKLE_KEYS: tuple[tuple[str, str], ...] = (
 # canonical key is absent so a dump carrying both can never
 # double-count.  (Distinct from the STAT-column candidates above:
 # those absorb nflverse renames, this absorbs Sleeper's.)
+#
+# DERIVED, not hand-listed.  This started as a one-entry literal
+# ``{"idp_pass_def": "idp_pd"}`` fixing the key that was noticed.
+# ``KEY_ALIASES`` knows **eight**, and a second one is live in this very
+# league — ``idp_qb_hit`` at 2.13/event, which the module reads as
+# ``idp_hit``.  Measured on 2025: passes-defended cost 11,119 points and
+# QB hits 6,545.
+#
+# Half-fixing was not half-right, it was differently wrong: PD is a
+# cornerback stat and QB hits are an edge-rusher stat, so correcting
+# only PD tilts DB up against DL by 11k points with no offsetting
+# credit to the linemen who were owed 6.5k.  A partial correction to a
+# *relative* ranking introduces a bias that no correction at all does
+# not.
+#
+# Deriving from the one map that already enumerates them means the next
+# alias Sleeper adds is picked up by both layers at once, instead of
+# drifting until someone notices a position group scoring low.
 _SCORING_KEY_ALIASES: dict[str, str] = {
-    "idp_pass_def": "idp_pd",
+    alias: canonical for alias, canonical in _SLEEPER_KEY_ALIASES.items() if alias != canonical
 }
 
 

--- a/tests/nfl_data/test_realized_points.py
+++ b/tests/nfl_data/test_realized_points.py
@@ -4,7 +4,10 @@ the 'value vs realized' feature in the upgraded player popup."""
 
 from __future__ import annotations
 
+import pytest
+
 from src.nfl_data import realized_points as rp
+from src.scoring import sleeper_ingest
 
 
 def _half_ppr():
@@ -195,6 +198,60 @@ def test_alias_never_double_counts_when_both_keys_present():
     out = rp.compute_weekly_points(stat, {"idp_pd": 1.5, "idp_pass_def": 5.32}, position="CB")
     # canonical key wins; the alias must not add a second contribution
     assert out.fantasy_points == 3 * 1.5
+
+
+def test_idp_qb_hit_alias_scores_hits():
+    """The SECOND live alias in this league, missed by the first fix.
+
+    ``idp_qb_hit`` reads 2.13/event in the dynasty_main dump while this
+    module scores ``idp_hit``. Fails against the one-entry alias map:
+    QB hits scored 0, which on 2025 data was 3,073 hits / 6,545 points.
+    """
+    stat = {"season": 2025, "week": 1, "position": "EDGE", "def_qb_hits": 4}
+    out = rp.compute_weekly_points(stat, {"idp_qb_hit": 2.13}, position="EDGE")
+    assert out.fantasy_points == pytest.approx(4 * 2.13)
+
+
+def test_every_sleeper_alias_is_honoured_not_just_the_noticed_one():
+    """Pins the derivation, not a hand-list.
+
+    The first fix enumerated the one key someone tripped over.
+    ``KEY_ALIASES`` knew eight, and two of those are live here — so a
+    hand-list is a guard that stops firing the moment Sleeper adds a
+    ninth. Deriving is what makes this checkable at all.
+
+    Half-fixing was not half-right: PD is a cornerback stat and QB hits
+    an edge-rusher stat, so correcting only PD tilts DB against DL. A
+    partial correction to a *relative* ranking introduces a bias that no
+    correction does not.
+    """
+    expected = {a: c for a, c in sleeper_ingest.KEY_ALIASES.items() if a != c}
+    # Guard the guard: if KEY_ALIASES ever stops carrying real aliases,
+    # an empty expectation would make every assertion below vacuous.
+    assert len(expected) >= 8, "KEY_ALIASES no longer enumerates the aliases this derives from"
+    assert rp._SCORING_KEY_ALIASES == expected
+
+
+@pytest.mark.parametrize(
+    "alias,canonical,stat_col,stat_val",
+    [
+        ("idp_pass_def", "idp_pd", "def_pass_defended", 3),
+        ("idp_qb_hit", "idp_hit", "def_qb_hits", 4),
+        ("idp_tfl", "idp_tkl_loss", "def_tackles_for_loss", 2),
+        ("idp_fr", "idp_fum_rec", "def_fumble_recovery_own", 1),
+        ("idp_td", "idp_def_td", "def_tds", 1),
+    ],
+)
+def test_alias_scores_and_never_double_counts(alias, canonical, stat_col, stat_val):
+    """Each alias pays once under the alias, and once under both."""
+    stat = {"season": 2025, "week": 1, "position": "LB", stat_col: stat_val}
+
+    alias_only = rp.compute_weekly_points(stat, {alias: 5.0}, position="LB")
+    assert alias_only.fantasy_points == pytest.approx(stat_val * 5.0)
+
+    # Canonical present too — it wins, and the alias adds nothing.
+    both = rp.compute_weekly_points(stat, {canonical: 2.0, alias: 5.0}, position="LB")
+    assert both.fantasy_points == pytest.approx(stat_val * 2.0)
 
 
 def test_fumble_recovery_column_fallback_for_direct_rows():


### PR DESCRIPTION
Follow-up to #600 (merged), which fixed the scoring-key alias someone happened to trip over. `sleeper_ingest.KEY_ALIASES` already enumerated **eight**, and a second one is live in this league.

## Measured on 2025 nflverse data

| alias in the league dump | module read | value | 2025 points unscored | who it hits |
|---|---|---|---|---|
| `idp_pass_def` | `idp_pd` | 5.32 | 11,119 | cornerbacks | 
| `idp_qb_hit` | `idp_hit` | 2.13 | **6,545** | edge rushers |

The first was fixed by #600. The second was still scoring **zero**.

Top individuals: Mike Jackson 23 PD = 122 pts, Zach Allen 51 QB hits = 109 pts. For a corner whose realized season lands near 150–200 points, that is not a rounding error.

Verified independently before touching anything — the league dump carries `idp_pass_def` and `idp_qb_hit` and carries neither `idp_pd` nor `idp_hit`, so both resolved to absent and scored nothing.

## Why the partial fix needed completing rather than leaving

PD is a cornerback stat; QB hits are an edge-rusher stat. Correcting only PD tilts DB up against DL by 11k points while the linemen stay owed 6.5k.

**A partial correction to a *relative* ranking introduces a bias that no correction does not** — the arithmetic gets closer to true while the ordering gets further from it. That is the argument for finishing it now rather than filing it.

## The change

The map is **derived** from `KEY_ALIASES` instead of restating it, so the ninth alias Sleeper adds is picked up by both layers at once rather than drifting until someone notices a position group scoring low. The never-double-count guard is unchanged and still structural — apply only when the canonical key is absent.

One import added (`src.scoring.sleeper_ingest` → `src.nfl_data.realized_points`); verified no circular import.

## Tests

Six new, **all observed failing against the one-entry map first**. The `idp_pass_def` case correctly passed pre-fix, since that one was already fixed — which is the control that shows the others are failing for the right reason.

The derivation test asserts `KEY_ALIASES` still carries ≥8 real aliases *before* comparing, so it cannot pass vacuously if that map is ever emptied.

`tests/nfl_data/ tests/bdvm/ tests/scoring/`: 393 passed. `ruff format --check` + `ruff check` clean. Full CI-tier suite was still running locally at push time — CI is the gate.

## Docs

`UNIMPLEMENTED_BACKLOG.md` was stale within an hour of being written. Its header now says so plainly and maps each superseded item to the PR that displaced it; this finding is recorded as a new §13.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3t99R7ffe41nuss8txDHA)_