### PR TITLE
feat(bdvm): rankings gap column + signal alerts + Mike Clay offense projections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,6 +455,27 @@ Operational surfaces (post-merge additions):
   it (session jar shared with the rankings fetch timer; stage self-skips
   without it). Exit codes 0/1/2 in the playerctx style; runs on prod
   because the endpoints read local gitignored ``data/``.
+- **Rankings gap column**: /rankings grows a "Fund gap" column
+  (fundamental balanced minus market, tinted by BDVM signal) joined
+  onto board rows AT RENDER TIME from ``/api/bdvm/values`` —
+  playerId-first, name fallback (``lib/bdvm.js::buildBdvmIndex`` /
+  ``bdvmEntryForRow``). The column exists only while the endpoint
+  serves an ok payload and vanishes silently on any 503 (flag off, no
+  snapshot, wrong league). Ranks and the ``#`` column stay
+  backend-stamped — this is display enrichment, never a re-rank; the
+  page's ``presorted`` sort switch gained a ``case "gap"`` (nulls sink).
+- **Signal alerts**: ``src/api/bdvm_signal_alerts.py`` piggybacks on the
+  daily ``/api/signal-alerts/run`` sweep (no new timer). Separate
+  detector from the terminal one by design: different label set
+  (STRONG_BUY..STRONG_SELL actionable; HOLD/NO_MARKET never) and a
+  separate user_kv namespace (``bdvmSignalAlertStateByLeague``, keys
+  ``bdvm:{playerId}``). Roster-scoped via the BDVM roster analysis;
+  whole-league board computed once per league per sweep. **Baseline
+  seeding**: the first sweep for a (user, league) records current
+  actionable signals silently (``notifiedAt: 0``) so flag-on day never
+  floods inboxes — pinned in ``tests/api/test_bdvm_signal_alerts.py``.
+  Flag off → the sweep stamps ``bdvmEnabled: false`` and skips
+  entirely.
 
 ### Single Source of Truth: Rankings Override Path
 Custom source configurations (user-toggled sources or custom weights) flow through the **SAME** canonical pipeline as the default board. There is no frontend ranking engine, period — not even a fallback. `buildRows` is a pure materializer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,14 +403,25 @@ test-pinned (``tests/bdvm/``):
   ``GET /api/bdvm/trades`` (double-positive scan: each side must gain
   in its OWN strategy currency, gated by single-market fairness).
 - Projections come from immutable snapshots under
-  ``data/bdvm/projections/``: real sources first — The IDP Show
-  projections via ``scripts/fetch_idpshow_projections.py``
-  (authenticated Datawrapper/Sheet pattern shared with the idpShow
-  rankings fetcher; ``--csv`` for a manually downloaded sheet) and the
-  manual-CSV adapter — else the §8.3 reconstructed baseline built by
+  ``data/bdvm/projections/``: real sources first — **Mike Clay's ESPN
+  guide** via ``scripts/fetch_clay_projections.py`` (public CDN PDF,
+  ``pdftotext -layout``, team pages only: raw season stat lines for
+  offense — the real OFFENSE source — plus a second IDP feed; combined
+  tackles split with the shared 0.62 solo share; a two-way player gets
+  ONE record combining both sides under the DEFENSIVE position so the
+  scoring gate counts everything; same-side name collisions dropped,
+  never guessed), **The IDP Show** projections via
+  ``scripts/fetch_idpshow_projections.py`` (authenticated
+  Datawrapper/Sheet pattern shared with the idpShow rankings fetcher;
+  ``--csv`` for a manually downloaded sheet) and the manual-CSV
+  adapter — else the §8.3 reconstructed baseline built by
   ``scripts/bdvm_build_baseline.py`` (realized nflverse PPG under the
   league's exact scoring + rookie draft-slot priors, all flagged
-  ``is_proxy``).  Real records supersede proxies per player at merge.
+  ``is_proxy``; carries real records forward on rebuild).  All real
+  sources merge via the shared ``supersede_merge_into_snapshot``
+  policy: each replaces its own prior run wholesale and supersedes
+  proxies per player while other real sources carry through, so a
+  defender covered by Clay AND IDP Show gets a two-source consensus.
   Structured events (closed ontology,
   ``config/bdvm/event_types_v1.json``) adjust module inputs — never a
   final score — from ``data/bdvm/events/<season>.json``.
@@ -451,10 +462,11 @@ Operational surfaces (post-merge additions):
   ``frontend/__tests__/bdvm-lib.test.js`` + ``components/bdvm-page.test.jsx``.
 - **Snapshot cadence**: ``scripts/refresh_bdvm_projections.py`` (weekly
   ``dynasty-bdvm-refresh`` systemd timer, Tue 06:10 UTC) rebuilds the
-  reconstructed baseline then merges The IDP Show real projections over
-  it (session jar shared with the rankings fetch timer; stage self-skips
-  without it). Exit codes 0/1/2 in the playerctx style; runs on prod
-  because the endpoints read local gitignored ``data/``.
+  reconstructed baseline, then merges Mike Clay's guide (self-skips
+  without poppler-utils or on a CDN 404), then The IDP Show real
+  projections (session jar shared with the rankings fetch timer; stage
+  self-skips without it). Exit codes 0/1/2 in the playerctx style; runs
+  on prod because the endpoints read local gitignored ``data/``.
 - **Rankings gap column**: /rankings grows a "Fund gap" column
   (fundamental balanced minus market, tinted by BDVM signal) joined
   onto board rows AT RENDER TIME from ``/api/bdvm/values`` —

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -58,7 +58,7 @@ Timers rendered + enabled by `deploy/install-systemd-service.sh`
 | `dynasty-dlf-fetch.*` | DLF CSV fetch + push (CI is Cloudflare-blocked) | Every 2h | DLF creds in `.env` |
 | `dynasty-idpshow-fetch.*` | IDP Show rankings fetch + push | Every 2h | always |
 | `dynasty-playerctx-refresh.*` | Player context (contracts / snap share / depth chart) → `data/playerctx/snapshot.json`, served by `/api/playerctx/player` | Weekly Tue 05:40 UTC | always (public data, no creds) |
-| `dynasty-bdvm-refresh.*` | BDVM projection snapshots (reconstructed baseline + IDP Show real projections) → `data/bdvm/projections/<season>/`, served by `/api/bdvm/*` (flag `bdvm_engine`) | Weekly Tue 06:10 UTC | always (baseline needs no creds; IDP Show stage self-skips without the session jar) |
+| `dynasty-bdvm-refresh.*` | BDVM projection snapshots (reconstructed baseline + Mike Clay ESPN guide + IDP Show real projections) → `data/bdvm/projections/<season>/`, served by `/api/bdvm/*` (flag `bdvm_engine`) | Weekly Tue 06:10 UTC | always (baseline + Clay need no creds; Clay self-skips without poppler-utils; IDP Show stage self-skips without the session jar) |
 
 `dynasty-playerctx-refresh` and `dynasty-bdvm-refresh` must run **on
 prod**, not in CI: their endpoints read local files and `data/` is

--- a/deploy/systemd/dynasty-bdvm-refresh.service.template
+++ b/deploy/systemd/dynasty-bdvm-refresh.service.template
@@ -5,9 +5,11 @@ Wants=network-online.target
 
 # Produces immutable snapshots under data/bdvm/projections/<season>/ —
 # what GET /api/bdvm/values (feature flag: bdvm_engine) prices players
-# from.  Two stages via scripts/refresh_bdvm_projections.py:
+# from.  Three stages via scripts/refresh_bdvm_projections.py:
 #   1. reconstructed baseline (public nflverse, no credentials)
-#   2. The IDP Show real projections (cookies staged from the
+#   2. Mike Clay's ESPN guide (public CDN PDF; self-skips when
+#      poppler-utils is missing or the seasonal URL 404s)
+#   3. The IDP Show real projections (cookies staged from the
 #      idpshow-fetch work dir; stage self-skips when absent)
 #
 # WHY A PROD-SIDE TIMER AND NOT CI: the endpoint reads a LOCAL file

--- a/frontend/__tests__/bdvm-lib.test.js
+++ b/frontend/__tests__/bdvm-lib.test.js
@@ -19,6 +19,9 @@ import {
   buildBdvmPickRows,
   buildBdvmRosterRows,
   buildBdvmTradeRows,
+  buildBdvmIndex,
+  bdvmEntryForRow,
+  bdvmSignalEdgeCss,
   bdvmGroupOptions,
   bdvmSignalTone,
   bdvmDirectionTone,
@@ -206,6 +209,48 @@ describe("buildBdvmTradeRows", () => {
     expect(row.bGain).toBe(250.0);
     expect(row.minGain).toBe(250.0);
     expect(row.fairnessBasis).toBe("single_market");
+  });
+});
+
+describe("buildBdvmIndex + bdvmEntryForRow (rankings gap join)", () => {
+  const payload = {
+    players: [
+      player("Elite Backer", { playerId: "sid1" }),
+      player("No Id Guy", { playerId: null }),
+    ],
+  };
+
+  it("joins playerId-first, then lowercased name", () => {
+    const index = buildBdvmIndex(payload);
+    // rankings rows carry playerId at top level or under raw
+    expect(bdvmEntryForRow(index, { raw: { playerId: "sid1" }, name: "X" }).gap).toBe(200.0);
+    expect(bdvmEntryForRow(index, { playerId: "sid1", name: "X" }).gap).toBe(200.0);
+    expect(bdvmEntryForRow(index, { name: "NO ID GUY" }).gap).toBe(200.0);
+    expect(bdvmEntryForRow(index, { name: "Unknown Player" })).toBeNull();
+  });
+
+  it("returns null for an empty or non-ok payload shape", () => {
+    expect(buildBdvmIndex({ players: [] })).toBeNull();
+    expect(buildBdvmIndex(null)).toBeNull();
+  });
+
+  it("null index resolves nothing (column vanishes)", () => {
+    expect(bdvmEntryForRow(null, { name: "Elite Backer" })).toBeNull();
+  });
+
+  it("entries carry the tooltip fields", () => {
+    const index = buildBdvmIndex(payload);
+    const entry = bdvmEntryForRow(index, { name: "elite backer" });
+    expect(entry.fundamental).toBe(5000);
+    expect(entry.marketValue).toBe(4800);
+    expect(entry.signal).toBe("BUY");
+  });
+
+  it("maps signals onto the Edge column's pill classes", () => {
+    expect(bdvmSignalEdgeCss("BUY")).toBe("edge-buy");
+    expect(bdvmSignalEdgeCss("STRONG_SELL")).toBe("edge-sell");
+    expect(bdvmSignalEdgeCss("HOLD")).toBe("edge-hold");
+    expect(bdvmSignalEdgeCss("NO_MARKET")).toBe("");
   });
 });
 

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -43,6 +43,14 @@ import {
   teamOptions,
 } from "@/lib/player-filters";
 import { buildTeamByPlayer } from "@/lib/waiver-logic";
+import { useBdvmEndpoint } from "@/components/useBdvm";
+import {
+  buildBdvmIndex,
+  bdvmEntryForRow,
+  bdvmSignalEdgeCss,
+  formatBdvmGap,
+  formatBdvmValue,
+} from "@/lib/bdvm";
 import HillCurveExplorer from "@/components/graphs/HillCurveExplorer";
 import TierGapWaterfall from "@/components/graphs/TierGapWaterfall";
 import RankChangeGlyph from "@/components/graphs/RankChangeGlyph";
