### PR TITLE
feat(bdvm): /bdvm frontend surface + weekly snapshot refresh cadence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -437,6 +437,25 @@ feed (everything live is market-rank derived), so BDVM ships with a
 manual-CSV projection adapter + a reconstructed-baseline proxy builder
 and stays dormant until snapshots exist under ``data/bdvm/projections/``.
 
+Operational surfaces (post-merge additions):
+
+- **Frontend**: ``/bdvm`` ("Fundamentals", Intel nav group) renders the
+  three endpoints — value board (strategy-currency selector, surplus-mode
+  ablation, fundamental-vs-market gap + signals), roster strategy
+  capitals with expandable assets, and the double-positive trade scan.
+  Pure display layer: ``frontend/lib/bdvm.js`` only reshapes/formats
+  backend numbers (same materializer rule as ``buildRows``); the flag-off
+  503 renders an explicit "engine switched off" state, never a generic
+  error (``classifyBdvmFailure`` distinguishes the three 503 variants).
+  Dev bridge routes at ``frontend/app/api/bdvm/*``; tests in
+  ``frontend/__tests__/bdvm-lib.test.js`` + ``components/bdvm-page.test.jsx``.
+- **Snapshot cadence**: ``scripts/refresh_bdvm_projections.py`` (weekly
+  ``dynasty-bdvm-refresh`` systemd timer, Tue 06:10 UTC) rebuilds the
+  reconstructed baseline then merges The IDP Show real projections over
+  it (session jar shared with the rankings fetch timer; stage self-skips
+  without it). Exit codes 0/1/2 in the playerctx style; runs on prod
+  because the endpoints read local gitignored ``data/``.
+
 ### Single Source of Truth: Rankings Override Path
 Custom source configurations (user-toggled sources or custom weights) flow through the **SAME** canonical pipeline as the default board. There is no frontend ranking engine, period — not even a fallback. `buildRows` is a pure materializer.
 

--- a/deploy/idpshow_fetch_and_push.sh
+++ b/deploy/idpshow_fetch_and_push.sh
@@ -28,8 +28,9 @@
 #   2. fetch + reset --hard origin/main so we always start from the
 #      latest CI-committed state.
 #   3. Pull cached cookies from ``$WORK_DIR/idpshow_session.json``.
-#   4. Run ``scripts/fetch_idpshow.py``.  The fetcher refreshes its
-#      own cookie expiry on success; we copy the result back.
+#   4. Run ``scripts/fetch_idpshow.py``.  (The fetcher only READS the
+#      jar — no code path rewrites cookies; re-mints are human-made
+#      directly into ``$WORK_DIR``, which stays the source of truth.)
 #   5. Stamp ``data/scrape_state/idpShow_last_success`` with the
 #      current epoch, stage the CSV + stamp, commit, push.  Push
 #      retries on rebase conflict (CI's data-refresh cron also
@@ -86,8 +87,9 @@ if ! "${VENV_PYTHON}" scripts/fetch_idpshow.py; then
   exit 1
 fi
 
-# Persist the (possibly refreshed) session jar back to the work dir
-# so the next run can skip re-checking the cookie.
+# Copy the repo-clone jar back to the work dir.  Today this is a
+# byte-identical no-op safeguard (the fetcher never rewrites the jar);
+# it only matters if a future fetcher starts refreshing cookies.
 if [[ -f "${REPO_DIR}/idpshow_session.json" ]]; then
   cp -f "${REPO_DIR}/idpshow_session.json" "${SESSION_FILE}"
   chmod 600 "${SESSION_FILE}"

--- a/deploy/install-systemd-service.sh
+++ b/deploy/install-systemd-service.sh
@@ -387,6 +387,54 @@ main() {
     fi
   fi
 
+  # ── BDVM projection refresh timer (weekly snapshots for /api/bdvm/*) ──
+  # Builds data/bdvm/projections/<season>/ snapshots — a LOCAL file the
+  # bdvm_engine-flagged endpoints read, so like playerctx the producer
+  # must run where the reader lives.  The baseline stage needs NO
+  # credentials (public nflverse); the IDP Show stage self-skips when
+  # the session jar is absent, so this installs unconditionally
+  # whenever both templates are present.  Safe while the flag is OFF:
+  # snapshots are the prerequisite for flipping it.
+  local bdvm_service_template="${APP_DIR}/deploy/systemd/dynasty-bdvm-refresh.service.template"
+  local bdvm_timer_template="${APP_DIR}/deploy/systemd/dynasty-bdvm-refresh.timer.template"
+  local bdvm_service_name="${SERVICE_NAME}-bdvm-refresh"
+  local bdvm_service_path="/etc/systemd/system/${bdvm_service_name}.service"
+  local bdvm_timer_path="/etc/systemd/system/${bdvm_service_name}.timer"
+  local bdvm_needs_install=false
+
+  if [[ -f "${bdvm_service_template}" && -f "${bdvm_timer_template}" ]]; then
+    if sudo -n "${SYSTEMCTL_BIN}" cat "${bdvm_service_name}.timer" >/dev/null 2>&1; then
+      if [[ "${force_install_on}" == "true" ]]; then
+        log "FORCE_SERVICE_INSTALL enabled; rewriting ${bdvm_service_path} + timer."
+        bdvm_needs_install=true
+      else
+        log "BDVM-refresh timer already installed; skipping."
+      fi
+    else
+      log "Installing BDVM projection refresh service + timer."
+      bdvm_needs_install=true
+    fi
+
+    if [[ "${bdvm_needs_install}" == "true" ]]; then
+      local tmp_bdvm_service tmp_bdvm_timer
+      tmp_bdvm_service="$(mktemp)"
+      tmp_bdvm_timer="$(mktemp)"
+      sed \
+        -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
+        -e "s/__APP_USER__/$(escape_sed_replacement "${APP_USER}")/g" \
+        -e "s/__APP_DIR__/$(escape_sed_replacement "${APP_DIR}")/g" \
+        -e "s/__VENV_DIR__/$(escape_sed_replacement "${VENV_DIR}")/g" \
+        "${bdvm_service_template}" > "${tmp_bdvm_service}"
+      sed \
+        -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
+        "${bdvm_timer_template}" > "${tmp_bdvm_timer}"
+      sudo -n "${INSTALL_BIN}" -m 0644 "${tmp_bdvm_service}" "${bdvm_service_path}"
+      sudo -n "${INSTALL_BIN}" -m 0644 "${tmp_bdvm_timer}" "${bdvm_timer_path}"
+      rm -f "${tmp_bdvm_service}" "${tmp_bdvm_timer}"
+      log "Installed ${bdvm_service_name}.service + .timer"
+    fi
+  fi
+
   # ── DLF fetch timer (prod-side replacement for CI fetch_dlf.py) ────────
   # CI cannot run scripts/fetch_dlf.py — Cloudflare 403s the GitHub
   # Actions runner IPs.  The same script succeeds from prod, so this
@@ -545,6 +593,19 @@ main() {
       # --no-block: a ~3 min download must never stall the deploy.
       sudo -n "${SYSTEMCTL_BIN}" start --no-block "${playerctx_service_name}.service" || \
         log "Note: initial player-context build could not be started; the timer will cover it."
+    fi
+  fi
+  if [[ "${bdvm_needs_install}" == "true" ]]; then
+    # --now arms the timer immediately; the FIRST snapshots are built
+    # by the explicit kick below rather than waiting for Tuesday, so
+    # /api/bdvm/values has data the moment the flag is flipped.
+    sudo -n "${SYSTEMCTL_BIN}" enable --now "${bdvm_service_name}.timer"
+    log "Enabled ${bdvm_service_name}.timer"
+    if ! ls "${APP_DIR}"/data/bdvm/projections/*/projections_*.json >/dev/null 2>&1; then
+      log "No BDVM projection snapshot yet — kicking an initial build in the background."
+      # --no-block: multi-minute nflverse downloads must never stall the deploy.
+      sudo -n "${SYSTEMCTL_BIN}" start --no-block "${bdvm_service_name}.service" || \
+        log "Note: initial BDVM snapshot build could not be started; the timer will cover it."
     fi
   fi
   if [[ "${dlf_fetch_needs_install}" == "true" ]]; then

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -58,10 +58,15 @@ Timers rendered + enabled by `deploy/install-systemd-service.sh`
 | `dynasty-dlf-fetch.*` | DLF CSV fetch + push (CI is Cloudflare-blocked) | Every 2h | DLF creds in `.env` |
 | `dynasty-idpshow-fetch.*` | IDP Show rankings fetch + push | Every 2h | always |
 | `dynasty-playerctx-refresh.*` | Player context (contracts / snap share / depth chart) → `data/playerctx/snapshot.json`, served by `/api/playerctx/player` | Weekly Tue 05:40 UTC | always (public data, no creds) |
+| `dynasty-bdvm-refresh.*` | BDVM projection snapshots (reconstructed baseline + IDP Show real projections) → `data/bdvm/projections/<season>/`, served by `/api/bdvm/*` (flag `bdvm_engine`) | Weekly Tue 06:10 UTC | always (baseline needs no creds; IDP Show stage self-skips without the session jar) |
 
-`dynasty-playerctx-refresh` must run **on prod**, not in CI: the
-endpoint reads a local file and `data/` is gitignored, so a CI-built
-snapshot would never reach the VPS.  See `docs/playerctx.md`.
+`dynasty-playerctx-refresh` and `dynasty-bdvm-refresh` must run **on
+prod**, not in CI: their endpoints read local files and `data/` is
+gitignored, so a CI-built snapshot would never reach the VPS.  See
+`docs/playerctx.md`; for BDVM, `scripts/refresh_bdvm_projections.py`
+documents the stage/exit-code contract, and the IDP Show session jar
+is shared with the rankings timer at
+`/var/lib/idpshow-fetch/idpshow_session.json`.
 
 ## Manual runs
 

--- a/deploy/systemd/dynasty-bdvm-refresh.service.template
+++ b/deploy/systemd/dynasty-bdvm-refresh.service.template
@@ -1,0 +1,49 @@
+[Unit]
+Description=Dynasty Trade Calculator BDVM projection snapshot refresh (__SERVICE_NAME__)
+After=network-online.target
+Wants=network-online.target
+
+# Produces immutable snapshots under data/bdvm/projections/<season>/ —
+# what GET /api/bdvm/values (feature flag: bdvm_engine) prices players
+# from.  Two stages via scripts/refresh_bdvm_projections.py:
+#   1. reconstructed baseline (public nflverse, no credentials)
+#   2. The IDP Show real projections (cookies staged from the
+#      idpshow-fetch work dir; stage self-skips when absent)
+#
+# WHY A PROD-SIDE TIMER AND NOT CI: the endpoint reads a LOCAL file
+# and data/ is gitignored repo-wide, so a snapshot built on a CI
+# runner never reaches the VPS.  The producer has to run where the
+# reader lives — same reasoning as the player-context refresh.
+#
+# Safe to install while bdvm_engine is OFF: snapshots are the
+# prerequisite for flipping the flag, and building them touches no
+# existing route or data.
+#
+# Exit codes (scripts/refresh_bdvm_projections.py):
+#   0 - at least one stage wrote a snapshot
+#   1 - soft failure; last-good snapshot untouched
+#   2 - a stage hard-errored; last-good untouched
+# systemd reports 1 and 2 as unit failures so the journal shows them.
+# On 1/2 the previously written snapshot stays live (stale projections
+# beat no projections); on 0 the baseline stage carries prior real
+# records forward, so a rebuild never downgrades real → proxy. Reruns
+# on the same day are no-op successes (immutable date-stamped
+# snapshots), so boot catch-ups stay green.
+
+[Service]
+Type=oneshot
+User=__APP_USER__
+Group=__APP_USER__
+WorkingDirectory=__APP_DIR__
+EnvironmentFile=-__APP_DIR__/.env
+ExecStart=__VENV_DIR__/bin/python __APP_DIR__/scripts/refresh_bdvm_projections.py
+StandardOutput=journal
+StandardError=journal
+# Dominated by the nflverse weekly-stats downloads (3 seasons, cached
+# by ETag on repeat runs).  Background enrichment — never user-facing.
+Nice=10
+IOSchedulingClass=idle
+TimeoutStartSec=1200
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/dynasty-bdvm-refresh.timer.template
+++ b/deploy/systemd/dynasty-bdvm-refresh.timer.template
@@ -1,0 +1,27 @@
+[Unit]
+Description=Weekly BDVM projection snapshot refresh for __SERVICE_NAME__
+# Deliberately NO Requires= on the service here: [Timer] Unit= already
+# binds it, and a [Unit] Requires= would (a) start the service on every
+# boot regardless of OnCalendar and (b) let a service failure stop the
+# timer itself, killing the weekly schedule.  Persistent=true below is
+# the intended catch-up mechanism for missed runs.
+
+[Timer]
+# Weekly, Tuesday 06:10 UTC.  Cadence rationale: the baseline stage
+# consumes nflverse weekly stats, which republish on the same Tuesday
+# cadence the player-context refresh and the Hill-curve refit already
+# target; preseason projections themselves move slower than weekly.
+#
+# Slot rationale: playerctx fires 05:40+<=10min jitter and finishes in
+# ~3 min, so 06:10 starts strictly after it on the same box; the
+# randomized delay keeps us off nflverse's release CDN on the same
+# second as every other weekly consumer.  Persistent=true backfills a
+# missed run after a reboot.
+OnCalendar=Tue *-*-* 06:10:00 UTC
+RandomizedDelaySec=600
+Persistent=true
+AccuracySec=2min
+Unit=__SERVICE_NAME__-bdvm-refresh.service
+
+[Install]
+WantedBy=timers.target

