### PR TITLE
BDVM live surfaces: trade eval, in-season posterior, news events, draft join

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -495,6 +495,52 @@ Operational surfaces (post-merge additions):
   floods inboxes — pinned in ``tests/api/test_bdvm_signal_alerts.py``.
   Flag off → the sweep stamps ``bdvmEnabled: false`` and skips
   entirely.
+- **Trade calculator check**: ``POST /api/bdvm/trade-eval``
+  (``src/api/bdvm_api.py::get_bdvm_trade_eval``) CES-evaluates ONE
+  specific trade in every strategy currency — package math is
+  ``package_value`` (§3.13), never a plain sum. Asset refs resolve
+  playerId-first → normalized name → pick name (picks use the
+  strategy's distribution EV); unresolvable refs are reported in
+  ``unresolved`` per side, never silently priced at zero. Renders as
+  the "Fundamentals check (BDVM)" panel on /trade
+  (``frontend/components/BdvmTradePanel.jsx``, below RosTradeFitPanel):
+  display-only, never touches sideTotals/TradeMeter, silent-vanish on
+  any non-ok. Tests: ``tests/bdvm/test_trade_eval.py``.
+- **In-season updating** (§8.4): ``run_valuation(actuals=...)`` blends
+  realized weekly PPG — scored under the league's exact settings from
+  nflverse weekly rows (``src/bdvm/actuals.py``, REG weeks only, its
+  own 24h disk-cache key) — into the projection posterior via
+  ``blend_ros_mu`` (``w = n_prior/(n_prior+weeks)``, n_prior 6 offense
+  / 8 IDP); σ shrinks by ``√w_prior``; ROS drops already-played weeks
+  via ``current_week``. Preseason is an exact no-op (``meta.inSeason
+  = {"active": false}``). ``bdvm_api`` refreshes actuals once per UTC
+  day per season — the values cache key carries the day, so boards
+  self-update daily in season with zero new timers. Tests:
+  ``tests/bdvm/test_inseason.py``.
+- **News → events ingestion**: ``src/bdvm/news_events.py`` piggybacks
+  on the same daily signal-alerts sweep (runs BEFORE the per-user
+  loop). Aggregated headlines map via conservative ordered keyword
+  rules onto 12 of the 18 §7 ontology types (no match → NOTHING,
+  ambiguous player mention → NOTHING). Auto events land in the
+  speculation lane structurally: ``confidence = 0.45 < 0.5`` means
+  ``effective_impact`` suppresses every non-sigma channel — a headline
+  can widen uncertainty but can NEVER move a mean; raising confidence
+  is a human edit to ``data/bdvm/events/<season>.json``. Merge is
+  dedup-by-eventId (``news:<item-id>:<player-key>``) with
+  existing-wins (human-raised confidence survives re-ingest), prunes
+  only ``news:*`` events (90d), and refuses on a corrupt file rather
+  than discarding human entries. The events-file fingerprint
+  (mtime_ns, size) sits in the bdvm_api cache key, so every write
+  invalidates cached boards. Tests: ``tests/bdvm/test_news_events.py``.
+- **Draft board join**: /draft grows a "Fund gap" column on the
+  RookieBoard — name-based join only (draft rows are keyed by
+  ``playerSlug`` and carry no playerId) — plus a collapsed-by-default
+  "Fundamental pick values (BDVM)" panel (balanced-strategy pick
+  EV / hit% / median / ceiling beside the market anchor, from
+  ``buildBdvmPickRows``). Same silent-vanish posture as the rankings
+  gap column; sorting by gap sinks unpriced rows; auction math and
+  backend-stamped ranks untouched. Tests:
+  ``frontend/__tests__/components/DraftBoardSort.test.jsx``.
 
 ### Single Source of Truth: Rankings Override Path
 Custom source configurations (user-toggled sources or custom weights) flow through the **SAME** canonical pipeline as the default board. There is no frontend ranking engine, period — not even a fallback. `buildRows` is a pure materializer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -501,8 +501,11 @@ Operational surfaces (post-merge additions):
   ``package_value`` (§3.13), never a plain sum. Asset refs resolve
   playerId-first → normalized name → pick name (picks use the
   strategy's distribution EV); unresolvable refs are reported in
-  ``unresolved`` per side, never silently priced at zero. Renders as
-  the "Fundamentals check (BDVM)" panel on /trade
+  ``unresolved`` per side, never silently priced at zero. The route
+  parses its body BEFORE the shared gate so the body ``leagueKey``
+  reaches the resolver (POST convention — pinned by
+  ``tests/bdvm/test_endpoint.py``). Renders as the "Fundamentals
+  check (BDVM)" panel on /trade
   (``frontend/components/BdvmTradePanel.jsx``, below RosTradeFitPanel):
   display-only, never touches sideTotals/TradeMeter, silent-vanish on
   any non-ok. Tests: ``tests/bdvm/test_trade_eval.py``.
@@ -512,26 +515,43 @@ Operational surfaces (post-merge additions):
   own 24h disk-cache key) — into the projection posterior via
   ``blend_ros_mu`` (``w = n_prior/(n_prior+weeks)``, n_prior 6 offense
   / 8 IDP); σ shrinks by ``√w_prior``; ROS drops already-played weeks
-  via ``current_week``. Preseason is an exact no-op (``meta.inSeason
-  = {"active": false}``). ``bdvm_api`` refreshes actuals once per UTC
-  day per season — the values cache key carries the day, so boards
-  self-update daily in season with zero new timers. Tests:
-  ``tests/bdvm/test_inseason.py``.
+  via ``current_week`` (uncapped — after the week-18 slate it is 19 so
+  ROS sums zero, never double-counting the banked final week), with a
+  per-player boundary-week rule: the in-progress week counts as
+  remaining for players who haven't played it yet (nflverse publishes
+  game-by-game). The actuals season is the CALENDAR NFL season
+  (``current_nfl_season``: Sept–Dec → year, Jan → year−1, else None)
+  — NEVER ``currentDraftYear``, which points one season ahead for the
+  whole Sept–Jan window and would make the posterior structurally
+  unreachable. Distinct players colliding on a normalized name are
+  dropped (chimera guard, projection-side policy). Preseason is an
+  exact no-op (``meta.inSeason = {"active": false}``). ``bdvm_api``
+  refreshes actuals once per UTC day; fetch FAILURES are returned but
+  never memoized, so a transient blip can't pin the board to preseason
+  values until midnight. Tests: ``tests/bdvm/test_inseason.py``.
 - **News → events ingestion**: ``src/bdvm/news_events.py`` piggybacks
   on the same daily signal-alerts sweep (runs BEFORE the per-user
   loop). Aggregated headlines map via conservative ordered keyword
-  rules onto 12 of the 18 §7 ontology types (no match → NOTHING,
-  ambiguous player mention → NOTHING). Auto events land in the
-  speculation lane structurally: ``confidence = 0.45 < 0.5`` means
-  ``effective_impact`` suppresses every non-sigma channel — a headline
-  can widen uncertainty but can NEVER move a mean; raising confidence
-  is a human edit to ``data/bdvm/events/<season>.json``. Merge is
-  dedup-by-eventId (``news:<item-id>:<player-key>``) with
-  existing-wins (human-raised confidence survives re-ingest), prunes
-  only ``news:*`` events (90d), and refuses on a corrupt file rather
-  than discarding human entries. The events-file fingerprint
-  (mtime_ns, size) sits in the bdvm_api cache key, so every write
-  invalidates cached boards. Tests: ``tests/bdvm/test_news_events.py``.
+  rules onto 11 of the 18 §7 ontology types (no match → NOTHING;
+  ambiguous player mention → NOTHING; advice/listicle language —
+  "trade targets", "who makes the cut", rankings/waiver/mock-draft
+  vocabulary — → NOTHING; items naming >3 players → NOTHING;
+  ACTIVATED_RETURN deliberately unmapped because its impact narrows
+  σ). Auto events land in the speculation lane structurally:
+  ``confidence = 0.45 < 0.5`` means ``effective_impact`` suppresses
+  every non-sigma channel AND clamps ``sigma_mult ≥ 1.0`` — a headline
+  can widen uncertainty but can NEVER move a mean or narrow σ; raising
+  confidence is a human edit to ``data/bdvm/events/<season>.json``.
+  Merge is dedup-by-eventId (``news:<item-id>:<player-key>``) plus
+  same-fact suppression (one ``(playerKey, eventType)`` per 14 days —
+  N providers ≠ N sigma wideners) with existing-wins; the 90d prune
+  touches only ``news:*`` events still at speculation confidence
+  (human-raised confidence exempts an event); refuses on corrupt OR
+  valid-JSON-wrong-shape files rather than discarding human entries,
+  and preserves extra top-level keys (``_comment``) on rewrite. The
+  events-file fingerprint (mtime_ns, size) sits in the bdvm_api cache
+  key, so every write invalidates cached boards. Tests:
+  ``tests/bdvm/test_news_events.py``.
 - **Draft board join**: /draft grows a "Fund gap" column on the
   RookieBoard — name-based join only (draft rows are keyed by
   ``playerSlug`` and carry no playerId) — plus a collapsed-by-default

--- a/frontend/__tests__/components/BdvmTradePanel.test.jsx
+++ b/frontend/__tests__/components/BdvmTradePanel.test.jsx
@@ -1,0 +1,134 @@
+/**
+ * BdvmTradePanel — the fundamentals check on /trade.
+ *
+ * The properties that matter:
+ * 1. Silent-vanish degrade (rankings gap-column precedent for add-on
+ *    surfaces): 503 / non-ok status / network error → the panel
+ *    renders NOTHING, never a generic error beside the trade grade.
+ * 2. An ok payload renders every strategy currency the backend
+ *    returned, plus the unresolved-assets note — assets the board
+ *    declines to price are LISTED, never silently zeroed.
+ * 3. No request at all until both sides carry assets (empty trade →
+ *    nothing to evaluate → no fetch, no panel).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+
+import BdvmTradePanel from "@/components/BdvmTradePanel";
+
+const OK_BODY = {
+  status: "ok",
+  byStrategy: {
+    balanced: { sideA: 5000, sideB: 4200, edge: 800, edgePct: 17.4 },
+    contender: { sideA: 4600, sideB: 4900, edge: -300, edgePct: -6.3 },
+  },
+  unresolved: { sideA: [], sideB: ["2027 Round 5 (mystery)"] },
+};
+
+function sidesWith(namesA, namesB) {
+  const mk = (names) => ({
+    assets: names.map((name) => ({ name, raw: { playerId: null } })),
+  });
+  return [mk(namesA), mk(namesB)];
+}
+
+function mockFetch(status, body) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  });
+}
+
+async function settle() {
+  // 600ms debounce, then the fetch promise chain.
+  await act(async () => {
+    vi.advanceTimersByTime(700);
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("BdvmTradePanel", () => {
+  it("renders per-strategy rows and the unresolved note on ok", async () => {
+    global.fetch = mockFetch(200, OK_BODY);
+    render(
+      <BdvmTradePanel
+        sides={sidesWith(["Alpha Back"], ["Bravo Wide"])}
+        leagueKey="dynasty_main"
+      />,
+    );
+    await settle();
+
+    expect(screen.getByText("Fundamentals check (BDVM)")).toBeInTheDocument();
+    // Only the strategies the backend returned render.
+    expect(screen.getByText("Balanced")).toBeInTheDocument();
+    expect(screen.getByText("Contender")).toBeInTheDocument();
+    expect(screen.queryByText("Rebuilder")).toBeNull();
+    // Unpriced assets are listed, never silently dropped.
+    expect(
+      screen.getByText(/Not priced by the fundamental board/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/2027 Round 5 \(mystery\)/)).toBeInTheDocument();
+  });
+
+  it("vanishes silently on a 503 (flag off / not ready)", async () => {
+    global.fetch = mockFetch(503, { error: "bdvm_disabled" });
+    const { container } = render(
+      <BdvmTradePanel
+        sides={sidesWith(["Alpha Back"], ["Bravo Wide"])}
+        leagueKey="dynasty_main"
+      />,
+    );
+    await settle();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("vanishes silently on a network error", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("boom"));
+    const { container } = render(
+      <BdvmTradePanel
+        sides={sidesWith(["Alpha Back"], ["Bravo Wide"])}
+        leagueKey="dynasty_main"
+      />,
+    );
+    await settle();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("makes no request while either side is empty", async () => {
+    global.fetch = mockFetch(200, OK_BODY);
+    const { container } = render(
+      <BdvmTradePanel sides={sidesWith(["Alpha Back"], [])} leagueKey="dynasty_main" />,
+    );
+    await settle();
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("makes no request for 3+ team trades (CES eval is two-sided)", async () => {
+    global.fetch = mockFetch(200, OK_BODY);
+    const sides = [
+      ...sidesWith(["Alpha Back"], ["Bravo Wide"]),
+      { assets: [{ name: "Charlie End", raw: { playerId: null } }] },
+    ];
+    const { container } = render(
+      <BdvmTradePanel sides={sides} leagueKey="dynasty_main" />,
+    );
+    await settle();
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/__tests__/components/DraftBoardSort.test.jsx
+++ b/frontend/__tests__/components/DraftBoardSort.test.jsx
@@ -31,6 +31,7 @@ vi.mock("next/navigation", () => ({
 }));
 
 import { RookieBoard } from "@/app/draft/page";
+import { buildBdvmIndex } from "@/lib/bdvm";
 
 function player(id, name, rank, winBid, tier = "A") {
   return {
@@ -61,10 +62,11 @@ const PLAYERS = [
   player("p3", "Charlie End", 3, 30),
 ];
 
-function renderBoard() {
+function renderBoard(extraProps = {}) {
   const noop = () => {};
   return render(
     <RookieBoard
+      {...extraProps}
       stats={{
         enrichedPlayers: PLAYERS,
         tierStats: {},
@@ -179,5 +181,67 @@ describe("draft board sortable headers", () => {
     const desc = boardOrder();
     await user.click(screen.getByRole("button", { name: "Player" }));
     expect(boardOrder()).toEqual([...desc].reverse());
+  });
+});
+
+/**
+ * BDVM Fund gap column — flag-gated join, same posture as the rankings
+ * page: the column exists only when a bdvmIndex is supplied (endpoint
+ * answered ok) and vanishes entirely without one.  Draft rows carry no
+ * playerId, so the join is name-based via buildBdvmIndex's byName map.
+ */
+describe("draft board BDVM fund gap column", () => {
+  // Real index built by the real helper — exercises the actual join
+  // path, not a hand-rolled Map shape that could drift.
+  const bdvmIndex = buildBdvmIndex({
+    players: [
+      {
+        name: "Alpha Back",
+        market: { gap: 512, marketValue: 4000 },
+        tradeValue: { balanced: 4512 },
+        signal: { signal: "BUY", reason: "market underprices profile" },
+      },
+      {
+        name: "Bravo Wide",
+        market: { gap: -240, marketValue: 3000 },
+        tradeValue: { balanced: 2760 },
+        signal: { signal: "SELL", reason: "aging curve" },
+      },
+      // Charlie End deliberately absent → unpriced, muted dash.
+    ],
+  });
+
+  it("column is absent without an index and present with one", () => {
+    const { unmount } = renderBoard();
+    expect(screen.queryByRole("button", { name: "Fund gap" })).toBeNull();
+    unmount();
+
+    renderBoard({ bdvmIndex });
+    expect(screen.getByRole("button", { name: "Fund gap" })).toBeInTheDocument();
+  });
+
+  it("shows signed gaps for priced rows and a dash for unpriced rows", () => {
+    renderBoard({ bdvmIndex });
+    expect(screen.getByText("+512")).toBeInTheDocument();
+    expect(screen.getByText("−240")).toBeInTheDocument();
+    // Charlie End has no fundamental value: his row's gap cell is a dash.
+    const charlieRow = screen.getByText("Charlie End").closest("tr");
+    const cells = within(charlieRow).getAllByRole("cell");
+    // Fund gap sits right after Market (rank, tier, tag, rec, player,
+    // preDraft, market, gap → index 7).
+    expect(cells[7].textContent.trim()).toBe("—");
+  });
+
+  it("sorts by gap with unpriced rows sinking in both directions", async () => {
+    const user = userEvent.setup();
+    renderBoard({ bdvmIndex });
+
+    await user.click(screen.getByRole("button", { name: "Fund gap" }));
+    // Descending: +512, −240, then unpriced sinks.
+    expect(boardOrder()).toEqual(["Alpha Back", "Bravo Wide", "Charlie End"]);
+
+    await user.click(screen.getByRole("button", { name: "Fund gap" }));
+    // Ascending: −240, +512 — unpriced STILL last.
+    expect(boardOrder()).toEqual(["Bravo Wide", "Alpha Back", "Charlie End"]);
   });
 });