@@ -304,6 +312,17 @@ export default function RankingsPage() {
   // Recent news → per-row news chip (lookupPlayerNews is O(1); the
   // news hook is single-flighted at module level).
   const { byPlayer: newsByPlayer } = useNews();
+
+  // BDVM fundamental gap — optional flag-gated enrichment. Non-blocking:
+  // the board renders without it; the column appears only when the
+  // endpoint answers ok (bdvm_engine on + a projection snapshot exists)
+  // and vanishes silently on any 503/failure. League-config-scoped data
+  // joined onto rows at render time — never stamped into the contract.
+  const { data: bdvmData, failure: bdvmFailure } = useBdvmEndpoint("/api/bdvm/values");
+  const bdvmIndex = useMemo(
+    () => (!bdvmFailure && bdvmData?.status === "ok" ? buildBdvmIndex(bdvmData) : null),
+    [bdvmData, bdvmFailure],
+  );
   const newsPlayerMeta = useMemo(() => buildPlayerMetaIndex(rows), [rows]);
   const [query, setQuery] = useState("");
   const [posFilter, setPosFilter] = useState("all");
@@ -537,6 +556,16 @@ export default function RankingsPage() {
           vb = order[b.confidenceBucket] ?? 3;
           return (va - vb) * dir;
         }
+        case "gap": {
+          // BDVM fundamental gap. Unpriced/no-market rows sink to the
+          // bottom regardless of direction, then keep rank order.
+          const ga = bdvmEntryForRow(bdvmIndex, a)?.gap;
+          const gb = bdvmEntryForRow(bdvmIndex, b)?.gap;
+          if (ga == null && gb == null) return resolvedRank(a) - resolvedRank(b);
+          if (ga == null) return 1;
+          if (gb == null) return -1;
+          return (ga - gb) * dir;
+        }
         default: {
           // Dynamic source-column sort: col === `src:${sourceKey}`.
           // Sort by the same 9,999-scale ``valueContribution`` the cell
@@ -580,6 +609,7 @@ export default function RankingsPage() {
     advCriteria,
     advActiveCount,
     teamByPlayer,
+    bdvmIndex,
   ]);
 
   // ── Top movers (from the current filtered view — pre-R2 behavior) ──
@@ -1068,41 +1098,86 @@ export default function RankingsPage() {
           );
         },
       },
-      {
-        key: "signal",
-        header: "Signal",
+    );
+
+    // BDVM fundamental gap — present only while the flag-gated endpoint
+    // serves an ok payload (see the bdvmIndex memo). Display-only join;
+    // ranks and the # column stay backend-stamped.
+    if (bdvmIndex) {
+      cols.push({
+        key: "gap",
+        header: "Fund gap",
+        numeric: true,
+        sortable: true,
         hideBelow: "md",
-        width: 170,
+        width: 110,
+        headerTitle:
+          "BDVM fundamental value (balanced) minus market anchor — " +
+          "positive means the market underprices the player. " +
+          "Visible only while the BDVM engine is enabled.",
         render: (row) => {
-          const action = actionLabel(row);
-          const cautions = cautionLabels(row);
-          return (
-            <>
-              {action && (
-                <span
-                  className={`action-label ${action.css}`}
-                  title={action.title}
-                >
-                  {action.label}
-                </span>
-              )}
-              {cautions.map((c) => (
-                <span
-                  key={c.label}
-                  className={`action-label ${c.css}`}
-                  title={c.title}
-                >
-                  {c.label}
-                </span>
-              ))}
-              {!action && cautions.length === 0 && (
-                <span className="muted">—</span>
-              )}
-            </>
+          const entry = bdvmEntryForRow(bdvmIndex, row);
+          if (!entry) return <span className="muted">—</span>;
+          if (entry.gap == null) {
+            return (
+              <span
+                className="muted"
+                title={entry.signalReason || "no market anchor for this asset"}
+              >
+                —
+              </span>
+            );
+          }
+          const css = bdvmSignalEdgeCss(entry.signal);
+          const title =
+            `${entry.signal}: ${entry.signalReason} — fundamental ` +
+            `${formatBdvmValue(entry.fundamental)} vs market ` +
+            `${formatBdvmValue(entry.marketValue)}`;
+          return css ? (
+            <span className={`edge-label ${css}`} title={title}>
+              {formatBdvmGap(entry.gap)}
+            </span>
+          ) : (
+            <span title={title}>{formatBdvmGap(entry.gap)}</span>
           );
         },
+      });
+    }
+
+    cols.push({
+      key: "signal",
+      header: "Signal",
+      hideBelow: "md",
+      width: 170,
+      render: (row) => {
+        const action = actionLabel(row);
+        const cautions = cautionLabels(row);
+        return (
+          <>
+            {action && (
+              <span
+                className={`action-label ${action.css}`}
+                title={action.title}
+              >
+                {action.label}
+              </span>
+            )}
+            {cautions.map((c) => (
+              <span
+                key={c.label}
+                className={`action-label ${c.css}`}
+                title={c.title}
+              >
+                {c.label}
+              </span>
+            ))}
+            {!action && cautions.length === 0 && (
+              <span className="muted">—</span>
+            )}
+          </>
+        );
       },
-    );
+    });
 
     return cols;
   }, [
@@ -1115,6 +1190,7 @@ export default function RankingsPage() {
     positionRankByName,
     openPlayerPopup,
     toggleWatchlist,
+    bdvmIndex,
   ]);
 
   const totalCols = columns.length;

--- a/frontend/lib/bdvm.js
+++ b/frontend/lib/bdvm.js
@@ -172,6 +172,61 @@ export function buildBdvmTradeRows(payload) {
   }));
 }
 
