### PR TITLE
Fix SAF position gap, re-measure IDP scoring fit, turn the flag on

### DIFF
--- a/src/api/feature_flags.py
+++ b/src/api/feature_flags.py
@@ -146,34 +146,29 @@ _DEFAULTS: Final[dict[str, bool]] = {
     # depth, and re-allocates between IDP positions rather than
     # inflating IDP as a whole — see src/league_intel/scoring_fit.py.
     #
-    # OFF by default, unlike te_basis_conversion.  Flip with
-    # RISKIT_FEATURE_IDP_SCORING_FIT=1.
+    # ON by default as of 2026-07-27, on the operator's explicit
+    # direction and after re-measuring the blast radius the
+    # ``value_moving_on`` gate requires.  Rollback:
+    # RISKIT_FEATURE_IDP_SCORING_FIT=0.
     #
-    # 2026-07-27, operator delegated the decision and it stays OFF.
-    # Not because the edge is doubted — the Tier 2 measurement is real
-    # and the risk is lower than it looks, since this axis reaches only
-    # ``build_board_adjustments``, i.e. the OPT-IN league-adjusted lens,
-    # never the default market board.  It stays off because
-    # ``tests/api/test_feature_flags.py`` requires a MEASURED blast
-    # radius for any value-moving default-ON flag, and an attempt to
-    # re-derive one in that session returned an empty positional map.
-    # That turned out to be a harness fault — the persisted actuals
-    # carry raw positions (DT/DE/CB/SAF/FS) and the scoring engine
-    # dropped ``SAF`` as unknown, so the DL/LB/DB family mapping was
-    # never applied — but "my harness was wrong" and "the fit collapsed"
-    # are indistinguishable until it is re-run correctly.
+    # THE DIRECTION IN THE ORIGINAL MEASUREMENT WAS BACKWARDS.  #592
+    # recorded "relative to DB, pays DL about +7% and LB about +3%".
+    # Re-run through the module's own entry point on raw nflverse rows,
+    # with both leagues' scoring_settings verified byte-identical to
+    # what #592 recorded (zero drift on all 8 IDP keys), it measures
+    # DB 1.0366 / DL 1.0001 / LB 0.9633 — DB highest, LB lowest.
     #
-    # Turning a value-moving flag on from a number that could not be
-    # reproduced at the time is the exact defect class this codebase
-    # keeps paying for.  Re-run the measurement with the family mapping
-    # applied, record the blast radius here and in ``value_moving_on``,
-    # and then flip it.  The cost of waiting is one env var.
+    # The rate card settles which is right: idp_pass_def is 2.52x UP
+    # (a DB stat, and the biggest move on the board) while idp_sack is
+    # 0.64x DOWN (the signature DL stat) and idp_tkl_solo 0.92x DOWN
+    # (the LB volume stat).  A league that pays coverage and discounts
+    # sacks cannot be tilting toward DL.  See scoring_fit's docstring.
     #
-    # Note what is deliberately NOT behind this flag: a per-player IDP
-    # multiplier.  The same data supports one arithmetically and it is
-    # noise — see the module docstring for the depth-stability
-    # measurement that rules it out.
-    "idp_scoring_fit": False,
+    # Scope: this axis reaches only ``build_board_adjustments`` — the
+    # OPT-IN league-adjusted lens.  The default market board is
+    # untouched, which is why enabling it is a smaller step than the
+    # blast radius below makes it sound.
+    "idp_scoring_fit": True,
     # Per-player reception-depth tilt (Tier 2).  Separate from
     # idp_scoring_fit above rather than sharing it: that flag is named
     # for IDP, and using it to gate an offence feature would make the

--- a/src/league_comparison/scoring_engine.py
+++ b/src/league_comparison/scoring_engine.py
@@ -123,7 +123,14 @@ def _canonical_position(raw_pos: str | None) -> str | None:
         return "DL"
     if aliased in {"LB", "ILB", "OLB", "MLB"}:
         return "LB"
-    if aliased in {"DB", "CB", "S", "FS", "SS"}:
+    # ``SAF`` is nflverse's own spelling for a safety and appears on
+    # 1,441 of the 11,540 persisted 2025 IDP player-weeks — the third
+    # largest defensive group after LB and CB.  It was in neither
+    # POSITION_ALIASES nor this table, so every safety was dropped from
+    # every scoring comparison, silently: the only trace was a
+    # ``unknown_positions_dropped`` warning listing it beside genuinely
+    # untracked positions like K, P and OL.
+    if aliased in {"DB", "CB", "S", "SAF", "FS", "SS"}:
         return "DB"
     return None
 

--- a/src/league_intel/scoring_fit.py
+++ b/src/league_intel/scoring_fit.py
@@ -38,21 +38,57 @@ of a real player-selection edge. The most "mispriced" players by this
 measure were Kemon Hall, Cory Durden and Jack Cochrane: bench bodies
 near the scoring floor, not targets.
 
-The **position-level** median, by contrast, is rock stable across depth::
-
-    DL   1.089  1.089  1.088  1.087      <- moves 0.002 across 5x the pool
-    LB   1.043  1.048  1.051  1.049
-    DB   1.014  1.014  1.007  0.994
-
-That stability is what makes it trustworthy. Within a position, DL stat
+The **position-level** median, by contrast, is stable across depth, and
+that stability is what makes it trustworthy. Within a position, stat
 mixes are similar enough that the per-key inversions largely cancel and
 move the whole cohort together; they do not separate players inside it.
 
-So the edge is real and it is **positional**: relative to DB, this
-league pays DL about +7% and LB about +3%. That is worth acting on in a
-trade calculator. A per-player multiplier built from the same data would
-be ±5% of noise wearing the costume of a measurement, which is the
-defect class this repo keeps paying for — so the API does not offer one.
+So the edge is real and it is **positional**. A per-player multiplier
+built from the same data would be ±5% of noise wearing the costume of a
+measurement, which is the defect class this repo keeps paying for — so
+the API does not offer one.
+
+THE DIRECTION, RE-MEASURED 2026-07-27 — AND CORRECTED
+─────────────────────────────────────────────────────
+This docstring previously recorded ``DL 1.089 / LB 1.043 / DB 1.014``
+and concluded "relative to DB, this league pays DL about +7% and LB
+about +3%". **That direction was wrong, and it was backwards.**
+
+Re-run through this module's own public entry point on raw nflverse
+weekly rows, with both leagues' live ``scoring_settings`` (verified
+byte-identical to the values the original measurement recorded — zero
+drift on all 8 IDP keys), the mean-normalised multipliers are::
+
+    DB   1.0366     raw 1.2031   n=288   depth drift 0.029
+    DL   1.0001     raw 1.1608   n=213   depth drift 0.026
+    LB   0.9633     raw 1.1180   n=203   depth drift 0.015
+
+DB highest, LB lowest — the reverse of what was recorded.
+
+The rate card says the new numbers are the right ones, and this is the
+check that settles it rather than the arithmetic agreeing with itself:
+
+* ``idp_pass_def`` is **2.52x UP**, the single largest move on the
+  board, and pass deflections are overwhelmingly a DB stat. ``idp_int``
+  is 0.86x down, but PD volume dwarfs INT volume, so DB nets up.
+* ``idp_sack`` is **0.64x DOWN** — the largest cut, and the signature
+  DL stat. ``idp_qb_hit`` 1.97x and ``idp_tkl_loss`` 2.06x roughly
+  offset it, leaving DL flat.
+* ``idp_tkl_solo``, the LB volume stat, is 0.92x down against
+  ``idp_tkl_ast`` 1.07x up — a net cut on the stat LBs accumulate most.
+
+A league that pays coverage and disruption and discounts sacks cannot
+be tilting toward DL. The old figures were not reproducible through
+this API with identical inputs, and asserting a tilt whose direction
+contradicts its own rate card is exactly what the mechanical check
+above exists to prevent.
+
+Part of the gap was a real bug, fixed alongside this: ``SAF`` — the
+nflverse spelling for a safety, 1,468 of the 2025 regular-season rows —
+was in neither ``POSITION_ALIASES`` nor ``scoring_engine``'s IDP
+collapse table, so every safety was silently dropped from the DB
+cohort. Including them moves DB from 1.0594 to 1.0366 and grows the
+cohort from 188 to 288. It narrows the tilt; it does not create it.
 
 Scale is meaningless; only the tilt is real
 ───────────────────────────────────────────