--- a/frontend/__tests__/bdvm-lib.test.js
+++ b/frontend/__tests__/bdvm-lib.test.js
@@ -1,0 +1,236 @@
+/**
+ * bdvm-lib.test.js — the /bdvm display helpers.
+ *
+ * Dangerous cases, in order:
+ * 1. The three 503 variants MUST classify differently — rendering
+ *    flag-off as a generic error (or vice versa) misleads the operator.
+ * 2. Null market values must render as absence ("—"), never as 0 — the
+ *    backend's §9.5 no-fabrication rule extends to the UI.
+ * 3. Row building must not mutate the payload (it is cached by the
+ *    hook and re-shaped per strategy switch).
+ * 4. Strategy switching must re-order rows by THAT currency — the
+ *    whole point of strategy currencies is that the order changes.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  classifyBdvmFailure,
+  buildBdvmValueRows,
+  buildBdvmPickRows,
+  buildBdvmRosterRows,
+  buildBdvmTradeRows,
+  bdvmGroupOptions,
+  bdvmSignalTone,
+  bdvmDirectionTone,
+  formatBdvmValue,
+  formatBdvmGap,
+  formatBdvmDecimal,
+} from "@/lib/bdvm";
+
+function player(name, overrides = {}) {
+  return {
+    playerId: `id-${name}`,
+    name,
+    position: "WR",
+    group: "WR",
+    raw: { age: 25.0 },
+    tradeValue: { contender: 5000, balanced: 5000, rebuilder: 5000, risk_neutral: 5000 },
+    projection: { fpg: 15.0, sourceCount: 2, anyProxy: false, sources: ["a"] },
+    market: { marketValue: 4800, marketSource: "ktcSfTep", gap: 200.0 },
+    signal: { signal: "BUY", reason: "gap" },
+    quality: { confidenceScore: 0.7, confidenceLabel: "medium" },
+    range: { floor_p20: 4000, median: 5000, ceiling_p85: 6200 },
+    dynastyScore0to100: 88.2,
+    ...overrides,
+  };
+}
+
+describe("classifyBdvmFailure", () => {
+  it("distinguishes the three 503 variants", () => {
+    expect(classifyBdvmFailure(503, { error: "feature_disabled", flag: "bdvm_engine" }).kind).toBe(
+      "disabled",
+    );
+    expect(classifyBdvmFailure(503, { error: "data_not_ready", message: "m" }).kind).toBe(
+      "not_ready",
+    );
+    expect(classifyBdvmFailure(503, { error: "bdvm_unavailable", message: "boom" }).kind).toBe(
+      "unavailable",
+    );
+  });
+
+  it("maps 401 to auth and unknown statuses to error with a message", () => {
+    expect(classifyBdvmFailure(401, null).kind).toBe("auth");
+    const err = classifyBdvmFailure(500, null);
+    expect(err.kind).toBe("error");
+    expect(err.message).toBe("HTTP 500");
+  });
+
+  it("returns null on 2xx", () => {
+    expect(classifyBdvmFailure(200, { status: "ok" })).toBeNull();
+  });
+
+  it("survives a non-JSON body", () => {
+    expect(classifyBdvmFailure(503, null).kind).toBe("error");
+  });
+});
+
+describe("buildBdvmValueRows", () => {
+  it("orders by the selected strategy currency and stamps 1-based ranks", () => {
+    const payload = {
+      players: [
+        player("Old Vet", {
+          tradeValue: { contender: 9000, balanced: 6000, rebuilder: 2000, risk_neutral: 6000 },
+        }),
+        player("Young Stash", {
+          tradeValue: { contender: 3000, balanced: 5500, rebuilder: 8000, risk_neutral: 5500 },
+        }),
+      ],
+    };
+    const byContender = buildBdvmValueRows(payload, "contender");
+    expect(byContender.map((r) => r.name)).toEqual(["Old Vet", "Young Stash"]);
+    expect(byContender[0].rank).toBe(1);
+    const byRebuilder = buildBdvmValueRows(payload, "rebuilder");
+    expect(byRebuilder.map((r) => r.name)).toEqual(["Young Stash", "Old Vet"]);
+  });
+
+  it("does not mutate the payload", () => {
+    const payload = { players: [player("A"), player("B")] };
+    const snapshot = JSON.stringify(payload);
+    buildBdvmValueRows(payload, "balanced");
+    expect(JSON.stringify(payload)).toBe(snapshot);
+  });
+
+  it("carries null market fields as null, never 0", () => {
+    const payload = {
+      players: [
+        player("No Market", {
+          market: {
+            marketValue: null,
+            marketSource: null,
+            gap: null,
+            liquidity: 0.0,
+          },
+          signal: { signal: "NO_MARKET", reason: "no anchor" },
+        }),
+      ],
+    };
+    const [row] = buildBdvmValueRows(payload, "balanced");
+    expect(row.marketValue).toBeNull();
+    expect(row.gap).toBeNull();
+    expect(formatBdvmValue(row.marketValue)).toBe("—");
+    expect(formatBdvmGap(row.gap)).toBe("—");
+  });
+
+  it("flags proxy projections", () => {
+    const payload = {
+      players: [player("Proxy Guy", { projection: { fpg: 8, anyProxy: true, sourceCount: 1 } })],
+    };
+    expect(buildBdvmValueRows(payload, "balanced")[0].anyProxy).toBe(true);
+  });
+
+  it("handles a missing players array", () => {
+    expect(buildBdvmValueRows({}, "balanced")).toEqual([]);
+    expect(buildBdvmValueRows(null, "balanced")).toEqual([]);
+  });
+});
+
+describe("bdvmGroupOptions", () => {
+  it("orders known groups QB-first and appends unknowns", () => {
+    const rows = [{ group: "LB" }, { group: "QB" }, { group: "XX" }, { group: "QB" }];
+    expect(bdvmGroupOptions(rows)).toEqual(["QB", "LB", "XX"]);
+  });
+});
+
+describe("buildBdvmPickRows", () => {
+  it("sorts priced picks by strategy EV and sinks unpriced ones", () => {
+    const payload = {
+      picks: [
+        { name: "2027 Mid 1st", assetClass: "pick", distribution: null, reason: "unparseable_pick_name", market: { marketValue: 5000, marketSource: "ktcSfTep", liquidity: 0.5 } },
+        { name: "2027 1.05", assetClass: "pick", overallSlot: 5, pickYear: 2027, yearsOut: 1, market: { marketValue: 6000, marketSource: "ktcSfTep", liquidity: 0.5 }, distribution: { balanced: { ev: 4200, p_hit: 0.4, p_mid: 0.3, p_miss: 0.3, ceiling: 8000, median: 3800, class_strength: 1.0, years_out: 1.0 } } },
+      ],
+    };
+    const rows = buildBdvmPickRows(payload, "balanced");
+    expect(rows[0].name).toBe("2027 1.05");
+    expect(rows[0].ev).toBe(4200);
+    expect(rows[1].unpriced).toBe(true);
+    expect(rows[1].ev).toBeNull();
+  });
+});
+
+describe("buildBdvmRosterRows", () => {
+  it("flattens capitals and keeps assets for the drawer", () => {
+    const payload = {
+      rosters: [
+        {
+          name: "Team A",
+          ownerId: "o1",
+          rosterId: 1,
+          assetCount: 20,
+          unmatchedPlayerIds: 2,
+          capitals: { contender: 50000.5, balanced: 48000, rebuilder: 40000, risk_neutral: 47000 },
+          nowFutureRatio: 1.25,
+          valueWeightedAge: 26.4,
+          starterFpg: 130.2,
+          positionalSurplus: { WR: 1 },
+          pickCount: 4,
+          assets: [{ playerId: "p", name: "X", tradeValue: { balanced: 9000 } }],
+          direction: "contend",
+          strategy: "contender",
+        },
+      ],
+    };
+    const [row] = buildBdvmRosterRows(payload);
+    expect(row.key).toBe("o1");
+    expect(row.contender).toBe(50000.5);
+    expect(row.direction).toBe("contend");
+    expect(row.assets).toHaveLength(1);
+  });
+});
+
+describe("buildBdvmTradeRows", () => {
+  it("flattens both sides with own-currency gains", () => {
+    const payload = {
+      trades: [
+        {
+          from: { ownerId: "a", name: "Team A", strategy: "contender", gives: ["X", "Y"], gain: 400.0 },
+          to: { ownerId: "b", name: "Team B", strategy: "rebuilder", gives: ["Z"], gain: 250.0 },
+          marketFairnessPct: 6.5,
+          fairnessBasis: "single_market",
+          doublePositive: true,
+          minGain: 250.0,
+        },
+      ],
+    };
+    const [row] = buildBdvmTradeRows(payload);
+    expect(row.aGives).toEqual(["X", "Y"]);
+    expect(row.bGain).toBe(250.0);
+    expect(row.minGain).toBe(250.0);
+    expect(row.fairnessBasis).toBe("single_market");
+  });
+});
+
+describe("tones and formatting", () => {
+  it("maps signals to meaningful tones", () => {
+    expect(bdvmSignalTone("BUY")).toBe("positive");
+    expect(bdvmSignalTone("STRONG_SELL")).toBe("negative");
+    expect(bdvmSignalTone("SELL")).toBe("warning");
+    expect(bdvmSignalTone("NO_MARKET")).toBe("outline");
+    expect(bdvmSignalTone("HOLD")).toBe("neutral");
+  });
+
+  it("never renders rebuild as negative — it is a strategy, not a failure", () => {
+    expect(bdvmDirectionTone("rebuild")).toBe("info");
+    expect(bdvmDirectionTone("contend")).toBe("positive");
+    expect(bdvmDirectionTone("retool")).toBe("neutral");
+  });
+
+  it("formats gaps signed and absences as em dash", () => {
+    expect(formatBdvmGap(412.4)).toBe("+412");
+    expect(formatBdvmGap(-93)).toBe("−93");
+    expect(formatBdvmGap(0.2)).toBe("0");
+    expect(formatBdvmGap(null)).toBe("—");
+    expect(formatBdvmDecimal(null)).toBe("—");
+    expect(formatBdvmDecimal(25.04)).toBe("25.0");
+    expect(formatBdvmValue(9999.6)).toBe((10000).toLocaleString());
+  });
+});

--- a/frontend/__tests__/components/bdvm-page.test.jsx
+++ b/frontend/__tests__/components/bdvm-page.test.jsx
@@ -1,0 +1,144 @@
+/**
+ * /bdvm page smoke tests — the states that must never blur:
+ * flag-off (503 feature_disabled) is an explanation, not an error;
+ * no_projection_snapshot (HTTP 200) tells the operator what to run;
+ * a real payload renders the board with backend numbers verbatim.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import BdvmPage from "@/app/bdvm/page";
+
+function jsonResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  };
+}
+
+const OK_PAYLOAD = {
+  status: "ok",
+  meta: {
+    modelVersion: "1.0.0",
+    paramSetId: "params_v1:abc123",
+    counts: { priced: 2, unpriced: 1 },
+    projectionSnapshot: { asOf: "2026-07-27", recordCount: 2815 },
+  },
+  replacement: {},
+  players: [
+    {
+      playerId: "p1",
+      name: "Elite Backer",
+      position: "LB",
+      group: "LB",
+      raw: { age: 24.0 },
+      tradeValue: { contender: 7000, balanced: 7200, rebuilder: 7400, risk_neutral: 7100 },
+      projection: { fpg: 16.8, sourceCount: 1, anyProxy: false },
+      market: { marketValue: 6400, marketSource: "idpTradeCalc", gap: 800.0 },
+      signal: { signal: "BUY", reason: "gap above threshold" },
+      quality: { confidenceScore: 0.6, confidenceLabel: "medium" },
+      range: { floor_p20: 6000, ceiling_p85: 8500 },
+      dynastyScore0to100: 95.0,
+    },
+    {
+      playerId: "p2",
+      name: "Proxy Vet",
+      position: "WR",
+      group: "WR",
+      raw: { age: 29.5 },
+      tradeValue: { contender: 5200, balanced: 4200, rebuilder: 2100, risk_neutral: 4100 },
+      projection: { fpg: 13.1, sourceCount: 1, anyProxy: true },
+      market: { marketValue: null, marketSource: null, gap: null },
+      signal: { signal: "NO_MARKET", reason: "no anchor" },
+      quality: { confidenceScore: 0.3, confidenceLabel: "low" },
+      range: { floor_p20: 3000, ceiling_p85: 5000 },
+      dynastyScore0to100: 41.0,
+    },
+  ],
+  picks: [],
+  unpriced: [{ name: "No Age Guy", reason: "missing_age", position: "CB" }],
+};
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("BdvmPage states", () => {
+  it("renders the flag-off explanation on 503 feature_disabled", async () => {
+    fetch.mockResolvedValue(
+      jsonResponse(503, { error: "feature_disabled", flag: "bdvm_engine" }),
+    );
+    render(<BdvmPage />);
+    expect(
+      await screen.findByText("BDVM engine is switched off"),
+    ).toBeInTheDocument();
+    // Never a generic error banner for a configuration state.
+    expect(screen.queryByText("Fundamentals unavailable")).toBeNull();
+  });
+
+  it("tells the operator what to run when no snapshot exists", async () => {
+    fetch.mockResolvedValue(
+      jsonResponse(200, {
+        status: "no_projection_snapshot",
+        meta: { projectionSnapshot: null },
+        message: "BDVM has no projection snapshot for season 2026",
+        players: [],
+        picks: [],
+        unpriced: [],
+        replacement: {},
+      }),
+    );
+    render(<BdvmPage />);
+    expect(
+      await screen.findByText("No projection snapshot yet"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/refresh_bdvm_projections/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders backend numbers verbatim on a real payload", async () => {
+    fetch.mockResolvedValue(jsonResponse(200, OK_PAYLOAD));
+    render(<BdvmPage />);
+    expect(await screen.findByText("Elite Backer")).toBeInTheDocument();
+    // balanced trade value, rounded + locale-formatted
+    expect(screen.getByText((7200).toLocaleString())).toBeInTheDocument();
+    expect(screen.getByText("+800")).toBeInTheDocument();
+    expect(screen.getByText("Buy")).toBeInTheDocument();
+    // proxy projection is labeled, null market renders as absence
+    expect(screen.getByText("proxy")).toBeInTheDocument();
+    expect(screen.getByText("No market")).toBeInTheDocument();
+    // meta strip shows the snapshot stamp
+    expect(screen.getByText("2026-07-27")).toBeInTheDocument();
+  });
+
+  it("keeps the values payload across a tab round-trip without refetching", async () => {
+    fetch.mockImplementation(async (url) => {
+      if (String(url).startsWith("/api/bdvm/roster")) {
+        return jsonResponse(200, { status: "ok", rosters: [], meta: {} });
+      }
+      return jsonResponse(200, OK_PAYLOAD);
+    });
+    const user = userEvent.setup();
+    render(<BdvmPage />);
+    await screen.findByText("Elite Backer");
+    const valuesCalls = () =>
+      fetch.mock.calls.filter((c) => String(c[0]).startsWith("/api/bdvm/values")).length;
+    expect(valuesCalls()).toBe(1);
+
+    await user.click(screen.getByRole("tab", { name: "Rosters" }));
+    await screen.findByText("No rosters");
+
+    await user.click(screen.getByRole("tab", { name: "Value Board" }));
+    // payload survives the round-trip; no second /values fetch
+    expect(await screen.findByText("Elite Backer")).toBeInTheDocument();
+    expect(valuesCalls()).toBe(1);
+  });
+});

--- a/frontend/__tests__/nav-model.test.js
+++ b/frontend/__tests__/nav-model.test.js
@@ -33,6 +33,7 @@ const ROUTES_THAT_MUST_BE_REACHABLE = [
   "/waivers",
   "/rosters",
   "/edge",
+  "/bdvm",
   "/intel",
   "/idptc-rookies",
   "/league",

--- a/frontend/app/api/bdvm/roster/route.js
+++ b/frontend/app/api/bdvm/roster/route.js
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { proxyGet } from "@/lib/backend-proxy";
+
+// Dev-flow bridge only — in production nginx routes /api/* straight to
+// FastAPI. Roster analysis rides the cached values payload server-side
+// but may trigger the first compute, hence the long timeout.
+export async function GET(request) {
+  try {
+    const searchParams = {};
+    const leagueKey = request?.nextUrl?.searchParams?.get("leagueKey");
+    if (leagueKey) searchParams.leagueKey = leagueKey;
+    const { data, status } = await proxyGet("/api/bdvm/roster", {
+      searchParams,
+      timeoutMs: 30000,
+    });
+    return NextResponse.json(data, { status });
+  } catch (err) {
+    return NextResponse.json(
+      { error: "bdvm_unavailable", detail: err?.message },
+      { status: 503 },
+    );
+  }
+}

--- a/frontend/app/api/bdvm/trades/route.js
+++ b/frontend/app/api/bdvm/trades/route.js
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { proxyGet } from "@/lib/backend-proxy";
+
+// Dev-flow bridge only — in production nginx routes /api/* straight to
+// FastAPI. The double-positive scan runs on request (200k+ candidate
+// packages server-side), hence the long timeout.
+export async function GET(request) {
+  try {
+    const searchParams = {};
+    for (const key of ["leagueKey", "team"]) {
+      const value = request?.nextUrl?.searchParams?.get(key);
+      if (value) searchParams[key] = value;
+    }
+    const { data, status } = await proxyGet("/api/bdvm/trades", {
+      searchParams,
+      timeoutMs: 30000,
+    });
+    return NextResponse.json(data, { status });
+  } catch (err) {
+    return NextResponse.json(
+      { error: "bdvm_unavailable", detail: err?.message },
+      { status: 503 },
+    );
+  }
+}

--- a/frontend/app/api/bdvm/values/route.js
+++ b/frontend/app/api/bdvm/values/route.js
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { proxyGet } from "@/lib/backend-proxy";
+
+// Dev-flow bridge only — in production nginx routes /api/* straight to
+// FastAPI. First compute of a BDVM valuation takes seconds (full
+// engine run before the cache warms), hence the long timeout.
+export async function GET(request) {
+  try {
+    const searchParams = {};
+    for (const key of ["leagueKey", "surplusMode"]) {
+      const value = request?.nextUrl?.searchParams?.get(key);
+      if (value) searchParams[key] = value;
+    }
+    const { data, status } = await proxyGet("/api/bdvm/values", {
+      searchParams,
+      timeoutMs: 30000,
+    });
+    return NextResponse.json(data, { status });
+  } catch (err) {
+    return NextResponse.json(
+      { error: "bdvm_unavailable", detail: err?.message },
+      { status: 503 },
+    );
+  }
+}

--- a/frontend/app/bdvm/bdvm.module.css
+++ b/frontend/app/bdvm/bdvm.module.css
@@ -1,0 +1,107 @@
+/* bdvm.module.css — /bdvm Fundamentals structural styles (token-driven). */
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+/* ── Meta strip ───────────────────────────────────────────────────── */
+.statGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-2);
+}
+@media (width < 768px) {
+  .statGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+/* ── Controls ─────────────────────────────────────────────────────── */
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+}
+.controlsSearch {
+  flex: 1;
+  min-width: 160px;
+}
+.controlsSelect {
+  width: auto;
+  min-width: 130px;
+}
+.resultCount {
+  margin: 0;
+  font-size: var(--font-size-2xs);
+  color: var(--text-tertiary);
+  white-space: nowrap;
+}
+
+/* ── Cells ────────────────────────────────────────────────────────── */
+.playerCell {
+  display: inline-flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+.playerName {
+  font-weight: var(--font-weight-medium);
+  color: var(--text-primary);
+}
+.cellNote {
+  font-size: var(--font-size-2xs);
+  color: var(--text-tertiary);
+}
+
+/* ── Trade package cells ──────────────────────────────────────────── */
+.packageSide {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.packageTeam {
+  font-weight: var(--font-weight-medium);
+}
+.packageAssets {
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+}
+
+/* ── Roster expansion drawer ──────────────────────────────────────── */
+.drawerCell {
+  padding: 0 var(--space-4) var(--space-3);
+  background: var(--surface-1);
+}
+.drawerTitle {
+  margin: var(--space-2) 0;
+  font-size: var(--font-size-2xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-tertiary);
+}
+.drawerList {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--space-1) var(--space-3);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: var(--font-size-xs);
+}
+.drawerAssetValue {
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Footnotes ────────────────────────────────────────────────────── */
+.footnote {
+  margin: 0;
+  padding: var(--space-2) var(--space-4) var(--space-3);
+  font-size: var(--font-size-2xs);
+  color: var(--text-tertiary);
+  max-width: 90ch;
+}

--- a/frontend/app/bdvm/page.jsx
+++ b/frontend/app/bdvm/page.jsx
@@ -1,0 +1,723 @@
+"use client";
+
+/**
+ * /bdvm — Fundamentals: the BDVM projection-driven value board beside
+ * the market, per-roster strategy capitals, and the double-positive
+ * trade scan. Reads GET /api/bdvm/values|roster|trades (feature flag
+ * `bdvm_engine`, default OFF — the page renders an explicit
+ * flag-off state, Pattern B, never a generic error).
+ *
+ * Every number rendered here is backend-computed. Client code only
+ * filters, sorts by backend-stamped columns, and formats.
+ */
+
+import { useMemo, useState } from "react";
+import {
+  Badge,
+  Banner,
+  Confidence,
+  DataTable,
+  EmptyState,
+  Input,
+  PageHeader,
+  Panel,
+  SegmentedControl,
+  Select,
+  SkeletonTable,
+  StatTile,
+  Tabs,
+  tabId,
+  tabPanelId,
+} from "@/components/ds";
+import { useBdvmEndpoint } from "@/components/useBdvm";
+import {
+  BDVM_STRATEGIES,
+  BDVM_SURPLUS_MODES,
+  bdvmDirectionTone,
+  bdvmGroupOptions,
+  bdvmSignalTone,
+  buildBdvmPickRows,
+  buildBdvmRosterRows,
+  buildBdvmTradeRows,
+  buildBdvmValueRows,
+  formatBdvmDecimal,
+  formatBdvmGap,
+  formatBdvmValue,
+} from "@/lib/bdvm";
+import styles from "./bdvm.module.css";
+
+const TABS = [
+  { id: "values", label: "Value Board" },
+  { id: "rosters", label: "Rosters" },
+  { id: "trades", label: "Trade Scan" },
+];
+
+const SIGNAL_LABELS = {
+  STRONG_BUY: "Strong buy",
+  BUY: "Buy",
+  HOLD: "Hold",
+  SELL: "Sell",
+  STRONG_SELL: "Strong sell",
+  NO_MARKET: "No market",
+};
+
+/** Page-scale special states shared by all three endpoints. */
+function BdvmFailure({ failure }) {
+  if (!failure) return null;
+  if (failure.kind === "disabled") {
+    return (
+      <EmptyState
+        title="BDVM engine is switched off"
+        description={
+          "Fundamentals are behind the bdvm_engine feature flag (default off). " +
+          "An operator can enable it with RISKIT_FEATURE_BDVM_ENGINE=1 on the " +
+          "backend once projection snapshots exist — nothing else on the site " +
+          "changes either way."
+        }
+      />
+    );
+  }
+  if (failure.kind === "not_ready") {
+    return (
+      <Banner tone="warning" title="Data not ready for this league">
+        {failure.message ||
+          "The backend has no contract loaded for the selected league yet."}
+      </Banner>
+    );
+  }
+  if (failure.kind === "auth") {
+    return (
+      <Banner tone="warning" title="Sign in required">
+        {failure.message}
+      </Banner>
+    );
+  }
+  return (
+    <Banner tone="negative" title="Fundamentals unavailable">
+      {failure.message}
+    </Banner>
+  );
+}
+
+function ValuesTab({ active, surplusMode, setSurplusMode }) {
+  const params = useMemo(
+    () => (surplusMode === "option" ? {} : { surplusMode }),
+    [surplusMode],
+  );
+  // Kept mounted across tab switches (like the sibling tabs) so
+  // strategy/filter state and the fetched payload survive; the hook
+  // itself skips refetching on re-activation.
+  const { loading, data, failure } = useBdvmEndpoint("/api/bdvm/values", {
+    params,
+    enabled: active,
+  });
+  const [strategy, setStrategy] = useState("balanced");
+  const [group, setGroup] = useState("");
+  const [query, setQuery] = useState("");
+
+  const allRows = useMemo(
+    () => (data?.status === "ok" ? buildBdvmValueRows(data, strategy) : []),
+    [data, strategy],
+  );
+  const groups = useMemo(() => bdvmGroupOptions(allRows), [allRows]);
+  const rows = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return allRows.filter(
+      (r) =>
+        (!group || r.group === group) &&
+        (!q || r.name.toLowerCase().includes(q)),
+    );
+  }, [allRows, group, query]);
+  const pickRows = useMemo(
+    () => (data?.status === "ok" ? buildBdvmPickRows(data, strategy) : []),
+    [data, strategy],
+  );
+
+  if (!active) return null;
+  if (loading) {
+    return (
+      <Panel flush title="Fundamental value board">
+        <SkeletonTable rows={12} columns={8} />
+      </Panel>
+    );
+  }
+  if (failure) return <BdvmFailure failure={failure} />;
+  if (data?.status === "no_projection_snapshot") {
+    return (
+      <EmptyState
+        title="No projection snapshot yet"
+        description={
+          "BDVM prices players from immutable projection snapshots and none " +
+          "exists for this season. On the server, run " +
+          "scripts/refresh_bdvm_projections.py (the dynasty-bdvm-refresh " +
+          "timer does this weekly)."
+        }
+      />
+    );
+  }
+
+  const meta = data?.meta || {};
+  const counts = meta.counts || {};
+  const snapshot = meta.projectionSnapshot || {};
+
+  const columns = [
+    { key: "rank", header: "#", numeric: true, width: "3rem" },
+    {
+      key: "name",
+      header: "Player",
+      sortable: true,
+      render: (r) => (
+        <span className={styles.playerCell}>
+          <span className={styles.playerName}>{r.name}</span>
+          <Badge tone="outline">{r.position}</Badge>
+          {r.anyProxy ? (
+            <Badge
+              tone="neutral"
+              title="Priced from the reconstructed-baseline proxy, not a real projection source"
+            >
+              proxy
+            </Badge>
+          ) : null}
+        </span>
+      ),
+    },
+    {
+      key: "age",
+      header: "Age",
+      numeric: true,
+      sortable: true,
+      hideBelow: "md",
+      render: (r) => formatBdvmDecimal(r.age),
+    },
+    {
+      key: "fpg",
+      header: "FPG",
+      headerTitle: "Projected fantasy points per game under this league's scoring",
+      numeric: true,
+      sortable: true,
+      hideBelow: "sm",
+      render: (r) => formatBdvmDecimal(r.fpg),
+    },
+    {
+      key: "tradeValue",
+      header: "Fundamental",
+      headerTitle: "BDVM trade value in the selected strategy currency (0–10000)",
+      numeric: true,
+      sortable: true,
+      render: (r) => formatBdvmValue(r.tradeValue),
+    },
+    {
+      key: "marketValue",
+      header: "Market",
+      headerTitle: "Market anchor (KTC / IDP TradeCalc)",
+      numeric: true,
+      sortable: true,
+      hideBelow: "sm",
+      render: (r) => formatBdvmValue(r.marketValue),
+    },
+    {
+      key: "gap",
+      header: "Gap",
+      headerTitle: "Fundamental (balanced) minus market — positive means the market underprices",
+      numeric: true,
+      sortable: true,
+      render: (r) => formatBdvmGap(r.gap),
+    },
+    {
+      key: "signal",
+      header: "Signal",
+      sortable: true,
+      render: (r) =>
+        r.signal ? (
+          <Badge tone={bdvmSignalTone(r.signal)} title={r.signalReason}>
+            {SIGNAL_LABELS[r.signal] || r.signal}
+          </Badge>
+        ) : (
+          "—"
+        ),
+    },
+    {
+      key: "score",
+      header: "Score",
+      headerTitle: "Percentile of balanced fundamental value among priced players (0–100)",
+      numeric: true,
+      sortable: true,
+      hideBelow: "lg",
+      render: (r) => formatBdvmDecimal(r.score, 0),
+    },
+    {
+      key: "confidenceScore",
+      header: "Conf",
+      headerTitle: "Model confidence (provisional by policy in v1)",
+      numeric: true,
+      hideBelow: "lg",
+      render: (r) => (
+        <Confidence confidence={r.confidenceScore} showWhen="always" />
+      ),
+    },
+  ];
+
+  const pickColumns = [
+    { key: "name", header: "Pick", sortable: true },
+    {
+      key: "ev",
+      header: "EV",
+      headerTitle: "Expected value of the pick's outcome distribution (selected strategy)",
+      numeric: true,
+      sortable: true,
+      render: (r) =>
+        r.unpriced ? (
+          <span className={styles.cellNote}>{r.reason || "unpriced"}</span>
+        ) : (
+          formatBdvmValue(r.ev)
+        ),
+    },
+    {
+      key: "pHit",
+      header: "P(hit)",
+      numeric: true,
+      hideBelow: "sm",
+      render: (r) => (r.pHit == null ? "—" : `${Math.round(r.pHit * 100)}%`),
+    },
+    {
+      key: "median",
+      header: "Median",
+      numeric: true,
+      hideBelow: "md",
+      render: (r) => formatBdvmValue(r.median),
+    },
+    {
+      key: "marketValue",
+      header: "Market",
+      numeric: true,
+      sortable: true,
+      render: (r) => formatBdvmValue(r.marketValue),
+    },
+  ];
+
+  return (
+    <>
+      <div className={styles.statGrid}>
+        <StatTile label="Players priced" value={String(counts.priced ?? "—")} />
+        <StatTile
+          label="Unpriced (honest)"
+          value={String(counts.unpriced ?? "—")}
+          meta="no projection / age"
+        />
+        <StatTile
+          label="Snapshot"
+          value={snapshot.asOf || "—"}
+          meta={
+            snapshot.recordCount ? `${snapshot.recordCount} records` : undefined
+          }
+        />
+        <StatTile
+          label="Model"
+          value={meta.modelVersion || "—"}
+          meta={meta.paramSetId}
+        />
+      </div>
+
+      <Panel flush title="Fundamental value board">
+        <div className={styles.controls}>
+          <SegmentedControl
+            label="Strategy currency"
+            options={BDVM_STRATEGIES}
+            value={strategy}
+            onChange={setStrategy}
+          />
+          <Select
+            aria-label="Position group"
+            className={styles.controlsSelect}
+            value={group}
+            onChange={(e) => setGroup(e.target.value)}
+            options={[
+              { value: "", label: "All positions" },
+              ...groups.map((g) => ({ value: g, label: g })),
+            ]}
+          />
+          <Select
+            aria-label="Surplus model"
+            className={styles.controlsSelect}
+            value={surplusMode}
+            onChange={(e) => setSurplusMode(e.target.value)}
+            options={BDVM_SURPLUS_MODES}
+          />
+          <Input
+            aria-label="Search players"
+            className={styles.controlsSearch}
+            placeholder="Search players…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          <p className={styles.resultCount}>
+            {rows.length} of {allRows.length}
+          </p>
+        </div>
+        <DataTable
+          caption="BDVM fundamental values vs market, per player"
+          columns={columns}
+          rows={rows}
+          rowKey={(r) => r.playerId || r.name}
+          density="compact"
+          defaultSort={{ key: "tradeValue", direction: "desc" }}
+          emptyState={
+            <EmptyState
+              title="No players match"
+              description="Adjust the position filter or search."
+            />
+          }
+        />
+        <p className={styles.footnote}>
+          Fundamentals compute with zero market inputs; the market column is
+          compared strictly afterward. Values marked proxy come from the
+          reconstructed baseline (realized production under this league&apos;s
+          scoring), not a forward projection source.
+        </p>
+      </Panel>
+
+      {pickRows.length > 0 ? (
+        <Panel
+          flush
+          title="Rookie picks"
+          subtitle="Priced as outcome distributions, not point values"
+        >
+          <DataTable
+            caption="BDVM pick values by outcome distribution"
+            columns={pickColumns}
+            rows={pickRows}
+            rowKey={(r) => r.name}
+            density="compact"
+            emptyState={<EmptyState title="No picks in the contract" />}
+          />
+        </Panel>
+      ) : null}
+    </>
+  );
+}
+
+function RostersTab({ active }) {
+  const { loading, data, failure } = useBdvmEndpoint("/api/bdvm/roster", {
+    enabled: active,
+  });
+  const [expandedKey, setExpandedKey] = useState("");
+
+  const rows = useMemo(
+    () => (data?.status === "ok" ? buildBdvmRosterRows(data) : []),
+    [data],
+  );
+
+  if (!active) return null;
+  if (loading) {
+    return (
+      <Panel flush title="Roster strategy capitals">
+        <SkeletonTable rows={12} columns={7} />
+      </Panel>
+    );
+  }
+  if (failure) return <BdvmFailure failure={failure} />;
+  if (data?.status && data.status !== "ok") {
+    return (
+      <EmptyState
+        title="Roster analysis unavailable"
+        description={data.message || `Status: ${data.status}`}
+      />
+    );
+  }
+
+  const columns = [
+    { key: "name", header: "Team", sortable: true },
+    {
+      key: "direction",
+      header: "Direction",
+      sortable: true,
+      render: (r) =>
+        r.direction ? (
+          <Badge tone={bdvmDirectionTone(r.direction)}>{r.direction}</Badge>
+        ) : (
+          "—"
+        ),
+    },
+    {
+      key: "contender",
+      header: "Contender",
+      headerTitle: "Roster capital in the contender currency",
+      numeric: true,
+      sortable: true,
+      render: (r) => formatBdvmValue(r.contender),
+    },
+    {
+      key: "balanced",
+      header: "Balanced",
+      numeric: true,
+      sortable: true,
+      render: (r) => formatBdvmValue(r.balanced),
+    },
+    {
+      key: "rebuilder",
+      header: "Rebuilder",
+      numeric: true,
+      sortable: true,
+      render: (r) => formatBdvmValue(r.rebuilder),
+    },
+    {
+      key: "nowFutureRatio",
+      header: "Now / Future",
+      numeric: true,
+      sortable: true,
+      hideBelow: "md",
+      render: (r) => formatBdvmDecimal(r.nowFutureRatio, 2),
+    },
+    {
+      key: "valueWeightedAge",
+      header: "V-Age",
+      headerTitle: "Balanced-value-weighted roster age",
+      numeric: true,
+      sortable: true,
+      hideBelow: "md",
+      render: (r) => formatBdvmDecimal(r.valueWeightedAge),
+    },
+    {
+      key: "starterFpg",
+      header: "Starter FPG",
+      numeric: true,
+      sortable: true,
+      hideBelow: "lg",
+      render: (r) => formatBdvmDecimal(r.starterFpg),
+    },
+  ];
+
+  return (
+    <Panel flush title="Roster strategy capitals">
+      <DataTable
+        caption="Per-roster BDVM capitals, direction, and shape"
+        columns={columns}
+        rows={rows}
+        rowKey={(r) => r.key}
+        density="compact"
+        defaultSort={{ key: "balanced", direction: "desc" }}
+        onRowClick={(r) =>
+          setExpandedKey((k) => (k === r.key ? "" : r.key))
+        }
+        renderAfterRow={(r) =>
+          r.key === expandedKey ? (
+            <tr>
+              <td colSpan={columns.length} className={styles.drawerCell}>
+                <p className={styles.drawerTitle}>
+                  Top assets ({r.assetCount} matched, {r.pickCount} picks)
+                </p>
+                <ul className={styles.drawerList}>
+                  {r.assets.slice(0, 12).map((a) => (
+                    <li key={a.playerId || a.name}>
+                      {a.name}{" "}
+                      <span className={styles.drawerAssetValue}>
+                        {formatBdvmValue(a?.tradeValue?.balanced)}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </td>
+            </tr>
+          ) : null
+        }
+        emptyState={
+          <EmptyState
+            title="No rosters"
+            description="The contract has no Sleeper teams for this league."
+          />
+        }
+      />
+      <p className={styles.footnote}>
+        Direction is league-relative (now/future ratio vs the league
+        median). Capitals sum each roster&apos;s player values in that
+        strategy&apos;s own currency; picks are listed but not summed.
+      </p>
+    </Panel>
+  );
+}
+
+function TradesTab({ active }) {
+  const { loading, data, failure } = useBdvmEndpoint("/api/bdvm/trades", {
+    enabled: active,
+  });
+  const [team, setTeam] = useState("");
+
+  const allRows = useMemo(
+    () => (data?.status === "ok" ? buildBdvmTradeRows(data) : []),
+    [data],
+  );
+  const teams = useMemo(() => {
+    const names = new Set();
+    for (const r of allRows) {
+      if (r.aName) names.add(r.aName);
+      if (r.bName) names.add(r.bName);
+    }
+    return [...names].sort();
+  }, [allRows]);
+  const rows = useMemo(
+    () =>
+      team
+        ? allRows.filter((r) => r.aName === team || r.bName === team)
+        : allRows,
+    [allRows, team],
+  );
+
+  if (!active) return null;
+  if (loading) {
+    return (
+      <Panel flush title="Double-positive trade scan">
+        <SkeletonTable rows={8} columns={5} />
+      </Panel>
+    );
+  }
+  if (failure) return <BdvmFailure failure={failure} />;
+  if (data?.status && data.status !== "ok") {
+    return (
+      <EmptyState
+        title="Trade scan unavailable"
+        description={data.message || `Status: ${data.status}`}
+      />
+    );
+  }
+
+  const columns = [
+    {
+      key: "aName",
+      header: "Side A sends",
+      sortable: true,
+      render: (r) => (
+        <span className={styles.packageSide}>
+          <span className={styles.packageTeam}>
+            {r.aName} <Badge tone="outline">{r.aStrategy}</Badge>
+          </span>
+          <span className={styles.packageAssets}>{r.aGives.join(" + ")}</span>
+        </span>
+      ),
+    },
+    {
+      key: "aGain",
+      header: "A gains",
+      headerTitle: "Side A's gain in its OWN strategy currency",
+      numeric: true,
+      sortable: true,
+      render: (r) => formatBdvmValue(r.aGain),
+    },
+    {
+      key: "bName",
+      header: "Side B sends",
+      sortable: true,
+      render: (r) => (
+        <span className={styles.packageSide}>
+          <span className={styles.packageTeam}>
+            {r.bName} <Badge tone="outline">{r.bStrategy}</Badge>
+          </span>
+          <span className={styles.packageAssets}>{r.bGives.join(" + ")}</span>
+        </span>
+      ),
+    },
+    {
+      key: "bGain",
+      header: "B gains",
+      numeric: true,
+      sortable: true,
+      render: (r) => formatBdvmValue(r.bGain),
+    },
+    {
+      key: "minGain",
+      header: "Min gain",
+      headerTitle: "The smaller side's gain — how double-positive the package is",
+      numeric: true,
+      sortable: true,
+      render: (r) => formatBdvmValue(r.minGain),
+    },
+    {
+      key: "fairnessPct",
+      header: "Fairness",
+      headerTitle: "Market-value imbalance of the package (single-market when both sides share one market)",
+      numeric: true,
+      sortable: true,
+      hideBelow: "md",
+      render: (r) =>
+        r.fairnessPct == null ? "—" : `${formatBdvmDecimal(r.fairnessPct)}%`,
+    },
+  ];
+
+  return (
+    <Panel flush title="Double-positive trade scan">
+      <div className={styles.controls}>
+        <Select
+          aria-label="Filter by team"
+          className={styles.controlsSelect}
+          value={team}
+          onChange={(e) => setTeam(e.target.value)}
+          options={[
+            { value: "", label: "All teams" },
+            ...teams.map((t) => ({ value: t, label: t })),
+          ]}
+        />
+        <p className={styles.resultCount}>
+          {rows.length} of {allRows.length} packages
+          {typeof data?.scanned === "number"
+            ? ` · ${data.scanned.toLocaleString()} scanned`
+            : ""}
+        </p>
+      </div>
+      <DataTable
+        caption="Trades where each side gains in its own strategy currency"
+        columns={columns}
+        rows={rows}
+        rowKey={(r) => r.key}
+        density="compact"
+        defaultSort={{ key: "minGain", direction: "desc" }}
+        emptyState={
+          <EmptyState
+            title="No double-positive packages found"
+            description="With current rosters and values, no scanned package clears both sides' gain thresholds and the market-fairness gate."
+          />
+        }
+      />
+      <p className={styles.footnote}>
+        Each side&apos;s gain is priced in its own strategy currency (CES
+        package math). Market fairness never sums KTC and IDP TradeCalc
+        raw values on one side — mixed-market packages fall back to the
+        model&apos;s trade-clearing basis.
+      </p>
+    </Panel>
+  );
+}
+
+export default function BdvmPage() {
+  const [tab, setTab] = useState("values");
+  const [surplusMode, setSurplusMode] = useState("option");
+
+  return (
+    <section className={styles.page}>
+      <PageHeader
+        eyebrow="Intel"
+        title="Fundamentals"
+        description="BDVM projection-driven dynasty values — fundamentals first, market strictly after. A second value concept beside the market board, never merged into it."
+      />
+      <Tabs
+        idPrefix="bdvm"
+        label="Fundamentals sections"
+        tabs={TABS}
+        active={tab}
+        onChange={setTab}
+      />
+      <div
+        role="tabpanel"
+        id={tabPanelId("bdvm", tab)}
+        aria-labelledby={tabId("bdvm", tab)}
+        className={styles.page}
+      >
+        <ValuesTab
+          active={tab === "values"}
+          surplusMode={surplusMode}
+          setSurplusMode={setSurplusMode}
+        />
+        <RostersTab active={tab === "rosters"} />
+        <TradesTab active={tab === "trades"} />
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/useBdvm.js
+++ b/frontend/components/useBdvm.js
@@ -1,0 +1,121 @@
+"use client";
+
+/**
+ * useBdvmEndpoint — tri-state fetch for the BDVM endpoints
+ * (/api/bdvm/values | roster | trades) with the flag-off and
+ * data-not-ready states rendered distinctly from real errors.
+ *
+ * League threading follows the documented module pattern (see
+ * lib/dynasty-data.js: useLeague can't be imported from data modules —
+ * import cycle): read the active league key from localStorage at fetch
+ * time, and refetch on the `league:changed` / `auth:changed` window
+ * events that useLeague/login dispatch.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { classifyBdvmFailure } from "@/lib/bdvm";
+
+const LEAGUE_LOCAL_KEY = "next_active_league_v1";
+
+function readActiveLeagueKey() {
+  if (typeof window === "undefined") return "";
+  try {
+    return localStorage.getItem(LEAGUE_LOCAL_KEY) || "";
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * @param {string} path — relative endpoint ("/api/bdvm/values")
+ * @param {object} opts — { params: plain object of query params,
+ *                          enabled: fetch only when true (lazy tabs) }
+ * @returns {{ loading, data, failure, refetch }}
+ *   failure: null | { kind: "disabled"|"not_ready"|"unavailable"|"auth"|"error", message }
+ */
+export function useBdvmEndpoint(path, { params, enabled = true } = {}) {
+  const [loading, setLoading] = useState(Boolean(enabled));
+  const [data, setData] = useState(null);
+  const [failure, setFailure] = useState(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const abortRef = useRef(null);
+  // Last (path|params|refreshKey) combination that SETTLED (data or
+  // failure). Re-enabling a kept-mounted tab with an unchanged key
+  // must not refetch — only refetch()/league/auth events (refreshKey)
+  // or a param change do.
+  const settledKeyRef = useRef("");
+
+  // Serialize params so callers can pass literal objects without
+  // re-triggering the effect every render (siteOverridesKey pattern).
+  const paramsKey = useMemo(() => JSON.stringify(params || {}), [params]);
+
+  useEffect(() => {
+    const bump = () => setRefreshKey((k) => k + 1);
+    window.addEventListener("league:changed", bump);
+    window.addEventListener("auth:changed", bump);
+    return () => {
+      window.removeEventListener("league:changed", bump);
+      window.removeEventListener("auth:changed", bump);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+    const runKey = `${path}|${paramsKey}|${refreshKey}`;
+    if (settledKeyRef.current === runKey) return undefined;
+    const ctl = new AbortController();
+    abortRef.current?.abort();
+    abortRef.current = ctl;
+    let cancelled = false;
+
+    async function run() {
+      setLoading(true);
+      try {
+        const search = new URLSearchParams();
+        const leagueKey = readActiveLeagueKey();
+        if (leagueKey) search.set("leagueKey", leagueKey);
+        for (const [k, v] of Object.entries(JSON.parse(paramsKey))) {
+          if (v !== undefined && v !== null && v !== "") search.set(k, v);
+        }
+        const qs = search.toString();
+        const res = await fetch(qs ? `${path}?${qs}` : path, {
+          cache: "no-store",
+          signal: ctl.signal,
+        });
+        let body = null;
+        try {
+          body = await res.json();
+        } catch {
+          body = null;
+        }
+        if (cancelled) return;
+        const fail = classifyBdvmFailure(res.status, body);
+        if (fail) {
+          setFailure(fail);
+          setData(null);
+        } else {
+          setFailure(null);
+          setData(body);
+        }
+        settledKeyRef.current = runKey;
+      } catch (err) {
+        if (cancelled || err?.name === "AbortError") return;
+        setFailure({ kind: "error", message: err?.message || "Request failed" });
+        setData(null);
+        settledKeyRef.current = runKey;
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    run();
+    return () => {
+      cancelled = true;
+      ctl.abort();
+    };
+  }, [path, paramsKey, enabled, refreshKey]);
+
+  const refetch = useCallback(() => setRefreshKey((k) => k + 1), []);
+
+  return { loading, data, failure, refetch };
+}

--- a/frontend/lib/bdvm.js
+++ b/frontend/lib/bdvm.js
@@ -1,0 +1,225 @@
+/**
+ * bdvm.js — pure display helpers for the /bdvm Fundamentals surface.
+ *
+ * BDVM (src/bdvm/) is the projection-driven FUNDAMENTAL value concept,
+ * served by GET /api/bdvm/values|roster|trades behind the bdvm_engine
+ * feature flag. It is compared against the market board, never merged
+ * into it. This module only reshapes backend payloads for rendering —
+ * every number here is backend-computed (fundamentals, trade values,
+ * market gaps, signals, the 0-100 score). Sorting rows by a
+ * backend-stamped column and numbering them is table UX, not ranking
+ * math: the same rule that makes buildRows a pure materializer.
+ */
+
+export const BDVM_STRATEGIES = [
+  { value: "balanced", label: "Balanced" },
+  { value: "contender", label: "Contender" },
+  { value: "rebuilder", label: "Rebuilder" },
+  { value: "risk_neutral", label: "Risk-neutral" },
+];
+
+export const BDVM_SURPLUS_MODES = [
+  { value: "option", label: "Option value E[max(0, X−R)]" },
+  { value: "truncated", label: "Truncated max(0, μ−R)" },
+  { value: "plain", label: "Plain μ−R" },
+];
+
+/**
+ * Classify a non-2xx BDVM response into the states the page renders
+ * distinctly. The three 503 variants carry different `error` codes and
+ * MUST be told apart: flag-off is an expected configuration, not a
+ * failure.
+ *
+ * Returns null for 2xx; otherwise { kind, message } with kind one of
+ * "disabled" | "not_ready" | "unavailable" | "auth" | "error".
+ */
+export function classifyBdvmFailure(status, body) {
+  if (status >= 200 && status < 300) return null;
+  const code = body && typeof body === "object" ? body.error : "";
+  const message =
+    (body && typeof body === "object" && (body.message || body.detail)) || "";
+  if (status === 503 && code === "feature_disabled") {
+    return { kind: "disabled", message: "" };
+  }
+  if (status === 503 && code === "data_not_ready") {
+    return { kind: "not_ready", message };
+  }
+  if (status === 503 && code === "bdvm_unavailable") {
+    return { kind: "unavailable", message };
+  }
+  if (status === 401) {
+    return { kind: "auth", message: "Sign in to view fundamentals." };
+  }
+  return { kind: "error", message: message || `HTTP ${status}` };
+}
+
+function _num(v) {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+/**
+ * Flatten /api/bdvm/values players for the board table, ordered by the
+ * chosen strategy's trade value (backend-computed; we only sort and
+ * number). Input payload is never mutated.
+ */
+export function buildBdvmValueRows(payload, strategy) {
+  const players = Array.isArray(payload?.players) ? payload.players : [];
+  const rows = players.map((p) => {
+    const tv = p?.tradeValue || {};
+    const market = p?.market || {};
+    const quality = p?.quality || {};
+    const projection = p?.projection || {};
+    const range = p?.range || {};
+    return {
+      playerId: p?.playerId ?? p?.name ?? "",
+      name: p?.name ?? "",
+      position: p?.position ?? "",
+      group: p?.group ?? "",
+      age: _num(p?.raw?.age),
+      fpg: _num(projection.fpg),
+      anyProxy: Boolean(projection.anyProxy),
+      sourceCount: _num(projection.sourceCount) ?? 0,
+      tradeValue: _num(tv?.[strategy]),
+      tradeValueAll: tv,
+      marketValue: _num(market.marketValue),
+      marketSource: market.marketSource ?? null,
+      gap: _num(market.gap),
+      signal: p?.signal?.signal ?? "",
+      signalReason: p?.signal?.reason ?? "",
+      score: _num(p?.dynastyScore0to100),
+      confidenceLabel: quality.confidenceLabel ?? "",
+      confidenceScore: _num(quality.confidenceScore),
+      floor: _num(range.floor_p20),
+      ceiling: _num(range.ceiling_p85),
+    };
+  });
+  rows.sort((a, b) => (b.tradeValue ?? -1) - (a.tradeValue ?? -1));
+  return rows.map((r, i) => ({ ...r, rank: i + 1 }));
+}
+
+/** Distinct lineup groups present, in board order, for the filter. */
+export function bdvmGroupOptions(rows) {
+  const seen = new Set();
+  for (const r of rows) if (r.group) seen.add(r.group);
+  const order = ["QB", "RB", "WR", "TE", "DL", "LB", "DB", "K"];
+  const known = order.filter((g) => seen.has(g));
+  const extra = [...seen].filter((g) => !order.includes(g)).sort();
+  return [...known, ...extra];
+}
+
+/**
+ * Flatten /api/bdvm/values picks, ordered by the chosen strategy's EV
+ * (unparseable pick names sink to the bottom, still listed — they are
+ * unpriced, not hidden).
+ */
+export function buildBdvmPickRows(payload, strategy) {
+  const picks = Array.isArray(payload?.picks) ? payload.picks : [];
+  const rows = picks.map((p) => {
+    const dist = p?.distribution?.[strategy] || null;
+    return {
+      name: p?.name ?? "",
+      ev: _num(dist?.ev),
+      pHit: _num(dist?.p_hit),
+      median: _num(dist?.median),
+      ceiling: _num(dist?.ceiling),
+      marketValue: _num(p?.market?.marketValue),
+      marketSource: p?.market?.marketSource ?? null,
+      yearsOut: _num(p?.yearsOut),
+      unpriced: !p?.distribution,
+      reason: p?.reason ?? "",
+    };
+  });
+  rows.sort((a, b) => (b.ev ?? -1) - (a.ev ?? -1));
+  return rows;
+}
+
+/** Flatten /api/bdvm/roster rosters for the strategy table. */
+export function buildBdvmRosterRows(payload) {
+  const rosters = Array.isArray(payload?.rosters) ? payload.rosters : [];
+  return rosters.map((r) => ({
+    key: String(r?.ownerId || r?.name || ""),
+    name: r?.name ?? "",
+    direction: r?.direction ?? "",
+    strategy: r?.strategy ?? "",
+    contender: _num(r?.capitals?.contender),
+    balanced: _num(r?.capitals?.balanced),
+    rebuilder: _num(r?.capitals?.rebuilder),
+    nowFutureRatio: _num(r?.nowFutureRatio),
+    valueWeightedAge: _num(r?.valueWeightedAge),
+    starterFpg: _num(r?.starterFpg),
+    assetCount: _num(r?.assetCount) ?? 0,
+    pickCount: _num(r?.pickCount) ?? 0,
+    assets: Array.isArray(r?.assets) ? r.assets : [],
+  }));
+}
+
+/** Flatten /api/bdvm/trades packages for the double-positive table. */
+export function buildBdvmTradeRows(payload) {
+  const trades = Array.isArray(payload?.trades) ? payload.trades : [];
+  return trades.map((t, i) => ({
+    key: `${t?.from?.ownerId ?? ""}-${t?.to?.ownerId ?? ""}-${i}`,
+    aName: t?.from?.name ?? "",
+    aStrategy: t?.from?.strategy ?? "",
+    aGives: Array.isArray(t?.from?.gives) ? t.from.gives : [],
+    aGain: _num(t?.from?.gain),
+    bName: t?.to?.name ?? "",
+    bStrategy: t?.to?.strategy ?? "",
+    bGives: Array.isArray(t?.to?.gives) ? t.to.gives : [],
+    bGain: _num(t?.to?.gain),
+    minGain: _num(t?.minGain),
+    fairnessPct: _num(t?.marketFairnessPct),
+    fairnessBasis: t?.fairnessBasis ?? "",
+  }));
+}
+
+/** Badge tone for a market signal. Tones carry meaning: BUY/SELL are
+ * market semantics; NO_MARKET is an absence, not a state. */
+export function bdvmSignalTone(signal) {
+  switch (signal) {
+    case "STRONG_BUY":
+    case "BUY":
+      return "positive";
+    case "SELL":
+      return "warning";
+    case "STRONG_SELL":
+      return "negative";
+    case "NO_MARKET":
+      return "outline";
+    default:
+      return "neutral";
+  }
+}
+
+/** Badge tone for a roster direction. Rebuild is a strategy, not a bad
+ * outcome — info, never negative. */
+export function bdvmDirectionTone(direction) {
+  switch (direction) {
+    case "contend":
+      return "positive";
+    case "rebuild":
+      return "info";
+    default:
+      return "neutral";
+  }
+}
+
+/** "1,234" for trade-scale values; em dash for absent (never 0-for-null). */
+export function formatBdvmValue(v) {
+  if (typeof v !== "number" || !Number.isFinite(v)) return "—";
+  return Math.round(v).toLocaleString();
+}
+
+/** Signed gap: "+412" / "−93"; em dash when the market has no anchor. */
+export function formatBdvmGap(v) {
+  if (typeof v !== "number" || !Number.isFinite(v)) return "—";
+  const rounded = Math.round(v);
+  if (rounded > 0) return `+${rounded.toLocaleString()}`;
+  if (rounded < 0) return `−${Math.abs(rounded).toLocaleString()}`;
+  return "0";
+}
+
+/** One decimal, em dash for absent. */
+export function formatBdvmDecimal(v, digits = 1) {
+  if (typeof v !== "number" || !Number.isFinite(v)) return "—";
+  return v.toFixed(digits);
+}

--- a/frontend/lib/nav-model.js
+++ b/frontend/lib/nav-model.js
@@ -68,6 +68,7 @@ export const NAV_MODEL = [
     items: [
       { href: "/trending", label: "Trending", hint: "Biggest rank movers, last 1d/7d/30d", keywords: ["movers", "risers", "fallers"] },
       { href: "/edge", label: "Edge", hint: "Where ranking sources disagree most", keywords: ["signals", "disagreement"] },
+      { href: "/bdvm", label: "Fundamentals", hint: "BDVM projection-driven values vs the market", keywords: ["bdvm", "fundamental", "projections", "buy low"] },
       { href: "/intel", label: "Sharp Tracker", hint: "What league-mates buy/sell across their leagues", keywords: ["sleeper intelligence"] },
       { href: "/idptc-rookies", label: "Rookie Lab", hint: "Rookie board (IDPTC + KTC) with blurbs + export", keywords: ["rookies", "idptc"] },
     ],

--- a/scripts/bdvm_build_baseline.py
+++ b/scripts/bdvm_build_baseline.py
@@ -7,6 +7,18 @@ latest committed contract export by default), builds the BDVM §8.3
 proxy projections, and writes an immutable snapshot under
 ``data/bdvm/projections/<season>/``.
 
+Real (non-proxy) records from the previous latest snapshot are carried
+forward over the fresh proxy baseline: a weekly baseline rebuild must
+never silently downgrade the serving board from real projections back
+to proxies just because the real source's stage failed that week.
+Carried records keep their original per-record ``asOf``, so the
+consensus staleness penalty downweights them as they age instead of
+this script deleting them.
+
+Snapshots are immutable and date-stamped, so a same-day rerun (boot
+catch-up, manual ``systemctl start``) is a NO-OP success, not a
+failure — the expensive nflverse fetch is skipped entirely.
+
 Usage::
 
     python scripts/bdvm_build_baseline.py --season 2026
@@ -14,7 +26,8 @@ Usage::
         --contract exports/latest/dynasty_data_2026-07-27.json \
         --seasons-back 3 --label baseline
 
-Exit codes: 0 success, 1 nothing built, 2 error.
+Exit codes: 0 success (including the same-day no-op), 1 nothing built,
+2 error.
 """
 
 from __future__ import annotations
@@ -29,13 +42,40 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
+from src.bdvm import projections as _proj  # noqa: E402
 from src.bdvm.baseline import fetch_and_build_baseline  # noqa: E402
-from src.bdvm.projections import write_snapshot  # noqa: E402
+from src.bdvm.projections import (  # noqa: E402
+    ProjectionError,
+    latest_snapshot_path,
+    load_snapshot,
+    write_snapshot,
+)
 
 
 def _default_contract_path() -> Path | None:
     candidates = sorted(glob.glob(str(REPO_ROOT / "exports" / "latest" / "dynasty_data_*.json")))
     return Path(candidates[-1]) if candidates else None
+
+
+def _target_path(season: int, as_of: str, label: str) -> Path:
+    """The exact path write_snapshot would use (kept in lockstep)."""
+    suffix = f"_{label}" if label else ""
+    return _proj.SNAPSHOT_DIR / str(season) / f"projections_{str(as_of)[:10]}{suffix}.json"
+
+
+def merge_baseline_over_prior(new_records, prior_records):
+    """Carry prior real (non-proxy) records forward over a fresh proxy
+    baseline.
+
+    Real records win per player: the new proxy for a player covered by
+    a carried real record is dropped (same policy as
+    idpshow_projections.merge_into_snapshot, from the other side).
+    Returns (merged_records, carried_count).
+    """
+    real = [r for r in prior_records if not r.is_proxy]
+    covered = {r.player_key for r in real}
+    kept = [r for r in new_records if r.player_key not in covered]
+    return kept + real, len(real)
 
 
 def main() -> int:
@@ -53,6 +93,14 @@ def main() -> int:
     parser.add_argument("--dry-run", action="store_true", help="build but do not write")
     args = parser.parse_args()
 
+    as_of = datetime.now(timezone.utc).date().isoformat()
+
+    # Same-day rerun → no-op success BEFORE the expensive fetch.
+    target = _target_path(args.season, as_of, args.label)
+    if not args.dry_run and target.exists():
+        print(f"snapshot for today already exists — no-op: {target}")
+        return 0
+
     contract_path = args.contract or _default_contract_path()
     if contract_path is None or not contract_path.exists():
         print("ERROR: no contract export found for scoring settings", file=sys.stderr)
@@ -63,7 +111,6 @@ def main() -> int:
         print(f"ERROR: {contract_path} has no sleeper.scoringSettings", file=sys.stderr)
         return 2
 
-    as_of = datetime.now(timezone.utc).date().isoformat()
     try:
         records, summary = fetch_and_build_baseline(
             season=args.season,
@@ -81,10 +128,28 @@ def main() -> int:
     if not records:
         print("nothing built (no realized history?)", file=sys.stderr)
         return 1
+
+    prior = latest_snapshot_path(args.season)
+    if prior is not None:
+        try:
+            _prior_as_of, prior_records = load_snapshot(prior)
+        except (OSError, ValueError) as exc:
+            print(f"WARN: could not read prior snapshot {prior}: {exc}", file=sys.stderr)
+            prior_records = []
+        records, carried = merge_baseline_over_prior(records, prior_records)
+        if carried:
+            print(f"carried forward {carried} real (non-proxy) records from {prior.name}")
+
     if args.dry_run:
         print("dry run — snapshot not written")
         return 0
-    path = write_snapshot(records, season=args.season, as_of=as_of, label=args.label)
+    try:
+        path = write_snapshot(records, season=args.season, as_of=as_of, label=args.label)
+    except ProjectionError as exc:
+        # Race with a concurrent same-day run — the snapshot exists, so
+        # the day's work is done.
+        print(f"snapshot for today already exists — no-op ({exc})")
+        return 0
     print(f"snapshot written: {path} ({len(records)} records)")
     return 0
 

--- a/scripts/fetch_idpshow_projections.py
+++ b/scripts/fetch_idpshow_projections.py
@@ -35,7 +35,8 @@ Run
     python3 scripts/fetch_idpshow_projections.py --season 2026
     python3 scripts/fetch_idpshow_projections.py --season 2026 --dry-run
 
-Exit codes: 0 snapshot written, 1 no usable data / paywalled, 2 error.
+Exit codes: 0 snapshot written (or today's already exists — no-op),
+1 no usable data / paywalled, 2 error.
 """
 
 from __future__ import annotations
@@ -56,6 +57,7 @@ from src.bdvm.idpshow_projections import (  # noqa: E402
     pick_best_table,
     records_from_rows,
 )
+from src.bdvm.projections import ProjectionError  # noqa: E402
 from src.utils.name_clean import normalize_player_name  # noqa: E402
 
 ARTICLE_URL = "https://www.theidpshow.com/p/2026-idp-fantasy-football-projections-rankings"
@@ -145,7 +147,15 @@ def main() -> int:
     if args.dry_run:
         print("dry run — snapshot not written")
         return 0
-    _path, merge_summary = merge_into_snapshot(records, season=args.season, as_of=as_of)
+    try:
+        _path, merge_summary = merge_into_snapshot(records, season=args.season, as_of=as_of)
+    except ProjectionError as exc:
+        # Snapshots are immutable and date-stamped: a same-day rerun
+        # (boot catch-up, manual restart) collides with today's file.
+        # The day's merge already happened — no-op success, not a
+        # failure the journal blames on cookies.
+        print(f"snapshot for today already exists — no-op ({exc})")
+        return 0
     print(json.dumps(merge_summary, indent=1))
     return 0
 

--- a/scripts/refresh_bdvm_projections.py
+++ b/scripts/refresh_bdvm_projections.py
@@ -1,0 +1,232 @@
+"""Prod-side BDVM projection snapshot refresh (baseline + IDP Show).
+
+Composes the two existing snapshot producers into the one command the
+``dynasty-bdvm-refresh`` systemd timer runs weekly on the VPS:
+
+1. ``scripts/bdvm_build_baseline.py`` — the BDVM §8.3 reconstructed
+   baseline (public nflverse data, no credentials).  It carries prior
+   real (non-proxy) records forward, so a baseline rebuild can never
+   downgrade the serving board from real projections back to proxies.
+2. ``scripts/fetch_idpshow_projections.py`` — The IDP Show real IDP
+   projections (authenticated via ``idpshow_session.json``).  Real
+   records supersede baseline proxies per player at merge, so order
+   matters: baseline first, real source second.
+
+Both producers treat "today's snapshot already exists" as a no-op
+success, so boot-time catch-up runs and manual reruns stay green.
+
+WHY A PROD-SIDE TIMER AND NOT CI: ``GET /api/bdvm/values`` reads the
+latest snapshot under ``data/bdvm/projections/<season>/`` — a LOCAL
+file on the box serving the API (``data/`` is gitignored repo-wide).
+The producer has to run where the reader lives, exactly like the
+player-context refresh (see dynasty-playerctx-refresh.service.template).
+
+Session cookies: the fetcher reads only the repo-root
+``idpshow_session.json``.  The operator mints and refreshes cookies at
+the rankings-fetch work dir (``/var/lib/idpshow-fetch/`` — see
+scripts/fetch_idpshow.py), so before the IDP Show stage this script
+stages the FRESHEST jar into the repo root: newest mtime wins, the
+copy is atomic and 0600 from birth, and an unreadable candidate is a
+warning, never a crash — session trouble must not break the exit-code
+contract.  There is no copy-back: no fetcher ever mutates the jar.
+
+Exit codes (systemd journal contract, playerctx style):
+  0 - at least one stage wrote a snapshot
+  1 - soft failure: no stage wrote anything; last-good snapshot untouched
+  2 - a stage hard-errored (its own exit 2); last-good untouched
+
+Usage::
+
+    python scripts/refresh_bdvm_projections.py                # season auto
+    python scripts/refresh_bdvm_projections.py --season 2026
+    python scripts/refresh_bdvm_projections.py --skip-idpshow
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SESSION_NAME = "idpshow_session.json"
+DEFAULT_WORKDIR_SESSION = Path("/var/lib/idpshow-fetch") / SESSION_NAME
+REMINT_HINT = (
+    f"mint cookies per scripts/fetch_idpshow.py and place them at "
+    f"{DEFAULT_WORKDIR_SESSION} (or pass --session)"
+)
+
+
+def log(msg: str) -> None:
+    print(f"[bdvm-refresh] {msg}")
+
+
+def _auto_season() -> int:
+    """Target (upcoming) season.
+
+    Prefer the contract's ``currentDraftYear`` (the number the rest of
+    the platform runs on); fall back to a date rule (Jan/Feb belong to
+    the previous season) only when no contract export is readable.
+    """
+    exports = sorted((REPO / "exports" / "latest").glob("dynasty_data_*.json"))
+    if exports:
+        try:
+            payload = json.loads(exports[-1].read_text(encoding="utf-8"))
+            year = payload.get("currentDraftYear")
+            if isinstance(year, int) and 2000 < year < 2100:
+                return year
+        except (OSError, ValueError) as exc:
+            log(f"WARN: could not read season from {exports[-1].name}: {exc}")
+    now = datetime.now(timezone.utc)
+    return now.year - 1 if now.month <= 2 else now.year
+
+
+def _run_stage(name: str, cmd: list[str]) -> int:
+    log(f"stage {name}: {' '.join(cmd)}")
+    proc = subprocess.run(cmd, cwd=REPO)
+    log(f"stage {name}: exit {proc.returncode}")
+    return proc.returncode
+
+
+def _atomic_copy_0600(src: Path, dst: Path) -> None:
+    """Copy src → dst atomically, 0600 from birth (never a torn or
+    world-readable cookie jar, even mid-copy)."""
+    data = src.read_bytes()
+    fd, tmp_name = tempfile.mkstemp(dir=str(dst.parent), prefix=f".{dst.name}.")
+    try:
+        try:
+            os.write(fd, data)
+            os.fchmod(fd, 0o600)
+        finally:
+            os.close(fd)
+        os.replace(tmp_name, dst)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _stage_session_file(explicit: str | None) -> Path | None:
+    """Stage the freshest session jar into the repo root (newest wins).
+
+    The fetcher reads only ``REPO/idpshow_session.json``; the operator
+    re-mints cookies at the work-dir location.  An existing repo copy
+    is therefore REPLACED whenever a candidate is newer (mtime) — a
+    stale repo jar must never shadow a fresh re-mint forever.  Probe
+    order: --session, $BDVM_IDPSHOW_SESSION, the shared work-dir jar.
+    Any OSError on a candidate is a warning and the next candidate is
+    tried; staging problems never break the exit-code contract.
+
+    Returns the path staged from, or None when nothing was staged.
+    """
+    repo_session = REPO / SESSION_NAME
+    candidates = [
+        Path(explicit) if explicit else None,
+        Path(os.environ["BDVM_IDPSHOW_SESSION"])
+        if os.environ.get("BDVM_IDPSHOW_SESSION")
+        else None,
+        DEFAULT_WORKDIR_SESSION,
+    ]
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        try:
+            if not candidate.is_file():
+                continue
+            if repo_session.exists() and repo_session.stat().st_mtime >= candidate.stat().st_mtime:
+                continue  # repo copy is at least as fresh as this candidate
+            _atomic_copy_0600(candidate, repo_session)
+            log(f"staged session cookies from {candidate}")
+            return candidate
+        except OSError as exc:
+            log(f"WARN: could not stage session cookies from {candidate}: {exc}")
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--season",
+        type=int,
+        default=None,
+        help="target season (default: contract currentDraftYear, else date rule)",
+    )
+    parser.add_argument("--skip-baseline", action="store_true")
+    parser.add_argument("--skip-idpshow", action="store_true")
+    parser.add_argument(
+        "--session",
+        default=None,
+        help=f"path to {SESSION_NAME} to stage into the repo root "
+        f"(default probe: $BDVM_IDPSHOW_SESSION, then {DEFAULT_WORKDIR_SESSION})",
+    )
+    args = parser.parse_args()
+
+    season = args.season if args.season is not None else _auto_season()
+    log(f"refreshing BDVM projection snapshots for season {season}")
+
+    wrote_any = False
+    hard_error = False
+
+    if args.skip_baseline:
+        log("baseline stage skipped by flag")
+    else:
+        rc = _run_stage(
+            "baseline",
+            [sys.executable, "scripts/bdvm_build_baseline.py", "--season", str(season)],
+        )
+        if rc == 0:
+            wrote_any = True
+        elif rc == 1:
+            log("WARN: baseline built nothing; last-good snapshot untouched")
+        else:
+            log("ERROR: baseline stage hard-errored")
+            hard_error = True
+
+    if args.skip_idpshow:
+        log("idpshow stage skipped by flag")
+    else:
+        _stage_session_file(args.session)
+        repo_session = REPO / SESSION_NAME
+        if not repo_session.exists():
+            log(
+                "WARN: no idpshow session cookies found - skipping the real-source "
+                f"stage. Proxy-only snapshots remain flagged is_proxy; {REMINT_HINT}."
+            )
+        else:
+            rc = _run_stage(
+                "idpshow",
+                [sys.executable, "scripts/fetch_idpshow_projections.py", "--season", str(season)],
+            )
+            if rc == 0:
+                wrote_any = True
+            elif rc == 1:
+                log(
+                    "WARN: idpshow returned no usable data (expired cookies / paywall?). "
+                    "Previously merged real records stay on the board via the baseline "
+                    f"carry-forward; {REMINT_HINT}."
+                )
+            else:
+                log("ERROR: idpshow stage hard-errored")
+                hard_error = True
+
+    if wrote_any:
+        log("done: snapshot(s) written")
+        return 0
+    if hard_error:
+        log("done: hard error and nothing written")
+        return 2
+    log("done: nothing written (soft); last-good snapshot still serves")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/api/bdvm_api.py
+++ b/src/api/bdvm_api.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 import threading
+from collections import OrderedDict
 from typing import Any, Mapping
 
 from src.api import league_registry as _league_registry
@@ -30,8 +31,13 @@ from src.bdvm.service import run_valuation
 _LOGGER = logging.getLogger(__name__)
 
 _lock = threading.Lock()
-_cache_key: tuple | None = None
-_cache_value: dict[str, Any] | None = None
+# Small LRU, not a single slot: the roster/trades path always computes
+# with the default surplus mode while /api/bdvm/values may carry a
+# non-default one — a single-entry cache would make those two keys
+# evict each other on every alternation, turning each request into a
+# cold multi-second engine run.
+_VALUES_CACHE_MAX = 4
+_values_cache: OrderedDict[tuple, dict[str, Any]] = OrderedDict()
 
 _aux_lock = threading.Lock()
 _context_cache: dict[int, Mapping[str, Any]] = {}
@@ -88,7 +94,6 @@ def get_bdvm_values(
     params: ParamSet | None = None,
 ) -> dict[str, Any]:
     """Compute (or serve cached) BDVM values for one league."""
-    global _cache_key, _cache_value
     params = params or load_param_set()
     season = int(contract.get("currentDraftYear") or 0)
     snapshot = latest_snapshot_path(season) if season else None
@@ -101,8 +106,10 @@ def get_bdvm_values(
         surplus_mode,
     )
     with _lock:
-        if key == _cache_key and _cache_value is not None:
-            return _cache_value
+        cached = _values_cache.get(key)
+        if cached is not None:
+            _values_cache.move_to_end(key)
+            return cached
 
     roster_settings, idp_enabled, scoring_profile = _registry_settings_for(league_key)
     context = _context_for(season) if season else {}
@@ -119,8 +126,10 @@ def get_bdvm_values(
         schedule_weeks=schedule_weeks,
     )
     with _lock:
-        _cache_key = key
-        _cache_value = payload
+        _values_cache[key] = payload
+        _values_cache.move_to_end(key)
+        while len(_values_cache) > _VALUES_CACHE_MAX:
+            _values_cache.popitem(last=False)
     return payload
 
 
@@ -179,10 +188,8 @@ def get_bdvm_trades(
 
 def reset_cache() -> None:
     """Test hook."""
-    global _cache_key, _cache_value
     with _lock:
-        _cache_key = None
-        _cache_value = None
+        _values_cache.clear()
     with _aux_lock:
         _context_cache.clear()
         _schedule_cache.clear()

--- a/tests/bdvm/test_bdvm_api_cache.py
+++ b/tests/bdvm/test_bdvm_api_cache.py
@@ -1,0 +1,63 @@
+"""bdvm_api values cache: must be multi-entry.
+
+The roster/trades path always computes with the default surplus mode
+while /api/bdvm/values may carry a non-default one.  A single-slot
+cache makes those two keys evict each other on every alternation —
+every request becomes a cold multi-second engine run.  Pinned here:
+alternating keys coexist.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from src.api import bdvm_api
+
+
+def _contract():
+    # No currentDraftYear → season 0 → no snapshot/context/schedule
+    # lookups; run_valuation is mocked anyway.
+    return {"generatedAt": "2026-07-28T00:00:00Z", "playersArray": []}
+
+
+class TestValuesCacheIsMultiEntry(unittest.TestCase):
+    def setUp(self):
+        bdvm_api.reset_cache()
+        self.addCleanup(bdvm_api.reset_cache)
+
+    def test_alternating_surplus_modes_do_not_evict_each_other(self):
+        contract = _contract()
+        calls = []
+
+        def fake_run_valuation(_contract, **kwargs):
+            calls.append(kwargs.get("surplus_mode"))
+            return {"status": "ok", "meta": {"surplusMode": kwargs.get("surplus_mode")}}
+
+        with mock.patch.object(bdvm_api, "run_valuation", side_effect=fake_run_valuation):
+            bdvm_api.get_bdvm_values(contract, "dynasty_main", surplus_mode="truncated")
+            bdvm_api.get_bdvm_values(contract, "dynasty_main", surplus_mode="option")
+            out = bdvm_api.get_bdvm_values(contract, "dynasty_main", surplus_mode="truncated")
+        # third call is a cache hit — a single-slot cache would recompute
+        self.assertEqual(calls, ["truncated", "option"])
+        self.assertEqual(out["meta"]["surplusMode"], "truncated")
+
+    def test_lru_evicts_oldest_beyond_capacity(self):
+        contract = _contract()
+        with mock.patch.object(
+            bdvm_api,
+            "run_valuation",
+            side_effect=lambda _c, **kw: {"status": "ok", "meta": {}},
+        ) as rv:
+            for i in range(bdvm_api._VALUES_CACHE_MAX + 1):
+                bdvm_api.get_bdvm_values(contract, f"league_{i}")
+            first_count = rv.call_count
+            # league_0 was evicted → recompute; league_1.. still cached
+            bdvm_api.get_bdvm_values(contract, "league_0")
+            self.assertEqual(rv.call_count, first_count + 1)
+            bdvm_api.get_bdvm_values(contract, f"league_{bdvm_api._VALUES_CACHE_MAX}")
+            self.assertEqual(rv.call_count, first_count + 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_bdvm_build_baseline.py
+++ b/tests/scripts/test_bdvm_build_baseline.py
@@ -1,0 +1,150 @@
+"""Unit tests for ``scripts/bdvm_build_baseline.py``.
+
+Pins the two behaviors a weekly prod timer depends on:
+
+1. Carry-forward — a baseline rebuild must never evict real
+   (non-proxy) records from the serving snapshot; real records win per
+   player and keep their original as_of (staleness handles aging).
+2. Same-day rerun — snapshots are immutable and date-stamped, so a
+   boot-catch-up or manual rerun is a NO-OP success (exit 0) that
+   skips the expensive nflverse fetch entirely, not a red unit blamed
+   on upstream data.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "bdvm_build_baseline.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("bdvm_build_baseline", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+_mod = _load_module()
+
+from src.bdvm.projections import ProjectionRecord  # noqa: E402
+
+
+def _rec(key, *, proxy, source="reconstructedBaseline", as_of="2026-07-20"):
+    return ProjectionRecord(
+        source=source,
+        player_key=key,
+        position="LB",
+        season=2026,
+        as_of=as_of,
+        games=16.0,
+        fpg=10.0,
+        scoring_native=True,
+        is_proxy=proxy,
+    )
+
+
+class TestCarryForward(unittest.TestCase):
+    def test_real_records_win_per_player_and_keep_their_as_of(self):
+        new = [_rec("a", proxy=True, as_of="2026-07-28"), _rec("b", proxy=True, as_of="2026-07-28")]
+        prior = [
+            _rec("a", proxy=False, source="idpShowProjections", as_of="2026-07-21"),
+            _rec("c", proxy=True),  # prior proxies are NOT carried
+        ]
+        merged, carried = _mod.merge_baseline_over_prior(new, prior)
+        self.assertEqual(carried, 1)
+        by_key = {(r.player_key, r.source): r for r in merged}
+        # a: real record carried, new proxy dropped
+        self.assertIn(("a", "idpShowProjections"), by_key)
+        self.assertNotIn(("a", "reconstructedBaseline"), by_key)
+        self.assertEqual(by_key[("a", "idpShowProjections")].as_of, "2026-07-21")
+        # b: fresh proxy kept; c: stale prior proxy gone
+        self.assertIn(("b", "reconstructedBaseline"), by_key)
+        self.assertNotIn(("c", "reconstructedBaseline"), by_key)
+
+    def test_no_prior_reals_is_passthrough(self):
+        new = [_rec("a", proxy=True)]
+        merged, carried = _mod.merge_baseline_over_prior(new, [_rec("z", proxy=True)])
+        self.assertEqual(carried, 0)
+        self.assertEqual([r.player_key for r in merged], ["a"])
+
+
+class TestSameDayNoOp(unittest.TestCase):
+    def _contract(self, tmp: Path) -> Path:
+        path = tmp / "dynasty_data_2026-07-28.json"
+        path.write_text(json.dumps({"sleeper": {"scoringSettings": {"rec": 1.0}}}))
+        return path
+
+    def test_existing_target_short_circuits_before_the_fetch(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            season_dir = tmp / "2026"
+            season_dir.mkdir()
+            # today's baseline snapshot already exists
+            from datetime import datetime, timezone
+
+            today = datetime.now(timezone.utc).date().isoformat()
+            (season_dir / f"projections_{today}_baseline.json").write_text("{}")
+            fetch = mock.MagicMock(side_effect=AssertionError("fetch must not run"))
+            with (
+                mock.patch.object(_mod._proj, "SNAPSHOT_DIR", tmp),
+                mock.patch.object(_mod, "fetch_and_build_baseline", fetch),
+                mock.patch.object(
+                    sys,
+                    "argv",
+                    ["bdvm_build_baseline.py", "--season", "2026"],
+                ),
+            ):
+                rc = _mod.main()
+            self.assertEqual(rc, 0)
+            fetch.assert_not_called()
+
+    def test_write_race_collision_is_still_success(self):
+        import tempfile
+
+        from src.bdvm.projections import ProjectionError
+
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            contract = self._contract(tmp)
+            with (
+                mock.patch.object(_mod._proj, "SNAPSHOT_DIR", tmp / "snaps"),
+                mock.patch.object(
+                    _mod,
+                    "fetch_and_build_baseline",
+                    return_value=([_rec("a", proxy=True)], {"recordsBuilt": 1}),
+                ),
+                mock.patch.object(_mod, "latest_snapshot_path", return_value=None),
+                mock.patch.object(
+                    _mod,
+                    "write_snapshot",
+                    side_effect=ProjectionError("snapshot already exists (immutable): x"),
+                ),
+                mock.patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "bdvm_build_baseline.py",
+                        "--season",
+                        "2026",
+                        "--contract",
+                        str(contract),
+                    ],
+                ),
+            ):
+                rc = _mod.main()
+            self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_refresh_bdvm_projections.py
+++ b/tests/scripts/test_refresh_bdvm_projections.py
@@ -1,0 +1,211 @@
+"""Unit tests for ``scripts/refresh_bdvm_projections.py``.
+
+Pins the timer's operational contract: stage composition order,
+exit-code aggregation (0 wrote / 1 soft / 2 hard), session staging
+probe order, and the missing-session skip that keeps a proxy-only
+refresh a warning rather than a failure.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "refresh_bdvm_projections.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("refresh_bdvm_projections", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+_mod = _load_module()
+
+
+class TestAutoSeason(unittest.TestCase):
+    def test_prefers_contract_current_draft_year(self):
+        # The repo's committed export carries currentDraftYear; whatever
+        # it says is the answer (no date math involved).
+        exports = sorted((REPO / "exports" / "latest").glob("dynasty_data_*.json"))
+        if not exports:
+            self.skipTest("no contract export in tree")
+        season = _mod._auto_season()
+        self.assertIsInstance(season, int)
+        self.assertGreater(season, 2000)
+
+    def test_date_rule_fallback(self):
+        with mock.patch.object(_mod, "REPO", Path("/nonexistent")):
+            season = _mod._auto_season()
+        self.assertIsInstance(season, int)
+
+
+class _RunHarness(unittest.TestCase):
+    """Drive main() with _run_stage mocked to scripted exit codes."""
+
+    def _run(self, argv, stage_codes, session_exists=False):
+        calls = []
+
+        def fake_stage(name, cmd):
+            calls.append((name, cmd))
+            return stage_codes[name]
+
+        fake_session = mock.MagicMock()
+        fake_session.exists.return_value = session_exists
+        real_repo = _mod.REPO
+
+        class FakeRepo:
+            def __truediv__(self, other):
+                if other == _mod.SESSION_NAME:
+                    return fake_session
+                return real_repo / other
+
+        with (
+            mock.patch.object(_mod, "_run_stage", side_effect=fake_stage),
+            mock.patch.object(_mod, "_stage_session_file", return_value=None),
+            mock.patch.object(_mod, "REPO", FakeRepo()),
+            mock.patch.object(sys, "argv", ["refresh_bdvm_projections.py", *argv]),
+        ):
+            rc = _mod.main()
+        return rc, calls
+
+
+class TestExitCodeAggregation(_RunHarness):
+    def test_both_stages_write(self):
+        rc, calls = self._run(
+            ["--season", "2026"],
+            {"baseline": 0, "idpshow": 0},
+            session_exists=True,
+        )
+        self.assertEqual(rc, 0)
+        # order matters: proxies first so real records supersede them
+        self.assertEqual([c[0] for c in calls], ["baseline", "idpshow"])
+
+    def test_baseline_writes_idpshow_paywalled_is_still_success(self):
+        rc, _ = self._run(
+            ["--season", "2026"],
+            {"baseline": 0, "idpshow": 1},
+            session_exists=True,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_nothing_written_is_soft_failure(self):
+        rc, _ = self._run(
+            ["--season", "2026"],
+            {"baseline": 1, "idpshow": 1},
+            session_exists=True,
+        )
+        self.assertEqual(rc, 1)
+
+    def test_hard_error_with_nothing_written_is_2(self):
+        rc, _ = self._run(
+            ["--season", "2026"],
+            {"baseline": 2, "idpshow": 1},
+            session_exists=True,
+        )
+        self.assertEqual(rc, 2)
+
+    def test_hard_error_after_a_write_is_still_0(self):
+        # A written baseline serves; the idpshow error shows in the
+        # journal via the ERROR log line, not the exit code.
+        rc, _ = self._run(
+            ["--season", "2026"],
+            {"baseline": 0, "idpshow": 2},
+            session_exists=True,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_missing_session_skips_idpshow_stage(self):
+        rc, calls = self._run(
+            ["--season", "2026"],
+            {"baseline": 0},
+            session_exists=False,
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual([c[0] for c in calls], ["baseline"])
+
+    def test_skip_flags(self):
+        rc, calls = self._run(
+            ["--season", "2026", "--skip-baseline", "--skip-idpshow"],
+            {},
+        )
+        self.assertEqual(rc, 1)  # nothing written → soft
+        self.assertEqual(calls, [])
+
+
+class TestSessionStaging(unittest.TestCase):
+    """Staging must be newest-wins (a stale repo jar can never shadow a
+    fresh operator re-mint forever), atomic + 0600, and OSError-proof
+    (session trouble never breaks the exit-code contract)."""
+
+    def test_newer_candidate_replaces_stale_repo_copy(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            repo = base / "repo"
+            work = base / "work"
+            repo.mkdir()
+            work.mkdir()
+            repo_jar = repo / _mod.SESSION_NAME
+            repo_jar.write_text("stale")
+            os.utime(repo_jar, (1000, 1000))
+            candidate = work / _mod.SESSION_NAME
+            candidate.write_text("fresh")
+            os.utime(candidate, (2000, 2000))
+            with mock.patch.object(_mod, "REPO", repo):
+                staged_from = _mod._stage_session_file(str(candidate))
+            self.assertEqual(staged_from, candidate)
+            self.assertEqual(repo_jar.read_text(), "fresh")
+            self.assertEqual(repo_jar.stat().st_mode & 0o777, 0o600)
+
+    def test_fresher_repo_copy_is_kept(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            repo = base / "repo"
+            work = base / "work"
+            repo.mkdir()
+            work.mkdir()
+            repo_jar = repo / _mod.SESSION_NAME
+            repo_jar.write_text("current")
+            os.utime(repo_jar, (2000, 2000))
+            candidate = work / _mod.SESSION_NAME
+            candidate.write_text("older")
+            os.utime(candidate, (1000, 1000))
+            with mock.patch.object(_mod, "REPO", repo):
+                staged_from = _mod._stage_session_file(str(candidate))
+            self.assertIsNone(staged_from)
+            self.assertEqual(repo_jar.read_text(), "current")
+
+    def test_oserror_on_candidate_is_tolerated(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            repo = base / "repo"
+            repo.mkdir()
+            candidate = base / _mod.SESSION_NAME
+            candidate.write_text("x")
+            with (
+                mock.patch.object(_mod, "REPO", repo),
+                mock.patch.object(
+                    _mod, "_atomic_copy_0600", side_effect=OSError("permission denied")
+                ),
+            ):
+                # must not raise — the stage is skipped, contract preserved
+                self.assertIsNone(_mod._stage_session_file(str(candidate)))
+            self.assertFalse((repo / _mod.SESSION_NAME).exists())
+
+    def test_nothing_found_anywhere(self):
+        with mock.patch.object(_mod, "REPO", Path("/nonexistent")):
+            with mock.patch.object(_mod.Path, "is_file", return_value=False):
+                self.assertIsNone(_mod._stage_session_file("/also/nonexistent"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# BDVM goes usable: the Fundamentals page + the weekly snapshot cadence

Follow-up to #600 (BDVM v1 engine, merged). That PR shipped the engine behind the `bdvm_engine` flag with API-only access; this one adds the two operational layers that make it a product: a frontend surface to read it, and a prod-side timer to keep its projection snapshots fed. Still zero change to any existing route or the market board; the page renders an explicit "engine switched off" state while the flag is OFF.

## Frontend — `/bdvm` "Fundamentals" (Intel nav group)

- **Value board**: strategy-currency selector (contender / balanced / rebuilder / risk-neutral), surplus-mode ablation selector (`option` / `truncated` / `plain` → `?surplusMode=`), position + search filters, fundamental-vs-market columns with signed gap and BUY/SELL signal badges, proxy-projection labeling, backend 0–100 score, confidence ticks, rookie-pick EV table (unparseable picks listed as unpriced, not hidden), honest unpriced counts in the meta strip.
- **Rosters**: per-team strategy capitals, league-relative direction badge, now/future ratio, value-weighted age, starter FPG, click-to-expand top-assets drawer.
- **Trade scan**: double-positive packages — each side's gain in its **own** currency, min-gain ordering, market-fairness % + basis (`single_market` vs `model_clearing`), team filter.
- **House rules kept**: `frontend/lib/bdvm.js` is a pure display reshaper (same materializer rule as `buildRows` — every number is backend-computed); ds design-system primitives throughout; league threading via the documented localStorage + `league:changed`/`auth:changed` pattern; the three 503 variants (`feature_disabled` / `data_not_ready` / `bdvm_unavailable`) render distinctly. Dev bridge routes under `frontend/app/api/bdvm/*` follow the draft-capital `proxyGet` pattern (prod nginx bypasses them).
- Tabs stay mounted and the hook skips refetch on re-activation — tab round-trips keep filter state and never re-run the engine.

## Cadence — `dynasty-bdvm-refresh` (weekly, Tue 06:10 UTC)

- `scripts/refresh_bdvm_projections.py` composes the two producers in the order the merge policy requires: reconstructed baseline first, IDP Show real projections merged over it. Season auto-detected from the contract's `currentDraftYear`. Exit codes 0/1/2 in the playerctx style.
- Session jar staged **newest-wins** (atomic, 0600 from birth) from the shared rankings-fetch work dir (`/var/lib/idpshow-fetch/`); missing jar self-skips the stage with the re-mint instructions; **no copy-back** — no fetcher ever mutates the jar (false comments saying otherwise corrected here and in `idpshow_fetch_and_push.sh`).
- Systemd service + timer templates + installer block (installs unconditionally like playerctx — baseline needs no credentials; initial build kicked in the background on first install), README table row. Runs on prod because `/api/bdvm/*` reads local gitignored `data/`.

## Review-driven hardening (adversarial find→verify pass before push)

- **`bdvm_api` values cache: single slot → 4-entry LRU.** The roster/trades path always computes with the default surplus mode; a values request with a non-default `surplusMode` alternating with it would evict the single slot every time — each tab switch a cold multi-second engine run. Pinned by `tests/bdvm/test_bdvm_api_cache.py`.
- **Baseline rebuild carries real records forward.** `bdvm_build_baseline.py` now merges prior non-proxy records over each fresh proxy baseline (real wins per player, original `asOf` kept so staleness downweights naturally). Without this, a weekly rebuild + a failed IDP Show stage silently downgraded the serving board from real projections to proxies with a green exit code.
- **Same-day reruns are no-op successes.** Snapshots are immutable and date-stamped; boot catch-ups and manual restarts previously died on uncaught `ProjectionError` collisions reported as red units with journal messages blaming cookies/nflverse. Both producers now short-circuit (baseline before the expensive nflverse fetch) or catch the write race.
- **Timer omits `Requires=`** — with it, every boot force-starts the service and a service failure can deactivate the timer itself; `[Timer] Unit=` + `Persistent=true` are the correct binding.
- Session staging tolerates `OSError` per candidate (a bad jar can never break the exit-code contract).

## Tests

- **pytest: 4,656 passed** (19 new: carry-forward, same-day no-op, write-race, staging newest-wins + OSError tolerance, exit-code aggregation table, LRU cache behavior).
- **vitest: 1,344 passed** (16 lib tests — 503 classification, strategy re-ordering, null-market-renders-as-absence, non-mutation; 4 page tests — flag-off state, no-snapshot state, verbatim rendering, tab round-trip no-refetch regression).
- Next build + bundle budgets green; `ruff format --check` / `ruff check` clean; `bash -n` on the installer.

## Still on the operator (documented, not automatable from here)

First authenticated IDP Show projections pull needs the VPS session jar (`python3 scripts/refresh_bdvm_projections.py` there, or `scripts/fetch_idpshow_projections.py --csv` with a downloaded sheet); flag flip is `RISKIT_FEATURE_BDVM_ENGINE=1` + backend restart once snapshots exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMN5feuNUUYiLz69deJBTF

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMN5feuNUUYiLz69deJBTF)_