--- a/frontend/app/api/bdvm/trade-eval/route.js
+++ b/frontend/app/api/bdvm/trade-eval/route.js
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { proxyPost } from "@/lib/backend-proxy";
+
+// Dev-flow bridge only — in production nginx routes /api/* straight to
+// FastAPI. First compute of a BDVM valuation takes seconds (full
+// engine run before the cache warms), hence the long timeout.
+export async function POST(request) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  try {
+    const { data, status } = await proxyPost("/api/bdvm/trade-eval", body, {
+      timeoutMs: 30000,
+    });
+    return NextResponse.json(data, { status });
+  } catch (err) {
+    return NextResponse.json(
+      { error: "bdvm_unavailable", detail: err?.message },
+      { status: 503 },
+    );
+  }
+}

--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -58,10 +58,20 @@ import {
   updateTeam,
 } from "@/lib/draft-logic";
 import { classifyPos } from "@/lib/dynasty-data";
+import { useBdvmEndpoint } from "@/components/useBdvm";
+import {
+  buildBdvmIndex,
+  buildBdvmPickRows,
+  bdvmEntryForRow,
+  bdvmSignalEdgeCss,
+  formatBdvmGap,
+  formatBdvmValue,
+} from "@/lib/bdvm";
 import {
   Badge,
   Banner,
   Button,
+  CollapsiblePanel,
   Icon,
   Modal,
   PageHeader,
@@ -1052,6 +1062,7 @@ export function RookieBoard({
   tagFilter,
   onTagFilterChange,
   onAdd,
+  bdvmIndex,
 }) {
   const [sort, setSort] = useState({ col: "myWinningBid", asc: false });
 
@@ -1107,11 +1118,21 @@ export function RookieBoard({
           return (
             ((a.pick?.amount ?? -1) - (b.pick?.amount ?? -1)) * dir
           );
+        case "gap": {
+          // BDVM fundamental gap — unpriced rows sink regardless of
+          // direction (same null handling as the rankings page).
+          const ga = bdvmEntryForRow(bdvmIndex, a)?.gap;
+          const gb = bdvmEntryForRow(bdvmIndex, b)?.gap;
+          if (ga == null && gb == null) return 0;
+          if (ga == null) return 1;
+          if (gb == null) return -1;
+          return (ga - gb) * dir;
+        }
         default:
           return 0;
       }
     });
-  }, [stats.enrichedPlayers, sort, query, showDrafted, tagFilter]);
+  }, [stats.enrichedPlayers, sort, query, showDrafted, tagFilter, bdvmIndex]);
 
   // Tier-separator rows — only when the current sort groups by tier
   // naturally (rank or preDraft descending/ascending).  Scatter sorts