--- a/tests/api/test_feature_flags.py
+++ b/tests/api/test_feature_flags.py
@@ -62,6 +62,24 @@ def test_every_flag_defaults_off_except_safe_additive():
         # QB/RB/WR/IDP value changes.  Rank displacement median 7, p90
         # 22.  Rollback: RISKIT_FEATURE_TE_BASIS_CONVERSION=0.
         "te_basis_conversion",
+        # IDP positional scoring fit.  Blast radius measured against the
+        # 2026-07-27 live board (1,095 rows, 709 of them ranked):
+        #
+        #   280 IDP rows move — DB n=84 at +3.66%, DL n=113 at +0.01%,
+        #   LB n=83 at -3.67%.  ZERO non-IDP values change: the
+        #   multiplier is keyed on the DL/LB/DB family and nothing else
+        #   resolves to one.
+        #
+        #   Rank displacement across the ranked board: 544 rows shift,
+        #   median 4, p90 35, max 71.  279 of those are non-IDP rows
+        #   moving only because IDP rows moved past them — their VALUES
+        #   are untouched.
+        #
+        # Mean-normalised, so it re-allocates between IDP positions and
+        # cannot inflate IDP as a class.  Applies to the OPT-IN
+        # league-adjusted lens only, never the default market board.
+        # Rollback: RISKIT_FEATURE_IDP_SCORING_FIT=0.
+        "idp_scoring_fit",
     }
     off_only = {
         "dynamic_source_weights",  # held OFF until backtest data exists

--- a/tests/league_comparison/test_position_family_coverage.py
+++ b/tests/league_comparison/test_position_family_coverage.py
@@ -1,0 +1,84 @@
+"""Every IDP position nflverse actually emits must resolve to a family.
+
+``scoring_engine._canonical_position`` collapses fine-grained nflverse
+positions into DL / LB / DB. A position it does not recognise is dropped
+from every scoring comparison, and the only trace is one
+``unknown_positions_dropped`` log line that also lists genuinely
+untracked positions (K, P, OL, C, G...) — so a real gap looks exactly
+like the intended behaviour.
+
+``SAF`` sat in that gap. It is nflverse's spelling for a safety and
+covers **1,468 of the 18,539 persisted 2025 regular-season rows**, the
+third-largest defensive group after LB and CB. It was in neither
+``POSITION_ALIASES`` nor the local collapse table, so every safety was
+silently excluded from the IDP scoring-fit measurement — which shrank
+the DB cohort from 288 to 188 and moved DB's measured multiplier from
+1.0366 to 1.0594.
+
+These tests pin the vocabulary against what the feed actually contains,
+rather than against a list someone remembered to update.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.league_comparison.scoring_engine import _canonical_position
+
+#: Every defensive position observed on the live 2025 nflverse weekly
+#: feed, with the family it must collapse to. Counts are the measured
+#: regular-season row counts, kept so a future reader can tell a
+#: high-volume gap from a rounding error.
+OBSERVED_IDP_POSITIONS = {
+    "LB": ("LB", 2819),
+    "CB": ("DB", 1926),
+    "DT": ("DL", 1517),
+    "SAF": ("DB", 1468),  # the one that was missing
+    "DE": ("DL", 1440),
+    "DB": ("DB", 386),
+    "OLB": ("LB", 224),
+    "FS": ("DB", 140),
+}
+
+
+@pytest.mark.parametrize(
+    "raw,expected", sorted((k, v[0]) for k, v in OBSERVED_IDP_POSITIONS.items())
+)
+def test_every_observed_idp_position_resolves(raw, expected):
+    assert _canonical_position(raw) == expected, (
+        f"{raw!r} does not collapse to {expected}. nflverse emits it on the live "
+        "feed, so an unmapped value silently drops those players from every "
+        "scoring comparison."
+    )
+
+
+def test_safety_spellings_all_land_on_db():
+    """The specific gap, and its neighbours.
+
+    ``S``, ``FS`` and ``SS`` were already mapped; ``SAF`` was not, which
+    is why the hole was invisible — safeties *appeared* to be handled.
+    """
+    for spelling in ("S", "SS", "FS", "SAF"):
+        assert _canonical_position(spelling) == "DB", spelling
+
+
+def test_the_mapper_still_refuses_genuinely_untracked_positions():
+    """Non-vacuity, and the reason this cannot be fixed by mapping
+    everything to something.
+
+    Offensive line, kickers and punters have no IDP or skill scoring in
+    this model. If they started resolving, they would enter cohorts they
+    do not belong in and quietly move every measured ratio.
+    """
+    for raw in ("K", "P", "LS", "OL", "OT", "C", "G", "FB"):
+        assert _canonical_position(raw) is None, f"{raw!r} should not be tracked"
+
+
+def test_offensive_positions_are_untouched_by_the_idp_collapse():
+    for raw, expected in (("QB", "QB"), ("RB", "RB"), ("WR", "WR"), ("TE", "TE")):
+        assert _canonical_position(raw) == expected
+
+
+def test_blank_and_garbage_return_none_rather_than_guessing():
+    for raw in (None, "", "   ", "NOT_A_POSITION"):
+        assert _canonical_position(raw) is None

--- a/tests/league_intel/test_reception_fit.py
+++ b/tests/league_intel/test_reception_fit.py
@@ -289,15 +289,35 @@ def test_the_board_is_unchanged_without_a_measurement():
     assert with_none.explanations[0].league_adjusted_value == pytest.approx(5000)
 
 
-def test_the_reception_flag_is_separate_from_the_idp_one():
-    """Sharing `idp_scoring_fit` would make its name a lie: an operator
+def test_the_reception_flag_is_separate_from_the_idp_one(monkeypatch):
+    """Sharing ``idp_scoring_fit`` would make its name a lie: an operator
     disabling the IDP feature would silently also disable every receiver
-    adjustment. Both default off, independently."""
+    adjustment.
+
+    This used to assert both flags were ``False``, which passed for the
+    wrong reason — they merely happened to share a default. When
+    ``idp_scoring_fit`` was enabled on 2026-07-27 the test failed, having
+    caught a deliberate change rather than a regression.
+
+    Independence is the actual invariant, so that is what is asserted
+    now: two distinct keys, and moving one must not move the other. The
+    defaults are free to diverge, and today they do.
+    """
     from src.api import feature_flags
 
+    monkeypatch.setenv("RISKIT_FEATURE_IDP_SCORING_FIT", "1")
+    monkeypatch.setenv("RISKIT_FEATURE_RECEPTION_SCORING_FIT", "0")
     feature_flags.reload()
+    assert feature_flags.is_enabled("idp_scoring_fit") is True
     assert feature_flags.is_enabled("reception_scoring_fit") is False
+
+    # And the other way round, so the test cannot pass by both being
+    # wired to the same underlying switch in either direction.
+    monkeypatch.setenv("RISKIT_FEATURE_IDP_SCORING_FIT", "0")
+    monkeypatch.setenv("RISKIT_FEATURE_RECEPTION_SCORING_FIT", "1")
+    feature_flags.reload()
     assert feature_flags.is_enabled("idp_scoring_fit") is False
+    assert feature_flags.is_enabled("reception_scoring_fit") is True
 
 
 def test_the_resolver_is_inert_while_the_reception_flag_is_off(monkeypatch):

--- a/tests/league_intel/test_scoring_fit.py
+++ b/tests/league_intel/test_scoring_fit.py
@@ -259,10 +259,35 @@ def test_the_resolver_is_inert_while_the_flag_is_off(monkeypatch):
         gameplan.invalidate_scoring_fit_cache()
 
 
-def test_the_flag_defaults_off():
-    """Unlike te_basis_conversion, which the operator directed on. This
-    moves every IDP value on the board and nobody has asked for it."""
+def test_the_flag_defaults_on_and_the_rollback_still_works():
+    """The operator directed this ON on 2026-07-27, after the fit was
+    re-measured against a corrected position map.
+
+    It previously defaulted OFF with the rationale "nobody has asked for
+    it".  They have now asked, so the honest guard is no longer "is it
+    off" but "is the documented rollback real".  A default flipped ON
+    with a rollback that does not actually roll back is strictly worse
+    than one that never moved: the operator believes they have an escape
+    hatch they do not have.
+
+    ``RISKIT_FEATURE_IDP_SCORING_FIT=0`` is the rollback recorded in
+    ``_DEFAULTS``, in ``tests/api/test_feature_flags.py`` and in the
+    ``scoring_fit`` module docstring.  This exercises it.
+    """
     from src.api import feature_flags
 
     feature_flags.reload()
-    assert feature_flags.is_enabled("idp_scoring_fit") is False
+    assert feature_flags.is_enabled("idp_scoring_fit") is True
+
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        monkeypatch.setenv("RISKIT_FEATURE_IDP_SCORING_FIT", "0")
+        feature_flags.reload()
+        assert (
+            feature_flags.is_enabled("idp_scoring_fit") is False
+        ), "the documented rollback does not disable the flag"
+    finally:
+        monkeypatch.undo()
+        feature_flags.reload()
+
+    assert feature_flags.is_enabled("idp_scoring_fit") is True


### PR DESCRIPTION
You asked for `idp_scoring_fit` to be re-measured properly and turned on. Re-measuring first surfaced a data defect that had corrupted the original measurement, so this PR fixes that, re-measures, and then flips the flag.

## The defect

`scoring_engine._canonical_position` did not recognise **`SAF`**, which is nflverse's own spelling for a safety. It was in neither `POSITION_ALIASES` nor the local IDP collapse table, so **every safety was dropped from every scoring comparison** — 1,468 of the 18,539 persisted 2025 regular-season rows, the third-largest defensive group after LB and CB.

The drop was silent by construction. The only trace was one `unknown_positions_dropped` log line that also lists genuinely untracked positions (K, P, OL, C, G) — so a real gap looked exactly like intended behaviour. `S`, `FS` and `SS` *were* mapped, which is why the hole was invisible: safeties appeared to be handled.

## What it corrupted

Excluding safeties shrank the DB cohort from 288 to 188 and moved DB's measured multiplier from 1.0366 to 1.0594. With the gap closed, the measured direction is the **reverse** of what #592 recorded ("DL +7%, LB +3% relative to DB"):

| family | multiplier | raw | n | depth drift |
|---|---|---|---|---|
| DB | 1.0366 | 1.2031 | 288 | 0.029 |
| DL | 1.0001 | 1.1608 | 213 | 0.026 |
| LB | 0.9633 | 1.1180 | 203 | 0.015 |

Two checks establish this is a correction rather than a drift:

- **Settings did not change.** All 8 IDP keys are byte-identical to the values #592 recorded, so the input rate card is not what moved.
- **The rate card mechanically predicts the new ordering.** `idp_pass_def` is **2.52× up** (a DB stat, and the largest single move on the card), `idp_sack` is **0.64× down** (the DL signature stat), `idp_tkl_solo` is **0.92× down** (the LB volume stat). A card that pays coverage and discounts finishing plays should favour DBs.

## Blast radius

Measured against the 2026-07-27 live board (1,095 rows, 709 ranked) — measured, not argued:

- **280 IDP rows move**: DB n=84 **+3.66%**, DL n=113 **+0.01%**, LB n=83 **−3.67%**
- **0 non-IDP values change.** The multiplier keys on the DL/LB/DB family and nothing else resolves to one.
- **Rank displacement**: 544 rows shift, median 4, p90 35, max 71. 279 of those are non-IDP rows moving only because IDP rows passed them — their values are untouched.

The multiplier is mean-normalised, so it re-allocates *between* IDP positions and cannot inflate IDP as a class. It applies to the **opt-in league-adjusted lens only**, never the default market board.

**Rollback:** `RISKIT_FEATURE_IDP_SCORING_FIT=0`.

## Guards, each observed failing before its fix

- **`tests/league_comparison/test_position_family_coverage.py`** (new) pins every defensive position observed on the live 2025 feed to its family, with the measured row counts, plus a non-vacuity test that K/P/OL/C/G still resolve to `None`. Pinning against what the feed actually contains — rather than against a list someone remembered to update — is what would have caught `SAF`.
- **`test_scoring_fit.py::test_the_flag_defaults_off`** asserted the old default with the rationale *"nobody has asked for it"*. You have now asked, so the honest guard is no longer "is it off" but "is the documented rollback real" — a default flipped ON with a rollback that doesn't roll back is worse than one that never moved. Rewritten to exercise the env var in both directions, and verified non-vacuous by disabling the env-read path and watching it fail.
- **`test_reception_fit.py::test_..._separate_from_the_idp_one`** asserted both flags were `False`, which would have passed against a build that wired them to a single switch. Rewritten to assert independence via env toggles in both directions.

`tests/api/test_feature_flags.py` records the flag in `value_moving_on` with the blast radius above — deliberately **not** in `safe_on`, whose whole promise is that a member cannot move a number.

## Validation

- Hard gate: `pytest tests/ -x -q -m "not livedata"` → **4649 passed, 319 deselected**
- `ruff format --check .` → clean
- `ruff check` over the changed `.py` set → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeqwBFmFak84h3h7RaCZqa

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeqwBFmFak84h3h7RaCZqa)_