### PR TITLE
Keep reception-depth current in-season, and blend partial seasons

### DIFF
--- a/deploy/install-systemd-service.sh
+++ b/deploy/install-systemd-service.sh
@@ -435,6 +435,56 @@ main() {
     fi
   fi
 
+  # ── Reception-depth histogram timer ───────────────────────────────────
+  # Streams nflverse play-by-play into per-player reception-band
+  # histograms.  Like playerctx and BDVM the readers load a LOCAL file
+  # and data/ is gitignored, so the producer must run where the reader
+  # lives.  Needs no credentials (public nflverse), so this installs
+  # unconditionally whenever both templates are present.
+  #
+  # The unit treats exit 2 as success: "the current season has not
+  # kicked off" is the normal state from March to August, and a unit
+  # sitting red for half the year is a unit nobody reads.
+  local rd_service_template="${APP_DIR}/deploy/systemd/dynasty-reception-depth.service.template"
+  local rd_timer_template="${APP_DIR}/deploy/systemd/dynasty-reception-depth.timer.template"
+  local rd_service_name="${SERVICE_NAME}-reception-depth"
+  local rd_service_path="/etc/systemd/system/${rd_service_name}.service"
+  local rd_timer_path="/etc/systemd/system/${rd_service_name}.timer"
+  local rd_needs_install=false
+
+  if [[ -f "${rd_service_template}" && -f "${rd_timer_template}" ]]; then
+    if sudo -n "${SYSTEMCTL_BIN}" cat "${rd_service_name}.timer" >/dev/null 2>&1; then
+      if [[ "${force_install_on}" == "true" ]]; then
+        log "FORCE_SERVICE_INSTALL enabled; rewriting ${rd_service_path} + timer."
+        rd_needs_install=true
+      else
+        log "Reception-depth timer already installed; skipping."
+      fi
+    else
+      log "Installing reception-depth refresh service + timer."
+      rd_needs_install=true
+    fi
+
+    if [[ "${rd_needs_install}" == "true" ]]; then
+      local tmp_rd_service tmp_rd_timer
+      tmp_rd_service="$(mktemp)"
+      tmp_rd_timer="$(mktemp)"
+      sed \
+        -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
+        -e "s/__APP_USER__/$(escape_sed_replacement "${APP_USER}")/g" \
+        -e "s/__APP_DIR__/$(escape_sed_replacement "${APP_DIR}")/g" \
+        -e "s/__VENV_DIR__/$(escape_sed_replacement "${VENV_DIR}")/g" \
+        "${rd_service_template}" > "${tmp_rd_service}"
+      sed \
+        -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
+        "${rd_timer_template}" > "${tmp_rd_timer}"
+      sudo -n "${INSTALL_BIN}" -m 0644 "${tmp_rd_service}" "${rd_service_path}"
+      sudo -n "${INSTALL_BIN}" -m 0644 "${tmp_rd_timer}" "${rd_timer_path}"
+      rm -f "${tmp_rd_service}" "${tmp_rd_timer}"
+      log "Installed ${rd_service_name}.service + .timer"
+    fi
+  fi
+
   # ── DLF fetch timer (prod-side replacement for CI fetch_dlf.py) ────────
   # CI cannot run scripts/fetch_dlf.py — Cloudflare 403s the GitHub
   # Actions runner IPs.  The same script succeeds from prod, so this
@@ -594,6 +644,15 @@ main() {
       sudo -n "${SYSTEMCTL_BIN}" start --no-block "${playerctx_service_name}.service" || \
         log "Note: initial player-context build could not be started; the timer will cover it."
     fi
+  fi
+  if [[ "${rd_needs_install}" == "true" ]]; then
+    # --now arms the timer.  No initial kick here: the histograms for
+    # completed seasons are either already on disk or will be built by
+    # the first Wednesday run, and streaming three ~98 MB CSVs during a
+    # deploy would stall it for no gain.  The script skips seasons it
+    # already has, so that first run is cheap.
+    sudo -n "${SYSTEMCTL_BIN}" enable --now "${rd_service_name}.timer"
+    log "Enabled ${rd_service_name}.timer"
   fi
   if [[ "${bdvm_needs_install}" == "true" ]]; then
     # --now arms the timer immediately; the FIRST snapshots are built

--- a/deploy/systemd/dynasty-reception-depth.service.template
+++ b/deploy/systemd/dynasty-reception-depth.service.template
@@ -1,0 +1,59 @@
+[Unit]
+Description=Dynasty Trade Calculator reception-depth histogram refresh (__SERVICE_NAME__)
+After=network-online.target
+Wants=network-online.target
+
+# Produces per-player reception-band histograms under
+# data/nfl_data/actuals/reception_depth_<season>.jsonl by streaming
+# nflverse play-by-play.
+#
+# WHY THIS EXISTS: this league bands receptions by yards gained
+# (0.25/catch at 0-4 yards rising to 2.00 at 40+), an 8x spread that
+# every ranking source prices as a flat rate.  The band shape is what
+# src/league_intel/reception_fit.py turns into a per-player tilt, and
+# src/nfl_data/reception_shape_projection.py projects forward.
+#
+# WHY A CADENCE, when historical seasons never change: the CURRENT
+# season does.  A player whose role has changed — a checkdown back now
+# running deep routes, a rookie taking over a slot — only appears in
+# the data as those catches accumulate.  Without an in-season refresh
+# every player is priced on last year's shape all year.  Completed
+# seasons already on disk are skipped, so this streams one file, not
+# the whole history.
+#
+# WHY PROD-SIDE AND NOT CI: the readers load a LOCAL file and data/ is
+# gitignored repo-wide, so a histogram built on a CI runner never
+# reaches the VPS.  Same reasoning as the player-context and BDVM
+# refreshes.
+#
+# Exit codes (scripts/refresh_reception_depth.py):
+#   0 - refreshed at least one season
+#   1 - a season that SHOULD exist could not be fetched (release path
+#       likely moved) — this is the one worth investigating
+#   2 - nothing to do: the current season has not kicked off, or every
+#       requested season is already complete on disk
+#
+# 2 is the NORMAL state from March to August and is not a failure.
+# Reporting the offseason as failure would leave the unit red for
+# months and train everyone to ignore it — which is exactly when a
+# genuinely broken release path would slip past.  SuccessExitStatus
+# below keeps those months green.
+
+[Service]
+Type=oneshot
+User=__APP_USER__
+Group=__APP_USER__
+WorkingDirectory=__APP_DIR__
+EnvironmentFile=-__APP_DIR__/.env
+ExecStart=__VENV_DIR__/bin/python __APP_DIR__/scripts/refresh_reception_depth.py
+SuccessExitStatus=0 2
+StandardOutput=journal
+StandardError=journal
+# Streams one ~98 MB CSV and keeps only counts in memory.  Background
+# enrichment — never user-facing.
+Nice=10
+IOSchedulingClass=idle
+TimeoutStartSec=1800
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/dynasty-reception-depth.timer.template
+++ b/deploy/systemd/dynasty-reception-depth.timer.template
@@ -1,0 +1,28 @@
+[Unit]
+Description=Weekly reception-depth histogram refresh for __SERVICE_NAME__
+# Deliberately NO Requires= on the service: [Timer] Unit= already binds
+# it, and a [Unit] Requires= would start the service on every boot
+# regardless of OnCalendar and let a service failure deactivate the
+# timer itself.  Persistent=true is the intended catch-up for a missed
+# run.
+
+[Timer]
+# Weekly, Wednesday 07:20 UTC.
+#
+# Cadence: band histograms are season aggregates, so they gain nothing
+# from firing more often than the games do.  Weekly is the natural
+# grain and matches what the shape blend consumes.
+#
+# Slot: Tuesday already carries playerctx (05:40), the Hill-curve refit
+# and the BDVM refresh (06:10).  Wednesday keeps this off that stack
+# and lands after nflverse has published the week's completed pbp.  The
+# randomized delay keeps us off the release CDN on the same second as
+# every other weekly consumer.
+OnCalendar=Wed *-*-* 07:20:00 UTC
+RandomizedDelaySec=900
+Persistent=true
+AccuracySec=2min
+Unit=__SERVICE_NAME__-reception-depth.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/refresh_reception_depth.py
+++ b/scripts/refresh_reception_depth.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Refresh per-player reception-band histograms from nflverse play-by-play.
+
+Keeps the current season current, and backfills the prior seasons the
+shape projection blends with.
+
+Why this needs a cadence at all
+───────────────────────────────
+Historical seasons never change, so a one-off build would do for them.
+The current season does change — every week adds catches, and a player
+whose role has changed (a checkdown back running deep routes, a rookie
+taking over a slot) only shows up in the data as those catches
+accumulate. Without an in-season refresh the board would price every
+player on last year's shape all year.
+
+Exit codes follow the playerctx convention:
+
+    0  every requested season is up to date
+    1  a season that should exist could not be fetched
+    2  nothing to do (the current season has not kicked off)
+
+The distinction between 1 and 2 is the point. nflverse publishes a
+season's pbp only once that season starts, so a 404 in July is expected
+and must not page anyone; a 404 in November means the release path
+moved. ``reception_depth.season_has_plausibly_started`` draws that line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from src.nfl_data.reception_depth import (  # noqa: E402
+    depth_path,
+    persist_reception_depth,
+    season_has_plausibly_started,
+)
+
+_LOGGER = logging.getLogger("refresh_reception_depth")
+
+#: How many seasons back to keep. The shape projection blends seasons
+#: with a one-season half-life, so the third season back already counts
+#: for a quarter and the fourth would be noise with a filename.
+DEFAULT_LOOKBACK_SEASONS: int = 3
+
+
+def _current_season(now: datetime | None = None) -> int:
+    """The season whose games are being played, or the one just ended.
+
+    January and February belong to the PREVIOUS season's playoffs, so a
+    naive ``now.year`` would ask for a season that has not started and
+    report "nothing to do" through the entire postseason.
+    """
+    now = now or datetime.now(timezone.utc)
+    return now.year - 1 if now.month <= 2 else now.year
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--seasons", type=int, nargs="*", help="explicit seasons; default is recent"
+    )
+    parser.add_argument("--lookback", type=int, default=DEFAULT_LOOKBACK_SEASONS)
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="rebuild seasons already on disk (historical seasons are immutable, "
+        "so by default only the current one is refetched)",
+    )
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(name)s %(message)s",
+    )
+
+    current = _current_season()
+    if args.seasons:
+        seasons = sorted({int(s) for s in args.seasons})
+    else:
+        seasons = sorted(range(current - args.lookback + 1, current + 1))
+
+    wanted: list[int] = []
+    for season in seasons:
+        if not season_has_plausibly_started(season):
+            _LOGGER.info("season %d has not kicked off — skipping", season)
+            continue
+        # Completed seasons are immutable once written; only the season
+        # in progress is worth re-fetching on a schedule.
+        if not args.force and season != current and depth_path(season).exists():
+            _LOGGER.info("season %d already on disk and complete — skipping", season)
+            continue
+        wanted.append(season)
+
+    if not wanted:
+        _LOGGER.info("nothing to refresh")
+        return 2
+
+    result = persist_reception_depth(wanted)
+    built = {int(s) for s in (result.get("seasons") or [])}
+    missing = [s for s in wanted if s not in built]
+
+    _LOGGER.info(
+        "reception_depth refreshed seasons=%s players=%s receptions=%s",
+        sorted(built),
+        result.get("players"),
+        result.get("receptions"),
+    )
+    if missing:
+        _LOGGER.error(
+            "seasons %s should exist but produced nothing — check the pbp "
+            "release path and the logs above",
+            missing,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/nfl_data/reception_depth.py
+++ b/src/nfl_data/reception_depth.py
@@ -112,6 +112,32 @@ _HTTP_TIMEOUT_SEC = 180.0
 _USER_AGENT = "brisket-reception-depth/1.0"
 
 
+#: Month in which the NFL regular season starts. Used only to tell an
+#: expected pre-season 404 apart from a broken release path —
+#: deliberately coarse, because the alternative is fetching a schedule
+#: to answer a question about log severity.
+_SEASON_START_MONTH: int = 9
+
+
+def season_has_plausibly_started(season: int, *, now: datetime | None = None) -> bool:
+    """Has ``season`` kicked off, as far as the calendar can tell?
+
+    Answers exactly one question: is a 404 from the pbp release expected,
+    or does it mean the URL moved?
+
+    Erring toward "started" for any past season means a genuinely stale
+    URL is never silenced. Erring toward "not started" only within the
+    current year's preseason means the offseason stays quiet.
+    """
+    now = now or datetime.now(timezone.utc)
+    season = int(season)
+    if season < now.year:
+        return True
+    if season > now.year:
+        return False
+    return now.month >= _SEASON_START_MONTH
+
+
 def band_for_yards(yards: float) -> str:
     """Which Sleeper band a reception of ``yards`` falls in.
 
@@ -296,11 +322,30 @@ def persist_reception_depth(
                     resp.close()
         except urllib.error.HTTPError as exc:
             if getattr(exc, "code", 0) == 404:
-                _LOGGER.error(
-                    "reception_depth=url_stale season=%d status=404 — the pbp "
-                    "release path no longer exists; update _PBP_URL. No rows.",
-                    season,
-                )
+                # A 404 means two completely different things, and they
+                # must not share a message. nflverse publishes a
+                # season's pbp file only once that season kicks off, so
+                # a 404 for the current season in July is EXPECTED and
+                # is not an error. A 404 for a season that HAS started
+                # means the release path moved.
+                #
+                # Logging both as "url_stale, update _PBP_URL" would cry
+                # wolf every offseason, and once an operator learns to
+                # ignore that, a genuinely stale URL reads identically.
+                if not season_has_plausibly_started(season):
+                    _LOGGER.info(
+                        "reception_depth=not_started season=%d — nflverse "
+                        "publishes pbp once the season kicks off; nothing to "
+                        "fetch yet.",
+                        season,
+                    )
+                else:
+                    _LOGGER.error(
+                        "reception_depth=url_stale season=%d status=404 — this "
+                        "season has started, so the release path no longer "
+                        "exists; update _PBP_URL. No rows.",
+                        season,
+                    )
             else:
                 _LOGGER.warning("reception_depth=http season=%d status=%s", season, exc)
             continue

--- a/src/nfl_data/reception_shape_projection.py
+++ b/src/nfl_data/reception_shape_projection.py
@@ -70,11 +70,60 @@ _LOGGER = logging.getLogger(__name__)
 __all__ = [
     "SHRINK_K",
     "MIN_RECEPTIONS_FOR_SHAPE",
+    "RECENCY_HALF_LIFE_SEASONS",
+    "blend_seasons",
     "expected_points_per_catch",
     "fit_shrinkage_constant",
     "position_shapes",
     "project_band_shape",
 ]
+
+#: How fast older seasons lose weight. At a half-life of 1.0 the prior
+#: season counts half as much as the current one, the season before that
+#: a quarter, and so on.
+#:
+#: Chosen rather than fitted, and the distinction is deliberate:
+#: :data:`SHRINK_K` is fitted because there is a clean held-out target
+#: for it (next season's per-catch value). Recency weighting has no such
+#: target without a longer history than the three seasons on disk, and
+#: fitting it on two transitions would be reading noise. 1.0 is the
+#: conventional default; it is a prior, not a measurement, and is
+#: labelled as one.
+RECENCY_HALF_LIFE_SEASONS: float = 1.0
+
+
+def blend_seasons(
+    bands_by_season: Mapping[int, Mapping[str, float]],
+    *,
+    half_life: float = RECENCY_HALF_LIFE_SEASONS,
+) -> dict[str, float]:
+    """Combine several seasons of raw band counts into one weighted count.
+
+    **This is what makes an in-season shape usable.** In week 4 a player
+    has maybe 15 catches — far too few to trust on their own, and
+    :func:`project_band_shape` would rightly shrink almost all of it
+    away toward his position. But his last two seasons are still
+    informative about how he catches, and a receiver whose role has
+    genuinely changed will pull his blended shape as the current season
+    accumulates.
+
+    Counts are weighted, not shapes, so sample size carries through: a
+    3-catch current season contributes 3 weighted catches, not an equal
+    vote with a 90-catch prior. The result feeds
+    :func:`project_band_shape` exactly as a single season would, so
+    shrinkage still applies on top.
+    """
+    if not bands_by_season:
+        return {b: 0.0 for b in BAND_KEYS}
+    newest = max(int(s) for s in bands_by_season)
+    out = {b: 0.0 for b in BAND_KEYS}
+    for season, bands in bands_by_season.items():
+        age = newest - int(season)
+        weight = 0.5 ** (age / float(half_life)) if half_life > 0 else (1.0 if age == 0 else 0.0)
+        for b in BAND_KEYS:
+            out[b] += weight * max(0.0, float((bands or {}).get(b, 0) or 0))
+    return out
+
 
 #: Below this the player's own shape is ignored entirely and the
 #: position shape is used unchanged. A handful of catches carries no

--- a/tests/deploy/test_reception_depth_timer_is_wired.py
+++ b/tests/deploy/test_reception_depth_timer_is_wired.py
@@ -1,0 +1,93 @@
+"""The reception-depth timer must be installed AND enabled.
+
+This repo has a recurring shape: a component is built, tested, and never
+connected — `src/api/chat.py`, `src/trade/finder.py`, the TE basis
+curve. A systemd unit has its own version of that failure, and it is
+quieter: a template that exists but no installer block, or an installer
+block that writes the unit but never runs `enable --now`. Either way
+`systemctl list-timers` is empty and the data just never refreshes.
+
+Nothing about a stale histogram looks like an error. The board keeps
+serving last season's reception shapes indefinitely, which is precisely
+the thing an in-season refresh exists to prevent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+_INSTALLER = _REPO / "deploy" / "install-systemd-service.sh"
+_SERVICE = _REPO / "deploy" / "systemd" / "dynasty-reception-depth.service.template"
+_TIMER = _REPO / "deploy" / "systemd" / "dynasty-reception-depth.timer.template"
+_SCRIPT = _REPO / "scripts" / "refresh_reception_depth.py"
+
+
+def _installer() -> str:
+    return _INSTALLER.read_text(encoding="utf-8", errors="replace")
+
+
+def test_both_templates_exist():
+    assert _SERVICE.is_file()
+    assert _TIMER.is_file()
+
+
+def test_the_installer_writes_both_units():
+    body = _installer()
+    assert "dynasty-reception-depth.service.template" in body
+    assert "dynasty-reception-depth.timer.template" in body
+
+
+def test_the_installer_enables_the_timer():
+    """Installing a unit without enabling it is a unit that never runs.
+
+    ``list-timers`` would be empty and the only symptom would be
+    histograms quietly frozen at whatever season was last built.
+    """
+    body = _installer()
+    assert 'enable --now "${rd_service_name}.timer"' in body
+
+
+def test_the_service_points_at_a_script_that_exists():
+    """A unit whose ExecStart is a typo fails only on the box, weeks
+    later, in a journal nobody is reading."""
+    assert _SCRIPT.is_file()
+    assert "scripts/refresh_reception_depth.py" in _SERVICE.read_text(encoding="utf-8")
+
+
+def test_the_offseason_exit_code_counts_as_success():
+    """Exit 2 means "the season has not kicked off", which is the normal
+    state from March to August.
+
+    Without ``SuccessExitStatus`` the unit sits failed for half the year
+    — and a unit that is always red is one nobody looks at, which is
+    exactly when the exit-1 case (release path moved) would slip past.
+    """
+    body = _SERVICE.read_text(encoding="utf-8")
+    assert "SuccessExitStatus=0 2" in body
+
+
+def test_the_timer_does_not_bind_the_service_with_requires():
+    """``[Unit] Requires=`` on a timer force-starts the service on every
+    boot and lets a service failure deactivate the timer itself.
+
+    The repo's other timers carry this warning in a comment; this one
+    must not be the exception that reintroduces it.
+    """
+    body = _TIMER.read_text(encoding="utf-8")
+    # Strip comments first. The template CONTAINS the string
+    # "Requires=" inside the comment explaining why there deliberately
+    # is not one, and a naive scan reads that prose as the directive —
+    # the same false positive that made a documentation comment look
+    # like an endpoint caller elsewhere in this repo.
+    directives = "\n".join(line for line in body.split("\n") if not line.lstrip().startswith("#"))
+    unit_section = directives.split("[Timer]", 1)[0]
+    assert "Requires=" not in unit_section, (
+        "the [Unit] section binds the service with Requires=, which force-starts "
+        "it on every boot and lets a service failure deactivate the timer"
+    )
+    assert "Persistent=true" in directives, "a missed run must be caught up"
+
+
+def test_the_timer_names_the_service_it_runs():
+    assert "Unit=__SERVICE_NAME__-reception-depth.service" in _TIMER.read_text(encoding="utf-8")

--- a/tests/nfl_data/test_reception_depth_season_start.py
+++ b/tests/nfl_data/test_reception_depth_season_start.py
@@ -1,0 +1,53 @@
+"""A pre-season 404 and a broken release path must not look alike.
+
+nflverse publishes a season's play-by-play only once that season kicks
+off. Asking for the current season in July therefore 404s, and that is
+normal. Asking for a season that HAS started and getting a 404 means the
+release path moved — which is exactly what happened to this repo before,
+when an nflverse rename made IDP tackles score zero for a season.
+
+Before this, both logged ERROR "the pbp release path no longer exists;
+update _PBP_URL". That fires every offseason for a URL that is fine, and
+once an operator learns to ignore it, the real breakage reads the same.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from src.nfl_data.reception_depth import season_has_plausibly_started
+
+
+def _at(year, month):
+    return datetime(year, month, 15, tzinfo=timezone.utc)
+
+
+def test_the_current_season_has_not_started_in_the_offseason():
+    """The live case: it is July 2026 and play_by_play_2026.csv 404s."""
+    assert not season_has_plausibly_started(2026, now=_at(2026, 7))
+
+
+def test_the_current_season_has_started_once_september_arrives():
+    assert season_has_plausibly_started(2026, now=_at(2026, 9))
+    assert season_has_plausibly_started(2026, now=_at(2026, 12))
+
+
+def test_every_past_season_counts_as_started():
+    """So a genuinely stale URL is never silenced.
+
+    A 404 on a completed season is always a real problem, whatever month
+    it is asked in.
+    """
+    for month in (1, 7, 9, 12):
+        assert season_has_plausibly_started(2024, now=_at(2026, month))
+        assert season_has_plausibly_started(2025, now=_at(2026, month))
+
+
+def test_a_future_season_has_not_started():
+    assert not season_has_plausibly_started(2027, now=_at(2026, 12))
+
+
+def test_the_two_states_are_actually_distinguishable():
+    """Non-vacuity: the predicate must not answer the same for both."""
+    assert season_has_plausibly_started(2025, now=_at(2026, 7)) is True
+    assert season_has_plausibly_started(2026, now=_at(2026, 7)) is False

--- a/tests/nfl_data/test_reception_shape_projection.py
+++ b/tests/nfl_data/test_reception_shape_projection.py
@@ -180,3 +180,65 @@ def test_the_shipped_constant_sits_in_the_fitted_range():
     between roughly 30 and 60. This pins that the shipped value stays in
     that basin rather than drifting to an endpoint."""
     assert 30.0 <= SHRINK_K <= 60.0
+
+
+# ── In-season blending ───────────────────────────────────────────────
+
+
+def test_blending_weights_counts_not_shapes():
+    """Sample size must carry through the blend.
+
+    A 3-catch current season must not get an equal vote with a 90-catch
+    prior. Weighting shapes rather than counts would do exactly that,
+    and would hand the loudest voice to the least evidence — in week 2,
+    every week.
+    """
+    from src.nfl_data.reception_shape_projection import blend_seasons
+
+    blended = blend_seasons({2025: {"rec_0_4": 90}, 2026: {"rec_40p": 3}})
+    assert blended["rec_40p"] == pytest.approx(3.0)
+    assert blended["rec_0_4"] == pytest.approx(45.0)  # 90 at half weight
+    assert blended["rec_0_4"] > blended["rec_40p"], "3 catches outvoted 90"
+
+
+def test_the_current_season_is_weighted_highest():
+    from src.nfl_data.reception_shape_projection import blend_seasons
+
+    blended = blend_seasons(
+        {2024: {"rec_0_4": 100}, 2025: {"rec_0_4": 100}, 2026: {"rec_0_4": 100}}
+    )
+    # 100 + 50 + 25 across three seasons at a one-season half-life.
+    assert blended["rec_0_4"] == pytest.approx(175.0)
+
+
+def test_a_changed_role_pulls_the_blend_as_the_season_accumulates():
+    """The property that makes in-season data worth ingesting at all.
+
+    A player who was a checkdown back and is now running deep routes
+    should move — slowly at first, then decisively — rather than being
+    pinned to his history forever.
+    """
+    from src.nfl_data.reception_shape_projection import blend_seasons
+
+    prior = {"rec_0_4": 80}
+    early = blend_seasons({2025: prior, 2026: {"rec_40p": 5}})
+    late = blend_seasons({2025: prior, 2026: {"rec_40p": 60}})
+    share_early = early["rec_40p"] / sum(early.values())
+    share_late = late["rec_40p"] / sum(late.values())
+    assert share_early < 0.2, "5 catches should barely move him"
+    assert share_late > 0.5, "60 catches should dominate an old shape"
+    assert share_late > share_early
+
+
+def test_blending_a_single_season_is_a_no_op():
+    from src.nfl_data.reception_shape_projection import blend_seasons
+
+    assert blend_seasons({2025: {"rec_10_19": 40}})["rec_10_19"] == pytest.approx(40.0)
+
+
+def test_blending_nothing_is_empty_not_uniform():
+    from src.nfl_data.reception_shape_projection import blend_seasons
+
+    blended = blend_seasons({})
+    assert sum(blended.values()) == 0.0
+    assert project_band_shape(blended, None) is None, "empty must stay unknown"

--- a/tests/scripts/test_refresh_reception_depth.py
+++ b/tests/scripts/test_refresh_reception_depth.py
@@ -1,0 +1,113 @@
+"""Exit-code contract for the reception-depth refresh.
+
+Three outcomes that a scheduler must be able to tell apart:
+
+    0  refreshed something
+    1  a season that SHOULD exist could not be fetched  -> page someone
+    2  nothing to do (season not started, or all complete)
+
+Collapsing 1 and 2 is the failure this guards. nflverse publishes a
+season's play-by-play only once it kicks off, so a 404 every offseason
+is normal — reporting it as failure would make the unit red for months
+and train everyone to ignore it, which is exactly when a genuinely
+broken release path would slip through.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO / "scripts" / "refresh_reception_depth.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("refresh_reception_depth", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def script():
+    return _load()
+
+
+def test_a_season_that_has_not_started_is_nothing_to_do_not_failure(script, monkeypatch):
+    called = []
+    monkeypatch.setattr(script, "persist_reception_depth", lambda s: called.append(s) or {})
+    monkeypatch.setattr(script, "season_has_plausibly_started", lambda s, **k: False)
+    assert script.main(["--seasons", "2026"]) == 2
+    assert called == [], "must not even attempt a season that has not kicked off"
+
+
+def test_a_started_season_that_yields_nothing_is_a_failure(script, monkeypatch):
+    """The case that must page someone: the season has started, so a
+    missing file means the release path moved."""
+    monkeypatch.setattr(script, "season_has_plausibly_started", lambda s, **k: True)
+    monkeypatch.setattr(script, "depth_path", lambda s, **k: Path("/nonexistent"))
+    monkeypatch.setattr(
+        script, "persist_reception_depth", lambda s: {"seasons": [], "players": 0, "receptions": 0}
+    )
+    assert script.main(["--seasons", "2025"]) == 1
+
+
+def test_a_successful_refresh_returns_zero(script, monkeypatch):
+    monkeypatch.setattr(script, "season_has_plausibly_started", lambda s, **k: True)
+    monkeypatch.setattr(script, "depth_path", lambda s, **k: Path("/nonexistent"))
+    monkeypatch.setattr(
+        script,
+        "persist_reception_depth",
+        lambda s: {"seasons": list(s), "players": 400, "receptions": 11000},
+    )
+    assert script.main(["--seasons", "2025"]) == 0
+
+
+def test_completed_seasons_on_disk_are_not_refetched(script, monkeypatch):
+    """Historical seasons are immutable. Re-streaming a 98 MB CSV weekly
+    for data that cannot change is pure waste."""
+    monkeypatch.setattr(script, "season_has_plausibly_started", lambda s, **k: True)
+    monkeypatch.setattr(script, "_current_season", lambda now=None: 2026)
+    monkeypatch.setattr(script, "depth_path", lambda s, **k: Path(__file__))  # "exists"
+    called = []
+    monkeypatch.setattr(script, "persist_reception_depth", lambda s: called.append(s) or {})
+    assert script.main(["--seasons", "2024"]) == 2
+    assert called == []
+
+
+def test_force_overrides_the_skip(script, monkeypatch):
+    monkeypatch.setattr(script, "season_has_plausibly_started", lambda s, **k: True)
+    monkeypatch.setattr(script, "depth_path", lambda s, **k: Path(__file__))
+    monkeypatch.setattr(
+        script,
+        "persist_reception_depth",
+        lambda s: {"seasons": list(s), "players": 1, "receptions": 1},
+    )
+    assert script.main(["--seasons", "2024", "--force"]) == 0
+
+
+def test_january_belongs_to_the_previous_season(script):
+    """The off-by-one that would silence the entire postseason.
+
+    In January the games being played are the PREVIOUS season's
+    playoffs. A naive ``now.year`` would ask for a season that has not
+    started, report "nothing to do", and stop updating shapes through
+    the most valuable weeks of the year.
+    """
+    jan = datetime(2027, 1, 15, tzinfo=timezone.utc)
+    assert script._current_season(jan) == 2026
+    feb = datetime(2027, 2, 20, tzinfo=timezone.utc)
+    assert script._current_season(feb) == 2026
+    sep = datetime(2027, 9, 15, tzinfo=timezone.utc)
+    assert script._current_season(sep) == 2027
+
+
+def test_the_default_lookback_covers_what_the_blend_uses(script):
+    """The blend uses a one-season half-life, so the third season back
+    already counts a quarter. Fetching more would be filenames, not
+    signal."""
+    assert script.DEFAULT_LOOKBACK_SEASONS == 3


### PR DESCRIPTION
Band shapes were built by hand and only for completed seasons, so every player was priced on **last year's** catch distribution all year. A checkdown back who starts running deep routes, or a rookie taking over a slot, wouldn't show up in the data until the following offseason.

## A 404 meant two different things and said one

nflverse publishes a season's play-by-play only once that season kicks off. Verified today:

```
play_by_play_2025.csv -> HTTP 200
play_by_play_2026.csv -> HTTP 404   (season starts in September)
```

The handler logged **every** 404 at ERROR as *"the pbp release path no longer exists; update `_PBP_URL`"*.

That fires all offseason for a URL that's fine — and once an operator learns to ignore it, a genuinely moved release path reads identically. This repo has already lost a season of IDP tackle scoring to an nflverse rename, so that's not hypothetical.

`season_has_plausibly_started` now splits them: INFO "not started" before September of the season's own year, ERROR "url_stale" for any season that should have data.

## Partial seasons are noisy — which the shrinkage already knew how to handle

In week 4 a player has ~15 catches, far too few to trust; `project_band_shape` would rightly shrink nearly all of it away. But his prior seasons still describe how he catches.

`blend_seasons` combines seasons with a one-season half-life **before** shrinkage, weighting **counts** rather than shapes so sample size carries through — a 3-catch current season contributes 3 weighted catches, not an equal vote with a 90-catch prior. A genuinely changed role pulls the blend as the season accumulates; pinned by a test asserting 5 catches barely move a player and 60 dominate an old shape.

The half-life is **1.0 and labelled a prior, not a measurement**. `SHRINK_K` is fitted because it has a clean held-out target; recency weighting has none without a longer history than the three seasons on disk, and fitting it on two transitions would be reading noise.

## Cadence

`scripts/refresh_reception_depth.py` plus a weekly Wednesday timer, following the playerctx/BDVM prod-side pattern — the readers load a **local** file and `data/` is gitignored, so a histogram built on CI never reaches the box. Completed seasons already on disk are skipped, so a run streams one file rather than the whole history.

Exit codes 0/1/2, and **the unit treats 2 as success**. "The season has not kicked off" is normal from March to August; a unit sitting red for half the year is one nobody reads, which is exactly when the exit-1 case would slip past. `_current_season` treats January/February as the *previous* season, or the refresh would go quiet through the entire postseason.

A test pins that the timer is installed **and enabled**. This repo's recurring failure is a component built and never connected, and a systemd unit's version of that is silent — no error, just data that stops updating.

## Two false positives caught while writing the guards

Both the same shape as ones this repo has hit before:

1. The timer template *contains* the string `Requires=` inside the comment explaining why there deliberately isn't one — a naive scan read the prose as the directive.
2. My first simulation of a real `Requires=` inserted it *into that comment*, because the comment also contains `[Timer]`. It reported "NOT CAUGHT" against a guard that was fine.

Comments are stripped before scanning, and the guard is verified firing on a correctly-anchored real directive.

## Validation

- Hard gate: **4864 passed, 319 deselected**
- `ruff format --check .` and `ruff check` clean on the changed set
- `bash -n` on the installer
- Script exercised live: exits 2 with clean INFO today (2026 not started, 2023–25 complete on disk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeqwBFmFak84h3h7RaCZqa

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeqwBFmFak84h3h7RaCZqa)_