### PR TITLE
feat(bdvm): vocabulary-aware IDP consensus weighting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,6 +422,13 @@ test-pinned (``tests/bdvm/``):
   policy: each replaces its own prior run wholesale and supersedes
   proxies per player while other real sources carry through, so a
   defender covered by Clay AND IDP Show gets a two-source consensus.
+  The consensus is **vocabulary-aware**: a stat-line record whose
+  league-scored IDP categories are a strict subset of a peer's (Clay
+  publishes no TFL/PD — categories this league pays 4.25/5.32 for) is
+  down-weighted by the labelled prior
+  ``projection_consensus.vocabulary_dominated_weight_mult`` instead of
+  dragging the mean down or silently imputing the missing categories;
+  affected sources are stamped in ``projection.vocabularyLimitedSources``.
   Structured events (closed ontology,
   ``config/bdvm/event_types_v1.json``) adjust module inputs — never a
   final score — from ``data/bdvm/events/<season>.json``.

--- a/config/bdvm/params_v1.json
+++ b/config/bdvm/params_v1.json
@@ -1,230 +1,611 @@
 {
-  "_comment": [
-    "BDVM v1 parameter set. EVERY number here is a STARTING PRIOR from the",
-    "BDVM v1.0 research document (docs/research/bdvm-v1/BDVM_v1_complete.pdf,",
-    "Part 6) — informed by published research but NOT backtested truth.",
-    "Do not edit in place once a param_set_id has shipped values: copy to a",
-    "new file (params_v2.json, ...), change, and point BDVM_PARAM_SET at it.",
-    "The param_set_id is a content hash, so any edit produces a new id."
+ "_comment": [
+  "BDVM v1 parameter set. EVERY number here is a STARTING PRIOR from the",
+  "BDVM v1.0 research document (docs/research/bdvm-v1/BDVM_v1_complete.pdf,",
+  "Part 6) \u2014 informed by published research but NOT backtested truth.",
+  "Do not edit in place once a param_set_id has shipped values: copy to a",
+  "new file (params_v2.json, ...), change, and point BDVM_PARAM_SET at it.",
+  "The param_set_id is a content hash, so any edit produces a new id."
+ ],
+ "schema_version": 1,
+ "label": "bdvm-v1-priors",
+ "model_version": "1.0.0",
+ "positions_true": [
+  "QB",
+  "RB",
+  "WR",
+  "TE",
+  "DT",
+  "EDGE",
+  "LB",
+  "CB",
+  "S"
+ ],
+ "_comment_platform_fallback": [
+  "When a player's true position is unknown we only know the platform",
+  "lineup group (Sleeper: DL / LB / DB). These fallbacks pick the modelling",
+  "position used for curves/hazard/CV, and the engine widens sigma via",
+  "unknown_true_position_sigma_mult and lowers data quality."
+ ],
+ "platform_group_fallback_position": {
+  "DL": "EDGE",
+  "LB": "LB",
+  "DB": "S",
+  "QB": "QB",
+  "RB": "RB",
+  "WR": "WR",
+  "TE": "TE"
+ },
+ "unknown_true_position_sigma_mult": 1.1,
+ "age_curves": {
+  "_comment": "pos/archetype -> [peak_age, c_up, c_dn]; asymmetric Gaussian",
+  "QB_pocket": [
+   30.0,
+   0.006,
+   0.01
   ],
-  "schema_version": 1,
-  "label": "bdvm-v1-priors",
-  "model_version": "1.0.0",
-
-  "positions_true": ["QB", "RB", "WR", "TE", "DT", "EDGE", "LB", "CB", "S"],
-
-  "_comment_platform_fallback": [
-    "When a player's true position is unknown we only know the platform",
-    "lineup group (Sleeper: DL / LB / DB). These fallbacks pick the modelling",
-    "position used for curves/hazard/CV, and the engine widens sigma via",
-    "unknown_true_position_sigma_mult and lowers data quality."
+  "QB_dual": [
+   26.0,
+   0.01,
+   0.028
   ],
-  "platform_group_fallback_position": {
-    "DL": "EDGE",
-    "LB": "LB",
-    "DB": "S",
-    "QB": "QB",
-    "RB": "RB",
-    "WR": "WR",
-    "TE": "TE"
+  "RB": [
+   25.0,
+   0.012,
+   0.03
+  ],
+  "WR": [
+   27.0,
+   0.014,
+   0.024
+  ],
+  "TE": [
+   27.5,
+   0.03,
+   0.018
+  ],
+  "DT": [
+   27.5,
+   0.016,
+   0.02
+  ],
+  "EDGE": [
+   27.0,
+   0.014,
+   0.022
+  ],
+  "LB": [
+   26.5,
+   0.012,
+   0.03
+  ],
+  "CB": [
+   26.0,
+   0.01,
+   0.03
+  ],
+  "S": [
+   27.0,
+   0.012,
+   0.026
+  ]
+ },
+ "mileage": {
+  "_comment": "pos -> [unit, reference_load, load_per_effective_year, cap_years]",
+  "RB": [
+   "touches",
+   750.0,
+   500.0,
+   2.5
+  ],
+  "WR": [
+   "targets",
+   500.0,
+   450.0,
+   1.5
+  ],
+  "TE": [
+   "targets",
+   400.0,
+   450.0,
+   1.5
+  ],
+  "QB": [
+   "dropbacks",
+   2000.0,
+   2500.0,
+   1.0
+  ],
+  "LB": [
+   "snaps",
+   3000.0,
+   2200.0,
+   1.5
+  ],
+  "EDGE": [
+   "snaps",
+   3000.0,
+   2400.0,
+   1.5
+  ],
+  "DT": [
+   "snaps",
+   3000.0,
+   2400.0,
+   1.0
+  ],
+  "CB": [
+   "snaps",
+   3000.0,
+   2400.0,
+   1.5
+  ],
+  "S": [
+   "snaps",
+   3000.0,
+   2400.0,
+   1.5
+  ]
+ },
+ "base_hazard": {
+  "_comment": "pos -> [[age_upper_bound_exclusive, annual_hazard], ...]; fallthrough 0.5",
+  "QB": [
+   [
+    24,
+    0.16
+   ],
+   [
+    27,
+    0.1
+   ],
+   [
+    30,
+    0.09
+   ],
+   [
+    33,
+    0.14
+   ],
+   [
+    36,
+    0.24
+   ],
+   [
+    99,
+    0.38
+   ]
+  ],
+  "RB": [
+   [
+    24,
+    0.11
+   ],
+   [
+    26,
+    0.15
+   ],
+   [
+    27,
+    0.22
+   ],
+   [
+    28,
+    0.3
+   ],
+   [
+    29,
+    0.38
+   ],
+   [
+    99,
+    0.5
+   ]
+  ],
+  "WR": [
+   [
+    24,
+    0.13
+   ],
+   [
+    27,
+    0.09
+   ],
+   [
+    29,
+    0.13
+   ],
+   [
+    31,
+    0.22
+   ],
+   [
+    33,
+    0.34
+   ],
+   [
+    99,
+    0.46
+   ]
+  ],
+  "TE": [
+   [
+    24,
+    0.16
+   ],
+   [
+    27,
+    0.1
+   ],
+   [
+    30,
+    0.12
+   ],
+   [
+    32,
+    0.2
+   ],
+   [
+    34,
+    0.32
+   ],
+   [
+    99,
+    0.44
+   ]
+  ],
+  "DT": [
+   [
+    24,
+    0.14
+   ],
+   [
+    27,
+    0.1
+   ],
+   [
+    30,
+    0.14
+   ],
+   [
+    32,
+    0.24
+   ],
+   [
+    99,
+    0.38
+   ]
+  ],
+  "EDGE": [
+   [
+    24,
+    0.14
+   ],
+   [
+    27,
+    0.1
+   ],
+   [
+    30,
+    0.15
+   ],
+   [
+    32,
+    0.26
+   ],
+   [
+    99,
+    0.4
+   ]
+  ],
+  "LB": [
+   [
+    24,
+    0.15
+   ],
+   [
+    27,
+    0.12
+   ],
+   [
+    29,
+    0.18
+   ],
+   [
+    31,
+    0.28
+   ],
+   [
+    99,
+    0.42
+   ]
+  ],
+  "CB": [
+   [
+    24,
+    0.18
+   ],
+   [
+    27,
+    0.15
+   ],
+   [
+    29,
+    0.22
+   ],
+   [
+    31,
+    0.32
+   ],
+   [
+    99,
+    0.46
+   ]
+  ],
+  "S": [
+   [
+    24,
+    0.16
+   ],
+   [
+    27,
+    0.13
+   ],
+   [
+    29,
+    0.19
+   ],
+   [
+    31,
+    0.29
+   ],
+   [
+    99,
+    0.44
+   ]
+  ]
+ },
+ "hazard_adjusters": {
+  "_comment": "multiplicative adjusters around reference points; clip bounds",
+  "role_security": {
+   "gamma": 0.55,
+   "reference": 0.6
   },
-  "unknown_true_position_sigma_mult": 1.10,
-
-  "age_curves": {
-    "_comment": "pos/archetype -> [peak_age, c_up, c_dn]; asymmetric Gaussian",
-    "QB_pocket": [30.0, 0.006, 0.010],
-    "QB_dual": [26.0, 0.010, 0.028],
-    "RB": [25.0, 0.012, 0.030],
-    "WR": [27.0, 0.014, 0.024],
-    "TE": [27.5, 0.030, 0.018],
-    "DT": [27.5, 0.016, 0.020],
-    "EDGE": [27.0, 0.014, 0.022],
-    "LB": [26.5, 0.012, 0.030],
-    "CB": [26.0, 0.010, 0.030],
-    "S": [27.0, 0.012, 0.026]
+  "draft_capital": {
+   "gamma": 0.3,
+   "reference": 0.5,
+   "decays": true
   },
-
-  "mileage": {
-    "_comment": "pos -> [unit, reference_load, load_per_effective_year, cap_years]",
-    "RB": ["touches", 750.0, 500.0, 2.5],
-    "WR": ["targets", 500.0, 450.0, 1.5],
-    "TE": ["targets", 400.0, 450.0, 1.5],
-    "QB": ["dropbacks", 2000.0, 2500.0, 1.0],
-    "LB": ["snaps", 3000.0, 2200.0, 1.5],
-    "EDGE": ["snaps", 3000.0, 2400.0, 1.5],
-    "DT": ["snaps", 3000.0, 2400.0, 1.0],
-    "CB": ["snaps", 3000.0, 2400.0, 1.5],
-    "S": ["snaps", 3000.0, 2400.0, 1.5]
+  "contract_security": {
+   "gamma": 0.25,
+   "reference": 0.6
   },
-
-  "base_hazard": {
-    "_comment": "pos -> [[age_upper_bound_exclusive, annual_hazard], ...]; fallthrough 0.5",
-    "QB": [[24, 0.16], [27, 0.10], [30, 0.09], [33, 0.14], [36, 0.24], [99, 0.38]],
-    "RB": [[24, 0.11], [26, 0.15], [27, 0.22], [28, 0.30], [29, 0.38], [99, 0.50]],
-    "WR": [[24, 0.13], [27, 0.09], [29, 0.13], [31, 0.22], [33, 0.34], [99, 0.46]],
-    "TE": [[24, 0.16], [27, 0.10], [30, 0.12], [32, 0.20], [34, 0.32], [99, 0.44]],
-    "DT": [[24, 0.14], [27, 0.10], [30, 0.14], [32, 0.24], [99, 0.38]],
-    "EDGE": [[24, 0.14], [27, 0.10], [30, 0.15], [32, 0.26], [99, 0.40]],
-    "LB": [[24, 0.15], [27, 0.12], [29, 0.18], [31, 0.28], [99, 0.42]],
-    "CB": [[24, 0.18], [27, 0.15], [29, 0.22], [31, 0.32], [99, 0.46]],
-    "S": [[24, 0.16], [27, 0.13], [29, 0.19], [31, 0.29], [99, 0.44]]
+  "durability": {
+   "gamma": 0.35,
+   "reference": 0.6
   },
-
-  "hazard_adjusters": {
-    "_comment": "multiplicative adjusters around reference points; clip bounds",
-    "role_security": {"gamma": 0.55, "reference": 0.6},
-    "draft_capital": {"gamma": 0.30, "reference": 0.5, "decays": true},
-    "contract_security": {"gamma": 0.25, "reference": 0.6},
-    "durability": {"gamma": 0.35, "reference": 0.6},
-    "production_z": {"gamma": 0.18, "clip": 2.0},
-    "designation_risk": {"gamma": 0.20},
-    "clip_lo": 0.02,
-    "clip_hi": 0.85
+  "production_z": {
+   "gamma": 0.18,
+   "clip": 2.0
   },
-
-  "cv_base": {
-    "QB": 0.26, "RB": 0.36, "WR": 0.34, "TE": 0.36,
-    "DT": 0.32, "EDGE": 0.34, "LB": 0.26, "CB": 0.40, "S": 0.30
+  "designation_risk": {
+   "gamma": 0.2
   },
-  "drift_vol": {
-    "QB": 0.16, "RB": 0.30, "WR": 0.22, "TE": 0.22,
-    "DT": 0.20, "EDGE": 0.22, "LB": 0.22, "CB": 0.30, "S": 0.24
-  },
-  "sigma_multipliers": {
-    "role_uncertainty": 0.90,
-    "event_volatility": 0.45,
-    "small_sample": 0.60
-  },
-
-  "ascension": {
-    "tau": 1.5,
-    "kappa_min": -0.15,
-    "kappa_max": 0.60,
-    "kappa_force_zero_after_season": 4,
-    "draft_capital_decay_rate": 0.45,
-    "college_decay_rate": 1.10,
-    "kappa_weights": {
-      "_comment": "kappa = clip(b1*DC + b2*w_col*COL + b3*OPP + b4*YOUTH - b5*INCUMBENT)",
-      "draft_capital": 0.30,
-      "college": 0.15,
-      "opportunity": 0.25,
-      "youth": 0.05,
-      "incumbency": 0.30
-    }
-  },
-
-  "event_regression": {
-    "_comment": "applied to mu(t>=1) only, never the current-season projection",
-    "offense_td_rate": 0.40,
-    "sack_to_expected": 0.35
-  },
-
-  "strategies": {
-    "contender": {
-      "discount": 0.72, "horizon": 4,
-      "usability": [1.00, 0.95, 0.80, 0.65, 0.55],
-      "risk_lambda": 0.20, "pick_premium": 0.92, "playoff_weight": 0.35
-    },
-    "balanced": {
-      "discount": 0.85, "horizon": 6,
-      "usability": [1.00, 1.00, 1.00, 0.95, 0.90, 0.85, 0.80],
-      "risk_lambda": 0.10, "pick_premium": 1.00, "playoff_weight": 0.15
-    },
-    "rebuilder": {
-      "discount": 0.93, "horizon": 8,
-      "usability": [0.45, 0.75, 1.00, 1.00, 1.00, 0.95, 0.90, 0.85, 0.80],
-      "risk_lambda": -0.10, "pick_premium": 1.08, "playoff_weight": 0.0
-    },
-    "risk_neutral": {
-      "discount": 0.85, "horizon": 6,
-      "usability": [1.00, 1.00, 1.00, 0.95, 0.90, 0.85, 0.80],
-      "risk_lambda": 0.0, "pick_premium": 1.00, "playoff_weight": 0.15
-    }
-  },
-  "risk_lambda_dispersion_coeff": 0.35,
-
-  "scale": {
-    "stud_gamma": 1.20,
-    "target_top_value": 9800.0,
-    "trade_value_max": 10000.0
-  },
-
-  "package": {
-    "theta": 1.20,
-    "theta_shallow_league": 1.35,
-    "shallow_roster_size_threshold": 26,
-    "roster_spot_cost": 120.0
-  },
-
-  "market": {
-    "tau_model": 0.85,
-    "tau_model_small_sample_mult": 0.40,
-    "tau_market_idp_mult": 0.45,
-    "tau_market_rookie_mult": 0.55,
-    "tau_market_dispersion_mult": 0.50,
-    "lambda_market_fundamental": 0.0,
-    "lambda_market_display": 0.25,
-    "lambda_market_clearing": 0.50,
-    "liquidity": {"base": 0.35, "dispersion_coeff": 1.6, "clip_lo": 0.2, "clip_hi": 1.0},
-    "signal_thresholds": {
-      "strong_buy_alpha": 900.0, "buy_alpha": 400.0,
-      "sell_alpha": -400.0, "strong_sell_alpha": -900.0,
-      "gap_persistence_days": 14, "strong_buy_min_liquidity": 0.5
-    }
-  },
-
-  "games": {
-    "default_games": 17.0,
-    "future_games_base": 0.86,
-    "future_games_durability_coeff": 0.10,
-    "season_length": 17.0
-  },
-
-  "annual_load_rate": {
-    "_comment": "career-load accumulation per future season, by position",
-    "RB": 260.0, "WR": 120.0, "TE": 90.0, "QB": 560.0, "default": 700.0
-  },
-
-  "probabilities": {
-    "elite_pool_rank_divisor": 2,
-    "elite_fallback_mult": 1.75,
-    "elite_fallback_floor_frac": 0.45,
-    "breakout_mult": 1.35
-  },
-
-  "ros": {
-    "n_prior_offense": 6.0,
-    "n_prior_idp": 8.0
-  },
-
-  "projection_consensus": {
-    "trim_frac": 0.10,
-    "trim_min_sources": 5,
-    "max_single_source_weight": 0.35,
-    "equal_weight_shrinkage": 0.30,
-    "stale_after_days": 21,
-    "stale_weight_mult": 0.5
-  },
-
-  "replacement": {
-    "_comment": [
-      "waiver_buffer: startable-quality players per team rostered beyond the",
-      "startable count, by lineup group. THE most sensitive knob in the model",
-      "(it sets the origin of the value scale). Groups absent here use",
-      "default_buffer."
-    ],
-    "waiver_buffer": {
-      "QB": 0.85, "RB": 0.75, "WR": 1.00, "TE": 0.40,
-      "DL": 0.50, "LB": 0.50, "DB": 0.50,
-      "DT": 0.50, "EDGE": 0.50, "CB": 0.50, "S": 0.50, "K": 0.25
-    },
-    "default_buffer": 0.50,
-    "best_ball_buffer_bump": {"RB": 0.5, "WR": 0.5}
-  },
-
-  "single_source_projection_sigma_mult": 1.50,
-  "missing_projection_impute": {
-    "enabled": false,
-    "_comment": "v1: a player with no projection gets NO fundamental value (status=unpriced), never a silent zero or a fabricated number."
+  "clip_lo": 0.02,
+  "clip_hi": 0.85
+ },
+ "cv_base": {
+  "QB": 0.26,
+  "RB": 0.36,
+  "WR": 0.34,
+  "TE": 0.36,
+  "DT": 0.32,
+  "EDGE": 0.34,
+  "LB": 0.26,
+  "CB": 0.4,
+  "S": 0.3
+ },
+ "drift_vol": {
+  "QB": 0.16,
+  "RB": 0.3,
+  "WR": 0.22,
+  "TE": 0.22,
+  "DT": 0.2,
+  "EDGE": 0.22,
+  "LB": 0.22,
+  "CB": 0.3,
+  "S": 0.24
+ },
+ "sigma_multipliers": {
+  "role_uncertainty": 0.9,
+  "event_volatility": 0.45,
+  "small_sample": 0.6
+ },
+ "ascension": {
+  "tau": 1.5,
+  "kappa_min": -0.15,
+  "kappa_max": 0.6,
+  "kappa_force_zero_after_season": 4,
+  "draft_capital_decay_rate": 0.45,
+  "college_decay_rate": 1.1,
+  "kappa_weights": {
+   "_comment": "kappa = clip(b1*DC + b2*w_col*COL + b3*OPP + b4*YOUTH - b5*INCUMBENT)",
+   "draft_capital": 0.3,
+   "college": 0.15,
+   "opportunity": 0.25,
+   "youth": 0.05,
+   "incumbency": 0.3
   }
+ },
+ "event_regression": {
+  "_comment": "applied to mu(t>=1) only, never the current-season projection",
+  "offense_td_rate": 0.4,
+  "sack_to_expected": 0.35
+ },
+ "strategies": {
+  "contender": {
+   "discount": 0.72,
+   "horizon": 4,
+   "usability": [
+    1.0,
+    0.95,
+    0.8,
+    0.65,
+    0.55
+   ],
+   "risk_lambda": 0.2,
+   "pick_premium": 0.92,
+   "playoff_weight": 0.35
+  },
+  "balanced": {
+   "discount": 0.85,
+   "horizon": 6,
+   "usability": [
+    1.0,
+    1.0,
+    1.0,
+    0.95,
+    0.9,
+    0.85,
+    0.8
+   ],
+   "risk_lambda": 0.1,
+   "pick_premium": 1.0,
+   "playoff_weight": 0.15
+  },
+  "rebuilder": {
+   "discount": 0.93,
+   "horizon": 8,
+   "usability": [
+    0.45,
+    0.75,
+    1.0,
+    1.0,
+    1.0,
+    0.95,
+    0.9,
+    0.85,
+    0.8
+   ],
+   "risk_lambda": -0.1,
+   "pick_premium": 1.08,
+   "playoff_weight": 0.0
+  },
+  "risk_neutral": {
+   "discount": 0.85,
+   "horizon": 6,
+   "usability": [
+    1.0,
+    1.0,
+    1.0,
+    0.95,
+    0.9,
+    0.85,
+    0.8
+   ],
+   "risk_lambda": 0.0,
+   "pick_premium": 1.0,
+   "playoff_weight": 0.15
+  }
+ },
+ "risk_lambda_dispersion_coeff": 0.35,
+ "scale": {
+  "stud_gamma": 1.2,
+  "target_top_value": 9800.0,
+  "trade_value_max": 10000.0
+ },
+ "package": {
+  "theta": 1.2,
+  "theta_shallow_league": 1.35,
+  "shallow_roster_size_threshold": 26,
+  "roster_spot_cost": 120.0
+ },
+ "market": {
+  "tau_model": 0.85,
+  "tau_model_small_sample_mult": 0.4,
+  "tau_market_idp_mult": 0.45,
+  "tau_market_rookie_mult": 0.55,
+  "tau_market_dispersion_mult": 0.5,
+  "lambda_market_fundamental": 0.0,
+  "lambda_market_display": 0.25,
+  "lambda_market_clearing": 0.5,
+  "liquidity": {
+   "base": 0.35,
+   "dispersion_coeff": 1.6,
+   "clip_lo": 0.2,
+   "clip_hi": 1.0
+  },
+  "signal_thresholds": {
+   "strong_buy_alpha": 900.0,
+   "buy_alpha": 400.0,
+   "sell_alpha": -400.0,
+   "strong_sell_alpha": -900.0,
+   "gap_persistence_days": 14,
+   "strong_buy_min_liquidity": 0.5
+  }
+ },
+ "games": {
+  "default_games": 17.0,
+  "future_games_base": 0.86,
+  "future_games_durability_coeff": 0.1,
+  "season_length": 17.0
+ },
+ "annual_load_rate": {
+  "_comment": "career-load accumulation per future season, by position",
+  "RB": 260.0,
+  "WR": 120.0,
+  "TE": 90.0,
+  "QB": 560.0,
+  "default": 700.0
+ },
+ "probabilities": {
+  "elite_pool_rank_divisor": 2,
+  "elite_fallback_mult": 1.75,
+  "elite_fallback_floor_frac": 0.45,
+  "breakout_mult": 1.35
+ },
+ "ros": {
+  "n_prior_offense": 6.0,
+  "n_prior_idp": 8.0
+ },
+ "projection_consensus": {
+  "trim_frac": 0.1,
+  "trim_min_sources": 5,
+  "max_single_source_weight": 0.35,
+  "equal_weight_shrinkage": 0.3,
+  "stale_after_days": 21,
+  "stale_weight_mult": 0.5,
+  "vocabulary_dominated_weight_mult": 0.25
+ },
+ "replacement": {
+  "_comment": [
+   "waiver_buffer: startable-quality players per team rostered beyond the",
+   "startable count, by lineup group. THE most sensitive knob in the model",
+   "(it sets the origin of the value scale). Groups absent here use",
+   "default_buffer."
+  ],
+  "waiver_buffer": {
+   "QB": 0.85,
+   "RB": 0.75,
+   "WR": 1.0,
+   "TE": 0.4,
+   "DL": 0.5,
+   "LB": 0.5,
+   "DB": 0.5,
+   "DT": 0.5,
+   "EDGE": 0.5,
+   "CB": 0.5,
+   "S": 0.5,
+   "K": 0.25
+  },
+  "default_buffer": 0.5,
+  "best_ball_buffer_bump": {
+   "RB": 0.5,
+   "WR": 0.5
+  }
+ },
+ "single_source_projection_sigma_mult": 1.5,
+ "missing_projection_impute": {
+  "enabled": false,
+  "_comment": "v1: a player with no projection gets NO fundamental value (status=unpriced), never a silent zero or a fabricated number."
+ }
 }

--- a/src/bdvm/projections.py
+++ b/src/bdvm/projections.py
@@ -100,11 +100,59 @@ class ConsensusProjection:
     any_proxy: bool
     all_scoring_native: bool
     stale_sources: tuple[str, ...] = ()
+    # Sources down-weighted because their stat line's league-scored IDP
+    # categories are a strict subset of a peer's (vocabulary-dominated).
+    vocabulary_limited: tuple[str, ...] = ()
 
 
 # ---------------------------------------------------------------------------
 # Consensus blend
 # ---------------------------------------------------------------------------
+
+
+def _idp_scoring_vocabulary(
+    scoring_settings: Mapping[str, Any],
+) -> tuple[frozenset[str], dict[str, str]]:
+    """(league-scored IDP category ids, stat-column → category map).
+
+    Derived from the production scoring vocabulary in
+    ``realized_points`` (its private maps are the single source of
+    truth for which stat columns feed which Sleeper keys — ADR-005;
+    duplicating the list here is exactly the drift this module must
+    not create).  Categories collapse column-name variants
+    (``def_pass_defended`` / ``def_passes_defended``) so two sources
+    spelling the same category differently compare as equals.
+    """
+    from src.nfl_data.realized_points import (  # noqa: PLC0415
+        _IDP_KEYS,
+        _IDP_TACKLE_KEYS,
+        _SCORING_KEY_ALIASES,
+    )
+
+    effective = dict(scoring_settings)
+    for alias, canonical in _SCORING_KEY_ALIASES.items():
+        if alias in effective and canonical not in effective:
+            effective[canonical] = effective[alias]
+
+    def _nonzero(key: str) -> bool:
+        try:
+            return abs(float(effective.get(key) or 0.0)) > 0.0
+        except (TypeError, ValueError):
+            return False
+
+    col_to_cat: dict[str, str] = {}
+    scored: set[str] = set()
+    for sleeper_key, (candidates, _label) in _IDP_KEYS.items():
+        for col in candidates:
+            col_to_cat[col] = sleeper_key
+        if _nonzero(sleeper_key):
+            scored.add(sleeper_key)
+    # All tackle columns resolve through one view — one category.
+    for col in ("def_tackles_solo", "def_tackle_assists", "def_tackles"):
+        col_to_cat[col] = "idp_tkl"
+    if any(_nonzero(key) for key, _label in _IDP_TACKLE_KEYS):
+        scored.add("idp_tkl")
+    return frozenset(scored), col_to_cat
 
 
 def _staleness_weight(
@@ -176,6 +224,43 @@ def blend_consensus(
             stale.append(r.source)
         scored.append((r, fpg, w, native))
 
+    # Vocabulary-aware down-weighting.  A stat-line record whose
+    # league-scored IDP categories are a STRICT SUBSET of a peer's is
+    # known-incomplete under THIS league's scoring — e.g. a source
+    # publishing no TFL/PD in a league that pays 4.25/5.32 for them is
+    # biased low by construction, not lower on the player.  A plain
+    # mean would drag every dual-covered defender down by the missing
+    # categories' value.  Down-weighting via a labelled prior keeps
+    # the corroboration signal without silently imputing the missing
+    # categories (§6.3: never invent numbers).  Proxies and
+    # direct-points records compare as None: complete-by-construction
+    # or unknowable — they neither dominate nor get dominated.
+    vocab_limited: list[str] = []
+    vocab_mult = float(cfg.get("vocabulary_dominated_weight_mult", 1.0))
+    if vocab_mult < 1.0 and len(scored) >= 2:
+        scored_cats, col_to_cat = _idp_scoring_vocabulary(scoring_settings)
+        vocabs: list[frozenset[str] | None] = []
+        for r, _fpg, _w, _native in scored:
+            if r.is_proxy or not r.stat_line:
+                vocabs.append(None)
+            else:
+                cats = frozenset(
+                    col_to_cat[c] for c in r.stat_line if col_to_cat.get(c) in scored_cats
+                )
+                vocabs.append(cats or None)
+        for i, vocab_i in enumerate(vocabs):
+            if vocab_i is None:
+                continue
+            dominated = any(
+                vocab_j is not None and vocab_i < vocab_j
+                for j, vocab_j in enumerate(vocabs)
+                if j != i
+            )
+            if dominated:
+                r, fpg, w, native = scored[i]
+                scored[i] = (r, fpg, w * vocab_mult, native)
+                vocab_limited.append(r.source)
+
     # Trim extremes when enough sources exist.
     if len(scored) >= int(cfg["trim_min_sources"]) and float(cfg["trim_frac"]) > 0:
         scored.sort(key=lambda t: t[1])
@@ -203,6 +288,7 @@ def blend_consensus(
         any_proxy=any(r.is_proxy for (r, _, _, _) in scored),
         all_scoring_native=all(native for (_, _, _, native) in scored),
         stale_sources=tuple(stale),
+        vocabulary_limited=tuple(vocab_limited),
     )
 
 

--- a/src/bdvm/service.py
+++ b/src/bdvm/service.py
@@ -478,6 +478,7 @@ def run_valuation(
                     "sources": list(blended.sources),
                     "anyProxy": blended.any_proxy,
                     "staleSources": list(blended.stale_sources),
+                    "vocabularyLimitedSources": list(blended.vocabulary_limited),
                 },
                 "replacement": {
                     "group": v.group,

--- a/tests/bdvm/test_projections.py
+++ b/tests/bdvm/test_projections.py
@@ -241,3 +241,117 @@ class TestReconstructedBaseline(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+IDP_SCORING = {
+    "idp_tkl_solo": 1.33,
+    "idp_tkl_ast": 0.8,
+    "idp_tkl_loss": 4.25,
+    "idp_sack": 2.92,
+    "idp_int": 5.32,
+    "idp_pass_def": 5.32,  # alias spelling — the live league's dump
+}
+
+
+def _stat_rec(source, stats, *, key="dual lb", pos="LB", as_of="2026-07-25", proxy=False):
+    return ProjectionRecord(
+        source=source,
+        player_key=key,
+        position=pos,
+        season=2026,
+        as_of=as_of,
+        games=17.0,
+        stat_line=stats,
+        stat_basis="season",
+        is_proxy=proxy,
+    )
+
+
+class TestVocabularyDomination(unittest.TestCase):
+    """A source whose stat line omits categories THIS league pays for
+    (Clay: no TFL/PD) is biased low by construction — the blend must
+    not average that bias in at full weight.  Down-weighting is a
+    labelled prior, never silent imputation."""
+
+    # Clay-style: solo/ast/sack/int only.  ~ (62*1.33+38*0.8+3*2.92+1*5.32)/17
+    CLAY = {
+        "def_tackles_solo": 62.0,
+        "def_tackle_assists": 38.0,
+        "def_sacks": 3.0,
+        "def_interceptions": 1.0,
+    }
+    # IDP-Show-style: same core numbers PLUS the categories Clay omits.
+    FULL = {
+        "def_tackles_solo": 62.0,
+        "def_tackle_assists": 38.0,
+        "def_sacks": 3.0,
+        "def_interceptions": 1.0,
+        "def_tackles_for_loss": 8.0,
+        "def_pass_defended": 4.0,
+    }
+
+    def _blend(self, records, scoring=IDP_SCORING):
+        return blend_consensus(
+            records,
+            scoring_settings=scoring,
+            snapshot_as_of="2026-07-27",
+            params=PARAMS,
+        )
+
+    def test_subset_line_is_down_weighted_toward_the_complete_source(self):
+        clay = _stat_rec("clayProjections", self.CLAY)
+        full = _stat_rec("idpShowProjections", self.FULL)
+        c = self._blend([clay, full])
+        fpg_clay, _ = clay.resolve_fpg(IDP_SCORING)
+        fpg_full, _ = full.resolve_fpg(IDP_SCORING)
+        mult = PARAMS["projection_consensus"]["vocabulary_dominated_weight_mult"]
+        expected = (mult * fpg_clay + 1.0 * fpg_full) / (mult + 1.0)
+        self.assertEqual(c.vocabulary_limited, ("clayProjections",))
+        self.assertAlmostEqual(c.mu_fpg, expected, places=6)
+        # materially closer to the complete line than a plain mean
+        self.assertGreater(c.mu_fpg, (fpg_clay + fpg_full) / 2)
+
+    def test_no_domination_when_league_ignores_the_missing_categories(self):
+        # Solo/ast/sack/int-only league: TFL/PD carry no weight, so the
+        # two vocabularies are EQUAL after filtering — plain mean.
+        scoring = {"idp_tkl_solo": 1.0, "idp_tkl_ast": 0.5, "idp_sack": 4.0, "idp_int": 4.0}
+        clay = _stat_rec("clayProjections", self.CLAY)
+        full = _stat_rec("idpShowProjections", self.FULL)
+        c = self._blend([clay, full], scoring=scoring)
+        self.assertEqual(c.vocabulary_limited, ())
+        fpg_clay, _ = clay.resolve_fpg(scoring)
+        fpg_full, _ = full.resolve_fpg(scoring)
+        self.assertAlmostEqual(c.mu_fpg, (fpg_clay + fpg_full) / 2, places=6)
+
+    def test_alias_scoring_key_counts_as_scored(self):
+        # League spells passes-defended as idp_pass_def (alias) — PD
+        # must still count as a scored category.
+        scoring = {"idp_tkl_solo": 1.0, "idp_pass_def": 5.32}
+        clay = _stat_rec("clayProjections", self.CLAY)
+        full = _stat_rec("idpShowProjections", self.FULL)
+        c = self._blend([clay, full], scoring=scoring)
+        self.assertEqual(c.vocabulary_limited, ("clayProjections",))
+
+    def test_proxy_never_dominates_a_real_source(self):
+        clay = _stat_rec("clayProjections", self.CLAY)
+        proxy = rec("reconstructedBaseline", 9.0, key="dual lb", pos="LB", is_proxy=True)
+        c = self._blend([clay, proxy])
+        self.assertEqual(c.vocabulary_limited, ())
+
+    def test_direct_points_record_neither_dominates_nor_is_dominated(self):
+        clay = _stat_rec("clayProjections", self.CLAY)
+        direct = rec("idpShowProjections", 12.0, key="dual lb", pos="LB")
+        c = self._blend([clay, direct])
+        self.assertEqual(c.vocabulary_limited, ())
+
+    def test_single_source_untouched(self):
+        c = self._blend([_stat_rec("clayProjections", self.CLAY)])
+        self.assertEqual(c.vocabulary_limited, ())
+
+    def test_column_spelling_variants_compare_as_the_same_category(self):
+        # def_passes_defended vs def_pass_defended are ONE category —
+        # neither line dominates the other.
+        a = _stat_rec("srcA", {**self.CLAY, "def_pass_defended": 4.0})
+        b = _stat_rec("srcB", {**self.CLAY, "def_passes_defended": 5.0})
+        c = self._blend([a, b])
+        self.assertEqual(c.vocabulary_limited, ())


### PR DESCRIPTION
# Don't average in a bias you can see coming

Follow-up to #610 (merged). With two real IDP feeds, the consensus blend had one known structural bias: Mike Clay's defense block publishes no TFL/PD — categories the live league pays **4.25/5.32** for — so his defender lines are biased low *by construction*, not because he's lower on the player. A plain equal-weight mean dragged every dual-covered defender down by half the missing categories' value (measured live: a −2.15 FPG bias on a full-line LB).

## The rule

`blend_consensus` is now **vocabulary-aware**: a non-proxy stat-line record whose league-scored IDP categories are a **strict subset** of a peer's is down-weighted by the labelled prior `projection_consensus.vocabulary_dominated_weight_mult` (0.25).

- **Data-driven, no source names hardcoded** — the test is per player-record pair against what each line actually publishes, filtered to what *this league's scoring* actually pays for. In a league that doesn't score TFL/PD, Clay's line isn't incomplete and nothing is down-weighted (test-pinned).
- **Vocabulary derives from the production scoring maps** in `realized_points` (ADR-005 — never a second hand-kept list), honors the `idp_pass_def` alias spelling the live league dump uses, and collapses column-name variants (`def_pass_defended` / `def_passes_defended`) so spelling differences can't fake a domination.
- **Proxies and direct-points records compare as None** — complete-by-construction or unknowable; they neither dominate nor get dominated.
- **Down-weighting, not exclusion, not imputation** — keeps the corroboration/dispersion signal from the incomplete source without inventing the missing categories (§6.3), and the prior is a labelled constant awaiting replacement by measured accuracy weights from the backtest harness once 2026 plays out.
- Affected sources are stamped per player in `projection.vocabularyLimitedSources` (same idiom as `staleSources`).

## Live verification (real contract scoring, dual-covered LB)

| | FPG |
|---|---|
| Clay-style line (no TFL/PD) | 10.46 |
| Complete line (with TFL/PD/FF) | 14.77 |
| Plain mean (before) | 12.62 |
| **Vocabulary-aware blend (after)** | **13.91**, `vocabularyLimitedSources: ["clayProjections"]` |

## Tests

**pytest: 4,831 passed** — 7 new: down-weight math against the exact expected weighted mean, no-domination when the league ignores the missing categories, alias scoring-key recognition, proxy neutrality, direct-points neutrality, single-source untouched, spelling variants compare as one category. `ruff format --check` / `ruff check` clean. (No frontend changes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMN5feuNUUYiLz69deJBTF

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMN5feuNUUYiLz69deJBTF)_