@@ -1228,6 +1249,7 @@ export function RookieBoard({
               >
                 Market
               </th>
+              {bdvmIndex ? th("Fund gap", "gap", 76) : null}
               {th("Fair", "inflatedFair", 70)}
               {th("Enforce", "enforceUpTo", 70)}
               {th("Win at", "myWinningBid", 80)}
@@ -1249,7 +1271,7 @@ export function RookieBoard({
                       key={`tier-${p.tier}`}
                       className="draft-tier-divider"
                     >
-                      <td colSpan={14}>
+                      <td colSpan={14 + (bdvmIndex ? 1 : 0)}>
                         <span
                           className={`draft-tier-chip draft-tier-${p.tier}`}
                           style={{ marginRight: 8 }}
@@ -1377,6 +1399,42 @@ export function RookieBoard({
                       ? fmt$(m) : "—";
                   })()}
                 </td>
+                {bdvmIndex ? (
+                  <td className="draft-money">
+                    {(() => {
+                      // BDVM fundamental gap — display-only join, same
+                      // idiom as the rankings page column. Rows the
+                      // fundamental board declines to price show a
+                      // muted dash, never a fabricated number.
+                      const entry = bdvmEntryForRow(bdvmIndex, p);
+                      if (!entry || entry.gap == null) {
+                        return (
+                          <span
+                            className="muted"
+                            title={
+                              entry?.signalReason ||
+                              "not priced by the fundamental board"
+                            }
+                          >
+                            —
+                          </span>
+                        );
+                      }
+                      const css = bdvmSignalEdgeCss(entry.signal);
+                      const title =
+                        `${entry.signal}: ${entry.signalReason} — fundamental ` +
+                        `${formatBdvmValue(entry.fundamental)} vs market ` +
+                        `${formatBdvmValue(entry.marketValue)}`;
+                      return css ? (
+                        <span className={`edge-label ${css}`} title={title}>
+                          {formatBdvmGap(entry.gap)}
+                        </span>
+                      ) : (
+                        <span title={title}>{formatBdvmGap(entry.gap)}</span>
+                      );
+                    })()}
+                  </td>
+                ) : null}
                 <td className="draft-money">{fmt$(p.inflatedFair)}</td>
                 <td className="draft-money">{fmt$(p.enforceUpTo)}</td>
                 <td
@@ -1506,7 +1564,7 @@ export function RookieBoard({
             {filtered.length === 0 && (
               <tr>
                 <td
-                  colSpan={13}
+                  colSpan={14 + (bdvmIndex ? 1 : 0)}
                   className="muted"
                   style={{ padding: 14, textAlign: "center" }}
                 >
@@ -3271,6 +3329,22 @@ export default function DraftDashboardPage() {
   const [showDrafted, setShowDrafted] = useState(false);
   const [query, setQuery] = useState("");
   const [tagFilter, setTagFilter] = useState("all"); // all | target | avoid | untagged
+  // BDVM fundamental values — optional flag-gated enrichment, same
+  // posture as the rankings gap column: the Fund gap column and the
+  // pick-value panel exist only while /api/bdvm/values answers ok and
+  // vanish silently on any 503 (flag off, no snapshot, wrong league).
+  const { data: bdvmData, failure: bdvmFailure } = useBdvmEndpoint("/api/bdvm/values");
+  const bdvmIndex = useMemo(
+    () => (!bdvmFailure && bdvmData?.status === "ok" ? buildBdvmIndex(bdvmData) : null),
+    [bdvmData, bdvmFailure],
+  );
+  const bdvmPickRows = useMemo(
+    () =>
+      !bdvmFailure && bdvmData?.status === "ok"
+        ? buildBdvmPickRows(bdvmData, "balanced")
+        : [],
+    [bdvmData, bdvmFailure],
+  );
   // Late-draft triage mode: when my slotPressure crosses 0.7, auto-
   // flip the board filter to "Targets" so I see only the players I
   // still want.  Tracked so a user who manually changes the filter
@@ -4702,7 +4776,56 @@ export default function DraftDashboardPage() {
         tagFilter={tagFilter}
         onTagFilterChange={setTagFilter}
         onAdd={onAdd}
+        bdvmIndex={bdvmIndex}
       />
+
+      {bdvmPickRows.length > 0 && (
+        <CollapsiblePanel
+          title="Fundamental pick values (BDVM)"
+          subtitle="Rookie-pick EV in the balanced strategy currency — hit rate and outcome spread from the fundamental model, market anchor beside it"
+          defaultCollapsed
+        >
+          <div className="draft-table-wrap">
+            <table className="draft-table">
+              <thead>
+                <tr>
+                  <th style={{ textAlign: "left" }}>Pick</th>
+                  <th style={{ width: 90, textAlign: "right" }}>EV</th>
+                  <th style={{ width: 80, textAlign: "right" }} title="Probability the pick returns a startable player">
+                    Hit %
+                  </th>
+                  <th style={{ width: 90, textAlign: "right" }}>Median</th>
+                  <th style={{ width: 90, textAlign: "right" }}>Ceiling</th>
+                  <th style={{ width: 100, textAlign: "right" }}>Market</th>
+                </tr>
+              </thead>
+              <tbody>
+                {bdvmPickRows.map((row) => (
+                  <tr key={row.name}>
+                    <td>{row.name}</td>
+                    <td className="draft-money">{formatBdvmValue(row.ev)}</td>
+                    <td className="draft-money">
+                      {row.pHit == null ? "—" : `${Math.round(row.pHit * 100)}%`}
+                    </td>
+                    <td className="draft-money">{formatBdvmValue(row.median)}</td>
+                    <td className="draft-money">{formatBdvmValue(row.ceiling)}</td>
+                    <td
+                      className="draft-money"
+                      title={row.marketSource || undefined}
+                    >
+                      {formatBdvmValue(row.marketValue)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="muted" style={{ margin: "var(--space-2) 0 0", fontSize: "var(--font-size-2xs)" }}>
+            Fundamental (projection-driven) values — compared against the
+            market, never merged into the auction math above.
+          </p>
+        </CollapsiblePanel>
+      )}
 
       <DraftGlossary />
 

--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -947,7 +947,7 @@ function DraftModal({ player, workspace, stats, onClose, onSubmit }) {
  * Way faster than opening the full draft modal when you just need
  * to log a sale.
  */
-function QuickRecordRow({ player, workspace, onSubmit, onCancel }) {
+function QuickRecordRow({ player, workspace, onSubmit, onCancel, colSpan = 14 }) {
   const myTeamIdx = workspace?.settings?.myTeamIdx ?? 0;
   const [teamIdx, setTeamIdx] = useState(myTeamIdx);
   const [amount, setAmount] = useState("");
@@ -971,7 +971,7 @@ function QuickRecordRow({ player, workspace, onSubmit, onCancel }) {
 
   return (
     <tr className="draft-quick-row">
-      <td colSpan={13}>
+      <td colSpan={colSpan}>
         <div className="draft-quick-inner">
           <span className="muted" style={{ fontSize: "0.7rem" }}>
             Quick record <strong>{player.name}</strong>
@@ -1555,6 +1555,7 @@ export function RookieBoard({
                       workspace={workspace}
                       onSubmit={onQuickSubmit}
                       onCancel={onQuickCancel}
+                      colSpan={14 + (bdvmIndex ? 1 : 0)}
                     />,
                   );
                 }

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -36,6 +36,7 @@ import { valuationBasisLabel, valuationBasisOf } from "@/lib/dynasty-data";
 import { useSettings } from "@/components/useSettings";
 import TradeDeltaHistogram from "@/components/graphs/TradeDeltaHistogram";
 import RosTradeFitPanel from "@/components/RosTradeFitPanel";
+import BdvmTradePanel from "@/components/BdvmTradePanel";
 import MultiTradeFlow from "@/components/graphs/MultiTradeFlow";
 import { useApp } from "@/components/AppShell";
 import { buildShareUrl, parseShareParam } from "@/lib/trade-share";
@@ -1804,6 +1805,7 @@ export default function TradePage() {
             valueMode={valueMode}
           />
           <RosTradeFitPanel sides={sides} settings={settings} />
+          <BdvmTradePanel sides={sides} leagueKey={selectedLeagueKey} />
 
           {sides.length === 2 ? (
             <Panel>

--- a/frontend/components/BdvmTradePanel.jsx
+++ b/frontend/components/BdvmTradePanel.jsx
@@ -1,0 +1,156 @@
+"use client";
+
+/**
+ * BdvmTradePanel — the fundamental (BDVM) read on the CURRENT trade,
+ * rendered beside the market grade on /trade.
+ *
+ * POSTs both sides' assets to /api/bdvm/trade-eval and shows the CES
+ * package value per strategy currency. Pure display: every number is
+ * backend-computed; this panel never touches sideTotals/TradeMeter
+ * (fundamental is COMPARED against market, never merged — CLAUDE.md).
+ *
+ * Degrade contract (rankings gap-column precedent for add-on
+ * surfaces): any 503 (flag off, no snapshot, wrong league), network
+ * error, or non-ok status → the panel renders NOTHING. Assets the
+ * fundamental board declines to price are listed, never zeroed
+ * silently — the backend reports them per side.
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Panel } from "@/components/ds";
+import { BDVM_STRATEGIES, formatBdvmValue } from "@/lib/bdvm";
+
+const LEAGUE_LOCAL_KEY = "next_active_league_v1";
+
+function readActiveLeagueKey() {
+  if (typeof window === "undefined") return "";
+  try {
+    return localStorage.getItem(LEAGUE_LOCAL_KEY) || "";
+  } catch {
+    return "";
+  }
+}
+
+function sideRefs(side) {
+  return (side?.assets || []).map((row) => ({
+    playerId: String(row?.raw?.playerId ?? row?.playerId ?? "").trim() || undefined,
+    name: row?.name || "",
+  }));
+}
+
+export default function BdvmTradePanel({ sides, leagueKey }) {
+  const [result, setResult] = useState(null);
+  const abortRef = useRef(null);
+
+  // Two-team trades only — the CES eval is a two-sided comparison.
+  const twoTeam = Array.isArray(sides) && sides.length === 2;
+  const refsA = useMemo(() => (twoTeam ? sideRefs(sides[0]) : []), [sides, twoTeam]);
+  const refsB = useMemo(() => (twoTeam ? sideRefs(sides[1]) : []), [sides, twoTeam]);
+  const signature = useMemo(
+    () => JSON.stringify([refsA.map((r) => r.name), refsB.map((r) => r.name), leagueKey]),
+    [refsA, refsB, leagueKey],
+  );
+
+  useEffect(() => {
+    if (!twoTeam || refsA.length === 0 || refsB.length === 0) {
+      setResult(null);
+      return undefined;
+    }
+    const timer = setTimeout(async () => {
+      abortRef.current?.abort();
+      const ctl = new AbortController();
+      abortRef.current = ctl;
+      try {
+        const res = await fetch("/api/bdvm/trade-eval", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "same-origin",
+          signal: ctl.signal,
+          body: JSON.stringify({
+            sideA: refsA,
+            sideB: refsB,
+            leagueKey: leagueKey || readActiveLeagueKey() || undefined,
+          }),
+        });
+        const body = await res.json().catch(() => null);
+        // Flag off / not ready / unavailable / anything non-ok →
+        // vanish silently. Never a generic error on an add-on panel.
+        if (!res.ok || !body || body.status !== "ok") {
+          setResult(null);
+          return;
+        }
+        setResult(body);
+      } catch {
+        setResult(null);
+      }
+    }, 600);
+    return () => {
+      clearTimeout(timer);
+      abortRef.current?.abort();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [signature]);
+
+  if (!result) return null;
+  const unresolved = [
+    ...(result.unresolved?.sideA || []),
+    ...(result.unresolved?.sideB || []),
+  ];
+
+  return (
+    <Panel
+      title="Fundamentals check (BDVM)"
+      subtitle="CES package values per strategy currency — does NOT change the trade math above"
+    >
+      <table className="bdvm-trade-table" style={{ width: "100%", borderCollapse: "collapse" }}>
+        <thead>
+          <tr>
+            <th style={{ textAlign: "left", padding: "4px 8px" }}>Strategy</th>
+            <th style={{ textAlign: "right", padding: "4px 8px" }}>Side A</th>
+            <th style={{ textAlign: "right", padding: "4px 8px" }}>Side B</th>
+            <th style={{ textAlign: "right", padding: "4px 8px" }}>Edge (A−B)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {BDVM_STRATEGIES.map(({ value, label }) => {
+            const row = result.byStrategy?.[value];
+            if (!row) return null;
+            const edgeCss =
+              row.edge > 0 ? "edge-buy" : row.edge < 0 ? "edge-sell" : "edge-hold";
+            return (
+              <tr key={value}>
+                <td style={{ padding: "4px 8px" }}>{label}</td>
+                <td style={{ textAlign: "right", padding: "4px 8px" }} data-numeric>
+                  {formatBdvmValue(row.sideA)}
+                </td>
+                <td style={{ textAlign: "right", padding: "4px 8px" }} data-numeric>
+                  {formatBdvmValue(row.sideB)}
+                </td>
+                <td style={{ textAlign: "right", padding: "4px 8px" }}>
+                  <span
+                    className={`edge-label ${edgeCss}`}
+                    title={`${row.edgePct > 0 ? "+" : ""}${row.edgePct}%`}
+                  >
+                    {row.edge > 0 ? "+" : ""}
+                    {formatBdvmValue(Math.abs(row.edge)) === "—"
+                      ? "—"
+                      : `${row.edge < 0 ? "−" : ""}${formatBdvmValue(Math.abs(row.edge))}`}
+                  </span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      {unresolved.length > 0 ? (
+        <p className="muted" style={{ margin: "var(--space-2) 0 0", fontSize: "var(--font-size-2xs)" }}>
+          Not priced by the fundamental board: {unresolved.join(", ")}
+        </p>
+      ) : null}
+      <p className="muted" style={{ margin: "var(--space-2) 0 0", fontSize: "var(--font-size-2xs)" }}>
+        A trade can be right in one strategy currency and wrong in another — a
+        contender and a rebuilder value the same package differently by design.
+      </p>
+    </Panel>
+  );
+}

--- a/frontend/scripts/check-bundle-sizes.mjs
+++ b/frontend/scripts/check-bundle-sizes.mjs
@@ -56,7 +56,7 @@ const BUDGETS_KB = {
   // the same PR and call it out — that's the audit trail.
   "/page": 90, // landing
   "/rankings/page": 65, // dense table + filter bar + popups
-  "/trade/page": 75, // calculator + simulator + breakdown
+  "/trade/page": 82, // calculator + simulator + breakdown; bumped 75→82 for the BDVM fundamentals-check panel (CES trade eval)
   "/draft/page": 128, // depth chart + analysis charts; bumped 125→128 for ScreenshotFab + Toast in shared layout (PR #432)
   "/edge/page": 30,
   "/finder/page": 20,

--- a/server.py
+++ b/server.py
@@ -4826,7 +4826,7 @@ async def post_waiver_faab_recommend(request: Request):
             contention_skip_reason = "no opponent rosters available — rival contention skipped."
         elif usable_balances * 2 < len(opponents):
             contention_skip_reason = (
-                "rival FAAB balances unavailable for most opponents — " "rival contention skipped."
+                "rival FAAB balances unavailable for most opponents — rival contention skipped."
             )
     if requested_team and requested_team_matched and contention_skip_reason is None:
         # teamAggression keyed by historical ownerIds — filter to
@@ -5233,6 +5233,55 @@ async def get_bdvm_trades(request: Request):
     try:
         payload = await run_in_threadpool(
             _bdvm_api.get_bdvm_trades, contract, league_cfg.key, team=team
+        )
+    except Exception as exc:  # noqa: BLE001
+        return JSONResponse(
+            status_code=503,
+            content={"error": "bdvm_unavailable", "message": str(exc), "leagueKey": league_cfg.key},
+        )
+    payload = dict(payload)
+    payload["leagueKey"] = league_cfg.key
+    return JSONResponse(content=payload)
+
+
+@app.post("/api/bdvm/trade-eval")
+async def post_bdvm_trade_eval(request: Request):
+    """CES evaluation of ONE specific trade in every strategy currency
+    (feature-flagged, default OFF).
+
+    Body::
+
+        {
+          "sideA": [{"playerId": "..."} | {"name": "..."} | "name", ...],
+          "sideB": [...],
+          "leagueKey": optional — standard resolver
+        }
+
+    Unresolvable refs are reported in ``unresolved`` per side, never
+    silently priced at zero.  Package math is the display-layer CES,
+    never a plain sum.
+    """
+    league_cfg, contract, err = _bdvm_gate_and_league(request)
+    if err is not None:
+        return err
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        return JSONResponse(status_code=400, content={"error": "invalid_json"})
+    side_a = body.get("sideA") if isinstance(body, dict) else None
+    side_b = body.get("sideB") if isinstance(body, dict) else None
+    if not isinstance(side_a, list) or not isinstance(side_b, list) or not (side_a or side_b):
+        return JSONResponse(
+            status_code=400,
+            content={"error": "bad_request", "message": "sideA and sideB must be lists"},
+        )
+    from src.api import bdvm_api as _bdvm_api  # noqa: PLC0415
+
+    try:
+        payload = await run_in_threadpool(
+            lambda: _bdvm_api.get_bdvm_trade_eval(
+                contract, league_cfg.key, side_a=side_a, side_b=side_b
+            )
         )
     except Exception as exc:  # noqa: BLE001
         return JSONResponse(
@@ -10391,6 +10440,37 @@ async def run_signal_alerts(request: Request):
             log.warning("bdvm flag check failed in signal sweep: %s", exc)
         bdvm_league_cache: dict[str, tuple[dict | None, dict[str, set]]] = {}
 
+        # News → structured-events ingest rides the same daily sweep
+        # (no extra timer).  Runs BEFORE the per-user loop so freshly
+        # ingested events feed this very sweep's valuations — the
+        # events-file fingerprint in bdvm_api's cache key makes the
+        # write invalidate any earlier cached board.  Auto events land
+        # in the §7 speculation lane (confidence < 0.5): they can only
+        # widen uncertainty, never move a mean.
+        bdvm_news_events_summary: dict | None = None
+        if bdvm_enabled:
+            try:
+                from src.bdvm import news_events as _bdvm_news_events  # noqa: PLC0415
+                from src.utils.name_clean import normalize_player_name  # noqa: PLC0415
+
+                _news_svc = _get_news_service()
+                _aggregated = _news_svc.aggregate(
+                    player_names=_live_player_names(),
+                    player_meta=_live_player_meta(),
+                )
+                _season = int(
+                    (latest_contract_data or {}).get("currentDraftYear")
+                    or datetime.now(timezone.utc).year
+                )
+                bdvm_news_events_summary = _bdvm_news_events.ingest_news_events(
+                    [it.to_dict() for it in _aggregated.items],
+                    season=_season,
+                    name_normalizer=normalize_player_name,
+                )
+            except Exception as exc:  # noqa: BLE001
+                log.warning("bdvm news-events ingest failed: %s", exc)
+                bdvm_news_events_summary = {"ok": False, "error": str(exc)}
+
         def _bdvm_league_data(cfg_key: str, contract: dict):
             if cfg_key in bdvm_league_cache:
                 return bdvm_league_cache[cfg_key]
@@ -10562,6 +10642,7 @@ async def run_signal_alerts(request: Request):
             "processed": len(summary),
             "results": summary,
             "bdvmEnabled": bdvm_enabled,
+            "bdvmNewsEvents": bdvm_news_events_summary,
         }
 
     result = await run_in_threadpool(_run_sweep)

--- a/server.py
+++ b/server.py
@@ -5132,9 +5132,13 @@ async def get_bdvm_values(request: Request):
     return JSONResponse(content=payload)
 
 
-def _bdvm_gate_and_league(request: Request):
+def _bdvm_gate_and_league(request: Request, body: dict | None = None):
     """Shared gate for the BDVM family: flag check + league resolution +
-    contract readiness.  Returns (league_cfg, contract, error_response)."""
+    contract readiness.  Returns (league_cfg, contract, error_response).
+
+    POST callers must parse their body FIRST and pass it here — the
+    resolver only honors a body ``leagueKey`` when it receives the
+    body (CLAUDE.md: query string for GET, body field for POST)."""
     from src.api import feature_flags as _ff  # noqa: PLC0415
 
     if not _ff.is_enabled("bdvm_engine"):
@@ -5147,7 +5151,7 @@ def _bdvm_gate_and_league(request: Request):
             ),
         )
     try:
-        league_cfg = _resolve_league_for_request(request)
+        league_cfg = _resolve_league_for_request(request, body=body)
     except LeagueResolutionError as err:
         return None, None, err.json_response()
     contract = latest_contract_data
@@ -5261,13 +5265,18 @@ async def post_bdvm_trade_eval(request: Request):
     silently priced at zero.  Package math is the display-layer CES,
     never a plain sum.
     """
-    league_cfg, contract, err = _bdvm_gate_and_league(request)
-    if err is not None:
-        return err
     try:
         body = await request.json()
     except Exception:  # noqa: BLE001
         return JSONResponse(status_code=400, content={"error": "invalid_json"})
+    # Body parses BEFORE the gate: the frontend sends leagueKey in the
+    # JSON body (the POST convention), and the resolver only sees it
+    # when the body is passed through.
+    league_cfg, contract, err = _bdvm_gate_and_league(
+        request, body=body if isinstance(body, dict) else None
+    )
+    if err is not None:
+        return err
     side_a = body.get("sideA") if isinstance(body, dict) else None
     side_b = body.get("sideB") if isinstance(body, dict) else None
     if not isinstance(side_a, list) or not isinstance(side_b, list) or not (side_a or side_b):

--- a/src/api/bdvm_api.py
+++ b/src/api/bdvm_api.py
@@ -42,6 +42,11 @@ _values_cache: OrderedDict[tuple, dict[str, Any]] = OrderedDict()
 _aux_lock = threading.Lock()
 _context_cache: dict[int, Mapping[str, Any]] = {}
 _schedule_cache: dict[int, Mapping[str, Any] | None] = {}
+# In-season actuals change WEEKLY, so unlike context/schedule this
+# cache keys on (season, UTC day) — a failed or preseason-empty fetch
+# is retried the next day, and the day rides the ingest layer's 24h
+# disk TTL underneath.
+_actuals_cache: dict[tuple[int, str], tuple[int | None, Mapping[str, Any]]] = {}
 
 
 def _registry_settings_for(league_key: str) -> tuple[Mapping[str, Any] | None, bool, str]:
@@ -86,6 +91,56 @@ def _schedule_for(season: int) -> Mapping[str, Any] | None:
     return sched
 
 
+def _events_fingerprint(season: int) -> tuple[int, int] | None:
+    """(mtime_ns, size) of the season's events file, or None.
+
+    Joins the values cache key so writing/editing
+    ``data/bdvm/events/<season>.json`` (the daily news→events ingest,
+    or a hand edit) invalidates cached valuations — without this, a
+    new event would sit unseen until the next contract rebuild.
+    """
+    try:
+        from src.bdvm.events import EVENTS_DIR  # noqa: PLC0415
+
+        stat = (EVENTS_DIR / f"{season}.json").stat()
+        return (stat.st_mtime_ns, stat.st_size)
+    except OSError:
+        return None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _today() -> str:
+    from datetime import datetime, timezone  # noqa: PLC0415
+
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _actuals_for(contract: Mapping[str, Any], season: int) -> tuple[int | None, Mapping[str, Any]]:
+    """Current-season weekly actuals, cached per (season, UTC day)."""
+    cache_key = (season, _today())
+    with _aux_lock:
+        if cache_key in _actuals_cache:
+            return _actuals_cache[cache_key]
+    try:
+        from src.bdvm.actuals import fetch_current_season_actuals  # noqa: PLC0415
+        from src.utils.name_clean import normalize_player_name  # noqa: PLC0415
+
+        scoring = (contract.get("sleeper") or {}).get("scoringSettings") or {}
+        result = fetch_current_season_actuals(
+            season, scoring, name_normalizer=normalize_player_name
+        )
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.warning("bdvm: in-season actuals unavailable: %s", exc)
+        result = (None, {})
+    with _aux_lock:
+        # Drop stale day entries so the cache never grows unbounded.
+        for old_key in [k for k in _actuals_cache if k[1] != cache_key[1]]:
+            _actuals_cache.pop(old_key, None)
+        _actuals_cache[cache_key] = result
+    return result
+
+
 def get_bdvm_values(
     contract: Mapping[str, Any],
     league_key: str,
@@ -97,6 +152,7 @@ def get_bdvm_values(
     params = params or load_param_set()
     season = int(contract.get("currentDraftYear") or 0)
     snapshot = latest_snapshot_path(season) if season else None
+    actuals = _actuals_for(contract, season) if season else (None, {})
     key = (
         id(contract),
         contract.get("generatedAt"),
@@ -104,6 +160,12 @@ def get_bdvm_values(
         params.param_set_id,
         str(snapshot) if snapshot else None,
         surplus_mode,
+        # In-season freshness: a new observed week (or day rollover
+        # after one) must recompute; events-file edits are covered by
+        # the fingerprint.
+        actuals[0],
+        _today() if actuals[0] is not None else None,
+        _events_fingerprint(season),
     )
     with _lock:
         cached = _values_cache.get(key)
@@ -124,6 +186,7 @@ def get_bdvm_values(
         surplus_mode=surplus_mode,
         context=context,
         schedule_weeks=schedule_weeks,
+        actuals=actuals,
     )
     with _lock:
         _values_cache[key] = payload
@@ -169,6 +232,125 @@ def get_bdvm_roster(
     return analysis
 
 
+def get_bdvm_trade_eval(
+    contract: Mapping[str, Any],
+    league_key: str,
+    *,
+    side_a: list[Any],
+    side_b: list[Any],
+    params: ParamSet | None = None,
+) -> dict[str, Any]:
+    """CES evaluation of ONE specific trade in every strategy currency.
+
+    ``side_a`` / ``side_b`` are asset refs: dicts with ``playerId`` or
+    ``name``, or plain strings (player names or pick names like
+    "2027 1.05").  Resolution is playerId-first, then normalized name,
+    then the pick table.  Unresolvable refs are REPORTED, never
+    silently priced at zero — a trade grade that quietly dropped an
+    asset would be worse than no grade.
+
+    Package math is the display-layer CES (never a plain sum — §3.13);
+    when both sides' rosters are known to the BDVM roster analysis,
+    the own-currency double-positive verdict is included.
+    """
+    params = params or load_param_set()
+    values = get_bdvm_values(contract, league_key, params=params)
+    if values.get("status") != "ok":
+        return {
+            "status": values.get("status"),
+            "message": values.get("message"),
+            "byStrategy": {},
+        }
+
+    from src.bdvm.trade_math import package_value  # noqa: PLC0415
+    from src.utils.name_clean import normalize_player_name  # noqa: PLC0415
+
+    strategies = [s for s in ("contender", "balanced", "rebuilder", "risk_neutral")]
+    by_id: dict[str, dict] = {}
+    by_name: dict[str, dict] = {}
+    for p in values.get("players") or []:
+        pid = str(p.get("playerId") or "")
+        if pid:
+            by_id[pid] = p
+        name = str(p.get("name") or "")
+        if name:
+            by_name[normalize_player_name(name)] = p
+    picks_by_name = {
+        str(p.get("name") or "").lower(): p
+        for p in values.get("picks") or []
+        if p.get("distribution")
+    }
+
+    def _resolve(ref: Any) -> tuple[dict | None, str, str]:
+        """(strategy→value source dict, kind, label) or (None, 'unresolved', label)."""
+        if isinstance(ref, Mapping):
+            pid = str(ref.get("playerId") or "").strip()
+            label = str(ref.get("name") or pid)
+            if pid and pid in by_id:
+                return by_id[pid], "player", label
+            name = str(ref.get("name") or "").strip()
+        else:
+            name = str(ref or "").strip()
+            label = name
+        if not name:
+            return None, "unresolved", label
+        player = by_name.get(normalize_player_name(name))
+        if player is not None:
+            return player, "player", name
+        pick = picks_by_name.get(name.lower())
+        if pick is not None:
+            return pick, "pick", name
+        return None, "unresolved", name
+
+    def _side_values(refs: list[Any]) -> tuple[dict[str, list[float]], list[str], list[dict]]:
+        per_strategy: dict[str, list[float]] = {s: [] for s in strategies}
+        unresolved: list[str] = []
+        resolved: list[dict] = []
+        for ref in refs or []:
+            asset, kind, label = _resolve(ref)
+            if asset is None:
+                unresolved.append(label)
+                continue
+            entry: dict[str, Any] = {"name": label, "kind": kind, "values": {}}
+            for s in strategies:
+                if kind == "player":
+                    v = float((asset.get("tradeValue") or {}).get(s) or 0.0)
+                else:
+                    v = float(((asset.get("distribution") or {}).get(s) or {}).get("ev") or 0.0)
+                per_strategy[s].append(v)
+                entry["values"][s] = round(v, 1)
+            resolved.append(entry)
+        return per_strategy, unresolved, resolved
+
+    a_vals, a_unresolved, a_assets = _side_values(side_a)
+    b_vals, b_unresolved, b_assets = _side_values(side_b)
+
+    by_strategy: dict[str, dict[str, float]] = {}
+    for s in strategies:
+        pkg_a = package_value(a_vals[s], params)
+        pkg_b = package_value(b_vals[s], params)
+        total = max(1.0, pkg_a + pkg_b)
+        by_strategy[s] = {
+            "sideA": round(pkg_a, 1),
+            "sideB": round(pkg_b, 1),
+            "edge": round(pkg_a - pkg_b, 1),
+            "edgePct": round(100.0 * (pkg_a - pkg_b) / total, 1),
+        }
+
+    return {
+        "status": "ok",
+        "byStrategy": by_strategy,
+        "sideAAssets": a_assets,
+        "sideBAssets": b_assets,
+        "unresolved": {"sideA": a_unresolved, "sideB": b_unresolved},
+        "meta": {
+            "packageMath": "ces",
+            "valuationAsOf": (values.get("meta") or {}).get("asOf"),
+            "paramSetId": (values.get("meta") or {}).get("paramSetId"),
+        },
+    }
+
+
 def get_bdvm_trades(
     contract: Mapping[str, Any],
     league_key: str,
@@ -193,3 +375,4 @@ def reset_cache() -> None:
     with _aux_lock:
         _context_cache.clear()
         _schedule_cache.clear()
+        _actuals_cache.clear()

--- a/src/api/bdvm_api.py
+++ b/src/api/bdvm_api.py
@@ -116,9 +116,26 @@ def _today() -> str:
     return datetime.now(timezone.utc).date().isoformat()
 
 
-def _actuals_for(contract: Mapping[str, Any], season: int) -> tuple[int | None, Mapping[str, Any]]:
-    """Current-season weekly actuals, cached per (season, UTC day)."""
-    cache_key = (season, _today())
+def _actuals_for(contract: Mapping[str, Any]) -> tuple[int | None, Mapping[str, Any]]:
+    """In-progress-season weekly actuals, cached per (season, UTC day).
+
+    The season is the CALENDAR NFL season (``current_nfl_season``),
+    never the contract's ``currentDraftYear`` — the draft year points
+    one season ahead for the entire Sept–Jan window, which would make
+    the posterior structurally unreachable in production.
+
+    A fetch that RAISES is returned but NOT memoized: a transient
+    nflverse/network blip on the day's first request must not pin the
+    board to preseason values until midnight.  (An empty SUCCESS is
+    cached for the day — that's the honest preseason/early-window
+    signal.)
+    """
+    from src.bdvm.actuals import current_nfl_season  # noqa: PLC0415
+
+    nfl_season = current_nfl_season()
+    if nfl_season is None:
+        return (None, {})
+    cache_key = (nfl_season, _today())
     with _aux_lock:
         if cache_key in _actuals_cache:
             return _actuals_cache[cache_key]
@@ -128,11 +145,11 @@ def _actuals_for(contract: Mapping[str, Any], season: int) -> tuple[int | None, 
 
         scoring = (contract.get("sleeper") or {}).get("scoringSettings") or {}
         result = fetch_current_season_actuals(
-            season, scoring, name_normalizer=normalize_player_name
+            scoring, name_normalizer=normalize_player_name, season=nfl_season
         )
     except Exception as exc:  # noqa: BLE001
-        _LOGGER.warning("bdvm: in-season actuals unavailable: %s", exc)
-        result = (None, {})
+        _LOGGER.warning("bdvm: in-season actuals unavailable (not cached, will retry): %s", exc)
+        return (None, {})
     with _aux_lock:
         # Drop stale day entries so the cache never grows unbounded.
         for old_key in [k for k in _actuals_cache if k[1] != cache_key[1]]:
@@ -152,7 +169,7 @@ def get_bdvm_values(
     params = params or load_param_set()
     season = int(contract.get("currentDraftYear") or 0)
     snapshot = latest_snapshot_path(season) if season else None
-    actuals = _actuals_for(contract, season) if season else (None, {})
+    actuals = _actuals_for(contract)
     key = (
         id(contract),
         contract.get("generatedAt"),

--- a/src/bdvm/actuals.py
+++ b/src/bdvm/actuals.py
@@ -6,6 +6,16 @@ scoring, via the same production loop the reconstructed baseline uses
 (``normalize_weekly_row`` + ``compute_weekly_points`` — ADR-005: one
 scoring engine, never two).
 
+Which season?  The CALENDAR one, never ``currentDraftYear``.  The
+contract's draft year is the *upcoming rookie draft* and rolls to
+year+1 mid-summer — during the entire Sept–Jan regular season it
+points one season ahead, whose weekly file doesn't exist yet.  Keying
+the fetch on it would make the posterior structurally unreachable in
+production.  ``current_nfl_season`` derives the season being played
+from today's date instead, and returns ``None`` outside the Sept–Jan
+window so offseason boards stay forward-looking (no completed-season
+actuals blended into next year's projections).
+
 Preseason honesty: before the season starts the file simply doesn't
 exist upstream (the fetch returns nothing) and this module returns
 ``(None, {})`` — callers degrade to the preseason projection with an
@@ -15,11 +25,30 @@ explicit meta stamp, never a fabricated update.  An empty result is
 
 from __future__ import annotations
 
+from datetime import date, datetime, timezone
 from typing import Any, Callable, Mapping
 
 from src.bdvm.baseline import normalize_weekly_row
 from src.bdvm.context import TRUE_POSITION_MAP
 from src.nfl_data.realized_points import compute_weekly_points
+
+
+def current_nfl_season(today: date | None = None) -> int | None:
+    """NFL season whose REG weeks are being played right now, else None.
+
+    Sept–Dec → this year; Jan → last year (week 18 spills into early
+    January); Feb–Aug → None.  The None window is deliberate: after the
+    season completes, blending a finished season's actuals into the
+    NEXT season's projection set would be §8.4 applied across a season
+    boundary — dynasty boards go back to forward-looking preseason
+    semantics instead.
+    """
+    d = today or datetime.now(timezone.utc).date()
+    if d.month >= 9:
+        return d.year
+    if d.month == 1:
+        return d.year - 1
+    return None
 
 
 def weekly_points_from_rows(
@@ -32,10 +61,20 @@ def weekly_points_from_rows(
     """(current_week, player_key → [(week, points), ...]) from raw rows.
 
     Regular-season rows of ``season`` only.  ``current_week`` is the
-    next unplayed week (max observed + 1, capped at 18); ``None`` when
-    no rows exist — the preseason no-op signal.
+    next unplayed week (max observed + 1 — deliberately UNCAPPED: after
+    the week-18 slate it becomes 19 so ROS correctly sums zero
+    remaining weeks instead of double-counting the banked final week);
+    ``None`` when no rows exist — the preseason no-op signal.
+
+    Distinct players colliding on a normalized name (real precedent:
+    Byron Murphy / Byron Murphy II, both active) are DROPPED, mirroring
+    the projection side's same-side collision policy — a per-week max
+    over two different players is a chimera biased high by
+    construction, and moving a player's µ on production that isn't his
+    is worse than leaving him on the preseason prior.
     """
     samples: dict[str, dict[int, float]] = {}
+    ids_by_key: dict[str, set[str]] = {}
     max_week = 0
     for raw in weekly_rows or []:
         try:
@@ -61,36 +100,52 @@ def weekly_points_from_rows(
         if week <= 0:
             continue
         key = name_normalizer(name)
-        # A player appears once per week; if a source ever duplicates,
-        # keep the larger line rather than double-counting.
+        pid = str(raw.get("player_id") or raw.get("gsis_id") or "").strip()
+        if pid:
+            ids_by_key.setdefault(key, set()).add(pid)
+        # The same player can appear once per week; if a source ever
+        # duplicates that row, keep the larger line rather than
+        # double-counting.  (Cross-PLAYER merges are handled by the
+        # collision drop below, not by this max.)
         bucket = samples.setdefault(key, {})
         bucket[week] = max(bucket.get(week, float("-inf")), float(rp.fantasy_points))
         max_week = max(max_week, week)
     if max_week <= 0:
         return None, {}
-    current_week = min(18, max_week + 1)
+    for key, ids in ids_by_key.items():
+        if len(ids) > 1:
+            samples.pop(key, None)
+    current_week = max_week + 1
     return current_week, {key: sorted(by_week.items()) for key, by_week in samples.items()}
 
 
 def fetch_current_season_actuals(
-    season: int,
     scoring_settings: Mapping[str, Any],
     *,
     name_normalizer: Callable[[str], str],
+    season: int | None = None,
+    today: date | None = None,
 ) -> tuple[int | None, dict[str, list[tuple[int, float]]]]:
-    """Fetch + score this season's weekly rows.
+    """Fetch + score the in-progress season's weekly rows.
 
-    Fetches ``[season]`` ALONE so the current season gets its own
-    24h-TTL disk-cache entry (the ingest cache keys on the whole year
-    list — bundling years would refetch history weekly).  Any fetch
-    problem degrades to ``(None, {})``.
+    ``season`` defaults to ``current_nfl_season(today)``; outside the
+    Sept–Jan window that is None and the result is the preseason
+    signal without any fetch.  Fetches ``[season]`` ALONE so the
+    current season gets its own 24h-TTL disk-cache entry (the ingest
+    cache keys on the whole year list — bundling years would refetch
+    history weekly).
+
+    Fetch/network errors RAISE so the caller can decide not to
+    memoize them — a transient blip must not pin the whole board to
+    preseason values for the rest of the day.
     """
-    try:
-        from src.nfl_data import ingest  # noqa: PLC0415
-
-        rows = ingest.fetch_weekly_stats([int(season)]) or []
-    except Exception:  # noqa: BLE001
+    if season is None:
+        season = current_nfl_season(today)
+    if season is None:
         return None, {}
+    from src.nfl_data import ingest  # noqa: PLC0415
+
+    rows = ingest.fetch_weekly_stats([int(season)]) or []
     return weekly_points_from_rows(
         rows, scoring_settings, season=season, name_normalizer=name_normalizer
     )

--- a/src/bdvm/actuals.py
+++ b/src/bdvm/actuals.py
@@ -1,0 +1,96 @@
+"""Current-season realized weekly points — the in-season evidence feed.
+
+Turns nflverse's in-progress ``stats_player_week_<season>.csv`` into
+per-player weekly fantasy-point samples under THIS league's exact
+scoring, via the same production loop the reconstructed baseline uses
+(``normalize_weekly_row`` + ``compute_weekly_points`` — ADR-005: one
+scoring engine, never two).
+
+Preseason honesty: before the season starts the file simply doesn't
+exist upstream (the fetch returns nothing) and this module returns
+``(None, {})`` — callers degrade to the preseason projection with an
+explicit meta stamp, never a fabricated update.  An empty result is
+"no evidence yet", NOT "zero production".
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+from src.bdvm.baseline import normalize_weekly_row
+from src.bdvm.context import TRUE_POSITION_MAP
+from src.nfl_data.realized_points import compute_weekly_points
+
+
+def weekly_points_from_rows(
+    weekly_rows: list[Mapping[str, Any]],
+    scoring_settings: Mapping[str, Any],
+    *,
+    season: int,
+    name_normalizer: Callable[[str], str],
+) -> tuple[int | None, dict[str, list[tuple[int, float]]]]:
+    """(current_week, player_key → [(week, points), ...]) from raw rows.
+
+    Regular-season rows of ``season`` only.  ``current_week`` is the
+    next unplayed week (max observed + 1, capped at 18); ``None`` when
+    no rows exist — the preseason no-op signal.
+    """
+    samples: dict[str, dict[int, float]] = {}
+    max_week = 0
+    for raw in weekly_rows or []:
+        try:
+            if int(raw.get("season") or 0) != int(season):
+                continue
+        except (TypeError, ValueError):
+            continue
+        if str(raw.get("season_type") or "REG").upper() != "REG":
+            continue
+        name = str(raw.get("player_display_name") or raw.get("player_name") or "").strip()
+        if not name:
+            continue
+        listing = str(raw.get("position") or "").upper()
+        position = TRUE_POSITION_MAP.get(listing, listing)
+        row = normalize_weekly_row(raw)
+        rp = compute_weekly_points(row, dict(scoring_settings), position=position)
+        if rp is None:
+            continue
+        try:
+            week = int(raw.get("week") or 0)
+        except (TypeError, ValueError):
+            continue
+        if week <= 0:
+            continue
+        key = name_normalizer(name)
+        # A player appears once per week; if a source ever duplicates,
+        # keep the larger line rather than double-counting.
+        bucket = samples.setdefault(key, {})
+        bucket[week] = max(bucket.get(week, float("-inf")), float(rp.fantasy_points))
+        max_week = max(max_week, week)
+    if max_week <= 0:
+        return None, {}
+    current_week = min(18, max_week + 1)
+    return current_week, {key: sorted(by_week.items()) for key, by_week in samples.items()}
+
+
+def fetch_current_season_actuals(
+    season: int,
+    scoring_settings: Mapping[str, Any],
+    *,
+    name_normalizer: Callable[[str], str],
+) -> tuple[int | None, dict[str, list[tuple[int, float]]]]:
+    """Fetch + score this season's weekly rows.
+
+    Fetches ``[season]`` ALONE so the current season gets its own
+    24h-TTL disk-cache entry (the ingest cache keys on the whole year
+    list — bundling years would refetch history weekly).  Any fetch
+    problem degrades to ``(None, {})``.
+    """
+    try:
+        from src.nfl_data import ingest  # noqa: PLC0415
+
+        rows = ingest.fetch_weekly_stats([int(season)]) or []
+    except Exception:  # noqa: BLE001
+        return None, {}
+    return weekly_points_from_rows(
+        rows, scoring_settings, season=season, name_normalizer=name_normalizer
+    )

--- a/src/bdvm/events.py
+++ b/src/bdvm/events.py
@@ -121,7 +121,16 @@ def effective_impact(
         value = float(raw)
         if channel == "sigma_mult":
             # multiplicative channel: scale the log-effect
-            out[channel] = math.exp(math.log(max(1e-6, value)) * scale)
+            scaled = math.exp(math.log(max(1e-6, value)) * scale)
+            if speculative:
+                # Speculation may only WIDEN sigma.  Without this
+                # clamp a sub-1.0 sigma_mult (ACTIVATED_RETURN's 0.95)
+                # would let a rumor NARROW uncertainty and move option
+                # value downward — the exact one-way promise the
+                # speculation lane makes would be broken in the one
+                # channel it leaves open.
+                scaled = max(1.0, scaled)
+            out[channel] = scaled
         elif channel == "hazard_mult":
             if speculative:
                 continue

--- a/src/bdvm/news_events.py
+++ b/src/bdvm/news_events.py
@@ -42,16 +42,42 @@ _AUTO_EVENT_MAX_AGE_DAYS = 90
 _AUTO_CONFIDENCE = 0.45  # strictly below the §7 speculation threshold
 _AUTO_RELIABILITY = 0.6  # aggregated headlines, not primary reporting
 
+# A second same-type auto event for the same player inside this window
+# is suppressed on merge.  The aggregate feed carries the same story
+# from several providers (each with its own item id) plus weekly
+# advice churn — without this, N providers would stack N sigma
+# wideners for one real-world fact.
+_DUP_EVENT_WINDOW_DAYS = 14
+
+# List/advice articles name many players; real transaction or injury
+# reporting names one or two.  An item mentioning more than this many
+# players is editorial coverage, not an event about any of them.
+_MAX_PLAYER_MENTIONS = 3
+
+# Advice/listicle language → NOTHING, checked before every rule.  The
+# aggregate feed includes fantasy-advice RSS providers whose headlines
+# are full of transaction VOCABULARY about players nothing happened to
+# ("trade targets", "who makes the cut", "buy low").  Conservative by
+# design: suppressing a real story costs one speculative sigma
+# widener; passing an advice column through costs dozens of them.
+_ADVICE_NOISE_RE = re.compile(
+    r"trade (?:target|value|advice|candidate|bait|chart|calculator)s?"
+    r"|buy[- ]low|sell[- ]high|start[ /-]?sit|waiver wire|mock draft"
+    r"|rankings?|sleepers?|projections?|preview|outlook|cheat sheet"
+    r"|top[- ]\d+|tiers?\b|roster (?:projection|prediction|bubble)"
+    r"|makes? the (?:final )?cut|cut candidates?",
+    re.I,
+)
+
 # Conservative keyword rules, checked IN ORDER — first match wins.
 # Only ontology types with an unambiguous news-side signal appear;
-# everything else stays human-entry only.
+# everything else stays human-entry only.  ACTIVATED_RETURN is
+# deliberately absent: its ontology impact NARROWS sigma, and the
+# speculation lane may only widen — a headline-confidence event of
+# that type would be a no-op at best (effective_impact clamps it).
 _RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("SURGERY", re.compile(r"surgery|torn|\bacl\b|achilles|season[- ]ending", re.I)),
     ("SUSPENSION", re.compile(r"suspend|suspension", re.I)),
-    (
-        "ACTIVATED_RETURN",
-        re.compile(r"activated|cleared to (?:play|practice)|returns? to practice", re.I),
-    ),
     (
         "INJURY",
         re.compile(
@@ -74,7 +100,7 @@ _RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
         re.compile(r"demoted|loses? (?:the )?starting (?:job|role)|benched", re.I),
     ),
     ("TRADE", re.compile(r"\btrade[ds]?\b|acquired (?:via|in a) trade", re.I)),
-    ("RELEASE", re.compile(r"released|waived|\bcut\b", re.I)),
+    ("RELEASE", re.compile(r"released|waived", re.I)),
     ("CONTRACT_EXTENSION", re.compile(r"extension|extended (?:his|the) contract", re.I)),
     ("FRANCHISE_TAG", re.compile(r"franchise tag", re.I)),
     ("SIGNING", re.compile(r"\bsigns?\b|\bsigned\b|agrees? to (?:a )?(?:deal|terms)", re.I)),
@@ -86,6 +112,8 @@ def classify_news_item(item: Mapping[str, Any]) -> str | None:
     text = f"{item.get('headline') or ''} {item.get('body') or item.get('summary') or ''}"
     if not text.strip():
         return None
+    if _ADVICE_NOISE_RE.search(text):
+        return None  # advice/listicle coverage, not an event
     for event_type, pattern in _RULES:
         if pattern.search(text):
             return event_type
@@ -102,6 +130,9 @@ def map_news_items_to_events(
     for item in items or []:
         if not isinstance(item, Mapping):
             continue
+        mentions = item.get("players") or []
+        if len(mentions) > _MAX_PLAYER_MENTIONS:
+            continue  # list article, not an event about any one player
         event_type = classify_news_item(item)
         if event_type is None:
             continue
@@ -137,7 +168,18 @@ def map_news_items_to_events(
 
 
 def _is_auto(event: Mapping[str, Any]) -> bool:
-    return str(event.get("eventId") or "").startswith("news:")
+    """Still machine-owned: news:* eventId AND speculation-lane
+    confidence.  A human who raised confidence to >= 0.5 turned the
+    entry into a confirmed, mean-affecting event — it keeps its
+    news:* id (that's what existing-wins protects) but is no longer
+    ours to prune; deleting it would silently discard human work while
+    the event still carries most of its half-life strength."""
+    if not str(event.get("eventId") or "").startswith("news:"):
+        return False
+    try:
+        return float(event.get("confidence")) < 0.5
+    except (TypeError, ValueError):
+        return True  # news:* with unparseable confidence → still ours
 
 
 def _is_stale_auto(event: Mapping[str, Any], today: datetime) -> bool:
@@ -150,6 +192,15 @@ def _is_stale_auto(event: Mapping[str, Any], today: datetime) -> bool:
     except (TypeError, ValueError):
         return True  # unparseable auto event → prune
     return today - effective > timedelta(days=_AUTO_EVENT_MAX_AGE_DAYS)
+
+
+def _event_date(event: Mapping[str, Any]) -> datetime | None:
+    try:
+        return datetime.fromisoformat(str(event.get("effectiveDate"))[:10]).replace(
+            tzinfo=timezone.utc
+        )
+    except (TypeError, ValueError):
+        return None
 
 
 def merge_events_file(
@@ -171,18 +222,45 @@ def merge_events_file(
     today = now or datetime.now(timezone.utc)
 
     existing: list[dict[str, Any]] = []
+    payload: dict[str, Any] = {}
     if path.exists():
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
-            existing = list(payload.get("events") or [])
         except (OSError, ValueError):
             # A corrupt events file must not brick ingestion, but we
             # also must not silently discard human entries — refuse.
             return {"ok": False, "reason": "events_file_unreadable", "path": str(path)}
+        # Valid JSON with the wrong SHAPE is the classic hand-edit slip
+        # ("events": {...} instead of [...]).  Iterating it anyway
+        # would masquerade the operator's entries as prunable garbage
+        # and rewrite the file without them — refuse just as hard as
+        # for unparseable JSON.
+        if not isinstance(payload, dict) or not isinstance(payload.get("events", []), list):
+            return {"ok": False, "reason": "events_file_invalid_shape", "path": str(path)}
+        existing = list(payload.get("events") or [])
+        if not all(isinstance(e, Mapping) for e in existing):
+            return {"ok": False, "reason": "events_file_invalid_shape", "path": str(path)}
 
-    seen = {str(e.get("eventId")) for e in existing if isinstance(e, Mapping)}
-    added = [e for e in new_events if e["eventId"] not in seen]
-    kept = [e for e in existing if isinstance(e, Mapping) and not _is_stale_auto(e, today)]
+    seen = {str(e.get("eventId")) for e in existing}
+    # Same-fact suppression: the same real-world story arrives from N
+    # providers under N item ids, and again in next week's coverage.
+    # One (playerKey, eventType) inside the window is one fact — the
+    # sigma widener must not stack per provider.
+    recent: set[tuple[str, str]] = set()
+    for e in existing:
+        d = _event_date(e)
+        if d is not None and (today - d).days <= _DUP_EVENT_WINDOW_DAYS:
+            recent.add((str(e.get("playerKey")), str(e.get("eventType"))))
+    added = []
+    for e in new_events:
+        if e["eventId"] in seen:
+            continue
+        fact = (str(e.get("playerKey")), str(e.get("eventType")))
+        if fact in recent:
+            continue
+        recent.add(fact)
+        added.append(e)
+    kept = [e for e in existing if not _is_stale_auto(e, today)]
     pruned = len(existing) - len(kept)
 
     if not added and not pruned:
@@ -197,8 +275,10 @@ def merge_events_file(
     merged = kept + added
     root.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(".json.tmp")
+    # Preserve any other top-level keys a human added (e.g. a
+    # _comment block, the convention config/bdvm files use).
     tmp.write_text(
-        json.dumps({"events": merged}, indent=1) + "\n",
+        json.dumps({**payload, "events": merged}, indent=1) + "\n",
         encoding="utf-8",
     )
     tmp.replace(path)

--- a/src/bdvm/news_events.py
+++ b/src/bdvm/news_events.py
@@ -1,0 +1,226 @@
+"""News → BDVM structured events (auto-ingested speculation lane).
+
+Maps aggregated news items onto the closed §7 ontology and merges them
+into ``data/bdvm/events/<season>.json`` — the file ``run_valuation``
+already loads.  This converts a dormant subsystem (the events engine
+shipped fully built but fed by an empty file) into a live one that
+reacts to the real world between weekly snapshots.
+
+Safety rules, all structural:
+
+* **Closed ontology only.**  A headline that doesn't match a
+  conservative keyword rule maps to NOTHING — never a guessed type.
+* **Speculation lane, always.**  Auto-ingested events carry
+  ``confidence = 0.45`` — below the §7 speculation threshold (0.5), so
+  ``effective_impact`` suppresses every µ/hazard/games channel and only
+  ``sigma_mult`` survives.  Headlines can widen uncertainty; they can
+  never move a player's mean.  Raising confidence above 0.5 is a HUMAN
+  edit to the events file, not something this module can do.
+* **Ambiguous mentions skipped.**  A mention the news layer couldn't
+  attribute to exactly one player never becomes an event.
+* **Deduped + pruned.**  ``eventId = news:<item-id>:<player-key>`` —
+  re-ingesting the same story is a no-op; auto events older than
+  ``_AUTO_EVENT_MAX_AGE_DAYS`` are pruned on merge.  Human-authored
+  events (any other eventId shape) are NEVER touched.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping
+
+from src.bdvm.events import EVENTS_DIR
+
+# Auto events are pruned after this many days (the longest half-life
+# among mapped types is 180d; by 90d a 0.45-confidence sigma widener
+# has decayed to noise).
+_AUTO_EVENT_MAX_AGE_DAYS = 90
+
+_AUTO_CONFIDENCE = 0.45  # strictly below the §7 speculation threshold
+_AUTO_RELIABILITY = 0.6  # aggregated headlines, not primary reporting
+
+# Conservative keyword rules, checked IN ORDER — first match wins.
+# Only ontology types with an unambiguous news-side signal appear;
+# everything else stays human-entry only.
+_RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("SURGERY", re.compile(r"surgery|torn|\bacl\b|achilles|season[- ]ending", re.I)),
+    ("SUSPENSION", re.compile(r"suspend|suspension", re.I)),
+    (
+        "ACTIVATED_RETURN",
+        re.compile(r"activated|cleared to (?:play|practice)|returns? to practice", re.I),
+    ),
+    (
+        "INJURY",
+        re.compile(
+            r"injur|placed on ir|\bon the ir\b|\bto ir\b|concussion|sprain|strain|fracture|hamstring",
+            re.I,
+        ),
+    ),
+    (
+        "PRACTICE_LIMITATION",
+        re.compile(r"questionable|doubtful|limited (?:in )?practice|did not practice", re.I),
+    ),
+    (
+        "DEPTH_CHART_PROMOTION",
+        re.compile(
+            r"named (?:the )?starter|promoted to|elevated to (?:the )?(?:starting|first)", re.I
+        ),
+    ),
+    (
+        "DEPTH_CHART_DEMOTION",
+        re.compile(r"demoted|loses? (?:the )?starting (?:job|role)|benched", re.I),
+    ),
+    ("TRADE", re.compile(r"\btrade[ds]?\b|acquired (?:via|in a) trade", re.I)),
+    ("RELEASE", re.compile(r"released|waived|\bcut\b", re.I)),
+    ("CONTRACT_EXTENSION", re.compile(r"extension|extended (?:his|the) contract", re.I)),
+    ("FRANCHISE_TAG", re.compile(r"franchise tag", re.I)),
+    ("SIGNING", re.compile(r"\bsigns?\b|\bsigned\b|agrees? to (?:a )?(?:deal|terms)", re.I)),
+)
+
+
+def classify_news_item(item: Mapping[str, Any]) -> str | None:
+    """Ontology type for one news item, or None (never guess)."""
+    text = f"{item.get('headline') or ''} {item.get('body') or item.get('summary') or ''}"
+    if not text.strip():
+        return None
+    for event_type, pattern in _RULES:
+        if pattern.search(text):
+            return event_type
+    return None
+
+
+def map_news_items_to_events(
+    items: Iterable[Mapping[str, Any]],
+    *,
+    name_normalizer: Callable[[str], str],
+) -> list[dict[str, Any]]:
+    """News item dicts → event dicts in the events-file JSON shape."""
+    events: list[dict[str, Any]] = []
+    for item in items or []:
+        if not isinstance(item, Mapping):
+            continue
+        event_type = classify_news_item(item)
+        if event_type is None:
+            continue
+        item_id = str(item.get("id") or "").strip()
+        if not item_id:
+            continue
+        ts = str(item.get("ts") or item.get("publishedAt") or "")
+        effective_date = ts[:10] if len(ts) >= 10 else ""
+        if not effective_date:
+            continue
+        headline = str(item.get("headline") or "")[:140]
+        for mention in item.get("players") or []:
+            if not isinstance(mention, Mapping):
+                continue
+            if mention.get("ambiguous"):
+                continue  # attribution unclear → no event, ever
+            name = str(mention.get("name") or "").strip()
+            if not name:
+                continue
+            player_key = name_normalizer(name)
+            events.append(
+                {
+                    "eventId": f"news:{item_id}:{player_key}",
+                    "playerKey": player_key,
+                    "eventType": event_type,
+                    "effectiveDate": effective_date,
+                    "confidence": _AUTO_CONFIDENCE,
+                    "sourceReliability": _AUTO_RELIABILITY,
+                    "notes": headline,
+                }
+            )
+    return events
+
+
+def _is_auto(event: Mapping[str, Any]) -> bool:
+    return str(event.get("eventId") or "").startswith("news:")
+
+
+def _is_stale_auto(event: Mapping[str, Any], today: datetime) -> bool:
+    if not _is_auto(event):
+        return False
+    try:
+        effective = datetime.fromisoformat(str(event.get("effectiveDate"))[:10]).replace(
+            tzinfo=timezone.utc
+        )
+    except (TypeError, ValueError):
+        return True  # unparseable auto event → prune
+    return today - effective > timedelta(days=_AUTO_EVENT_MAX_AGE_DAYS)
+
+
+def merge_events_file(
+    new_events: list[dict[str, Any]],
+    *,
+    season: int,
+    base_dir: Path | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Merge auto events into the season's events file.
+
+    Existing events win on eventId collision (an event, once written,
+    is stable — a human may have edited its confidence upward).  Only
+    auto (``news:``) events are ever pruned; human-authored entries
+    pass through untouched, always.
+    """
+    root = base_dir or EVENTS_DIR
+    path = root / f"{season}.json"
+    today = now or datetime.now(timezone.utc)
+
+    existing: list[dict[str, Any]] = []
+    if path.exists():
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            existing = list(payload.get("events") or [])
+        except (OSError, ValueError):
+            # A corrupt events file must not brick ingestion, but we
+            # also must not silently discard human entries — refuse.
+            return {"ok": False, "reason": "events_file_unreadable", "path": str(path)}
+
+    seen = {str(e.get("eventId")) for e in existing if isinstance(e, Mapping)}
+    added = [e for e in new_events if e["eventId"] not in seen]
+    kept = [e for e in existing if isinstance(e, Mapping) and not _is_stale_auto(e, today)]
+    pruned = len(existing) - len(kept)
+
+    if not added and not pruned:
+        return {
+            "ok": True,
+            "added": 0,
+            "pruned": 0,
+            "total": len(existing),
+            "unchanged": True,
+        }
+
+    merged = kept + added
+    root.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(
+        json.dumps({"events": merged}, indent=1) + "\n",
+        encoding="utf-8",
+    )
+    tmp.replace(path)
+    return {
+        "ok": True,
+        "added": len(added),
+        "pruned": pruned,
+        "total": len(merged),
+        "path": str(path),
+    }
+
+
+def ingest_news_events(
+    items: Iterable[Mapping[str, Any]],
+    *,
+    season: int,
+    name_normalizer: Callable[[str], str],
+    base_dir: Path | None = None,
+) -> dict[str, Any]:
+    """End-to-end: classify + map + merge.  Never raises upward design;
+    callers still wrap (piggyback posture)."""
+    events = map_news_items_to_events(items, name_normalizer=name_normalizer)
+    summary = merge_events_file(events, season=season, base_dir=base_dir)
+    summary["mapped"] = len(events)
+    return summary

--- a/src/bdvm/service.py
+++ b/src/bdvm/service.py
@@ -15,6 +15,7 @@ never a silent zero, never an invented value.
 from __future__ import annotations
 
 import json
+import math
 import re
 import statistics
 from datetime import datetime, timezone
@@ -41,7 +42,8 @@ from src.bdvm.projections import (
     load_snapshot,
 )
 from src.bdvm.replacement import ReplacementEngine
-from src.bdvm.ros import ros_value
+from src.bdvm.ros import blend_ros_mu, ros_projection_weight, ros_value
+from src.bdvm.scoring import is_idp_position
 from src.bdvm.survival import RiskProfile
 from src.utils.name_clean import normalize_player_name
 
@@ -136,13 +138,16 @@ def _ros_for_player(
     *,
     schedule_weeks: Mapping[str, list] | None,
     params: ParamSet,
+    current_week: int | None = None,
 ) -> dict[str, Any] | None:
-    """Preseason rest-of-season value (single horizon, no aging/survival).
+    """Rest-of-season value (single horizon, no aging/survival).
 
     Requires the league schedule (byes) for the player's NFL team; when
     unavailable the field is None with no fabrication.  Preseason
-    ``w_proj`` = 1, so µ_ROS is the blended projection itself; in-season
-    recent-form blending activates once weekly points are wired.
+    (``current_week`` None) sums the full slate and µ_ROS is the
+    blended projection itself; in-season, ``blended`` already carries
+    the §8.4 posterior and only weeks >= ``current_week`` are summed —
+    played weeks are banked points, not remaining value.
     """
     if not schedule_weeks:
         return None
@@ -150,6 +155,8 @@ def _ros_for_player(
     weeks = schedule_weeks.get(team)
     if not weeks:
         return {"value": None, "reason": f"no_schedule_for_team:{team or 'FA'}"}
+    if current_week is not None:
+        weeks = [wk for wk in weeks if wk.week >= current_week]
     sigma0 = v.seasons[0]["sigma"]
     replacement = v.raw["replacement"]
     out: dict[str, Any] = {"muRos": round(blended.mu_fpg, 3), "weeks": len(weeks)}
@@ -198,6 +205,7 @@ def run_valuation(
     context: Mapping[str, "PlayerContext"] | None = None,
     events: Iterable["PlayerEvent"] | None = None,
     schedule_weeks: Mapping[str, list] | None = None,
+    actuals: tuple[int | None, Mapping[str, list]] | None = None,
 ) -> dict[str, Any]:
     """Compute BDVM fundamental values for every priceable asset.
 
@@ -211,7 +219,16 @@ def run_valuation(
     ``src.bdvm.context``) enriches inputs when the contract row lacks
     them; ``events`` are structured §7 events (auto-loaded from
     ``data/bdvm/events/<season>.json`` when None); ``schedule_weeks``
-    maps NFL team → RosWeek list for the preseason ROS output.
+    maps NFL team → RosWeek list for the ROS output.
+
+    ``actuals`` is the in-season evidence feed:
+    ``(current_week, player_key → [(week, points), ...])`` from
+    ``src.bdvm.actuals``.  When present, each covered player's
+    consensus is replaced by the §8.4 posterior — the preseason µ
+    shrinks toward realized per-game production with weight
+    ``n_prior/(n_prior + weeks_played)`` (``blend_ros_mu``), σ shrinks
+    by the same evidence factor, and ROS sums only the REMAINING
+    weeks.  ``(None, {})`` or omitted → exact preseason behavior.
     """
     params = params or load_param_set()
     as_of = _utc_now_iso()
@@ -295,6 +312,48 @@ def run_valuation(
         )
         if blended is not None:
             consensus[key] = blended
+
+    # ---- in-season posterior update (§8.4) ---------------------------------
+    # ONE mutation point, BEFORE pools/replacement: replacement levels,
+    # group z-stats, engine µ/σ, and ROS all read from ``consensus``,
+    # so updating here keeps every downstream number on the same
+    # posterior.  µ shrinks toward realized production with weight
+    # n_prior/(n_prior + weeks_played); σ shrinks by the same evidence
+    # factor (more observed games → less cross-source uncertainty).
+    # Players without observed weeks keep the preseason consensus
+    # untouched — absence of evidence is never evidence of zero.
+    current_week: int | None = None
+    inseason_updated = 0
+    if actuals is not None:
+        current_week, weekly_by_key = actuals
+        if current_week is not None and weekly_by_key:
+            for key, blended in list(consensus.items()):
+                samples = weekly_by_key.get(key)
+                if not samples:
+                    continue
+                weeks_played = float(len(samples))
+                mu_recent = sum(pts for _wk, pts in samples) / weeks_played
+                is_idp = is_idp_position(blended.position)
+                mu_post = blend_ros_mu(
+                    blended.mu_fpg,
+                    mu_recent,
+                    weeks_played,
+                    is_idp=is_idp,
+                    params=params,
+                )
+                w_prior = ros_projection_weight(weeks_played, is_idp=is_idp, params=params)
+                sigma_post = blended.sigma_source * math.sqrt(w_prior)
+                consensus[key] = _dc_replace(blended, mu_fpg=mu_post, sigma_source=sigma_post)
+                inseason_updated += 1
+    meta["inSeason"] = (
+        {
+            "currentWeek": current_week,
+            "playersUpdated": inseason_updated,
+            "source": "nflverse stats_player_week",
+        }
+        if current_week is not None
+        else {"active": False}
+    )
 
     # ---- pools + replacement (from projections only) ----------------------
     pools = build_group_pools(consensus.values(), cfg)
@@ -502,7 +561,12 @@ def run_valuation(
         }
         entry["events"] = extras.get("eventAudit", [])
         entry["ros"] = _ros_for_player(
-            v, blended, row, schedule_weeks=schedule_weeks, params=params
+            v,
+            blended,
+            row,
+            schedule_weeks=schedule_weeks,
+            params=params,
+            current_week=current_week,
         )
         players_out.append(entry)
 

--- a/src/bdvm/service.py
+++ b/src/bdvm/service.py
@@ -74,7 +74,15 @@ _EVENT_VOL_PRIOR = {
     "TE": 0.35,
 }
 
-_PICK_SLOT_RE = re.compile(r"(?P<year>20\d{2})\s+(?P<round>\d)\.(?P<slot>\d{2})")
+# Accepts both the bare "2026 1.04" form and the platform's canonical
+# slot-pick displayName "2026 Pick 1.04" — the exact string the trade
+# page and /api/data rows carry.  Without the optional token every
+# canonical slot pick fell through to unparseable_pick_name and the
+# whole current-year pick board (and any trade-eval ref to it) was
+# unpriced.
+_PICK_SLOT_RE = re.compile(
+    r"(?P<year>20\d{2})\s+(?:pick\s+)?(?P<round>\d)\.(?P<slot>\d{1,2})", re.IGNORECASE
+)
 _PICK_TIER_RE = re.compile(
     r"(?P<year>20\d{2})\s+(?P<tier>Early|Mid|Late)\s+(?P<round>1st|2nd|3rd|4th)", re.IGNORECASE
 )
@@ -139,6 +147,7 @@ def _ros_for_player(
     schedule_weeks: Mapping[str, list] | None,
     params: ParamSet,
     current_week: int | None = None,
+    played_weeks: set[int] | None = None,
 ) -> dict[str, Any] | None:
     """Rest-of-season value (single horizon, no aging/survival).
 
@@ -146,8 +155,15 @@ def _ros_for_player(
     unavailable the field is None with no fabrication.  Preseason
     (``current_week`` None) sums the full slate and µ_ROS is the
     blended projection itself; in-season, ``blended`` already carries
-    the §8.4 posterior and only weeks >= ``current_week`` are summed —
-    played weeks are banked points, not remaining value.
+    the §8.4 posterior and played weeks are banked points, not
+    remaining value.
+
+    Boundary week: ``current_week`` is global (max week observed
+    league-wide + 1), but nflverse publishes game-by-game — after
+    Thursday night the file already holds week-W rows while ~30 teams
+    haven't played W yet.  For THIS player, week W counts as remaining
+    unless it appears in ``played_weeks`` — otherwise one real week of
+    value would vanish league-wide for three days every week.
     """
     if not schedule_weeks:
         return None
@@ -156,7 +172,13 @@ def _ros_for_player(
     if not weeks:
         return {"value": None, "reason": f"no_schedule_for_team:{team or 'FA'}"}
     if current_week is not None:
-        weeks = [wk for wk in weeks if wk.week >= current_week]
+        boundary = current_week - 1
+        played = played_weeks or set()
+        weeks = [
+            wk
+            for wk in weeks
+            if wk.week >= current_week or (wk.week == boundary and boundary not in played)
+        ]
     sigma0 = v.seasons[0]["sigma"]
     replacement = v.raw["replacement"]
     out: dict[str, Any] = {"muRos": round(blended.mu_fpg, 3), "weeks": len(weeks)}
@@ -324,9 +346,16 @@ def run_valuation(
     # untouched — absence of evidence is never evidence of zero.
     current_week: int | None = None
     inseason_updated = 0
+    # Per-player played weeks, for the ROS boundary-week rule (a week
+    # some teams have played and others haven't is remaining for the
+    # teams that haven't).
+    actuals_played: dict[str, set[int]] = {}
     if actuals is not None:
         current_week, weekly_by_key = actuals
         if current_week is not None and weekly_by_key:
+            actuals_played = {
+                key: {wk for wk, _pts in samples} for key, samples in weekly_by_key.items()
+            }
             for key, blended in list(consensus.items()):
                 samples = weekly_by_key.get(key)
                 if not samples:
@@ -567,6 +596,9 @@ def run_valuation(
             schedule_weeks=schedule_weeks,
             params=params,
             current_week=current_week,
+            played_weeks=actuals_played.get(
+                normalize_player_name(str(row.get("canonicalName") or row.get("displayName") or ""))
+            ),
         )
         players_out.append(entry)
 

--- a/tests/bdvm/test_endpoint.py
+++ b/tests/bdvm/test_endpoint.py
@@ -70,6 +70,32 @@ class TestBdvmEndpoint(unittest.TestCase):
         # resolver error wins.  Either way it must not be a 500.
         self.assertLess(resp.status_code, 500)
 
+    def test_trade_eval_body_league_key_reaches_the_resolver(self):
+        # BdvmTradePanel sends leagueKey in the JSON body (the POST
+        # convention).  The route must parse the body BEFORE the gate
+        # and thread it through — resolving from the query string only
+        # would silently price the trade against the wrong league's
+        # replacement levels (review finding, 2026-07-28).
+        os.environ["RISKIT_FEATURE_BDVM_ENGINE"] = "1"
+        feature_flags.reload()
+        seen: dict = {}
+
+        def spy_resolve(request, *, body=None, require_loaded_contract=False):
+            seen["body"] = body
+            raise server.LeagueResolutionError(400, "unknown_league", "short-circuit for test")
+
+        with mock.patch.object(server, "_resolve_league_for_request", spy_resolve):
+            resp = self.client.post(
+                "/api/bdvm/trade-eval",
+                json={
+                    "sideA": [{"name": "Someone"}],
+                    "sideB": [{"name": "Someone Else"}],
+                    "leagueKey": "league_b",
+                },
+            )
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual((seen.get("body") or {}).get("leagueKey"), "league_b")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/bdvm/test_inseason.py
+++ b/tests/bdvm/test_inseason.py
@@ -16,8 +16,13 @@ The contract under test:
 from __future__ import annotations
 
 import unittest
+from datetime import date
 
-from src.bdvm.actuals import weekly_points_from_rows
+from src.bdvm.actuals import (
+    current_nfl_season,
+    fetch_current_season_actuals,
+    weekly_points_from_rows,
+)
 from src.bdvm.params import load_param_set
 from src.bdvm.ros import ros_projection_weight
 from src.bdvm.service import run_valuation
@@ -169,6 +174,13 @@ class TestRosRemainingWeeks(unittest.TestCase):
         self.assertEqual(pre_ros["weeks"], 18)
         self.assertEqual(mid_ros["weeks"], 9)  # weeks 10..18
         self.assertLess(mid_ros["balanced"], pre_ros["balanced"])
+        # Boundary week: current_week=10 means SOME team has played
+        # week 9 — Quiet WR has no week-9 sample, so his week 9 is
+        # still remaining (nflverse publishes game-by-game; dropping
+        # the in-progress week for everyone would vanish a real week
+        # of value league-wide from Thursday to Monday).
+        quiet_ros = next(p for p in mid["players"] if p["name"] == "Quiet WR")["ros"]
+        self.assertEqual(quiet_ros["weeks"], 10)  # weeks 9..18
 
 
 class TestActualsFeed(unittest.TestCase):
@@ -208,6 +220,78 @@ class TestActualsFeed(unittest.TestCase):
 
     def test_no_rows_is_preseason(self):
         week, by_key = weekly_points_from_rows([], SCORING, season=2026, name_normalizer=_norm)
+        self.assertIsNone(week)
+        self.assertEqual(by_key, {})
+
+    def test_week_18_played_means_zero_remaining(self):
+        # current_week is deliberately UNCAPPED: after the final slate
+        # it must be 19 so ROS sums zero remaining weeks — a cap at 18
+        # would double-count the banked final week as future value.
+        rows = [
+            {
+                "player_display_name": "Steady WR",
+                "position": "WR",
+                "season": 2026,
+                "week": 18,
+                "season_type": "REG",
+                "receptions": 5,
+                "receiving_yards": 70,
+            }
+        ]
+        week, _ = weekly_points_from_rows(rows, SCORING, season=2026, name_normalizer=_norm)
+        self.assertEqual(week, 19)
+
+    def test_distinct_players_colliding_on_name_are_dropped(self):
+        # Byron Murphy (CB) vs Byron Murphy II (DT): the suffix strips
+        # to the same key.  A per-week max over two different players
+        # is a chimera — mirror the projection side and drop the key.
+        def row(pid, week, yards):
+            return {
+                "player_display_name": "Byron Murphy",
+                "player_id": pid,
+                "position": "WR",
+                "season": 2026,
+                "week": week,
+                "season_type": "REG",
+                "receptions": 1,
+                "receiving_yards": yards,
+            }
+
+        _week, by_key = weekly_points_from_rows(
+            [row("00-001", 1, 100), row("00-002", 1, 50), row("00-002", 2, 60)],
+            SCORING,
+            season=2026,
+            name_normalizer=_norm,
+        )
+        self.assertNotIn("byron murphy", by_key)
+        # Same player id duplicated is NOT a collision — max dedupe.
+        _week, by_key = weekly_points_from_rows(
+            [row("00-001", 1, 100), row("00-001", 1, 100)],
+            SCORING,
+            season=2026,
+            name_normalizer=_norm,
+        )
+        self.assertEqual(by_key["byron murphy"], [(1, 11.0)])
+
+
+class TestSeasonDerivation(unittest.TestCase):
+    """The actuals season is the CALENDAR NFL season — never
+    currentDraftYear, which points one season ahead for the entire
+    Sept–Jan window (review finding, 2026-07-28)."""
+
+    def test_calendar_window(self):
+        self.assertEqual(current_nfl_season(date(2026, 9, 10)), 2026)
+        self.assertEqual(current_nfl_season(date(2026, 12, 31)), 2026)
+        self.assertEqual(current_nfl_season(date(2027, 1, 5)), 2026)  # week 18 spill
+        self.assertIsNone(current_nfl_season(date(2026, 7, 28)))  # preseason
+        self.assertIsNone(current_nfl_season(date(2027, 3, 1)))  # offseason
+
+    def test_out_of_window_is_preseason_signal_without_fetch(self):
+        # July: no season in progress → (None, {}) and NO network call
+        # (a fetch would raise inside the sandboxed test env).
+        week, by_key = fetch_current_season_actuals(
+            SCORING, name_normalizer=_norm, today=date(2026, 7, 28)
+        )
         self.assertIsNone(week)
         self.assertEqual(by_key, {})
 

--- a/tests/bdvm/test_inseason.py
+++ b/tests/bdvm/test_inseason.py
@@ -1,0 +1,216 @@
+"""In-season updating: realized weekly production → posterior µ/σ + ROS.
+
+The contract under test:
+1. Preseason no-op — ``actuals=(None, {})`` (or omitted) produces the
+   EXACT preseason payload; before week 1 nothing may drift.
+2. Posterior math — µ shrinks toward realized per-game production with
+   weight n_prior/(n_prior + weeks_played) (blend_ros_mu, the §8.4
+   posterior finally wired live); σ shrinks by √(that weight).
+3. Players with no observed weeks keep the preseason consensus —
+   absence of evidence is never evidence of zero.
+4. ROS sums only REMAINING weeks once a current week exists.
+5. The actuals feed itself scores rows under league rules via the one
+   production scoring path, and returns (None, {}) with no rows.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.bdvm.actuals import weekly_points_from_rows
+from src.bdvm.params import load_param_set
+from src.bdvm.ros import ros_projection_weight
+from src.bdvm.service import run_valuation
+
+PARAMS = load_param_set("params_v1")
+
+SCORING = {"rec": 1.0, "rec_yd": 0.1, "idp_tkl_solo": 1.5}
+_norm = lambda s: s.lower()  # noqa: E731
+
+
+def _contract():
+    return {
+        "generatedAt": "x",
+        "currentDraftYear": 2026,
+        "sleeper": {
+            "scoringSettings": SCORING,
+            "rosterPositions": ["QB", "WR", "WR", "LB", "BN", "BN"],
+            "leagueSettings": {"num_teams": 12},
+        },
+        "playersArray": [
+            {
+                "playerId": "w1",
+                "canonicalName": "steady wr",
+                "displayName": "Steady WR",
+                "position": "WR",
+                "assetClass": "offense",
+                "age": 25.0,
+                "yearsExp": 3,
+            },
+            {
+                "playerId": "w2",
+                "canonicalName": "quiet wr",
+                "displayName": "Quiet WR",
+                "position": "WR",
+                "assetClass": "offense",
+                "age": 25.0,
+                "yearsExp": 3,
+            },
+        ],
+    }
+
+
+def _records():
+    from src.bdvm.projections import ProjectionRecord
+
+    return [
+        ProjectionRecord(
+            source="a",
+            player_key=key,
+            position="WR",
+            season=2026,
+            as_of="2026-07-20",
+            games=17.0,
+            fpg=12.0,
+            scoring_native=True,
+        )
+        for key in ("steady wr", "quiet wr")
+    ]
+
+
+def _run(actuals=None, schedule_weeks=None):
+    return run_valuation(
+        _contract(),
+        league_key="dynasty_main",
+        params=PARAMS,
+        projection_records=_records(),
+        snapshot_as_of="2026-07-27",
+        season=2026,
+        actuals=actuals,
+        schedule_weeks=schedule_weeks,
+    )
+
+
+class TestPreseasonNoOp(unittest.TestCase):
+    def test_omitted_and_empty_actuals_are_identical(self):
+        base = _run(actuals=None)
+        empty = _run(actuals=(None, {}))
+        self.assertEqual(base["meta"]["inSeason"], {"active": False})
+        self.assertEqual(empty["meta"]["inSeason"], {"active": False})
+        for p_base, p_empty in zip(base["players"], empty["players"]):
+            self.assertEqual(p_base["projection"]["fpg"], p_empty["projection"]["fpg"])
+            self.assertEqual(p_base["tradeValue"], p_empty["tradeValue"])
+
+
+class TestPosterior(unittest.TestCase):
+    def test_mu_shrinks_toward_actuals_with_prior_weight(self):
+        # 4 weeks at 20.0 FPG against a 12.0 preseason µ (offense
+        # n_prior = 6): posterior = w·12 + (1−w)·20, w = 6/(6+4).
+        samples = [(1, 20.0), (2, 20.0), (3, 20.0), (4, 20.0)]
+        payload = _run(actuals=(5, {"steady wr": samples}))
+        w = ros_projection_weight(4.0, is_idp=False, params=PARAMS)
+        expected_mu = w * 12.0 + (1 - w) * 20.0
+        steady = next(p for p in payload["players"] if p["name"] == "Steady WR")
+        self.assertAlmostEqual(steady["projection"]["fpg"], round(expected_mu, 3), places=3)
+        self.assertEqual(payload["meta"]["inSeason"]["currentWeek"], 5)
+        self.assertEqual(payload["meta"]["inSeason"]["playersUpdated"], 1)
+
+    def test_unobserved_player_keeps_preseason_mu(self):
+        payload = _run(actuals=(5, {"steady wr": [(1, 20.0)]}))
+        quiet = next(p for p in payload["players"] if p["name"] == "Quiet WR")
+        self.assertAlmostEqual(quiet["projection"]["fpg"], 12.0, places=3)
+
+    def test_sigma_shrinks_with_evidence(self):
+        base = _run()
+        updated = _run(actuals=(9, {"steady wr": [(w, 12.0) for w in range(1, 9)]}))
+        s_base = next(p for p in base["players"] if p["name"] == "Steady WR")
+        s_upd = next(p for p in updated["players"] if p["name"] == "Steady WR")
+        # identical production → µ unchanged, σ_source strictly smaller
+        self.assertAlmostEqual(s_upd["projection"]["fpg"], s_base["projection"]["fpg"], places=3)
+        self.assertLess(
+            s_upd["projection"]["sigmaSource"], s_base["projection"]["sigmaSource"] + 1e-9
+        )
+
+
+class TestRosRemainingWeeks(unittest.TestCase):
+    def _weeks(self):
+        from src.bdvm.ros import RosWeek
+
+        return {"KC": [RosWeek(week=w, is_bye=(w == 6), p_active=1.0) for w in range(1, 19)]}
+
+    def _contract_with_team(self):
+        c = _contract()
+        for row in c["playersArray"]:
+            row["team"] = "KC"
+        return c
+
+    def test_ros_counts_only_remaining_weeks(self):
+        pre = run_valuation(
+            self._contract_with_team(),
+            league_key="dynasty_main",
+            params=PARAMS,
+            projection_records=_records(),
+            snapshot_as_of="2026-07-27",
+            season=2026,
+            schedule_weeks=self._weeks(),
+        )
+        mid = run_valuation(
+            self._contract_with_team(),
+            league_key="dynasty_main",
+            params=PARAMS,
+            projection_records=_records(),
+            snapshot_as_of="2026-07-27",
+            season=2026,
+            schedule_weeks=self._weeks(),
+            actuals=(10, {"steady wr": [(w, 12.0) for w in range(1, 10)]}),
+        )
+        pre_ros = next(p for p in pre["players"] if p["name"] == "Steady WR")["ros"]
+        mid_ros = next(p for p in mid["players"] if p["name"] == "Steady WR")["ros"]
+        self.assertEqual(pre_ros["weeks"], 18)
+        self.assertEqual(mid_ros["weeks"], 9)  # weeks 10..18
+        self.assertLess(mid_ros["balanced"], pre_ros["balanced"])
+
+
+class TestActualsFeed(unittest.TestCase):
+    def test_rows_score_under_league_rules_week_granular(self):
+        rows = [
+            {
+                "player_display_name": "Steady WR",
+                "position": "WR",
+                "season": 2026,
+                "week": 1,
+                "season_type": "REG",
+                "receptions": 5,
+                "receiving_yards": 70,
+            },
+            {  # playoffs excluded
+                "player_display_name": "Steady WR",
+                "position": "WR",
+                "season": 2026,
+                "week": 19,
+                "season_type": "POST",
+                "receptions": 9,
+                "receiving_yards": 150,
+            },
+            {  # other season excluded
+                "player_display_name": "Steady WR",
+                "position": "WR",
+                "season": 2025,
+                "week": 2,
+                "season_type": "REG",
+                "receptions": 9,
+                "receiving_yards": 150,
+            },
+        ]
+        week, by_key = weekly_points_from_rows(rows, SCORING, season=2026, name_normalizer=_norm)
+        self.assertEqual(week, 2)
+        self.assertEqual(by_key["steady wr"], [(1, 12.0)])  # 5 rec + 7.0 yds
+
+    def test_no_rows_is_preseason(self):
+        week, by_key = weekly_points_from_rows([], SCORING, season=2026, name_normalizer=_norm)
+        self.assertIsNone(week)
+        self.assertEqual(by_key, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bdvm/test_news_events.py
+++ b/tests/bdvm/test_news_events.py
@@ -1,0 +1,207 @@
+"""News → structured-events ingestion.
+
+The safety properties that must hold, in order:
+1. Auto events ALWAYS land in the speculation lane (confidence < 0.5)
+   — effective_impact suppresses every non-sigma channel, so a
+   headline can widen uncertainty but can never move a mean, shift
+   hazard, or dock games.
+2. Closed ontology: unmatched headlines map to nothing; ambiguous
+   player mentions map to nothing.
+3. Merge is dedup-by-eventId with existing-wins (a human may have
+   raised an event's confidence — re-ingest must not undo that), and
+   pruning touches ONLY news:* events.
+4. The events-file fingerprint participates in the values cache key —
+   writing the file invalidates cached boards.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+from src.bdvm import news_events as ne
+from src.bdvm.events import PlayerEvent, effective_impact
+
+_norm = lambda s: s.lower()  # noqa: E731
+
+
+def _item(headline, *, item_id="prov-abc123", players=None, ts="2026-07-28T12:00:00Z", body=""):
+    return {
+        "id": item_id,
+        "ts": ts,
+        "headline": headline,
+        "body": body,
+        "players": players
+        if players is not None
+        else [{"name": "Elite Backer", "impact": "negative", "ambiguous": False}],
+    }
+
+
+class TestClassification(unittest.TestCase):
+    def test_keyword_rules_map_conservatively(self):
+        cases = {
+            "Star LB tears ACL in practice": "SURGERY",
+            "RB suspended six games": "SUSPENSION",
+            "WR activated from IR": "ACTIVATED_RETURN",
+            "QB suffers hamstring injury": "INJURY",
+            "TE questionable for opener": "PRACTICE_LIMITATION",
+            "CB named starter for week 1": "DEPTH_CHART_PROMOTION",
+            "Veteran benched after rough outing": "DEPTH_CHART_DEMOTION",
+            "Team trades edge rusher to rival": "TRADE",
+            "Safety released after camp": "RELEASE",
+            "Star agrees to contract extension": "CONTRACT_EXTENSION",
+            "Club places franchise tag on DT": "FRANCHISE_TAG",
+            "FA linebacker signs two-year deal": "SIGNING",
+        }
+        for headline, expected in cases.items():
+            self.assertEqual(ne.classify_news_item(_item(headline)), expected, headline)
+
+    def test_unmatched_headline_maps_to_nothing(self):
+        self.assertIsNone(ne.classify_news_item(_item("Player has great practice, looks fast")))
+
+    def test_order_prefers_specific_over_general(self):
+        # "season-ending injury" must be SURGERY-tier, not generic INJURY
+        self.assertEqual(
+            ne.classify_news_item(_item("Season-ending injury for star WR")), "SURGERY"
+        )
+
+
+class TestMapping(unittest.TestCase):
+    def test_auto_events_are_speculation_sigma_only(self):
+        events = ne.map_news_items_to_events(
+            [_item("RB suspended six games")], name_normalizer=_norm
+        )
+        self.assertEqual(len(events), 1)
+        e = events[0]
+        self.assertLess(e["confidence"], 0.5)
+        # Prove the §7 machinery treats it as sigma-only: build the real
+        # PlayerEvent and check the effective impact channels.
+        pe = PlayerEvent(
+            event_id=e["eventId"],
+            player_key=e["playerKey"],
+            event_type=e["eventType"],
+            effective_date=e["effectiveDate"],
+            confidence=e["confidence"],
+            source_reliability=e["sourceReliability"],
+        )
+        impact = effective_impact(pe, as_of=e["effectiveDate"])
+        non_sigma = {k: v for k, v in impact.items() if k != "sigma_mult"}
+        self.assertEqual(non_sigma, {})
+
+    def test_ambiguous_mentions_skipped(self):
+        events = ne.map_news_items_to_events(
+            [
+                _item(
+                    "WR suffers hamstring injury",
+                    players=[{"name": "Smith", "ambiguous": True}],
+                )
+            ],
+            name_normalizer=_norm,
+        )
+        self.assertEqual(events, [])
+
+    def test_event_id_is_stable_per_item_and_player(self):
+        events = ne.map_news_items_to_events(
+            [_item("QB suffers hamstring injury", item_id="espn-deadbeef")],
+            name_normalizer=_norm,
+        )
+        self.assertEqual(events[0]["eventId"], "news:espn-deadbeef:elite backer")
+
+
+class TestMerge(unittest.TestCase):
+    def _event(self, event_id, date="2026-07-28", **kw):
+        return {
+            "eventId": event_id,
+            "playerKey": "elite backer",
+            "eventType": "INJURY",
+            "effectiveDate": date,
+            "confidence": kw.get("confidence", 0.45),
+        }
+
+    def test_existing_wins_on_collision_and_human_events_untouched(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            human = self._event("manual-1", date="2025-01-01", confidence=0.9)
+            edited = self._event("news:x:elite backer", confidence=0.9)  # human-raised
+            (base / "2026.json").write_text(json.dumps({"events": [human, edited]}))
+            summary = ne.merge_events_file(
+                [self._event("news:x:elite backer"), self._event("news:y:elite backer")],
+                season=2026,
+                base_dir=base,
+                now=datetime(2026, 7, 28, tzinfo=timezone.utc),
+            )
+            self.assertTrue(summary["ok"])
+            self.assertEqual(summary["added"], 1)  # only news:y is new
+            stored = json.loads((base / "2026.json").read_text())["events"]
+            by_id = {e["eventId"]: e for e in stored}
+            # collision kept the HUMAN-EDITED confidence
+            self.assertEqual(by_id["news:x:elite backer"]["confidence"], 0.9)
+            # ancient HUMAN event survives pruning (only news:* prune)
+            self.assertIn("manual-1", by_id)
+
+    def test_stale_auto_events_pruned(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            old_auto = self._event("news:old:someone", date="2026-01-01")
+            (base / "2026.json").write_text(json.dumps({"events": [old_auto]}))
+            summary = ne.merge_events_file(
+                [],
+                season=2026,
+                base_dir=base,
+                now=datetime(2026, 7, 28, tzinfo=timezone.utc),
+            )
+            self.assertEqual(summary["pruned"], 1)
+            stored = json.loads((base / "2026.json").read_text())["events"]
+            self.assertEqual(stored, [])
+
+    def test_no_change_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            summary = ne.merge_events_file([], season=2026, base_dir=base)
+            self.assertTrue(summary.get("unchanged"))
+            self.assertFalse((base / "2026.json").exists())
+
+    def test_corrupt_file_refuses_rather_than_discarding(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            (base / "2026.json").write_text("{not json")
+            summary = ne.merge_events_file([self._event("news:x:a")], season=2026, base_dir=base)
+            self.assertFalse(summary["ok"])
+            self.assertEqual(summary["reason"], "events_file_unreadable")
+            self.assertEqual((base / "2026.json").read_text(), "{not json")
+
+
+class TestCacheFingerprint(unittest.TestCase):
+    def test_events_file_write_invalidates_values_cache(self):
+        from src.api import bdvm_api
+        from src.bdvm import events as events_mod
+
+        bdvm_api.reset_cache()
+        self.addCleanup(bdvm_api.reset_cache)
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            with (
+                mock.patch.object(events_mod, "EVENTS_DIR", base),
+                mock.patch.object(bdvm_api, "latest_snapshot_path", return_value=None),
+                mock.patch.object(bdvm_api, "_actuals_for", return_value=(None, {})),
+                mock.patch.object(
+                    bdvm_api,
+                    "run_valuation",
+                    side_effect=lambda _c, **kw: {"status": "ok", "meta": {}},
+                ) as rv,
+            ):
+                contract = {"generatedAt": "x", "currentDraftYear": 2026}
+                bdvm_api.get_bdvm_values(contract, "dynasty_main")
+                bdvm_api.get_bdvm_values(contract, "dynasty_main")
+                self.assertEqual(rv.call_count, 1)  # cached
+                (base / "2026.json").write_text('{"events": []}')
+                bdvm_api.get_bdvm_values(contract, "dynasty_main")
+                self.assertEqual(rv.call_count, 2)  # fingerprint change → recompute
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bdvm/test_news_events.py
+++ b/tests/bdvm/test_news_events.py
@@ -46,7 +46,6 @@ class TestClassification(unittest.TestCase):
         cases = {
             "Star LB tears ACL in practice": "SURGERY",
             "RB suspended six games": "SUSPENSION",
-            "WR activated from IR": "ACTIVATED_RETURN",
             "QB suffers hamstring injury": "INJURY",
             "TE questionable for opener": "PRACTICE_LIMITATION",
             "CB named starter for week 1": "DEPTH_CHART_PROMOTION",
@@ -63,11 +62,29 @@ class TestClassification(unittest.TestCase):
     def test_unmatched_headline_maps_to_nothing(self):
         self.assertIsNone(ne.classify_news_item(_item("Player has great practice, looks fast")))
 
+    def test_activated_return_is_not_auto_ingested(self):
+        # ACTIVATED_RETURN's ontology impact NARROWS sigma; the
+        # speculation lane may only widen, so the ingest never emits it.
+        self.assertIsNone(ne.classify_news_item(_item("WR activated from IR")))
+
     def test_order_prefers_specific_over_general(self):
         # "season-ending injury" must be SURGERY-tier, not generic INJURY
         self.assertEqual(
             ne.classify_news_item(_item("Season-ending injury for star WR")), "SURGERY"
         )
+
+    def test_advice_listicle_language_maps_to_nothing(self):
+        # The aggregate feed carries fantasy-advice RSS whose headlines
+        # are full of transaction VOCABULARY about players nothing
+        # happened to — they must never become events.
+        for headline in (
+            "Dynasty trade targets: buy low on these five veterans",
+            "53-man roster projection: who makes the final cut?",
+            "Week 1 rankings: top-24 wideouts",
+            "Waiver wire adds and start/sit advice",
+            "Rookie mock draft 3.0",
+        ):
+            self.assertIsNone(ne.classify_news_item(_item(headline)), headline)
 
 
 class TestMapping(unittest.TestCase):
@@ -92,6 +109,33 @@ class TestMapping(unittest.TestCase):
         non_sigma = {k: v for k, v in impact.items() if k != "sigma_mult"}
         self.assertEqual(non_sigma, {})
 
+    def test_speculation_sigma_may_only_widen(self):
+        # ACTIVATED_RETURN's ontology sigma_mult is 0.95 — a NARROWER.
+        # At speculation confidence the clamp must hold it at 1.0: a
+        # rumor may widen uncertainty, never shrink it (and thereby
+        # move option value).
+        pe = PlayerEvent(
+            event_id="news:x:someone",
+            player_key="someone",
+            event_type="ACTIVATED_RETURN",
+            effective_date="2026-07-28",
+            confidence=0.45,
+            source_reliability=0.6,
+        )
+        impact = effective_impact(pe, as_of="2026-07-28")
+        self.assertGreaterEqual(impact.get("sigma_mult", 1.0), 1.0)
+        # At CONFIRMED confidence the narrower passes through untouched.
+        confirmed = PlayerEvent(
+            event_id="manual-1",
+            player_key="someone",
+            event_type="ACTIVATED_RETURN",
+            effective_date="2026-07-28",
+            confidence=0.95,
+            source_reliability=1.0,
+        )
+        impact_c = effective_impact(confirmed, as_of="2026-07-28")
+        self.assertLess(impact_c.get("sigma_mult", 1.0), 1.0)
+
     def test_ambiguous_mentions_skipped(self):
         events = ne.map_news_items_to_events(
             [
@@ -111,13 +155,22 @@ class TestMapping(unittest.TestCase):
         )
         self.assertEqual(events[0]["eventId"], "news:espn-deadbeef:elite backer")
 
+    def test_list_articles_with_many_mentions_are_skipped(self):
+        # An item naming 4+ players is editorial coverage, not an event
+        # about any one of them.
+        many = [{"name": f"Player {i}", "ambiguous": False} for i in range(4)]
+        events = ne.map_news_items_to_events(
+            [_item("QB suffers hamstring injury", players=many)], name_normalizer=_norm
+        )
+        self.assertEqual(events, [])
+
 
 class TestMerge(unittest.TestCase):
-    def _event(self, event_id, date="2026-07-28", **kw):
+    def _event(self, event_id, date="2026-07-28", player="elite backer", **kw):
         return {
             "eventId": event_id,
-            "playerKey": "elite backer",
-            "eventType": "INJURY",
+            "playerKey": player,
+            "eventType": kw.get("event_type", "INJURY"),
             "effectiveDate": date,
             "confidence": kw.get("confidence", 0.45),
         }
@@ -129,7 +182,13 @@ class TestMerge(unittest.TestCase):
             edited = self._event("news:x:elite backer", confidence=0.9)  # human-raised
             (base / "2026.json").write_text(json.dumps({"events": [human, edited]}))
             summary = ne.merge_events_file(
-                [self._event("news:x:elite backer"), self._event("news:y:elite backer")],
+                [
+                    self._event("news:x:elite backer"),
+                    # different player → genuinely distinct fact (a same-
+                    # player same-type event inside the window would be
+                    # dup-suppressed, by design)
+                    self._event("news:y:other guy", player="other guy"),
+                ],
                 season=2026,
                 base_dir=base,
                 now=datetime(2026, 7, 28, tzinfo=timezone.utc),
@@ -142,6 +201,74 @@ class TestMerge(unittest.TestCase):
             self.assertEqual(by_id["news:x:elite backer"]["confidence"], 0.9)
             # ancient HUMAN event survives pruning (only news:* prune)
             self.assertIn("manual-1", by_id)
+
+    def test_same_fact_from_second_provider_does_not_stack(self):
+        # The same real-world story arrives from N providers under N
+        # item ids — one (playerKey, eventType) inside the window is
+        # ONE fact, not N sigma wideners.
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            (base / "2026.json").write_text(
+                json.dumps({"events": [self._event("news:espn-1:elite backer", date="2026-07-25")]})
+            )
+            summary = ne.merge_events_file(
+                [self._event("news:pfp-9:elite backer")],
+                season=2026,
+                base_dir=base,
+                now=datetime(2026, 7, 28, tzinfo=timezone.utc),
+            )
+            self.assertTrue(summary["ok"])
+            self.assertEqual(summary["added"], 0)
+            self.assertTrue(summary.get("unchanged"))
+
+    def test_human_raised_confidence_survives_the_prune(self):
+        # A human who raised a news:* event's confidence to >= 0.5
+        # turned it into a confirmed, mean-affecting event — the 90d
+        # auto-prune must not delete their work while the event still
+        # carries half-life strength.
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            raised = self._event("news:old:elite backer", date="2026-01-01", confidence=0.95)
+            still_auto = self._event("news:old2:other guy", date="2026-01-01", player="other guy")
+            (base / "2026.json").write_text(json.dumps({"events": [raised, still_auto]}))
+            summary = ne.merge_events_file(
+                [], season=2026, base_dir=base, now=datetime(2026, 7, 28, tzinfo=timezone.utc)
+            )
+            self.assertEqual(summary["pruned"], 1)  # only the untouched auto event
+            stored = json.loads((base / "2026.json").read_text())["events"]
+            self.assertEqual([e["eventId"] for e in stored], ["news:old:elite backer"])
+
+    def test_valid_json_wrong_shape_refuses(self):
+        # "events": {...} instead of [...] — the classic hand-edit slip.
+        # Iterating it would masquerade the operator's entries as
+        # prunable garbage; refuse as hard as for unparseable JSON.
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            original = json.dumps({"events": {"eventId": "manual-1"}})
+            (base / "2026.json").write_text(original)
+            summary = ne.merge_events_file([self._event("news:x:a")], season=2026, base_dir=base)
+            self.assertFalse(summary["ok"])
+            self.assertEqual(summary["reason"], "events_file_invalid_shape")
+            self.assertEqual((base / "2026.json").read_text(), original)
+
+    def test_extra_top_level_keys_survive_rewrite(self):
+        # A human _comment block (the config/bdvm convention) must not
+        # be dropped by the merge's rewrite.
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            (base / "2026.json").write_text(
+                json.dumps({"_comment": ["operator notes"], "events": []})
+            )
+            summary = ne.merge_events_file(
+                [self._event("news:x:elite backer")],
+                season=2026,
+                base_dir=base,
+                now=datetime(2026, 7, 28, tzinfo=timezone.utc),
+            )
+            self.assertTrue(summary["ok"])
+            stored = json.loads((base / "2026.json").read_text())
+            self.assertEqual(stored["_comment"], ["operator notes"])
+            self.assertEqual(len(stored["events"]), 1)
 
     def test_stale_auto_events_pruned(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/bdvm/test_service.py
+++ b/tests/bdvm/test_service.py
@@ -121,6 +121,15 @@ def build_contract():
                 "canonicalSiteValues": {"ktcSfTep": 5600},
             },
             {
+                # The platform's canonical slot-pick displayName form —
+                # the one every real /api/data pick row carries.
+                "canonicalName": "2026 Pick 1.04",
+                "displayName": "2026 Pick 1.04",
+                "assetClass": "pick",
+                "position": "PICK",
+                "canonicalSiteValues": {"ktcSfTep": 5200},
+            },
+            {
                 "canonicalName": "mystery pick",
                 "displayName": "Mystery Pick",
                 "assetClass": "pick",
@@ -238,6 +247,13 @@ class TestEndToEnd(unittest.TestCase):
         dist = slot_pick["distribution"]["balanced"]
         self.assertLessEqual(abs(dist["ev"] - 3479.0), 1.0)  # Appendix C pick 3
         self.assertAlmostEqual(dist["p_hit"] + dist["p_mid"] + dist["p_miss"], 1.0)
+        # The canonical "YYYY Pick R.SS" displayName — the form the live
+        # contract and the trade page actually use — must parse too;
+        # before the regex allowed the "Pick" token, all 72 real slot
+        # picks were unpriced (review finding, 2026-07-28).
+        canonical = picks["2026 Pick 1.04"]
+        self.assertEqual(canonical["overallSlot"], 4)
+        self.assertIsNotNone(canonical["distribution"])
         mystery = picks["Mystery Pick"]
         self.assertIsNone(mystery["distribution"])
         self.assertEqual(mystery["reason"], "unparseable_pick_name")

--- a/tests/bdvm/test_trade_eval.py
+++ b/tests/bdvm/test_trade_eval.py
@@ -1,0 +1,131 @@
+"""BDVM trade-eval: CES per-strategy grading of one specific trade.
+
+The honesty rule under test: unresolvable refs are REPORTED per side,
+never silently priced at zero — a grade that quietly dropped an asset
+would be worse than no grade.  And package math is CES, never a plain
+sum (a 2-for-1 quantity dump must not grade as the sum of its parts).
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from src.api import bdvm_api
+from src.bdvm.params import load_param_set
+from src.bdvm.trade_math import package_value
+
+PARAMS = load_param_set("params_v1")
+
+VALUES_PAYLOAD = {
+    "status": "ok",
+    "meta": {"asOf": "2026-07-28T00:00:00Z", "paramSetId": "params_v1:test"},
+    "players": [
+        {
+            "playerId": "p1",
+            "name": "Elite Backer",
+            "tradeValue": {
+                "contender": 7000.0,
+                "balanced": 7200.0,
+                "rebuilder": 7400.0,
+                "risk_neutral": 7100.0,
+            },
+        },
+        {
+            "playerId": "p2",
+            "name": "Old Vet",
+            "tradeValue": {
+                "contender": 6000.0,
+                "balanced": 5000.0,
+                "rebuilder": 3000.0,
+                "risk_neutral": 4900.0,
+            },
+        },
+        {
+            "playerId": "p3",
+            "name": "Young Stash",
+            "tradeValue": {
+                "contender": 2000.0,
+                "balanced": 3500.0,
+                "rebuilder": 5000.0,
+                "risk_neutral": 3400.0,
+            },
+        },
+    ],
+    "picks": [
+        {
+            "name": "2027 1.05",
+            "distribution": {
+                "contender": {"ev": 3000.0},
+                "balanced": {"ev": 3600.0},
+                "rebuilder": {"ev": 4200.0},
+                "risk_neutral": {"ev": 3500.0},
+            },
+        }
+    ],
+}
+
+
+class TestTradeEval(unittest.TestCase):
+    def setUp(self):
+        bdvm_api.reset_cache()
+        self.addCleanup(bdvm_api.reset_cache)
+        patcher = mock.patch.object(bdvm_api, "get_bdvm_values", return_value=VALUES_PAYLOAD)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _eval(self, side_a, side_b):
+        return bdvm_api.get_bdvm_trade_eval(
+            {"generatedAt": "x"}, "dynasty_main", side_a=side_a, side_b=side_b
+        )
+
+    def test_ces_not_plain_sum(self):
+        out = self._eval([{"playerId": "p1"}], [{"playerId": "p2"}, {"playerId": "p3"}])
+        self.assertEqual(out["status"], "ok")
+        bal = out["byStrategy"]["balanced"]
+        expected_a = package_value([7200.0], PARAMS)
+        expected_b = package_value([5000.0, 3500.0], PARAMS)
+        self.assertAlmostEqual(bal["sideA"], round(expected_a, 1))
+        self.assertAlmostEqual(bal["sideB"], round(expected_b, 1))
+        # CES with theta>1 prices consolidation: the 2-asset side grades
+        # BELOW the plain sum of its parts.
+        self.assertLess(bal["sideB"], 5000.0 + 3500.0)
+        self.assertAlmostEqual(bal["edge"], round(expected_a - expected_b, 1))
+
+    def test_strategy_currencies_flip_the_verdict(self):
+        out = self._eval([{"playerId": "p2"}], [{"playerId": "p3"}])
+        self.assertGreater(out["byStrategy"]["contender"]["edge"], 0)  # vet wins now
+        self.assertLess(out["byStrategy"]["rebuilder"]["edge"], 0)  # stash wins later
+
+    def test_picks_resolve_by_name_with_strategy_ev(self):
+        out = self._eval(["2027 1.05"], [{"playerId": "p3"}])
+        self.assertEqual(out["sideAAssets"][0]["kind"], "pick")
+        self.assertAlmostEqual(out["byStrategy"]["rebuilder"]["sideA"], 4200.0)
+        self.assertEqual(out["unresolved"], {"sideA": [], "sideB": []})
+
+    def test_name_refs_resolve_case_insensitively(self):
+        out = self._eval(["elite backer"], ["OLD VET"])
+        self.assertEqual(out["unresolved"], {"sideA": [], "sideB": []})
+        self.assertEqual(out["sideAAssets"][0]["kind"], "player")
+
+    def test_unresolved_refs_are_reported_not_zeroed(self):
+        out = self._eval([{"playerId": "p1"}, "Total Mystery"], [{"playerId": "p2"}])
+        self.assertEqual(out["unresolved"]["sideA"], ["Total Mystery"])
+        # side A's package contains ONLY the resolved asset
+        self.assertAlmostEqual(
+            out["byStrategy"]["balanced"]["sideA"], round(package_value([7200.0], PARAMS), 1)
+        )
+
+    def test_non_ok_board_passes_through(self):
+        with mock.patch.object(
+            bdvm_api,
+            "get_bdvm_values",
+            return_value={"status": "no_projection_snapshot", "message": "m"},
+        ):
+            out = self._eval([{"playerId": "p1"}], [])
+        self.assertEqual(out["status"], "no_projection_snapshot")
+        self.assertEqual(out["byStrategy"], {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Completes the "do all 5" wave: the four remaining BDVM integrations (the fifth item — enablement — is a VPS-side checklist, listed at the bottom). All behind the existing `bdvm_engine` flag (default OFF); the market board and every existing route are untouched. A full adversarial review ran against the first commit and confirmed 13 defects; the second commit fixes every one, each pinned by a test.

## 1. Trade calculator check — `POST /api/bdvm/trade-eval` + panel on /trade

- CES-evaluates one specific trade in **every strategy currency** — package math is `package_value` (§3.13), never a plain sum, so consolidation prices correctly.
- Asset refs resolve playerId-first → normalized name → pick name (picks use the strategy's distribution EV). Unresolvable refs are reported per side, **never silently priced at zero**.
- Renders as the "Fundamentals check (BDVM)" panel on /trade below RosTradeFitPanel: display-only, never touches sideTotals/TradeMeter, silent-vanish on any non-ok (rankings gap-column precedent).
- Review fixes: the route now parses its body **before** the shared gate so the body `leagueKey` reaches the league resolver (it was silently resolving the wrong league); `_PICK_SLOT_RE` now accepts the canonical `"2026 Pick 1.04"` form (previously all 72 real slot picks were unpriceable).

## 2. In-season updating (§8.4)

- `run_valuation(actuals=...)` blends realized weekly PPG — scored under the league's exact settings from nflverse weekly rows, REG only — into the projection posterior via `blend_ros_mu` (`w = n_prior/(n_prior+weeks)`, n_prior 6 offense / 8 IDP); σ shrinks by `√w_prior`; ROS sums only remaining weeks. Preseason is an exact no-op.
- Boards self-update daily in season with zero new timers: `bdvm_api` refreshes actuals once per UTC day and the values cache key carries the observed week + day.
- Review fixes: the season is now the **calendar** NFL season (`current_nfl_season`) — keying on `currentDraftYear` pointed one season ahead for the whole Sept–Jan window, making the posterior structurally unreachable; `current_week` is uncapped (no double-count of the banked week-18 slate); a per-player boundary-week rule stops the in-progress week from vanishing league-wide after Thursday night; fetch failures are never memoized for the day; distinct players colliding on a normalized name are dropped instead of merged into a chimera.

## 3. News → structured events

- `src/bdvm/news_events.py` rides the existing daily signal-alerts sweep (no new timer): aggregated headlines map via conservative ordered keyword rules onto 11 of the 18 §7 ontology types. No match → nothing; ambiguous mention → nothing.
- Auto events land in the speculation lane **structurally**: confidence 0.45 < 0.5 means `effective_impact` suppresses every non-sigma channel — a headline can widen uncertainty but can never move a mean. The events-file fingerprint joins the values cache key, so every write invalidates cached boards.
- Review fixes: advice/listicle headlines ("trade targets", "who makes the cut") are filtered before any rule; items naming >3 players are skipped; one `(playerKey, eventType)` per 14 days on merge (N providers ≠ N sigma wideners); `effective_impact` clamps speculation `sigma_mult ≥ 1.0` (widen-only invariant, previously violable via ACTIVATED_RETURN, which is also no longer auto-mapped); the merge refuses valid-JSON-wrong-shape files instead of destroying human entries, preserves extra top-level keys, and the 90d prune spares `news:*` events a human raised to confirmed confidence.

## 4. Draft board join

- /draft grows a "Fund gap" column on the RookieBoard (name-based join — draft rows carry no playerId) and a collapsed-by-default "Fundamental pick values (BDVM)" panel (balanced-strategy EV / hit% / median / ceiling beside the market anchor).
- Same silent-vanish posture as the rankings gap column; sorting by gap sinks unpriced rows; auction math and backend-stamped ranks untouched. All colSpans (tier divider, empty state, quick-record row) track the live column count.

## Verification

- Full pytest: **5,179 passed, 25 skipped, 366 subtests** (13 new tests from the review wave).
- Frontend vitest: **1,357 passed** (new: `BdvmTradePanel.test.jsx`, BDVM column coverage in `DraftBoardSort.test.jsx`).
- Bundle budgets green; `/trade` bumped 75→82 KB for the new panel (documented in `check-bundle-sizes.mjs`).
- `ruff format` + `ruff check` clean on all touched files.

## 5. Enablement (VPS-side, after this merges — deploy is automatic on merge)

```bash
sudo apt-get install -y poppler-utils          # Clay PDF stage
bash deploy/install-systemd-service.sh          # installs BDVM snapshot timer + first build
echo 'RISKIT_FEATURE_BDVM_ENGINE=1' >> .env     # flags are env-only
sudo systemctl restart dynasty
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMN5feuNUUYiLz69deJBTF

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMN5feuNUUYiLz69deJBTF)_