### PR TITLE
Reception banding: split tilt from level, turn it on, and project it forward

### DIFF
--- a/docs/reception-banding.md
+++ b/docs/reception-banding.md
@@ -1,0 +1,149 @@
+# Reception-distance banding
+
+How this league's banded reception scoring is measured, projected, and
+applied — and which parts are measured versus assumed.
+
+## The scoring
+
+`dynasty_main` does not pay a flat PPR. It bands receptions by yards
+gained. Per-catch total (`rec` + the band key), against the comparison
+league's flat card:
+
+| band | this league | baseline | ratio |
+|---|---|---|---|
+| 0–4 yd | 0.25 | 0.75 | **0.33x** |
+| 5–9 yd | 0.50 | 0.75 | 0.67x |
+| 10–19 yd | 0.75 | 0.75 | 1.00x |
+| 20–29 yd | 1.00 | 0.75 | 1.33x |
+| 30–39 yd | 1.25 | 0.75 | 1.67x |
+| 40+ yd | 2.00 | 0.75 | **2.67x** |
+
+An 8x spread. Every ranking source prices a flat rate, so the market
+structurally cannot see this.
+
+## Where catches actually fall
+
+Measured over 11,217 receptions, 2025:
+
+| band | share |
+|---|---|
+| 0–4 | 22.5% |
+| 5–9 | 34.1% |
+| 10–19 | 29.6% |
+| 20–29 | 8.8% |
+| 30–39 | 3.0% |
+| 40+ | 2.0% |
+
+Catch-weighted value per reception: **0.6148 here vs 0.7500 baseline**.
+
+Note this is *not* the same as the unweighted band-table average. Real
+receptions skew short, so the typical catch is worth less than the
+middle band suggests.
+
+## Quote the tilt, never the 8x
+
+The 8x is per-catch. Receptions are only 17–33% of a skill player's
+points, so the composed effect on player VALUE is far smaller. Measured
+over 199 receivers with 20+ catches, 2025:
+
+```
+tilt   median 1.000   p10 0.942   p90 1.042   min 0.765   max 1.098
+```
+
+Coherent at the extremes rather than random — checkdown backs and
+short-area tight ends down (Jerome Ford 0.765), deep threats up (Alec
+Pierce 1.098).
+
+Anyone sizing a trade off "8x" will be wrong by an order of magnitude.
+
+## Tilt is measured; level is assumed
+
+The per-player *tilt* and the shared *level* have completely different
+epistemic status, and they are reported separately for that reason.
+
+A flat baseline scales every player by the same constant, so:
+
+| assumed market PPR | median ratio | p10 | p90 | **p90/p10** |
+|---|---|---|---|---|
+| 0.50 | 1.239 | 0.978 | 1.466 | **1.498** |
+| 0.75 | 0.826 | 0.652 | 0.977 | **1.498** |
+| 1.00 | 0.619 | 0.489 | 0.733 | **1.498** |
+
+**The spread is identical to three decimals. The level swings 2x and
+changes sign.** At 0.5 PPR the receiving corps marks up 24%; at 1.0 it
+marks down 38%.
+
+The baseline is one Sleeper league that happens to pay 0.75/catch.
+Nothing establishes that this is what dynasty boards price on.
+
+So `reception_fit` applies the tilt and holds the level out
+(`level_multiplier`, `levelApplied: false`). Acting on a number whose
+sign you cannot establish is worse than not acting.
+
+**Open work:** measure what reception rate dynasty boards actually price
+on. Until then the level stays reported and unapplied.
+
+## Projecting it forward
+
+No projection source publishes banded receptions, and probably none ever
+will. The decomposition that makes it tractable:
+
+```
+projected banded points
+    = projected receptions        (ordinary projection sources)
+    x expected points per catch   (src/nfl_data/reception_shape_projection.py)
+```
+
+The second factor is a player **trait**, not a forecast of events, and
+it is stable:
+
+| | n | r | beats league-mean by |
+|---|---|---|---|
+| 2023 → 2024 | 123 | 0.767 | 52.6% of squared error |
+| 2024 → 2025 | 128 | 0.718 | 44.3% of squared error |
+
+r ≈ 0.72–0.77 is high for a year-over-year fantasy metric; most sit
+between 0.3 and 0.5.
+
+### Shrinkage
+
+r is high, not 1.0. A 20-catch shape across six bands has empty cells by
+chance, so a raw observed shape would hand the largest adjustments to
+the players whose shapes are least known — the failure the IDP
+per-player attempt was refused for.
+
+Shrunk toward the player's **position** mean (not the league mean — an
+RB's distribution is a different distribution, not a noisy draw from the
+WR one), weighted by sample size: `w = n / (n + K)`.
+
+`K` is fitted, scored on held-out next-season per-catch value:
+
+| K | 2023→2024 | 2024→2025 | sum |
+|---|---|---|---|
+| 0 (own shape) | 0.005413 | 0.005977 | 0.011390 |
+| 20 | 0.004144 | 0.004305 | 0.008449 |
+| **40** | **0.004010** | **0.004087** | **0.008097** |
+| 60 | 0.004024 | 0.004077 | 0.008101 |
+| ∞ (position mean) | 0.004905 | 0.004927 | 0.009832 |
+
+**Shrinkage beats both endpoints on both pairs** — 26% better than
+trusting the player, 18% better than ignoring him. That result is what
+justifies the method; had it beaten neither, the constant would be
+decoration.
+
+The optimum is flat between ~30 and 60, so the exact value is not
+load-bearing.
+
+## Status
+
+| piece | state |
+|---|---|
+| Band extraction from play-by-play | done — `reception_depth.py`, 2023/2024/2025 on disk |
+| Historical scoring | exact |
+| Per-player tilt | done, flag **ON** (opt-in league-adjusted lens only) |
+| Shared level | measured, **not applied** — needs the market-rate question answered |
+| Shape projection + fitted shrinkage | done — `reception_shape_projection.py` |
+| Wiring projection into forward rankings | **open** — needs a reception-volume projection source |
+
+The last row is the remaining gap. Mike Clay's offense projections
+(PR #610) supply reception volume, which is the missing half.

--- a/src/api/feature_flags.py
+++ b/src/api/feature_flags.py
@@ -175,11 +175,33 @@ _DEFAULTS: Final[dict[str, bool]] = {
     # name a lie — an operator disabling "idp_scoring_fit" would
     # silently also disable every receiver adjustment.
     #
-    # Also OFF by default.  Note the magnitude before enabling: the
-    # per-catch spread is 8x but receptions are 17-33% of a player's
-    # points, so the VALUE move is around +/-8%, not +/-120%.  See
-    # src/league_intel/reception_fit.py.
-    "reception_scoring_fit": False,
+    # ON since 2026-07-28.  Reception-distance banding is the largest
+    # scoring divergence on this card and the market cannot see it: the
+    # per-catch spread is 8x (0.25 to 2.00) while every ranking source
+    # prices a flat rate.
+    #
+    # Magnitude, measured — quote THIS, not the 8x.  Receptions are only
+    # 17-33% of a skill player's points, so the composed VALUE tilt over
+    # 199 receivers with 20+ catches (2025) is:
+    #
+    #   median 1.000  p10 0.942  p90 1.042  min 0.765  max 1.098
+    #   0 of 199 at the clamp; dispersion drift 0.0226 (bound 0.12)
+    #
+    # Coherent at the extremes rather than random: checkdown backs and
+    # short-area tight ends down (Jerome Ford 0.765), deep threats up
+    # (Alec Pierce 1.098).  Year-over-year r=0.72-0.77, so the band shape
+    # is a real player trait rather than noise.
+    #
+    # The multipliers carry TILT ONLY.  The shared level (0.9543) is
+    # held out and reported separately, because it depends on the
+    # baseline league being what the market prices — an assumption that
+    # swings the level 2x and flips its sign across plausible rates.
+    # Mean-normalised, so this cannot inflate receivers as a class.
+    #
+    # Reaches the OPT-IN league-adjusted lens (/api/gameplan) only,
+    # never the default market board.
+    # Rollback: RISKIT_FEATURE_RECEPTION_SCORING_FIT=0.
+    "reception_scoring_fit": True,
     # BDVM — projection-driven fundamental dynasty valuation engine
     # (src/bdvm/, endpoints /api/bdvm/values|roster|trades).  Held OFF:
     # the engine is implemented and tested (tests/bdvm/); it serves an

--- a/src/league_intel/reception_fit.py
+++ b/src/league_intel/reception_fit.py
@@ -47,12 +47,47 @@ extremes are also coherent rather than random: deep threats at the top
 at the bottom (White, Gainwell, Ferguson), which is the axis the banding
 is built on.
 
-The median sits at ~0.96, so the receiving corps as a whole is priced
-slightly high by flat-PPR sources. That is a real level effect and it is
-kept rather than normalised away — unlike the IDP case, where the shared
-level was an artifact of rate-card generosity. Here both cards are being
-applied to the same catches, so a shared shift is a fact about the
-scoring, not about how the commissioners numbered their sheets.
+The tilt is robust; the level rests on an assumption
+────────────────────────────────────────────────────
+This section previously argued that the shared level should be KEPT
+rather than normalised away: unlike the IDP case, where the shared level
+is an artifact of rate-card generosity, here both cards score the same
+catches, so a shared shift is a fact about the scoring.
+
+That reasoning is sound **only if the baseline card is what the market
+actually prices**, and nothing establishes that. The baseline is one
+Sleeper league from ``config/league_comparison.json`` that happens to pay
+a flat 0.75/catch. Dynasty boards are built nearer 0.5 or 1.0.
+
+Measured across plausible market rates, on 201 receivers with 20+ catches
+(2025)::
+
+    assumed market PPR   median ratio    p10     p90    p90/p10
+              0.50           1.239      0.978   1.466    1.498
+              0.75           0.826      0.652   0.977    1.498
+              1.00           0.619      0.489   0.733    1.498
+
+**The spread is identical to three decimals; the level swings 2x.** A
+flat baseline scales every player by the same constant, so the tilt
+between players cannot depend on the assumption — and the level is
+nothing but the assumption. At 0.5 the whole receiving corps marks UP
+24%; at 1.0 it marks DOWN 38%. The direction flips.
+
+So the two halves are reported separately and only the tilt is applied
+by default:
+
+* :attr:`ReceptionFitMeasurement.multipliers` carries the **tilt** —
+  mean-normalised across the measured population, invariant to the
+  market-rate assumption, safe to act on.
+* :attr:`ReceptionFitMeasurement.level_multiplier` carries the shared
+  shift, stamped with the assumption that produced it. It is NOT folded
+  into the per-player multipliers, because acting on a number whose sign
+  you cannot establish is worse than not acting.
+
+The level is real in principle and may well be worth applying. Doing so
+needs a measured answer to "what reception rate do dynasty boards price
+on?", which is a separate piece of work — see
+``docs/reception-banding.md``.
 """
 
 from __future__ import annotations
@@ -79,10 +114,27 @@ __all__ = [
 #: rosterable in a 12-team league several times over.
 MIN_RECEPTIONS: int = 20
 
-#: Hard clamp on the composed multiplier. Nothing measured comes close
-#: (observed range 0.92-1.09); this exists so an upstream data fault
-#: cannot express itself as a 3x repricing.
-MAX_TILT: float = 0.25
+#: Hard clamp on the emitted tilt, so an upstream data fault cannot
+#: express itself as a 3x repricing.
+#:
+#: WIDENED 0.25 -> 0.35 on 2026-07-28, when the level was split out.
+#: The old bound was set against the pre-split range, which carried the
+#: level and sat near 0.92-1.09. Tilt is centred on 1.0 by construction
+#: and spreads wider: measured over 199 receivers (2025), min 0.765 and
+#: max 1.098.
+#:
+#: 0.765 against a 0.75 floor is 1.5% of headroom — the clamp had
+#: stopped being a backstop and started shaping the result, and it was
+#: binding hardest on exactly the archetype this measurement exists to
+#: find (Jerome Ford, a checkdown back). A safety bound that truncates
+#: the signal it is protecting is worse than none, because the
+#: truncation is invisible in the output.
+#:
+#: At 0.35 the observed extremes sit 15% inside the bound on both sides,
+#: and a genuine fault still cannot move a player more than a third.
+#: :func:`tests...test_the_bound_keeps_clear_of_real_data` fails if real
+#: data ever creeps back toward it.
+MAX_TILT: float = 0.35
 
 #: Depth probes and tolerance, mirroring
 #: :mod:`src.league_intel.scoring_fit` so the two measurements are
@@ -114,6 +166,19 @@ class ReceptionFitMeasurement:
     sample_size: int = 0
     reason: str = ""
 
+    level_multiplier: float = 1.0
+    """The shared shift, held OUT of :attr:`multipliers`.
+
+    This is the part that depends on the market-rate assumption — it
+    swings 2x and changes sign across plausible values (see the module
+    docstring). Reported so it can be inspected and later applied on
+    purpose; never folded in silently.
+    """
+
+    level_basis: str = ""
+    """What the level was measured against, so the number is never read
+    as more established than it is."""
+
     def multiplier_for(self, player_id_gsis: str) -> float:
         """1.0 for anything unmeasured or untrusted. Never raises."""
         if not self.trusted:
@@ -128,6 +193,9 @@ class ReceptionFitMeasurement:
             "sampleSize": self.sample_size,
             "dispersionDrift": round(self.dispersion_drift, 6),
             "medianMultiplier": round(self.median_multiplier, 6),
+            "levelMultiplier": round(self.level_multiplier, 6),
+            "levelApplied": False,
+            "levelBasis": self.level_basis,
             "reason": self.reason,
             "playerCount": len(self.multipliers),
         }
@@ -209,11 +277,10 @@ def measure_reception_depth_fit(
         share = max(0.0, min(1.0, float(share)))
 
         raw = 1.0 + share * (ratio - 1.0)
-        multiplier = max(1.0 - MAX_TILT, min(1.0 + MAX_TILT, raw))
-        multipliers[gsis] = multiplier
+        multipliers[gsis] = raw  # normalised and clamped below
         ratios[gsis] = ratio
         shares_out[gsis] = share
-        ranked.append((summary["receptions"], multiplier))
+        ranked.append((summary["receptions"], gsis))
 
     if len(multipliers) < 10:
         return ReceptionFitMeasurement(
@@ -222,6 +289,22 @@ def measure_reception_depth_fit(
             reason=f"only {len(multipliers)} players had both a band shape and a scored season",
         )
 
+    # Split level from tilt.  The level is the population median of the
+    # composed multiplier; the tilt is what remains once it is divided
+    # out.  Only the tilt survives into ``multipliers`` — see the module
+    # docstring for why the level cannot be applied on this evidence.
+    level = statistics.median(multipliers.values())
+    if level <= 0:
+        return ReceptionFitMeasurement(
+            season=season, measured=False, reason="degenerate level multiplier"
+        )
+    for gsis, raw in list(multipliers.items()):
+        tilt = raw / level
+        multipliers[gsis] = max(1.0 - MAX_TILT, min(1.0 + MAX_TILT, tilt))
+
+    # (receptions, tilt) so dispersion is probed by volume, resolved by
+    # id rather than by relying on dict and list orders coinciding.
+    ranked = [(rec, multipliers[g]) for rec, g in ranked]
     ranked.sort(key=lambda t: -t[0])
     probes = [_dispersion([m for _, m in ranked[:n]]) for n in _DEPTH_PROBES if len(ranked) >= n]
     probes = [p for p in probes if p > 0]
@@ -248,6 +331,12 @@ def measure_reception_depth_fit(
         dispersion_drift=drift,
         median_multiplier=median_mult,
         sample_size=len(multipliers),
+        level_multiplier=level,
+        level_basis=(
+            "population median of (1 + share x (per-catch ratio - 1)) against the "
+            "baseline league's card; DEPENDS on that card being what the market "
+            "prices, which is unestablished — held out of the per-player multipliers"
+        ),
         reason=(
             f"composed over {len(multipliers)} receivers with >={min_receptions} catches; "
             f"dispersion stable to {drift:.4f} across depths {_DEPTH_PROBES}"

--- a/src/nfl_data/reception_shape_projection.py
+++ b/src/nfl_data/reception_shape_projection.py
@@ -1,0 +1,250 @@
+"""Project a player's reception-band shape forward, for scoring rules
+that pay by catch distance.
+
+The problem
+───────────
+This league bands receptions by yards gained — 0.25/catch at 0-4 yards
+rising to 2.00 at 40+. Historical scoring can read the exact bands from
+play-by-play (:mod:`src.nfl_data.reception_depth`). **Projections
+cannot**: no projection source publishes banded receptions, and it is
+unlikely any ever will.
+
+What makes it tractable is that the two halves separate cleanly:
+
+    projected banded points
+        = projected receptions          (any ordinary projection source)
+        x expected points per catch     (this module)
+
+and the second factor is a **player trait**, not a forecast of events.
+
+Measured stability, per-catch value ratio year over year::
+
+    2023 -> 2024   n=123   r=0.767   beats league-mean by 52.6% of SSE
+    2024 -> 2025   n=128   r=0.718   beats league-mean by 44.3% of SSE
+
+r around 0.72-0.77 is high for a year-over-year fantasy metric — most
+sit between 0.3 and 0.5. Carrying a player's own shape forward is
+substantially better than assuming he catches like the average player at
+his position, which is what a flat rate implicitly assumes.
+
+Why shrinkage, and why toward POSITION
+───────────────────────────────────────
+r=0.72 is high, not 1.0. A player with 22 catches has a shape estimated
+from 22 draws across six bands — several will be empty by chance. Taking
+that shape at face value would hand the largest adjustments to the
+players whose shapes are least known, which is the failure mode the IDP
+per-player attempt was refused for (see
+:mod:`src.league_intel.scoring_fit`).
+
+So the estimate is shrunk toward the player's POSITION mean, weighted by
+sample size::
+
+    w = n / (n + K)
+    shape = w * player_shape + (1 - w) * position_shape
+
+Position rather than league-wide because the position means genuinely
+differ — an RB's catch distribution is not a noisy draw from the WR
+distribution, it is a different distribution, and shrinking toward the
+league would drag every back toward a shape no back has.
+
+:data:`SHRINK_K` is fitted, not chosen: see
+:func:`fit_shrinkage_constant`, which picks the K minimising next-season
+squared error on held-out seasons.
+
+What this module does NOT do
+────────────────────────────
+It does not project receptions. That is volume, it depends on offence,
+role, health and coaching, and it is what ordinary projection sources
+already publish. Combining the two is the caller's job.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping
+
+from src.nfl_data.reception_depth import BAND_KEYS, summarise_histogram
+
+_LOGGER = logging.getLogger(__name__)
+
+__all__ = [
+    "SHRINK_K",
+    "MIN_RECEPTIONS_FOR_SHAPE",
+    "expected_points_per_catch",
+    "fit_shrinkage_constant",
+    "position_shapes",
+    "project_band_shape",
+]
+
+#: Below this the player's own shape is ignored entirely and the
+#: position shape is used unchanged. A handful of catches carries no
+#: shape information worth the risk of pretending otherwise.
+MIN_RECEPTIONS_FOR_SHAPE: int = 8
+
+#: Shrinkage half-weight: at n == SHRINK_K the estimate is half the
+#: player's own shape and half his position's.
+#:
+#: FITTED, not chosen. :func:`fit_shrinkage_constant` scored candidate
+#: values on held-out next-season per-catch value (MSE, lower better)::
+#:
+#:     K            2023->2024   2024->2025   sum
+#:     0   own       0.005413     0.005977    0.011390
+#:     20            0.004144     0.004305    0.008449
+#:     40            0.004010     0.004087    0.008097   <- joint best
+#:     60            0.004024     0.004077    0.008101
+#:     inf position  0.004905     0.004927    0.009832
+#:
+#: Shrinkage beats BOTH endpoints on both pairs — 26% better than
+#: trusting the player's own shape, 18% better than ignoring him for the
+#: position mean. That is the result that justifies the method: if it
+#: had beaten neither, the shrinkage would be doing no work.
+#:
+#: The optimum is flat between roughly 30 and 60, so the exact value is
+#: not load-bearing; anything in that range performs within 1% of best.
+SHRINK_K: float = 40.0
+
+
+def _normalise(counts: Mapping[str, float]) -> dict[str, float]:
+    total = sum(max(0.0, float(counts.get(b, 0) or 0)) for b in BAND_KEYS)
+    if total <= 0:
+        return {b: 0.0 for b in BAND_KEYS}
+    return {b: max(0.0, float(counts.get(b, 0) or 0)) / total for b in BAND_KEYS}
+
+
+def position_shapes(
+    depth_payload: Mapping[str, Any],
+    positions: Mapping[str, str],
+    *,
+    min_receptions: int = MIN_RECEPTIONS_FOR_SHAPE,
+) -> dict[str, dict[str, float]]:
+    """Catch-weighted mean band shape per position.
+
+    Weighted by catches rather than by player: a position's shape should
+    describe how balls are actually caught at that position, and a
+    player-weighted mean would let a 9-catch specialist count as much as
+    a 100-catch workhorse.
+    """
+    acc: dict[str, dict[str, float]] = {}
+    for gsis, rec in (depth_payload.get("players") or {}).items():
+        if not isinstance(rec, dict):
+            continue
+        pos = str(positions.get(gsis) or "").upper()
+        if not pos:
+            continue
+        bands = rec.get("bands") or {}
+        if sum(int(bands.get(b, 0) or 0) for b in BAND_KEYS) < min_receptions:
+            continue
+        into = acc.setdefault(pos, {b: 0.0 for b in BAND_KEYS})
+        for b in BAND_KEYS:
+            into[b] += float(bands.get(b, 0) or 0)
+    return {pos: _normalise(counts) for pos, counts in acc.items()}
+
+
+def project_band_shape(
+    player_bands: Mapping[str, float] | None,
+    position_shape: Mapping[str, float] | None,
+    *,
+    shrink_k: float = SHRINK_K,
+    min_receptions: int = MIN_RECEPTIONS_FOR_SHAPE,
+) -> dict[str, float] | None:
+    """Shrink a player's observed band shape toward his position's.
+
+    Returns None when neither a usable player shape nor a position shape
+    is available — an explicit "unknown", never a fabricated uniform
+    distribution, which would silently price the player as league
+    average while looking like a measurement.
+    """
+    pos_shape = _normalise(position_shape or {}) if position_shape else None
+    if pos_shape is not None and sum(pos_shape.values()) <= 0:
+        pos_shape = None
+
+    n = sum(max(0.0, float((player_bands or {}).get(b, 0) or 0)) for b in BAND_KEYS)
+    if n < min_receptions:
+        return dict(pos_shape) if pos_shape else None
+    own = _normalise(player_bands or {})
+    if pos_shape is None:
+        return own
+
+    w = n / (n + float(shrink_k))
+    return {b: w * own[b] + (1.0 - w) * pos_shape[b] for b in BAND_KEYS}
+
+
+def expected_points_per_catch(
+    shape: Mapping[str, float] | None,
+    scoring: Mapping[str, Any],
+) -> float | None:
+    """Points a single reception is worth to a player with this shape.
+
+    ``None`` shape returns ``None`` rather than a flat rate: a caller
+    that cannot tell "unknown" from "league average" will quietly price
+    every unknown player as average.
+    """
+    if not shape:
+        return None
+    flat = float(scoring.get("rec") or 0.0)
+    return sum(float(shape.get(b, 0.0)) * (flat + float(scoring.get(b) or 0.0)) for b in BAND_KEYS)
+
+
+def fit_shrinkage_constant(
+    prior_payload: Mapping[str, Any],
+    later_payload: Mapping[str, Any],
+    positions: Mapping[str, str],
+    scoring: Mapping[str, Any],
+    *,
+    candidates: tuple[float, ...] = (0.0, 5.0, 10.0, 20.0, 30.0, 34.0, 40.0, 60.0, 100.0, 1e9),
+    min_receptions: int = 20,
+) -> dict[str, Any]:
+    """Pick the K that best predicts NEXT season's per-catch value.
+
+    The honest test for a shrinkage constant: shrink the prior season's
+    shape by each candidate K, price it under ``scoring``, and score it
+    against what the player's per-catch value actually turned out to be.
+
+    The two endpoints are the baseline models this must beat — K=0 is
+    "trust the player's own shape completely", K=infinity is "use the
+    position mean and ignore the player". A fitted K that beat neither
+    would mean the shrinkage is doing nothing.
+    """
+    pos_shapes = position_shapes(prior_payload, positions)
+    prior_players = prior_payload.get("players") or {}
+    later_players = later_payload.get("players") or {}
+
+    pairs: list[tuple[Mapping[str, float], str, float]] = []
+    for gsis, later in later_players.items():
+        prior = prior_players.get(gsis)
+        if not isinstance(prior, dict) or not isinstance(later, dict):
+            continue
+        later_summary = summarise_histogram(later.get("bands") or {})
+        if later_summary["receptions"] < min_receptions:
+            continue
+        actual = expected_points_per_catch(later_summary["shares"], scoring)
+        if actual is None:
+            continue
+        pos = str(positions.get(gsis) or "").upper()
+        pairs.append((prior.get("bands") or {}, pos, actual))
+
+    results: dict[float, float] = {}
+    for k in candidates:
+        sse = 0.0
+        used = 0
+        for bands, pos, actual in pairs:
+            shape = project_band_shape(bands, pos_shapes.get(pos), shrink_k=k)
+            pred = expected_points_per_catch(shape, scoring)
+            if pred is None:
+                continue
+            sse += (pred - actual) ** 2
+            used += 1
+        if used:
+            results[k] = sse / used
+
+    if not results:
+        return {"fitted": None, "reason": "no player had both seasons", "n": 0}
+    best = min(results, key=lambda k: results[k])
+    return {
+        "fitted": best,
+        "n": len(pairs),
+        "mseByK": {str(k): round(v, 8) for k, v in sorted(results.items())},
+        "mseAtBest": round(results[best], 8),
+        "mseTrustPlayer": round(results.get(0.0, float("nan")), 8),
+        "mseIgnorePlayer": round(results.get(max(candidates), float("nan")), 8),
+    }

--- a/tests/api/test_feature_flags.py
+++ b/tests/api/test_feature_flags.py
@@ -91,6 +91,30 @@ def test_every_flag_defaults_off_except_safe_additive():
         # wrong was the recorded rationale, including the one used to
         # justify turning this flag on.
         "idp_scoring_fit",
+        # Reception-distance banding — the largest scoring divergence on
+        # this card, and one the market structurally cannot see: the
+        # per-catch spread is 8x while every ranking source prices a
+        # flat rate.
+        #
+        # Blast radius measured over 199 receivers with 20+ catches
+        # (2025).  Quote the TILT, never the 8x:
+        #
+        #   median 1.000  p10 0.942  p90 1.042  min 0.765  max 1.098
+        #   0 of 199 at the clamp; dispersion drift 0.0226 (bound 0.12)
+        #
+        # Coherent at the extremes — checkdown backs and short-area
+        # tight ends down (Jerome Ford 0.765), deep threats up (Alec
+        # Pierce 1.098) — and the band shape is year-over-year stable
+        # (r=0.72-0.77), so it is a player trait rather than noise.
+        #
+        # Mean-normalised, so it re-allocates between receivers and
+        # cannot inflate the receiving corps as a class.  The shared
+        # LEVEL (0.9543) is deliberately held OUT: it depends on the
+        # baseline league being what the market prices, an assumption
+        # that swings the level 2x and flips its sign across plausible
+        # rates.  Opt-in league-adjusted lens only.
+        # Rollback: RISKIT_FEATURE_RECEPTION_SCORING_FIT=0.
+        "reception_scoring_fit",
     }
     off_only = {
         "dynamic_source_weights",  # held OFF until backtest data exists

--- a/tests/league_intel/test_fitted_curve_bounds.py
+++ b/tests/league_intel/test_fitted_curve_bounds.py
@@ -181,10 +181,43 @@ def test_a_mild_tilt_passes_through_unclamped():
         assert f.multiplier != pytest.approx(1.0 + MAX_TILT), "clamped a mild tilt"
 
 
-def test_the_two_sibling_fits_share_a_bound():
-    """These modules are explicitly built as siblings. The asymmetry
-    that let one go unbounded is what this pins shut."""
-    assert scoring_fit.MAX_TILT == reception_fit.MAX_TILT
+def test_both_sibling_fits_are_bounded_at_all():
+    """The asymmetry that let one go unbounded is what this pins shut.
+
+    An earlier version asserted the two bounds were EQUAL. That was a
+    proxy for the real property and it was wrong: the bounds should
+    track each measurement's own spread, and those differ. IDP
+    positional multipliers span 0.96-1.04 against a 0.25 bound, while
+    per-player reception tilt spans 0.765-1.098 and needed 0.35 to stop
+    the clamp shaping the result. Equality would have forced one of them
+    to be wrong for its data.
+
+    What must hold is that each exists and each is sane.
+    """
+    for mod in (scoring_fit, reception_fit):
+        bound = getattr(mod, "MAX_TILT", None)
+        assert bound is not None, f"{mod.__name__} has no MAX_TILT"
+        assert 0.0 < bound < 1.0, (
+            f"{mod.__name__}.MAX_TILT={bound} — a bound at or above 1.0 permits "
+            "a player's value to be zeroed or doubled, which is not a backstop"
+        )
+
+
+def test_each_bound_clears_its_own_measured_data():
+    """The principle the equality check was reaching for.
+
+    A bound must not bind on real data — that is the difference between
+    a fault backstop and a silent shaper. Each module records its own
+    measured extremes next to its constant; this asserts the bound sits
+    outside them with room.
+    """
+    # scoring_fit: measured IDP multipliers, 2026-07-28.
+    for observed in (0.9608, 1.0421):
+        assert 1.0 - scoring_fit.MAX_TILT < observed < 1.0 + scoring_fit.MAX_TILT
+
+    # reception_fit: measured per-player tilt over 199 receivers, 2025.
+    for observed in (0.765, 1.098):
+        assert 1.0 - reception_fit.MAX_TILT < observed < 1.0 + reception_fit.MAX_TILT
 
 
 # ── the curves the sweep found already sound ──────────────────────────

--- a/tests/league_intel/test_reception_fit.py
+++ b/tests/league_intel/test_reception_fit.py
@@ -20,6 +20,8 @@ depth, kept) from the IDP per-player one (fans out, refused).
 
 from __future__ import annotations
 
+import statistics
+
 import pytest
 
 from src.league_intel.reception_fit import (
@@ -67,30 +69,43 @@ def test_composition_shrinks_the_per_catch_ratio_toward_one():
     Applying the per-catch ratio straight to player value is the error
     this test exists to prevent.
     """
-    bands = {"rec_40p": 30, "rec_30_39": 10}  # all long
-    # Share deliberately below the level at which MAX_TILT would bind,
-    # so this test measures the COMPOSITION and not the clamp — the
-    # clamp has its own test and a fixture that hit both would not
-    # distinguish them.
+    # A MIXED population is required now that the level is split out.
+    # In a uniform cohort every receiver has the same shape, so there is
+    # no tilt between them by construction and every multiplier is
+    # exactly 1.0 — correct, but it tests nothing about composition.
     share = 0.15
-    players, shares = _uniform(20, bands, share=share)
-    m = measure_reception_depth_fit(_payload(players), shares, _MINE, _BASE, season=2025)
+    deep, deep_shares = _uniform(10, {"rec_40p": 30, "rec_30_39": 10}, share=share, prefix="d")
+    mid, mid_shares = _uniform(10, {"rec_10_19": 40}, share=share, prefix="m")
+    m = measure_reception_depth_fit(
+        _payload({**deep, **mid}), {**deep_shares, **mid_shares}, _MINE, _BASE, season=2025
+    )
     assert m.measured and m.trusted
 
-    gid = "p000"
-    per_catch = m.per_catch_ratios[gid]
-    multiplier = m.multipliers[gid]
-    assert per_catch > 2.0, "fixture is not actually a deep-threat shape"
-    assert multiplier < 1.0 + MAX_TILT, "fixture hit the clamp; it is testing the wrong thing"
-    # Exactly where the composition puts it, and far below the per-catch
-    # ratio it came from.
-    assert multiplier == pytest.approx(1.0 + share * (per_catch - 1.0))
-    # The claim stated as a shrinkage: the value moves by the SHARE of
-    # the per-catch move, so a 142% per-catch premium becomes a 21%
-    # value premium. Asserting the deviations rather than the raw
-    # numbers is what makes this about composition.
-    assert (multiplier - 1.0) == pytest.approx(share * (per_catch - 1.0))
-    assert (multiplier - 1.0) < 0.25 * (per_catch - 1.0)
+    per_catch_deep = m.per_catch_ratios["d000"]
+    per_catch_mid = m.per_catch_ratios["m000"]
+    assert per_catch_deep > 2.0, "fixture is not actually a deep-threat shape"
+
+    # The composed, pre-normalisation multipliers.
+    raw_deep = 1.0 + share * (per_catch_deep - 1.0)
+    raw_mid = 1.0 + share * (per_catch_mid - 1.0)
+
+    # The deep threat's TILT is his composed value relative to the
+    # population level, and it is far smaller than his per-catch ratio.
+    tilt_deep = m.multipliers["d000"]
+    assert tilt_deep == pytest.approx(raw_deep / m.level_multiplier)
+    assert tilt_deep < 1.0 + MAX_TILT, "fixture hit the clamp; it is testing the wrong thing"
+
+    # The shrinkage claim, stated on the ratio BETWEEN the two shapes so
+    # it is invariant to the level: a 2x+ per-catch gap becomes a value
+    # gap of only a few percent, because catches are a small slice of
+    # each player's points.
+    value_gap = raw_deep / raw_mid
+    per_catch_gap = per_catch_deep / per_catch_mid
+    assert per_catch_gap > 2.0
+    assert value_gap < 1.25, (
+        f"value gap {value_gap:.3f} from a per-catch gap of {per_catch_gap:.3f} — "
+        "composition is not shrinking the effect"
+    )
 
 
 def test_a_zero_reception_share_is_a_no_op_however_extreme_the_shape():
@@ -114,12 +129,56 @@ def test_the_direction_matches_the_band_the_catches_fall_in():
 
 
 def test_the_tilt_is_clamped(monkeypatch):
-    """An upstream data fault must not be able to express itself as a
-    3x repricing. The clamp is a backstop, not a shaper — on real 2025
-    data exactly one of 200 receivers reaches it."""
+    """An upstream data fault must not express itself as a 3x repricing.
+
+    The clamp is a backstop, not a shaper. Needs a MIXED population: the
+    clamp bounds a player's tilt relative to the population level, so a
+    uniform cohort — however extreme its shape — has every member at
+    exactly 1.0 and can never reach it.
+    """
+    deep, deep_shares = _uniform(12, {"rec_40p": 40}, share=1.0, prefix="d")
+    short, short_shares = _uniform(12, {"rec_0_4": 40}, share=1.0, prefix="s")
+    m = measure_reception_depth_fit(
+        _payload({**deep, **short}), {**deep_shares, **short_shares}, _MINE, _BASE, season=2025
+    )
+    assert m.multipliers["d000"] == pytest.approx(1.0 + MAX_TILT)
+    assert m.multipliers["s000"] == pytest.approx(1.0 - MAX_TILT)
+
+
+def test_a_uniform_cohort_has_no_tilt_and_all_of_the_level():
+    """The property that split the two apart.
+
+    If every receiver catches the same way, none is advantaged relative
+    to another — the entire effect is a level shift on the whole
+    receiving corps, which is exactly the part that depends on an
+    unestablished market rate. Pre-split this returned 1.25 for every
+    player, applying an assumption as if it were a measurement.
+    """
     players, shares = _uniform(20, {"rec_40p": 40}, share=1.0)
     m = measure_reception_depth_fit(_payload(players), shares, _MINE, _BASE, season=2025)
-    assert m.multipliers["p000"] == pytest.approx(1.0 + MAX_TILT)
+    for gid in players:
+        assert m.multipliers[gid] == pytest.approx(1.0), "a uniform cohort cannot have tilt"
+    assert m.level_multiplier > 1.5, "the level should carry the whole (large) effect"
+    assert m.level_basis, "the level must record what it was measured against"
+
+
+def test_the_level_is_never_folded_into_the_per_player_multipliers():
+    """The guard on the decision.
+
+    Multiplying tilt by level would re-apply the assumption this split
+    exists to hold back, and would look identical to the pre-split
+    output.
+    """
+    deep, deep_shares = _uniform(10, {"rec_40p": 40}, share=0.4, prefix="d")
+    mid, mid_shares = _uniform(10, {"rec_10_19": 40}, share=0.4, prefix="m")
+    m = measure_reception_depth_fit(
+        _payload({**deep, **mid}), {**deep_shares, **mid_shares}, _MINE, _BASE, season=2025
+    )
+    assert m.level_multiplier != pytest.approx(1.0), "fixture has no level to hold back"
+    assert statistics.median(m.multipliers.values()) == pytest.approx(
+        1.0, abs=1e-9
+    ), "the per-player multipliers still carry the level"
+    assert m.to_dict()["levelApplied"] is False
 
 
 def test_players_below_the_reception_floor_are_excluded():
@@ -336,3 +395,47 @@ def test_the_resolver_is_inert_while_the_reception_flag_is_off(monkeypatch):
     finally:
         feature_flags.reload()
         gameplan.invalidate_reception_fit_cache()
+
+
+#: Tilt extremes measured over 199 receivers with 20+ catches, 2025,
+#: after the level split. Recorded so a future change to the bound is
+#: judged against real data rather than intuition.
+_MEASURED_TILT_MIN = 0.765  # Jerome Ford, a checkdown back
+_MEASURED_TILT_MAX = 1.098  # Alec Pierce, a deep threat
+
+
+def test_the_bound_keeps_clear_of_real_data():
+    """A safety bound must not shape the result it is protecting.
+
+    At MAX_TILT=0.25 the measured minimum sat 1.5% above the floor —
+    binding hardest on precisely the archetype this measurement exists
+    to surface, and doing it invisibly. The bound was widened to 0.35.
+
+    This fails if the bound is tightened back, or if real data drifts
+    toward it, rather than letting either happen silently.
+    """
+    floor, ceil = 1.0 - MAX_TILT, 1.0 + MAX_TILT
+    assert floor < _MEASURED_TILT_MIN and _MEASURED_TILT_MAX < ceil
+
+    low_headroom = (_MEASURED_TILT_MIN - floor) / (1.0 - floor)
+    high_headroom = (ceil - _MEASURED_TILT_MAX) / (ceil - 1.0)
+    assert low_headroom > 0.10, (
+        f"only {low_headroom:.1%} headroom below — the clamp is shaping the "
+        "signal, not backstopping a fault"
+    )
+    assert high_headroom > 0.10, f"only {high_headroom:.1%} headroom above"
+
+
+def test_the_bound_still_contains_a_fault():
+    """Widening must not turn the backstop off.
+
+    An extreme mixed population still cannot move a player by more than
+    a third, which is the property the clamp exists for.
+    """
+    deep, deep_shares = _uniform(12, {"rec_40p": 40}, share=1.0, prefix="d")
+    short, short_shares = _uniform(12, {"rec_0_4": 40}, share=1.0, prefix="s")
+    m = measure_reception_depth_fit(
+        _payload({**deep, **short}), {**deep_shares, **short_shares}, _MINE, _BASE, season=2025
+    )
+    for v in m.multipliers.values():
+        assert 0.6 <= v <= 1.4, f"tilt {v} escaped a sane bound"

--- a/tests/nfl_data/test_reception_shape_projection.py
+++ b/tests/nfl_data/test_reception_shape_projection.py
@@ -1,0 +1,182 @@
+"""Projecting a reception-band shape forward.
+
+Historical banded scoring is exact — play-by-play carries every catch.
+Projections are the open half, because no source publishes banded
+receptions. The decomposition that makes it tractable::
+
+    projected banded points
+        = projected receptions      (ordinary projection sources)
+        x expected points per catch (this module)
+
+and the second factor is a player TRAIT rather than a forecast. Measured
+year-over-year r = 0.767 (2023->2024) and 0.718 (2024->2025), which is
+high for a fantasy metric — most sit between 0.3 and 0.5.
+
+The tests that matter most are the ones pinning what the shrinkage
+REFUSES to do. r=0.72 is not 1.0, and a 20-catch shape estimated across
+six bands has empty cells by chance. Taking it at face value would hand
+the largest adjustments to the players whose shapes are least known —
+the exact failure the IDP per-player attempt was refused for.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.nfl_data.reception_depth import BAND_KEYS
+from src.nfl_data.reception_shape_projection import (
+    MIN_RECEPTIONS_FOR_SHAPE,
+    SHRINK_K,
+    expected_points_per_catch,
+    fit_shrinkage_constant,
+    position_shapes,
+    project_band_shape,
+)
+
+_CARD = {
+    "rec": 0.08,
+    "rec_0_4": 0.17,
+    "rec_5_9": 0.42,
+    "rec_10_19": 0.67,
+    "rec_20_29": 0.92,
+    "rec_30_39": 1.17,
+    "rec_40p": 1.92,
+}
+
+_DEEP = {"rec_40p": 40}
+_SHORT = {"rec_0_4": 40}
+_POS_MID = {b: (1.0 if b == "rec_10_19" else 0.0) for b in BAND_KEYS}
+
+
+def test_a_large_sample_keeps_most_of_the_players_own_shape():
+    shape = project_band_shape({"rec_40p": 200}, _POS_MID)
+    w = 200 / (200 + SHRINK_K)
+    assert shape["rec_40p"] == pytest.approx(w)
+    assert w > 0.8, "a 200-catch season should be mostly the player's own shape"
+
+
+def test_a_small_sample_is_pulled_hard_toward_the_position():
+    """THE GUARD. A thin shape must not produce a large adjustment.
+
+    At n=10 the player keeps only 20% of his own shape, so an extreme
+    observed distribution cannot express itself as an extreme value.
+    """
+    shape = project_band_shape({"rec_40p": 10}, _POS_MID)
+    w = 10 / (10 + SHRINK_K)
+    assert shape["rec_40p"] == pytest.approx(w)
+    assert w < 0.25, "a 10-catch sample is being trusted far too much"
+
+
+def test_shrinkage_compresses_value_more_than_it_compresses_shape():
+    """The property that makes this safe in points terms."""
+    thin = expected_points_per_catch(project_band_shape({"rec_40p": 10}, _POS_MID), _CARD)
+    thick = expected_points_per_catch(project_band_shape({"rec_40p": 200}, _POS_MID), _CARD)
+    mid = expected_points_per_catch(_POS_MID, _CARD)
+    assert mid < thin < thick, "shrinkage should order thin between position and thick"
+    assert (thin - mid) < 0.35 * (thick - mid)
+
+
+def test_below_the_floor_the_player_shape_is_ignored_entirely():
+    shape = project_band_shape({"rec_40p": MIN_RECEPTIONS_FOR_SHAPE - 1}, _POS_MID)
+    assert shape == pytest.approx(_POS_MID)
+
+
+def test_an_unknown_player_returns_none_rather_than_a_flat_guess():
+    """Unknown and league-average must not be the same value.
+
+    Returning a uniform or position shape for a player with no data at
+    all would price him as average while looking like a measurement —
+    the failure mode this codebase keeps paying for.
+    """
+    assert project_band_shape(None, None) is None
+    assert project_band_shape({}, None) is None
+    assert expected_points_per_catch(None, _CARD) is None
+
+
+def test_position_shapes_are_catch_weighted_not_player_weighted():
+    """A 9-catch specialist must not count as much as a workhorse."""
+    payload = {
+        "players": {
+            "a": {"bands": {"rec_40p": 100}},
+            "b": {"bands": {"rec_0_4": 10}},
+        }
+    }
+    shapes = position_shapes(payload, {"a": "WR", "b": "WR"})
+    assert shapes["WR"]["rec_40p"] == pytest.approx(100 / 110)
+
+
+def test_positions_do_not_contaminate_each_other():
+    """An RB's catch distribution is a different distribution, not a
+    noisy draw from the WR one. Shrinking toward a pooled league mean
+    would drag every back toward a shape no back has."""
+    payload = {
+        "players": {
+            "wr": {"bands": {"rec_40p": 50}},
+            "rb": {"bands": {"rec_0_4": 50}},
+        }
+    }
+    shapes = position_shapes(payload, {"wr": "WR", "rb": "RB"})
+    assert shapes["WR"]["rec_40p"] == pytest.approx(1.0)
+    assert shapes["RB"]["rec_0_4"] == pytest.approx(1.0)
+
+
+def test_the_shape_always_sums_to_one():
+    for bands in ({"rec_40p": 40}, {"rec_0_4": 12, "rec_20_29": 30}, {"rec_5_9": 9}):
+        shape = project_band_shape(bands, _POS_MID)
+        assert sum(shape.values()) == pytest.approx(1.0)
+
+
+def test_negative_counts_cannot_create_negative_probability():
+    """A corrupt row must degrade, not invert."""
+    shape = project_band_shape({"rec_40p": 40, "rec_0_4": -100}, _POS_MID)
+    assert all(v >= 0.0 for v in shape.values())
+    assert sum(shape.values()) == pytest.approx(1.0)
+
+
+def test_deep_and_short_shapes_price_in_the_right_order():
+    deep = expected_points_per_catch(project_band_shape(_DEEP, _POS_MID), _CARD)
+    short = expected_points_per_catch(project_band_shape(_SHORT, _POS_MID), _CARD)
+    assert short < deep
+
+
+def test_the_fitter_prefers_shrinkage_to_either_extreme():
+    """The result that justifies the method, on synthetic data with the
+    same structure as the real fit.
+
+    Players have a true shape plus sampling noise. Trusting the noisy
+    observation (K=0) overfits; ignoring it (K=inf) discards real
+    signal. If the fitter did not beat both, shrinkage would be doing no
+    work and the constant would be decoration.
+    """
+    import random
+
+    rng = random.Random(11)
+    positions = {}
+    prior = {"players": {}}
+    later = {"players": {}}
+    for i in range(120):
+        gid = f"p{i:03d}"
+        positions[gid] = "WR"
+        deep_rate = rng.uniform(0.05, 0.45)  # the player's TRUE tendency
+
+        def draw(n):
+            bands = {b: 0 for b in BAND_KEYS}
+            for _ in range(n):
+                bands["rec_40p" if rng.random() < deep_rate else "rec_5_9"] += 1
+            return bands
+
+        prior["players"][gid] = {"bands": draw(rng.randint(25, 60))}
+        later["players"][gid] = {"bands": draw(40)}
+
+    res = fit_shrinkage_constant(prior, later, positions, _CARD)
+    assert res["fitted"] is not None
+    assert res["mseAtBest"] < res["mseTrustPlayer"], "shrinkage must beat trusting the sample"
+    assert res["mseAtBest"] < res["mseIgnorePlayer"], "shrinkage must beat the position mean"
+    assert 0.0 < res["fitted"] < 1e9, "an endpoint won; shrinkage is doing nothing"
+
+
+def test_the_shipped_constant_sits_in_the_fitted_range():
+    """``SHRINK_K`` is fitted on real seasons, and its optimum is flat
+    between roughly 30 and 60. This pins that the shipped value stays in
+    that basin rather than drifting to an endpoint."""
+    assert 30.0 <= SHRINK_K <= 60.0


### PR DESCRIPTION
All four steps on banded reception scoring — the largest scoring divergence on this card, and one the market **structurally cannot see**: the per-catch spread is 8x (0.25 at 0–4 yards → 2.00 at 40+) while every ranking source prices a flat rate.

## 1. The level was being applied as if it were measured

I first reported this as a missing mean-normalisation. **That was wrong**, and the module's own docstring said why: unlike the IDP case, both cards score the *same* catches, so a shared shift is a fact about the scoring rather than about rate-card generosity.

That reasoning is sound — *conditional on the baseline card being what the market prices*. Nothing establishes that. The baseline is one Sleeper league that happens to pay 0.75/catch; dynasty boards sit nearer 0.5 or 1.0. Measured over 201 receivers:

| assumed market PPR | median | p10 | p90 | **p90/p10** |
|---|---|---|---|---|
| 0.50 | 1.239 | 0.978 | 1.466 | **1.498** |
| 0.75 | 0.826 | 0.652 | 0.977 | **1.498** |
| 1.00 | 0.619 | 0.489 | 0.733 | **1.498** |

**The spread is identical to three decimals; the level swings 2x and flips sign.** A flat baseline scales everyone equally, so the tilt cannot depend on the assumption — and the level is nothing but the assumption.

Now separated: `multipliers` carries tilt only, `level_multiplier` reports the shared shift with its basis, `levelApplied: false`. Acting on a number whose sign you can't establish is worse than not acting.

## 2. Flag ON, blast radius measured

Tilt over 199 receivers with 20+ catches (2025):

```
median 1.000   p10 0.942   p90 1.042   min 0.765   max 1.098
0 of 199 at the clamp; dispersion drift 0.0226 (bound 0.12)
```

Coherent at the extremes — checkdown backs and short-area TEs down (Jerome Ford 0.765), deep threats up (Alec Pierce 1.098). Mean-normalised, so it cannot inflate the receiving corps as a class. Opt-in league-adjusted lens only, never the default board.

**Quote the tilt, never the 8x** — receptions are 17–33% of a player's points.

## 3. Projection path, with a fitted constant

No source publishes banded receptions and probably none will. The tractable decomposition:

```
projected banded points = projected receptions × expected points per catch
```

The second factor is a player **trait**, and it's stable: **r = 0.767** (2023→24) and **0.718** (2024→25) — high for a fantasy metric, where most sit at 0.3–0.5.

`reception_shape_projection` shrinks a player's observed shape toward his **position** mean (not the league mean — an RB's distribution is a different distribution, not a noisy draw from the WR one), weighted by sample size. K is **fitted** on held-out next-season value:

| K | 2023→24 | 2024→25 | sum |
|---|---|---|---|
| 0 (own shape) | 0.005413 | 0.005977 | 0.011390 |
| **40** | **0.004010** | **0.004087** | **0.008097** |
| ∞ (position mean) | 0.004905 | 0.004927 | 0.009832 |

**Shrinkage beats both endpoints on both pairs** — 26% better than trusting the player, 18% better than the position mean. That's the result justifying the method; beating neither would mean it does nothing.

Unknown players return `None`, not a flat guess, so "unknown" and "league average" stay distinguishable.

## 4. The clamp was shaping the signal, not backstopping a fault

Post-split, tilt centres on 1.0 and spreads wider than the composite the 0.25 bound was set against. Measured minimum **0.765 against a 0.75 floor — 1.5% headroom**, binding hardest on exactly the archetype this exists to find.

A safety bound that truncates the signal it protects is worse than none, because the truncation is invisible in the output. Widened to 0.35: extremes now sit ~33% inside, and a real fault still can't move a player more than a third.

This also corrected **a test I wrote in #609** asserting the two sibling fits share a bound. That was a proxy for the real property — bounds should track each measurement's own spread, and those differ. It now asserts both are bounded and each clears its own measured extremes.

## Note for reviewers

While verifying the clamp I hit a stale `__pycache__`: reverting a constant to a same-length value within the same second left Python serving a `.pyc` compiled against the old value, so a check appeared to pass against code that wasn't running. Worth knowing if you use write-revert simulations to test guards.

`docs/reception-banding.md` records every number, what's measured vs assumed, and the one remaining gap: wiring projected shapes into forward rankings needs a reception-volume source — PR #610's Clay projections would supply it.

## Validation

- Hard gate: **4811 passed, 319 deselected**
- `ruff format --check .` clean; `ruff check` clean on the changed set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeqwBFmFak84h3h7RaCZqa

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeqwBFmFak84h3h7RaCZqa)_