+/**
+ * Index /api/bdvm/values players for render-time joins onto board rows
+ * (the /rankings gap column). playerId-first with lowercased-name
+ * fallback — the same id-then-name idiom the ownership join uses.
+ * Returns null when the payload carries no joinable players, so
+ * callers can treat "no index" and "endpoint unavailable" identically
+ * (column vanishes).
+ */
+export function buildBdvmIndex(payload) {
+  const players = Array.isArray(payload?.players) ? payload.players : [];
+  const byId = new Map();
+  const byName = new Map();
+  for (const p of players) {
+    const entry = {
+      gap: _num(p?.market?.gap),
+      marketValue: _num(p?.market?.marketValue),
+      fundamental: _num(p?.tradeValue?.balanced),
+      signal: p?.signal?.signal ?? "",
+      signalReason: p?.signal?.reason ?? "",
+    };
+    const id = p?.playerId != null ? String(p.playerId).trim() : "";
+    if (id) byId.set(id, entry);
+    const name = p?.name ? String(p.name).toLowerCase() : "";
+    if (name) byName.set(name, entry);
+  }
+  return byId.size || byName.size ? { byId, byName } : null;
+}
+
+/** Resolve a board row against a buildBdvmIndex result (or null). */
+export function bdvmEntryForRow(index, row) {
+  if (!index || !row) return null;
+  const id = String(row?.raw?.playerId ?? row?.playerId ?? "").trim();
+  if (id && index.byId.has(id)) return index.byId.get(id);
+  const name = String(row?.name || "").toLowerCase();
+  return (name && index.byName.get(name)) || null;
+}
+
+/** Rankings-page pill class for a BDVM signal — reuses the Edge
+ * column's existing edge-buy/edge-sell/edge-hold styling so the two
+ * market columns read as one visual language. */
+export function bdvmSignalEdgeCss(signal) {
+  switch (signal) {
+    case "STRONG_BUY":
+    case "BUY":
+      return "edge-buy";
+    case "SELL":
+    case "STRONG_SELL":
+      return "edge-sell";
+    case "HOLD":
+      return "edge-hold";
+    default:
+      return "";
+  }
+}
+
 /** Badge tone for a market signal. Tones carry meaning: BUY/SELL are
  * market semantics; NO_MARKET is an absence, not a state. */
 export function bdvmSignalTone(signal) {

--- a/scripts/fetch_clay_projections.py
+++ b/scripts/fetch_clay_projections.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Fetch Mike Clay's ESPN projection guide into a BDVM snapshot.
+
+The guide is a public PDF on ESPN's fantasy draft-kit CDN::
+
+    https://g.espncdn.com/s/ffldraftkit/<yy>/NFLDK<season>_CS_ClayProjections<season>.pdf
+
+Flow
+----
+1. Download the PDF (or take a local file via ``--pdf``).
+2. Extract text with ``pdftotext -layout`` (poppler-utils — a soft
+   dependency: missing binary is a soft skip with an install hint,
+   never a crash).
+3. Parse the 32 team pages with the schema-tolerant adapter
+   (``src/bdvm/clay_projections.py``) — raw season stat lines for
+   offense, combined-tackle defense rows split solo/assist.
+4. Merge into the latest BDVM projection snapshot via the shared
+   supersede policy: Clay replaces its own prior run and supersedes
+   baseline proxies per player; IDP Show records carry through, so
+   defenders covered by both feeds get a two-source consensus.
+
+Usage::
+
+    python3 scripts/fetch_clay_projections.py --season 2026
+    python3 scripts/fetch_clay_projections.py --season 2026 --pdf ~/clay.pdf
+    python3 scripts/fetch_clay_projections.py --season 2026 --dry-run
+
+Exit codes: 0 snapshot written (or today's already exists — no-op),
+1 soft failure (download failed / pdftotext missing / not a usable
+guide), 2 unexpected error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+from src.bdvm.clay_projections import (  # noqa: E402
+    SOURCE_NAME,
+    merge_into_snapshot,
+    parse_clay_text,
+    records_from_rows,
+)
+from src.bdvm.projections import ProjectionError  # noqa: E402
+from src.utils.name_clean import normalize_player_name  # noqa: E402
+
+
+def default_url(season: int) -> str:
+    yy = str(season)[-2:]
+    return (
+        f"https://g.espncdn.com/s/ffldraftkit/{yy}/" f"NFLDK{season}_CS_ClayProjections{season}.pdf"
+    )
+
+
+def _download(url: str, dest: Path) -> bool:
+    try:
+        import requests  # noqa: PLC0415
+
+        resp = requests.get(url, timeout=90)
+        if resp.status_code != 200 or not resp.content.startswith(b"%PDF"):
+            print(
+                f"download failed: HTTP {resp.status_code}, "
+                f"content-type {resp.headers.get('content-type')!r}",
+                file=sys.stderr,
+            )
+            return False
+        dest.write_bytes(resp.content)
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"download failed: {exc}", file=sys.stderr)
+        return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--season", type=int, required=True)
+    parser.add_argument("--pdf", type=Path, default=None, help="parse a local PDF instead")
+    parser.add_argument("--url", default=None, help="override the CDN URL")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    if shutil.which("pdftotext") is None:
+        print(
+            "pdftotext not found — install poppler-utils "
+            "(apt-get install poppler-utils) to enable the Clay guide fetch.",
+            file=sys.stderr,
+        )
+        return 1
+
+    as_of = datetime.now(timezone.utc).date().isoformat()
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        if args.pdf is not None:
+            if not args.pdf.exists():
+                print(f"ERROR: {args.pdf} not found", file=sys.stderr)
+                return 2
+            pdf_path = args.pdf
+        else:
+            url = args.url or default_url(args.season)
+            print(f"fetching {url}")
+            pdf_path = tmp / "clay.pdf"
+            if not _download(url, pdf_path):
+                return 1
+
+        txt_path = tmp / "clay.txt"
+        proc = subprocess.run(
+            ["pdftotext", "-layout", str(pdf_path), str(txt_path)],
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            print(f"pdftotext failed: {proc.stderr.strip()}", file=sys.stderr)
+            return 1
+        text = txt_path.read_text(encoding="utf-8", errors="replace")
+
+    rows, report = parse_clay_text(text)
+    print(json.dumps(report, indent=1))
+    if not rows:
+        print("not a usable projection guide — nothing written", file=sys.stderr)
+        return 1
+
+    records, rec_summary = records_from_rows(
+        rows, season=args.season, as_of=as_of, name_normalizer=normalize_player_name
+    )
+    print(f"projection records ({SOURCE_NAME}): {json.dumps(rec_summary)}")
+    if args.dry_run:
+        print("dry run — snapshot not written")
+        return 0
+    try:
+        _path, merge_summary = merge_into_snapshot(records, season=args.season, as_of=as_of)
+    except ProjectionError as exc:
+        # Same-day rerun collides with today's immutable snapshot —
+        # the day's merge already happened; no-op success.
+        print(f"snapshot for today already exists — no-op ({exc})")
+        return 0
+    print(json.dumps(merge_summary, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/refresh_bdvm_projections.py
+++ b/scripts/refresh_bdvm_projections.py
@@ -7,10 +7,16 @@ Composes the two existing snapshot producers into the one command the
    baseline (public nflverse data, no credentials).  It carries prior
    real (non-proxy) records forward, so a baseline rebuild can never
    downgrade the serving board from real projections back to proxies.
-2. ``scripts/fetch_idpshow_projections.py`` — The IDP Show real IDP
-   projections (authenticated via ``idpshow_session.json``).  Real
-   records supersede baseline proxies per player at merge, so order
-   matters: baseline first, real source second.
+2. ``scripts/fetch_clay_projections.py`` — Mike Clay's ESPN guide
+   (public CDN PDF, no credentials; soft-skips if poppler-utils is
+   missing).  The first real OFFENSE source, plus a second IDP feed.
+3. ``scripts/fetch_idpshow_projections.py`` — The IDP Show real IDP
+   projections (authenticated via ``idpshow_session.json``).
+
+Real records supersede baseline proxies per player at merge, so order
+matters: baseline first, real sources after.  Clay and IDP Show
+records coexist (shared supersede policy replaces only a source's OWN
+prior run), giving defenders covered by both a two-source consensus.
 
 Both producers treat "today's snapshot already exists" as a no-op
 success, so boot-time catch-up runs and manual reruns stay green.
@@ -161,6 +167,7 @@ def main() -> int:
         help="target season (default: contract currentDraftYear, else date rule)",
     )
     parser.add_argument("--skip-baseline", action="store_true")
+    parser.add_argument("--skip-clay", action="store_true")
     parser.add_argument("--skip-idpshow", action="store_true")
     parser.add_argument(
         "--session",
@@ -189,6 +196,24 @@ def main() -> int:
             log("WARN: baseline built nothing; last-good snapshot untouched")
         else:
             log("ERROR: baseline stage hard-errored")
+            hard_error = True
+
+    if args.skip_clay:
+        log("clay stage skipped by flag")
+    else:
+        rc = _run_stage(
+            "clay",
+            [sys.executable, "scripts/fetch_clay_projections.py", "--season", str(season)],
+        )
+        if rc == 0:
+            wrote_any = True
+        elif rc == 1:
+            log(
+                "WARN: clay guide unavailable (CDN 404 / poppler missing?); "
+                "prior Clay records stay on the board via the baseline carry-forward"
+            )
+        else:
+            log("ERROR: clay stage hard-errored")
             hard_error = True
 
     if args.skip_idpshow:

--- a/server.py
+++ b/server.py
@@ -10374,6 +10374,46 @@ async def run_signal_alerts(request: Request):
     def _run_sweep() -> dict[str, object]:
         db = _user_kv.all_user_states()
         summary: list[dict] = []
+
+        # BDVM market-signal transitions piggyback on this same sweep
+        # (flag-gated; no extra timer).  The whole-league board + the
+        # ownerId → rostered-playerIds map are computed ONCE per league
+        # and shared across users — the engine run is the expensive
+        # part, the per-user slice is a set lookup.  Any failure here
+        # degrades to a "bdvm": {"error": ...} field, never a failed
+        # sweep.
+        bdvm_enabled = False
+        try:
+            from src.api import feature_flags as _ff  # noqa: PLC0415
+
+            bdvm_enabled = _ff.is_enabled("bdvm_engine")
+        except Exception as exc:  # noqa: BLE001
+            log.warning("bdvm flag check failed in signal sweep: %s", exc)
+        bdvm_league_cache: dict[str, tuple[dict | None, dict[str, set]]] = {}
+
+        def _bdvm_league_data(cfg_key: str, contract: dict):
+            if cfg_key in bdvm_league_cache:
+                return bdvm_league_cache[cfg_key]
+            values: dict | None = None
+            assets_by_owner: dict[str, set] = {}
+            try:
+                from src.api import bdvm_api as _bdvm_api  # noqa: PLC0415
+
+                values = _bdvm_api.get_bdvm_values(contract, cfg_key)
+                roster = _bdvm_api.get_bdvm_roster(contract, cfg_key)
+                if roster.get("status") == "ok":
+                    for r in roster.get("rosters") or []:
+                        oid = str(r.get("ownerId") or "")
+                        if oid:
+                            assets_by_owner[oid] = {
+                                str(a.get("playerId") or "") for a in (r.get("assets") or [])
+                            }
+            except Exception as exc:  # noqa: BLE001
+                log.warning("bdvm signal sweep data failed for %s: %s", cfg_key, exc)
+                values = None
+            bdvm_league_cache[cfg_key] = (values, assets_by_owner)
+            return values, assets_by_owner
+
         loaded_league = (
             (latest_contract_data or {}).get("meta", {}).get("leagueKey")
             if isinstance(latest_contract_data, dict)
@@ -10489,13 +10529,39 @@ async def run_signal_alerts(request: Request):
                     delivery=_deliver_email_smtp,
                     league_key=cfg.key,
                 )
-                user_summary.append({"leagueKey": cfg.key, **result})
+                league_summary = {"leagueKey": cfg.key, **result}
+                if bdvm_enabled:
+                    try:
+                        from src.api import bdvm_signal_alerts as _bdvm_alerts  # noqa: PLC0415
+
+                        values, assets_by_owner = _bdvm_league_data(cfg.key, contract)
+                        entries = _bdvm_alerts.roster_bdvm_entries(
+                            values, assets_by_owner.get(league_owner_id) or ()
+                        )
+                        league_summary["bdvm"] = _bdvm_alerts.process_user_bdvm_alerts(
+                            username,
+                            entries=entries,
+                            display_name=username,
+                            email=email,
+                            delivery=_deliver_email_smtp,
+                            league_key=cfg.key,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        log.warning(
+                            "bdvm signal alerts failed for %s / %s: %s",
+                            username,
+                            cfg.key,
+                            exc,
+                        )
+                        league_summary["bdvm"] = {"error": str(exc)}
+                user_summary.append(league_summary)
             if user_summary:
                 summary.append({"username": username, "byLeague": user_summary})
         return {
             "total_users_checked": len(db),
             "processed": len(summary),
             "results": summary,
+            "bdvmEnabled": bdvm_enabled,
         }
 
     result = await run_in_threadpool(_run_sweep)

--- a/src/api/bdvm_signal_alerts.py
+++ b/src/api/bdvm_signal_alerts.py
@@ -1,0 +1,307 @@
+"""BDVM market-signal alert tracking (fundamental-vs-market transitions).
+
+Fires when a rostered player's BDVM signal (``src/bdvm/market.py::
+buy_hold_sell`` — STRONG_BUY / BUY / HOLD / SELL / STRONG_SELL /
+NO_MARKET) flips into an actionable state since the user's last sweep.
+Piggybacks on the daily ``/api/signal-alerts/run`` cron (same posture
+as ops/source-health alerts: a broken detector degrades to an error
+field in the sweep summary, never a failed sweep).
+
+Deliberately a SEPARATE detector from ``signal_alerts.py``:
+
+* Different label sets — the terminal engine speaks RISK/SELL/BUY/
+  MONITOR; BDVM speaks STRONG_BUY..STRONG_SELL/NO_MARKET.  Appending
+  BDVM entries to the terminal signal list would silently drop
+  STRONG_* under the terminal's ACTIONABLE_SIGNALS.
+* Different state namespace — ``bdvmSignalAlertStateByLeague`` keyed
+  ``bdvm:{playerId}`` so terminal keys (``name::tag`` / ``sid:..``)
+  can never collide.
+
+Baseline seeding: the first sweep for a (user, league) — i.e. right
+after the ``bdvm_engine`` flag turns on — records every currently
+actionable signal WITHOUT firing.  Without this, flag-on day would
+flood every user with an alert for each rostered player already
+sitting in BUY/SELL.  The seeded entries carry ``notifiedAt: 0`` so a
+genuine change right after baseline alerts immediately.
+
+Honesty rules inherited from BDVM: entries only exist for players the
+board actually priced; NO_MARKET is an absence, never alerted on; a
+non-ok values payload yields zero entries (never fabricated).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Iterable
+
+from src.api import user_kv as _user_kv
+
+_LOGGER = logging.getLogger(__name__)
+
+# STRONG_* included (unlike the terminal set) — they are BDVM's most
+# actionable outputs.  HOLD is stability; NO_MARKET is an absence.
+ACTIONABLE_BDVM_SIGNALS = frozenset({"STRONG_BUY", "BUY", "SELL", "STRONG_SELL"})
+
+# Same flicker guard as signal_alerts: BUY → HOLD → BUY inside a half
+# day must not spam.
+_MIN_NOTIFY_INTERVAL_HOURS: float = 12.0
+
+_STATE_FIELD = "bdvmSignalAlertStateByLeague"
+
+
+def _utc_now_ms() -> int:
+    import time
+
+    return int(time.time() * 1000)
+
+
+def roster_bdvm_entries(
+    values_payload: dict[str, Any] | None,
+    roster_player_ids: Iterable[str],
+) -> list[dict[str, Any]]:
+    """Intersect the whole-league BDVM board with one roster.
+
+    The board is league-wide (every priced player); alerts are
+    roster-scoped like every other user alert, so the caller passes
+    the user's rostered playerIds (from the BDVM roster analysis).
+    Non-ok payloads yield [] — nothing is fabricated.
+    """
+    if not isinstance(values_payload, dict) or values_payload.get("status") != "ok":
+        return []
+    wanted = {str(pid) for pid in roster_player_ids or () if str(pid)}
+    if not wanted:
+        return []
+    entries: list[dict[str, Any]] = []
+    for player in values_payload.get("players") or []:
+        if not isinstance(player, dict):
+            continue
+        pid = str(player.get("playerId") or "")
+        if pid not in wanted:
+            continue
+        signal_block = player.get("signal") or {}
+        market = player.get("market") or {}
+        trade_value = player.get("tradeValue") or {}
+        entries.append(
+            {
+                "playerId": pid,
+                "name": player.get("name"),
+                "pos": player.get("position"),
+                "signal": str(signal_block.get("signal") or ""),
+                "reason": str(signal_block.get("reason") or ""),
+                "gap": market.get("gap"),
+                "fundamental": trade_value.get("balanced"),
+                "marketValue": market.get("marketValue"),
+            }
+        )
+    return entries
+
+
+def _load_state(
+    user_state: dict[str, Any],
+    league_key: str | None,
+) -> tuple[dict[str, Any], bool]:
+    """Return (league bucket, existed).  ``existed=False`` marks the
+    first-ever sweep for this (user, league) — the baseline-seeding
+    case.  An empty-but-present bucket counts as existed."""
+    by_league = user_state.get(_STATE_FIELD) or {}
+    if not isinstance(by_league, dict):
+        by_league = {}
+    key = str(league_key or "").strip()
+    bucket = by_league.get(key)
+    if isinstance(bucket, dict):
+        return dict(bucket), True
+    return {}, False
+
+
+def _persist_state(
+    username: str,
+    user_state: dict[str, Any],
+    league_key: str | None,
+    new_state: dict[str, Any],
+    *,
+    path: Any = None,
+) -> None:
+    key = str(league_key or "").strip()
+    existing_by_league = user_state.get(_STATE_FIELD) or {}
+    if not isinstance(existing_by_league, dict):
+        existing_by_league = {}
+    # merge_user_state is a shallow top-level merge; nesting one extra
+    # level keeps each league's bucket atomic (same shape rationale as
+    # signalAlertStateByLeague).
+    next_by_league = {**existing_by_league, key: new_state}
+    _user_kv.merge_user_state(username, {_STATE_FIELD: next_by_league}, path=path)
+
+
+def detect_bdvm_transitions(
+    username: str,
+    entries: list[dict[str, Any]],
+    *,
+    path: Any = None,
+    league_key: str | None = None,
+) -> tuple[list[dict[str, Any]], str]:
+    """Compare live BDVM signals to last-seen state.
+
+    Returns ``(transitions, mode)`` where mode is:
+      * ``"baseline_seeded"`` — first sweep for this (user, league);
+        actionable signals recorded silently, nothing fired.
+      * ``"ok"`` — normal comparison ran (transitions may be empty).
+      * ``"no_entries"`` — nothing to compare (empty roster slice or
+        non-ok board); state untouched so a later real first sweep
+        still gets baseline treatment.
+    """
+    if not username or not entries:
+        return [], "no_entries"
+
+    user_state = _user_kv.get_user_state(username, path=path)
+    alert_state, existed = _load_state(user_state, league_key)
+
+    if not existed:
+        seeded = {
+            f"bdvm:{e['playerId']}": {"signal": str(e.get("signal") or ""), "notifiedAt": 0}
+            for e in entries
+            if isinstance(e, dict)
+            and e.get("playerId")
+            and str(e.get("signal") or "") in ACTIONABLE_BDVM_SIGNALS
+        }
+        _persist_state(username, user_state, league_key, seeded, path=path)
+        return [], "baseline_seeded"
+
+    now = _utc_now_ms()
+    min_interval_ms = int(_MIN_NOTIFY_INTERVAL_HOURS * 3600 * 1000)
+
+    transitions: list[dict[str, Any]] = []
+    new_state: dict[str, dict[str, Any]] = dict(alert_state)
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        signal = str(entry.get("signal") or "")
+        if signal not in ACTIONABLE_BDVM_SIGNALS:
+            continue
+        pid = str(entry.get("playerId") or "").strip()
+        if not pid:
+            continue
+        state_key = f"bdvm:{pid}"
+        prev = alert_state.get(state_key) or {}
+        prev_signal = str(prev.get("signal") or "")
+        prev_notified_at = int(prev.get("notifiedAt") or 0)
+        if prev_signal == signal:
+            # Refresh last-seen so a quiet period never re-fires.
+            new_state[state_key] = {"signal": signal, "notifiedAt": prev_notified_at}
+            continue
+        if prev_notified_at and now - prev_notified_at < min_interval_ms:
+            new_state[state_key] = {"signal": signal, "notifiedAt": prev_notified_at}
+            continue
+        transitions.append(
+            {
+                "signalKey": state_key,
+                "playerId": pid,
+                "name": entry.get("name"),
+                "pos": entry.get("pos"),
+                "signal": signal,
+                "priorSignal": prev_signal or None,
+                "reason": entry.get("reason") or "",
+                "gap": entry.get("gap"),
+                "fundamental": entry.get("fundamental"),
+                "marketValue": entry.get("marketValue"),
+            }
+        )
+        new_state[state_key] = {"signal": signal, "notifiedAt": now}
+
+    # Persist even when nothing fired — last-seen must stay current.
+    _persist_state(username, user_state, league_key, new_state, path=path)
+    return transitions, "ok"
+
+
+def _fmt_value(v: Any) -> str:
+    if isinstance(v, (int, float)):
+        return f"{round(v):,}"
+    return "—"
+
+
+def _fmt_gap(v: Any) -> str:
+    if not isinstance(v, (int, float)):
+        return "—"
+    rounded = round(v)
+    return f"+{rounded:,}" if rounded > 0 else f"{rounded:,}"
+
+
+def format_bdvm_alert_email(
+    display_name: str,
+    transitions: list[dict[str, Any]],
+) -> dict[str, str]:
+    """Plain-text digest, same tone as the terminal signal digest."""
+    count = len(transitions)
+    subject = (
+        f"[Brisket] {count} BDVM market signal change{'' if count == 1 else 's'} on your roster"
+    )
+    lines: list[str] = []
+    lines.append(f"Hi {display_name},")
+    lines.append("")
+    lines.append(
+        f"{count} of your players changed fundamental-vs-market signal since your last check:"
+    )
+    lines.append("")
+    for t in transitions:
+        arrow = f"{t.get('priorSignal') or '—'} → {t['signal']}"
+        lines.append(f"  • {t['name']} ({t.get('pos') or '—'})  {arrow}")
+        lines.append(
+            f"    fundamental {_fmt_value(t.get('fundamental'))} vs market "
+            f"{_fmt_value(t.get('marketValue'))} (gap {_fmt_gap(t.get('gap'))})"
+        )
+        if t.get("reason"):
+            lines.append(f"    {t['reason']}")
+    lines.append("")
+    lines.append("Full board:  https://chaseupside.com/bdvm")
+    lines.append("")
+    lines.append("BDVM signals compare projection-driven fundamental value against the")
+    lines.append("market (KTC / IDP TradeCalc). They flow from the bdvm_engine feature —")
+    lines.append("an operator can switch it off to stop these entirely.")
+    lines.append("")
+    lines.append("— Risk It")
+    return {"subject": subject, "body": "\n".join(lines)}
+
+
+def process_user_bdvm_alerts(
+    username: str,
+    *,
+    entries: list[dict[str, Any]],
+    display_name: str | None = None,
+    email: str | None = None,
+    delivery: Callable[[str, str, str], bool] | None = None,
+    path: Any = None,
+    league_key: str | None = None,
+) -> dict[str, Any]:
+    """End-to-end: detect + deliver.  Mirrors
+    ``signal_alerts.process_user_alerts`` — reasons:
+    ``baseline_seeded | no_entries | no_transitions | no_email |
+    no_delivery_configured | delivery_error:* | ok |
+    delivery_returned_false``."""
+    transitions, mode = detect_bdvm_transitions(username, entries, path=path, league_key=league_key)
+    if mode != "ok":
+        return {"transitions": 0, "delivered": False, "reason": mode}
+    if not transitions:
+        return {"transitions": 0, "delivered": False, "reason": "no_transitions"}
+    if not email:
+        return {"transitions": len(transitions), "delivered": False, "reason": "no_email"}
+    if delivery is None:
+        return {
+            "transitions": len(transitions),
+            "delivered": False,
+            "reason": "no_delivery_configured",
+        }
+    formatted = format_bdvm_alert_email(display_name or username, transitions)
+    try:
+        ok = delivery(email, formatted["subject"], formatted["body"])
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.warning("bdvm signal alert delivery failed for %s: %s", username, exc)
+        return {
+            "transitions": len(transitions),
+            "delivered": False,
+            "reason": f"delivery_error:{type(exc).__name__}",
+        }
+    return {
+        "transitions": len(transitions),
+        "delivered": bool(ok),
+        "reason": "ok" if ok else "delivery_returned_false",
+    }

--- a/src/api/user_kv.py
+++ b/src/api/user_kv.py
@@ -81,6 +81,12 @@ KNOWN_KEYS = frozenset(
         # Prevents a SELL in league A from silently suppressing the same
         # player's SELL notification in league B.
         "signalAlertStateByLeague",
+        # Same shape, separate namespace, for BDVM fundamental-vs-market
+        # signal transitions (bdvm_signal_alerts.py).  State keys are
+        # ``bdvm:{playerId}`` so they can never collide with the terminal
+        # engine's ``name::tag`` / ``sid:..`` keys, and a first-ever
+        # bucket for a league is the baseline-seeding sentinel.
+        "bdvmSignalAlertStateByLeague",
         "updatedAt",
         # League preference — the user's currently-active league key from
         # the league registry (``src/api/league_registry``).  Persists

--- a/src/bdvm/clay_projections.py
+++ b/src/bdvm/clay_projections.py
@@ -1,0 +1,277 @@
+"""Mike Clay's ESPN projection guide → BDVM projection records.
+
+The first REAL (non-proxy) OFFENSE projection source — and a second
+IDP source beside The IDP Show.  The guide is a public PDF on ESPN's
+fantasy draft-kit CDN (``g.espncdn.com/s/ffldraftkit/<yy>/
+NFLDK<season>_CS_ClayProjections<season>.pdf``), fetched and
+text-extracted by ``scripts/fetch_clay_projections.py`` (pdftotext
+-layout).  Everything in this module is pure parsing/merging so it is
+fully testable offline against extracted-text fixtures.
+
+What we parse — the 32 TEAM pages only (the positional pages later in
+the guide re-list the same numbers in a different layout; the team
+pages cover every player down to the fringe):
+
+* OFFENSE rows: ``Pos Player Gm | Att Comp Yds TD INT Sk | Att Yds TD
+  | Tgt Rec Yd TD | Pts Rk`` — sixteen numbers after the name.  We
+  keep the RAW season stat line (never ESPN's PPR points), so the
+  record scores under the league's exact settings via the shared
+  scoring path.
+* DEFENSE rows (same physical lines, right-hand table): ``Pos Player
+  Snap Tkl Sack INT Rk``.  Tackles are COMBINED — split solo/assist
+  with the same documented ``TACKLE_SOLO_SHARE`` approximation the
+  IDP Show adapter uses.  The guide's FF column does not survive text
+  extraction; forced fumbles are omitted rather than guessed.
+
+Merge policy: the shared ``supersede_merge_into_snapshot`` — Clay's
+records replace their own prior run wholesale and supersede
+reconstructed-baseline proxies per player; IDP Show records carry
+through untouched, so defenders covered by both feeds get a genuine
+two-source consensus.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable, Mapping
+
+from src.bdvm.idpshow_projections import TACKLE_SOLO_SHARE
+from src.bdvm.projections import (
+    ProjectionRecord,
+    supersede_merge_into_snapshot,
+)
+
+SOURCE_NAME = "clayProjections"
+
+# Clay position labels → BDVM true positions.
+_DEF_POSITIONS = {"DI": "DT", "ED": "EDGE", "LB": "LB", "CB": "CB", "S": "S"}
+_OFF_POSITIONS = ("QB", "RB", "WR", "TE")
+
+# Offense: pos, name, then exactly 16 integers
+# (Gm Att Comp Yds TD INT Sk | Att Yds TD | Tgt Rec Yd TD | Pts Rk).
+_OFFENSE_ROW = re.compile(
+    r"^\s*(QB|RB|WR|TE)\s+(?!Total\b)([A-Za-z][\w.'\- ]*?)\s+(\d+(?:\s+\d+){15})(?!\S)"
+)
+
+# Defense (searched anywhere in the line — the tables sit side by
+# side): pos, name, Snap(int) Tkl(int) Sack(dec) INT(dec) Rk(int).
+_DEFENSE_ROW = re.compile(
+    r"\b(DI|ED|LB|CB|S)\s+(?!Total\b)([A-Za-z][\w.'\- ]*?)\s+"
+    r"(\d+)\s+(\d+)\s+(\d+\.\d+)\s+(\d+\.\d+)\s+(\d+)(?!\S)"
+)
+
+# The team-pages region ends where the positional re-lists begin.
+_POSITIONAL_HEADER = re.compile(r"^\s*Quarterback Projections\s*$", re.MULTILINE)
+
+_UPDATED_RE = re.compile(r"Updated:\s*(\d{1,2}/\d{1,2}/\d{4})")
+
+
+class ClayParseError(ValueError):
+    pass
+
+
+def _team_pages(text: str) -> str:
+    """Slice the extracted text down to the team-projection pages."""
+    match = _POSITIONAL_HEADER.search(text)
+    return text[: match.start()] if match else text
+
+
+def parse_clay_text(text: str) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Parse the extracted guide text.  Returns (rows, report).
+
+    Rows are dicts: ``{"name", "position", "games", "stats"}`` with
+    season-basis stat lines.  Duplicate names keep the first
+    occurrence (team pages list each player once; a dupe would be a
+    same-named player on another team — rare enough to flag, not
+    guess).
+    """
+    region = _team_pages(text)
+    rows: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    duplicates = 0
+    offense_count = 0
+    defense_count = 0
+
+    for line in region.split("\n"):
+        off = _OFFENSE_ROW.match(line)
+        if off:
+            pos, name, nums_blob = off.groups()
+            nums = [int(n) for n in nums_blob.split()]
+            (
+                games,
+                p_att,
+                p_comp,
+                p_yds,
+                p_td,
+                p_int,
+                p_sk,
+                r_att,
+                r_yds,
+                r_td,
+                tgt,
+                rec,
+                re_yds,
+                re_td,
+                _pts,
+                _rk,
+            ) = nums
+            key = (name.strip().lower(), "off")
+            if key in seen:
+                duplicates += 1
+            else:
+                seen.add(key)
+                stats = {
+                    "attempts": p_att,
+                    "completions": p_comp,
+                    "passing_yards": p_yds,
+                    "passing_tds": p_td,
+                    "interceptions": p_int,
+                    "sacks": p_sk,
+                    "carries": r_att,
+                    "rushing_yards": r_yds,
+                    "rushing_tds": r_td,
+                    "targets": tgt,
+                    "receptions": rec,
+                    "receiving_yards": re_yds,
+                    "receiving_tds": re_td,
+                }
+                rows.append(
+                    {
+                        "name": name.strip(),
+                        "position": pos,
+                        "games": float(games) if games else 17.0,
+                        "stats": {k: float(v) for k, v in stats.items() if v},
+                    }
+                )
+                offense_count += 1
+
+        for dmatch in _DEFENSE_ROW.finditer(line):
+            dpos, dname, _snap, tkl, sack, ints, _rk = dmatch.groups()
+            key = (dname.strip().lower(), "def")
+            if key in seen:
+                duplicates += 1
+                continue
+            seen.add(key)
+            combined = float(tkl)
+            stats = {
+                "def_tackles_solo": combined * TACKLE_SOLO_SHARE,
+                "def_tackle_assists": combined * (1.0 - TACKLE_SOLO_SHARE),
+                "def_sacks": float(sack),
+                "def_interceptions": float(ints),
+            }
+            rows.append(
+                {
+                    "name": dname.strip(),
+                    "position": _DEF_POSITIONS[dpos],
+                    "games": 17.0,  # defense block carries snaps, not games
+                    "stats": {k: v for k, v in stats.items() if v},
+                }
+            )
+            defense_count += 1
+
+    updated = _UPDATED_RE.search(text)
+    report: dict[str, Any] = {
+        "usable": offense_count >= 50,  # a real guide has hundreds
+        "offenseRows": offense_count,
+        "defenseRows": defense_count,
+        "duplicatesSkipped": duplicates,
+        "guideUpdated": updated.group(1) if updated else None,
+        "approximations": [
+            f"tackle_split_solo_share_{TACKLE_SOLO_SHARE:.2f}",
+            "forced_fumbles_unavailable_in_extraction",
+        ],
+    }
+    if not report["usable"]:
+        report["reason"] = "too_few_offense_rows_to_be_the_real_guide"
+        return [], report
+    return rows, report
+
+
+def records_from_rows(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    season: int,
+    as_of: str,
+    name_normalizer,
+) -> tuple[list[ProjectionRecord], dict[str, Any]]:
+    """Build one record per player.  Returns (records, summary).
+
+    Name-collision policy (BDVM keys players by normalized name):
+
+    * Offense row + defense row under ONE name is a TWO-WAY player
+      (Travis Hunter) — the stat lines are COMBINED into one record,
+      which scores as the sum under league rules: exactly his value in
+      an IDP league.  The record keeps the DEFENSIVE position: the
+      scoring gate lets an IDP position score offense keys too (a
+      defender's receptions count in real fantasy), while an offense
+      position gates the IDP keys off (the contract row decides the
+      lineup group regardless).
+    * Two rows on the SAME side under one name are two DIFFERENT
+      players this source cannot tell apart (Byron Murphy the CB vs
+      Byron Murphy the DT) — both are dropped and counted, never
+      guessed.
+    """
+    grouped: dict[str, list[Mapping[str, Any]]] = {}
+    for row in rows:
+        if not dict(row.get("stats") or {}):
+            # Zero-projection fringe rows (all columns 0) — honestly
+            # nothing to record; the player stays proxy/unpriced.
+            continue
+        grouped.setdefault(name_normalizer(row["name"]), []).append(row)
+
+    records: list[ProjectionRecord] = []
+    two_way: list[str] = []
+    ambiguous: list[str] = []
+    for key, group in grouped.items():
+        if len(group) == 1:
+            row = group[0]
+            stats = dict(row["stats"])
+            position = row["position"]
+            games = float(row.get("games") or 17.0)
+        elif len(group) == 2 and {g["position"] in _OFF_POSITIONS for g in group} == {True, False}:
+            offense = next(g for g in group if g["position"] in _OFF_POSITIONS)
+            defense = next(g for g in group if g["position"] not in _OFF_POSITIONS)
+            stats = {**dict(defense["stats"]), **dict(offense["stats"])}
+            position = defense["position"]
+            games = max(float(g.get("games") or 17.0) for g in group)
+            two_way.append(key)
+        else:
+            ambiguous.append(key)
+            continue
+        records.append(
+            ProjectionRecord(
+                source=SOURCE_NAME,
+                player_key=key,
+                position=position,
+                season=season,
+                as_of=as_of,
+                games=games,
+                stat_line=stats,
+                stat_basis="season",
+                is_proxy=False,
+            )
+        )
+    summary = {
+        "records": len(records),
+        "twoWayCombined": sorted(two_way),
+        "ambiguousSameNameDropped": sorted(ambiguous),
+    }
+    return records, summary
+
+
+def merge_into_snapshot(
+    new_records: list[ProjectionRecord],
+    *,
+    season: int,
+    as_of: str,
+    label: str = "clay",
+) -> tuple[Any, dict[str, Any]]:
+    if not new_records:
+        raise ClayParseError("refusing to write a snapshot from zero records")
+    return supersede_merge_into_snapshot(
+        new_records,
+        source_name=SOURCE_NAME,
+        season=season,
+        as_of=as_of,
+        label=label,
+    )

--- a/src/bdvm/idpshow_projections.py
+++ b/src/bdvm/idpshow_projections.py
@@ -31,12 +31,7 @@ import re
 from typing import Any, Iterable, Mapping
 
 from src.bdvm.context import TRUE_POSITION_MAP
-from src.bdvm.projections import (
-    ProjectionRecord,
-    latest_snapshot_path,
-    load_snapshot,
-    write_snapshot,
-)
+from src.bdvm.projections import ProjectionRecord, supersede_merge_into_snapshot
 
 SOURCE_NAME = "idpShowProjections"
 
@@ -331,28 +326,15 @@ def merge_into_snapshot(
     label: str = "idpshow",
 ) -> tuple[Any, dict[str, Any]]:
     """Merge real records over the latest snapshot (proxy-replacement
-    policy) and write a new immutable snapshot."""
+    policy) and write a new immutable snapshot.  The policy itself is
+    the shared ``supersede_merge_into_snapshot`` — one implementation
+    for every real source."""
     if not new_records:
         raise IdpShowParseError("refusing to write a snapshot from zero records")
-    existing: list[ProjectionRecord] = []
-    prior = latest_snapshot_path(season)
-    if prior is not None:
-        _as_of, existing = load_snapshot(prior)
-    covered = {r.player_key for r in new_records}
-    kept = [
-        r
-        for r in existing
-        if r.source != SOURCE_NAME  # replaced wholesale
-        and not (r.is_proxy and r.player_key in covered)  # proxy superseded
-    ]
-    merged = kept + new_records
-    path = write_snapshot(merged, season=season, as_of=as_of, label=label)
-    summary = {
-        "priorSnapshot": str(prior) if prior else None,
-        "priorRecords": len(existing),
-        "newRealRecords": len(new_records),
-        "proxiesSuperseded": sum(1 for r in existing if r.is_proxy and r.player_key in covered),
-        "mergedRecords": len(merged),
-        "snapshot": str(path),
-    }
-    return path, summary
+    return supersede_merge_into_snapshot(
+        new_records,
+        source_name=SOURCE_NAME,
+        season=season,
+        as_of=as_of,
+        label=label,
+    )

--- a/src/bdvm/projections.py
+++ b/src/bdvm/projections.py
@@ -289,6 +289,55 @@ def latest_snapshot_path(season: int, base_dir: Path | None = None) -> Path | No
     return candidates[-1] if candidates else None
 
 
+def supersede_merge_into_snapshot(
+    new_records: list[ProjectionRecord],
+    *,
+    source_name: str,
+    season: int,
+    as_of: str,
+    label: str,
+    base_dir: Path | None = None,
+) -> tuple[Path, dict[str, Any]]:
+    """Merge one real source's records over the latest snapshot and
+    write a new immutable snapshot.
+
+    The shared merge policy every real (non-proxy) source uses:
+
+    * this source's own prior records are replaced wholesale (a rerun
+      is authoritative for its source);
+    * reconstructed-baseline proxies are dropped for players the new
+      records cover (the proxy is a stand-in for absent data, BDVM
+      §8.3);
+    * every other source's records — real records from other feeds,
+      proxies for uncovered players — carry through untouched, so two
+      real sources coexist and feed the consensus as peers.
+    """
+    if not new_records:
+        raise ProjectionError("refusing to write a snapshot from zero records")
+    existing: list[ProjectionRecord] = []
+    prior = latest_snapshot_path(season, base_dir=base_dir)
+    if prior is not None:
+        _as_of, existing = load_snapshot(prior)
+    covered = {r.player_key for r in new_records}
+    kept = [
+        r
+        for r in existing
+        if r.source != source_name  # replaced wholesale
+        and not (r.is_proxy and r.player_key in covered)  # proxy superseded
+    ]
+    merged = kept + new_records
+    path = write_snapshot(merged, season=season, as_of=as_of, label=label, base_dir=base_dir)
+    summary = {
+        "priorSnapshot": str(prior) if prior else None,
+        "priorRecords": len(existing),
+        "newRealRecords": len(new_records),
+        "proxiesSuperseded": sum(1 for r in existing if r.is_proxy and r.player_key in covered),
+        "mergedRecords": len(merged),
+        "snapshot": str(path),
+    }
+    return path, summary
+
+
 # ---------------------------------------------------------------------------
 # Adapter: manual CSV drop
 # ---------------------------------------------------------------------------

--- a/tests/api/test_bdvm_signal_alerts.py
+++ b/tests/api/test_bdvm_signal_alerts.py
@@ -1,0 +1,307 @@
+"""BDVM market-signal transition alerts.
+
+The cases that matter, in order:
+
+1. Baseline seeding — the first sweep after the bdvm_engine flag turns
+   on must NOT flood the user with an alert for every rostered player
+   already sitting in BUY/SELL; it records state silently.
+2. A genuine transition right after baseline fires immediately (the
+   seeded notifiedAt is 0, not "now").
+3. The same-signal / flicker-guard / per-league-isolation semantics
+   mirror signal_alerts.py exactly — proven idioms, same tests.
+4. Roster scoping: the board is league-wide; entries are the
+   intersection with one roster's playerIds, and a non-ok board yields
+   nothing (never fabricated).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.api import bdvm_signal_alerts as mod
+from src.api import user_kv
+
+
+@pytest.fixture()
+def kv_path(tmp_path):
+    user_kv._SETUP_DONE.clear()
+    return tmp_path / "user_kv.sqlite"
+
+
+def _entry(pid, signal, name="Elite Backer", **kw):
+    return {
+        "playerId": pid,
+        "name": name,
+        "pos": kw.get("pos", "LB"),
+        "signal": signal,
+        "reason": kw.get("reason", "gap above threshold"),
+        "gap": kw.get("gap", 800.0),
+        "fundamental": kw.get("fundamental", 7200.0),
+        "marketValue": kw.get("marketValue", 6400.0),
+    }
+
+
+class TestBaselineSeeding:
+    def test_first_sweep_seeds_without_firing(self, kv_path):
+        entries = [_entry("p1", "BUY"), _entry("p2", "STRONG_SELL", name="Old Vet")]
+        transitions, mode = mod.detect_bdvm_transitions(
+            "u", entries, path=kv_path, league_key="dynasty_main"
+        )
+        assert mode == "baseline_seeded"
+        assert transitions == []
+        state = user_kv.get_user_state("u", path=kv_path)
+        bucket = state["bdvmSignalAlertStateByLeague"]["dynasty_main"]
+        assert bucket["bdvm:p1"] == {"signal": "BUY", "notifiedAt": 0}
+        assert bucket["bdvm:p2"]["signal"] == "STRONG_SELL"
+
+    def test_baseline_ignores_non_actionable(self, kv_path):
+        entries = [_entry("p1", "HOLD"), _entry("p2", "NO_MARKET")]
+        _t, mode = mod.detect_bdvm_transitions(
+            "u", entries, path=kv_path, league_key="dynasty_main"
+        )
+        assert mode == "baseline_seeded"
+        bucket = user_kv.get_user_state("u", path=kv_path)["bdvmSignalAlertStateByLeague"][
+            "dynasty_main"
+        ]
+        assert bucket == {}
+
+    def test_change_right_after_baseline_fires(self, kv_path):
+        mod.detect_bdvm_transitions(
+            "u", [_entry("p1", "BUY")], path=kv_path, league_key="dynasty_main"
+        )
+        transitions, mode = mod.detect_bdvm_transitions(
+            "u", [_entry("p1", "STRONG_SELL")], path=kv_path, league_key="dynasty_main"
+        )
+        assert mode == "ok"
+        assert len(transitions) == 1
+        assert transitions[0]["priorSignal"] == "BUY"
+        assert transitions[0]["signal"] == "STRONG_SELL"
+
+
+class TestTransitions:
+    def _seed(self, kv_path, league="dynasty_main"):
+        mod.detect_bdvm_transitions("u", [_entry("p1", "BUY")], path=kv_path, league_key=league)
+
+    def test_unchanged_signal_does_not_fire(self, kv_path):
+        self._seed(kv_path)
+        transitions, mode = mod.detect_bdvm_transitions(
+            "u", [_entry("p1", "BUY")], path=kv_path, league_key="dynasty_main"
+        )
+        assert mode == "ok"
+        assert transitions == []
+
+    def test_new_player_flip_to_actionable_fires(self, kv_path):
+        self._seed(kv_path)
+        # p9 was HOLD (untracked) at baseline; now BUY
+        transitions, _ = mod.detect_bdvm_transitions(
+            "u", [_entry("p9", "BUY", name="Riser")], path=kv_path, league_key="dynasty_main"
+        )
+        assert [t["playerId"] for t in transitions] == ["p9"]
+        assert transitions[0]["priorSignal"] is None
+
+    def test_flicker_within_cooldown_is_suppressed(self, kv_path):
+        self._seed(kv_path)
+        # fire once (BUY → SELL) — notifiedAt stamps "now"
+        first, _ = mod.detect_bdvm_transitions(
+            "u", [_entry("p1", "SELL")], path=kv_path, league_key="dynasty_main"
+        )
+        assert len(first) == 1
+        # immediate flip back — suppressed, but last-seen updated
+        second, _ = mod.detect_bdvm_transitions(
+            "u", [_entry("p1", "BUY")], path=kv_path, league_key="dynasty_main"
+        )
+        assert second == []
+        bucket = user_kv.get_user_state("u", path=kv_path)["bdvmSignalAlertStateByLeague"][
+            "dynasty_main"
+        ]
+        assert bucket["bdvm:p1"]["signal"] == "BUY"
+
+    def test_fires_again_after_cooldown(self, kv_path, monkeypatch):
+        self._seed(kv_path)
+        mod.detect_bdvm_transitions(
+            "u", [_entry("p1", "SELL")], path=kv_path, league_key="dynasty_main"
+        )
+        later = mod._utc_now_ms() + int(13 * 3600 * 1000)
+        monkeypatch.setattr(mod, "_utc_now_ms", lambda: later)
+        transitions, _ = mod.detect_bdvm_transitions(
+            "u", [_entry("p1", "BUY")], path=kv_path, league_key="dynasty_main"
+        )
+        assert len(transitions) == 1
+        assert transitions[0]["priorSignal"] == "SELL"
+
+    def test_cooldown_is_scoped_per_league(self, kv_path):
+        self._seed(kv_path, league="dynasty_main")
+        self._seed(kv_path, league="second_league")
+        a, _ = mod.detect_bdvm_transitions(
+            "u", [_entry("p1", "SELL")], path=kv_path, league_key="dynasty_main"
+        )
+        b, _ = mod.detect_bdvm_transitions(
+            "u", [_entry("p1", "SELL")], path=kv_path, league_key="second_league"
+        )
+        assert len(a) == 1 and len(b) == 1  # independent buckets
+
+    def test_no_entries_leaves_state_untouched(self, kv_path):
+        transitions, mode = mod.detect_bdvm_transitions(
+            "u", [], path=kv_path, league_key="dynasty_main"
+        )
+        assert (transitions, mode) == ([], "no_entries")
+        state = user_kv.get_user_state("u", path=kv_path)
+        assert "bdvmSignalAlertStateByLeague" not in state
+
+
+class TestRosterEntries:
+    def _payload(self):
+        return {
+            "status": "ok",
+            "players": [
+                {
+                    "playerId": "p1",
+                    "name": "Elite Backer",
+                    "position": "LB",
+                    "signal": {"signal": "BUY", "reason": "gap"},
+                    "market": {"gap": 800.0, "marketValue": 6400.0},
+                    "tradeValue": {"balanced": 7200.0},
+                },
+                {
+                    "playerId": "p2",
+                    "name": "Other Team Guy",
+                    "position": "WR",
+                    "signal": {"signal": "SELL", "reason": "x"},
+                    "market": {"gap": -500.0, "marketValue": 5000.0},
+                    "tradeValue": {"balanced": 4500.0},
+                },
+            ],
+        }
+
+    def test_intersects_with_roster(self):
+        entries = mod.roster_bdvm_entries(self._payload(), ["p1"])
+        assert [e["playerId"] for e in entries] == ["p1"]
+        assert entries[0]["signal"] == "BUY"
+        assert entries[0]["fundamental"] == 7200.0
+
+    def test_non_ok_board_yields_nothing(self):
+        assert mod.roster_bdvm_entries({"status": "no_projection_snapshot"}, ["p1"]) == []
+        assert mod.roster_bdvm_entries(None, ["p1"]) == []
+
+    def test_empty_roster_yields_nothing(self):
+        assert mod.roster_bdvm_entries(self._payload(), []) == []
+
+
+class TestProcessAndEmail:
+    def test_process_reports_baseline(self, kv_path):
+        out = mod.process_user_bdvm_alerts(
+            "u",
+            entries=[_entry("p1", "BUY")],
+            email="a@b.c",
+            delivery=lambda *a: True,
+            path=kv_path,
+            league_key="dynasty_main",
+        )
+        assert out == {"transitions": 0, "delivered": False, "reason": "baseline_seeded"}
+
+    def test_process_delivers_transition(self, kv_path):
+        sent = []
+
+        def stub(to, subject, body):
+            sent.append((to, subject, body))
+            return True
+
+        mod.process_user_bdvm_alerts(
+            "u",
+            entries=[_entry("p1", "BUY")],
+            email="a@b.c",
+            delivery=stub,
+            path=kv_path,
+            league_key="dynasty_main",
+        )
+        out = mod.process_user_bdvm_alerts(
+            "u",
+            entries=[_entry("p1", "STRONG_SELL")],
+            display_name="Jason",
+            email="a@b.c",
+            delivery=stub,
+            path=kv_path,
+            league_key="dynasty_main",
+        )
+        assert out["delivered"] is True and out["reason"] == "ok"
+        to, subject, body = sent[0]
+        assert to == "a@b.c"
+        assert "1 BDVM market signal change" in subject
+        assert "BUY → STRONG_SELL" in body
+        assert "fundamental 7,200 vs market 6,400 (gap +800)" in body
+        assert "/bdvm" in body
+
+    def test_no_email_reason(self, kv_path):
+        mod.detect_bdvm_transitions(
+            "u", [_entry("p1", "BUY")], path=kv_path, league_key="dynasty_main"
+        )
+        out = mod.process_user_bdvm_alerts(
+            "u",
+            entries=[_entry("p1", "SELL")],
+            email="",
+            path=kv_path,
+            league_key="dynasty_main",
+        )
+        assert out["reason"] == "no_email"
+
+    def test_delivery_error_reason(self, kv_path):
+        mod.detect_bdvm_transitions(
+            "u", [_entry("p1", "BUY")], path=kv_path, league_key="dynasty_main"
+        )
+
+        def boom(*_a):
+            raise RuntimeError("smtp down")
+
+        out = mod.process_user_bdvm_alerts(
+            "u",
+            entries=[_entry("p1", "SELL")],
+            email="a@b.c",
+            delivery=boom,
+            path=kv_path,
+            league_key="dynasty_main",
+        )
+        assert out["reason"] == "delivery_error:RuntimeError"
+        assert out["delivered"] is False
+
+    def test_email_formats_prior_none_and_negative_gap(self):
+        formatted = mod.format_bdvm_alert_email(
+            "Jason",
+            [
+                {
+                    "name": "Faller",
+                    "pos": "WR",
+                    "signal": "SELL",
+                    "priorSignal": None,
+                    "reason": "",
+                    "gap": -350.0,
+                    "fundamental": 4000.0,
+                    "marketValue": 4350.0,
+                }
+            ],
+        )
+        assert "— → SELL" in formatted["body"]
+        assert "(gap -350)" in formatted["body"]
+
+
+def test_sweep_reports_flag_state_and_stays_green_when_off(monkeypatch):
+    """With bdvm_engine at its default (OFF), the signal sweep runs
+    exactly as before and stamps bdvmEnabled=false — the detector adds
+    zero risk to the existing digest when the feature is dormant."""
+    from fastapi.testclient import TestClient
+
+    import server
+
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        # Patch AFTER lifespan so startup can't clobber the stubs (see
+        # test_signal_alerts.py for the rationale).
+        monkeypatch.setattr(server, "latest_contract_data", {"players": {}})
+        monkeypatch.setattr(server, "SIGNAL_ALERT_CRON_TOKEN", "test-token-abc123")
+        monkeypatch.setattr(server._user_kv, "all_user_states", lambda: {})
+        res = c.post(
+            "/api/signal-alerts/run",
+            headers={"Authorization": "Bearer test-token-abc123"},
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["bdvmEnabled"] is False
+    assert body["results"] == []

--- a/tests/bdvm/test_clay_projections.py
+++ b/tests/bdvm/test_clay_projections.py
@@ -1,0 +1,234 @@
+"""Mike Clay guide adapter: parsing, records, shared merge policy."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from src.bdvm import clay_projections as clay
+from src.bdvm import projections as bdvm_projections
+from src.bdvm.idpshow_projections import SOURCE_NAME as IDPSHOW_SOURCE
+from src.bdvm.projections import ProjectionRecord, load_snapshot, write_snapshot
+
+_norm = lambda s: s.lower()  # noqa: E731
+
+# Real lines from the 2026 guide's team pages (pdftotext -layout),
+# including the side-by-side offense+defense layout, totals rows that
+# must be skipped, and a fringe all-zero offense row.
+TEAM_PAGE = """
+                                                                  2026 Arizona Cardinals Projections
+               OFFENSE                               PASSING                    RUSHING           RECEIVING             PPR                                      DEFENSE
+  Pos             Player           Gm    Att    Comp Yds TD      INT   Sk   Att Yds TD      Tgt   Rec   Yd    TD    Pts     Rk      Pos               Player              Snap  Tkl   Sack INT FF Rk
+  QB          Jacoby Brissett      17    517     327 3359 15      9    40    47    210 1     0      0    0     0   200      29       DI           Walter Nolen             653  46     4.1 0.0   25
+   RB         Jeremiyah Love       17     0       0    0    0     0    0    255 1129 7      86     65 489      2   279      9        DI             Roy Lopez              556  43     2.9 0.0   56
+QB Total                           34    605     381 3949 18      11   46    55    242 2     0      0    0     0   236 131       DI Total                                2579 191     11.5 0.0 688
+  WR         Marvin Harrison Jr.   17     0       0    0    0     0    0     0      0   0   126    69 956      5   194      33      ED             Josh Sweat              492  30     8.2 0.1   47
+  WR            Jalen Brooks       17     0       0    0    0     0    0     0      0   0    0      0    0     0     0     182   ED Total                                2183 142     18.6 0.7 415
+   TE          Trey McBride        17     0       0    0    0     0    0     0      0   0   155   112 1068     6   252      1       LB            Mack Wilson              963 116     1.3 1.6   25
+ Total                             238   605     381 3949 18      11   46   407 1756 12     573   381 3949    18   1330 1147        CB            Will Johnson           1017   61     0.1 1.8   36
+                                                                                                                                     S            Budda Baker            1017 118      1.5 1.3   5
+"""
+
+POSITIONAL_TAIL = """
+                     Quarterback Projections
+    Quarterback        Team    Pos Rk FF Pt   G    P Att   Comp   P Yds   P TD   INT   Sk   Carry Ru Yds Ru TD
+       Josh Allen       BUF       1    369    17   509      340   3945     26     12   36    116   579    12
+"""
+
+
+def _many_offense_rows(n=60):
+    """The usability gate needs a realistic row count."""
+    return "\n".join(
+        f"  WR          Filler Player{i}      17     0       0    0    0     0    0     0      0   0   30     20 300      2    60      {i}"
+        for i in range(n)
+    )
+
+
+class TestParsing(unittest.TestCase):
+    def test_team_page_rows_parse_and_totals_skip(self):
+        text = TEAM_PAGE + _many_offense_rows()
+        rows, report = clay.parse_clay_text(text)
+        self.assertTrue(report["usable"])
+        by_name = {r["name"]: r for r in rows}
+        # Offense: QB with pass+rush; RB with rush+receive; WR receive-only
+        qb = by_name["Jacoby Brissett"]
+        self.assertEqual(qb["position"], "QB")
+        self.assertEqual(qb["stats"]["passing_yards"], 3359.0)
+        self.assertEqual(qb["stats"]["interceptions"], 9.0)
+        self.assertEqual(qb["stats"]["carries"], 47.0)
+        rb = by_name["Jeremiyah Love"]
+        self.assertEqual(rb["stats"]["rushing_yards"], 1129.0)
+        self.assertEqual(rb["stats"]["receptions"], 65.0)
+        self.assertNotIn("passing_yards", rb["stats"])  # zeros dropped
+        # Defense: combined tackles split, positions mapped
+        nolen = by_name["Walter Nolen"]
+        self.assertEqual(nolen["position"], "DT")
+        self.assertAlmostEqual(nolen["stats"]["def_tackles_solo"], 46 * 0.62)
+        self.assertAlmostEqual(nolen["stats"]["def_sacks"], 4.1)
+        self.assertEqual(by_name["Josh Sweat"]["position"], "EDGE")
+        self.assertEqual(by_name["Budda Baker"]["position"], "S")
+        # Totals rows never become players
+        self.assertNotIn("Total", by_name)
+        for name in by_name:
+            self.assertNotIn("Total", name)
+
+    def test_positional_pages_are_excluded(self):
+        text = TEAM_PAGE + _many_offense_rows() + POSITIONAL_TAIL
+        rows, _ = clay.parse_clay_text(text)
+        # Josh Allen appears only in the positional region → not parsed
+        self.assertNotIn("Josh Allen", {r["name"] for r in rows})
+
+    def test_updated_stamp_and_approximations_reported(self):
+        text = "Updated:                     7/25/2026\n" + TEAM_PAGE + _many_offense_rows()
+        _rows, report = clay.parse_clay_text(text)
+        self.assertEqual(report["guideUpdated"], "7/25/2026")
+        self.assertIn("tackle_split_solo_share_0.62", report["approximations"])
+        self.assertIn("forced_fumbles_unavailable_in_extraction", report["approximations"])
+
+    def test_thin_text_is_unusable(self):
+        rows, report = clay.parse_clay_text(TEAM_PAGE)  # only a handful of rows
+        self.assertFalse(report["usable"])
+        self.assertEqual(rows, [])
+
+
+class TestRecords(unittest.TestCase):
+    def test_zero_stat_fringe_rows_are_skipped(self):
+        text = TEAM_PAGE + _many_offense_rows()
+        rows, _ = clay.parse_clay_text(text)
+        records, _summary = clay.records_from_rows(
+            rows, season=2026, as_of="2026-07-28", name_normalizer=_norm
+        )
+        keys = {r.player_key for r in records}
+        self.assertNotIn("jalen brooks", keys)  # all-zero projection → honestly absent
+        self.assertIn("jacoby brissett", keys)
+
+    def test_records_score_under_league_rules(self):
+        text = TEAM_PAGE + _many_offense_rows()
+        rows, _ = clay.parse_clay_text(text)
+        records, _summary = clay.records_from_rows(
+            rows, season=2026, as_of="2026-07-28", name_normalizer=_norm
+        )
+        by_key = {r.player_key: r for r in records}
+        qb = by_key["jacoby brissett"]
+        league = {"pass_yd": 0.04, "pass_td": 4.0, "pass_int": -2.0, "rush_yd": 0.1, "rush_td": 6.0}
+        fpg, native = qb.resolve_fpg(league)
+        expected = (3359 * 0.04 + 15 * 4.0 + 9 * -2.0 + 210 * 0.1 + 1 * 6.0) / 17.0
+        self.assertTrue(native)
+        self.assertAlmostEqual(fpg, expected, places=6)
+        self.assertFalse(qb.is_proxy)
+
+    def test_two_way_player_combines_offense_and_defense(self):
+        """Travis Hunter: WR row + CB row under one name → ONE record
+        whose stat line is the union, scoring as the SUM — his actual
+        value in an IDP league.  The record must keep the DEFENSIVE
+        position: the scoring gate lets an IDP position score offense
+        keys (a defender's receptions count) while a WR position would
+        gate the IDP keys off."""
+        rows = [
+            {
+                "name": "Travis Hunter",
+                "position": "WR",
+                "games": 17.0,
+                "stats": {"targets": 100.0, "receptions": 70.0, "receiving_yards": 900.0},
+            },
+            {
+                "name": "Travis Hunter",
+                "position": "CB",
+                "games": 17.0,
+                "stats": {"def_tackles_solo": 30.0, "def_interceptions": 2.0},
+            },
+        ]
+        records, summary = clay.records_from_rows(
+            rows, season=2026, as_of="2026-07-28", name_normalizer=_norm
+        )
+        self.assertEqual(summary["twoWayCombined"], ["travis hunter"])
+        self.assertEqual(len(records), 1)
+        rec = records[0]
+        self.assertEqual(rec.position, "CB")
+        self.assertEqual(rec.stat_line["receptions"], 70.0)
+        self.assertEqual(rec.stat_line["def_interceptions"], 2.0)
+        league = {"rec": 1.0, "idp_int": 4.0}
+        fpg, native = rec.resolve_fpg(league)
+        self.assertTrue(native)
+        # both halves score: (70 rec × 1.0 + 2 INT × 4.0) / 17 games
+        self.assertAlmostEqual(fpg, (70.0 + 8.0) / 17.0, places=6)
+
+    def test_same_side_name_collision_drops_both(self):
+        """Byron Murphy the CB vs Byron Murphy the DT — two different
+        players this source cannot tell apart.  Dropped, never
+        averaged into a chimera."""
+        rows = [
+            {
+                "name": "Byron Murphy",
+                "position": "CB",
+                "games": 17.0,
+                "stats": {"def_tackles_solo": 40.0},
+            },
+            {
+                "name": "Byron Murphy",
+                "position": "DT",
+                "games": 17.0,
+                "stats": {"def_tackles_solo": 30.0, "def_sacks": 5.0},
+            },
+        ]
+        records, summary = clay.records_from_rows(
+            rows, season=2026, as_of="2026-07-28", name_normalizer=_norm
+        )
+        self.assertEqual(records, [])
+        self.assertEqual(summary["ambiguousSameNameDropped"], ["byron murphy"])
+
+
+class TestSharedMergePolicy(unittest.TestCase):
+    def _rec(self, key, source, *, proxy=False, pos="LB"):
+        return ProjectionRecord(
+            source=source,
+            player_key=key,
+            position=pos,
+            season=2026,
+            as_of="2026-07-27",
+            games=17.0,
+            fpg=10.0,
+            scoring_native=True,
+            is_proxy=proxy,
+        )
+
+    def test_clay_supersedes_proxies_but_coexists_with_idpshow(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            with mock.patch.object(bdvm_projections, "SNAPSHOT_DIR", base):
+                write_snapshot(
+                    [
+                        self._rec("shared lb", IDPSHOW_SOURCE),
+                        self._rec("shared lb", "reconstructedBaseline", proxy=True),
+                        self._rec("offense wr", "reconstructedBaseline", proxy=True, pos="WR"),
+                    ],
+                    season=2026,
+                    as_of="2026-07-27",
+                )
+                _path, summary = clay.merge_into_snapshot(
+                    [
+                        self._rec("shared lb", clay.SOURCE_NAME),
+                        self._rec("offense wr", clay.SOURCE_NAME, pos="WR"),
+                    ],
+                    season=2026,
+                    as_of="2026-07-28",
+                )
+                self.assertEqual(summary["proxiesSuperseded"], 2)
+                latest = bdvm_projections.latest_snapshot_path(2026)
+                _as_of, records = load_snapshot(latest)
+                by = {(r.player_key, r.source) for r in records}
+                # two-source consensus for the shared defender
+                self.assertIn(("shared lb", IDPSHOW_SOURCE), by)
+                self.assertIn(("shared lb", clay.SOURCE_NAME), by)
+                self.assertNotIn(("shared lb", "reconstructedBaseline"), by)
+                self.assertNotIn(("offense wr", "reconstructedBaseline"), by)
+
+    def test_zero_records_refuses(self):
+        with self.assertRaises(clay.ClayParseError):
+            clay.merge_into_snapshot([], season=2026, as_of="2026-07-28")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bdvm/test_idpshow_projections.py
+++ b/tests/bdvm/test_idpshow_projections.py
@@ -152,21 +152,12 @@ class TestMergePolicy(unittest.TestCase):
         )
 
     def test_real_records_supersede_proxies_only_for_covered_players(self):
+        # merge_into_snapshot delegates to the shared supersede policy,
+        # which resolves SNAPSHOT_DIR at call time — patching it is the
+        # only redirection needed.
         with tempfile.TemporaryDirectory() as td:
             base = Path(td)
-            with (
-                mock.patch.object(bdvm_projections, "SNAPSHOT_DIR", base),
-                mock.patch.object(
-                    idp,
-                    "latest_snapshot_path",
-                    lambda season: bdvm_projections.latest_snapshot_path(season, base_dir=base),
-                ),
-                mock.patch.object(
-                    idp,
-                    "write_snapshot",
-                    lambda recs, **kw: write_snapshot(recs, base_dir=base, **kw),
-                ),
-            ):
+            with mock.patch.object(bdvm_projections, "SNAPSHOT_DIR", base):
                 write_snapshot(
                     [self._proxy("covered lb"), self._proxy("uncovered wr", "WR")],
                     season=2026,
@@ -190,19 +181,7 @@ class TestMergePolicy(unittest.TestCase):
     def test_rerun_replaces_own_prior_records(self):
         with tempfile.TemporaryDirectory() as td:
             base = Path(td)
-            with (
-                mock.patch.object(bdvm_projections, "SNAPSHOT_DIR", base),
-                mock.patch.object(
-                    idp,
-                    "latest_snapshot_path",
-                    lambda season: bdvm_projections.latest_snapshot_path(season, base_dir=base),
-                ),
-                mock.patch.object(
-                    idp,
-                    "write_snapshot",
-                    lambda recs, **kw: write_snapshot(recs, base_dir=base, **kw),
-                ),
-            ):
+            with mock.patch.object(bdvm_projections, "SNAPSHOT_DIR", base):
                 idp.merge_into_snapshot(
                     [self._real("guy a")], season=2026, as_of="2026-07-27", label="run1"
                 )

--- a/tests/scripts/test_refresh_bdvm_projections.py
+++ b/tests/scripts/test_refresh_bdvm_projections.py
@@ -80,20 +80,20 @@ class _RunHarness(unittest.TestCase):
 
 
 class TestExitCodeAggregation(_RunHarness):
-    def test_both_stages_write(self):
+    def test_all_stages_write(self):
         rc, calls = self._run(
             ["--season", "2026"],
-            {"baseline": 0, "idpshow": 0},
+            {"baseline": 0, "clay": 0, "idpshow": 0},
             session_exists=True,
         )
         self.assertEqual(rc, 0)
         # order matters: proxies first so real records supersede them
-        self.assertEqual([c[0] for c in calls], ["baseline", "idpshow"])
+        self.assertEqual([c[0] for c in calls], ["baseline", "clay", "idpshow"])
 
-    def test_baseline_writes_idpshow_paywalled_is_still_success(self):
+    def test_baseline_writes_real_sources_soft_fail_is_still_success(self):
         rc, _ = self._run(
             ["--season", "2026"],
-            {"baseline": 0, "idpshow": 1},
+            {"baseline": 0, "clay": 1, "idpshow": 1},
             session_exists=True,
         )
         self.assertEqual(rc, 0)
@@ -101,7 +101,7 @@ class TestExitCodeAggregation(_RunHarness):
     def test_nothing_written_is_soft_failure(self):
         rc, _ = self._run(
             ["--season", "2026"],
-            {"baseline": 1, "idpshow": 1},
+            {"baseline": 1, "clay": 1, "idpshow": 1},
             session_exists=True,
         )
         self.assertEqual(rc, 1)
@@ -109,7 +109,7 @@ class TestExitCodeAggregation(_RunHarness):
     def test_hard_error_with_nothing_written_is_2(self):
         rc, _ = self._run(
             ["--season", "2026"],
-            {"baseline": 2, "idpshow": 1},
+            {"baseline": 2, "clay": 1, "idpshow": 1},
             session_exists=True,
         )
         self.assertEqual(rc, 2)
@@ -119,7 +119,15 @@ class TestExitCodeAggregation(_RunHarness):
         # journal via the ERROR log line, not the exit code.
         rc, _ = self._run(
             ["--season", "2026"],
-            {"baseline": 0, "idpshow": 2},
+            {"baseline": 0, "clay": 0, "idpshow": 2},
+            session_exists=True,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_clay_alone_writing_is_success(self):
+        rc, _ = self._run(
+            ["--season", "2026"],
+            {"baseline": 1, "clay": 0, "idpshow": 1},
             session_exists=True,
         )
         self.assertEqual(rc, 0)
@@ -127,15 +135,15 @@ class TestExitCodeAggregation(_RunHarness):
     def test_missing_session_skips_idpshow_stage(self):
         rc, calls = self._run(
             ["--season", "2026"],
-            {"baseline": 0},
+            {"baseline": 0, "clay": 0},
             session_exists=False,
         )
         self.assertEqual(rc, 0)
-        self.assertEqual([c[0] for c in calls], ["baseline"])
+        self.assertEqual([c[0] for c in calls], ["baseline", "clay"])
 
     def test_skip_flags(self):
         rc, calls = self._run(
-            ["--season", "2026", "--skip-baseline", "--skip-idpshow"],
+            ["--season", "2026", "--skip-baseline", "--skip-clay", "--skip-idpshow"],
             {},
         )
         self.assertEqual(rc, 1)  # nothing written → soft


### PR DESCRIPTION
# BDVM where you already work — and real offense projections to power it

Follow-up to #600 (engine) and #607 (Fundamentals page + snapshot cadence, both merged). Three additions, all dormant while `bdvm_engine` is off:

1. a "Fund gap" column on `/rankings`,
2. BDVM signal alerts in the daily digest,
3. **Mike Clay's ESPN projection guide as the real OFFENSE projection source** — the offense half of the board moves off reconstructed proxies.

## Rankings "Fund gap" column

- Fundamental (balanced) minus market anchor per player, rendered as a signed pill tinted with the Edge column's existing `edge-buy`/`edge-sell`/`edge-hold` classes by BDVM signal; tooltip carries signal, reason, and the fundamental-vs-market numbers; no-market rows show an em dash with the reason, never a fabricated zero.
- Joined onto board rows **at render time** from `/api/bdvm/values` (`lib/bdvm.js::buildBdvmIndex` / `bdvmEntryForRow`, playerId-first with name fallback). Appears only when the endpoint answers ok and **vanishes silently** on any 503. `buildRows` untouched; ranks stay backend-stamped; the `presorted` sort switch gained `case "gap"` (nulls sink). Bundle: 57.7 KB of the 65 KB budget.

## BDVM signal alerts

- `src/api/bdvm_signal_alerts.py` piggybacks on the daily `POST /api/signal-alerts/run` sweep — no new timer, same bearer gate and SMTP plumbing. Deliberately separate from the terminal detector (different label set — STRONG_* actionable; separate `bdvmSignalAlertStateByLeague` namespace keyed `bdvm:{playerId}`).
- Roster-scoped; whole-league board + ownerId→playerIds map computed once per league per sweep. 12h flicker guard, per-league cooldown isolation. **Baseline seeding**: the first sweep for a (user, league) records current actionable signals silently (`notifiedAt: 0`) — flag-on day never floods inboxes while a genuine change right after still alerts. Detector failure degrades to a `"bdvm": {"error": ...}` field, never a failed sweep; flag off stamps `bdvmEnabled: false`.

## Mike Clay projections (the offense source BDVM was missing)

- **Adapter** (`src/bdvm/clay_projections.py`): parses the guide's 32 team pages from `pdftotext -layout` output — raw season stat lines for offense (never ESPN's PPR points, so records score under the league's exact settings) plus a second IDP feed (Snap/Tkl/Sack/INT; combined tackles split with the shared 0.62 solo share; the FF column doesn't survive extraction — omitted, never guessed).
- **Name-collision policy**: offense row + defense row under one name = a TWO-WAY player (Travis Hunter) — combined into ONE record under the **defensive** position, because the scoring gate lets an IDP position score offense keys while WR would gate the IDP keys off (verified both ways). Two rows on the same side (Byron Murphy the CB vs the DT) = two players the source can't tell apart — dropped and reported, never averaged into a chimera.
- **Shared merge policy**: `supersede_merge_into_snapshot` extracted into `src/bdvm/projections.py` and used by both real sources — each replaces its own prior run wholesale and supersedes baseline proxies per player while other real sources carry through, so defenders covered by Clay **and** IDP Show get a genuine two-source consensus. The idpshow adapter now delegates to it (behavior pinned by its pre-existing tests).
- **Fetcher + cadence**: `scripts/fetch_clay_projections.py` (season-derived CDN URL, `--pdf`/`--url`/`--dry-run`, poppler-utils as a soft dependency with an install hint, same-day rerun no-op); `refresh_bdvm_projections` gains the clay stage (baseline → clay → idpshow), systemd template + README updated.
- **Live verification** (real 2026 guide, updated 7/25): 459 offense + 739 defense rows parse; 1,166 records after the collision policy; the board moves to **844 priced with 722 players on real Clay projections** (was 727 priced, all-proxy offense); Travis Hunter prices as CB with both sides combined.

## Tests

- **pytest: 4,756 passed** (32 new across the three features: baseline seeding, transition/flicker/per-league semantics, HTTP sweep flag-off; Clay parsing incl. totals-row and positional-page exclusion, two-way combination scoring both halves, same-side collision drop, league-rules scoring, shared-merge coexistence, three-stage orchestrator exit-code table).
- **vitest: 1,349 passed** (index/join tests; page smoke tests incl. the tab round-trip no-refetch regression).
- Next build + bundle budgets green; `ruff format --check` / `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMN5feuNUUYiLz69deJBTF