### PR TITLE
Fix a docstring that said a live flag was off, and pin it to the registry

### DIFF
--- a/src/league_intel/scoring_fit.py
+++ b/src/league_intel/scoring_fit.py
@@ -126,10 +126,25 @@ positions carries information, so the multipliers are normalised to a
 mean of 1.0 across the tracked positions. The result re-allocates value
 between IDP positions; it never inflates IDP as a whole.
 
-Flagged OFF
-───────────
-``RISKIT_FEATURE_IDP_SCORING_FIT`` defaults to 0. This moves every IDP
-value on the board and no operator has asked for it yet.
+Flagged ON since 2026-07-28
+───────────────────────────
+``RISKIT_FEATURE_IDP_SCORING_FIT`` defaults to **1**; set it to 0 to roll
+back.  Until 2026-07-28 this section still announced the opposite — that
+the default was 0 and no operator had asked for the feature — which
+stayed behind when the operator did ask and the default flipped in #606.
+A stale claim about live behaviour, in the one file a reader would open
+to find out.  ``tests/league_intel/test_flag_docs_match_reality.py`` now
+compares this paragraph against the registry.
+
+It reaches the OPT-IN league-adjusted lens only, never the default
+market board.  Blast radius on the 2026-07-28 board (1,094 rows): 398
+IDP rows move — DL n=145 +4.21%, DB n=139 -0.29%, LB n=114 -3.92% — and
+zero non-IDP values change.
+
+Two bounds apply to what this can emit.  ``MAX_DEPTH_DRIFT`` rejects a
+position whose ratio moves with sample depth (sampling noise), and
+``MAX_TILT`` caps the multiplier itself (input corruption).  They catch
+disjoint failures and both are needed; see ``MAX_TILT``.
 """
 
 from __future__ import annotations

--- a/tests/league_intel/test_flag_docs_match_reality.py
+++ b/tests/league_intel/test_flag_docs_match_reality.py
@@ -1,0 +1,89 @@
+"""A module's stated flag default must match the registry's actual one.
+
+``scoring_fit``'s docstring ended with a section headed "Flagged OFF"
+saying ``RISKIT_FEATURE_IDP_SCORING_FIT`` "defaults to 0 ... and no
+operator has asked for it yet". The operator asked, the default flipped
+to ``True`` in #606, and that paragraph stayed. For a day, the one file a
+reader would open to find out whether this feature affected their board
+told them it was switched off while it was switched on.
+
+That is the same shape as every guard this codebase keeps finding broken
+— the stated purpose and the actual predicate differ, and nothing forces
+them to agree. Documentation is not usually testable, but *this*
+sentence is: it is a claim about a value that lives three files away.
+
+Deliberately narrow. It does not police prose. It checks one thing —
+that a module claiming a flag is ON/OFF agrees with ``_DEFAULTS`` — and
+only for modules that make such a claim.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+
+import pytest
+
+from src.api import feature_flags
+
+#: ``(module path, flag name)`` for modules whose docstring states a
+#: default. Add a row when a module starts making the claim.
+_MODULES_CLAIMING_A_DEFAULT: tuple[tuple[str, str], ...] = (
+    ("src.league_intel.scoring_fit", "idp_scoring_fit"),
+    ("src.league_intel.reception_fit", "reception_scoring_fit"),
+)
+
+_ON = re.compile(r"flagged\s+on\b", re.I)
+_OFF = re.compile(r"flagged\s+off\b", re.I)
+
+
+def _docstring(module_path: str) -> str:
+    return importlib.import_module(module_path).__doc__ or ""
+
+
+@pytest.mark.parametrize("module_path,flag", _MODULES_CLAIMING_A_DEFAULT)
+def test_the_docstring_agrees_with_the_registry(module_path, flag):
+    doc = _docstring(module_path)
+    if flag not in feature_flags.registered_flags():
+        pytest.skip(f"{flag} is not a registered flag")
+
+    says_on = bool(_ON.search(doc))
+    says_off = bool(_OFF.search(doc))
+    if not (says_on or says_off):
+        return  # makes no claim; nothing to contradict
+
+    assert not (says_on and says_off), f"{module_path} says both ON and OFF — ambiguous to a reader"
+    actual = feature_flags.snapshot()[flag]
+    claimed = says_on
+    assert claimed == actual, (
+        f"{module_path} documents {flag} as "
+        f"{'ON' if claimed else 'OFF'} but the registry defaults it to "
+        f"{'ON' if actual else 'OFF'}. The docstring is the first place a "
+        "reader checks whether this affects their board."
+    )
+
+
+def test_the_check_can_actually_fail():
+    """Non-vacuity.
+
+    A regex-over-prose check is easy to write so that it matches nothing
+    and passes forever. This drives the comparison directly.
+    """
+    assert _ON.search("Flagged ON since 2026-07-28")
+    assert _OFF.search("Flagged OFF\n───────────")
+    assert not _ON.search("this module is flagged off")
+    # The real failure the test above would have caught, reconstructed:
+    # an OFF claim against a True default.
+    claimed, actual = False, True
+    assert claimed != actual
+
+
+def test_at_least_one_module_is_actually_covered():
+    """If every entry silently stopped making a claim, the parametrised
+    test would pass while checking nothing."""
+    claiming = [
+        m
+        for m, _ in _MODULES_CLAIMING_A_DEFAULT
+        if _ON.search(_docstring(m)) or _OFF.search(_docstring(m))
+    ]
+    assert claiming, "no module states a flag default any more — is this check still needed?"


### PR DESCRIPTION
Found while verifying #609 and #611 on merged `main`.

`scoring_fit`'s docstring ended with a section headed **"Flagged OFF"**, stating that `RISKIT_FEATURE_IDP_SCORING_FIT` *"defaults to 0 ... and no operator has asked for it yet"*.

You asked, the default flipped to `True` in #606, and that paragraph stayed. So the one file a reader opens to find out whether this feature moves their board told them it was switched **off** while it was switched **on**.

Same shape as every broken guard this codebase keeps turning up: the stated purpose and the actual predicate differ, and nothing forces them to agree. Prose isn't usually testable — but *this* sentence is, because it's a claim about a value living three files away.

## The check

Deliberately narrow. It does not police wording. For modules that state a flag default, it compares that claim against `_DEFAULTS` and fails naming both sides; modules making no claim are skipped.

## It caught a defect in my own fix, on the first run

My replacement paragraph quoted the old text verbatim, so the docstring matched both "Flagged ON" and "Flagged OFF" — ambiguous to the regex and, more importantly, to a human skimming it. Reworded to state one thing, then re-verified by restoring the stale header and watching it fail with the intended message:

```
src.league_intel.scoring_fit documents idp_scoring_fit as OFF but the
registry defaults it to ON. The docstring is the first place a reader
checks whether this affects their board.
```

## Also corrected in that section

What the flag actually does — opt-in league-adjusted lens only, 398 IDP rows move, zero non-IDP values change — and a pointer to the two independent bounds that constrain it (`MAX_DEPTH_DRIFT` for sampling noise, `MAX_TILT` for input corruption, added in #609).

## Validation

- Hard gate: `pytest tests/ -x -q -m "not livedata"` → **4794 passed, 319 deselected**
- `ruff format --check .` and `ruff check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeqwBFmFak84h3h7RaCZqa

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeqwBFmFak84h3h7RaCZqa)_