### PR TITLE
Sitewide performance audit: fix the ~10s page loads

### DIFF
--- a/docs/performance-optimization.md
+++ b/docs/performance-optimization.md
@@ -38,9 +38,9 @@ wins. The production win in this batch is the backend compact precompute.
 | Proxy view forwarding | Dev / Next-only | The Next proxy hardcoded `view=app`, so in the dev flow mobile's `view=compact` request was dropped (production was unaffected — it hits Python directly). | **Fixed** |
 | Proxy stream-through | Dev / Next-only | The Next proxy parsed + re-serialized the whole multi-MB contract per request, discarding the backend's gzip/ETag. Now streams the body through with an idle-abort timeout. | **Fixed** |
 | **Live-overlay serialization** | In normal operation (Sleeper overlay active for the loaded league), every `/api/data` request called `JSONResponse(content=scrubbed)` → re-serialized the **entire multi-MB payload on the event loop**. Now offloaded to a worker and cached per overlay window; adds ETag/304 + Vary. | **Fixed** |
-| Client caching | The client fetches `/api/dynasty-data` with `cache: "no-store"`, so the browser never revalidates with `If-None-Match` — every navigation re-downloads the payload even when unchanged. | **Blocked** — see below |
-| Frontend bundle | No bundle-size analysis yet; large client bundles delay first paint. | **Planned** |
-| Render cost | Rankings table / trade views: audit for unmemoized recompute on sort/filter/scroll. | **Planned** |
+| Client caching | The client fetches `/api/dynasty-data` with `cache: "no-store"`, so the browser never revalidates with `If-None-Match` — every navigation re-downloads the payload even when unchanged. | **Fixed** (2026-07-28) — `cache: "no-cache"`, see the sitewide-audit section below; the "Rejected" entry below documents why `"default"` was unsafe and why `"no-cache"` is not |
+| Frontend bundle | Analyzed 2026-07-28: NOT the bottleneck. 5 runtime deps, hand-rolled SVG charts, per-page chunks all under budget (`scripts/check-bundle-sizes.mjs`), shared chunk 102 KB. | **Closed (no action)** |
+| Render cost | Rankings table / trade views: audit for unmemoized recompute on sort/filter/scroll. | **Partially fixed** (2026-07-28: `displayRows` memoized; virtualization deliberately deferred — see audit section) |
 
 ## Done
 
@@ -100,6 +100,96 @@ Regression tests (`tests/api/test_league_routing.py`):
 `test_overlay_serialize_single_flights_concurrent_misses`,
 `test_overlay_serialize_cache_invalidates_on_version_change`,
 `test_cross_league_cache_slot_is_reused_across_refreshes`.
+
+## 2026-07-28 sitewide performance audit (the "10-second pages" fix)
+
+Full-stack audit + fix pass targeting the ~10s initial loads and
+page-to-page navigations. Root causes, in impact order, all verified in
+source and by measurement before changing anything:
+
+1. **Every page load ran the full ranking pipeline server-side —
+   twice.** The `/settings` default `tepMultiplier: 1.15` makes every
+   stock user "customized" (`tepMultiplierIsCustomized` treats any
+   finite number as an override), so every `fetchDynastyData` took the
+   override path: `GET` base + `POST /api/rankings/overrides?view=delta`,
+   and the POST rebuilt the whole pipeline synchronously ON the event
+   loop, uncached (~0.75s locally, seconds on prod hardware). The hook
+   mounts twice per page (AppShell + page), doubling all of it.
+   *The default was deliberately NOT changed* — posting 1.15 flat is a
+   different valuation than omitting it (ADR-015 basis curve), so the
+   fix is memoization, not semantics.
+2. **Cold Sleeper overlay rebuild = ~90 sequential HTTP round-trips
+   inline on `/api/data`** whenever the 15-min TTL expired (~7 of 8
+   windows, since the warm-behind only runs on the 2h scrape cadence),
+   with no single-flight — concurrent expirees each launched their own
+   storm.
+3. **Desktop production downloaded the full ~11.8 MB contract.**
+   `preferredDataView()` returned `"delta"` — not a valid GET view — so
+   the param was dropped and the server defaulted to `view=full`.
+4. **Event-loop blockers**: `/api/draft-capital` (~4s of openpyxl + six
+   blocking Sleeper calls per request, ×3 per /draft load),
+   `/api/terminal` + `/api/news` news aggregation evaluated as
+   *arguments* to `run_in_threadpool` (i.e. on the loop) with ~6 RSS
+   providers fetched sequentially, `/api/trade/suggestions` CPU on the
+   loop, `/api/status` disk globs per request, `_prime_latest_payload`
+   freezing the loop for seconds after every scrape.
+5. **No request dedup client-side** and `cache: "no-store"` defeating
+   the backend's working ETag/304 path.
+
+### Caches added (contract per CLAUDE.md's documentation rule)
+
+| Cache | Key | TTL / bound | Invalidation | Stale window | Why appropriate |
+|---|---|---|---|---|---|
+| `server._OVERRIDES_RESPONSE_CACHE` (bytes) | sha1(canonical POST body) + view + league + sleeper_matches | version-keyed (no TTL), 16 slots | `latest_data_etag` mismatch → rebuild in place; cleared by `_prime_latest_payload`; leagueAdjusted bypasses | none — versioned on contract generation | ~every client posts the identical stock body; output is a pure function of (body, contract generation) |
+| client `_cachedBaseContract` + inflight map | (leagueKey, view) | 30s | `_resetBaseContractCache()` on league switch + `auth:changed`; errors never cached | ≤30s — same as the server's `max-age=30` | collapses the double-mounted hook onto one fetch |
+| client merged-override memo + inflight | (POST body, league) pinned to base object identity | 30s | base identity change, key change, reset | ≤30s | same delta for same body+generation |
+| browser HTTP cache (`no-cache`) | URL | revalidate-always | 304 requires passing `_private_api_gate`; 401 after logout | none served without revalidation | unlocks zero-body 304s; see “Rejected” note below for why `"default"` was unsafe and `"no-cache"` is not |
+| `sleeper_overlay._CACHE` (upgraded) | sleeper_league_id | 15 min fresh (unchanged) | `force_refresh`, refresh completion | **15–30 min stale-serve with exactly one background refresher** (operator-approved); >30 min blocks on a single-flighted rebuild | roster/trade context, not valuations; was already 15 min stale by design |
+| `sleeper_overlay._BuildFetcher` | URL, scoped to ONE build | build lifetime | n/a | none — dedupes URLs previously fetched ms apart | trades+waivers read the same 19 weekly feeds; chain/roster lookups ran 2-3× per build |
+| `server._DRAFT_CAPITAL_CACHE` | league key | 300s | `?refresh=1`, scrape promotion, TTL | ≤5 min of pick-ownership data — same freshness class as the overlay | endpoint was ~4s of blocking work per request, ×3 per /draft load |
+| `server._DRAFT_WB_CACHE` (openpyxl workbook) | (path, mtime_ns, size) | none | file replacement | none — keyed on file identity | workbook changes only by deploy/edit |
+| `server._LIVE_CONTRACT_SCAN_MEMO` (names/meta) | `latest_data_etag` | single entry per kind | new contract generation | none | pure projections of the contract |
+| `NewsService._cache` (upgraded) | sha1 of known-names universe (was a ~2,000-string tuple) | **600s (was 180s, operator-approved)**; failure TTL unchanged | TTL | ≤10 min headlines | aggregated RSS rarely updates faster; providers now fetch concurrently so even cold refreshes are ~5s worst-case, not ~30s |
+| `server._DISK_PROBE_MEMO` (status/health probes) | helper name | 30s | TTL only | ≤30s on ages measured in hours | pure observability; polled every 60s from every page |
+
+### Other changes in this pass
+
+* `?view=array` (alias `desktop`): fifth precomputed `/api/data`
+  variant — the full contract minus the LEGACY `players` dict (a
+  parallel encoding of `playersArray`). 11.83 MB → 6.45 MB raw,
+  1.18 MB → 674 KB gzip, and `buildRows(full)` vs `buildRows(array)`
+  is row-for-row IDENTICAL (pinned by `tests/api/test_array_view.py` +
+  a 1,073-row live parity run). Desktop now requests it. `view=app`
+  and `view=compact` were both rejected for desktop: they drop
+  tier/confidence/audit fields that 20+ desktop surfaces render.
+* `_prime_latest_payload` restructured to compute-into-locals +
+  tight-swap publish, and the scrape-completion call site offloads it
+  to the threadpool. Failure now atomically publishes the empty
+  generation.
+* Weekly Sleeper transaction feeds + per-league lookups prefetched in
+  one bounded parallel wave; cold overlay build measured at 51 unique
+  calls (was ~90 with duplicates, fully sequential).
+* Route-level `loading.jsx` for the 12 main routes; preconnect to
+  sleepercdn.com; SW `NEVER_CACHE` now includes `/api/data` +
+  `/api/dynasty-data` (v7 bump); `/rankings` `displayRows` memoized;
+  `useTerminal` gained `skip` and all 8 call sites gate on team
+  resolution (kills the discarded `ownerId:""` duplicate);
+  `/tools/trade-coverage` uses a 4-wide worker pool instead of 12
+  sequential awaits.
+
+### Measured (local prod-topology harness: next build + next start + nginx-standin proxy)
+
+| Metric | Before | After |
+|---|---|---|
+| `POST /api/rankings/overrides` (stock body, warm) | 0.75–0.93s every call | **4ms** (memo hit; 0.73s once per scrape generation) |
+| `/api/data` desktop wire | 11.83 MB raw / 1.18 MB gzip (view=full) | 6.45 MB / 674 KB (view=array), then 304s |
+| `/api/terminal` | 7.8s cold / 20ms warm | 1.4s cold / 20ms warm |
+| `/api/draft-capital` | 3.9–4.1s EVERY request, on the loop | 2.6–3.2s cold (threadpooled) / **5ms** warm |
+| `/trade` page settle | 13.5s (LCP 12.4s) | **1.7s** (LCP 0.7s) |
+| `/draft` page settle | 11.4s | **1.6s** |
+| `/rankings` usable | 6.9s | **1.1s** |
+| `/` LCP | 2.7s | 0.8s |
+| per-page transfer | 2.5–4.9 MB | 2.1–3.4 MB (and ~0 on repeat within 30s) |
 
 ## Rejected (attempted, reverted)
 

--- a/frontend/__tests__/device-profile.test.js
+++ b/frontend/__tests__/device-profile.test.js
@@ -79,9 +79,13 @@ describe("device-profile", () => {
     expect(preferredDataView()).toBe("compact");
   });
 
-  it("preferredDataView → delta on desktop", () => {
+  it("preferredDataView → array on desktop", () => {
+    // "array" = full contract minus the legacy players dict — the
+    // zero-field-loss desktop view.  The old "delta" return was not a
+    // valid GET view and silently fell through to the ~12MB full
+    // payload.
     setWindow({ innerWidth: 1920 });
-    expect(preferredDataView()).toBe("delta");
+    expect(preferredDataView()).toBe("array");
   });
 
   it("preferredDataView → compact on slow network", () => {

--- a/frontend/__tests__/dynasty-data-dedup.test.js
+++ b/frontend/__tests__/dynasty-data-dedup.test.js
@@ -1,0 +1,178 @@
+/**
+ * Request dedup + TTL cache tests for the contract data layer.
+ *
+ * ``useDynastyData`` mounts at least twice per page (AppShell + the
+ * page component), and before these caches existed each mount issued
+ * its own multi-MB ``GET /api/dynasty-data`` and pipeline-rebuilding
+ * ``POST /api/rankings/overrides``.  Pinned here:
+ *
+ *   1. Concurrent default-path fetches share ONE network request.
+ *   2. A second call within the 30s TTL makes ZERO network requests.
+ *   3. TTL expiry triggers a revalidating refetch.
+ *   4. Concurrent override-path fetches share one GET + one POST.
+ *   5. ``_resetBaseContractCache`` drops everything.
+ *   6. The base fetch uses ``cache: "no-cache"`` (revalidate, never
+ *      silently replay) — NOT ``no-store`` (which would kill the 304
+ *      path) and NOT default (which could serve without revalidating).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  fetchDynastyData,
+  _resetBaseContractCache,
+  _resetValuationOverlayCache,
+} from "@/lib/dynasty-data.js";
+
+const BASE_PAYLOAD = {
+  ok: true,
+  source: "backend",
+  data: {
+    playersArray: [
+      {
+        displayName: "Player A",
+        canonicalName: "Player A",
+        position: "QB",
+        team: "AAA",
+        canonicalConsensusRank: 1,
+        rankDerivedValue: 9800,
+        sourceRanks: { ktc: 1 },
+      },
+    ],
+  },
+};
+
+const DELTA_PAYLOAD = {
+  mode: "delta",
+  rankingsOverride: { isCustomized: true },
+  rankingsDelta: {
+    playerKey: "displayName",
+    players: [
+      {
+        id: "Player A",
+        canonicalConsensusRank: 1,
+        rankDerivedValue: 9700,
+        sourceRanks: { ktc: 1 },
+      },
+    ],
+    activePlayerIds: ["Player A"],
+  },
+};
+
+function mockFetchRouting() {
+  return vi.fn(async (url) => {
+    if (String(url).includes("/api/rankings/overrides")) {
+      return { ok: true, json: async () => structuredClone(DELTA_PAYLOAD) };
+    }
+    return { ok: true, json: async () => structuredClone(BASE_PAYLOAD) };
+  });
+}
+
+describe("contract data layer dedup + TTL", () => {
+  const realFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = mockFetchRouting();
+    _resetBaseContractCache();
+    _resetValuationOverlayCache();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("concurrent default-path fetches share one network request", async () => {
+    const [a, b] = await Promise.all([fetchDynastyData(), fetchDynastyData()]);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+  });
+
+  it("a second call within the TTL makes zero network requests", async () => {
+    await fetchDynastyData();
+    await fetchDynastyData();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("TTL expiry triggers a refetch", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-28T12:00:00Z"));
+    await fetchDynastyData();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(new Date("2026-07-28T12:00:31Z"));
+    await fetchDynastyData();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("concurrent override-path fetches share one GET and one POST", async () => {
+    const opts = { tepMultiplier: 1.15 };
+    const [a, b] = await Promise.all([
+      fetchDynastyData(opts),
+      fetchDynastyData(opts),
+    ]);
+    const urls = globalThis.fetch.mock.calls.map(([u]) => String(u));
+    const gets = urls.filter((u) => u.includes("/api/dynasty-data"));
+    const posts = urls.filter((u) => u.includes("/api/rankings/overrides"));
+    expect(gets).toHaveLength(1);
+    expect(posts).toHaveLength(1);
+    expect(a).toBe(b);
+    expect(a.source).toBe("backend:override:delta");
+  });
+
+  it("a repeat override call within the TTL is served from the memo", async () => {
+    const opts = { tepMultiplier: 1.15 };
+    const first = await fetchDynastyData(opts);
+    const second = await fetchDynastyData(opts);
+    expect(second).toBe(first);
+    const posts = globalThis.fetch.mock.calls
+      .map(([u]) => String(u))
+      .filter((u) => u.includes("/api/rankings/overrides"));
+    expect(posts).toHaveLength(1);
+  });
+
+  it("a different override body misses the memo", async () => {
+    await fetchDynastyData({ tepMultiplier: 1.15 });
+    await fetchDynastyData({ tepMultiplier: 1.3 });
+    const posts = globalThis.fetch.mock.calls
+      .map(([u]) => String(u))
+      .filter((u) => u.includes("/api/rankings/overrides"));
+    expect(posts).toHaveLength(2);
+  });
+
+  it("_resetBaseContractCache drops base and merged caches", async () => {
+    await fetchDynastyData({ tepMultiplier: 1.15 });
+    _resetBaseContractCache();
+    await fetchDynastyData({ tepMultiplier: 1.15 });
+    const urls = globalThis.fetch.mock.calls.map(([u]) => String(u));
+    expect(urls.filter((u) => u.includes("/api/dynasty-data"))).toHaveLength(2);
+    expect(
+      urls.filter((u) => u.includes("/api/rankings/overrides")),
+    ).toHaveLength(2);
+  });
+
+  it("failed base fetches are never cached", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        text: async () => "boom",
+      })
+      .mockResolvedValue({
+        ok: true,
+        json: async () => structuredClone(BASE_PAYLOAD),
+      });
+    await expect(fetchDynastyData()).rejects.toThrow(/503/);
+    const result = await fetchDynastyData();
+    expect(result.ok).toBe(true);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("the base fetch revalidates with no-cache, never no-store", async () => {
+    await fetchDynastyData();
+    const [url, opts] = globalThis.fetch.mock.calls[0];
+    expect(String(url)).toMatch(/\/api\/dynasty-data/);
+    expect(opts?.cache).toBe("no-cache");
+  });
+});

--- a/frontend/app/angle/loading.jsx
+++ b/frontend/app/angle/loading.jsx
@@ -1,0 +1,16 @@
+import { SkeletonTable } from "@/components/ds/Skeleton";
+
+/**
+ * Route-level loading UI (/angle).  Rendered by the App Router the
+ * instant a navigation starts, before the route segment's JS chunk
+ * loads and the client page hydrates — the page previously showed
+ * nothing during that window.  Uses the shared token-styled skeleton
+ * so there is no layout shift when real content lands.
+ */
+export default function Loading() {
+  return (
+    <div style={{ padding: "16px" }} aria-busy="true" aria-live="polite">
+      <SkeletonTable rows={10} columns={5} />
+    </div>
+  );
+}

--- a/frontend/app/arbitrage/loading.jsx
+++ b/frontend/app/arbitrage/loading.jsx
@@ -1,0 +1,16 @@
+import { SkeletonTable } from "@/components/ds/Skeleton";
+
+/**
+ * Route-level loading UI (/arbitrage).  Rendered by the App Router the
+ * instant a navigation starts, before the route segment's JS chunk
+ * loads and the client page hydrates — the page previously showed
+ * nothing during that window.  Uses the shared token-styled skeleton
+ * so there is no layout shift when real content lands.
+ */
+export default function Loading() {
+  return (
+    <div style={{ padding: "16px" }} aria-busy="true" aria-live="polite">
+      <SkeletonTable rows={10} columns={5} />
+    </div>
+  );
+}

--- a/frontend/app/draft/loading.jsx
+++ b/frontend/app/draft/loading.jsx
@@ -1,0 +1,16 @@
+import { SkeletonTable } from "@/components/ds/Skeleton";
+
+/**
+ * Route-level loading UI (/draft).  Rendered by the App Router the
+ * instant a navigation starts, before the route segment's JS chunk
+ * loads and the client page hydrates — the page previously showed
+ * nothing during that window.  Uses the shared token-styled skeleton
+ * so there is no layout shift when real content lands.
+ */
+export default function Loading() {
+  return (
+    <div style={{ padding: "16px" }} aria-busy="true" aria-live="polite">
+      <SkeletonTable rows={10} columns={5} />
+    </div>
+  );
+}

--- a/frontend/app/edge/loading.jsx
+++ b/frontend/app/edge/loading.jsx
@@ -1,0 +1,16 @@
+import { SkeletonTable } from "@/components/ds/Skeleton";
+
+/**
+ * Route-level loading UI (/edge).  Rendered by the App Router the
+ * instant a navigation starts, before the route segment's JS chunk
+ * loads and the client page hydrates — the page previously showed
+ * nothing during that window.  Uses the shared token-styled skeleton
+ * so there is no layout shift when real content lands.
+ */
+export default function Loading() {
+  return (
+    <div style={{ padding: "16px" }} aria-busy="true" aria-live="polite">
+      <SkeletonTable rows={10} columns={5} />
+    </div>
+  );
+}

--- a/frontend/app/finder/loading.jsx
+++ b/frontend/app/finder/loading.jsx
@@ -1,0 +1,16 @@
+import { SkeletonTable } from "@/components/ds/Skeleton";
+
+/**
+ * Route-level loading UI (/finder).  Rendered by the App Router the
+ * instant a navigation starts, before the route segment's JS chunk
+ * loads and the client page hydrates — the page previously showed
+ * nothing during that window.  Uses the shared token-styled skeleton
+ * so there is no layout shift when real content lands.
+ */
+export default function Loading() {
+  return (
+    <div style={{ padding: "16px" }} aria-busy="true" aria-live="polite">
+      <SkeletonTable rows={10} columns={5} />
+    </div>
+  );
+}

--- a/frontend/app/layout.jsx
+++ b/frontend/app/layout.jsx
@@ -64,6 +64,16 @@ export const viewport = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
+      <head>
+        {/* Player headshots + team logos come from sleepercdn.com —
+            the one third-party origin.  Warming the connection saves
+            a DNS+TLS round-trip before the first avatar paints. */}
+        <link
+          rel="preconnect"
+          href="https://sleepercdn.com"
+          crossOrigin="anonymous"
+        />
+      </head>
       <body>
         <ServiceWorkerRegistrar />
         <PullToRefresh />

--- a/frontend/app/league/loading.jsx
+++ b/frontend/app/league/loading.jsx
@@ -1,0 +1,16 @@
+import { SkeletonTable } from "@/components/ds/Skeleton";
+
+/**
+ * Route-level loading UI (/league).  Rendered by the App Router the
+ * instant a navigation starts, before the route segment's JS chunk
+ * loads and the client page hydrates — the page previously showed
+ * nothing during that window.  Uses the shared token-styled skeleton
+ * so there is no layout shift when real content lands.
+ */
+export default function Loading() {
+  return (
+    <div style={{ padding: "16px" }} aria-busy="true" aria-live="polite">
+      <SkeletonTable rows={10} columns={5} />
+    </div>
+  );
+}

--- a/frontend/app/news/loading.jsx
+++ b/frontend/app/news/loading.jsx
@@ -1,0 +1,16 @@
+import { SkeletonTable } from "@/components/ds/Skeleton";
+
+/**
+ * Route-level loading UI (/news).  Rendered by the App Router the
+ * instant a navigation starts, before the route segment's JS chunk
+ * loads and the client page hydrates — the page previously showed
+ * nothing during that window.  Uses the shared token-styled skeleton
+ * so there is no layout shift when real content lands.
+ */
+export default function Loading() {
+  return (
+    <div style={{ padding: "16px" }} aria-busy="true" aria-live="polite">
+      <SkeletonTable rows={10} columns={5} />
+    </div>
+  );
+}

--- a/frontend/app/rankings/loading.jsx
+++ b/frontend/app/rankings/loading.jsx
@@ -1,0 +1,16 @@
+import { SkeletonTable } from "@/components/ds/Skeleton";
+
+/**
+ * Route-level loading UI (/rankings).  Rendered by the App Router the
+ * instant a navigation starts, before the route segment's JS chunk
+ * loads and the client page hydrates — the page previously showed
+ * nothing during that window.  Uses the shared token-styled skeleton
+ * so there is no layout shift when real content lands.
+ */
+export default function Loading() {
+  return (
+    <div style={{ padding: "16px" }} aria-busy="true" aria-live="polite">
+      <SkeletonTable rows={10} columns={5} />
+    </div>
+  );
+}

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -629,14 +629,22 @@ export default function RankingsPage() {
     };
   }, [ranked]);
 
-  // Apply row limit — search/filter bypasses the limit
-  const hasActiveFilter =
+  // Apply row limit — search/filter bypasses the limit.  Memoized:
+  // this slice runs on every render of a 1,800-line page, and when a
+  // filter is active `displayRows` is the FULL board (~1.1k rows), so
+  // a fresh array identity per render forced the whole table to
+  // reconcile even when nothing changed.
+  const hasActiveFilter = Boolean(
     query ||
-    posFilter !== "all" ||
-    confFilter !== "all" ||
-    activeLens !== "consensus" ||
-    advActiveCount > 0;
-  const displayRows = hasActiveFilter ? ranked : ranked.slice(0, rowLimit);
+      posFilter !== "all" ||
+      confFilter !== "all" ||
+      activeLens !== "consensus" ||
+      advActiveCount > 0,
+  );
+  const displayRows = useMemo(
+    () => (hasActiveFilter ? ranked : ranked.slice(0, rowLimit)),
+    [hasActiveFilter, ranked, rowLimit],
+  );
   const hasMore = !hasActiveFilter && ranked.length > rowLimit;
 
   // Per-position ranks (QB3, RB5, LB2…) — computed from the eligible

--- a/frontend/app/rosters/loading.jsx
+++ b/frontend/app/rosters/loading.jsx
@@ -1,0 +1,16 @@
+import { SkeletonTable } from "@/components/ds/Skeleton";
+
+/**
+ * Route-level loading UI (/rosters).  Rendered by the App Router the
+ * instant a navigation starts, before the route segment's JS chunk
+ * loads and the client page hydrates — the page previously showed
+ * nothing during that window.  Uses the shared token-styled skeleton
+ * so there is no layout shift when real content lands.
+ */
+export default function Loading() {
+  return (
+    <div style={{ padding: "16px" }} aria-busy="true" aria-live="polite">
+      <SkeletonTable rows={10} columns={5} />
+    </div>
+  );
+}

--- a/frontend/app/tools/trade-coverage/page.jsx
+++ b/frontend/app/tools/trade-coverage/page.jsx
@@ -54,29 +54,42 @@ export default function TradeCoveragePage() {
 
     async function run() {
       setProgress({ done: 0, total: availableTeams.length });
-      for (const team of availableTeams) {
-        if (cancelled) return;
-        const ownerId = String(team.ownerId || "");
-        if (!ownerId) continue;
-        try {
-          const payload = await fetchTerminalFor(ownerId, 180);
-          if (payload?.authenticated === false) {
-            setAuthOk(false);
+      // Bounded-concurrency pool (was a fully sequential await loop:
+      // 12 teams × ~3s of /api/terminal each = ~40s to settle).
+      // Per-team state is keyed by ownerId, so completion order is
+      // irrelevant; 4 in flight keeps the single-process backend
+      // responsive for other requests.
+      const queue = availableTeams
+        .map((team) => ({ team, ownerId: String(team.ownerId || "") }))
+        .filter((entry) => entry.ownerId);
+      const CONCURRENCY = 4;
+      async function worker() {
+        while (queue.length > 0) {
+          if (cancelled) return;
+          const { team, ownerId } = queue.shift();
+          try {
+            const payload = await fetchTerminalFor(ownerId, 180);
+            if (payload?.authenticated === false) {
+              setAuthOk(false);
+            }
+            if (cancelled) return;
+            setPerTeam((prev) => ({
+              ...prev,
+              [ownerId]: { team, payload, error: null },
+            }));
+          } catch (err) {
+            if (cancelled) return;
+            setPerTeam((prev) => ({
+              ...prev,
+              [ownerId]: { team, payload: null, error: err?.message || "fetch_failed" },
+            }));
           }
-          if (cancelled) return;
-          setPerTeam((prev) => ({
-            ...prev,
-            [ownerId]: { team, payload, error: null },
-          }));
-        } catch (err) {
-          if (cancelled) return;
-          setPerTeam((prev) => ({
-            ...prev,
-            [ownerId]: { team, payload: null, error: err?.message || "fetch_failed" },
-          }));
+          setProgress((p) => ({ ...p, done: p.done + 1 }));
         }
-        setProgress((p) => ({ ...p, done: p.done + 1 }));
       }
+      await Promise.all(
+        Array.from({ length: Math.min(CONCURRENCY, queue.length) }, worker),
+      );
     }
     run();
     return () => {

--- a/frontend/app/trade/loading.jsx
+++ b/frontend/app/trade/loading.jsx
@@ -1,0 +1,16 @@
+import { SkeletonTable } from "@/components/ds/Skeleton";
+
+/**
+ * Route-level loading UI (/trade).  Rendered by the App Router the
+ * instant a navigation starts, before the route segment's JS chunk
+ * loads and the client page hydrates — the page previously showed
+ * nothing during that window.  Uses the shared token-styled skeleton
+ * so there is no layout shift when real content lands.
+ */
+export default function Loading() {
+  return (
+    <div style={{ padding: "16px" }} aria-busy="true" aria-live="polite">
+      <SkeletonTable rows={10} columns={5} />
+    </div>
+  );
+}

--- a/frontend/app/trades/loading.jsx
+++ b/frontend/app/trades/loading.jsx
@@ -1,0 +1,16 @@
+import { SkeletonTable } from "@/components/ds/Skeleton";
+
+/**
+ * Route-level loading UI (/trades).  Rendered by the App Router the
+ * instant a navigation starts, before the route segment's JS chunk
+ * loads and the client page hydrates — the page previously showed
+ * nothing during that window.  Uses the shared token-styled skeleton
+ * so there is no layout shift when real content lands.
+ */
+export default function Loading() {
+  return (
+    <div style={{ padding: "16px" }} aria-busy="true" aria-live="polite">
+      <SkeletonTable rows={10} columns={5} />
+    </div>
+  );
+}

--- a/frontend/app/waivers/loading.jsx
+++ b/frontend/app/waivers/loading.jsx
@@ -1,0 +1,16 @@
+import { SkeletonTable } from "@/components/ds/Skeleton";
+
+/**
+ * Route-level loading UI (/waivers).  Rendered by the App Router the
+ * instant a navigation starts, before the route segment's JS chunk
+ * loads and the client page hydrates — the page previously showed
+ * nothing during that window.  Uses the shared token-styled skeleton
+ * so there is no layout shift when real content lands.
+ */
+export default function Loading() {
+  return (
+    <div style={{ padding: "16px" }} aria-busy="true" aria-live="polite">
+      <SkeletonTable rows={10} columns={5} />
+    </div>
+  );
+}

--- a/frontend/components/PlayerPopup.jsx
+++ b/frontend/components/PlayerPopup.jsx
@@ -754,8 +754,11 @@ export default function PlayerPopup({ row, siteKeys = [], onClose, onAddToTrade 
   // Injury impact lookup from the server-side signals block.
   // Only populated for roster players today — non-roster players
   // won't have impact data, and the chip simply doesn't render.
-  const { selectedTeam } = useTeam();
+  const { selectedTeam, loading: teamLoading } = useTeam();
   const { signals: serverSignals } = useTerminal({
+    // Hold the fetch until team identity resolves from the contract
+    // (prevents the discarded ownerId:"" duplicate call).
+    skip: teamLoading,
     ownerId: String(selectedTeam?.ownerId || ""),
     teamName: selectedTeam?.name || "",
     windowDays: 30,

--- a/frontend/components/terminal/BuySellHold.jsx
+++ b/frontend/components/terminal/BuySellHold.jsx
@@ -39,7 +39,7 @@ const DEFAULT_FILTERS = new Set([SIGNALS.RISK, SIGNALS.SELL, SIGNALS.MONITOR, SI
 
 export default function BuySellHold() {
   const { rows, rawData, openPlayerPopup } = useApp();
-  const { selectedTeam, selectedLeagueKey } = useTeam();  const { history, loading: historyLoading } = useRankHistory({ days: 30 });
+  const { selectedTeam, selectedLeagueKey, loading: teamLoading } = useTeam();  const { history, loading: historyLoading } = useRankHistory({ days: 30 });
   const {
     state: userState,
     dismissSignal,
@@ -52,6 +52,9 @@ export default function BuySellHold() {
   // local verdicts below so every card renders the injury chip
   // when applicable.
   const { signals: serverSignals } = useTerminal({
+    // Hold the fetch until team identity resolves from the contract
+    // (prevents the discarded ownerId:"" duplicate call).
+    skip: teamLoading,
     ownerId: String(selectedTeam?.ownerId || ""),
     teamName: selectedTeam?.name || "",
     windowDays: 30,

--- a/frontend/components/terminal/PortfolioSummary.jsx
+++ b/frontend/components/terminal/PortfolioSummary.jsx
@@ -49,7 +49,7 @@ function formatPct(v) {
  */
 export default function PortfolioSummary() {
   const { rows, rawData, openPlayerPopup } = useApp();
-  const { selectedTeam, idpEnabled } = useTeam();
+  const { selectedTeam, idpEnabled, loading: teamLoading } = useTeam();
   // IDP gating: skip the IDP positional bucket (and any IDP rows in
   // the positional stack) for leagues that don't support IDP.  The
   // portfolio computation still runs globally on the contract; we
@@ -69,6 +69,9 @@ export default function PortfolioSummary() {
   // the same backend-stamped row values but does the grouping in
   // the browser.
   const { portfolio: serverPortfolio } = useTerminal({
+    // Hold the fetch until team identity resolves from the contract
+    // (prevents the discarded ownerId:"" duplicate call).
+    skip: teamLoading,
     ownerId: String(selectedTeam?.ownerId || ""),
     teamName: selectedTeam?.name || "",
     windowDays: 30,

--- a/frontend/components/terminal/ScoutingIntel.jsx
+++ b/frontend/components/terminal/ScoutingIntel.jsx
@@ -43,7 +43,7 @@ function formatValue(v) {
  */
 export default function ScoutingIntel() {
   const { rows, rawData, openPlayerPopup } = useApp();
-  const { selectedTeam } = useTeam();
+  const { selectedTeam, loading: teamLoading } = useTeam();
   const { history, loading: historyLoading } = useRankHistory({ days: 30 });
 
   const sleeperTeams = rawData?.sleeper?.teams;
@@ -67,6 +67,9 @@ export default function ScoutingIntel() {
   // ``computePortfolio`` + ``computeInsights`` below so the panel
   // never renders a blank state waiting on the network.
   const { portfolio: serverPortfolio } = useTerminal({
+    // Hold the fetch until team identity resolves from the contract
+    // (prevents the discarded ownerId:"" duplicate call).
+    skip: teamLoading,
     ownerId: String(selectedTeam?.ownerId || ""),
     teamName: selectedTeam?.name || "",
     windowDays: 30,

--- a/frontend/components/terminal/StaleBanner.jsx
+++ b/frontend/components/terminal/StaleBanner.jsx
@@ -22,8 +22,11 @@ import { Banner } from "@/components/ds";
  * numerical drift against the current scrape as meaningful.
  */
 export default function StaleBanner() {
-  const { selectedTeam } = useTeam();
+  const { selectedTeam, loading: teamLoading } = useTeam();
   const { stale, staleAs, loading, error } = useTerminal({
+    // Hold the fetch until team identity resolves from the contract
+    // (prevents the discarded ownerId:"" duplicate call).
+    skip: teamLoading,
     ownerId: String(selectedTeam?.ownerId || ""),
     teamName: selectedTeam?.name || "",
     windowDays: 30,

--- a/frontend/components/terminal/TeamCommandHeader.jsx
+++ b/frontend/components/terminal/TeamCommandHeader.jsx
@@ -111,6 +111,9 @@ export default function TeamCommandHeader() {
   const { selectedLeague, leagues } = useLeague();
   const { history, loading: historyLoading } = useRankHistory({ days: 30 });
   const { teamAggregates: serverAggregates, loading: terminalLoading } = useTerminal({
+    // Hold the fetch until team identity resolves from the contract
+    // (prevents the discarded ownerId:"" duplicate call).
+    skip: teamLoading,
     ownerId: String(selectedTeam?.ownerId || ""),
     teamName: selectedTeam?.name || "",
     windowDays: 30,

--- a/frontend/components/terminal/TerminalLayout.jsx
+++ b/frontend/components/terminal/TerminalLayout.jsx
@@ -48,10 +48,13 @@ import styles from "./terminal.module.css";
  * but the big aggregates come from that one network call.
  */
 export default function TerminalLayout() {
-  const { selectedTeam } = useTeam();
+  const { selectedTeam, loading: teamLoading } = useTeam();
   // Prime the cache — the return value is intentionally unused; each
   // panel re-calls the hook with the same key.
   useTerminal({
+    // Hold the fetch until team identity resolves from the contract
+    // (prevents the discarded ownerId:"" duplicate call).
+    skip: teamLoading,
     ownerId: String(selectedTeam?.ownerId || ""),
     teamName: selectedTeam?.name || "",
     windowDays: 30,

--- a/frontend/components/terminal/WatchlistPanel.jsx
+++ b/frontend/components/terminal/WatchlistPanel.jsx
@@ -30,9 +30,12 @@ import styles from "./terminal.module.css";
  */
 export default function WatchlistPanel() {
   const { openPlayerPopup } = useApp();
-  const { selectedTeam } = useTeam();
+  const { selectedTeam, loading: teamLoading } = useTeam();
   const { state: userState, toggleWatchlist, serverBacked } = useUserState();
   const { watchlist: serverWatchlist = [] } = useTerminal({
+    // Hold the fetch until team identity resolves from the contract
+    // (prevents the discarded ownerId:"" duplicate call).
+    skip: teamLoading,
     ownerId: String(selectedTeam?.ownerId || ""),
     teamName: selectedTeam?.name || "",
     windowDays: 30,

--- a/frontend/components/useTerminal.js
+++ b/frontend/components/useTerminal.js
@@ -107,7 +107,7 @@ export function invalidateTerminalCache() {
  * widen to 7/30/90/180 via the window selector in the Team Command
  * Header.
  */
-export function useTerminal({ ownerId = "", teamName = "", windowDays = 30 } = {}) {
+export function useTerminal({ ownerId = "", teamName = "", windowDays = 30, skip = false } = {}) {
   const [state, setState] = useState({
     loading: true,
     error: null,
@@ -143,6 +143,12 @@ export function useTerminal({ ownerId = "", teamName = "", windowDays = 30 } = {
   }, []);
 
   useEffect(() => {
+    // ``skip`` (team identity still resolving from the contract):
+    // stay in the loading state without fetching.  Before this gate,
+    // every terminal surface fired an ``ownerId: ""`` fetch while the
+    // contract loaded and a second fetch once the team resolved —
+    // two /api/terminal builds per page view, one of them discarded.
+    if (skip) return undefined;
     const controller = new AbortController();
     setState((prev) => ({ ...prev, loading: true, error: null }));
     fetchTerminal({ ownerId, name: teamName, windowDays, signal: controller.signal })
@@ -160,7 +166,7 @@ export function useTerminal({ ownerId = "", teamName = "", windowDays = 30 } = {
         });
       });
     return () => controller.abort();
-  }, [ownerId, teamName, windowDays, leagueRefreshKey, valuationMode]);
+  }, [ownerId, teamName, windowDays, leagueRefreshKey, valuationMode, skip]);
 
   const value = useMemo(() => {
     const p = state.payload || {};

--- a/frontend/lib/device-profile.js
+++ b/frontend/lib/device-profile.js
@@ -79,14 +79,30 @@ export function adjustedPollingMs(baseMs, { when = "foreground" } = {}) {
 }
 
 /**
- * Append `view=compact` to /api/data URLs on mobile so the
- * frontend gets the ~500KB pruned view instead of ~4MB full.
- * The frontend materializer ignores missing audit fields
- * gracefully (shape test pins the contract).
+ * Which `/api/data` view the contract fetch should request.
+ *
+ *   Mobile / slow network → "compact" (prunes ~20 audit fields the
+ *   mobile UI never renders; materializer tolerates their absence).
+ *   Desktop → "array" (full contract minus the LEGACY `players` dict,
+ *   which is a parallel encoding of `playersArray` — the branch
+ *   `buildRows` prefers whenever present).  Identical board, identical
+ *   audit fields, roughly half the bytes and half the client-side
+ *   JSON.parse work vs the full view (~5.9MB vs ~11.8MB uncompressed).
+ *
+ * Desktop deliberately does NOT use "app"/"runtime" (drops
+ * `playersArray`, losing tier ids, confidence, and the audit fields
+ * 20+ desktop surfaces render) or "compact" (prunes audit fields the
+ * desktop rankings board and PlayerPopup show).  Row-parity against
+ * the full view is pinned by `tests/api/test_array_view.py`.
+ *
+ * Historical note: this used to return "delta" for desktop, which is
+ * NOT a valid `GET /api/data` view — the caller dropped it and the
+ * request went out with no view param at all, silently serving the
+ * full ~11.8MB payload to every desktop browser.
  */
 export function preferredDataView() {
   if (isMobileProfile() || isSlowNetwork()) {
     return "compact";
   }
-  return "delta";  // existing default
+  return "array";
 }

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -1386,17 +1386,42 @@ const RANKINGS_OVERRIDES_URL = "/api/rankings/overrides";
 const DEFAULT_DATA_URL = "/api/dynasty-data";
 
 // ── Base contract cache ──────────────────────────────────────────────
-// The rankings-override delta path needs a base payload to merge the
-// delta onto.  We keep the last successfully loaded full contract in
-// module-level state so the second call with overrides does not have
-// to refetch the 2.5MB base payload.
+// The multi-MB base contract is fetched by every ``useDynastyData``
+// mount — and the hook mounts at least twice per page (AppShell + the
+// page itself), with more mounts on league/auth events.  This block
+// collapses all of that onto one network fetch:
+//
+//   * ``_cachedBaseContract`` — last successful payload.  Cache key is
+//     ``(leagueKey, view)``; TTL is ``_BASE_CONTRACT_TTL_MS`` (30s,
+//     matching the server's ``Cache-Control: max-age=30`` — the client
+//     never holds data longer than the HTTP layer already permits).
+//     After the TTL the refetch goes out with ``cache: "no-cache"``,
+//     so an unchanged contract revalidates to a 304 instead of a
+//     multi-MB re-download.
+//   * ``_inflightBaseContract`` — in-flight promise, so concurrent
+//     mounts share one request instead of racing duplicates.
+//   * Invalidation: ``_resetBaseContractCache()`` (league switch via
+//     ``useLeague``, tests) and the module-scope ``auth:changed``
+//     listener below.  Errors are never cached.
 //
 // NOTE: rankings are scoped by scoring profile (see CLAUDE.md).  When
 // two leagues share a profile they share this cached contract.  We
 // still pass ``leagueKey`` on the wire so the server can stamp the
 // response with the right league's ``sleeper`` block (or null it
 // when the specific league's roster data isn't loaded yet).
+const _BASE_CONTRACT_TTL_MS = 30_000;
 let _cachedBaseContract = null;
+let _cachedBaseContractKey = "";
+let _cachedBaseContractAt = 0;
+let _inflightBaseContract = null; // { key, promise }
+
+// Memo of the final merged override result (base + delta).  Keyed on
+// the POST body + league + the base contract's object identity, so a
+// new base generation (or league switch) invalidates it naturally.
+// Same 30s TTL as the base cache.  Collapses the duplicate
+// ``POST /api/rankings/overrides`` fired by the double-mounted hook.
+let _cachedOverrideResult = null; // { key, base, at, value }
+let _inflightOverrideResult = null; // { key, base, promise }
 
 // Key to read the active league from localStorage — written by
 // ``useLeague`` whenever the user switches leagues.  We can't
@@ -1414,9 +1439,24 @@ function _readActiveLeagueKey() {
   }
 }
 
-/** Clear the in-memory base contract cache.  Useful for tests. */
+/** Clear every in-memory contract cache (base, merged override
+ * result, in-flight markers).  Called on league switch (``useLeague``),
+ * on ``auth:changed``, and from tests. */
 export function _resetBaseContractCache() {
   _cachedBaseContract = null;
+  _cachedBaseContractKey = "";
+  _cachedBaseContractAt = 0;
+  _inflightBaseContract = null;
+  _cachedOverrideResult = null;
+  _inflightOverrideResult = null;
+}
+
+// Login/logout must drop cached private payloads immediately — the
+// TTL alone would let a just-logged-out session keep rendering them.
+// (League switches already call ``_resetBaseContractCache`` directly
+// via ``useLeague``.)
+if (typeof window !== "undefined") {
+  window.addEventListener("auth:changed", _resetBaseContractCache);
 }
 
 async function _fetchBaseContract() {
@@ -1431,6 +1471,29 @@ async function _fetchBaseContract() {
   } catch {
     // device-profile is advisory only; absence just keeps old default.
   }
+  const cacheKey = `${leagueKey}|${view || ""}`;
+  if (
+    _cachedBaseContract &&
+    _cachedBaseContractKey === cacheKey &&
+    Date.now() - _cachedBaseContractAt < _BASE_CONTRACT_TTL_MS
+  ) {
+    return _cachedBaseContract;
+  }
+  if (_inflightBaseContract && _inflightBaseContract.key === cacheKey) {
+    return _inflightBaseContract.promise;
+  }
+  const promise = _fetchBaseContractNetwork(leagueKey, view, cacheKey);
+  _inflightBaseContract = { key: cacheKey, promise };
+  try {
+    return await promise;
+  } finally {
+    if (_inflightBaseContract && _inflightBaseContract.promise === promise) {
+      _inflightBaseContract = null;
+    }
+  }
+}
+
+async function _fetchBaseContractNetwork(leagueKey, view, cacheKey) {
   // Append leagueKey so the server can stamp ``meta.leagueKey`` and
   // ``meta.sleeperDataReady`` correctly on the response.  When the
   // active league shares the scoring profile with the loaded
@@ -1442,14 +1505,17 @@ async function _fetchBaseContract() {
   if (view && view !== "delta") params.set("view", view);
   const qs = params.toString();
   const url = qs ? `${DEFAULT_DATA_URL}?${qs}` : DEFAULT_DATA_URL;
-  // ``no-store`` is deliberate and must stay until the response is
-  // auth-scoped.  This contract is private (``_private_api_gate``) but
-  // is served with ``Cache-Control: public, max-age=30,
-  // stale-while-revalidate=300``; letting the browser HTTP cache hold it
-  // would allow an authenticated payload to be replayed after logout, or
-  // to the next account on a shared browser, without ever revalidating
-  // against the gate.
-  const res = await fetch(url, { cache: "no-store" });
+  // ``no-cache`` (not ``no-store``): the browser may STORE the response
+  // but must REVALIDATE before every reuse.  The backend serves this
+  // contract with ``Cache-Control: private, max-age=30,
+  // stale-while-revalidate=300`` plus an ``ETag``, and the
+  // ``_private_api_gate`` middleware 401s unauthenticated requests
+  // before any 304 can be minted — so after logout the revalidation
+  // fails and the cached payload is never replayed.  What ``no-cache``
+  // buys over ``no-store``: an unchanged contract answers with a
+  // zero-body 304 instead of a multi-MB re-download on every
+  // navigation past the in-memory TTL.
+  const res = await fetch(url, { cache: "no-cache" });
   if (!res.ok) {
     const txt = await res.text();
     throw new Error(`Failed to load dynasty data: ${res.status} ${txt}`);
@@ -1479,6 +1545,8 @@ async function _fetchBaseContract() {
   }
   if (wrapped && wrapped.data) {
     _cachedBaseContract = wrapped;
+    _cachedBaseContractKey = cacheKey;
+    _cachedBaseContractAt = Date.now();
   }
   return wrapped;
 }
@@ -1730,13 +1798,28 @@ export function mergeRankingsDelta(baseContract, delta) {
 // League-scoped, unlike ``_cachedBaseContract`` which is
 // scoring-profile-scoped. Reset together on a league switch.
 let _cachedValuationOverlay = null;
+let _inflightValuationOverlay = null;
 
 export function _resetValuationOverlayCache() {
   _cachedValuationOverlay = null;
+  _inflightValuationOverlay = null;
 }
 
 async function _fetchValuationOverlay() {
   if (_cachedValuationOverlay) return _cachedValuationOverlay;
+  if (_inflightValuationOverlay) return _inflightValuationOverlay;
+  const promise = _fetchValuationOverlayNetwork();
+  _inflightValuationOverlay = promise;
+  try {
+    return await promise;
+  } finally {
+    if (_inflightValuationOverlay === promise) {
+      _inflightValuationOverlay = null;
+    }
+  }
+}
+
+async function _fetchValuationOverlayNetwork() {
   try {
     const leagueKey = _readActiveLeagueKey();
     const qs = leagueKey ? `?leagueKey=${encodeURIComponent(leagueKey)}` : "";
@@ -1953,7 +2036,7 @@ export async function fetchDynastyData(opts = {}) {
   // cached base contract.  The backend bakes TEP into every TE's
   // rankDerivedValue stamp before producing the delta, so the
   // frontend never needs to multiply on render.
-  const base = _cachedBaseContract || (await _fetchBaseContract());
+  const base = await _fetchBaseContract();
 
   // Build the POST body: start from the siteOverrides map (legacy
   // shape) and stamp the tep_multiplier field on top only when the
@@ -1977,6 +2060,41 @@ export async function fetchDynastyData(opts = {}) {
     body.valuation_mode = "leagueAdjusted";
   }
 
+  // Merged-result memo: the double-mounted hook fires two identical
+  // override requests per page; serve the second from memory.  Key =
+  // POST body + active league; validity additionally requires the SAME
+  // base contract object (a new base generation or league switch
+  // yields a different reference) and the shared 30s TTL.  Only
+  // successful merges are cached — a fallback-to-base result must stay
+  // retryable.
+  const overrideKey = `${JSON.stringify(body)}|${_readActiveLeagueKey()}`;
+  if (
+    _cachedOverrideResult &&
+    _cachedOverrideResult.key === overrideKey &&
+    _cachedOverrideResult.base === base &&
+    Date.now() - _cachedOverrideResult.at < _BASE_CONTRACT_TTL_MS
+  ) {
+    return _cachedOverrideResult.value;
+  }
+  if (
+    _inflightOverrideResult &&
+    _inflightOverrideResult.key === overrideKey &&
+    _inflightOverrideResult.base === base
+  ) {
+    return _inflightOverrideResult.promise;
+  }
+  const promise = _postOverridesAndMerge(base, body, overrideKey);
+  _inflightOverrideResult = { key: overrideKey, base, promise };
+  try {
+    return await promise;
+  } finally {
+    if (_inflightOverrideResult && _inflightOverrideResult.promise === promise) {
+      _inflightOverrideResult = null;
+    }
+  }
+}
+
+async function _postOverridesAndMerge(base, body, overrideKey) {
   try {
     const overrideRes = await fetch(`${RANKINGS_OVERRIDES_URL}?view=delta`, {
       method: "POST",
@@ -1991,16 +2109,30 @@ export async function fetchDynastyData(opts = {}) {
         deltaPayload.mode === "delta" &&
         deltaPayload.rankingsDelta
       ) {
-        return mergeRankingsDelta(base, deltaPayload);
+        const merged = mergeRankingsDelta(base, deltaPayload);
+        _cachedOverrideResult = {
+          key: overrideKey,
+          base,
+          at: Date.now(),
+          value: merged,
+        };
+        return merged;
       }
       // Full-contract fallback: the backend may have returned a full
       // payload (e.g. proxy stripped view=delta).  Pass through.
       if (deltaPayload && (deltaPayload.players || deltaPayload.playersArray)) {
-        return {
+        const passthrough = {
           ok: true,
           source: "backend:override",
           data: deltaPayload,
         };
+        _cachedOverrideResult = {
+          key: overrideKey,
+          base,
+          at: Date.now(),
+          value: passthrough,
+        };
+        return passthrough;
       }
     } else if (typeof console !== "undefined" && console.warn) {
       console.warn(

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -53,7 +53,10 @@
 // v3: push + notificationclick handlers added.  Cache layout is
 // otherwise unchanged; the bump just forces an SW activation cycle so
 // existing tabs pick up the new event listeners.
-const CACHE_VERSION = "chaseupside-v6";
+// v7: /api/data + /api/dynasty-data added to NEVER_CACHE (stop the
+// per-navigation multi-MB cache.put of the private contract).  Bump
+// evicts runtime caches that may still hold contract payloads.
+const CACHE_VERSION = "chaseupside-v7";
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const RUNTIME_CACHE = `${CACHE_VERSION}-runtime`;
 const PUBLIC_LEAGUE_CACHE = `${CACHE_VERSION}-public-league`;
@@ -72,6 +75,13 @@ const NEVER_CACHE = [
   "/api/trade/simulate",
   "/api/signal-alerts/",
   "/api/rankings/overrides",
+  // The multi-MB private contract: networkFirst wrote it to
+  // CacheStorage on EVERY navigation but only ever read it back when
+  // offline — pure write cost per page load, plus private data at
+  // rest.  The in-memory data layer + HTTP ETag revalidation own this
+  // payload's caching now.
+  "/api/data",
+  "/api/dynasty-data",
 ];
 
 function isNeverCache(url) {

--- a/server.py
+++ b/server.py
@@ -312,6 +312,16 @@ latest_startup_data: dict | None = None
 latest_startup_data_bytes: bytes | None = None
 latest_startup_data_gzip_bytes: bytes | None = None
 latest_startup_data_etag: str | None = None
+# Array payload: full contract minus the LEGACY ``players`` dict.  The
+# dict and ``playersArray`` are parallel encodings of the same players
+# (~5.8MB + ~6.6MB of a ~12MB payload); ``playersArray`` is the richer
+# one and the only one the frontend materializer reads when present, so
+# desktop clients request this view and cut the wire/parse cost roughly
+# in half with zero field loss.
+latest_array_data: dict | None = None
+latest_array_data_bytes: bytes | None = None
+latest_array_data_gzip_bytes: bytes | None = None
+latest_array_data_etag: str | None = None
 # Compact payload for mobile / slow networks (~90% smaller).  Precomputed
 # (bytes + gzip + etag) at refresh time so the ``?view=compact`` fast path
 # never re-runs ``compact_contract`` + ``json.dumps`` + gzip on the event
@@ -1677,6 +1687,11 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
         latest_startup_data_gzip_bytes, \
         latest_startup_data_etag
     global \
+        latest_array_data, \
+        latest_array_data_bytes, \
+        latest_array_data_gzip_bytes, \
+        latest_array_data_etag
+    global \
         latest_compact_data, \
         latest_compact_data_bytes, \
         latest_compact_data_gzip_bytes, \
@@ -1696,6 +1711,10 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
     latest_startup_data_bytes = None
     latest_startup_data_gzip_bytes = None
     latest_startup_data_etag = None
+    latest_array_data = None
+    latest_array_data_bytes = None
+    latest_array_data_gzip_bytes = None
+    latest_array_data_etag = None
     latest_compact_data = None
     latest_compact_data_bytes = None
     latest_compact_data_gzip_bytes = None
@@ -1825,6 +1844,24 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
         latest_runtime_data_bytes = runtime_raw
         latest_runtime_data_gzip_bytes = gzip.compress(runtime_raw, compresslevel=5)
         latest_runtime_data_etag = hashlib.sha1(runtime_raw).hexdigest()
+
+        # Array payload: full contract minus the LEGACY ``players`` dict.
+        # ``playersArray`` and the dict are parallel encodings; the array
+        # is strictly richer (the dict's fields are underscore-mirrors +
+        # flat per-source values the array carries in structured form)
+        # and it is the branch ``buildRows`` prefers whenever present.
+        # Desktop clients request ``?view=array`` and get the identical
+        # board at roughly half the bytes/parse cost of the full view.
+        array_payload = dict(contract_payload)
+        array_payload.pop("players", None)
+        array_payload["payloadView"] = "array"
+        array_raw = json.dumps(array_payload, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        latest_array_data = array_payload
+        latest_array_data_bytes = array_raw
+        latest_array_data_gzip_bytes = gzip.compress(array_raw, compresslevel=5)
+        latest_array_data_etag = hashlib.sha1(array_raw).hexdigest()
 
         # Startup payload: same contract shape, but strips heavyweight fields
         # not needed for first screen render so first data-visible is faster.
@@ -2905,6 +2942,7 @@ async def get_data(request: Request):
         view = (request.query_params.get("view") or "").strip().lower()
         startup_view = view in {"startup", "boot", "initial"}
         runtime_view = view in {"app", "runtime", "lite"}
+        array_view = view in {"array", "desktop"}
         compact_view = view in {"compact", "slim"}
 
         payload_bytes = latest_data_bytes
@@ -2925,6 +2963,15 @@ async def get_data(request: Request):
             payload_etag = latest_runtime_data_etag
             payload_obj = latest_runtime_data
             payload_view_name = "runtime"
+        elif array_view and latest_array_data is not None:
+            # Desktop view: full contract minus the legacy ``players``
+            # dict (a parallel encoding of ``playersArray``).  Identical
+            # board, identical audit fields, ~half the bytes.
+            payload_bytes = latest_array_data_bytes
+            payload_gzip_bytes = latest_array_data_gzip_bytes
+            payload_etag = latest_array_data_etag
+            payload_obj = latest_array_data
+            payload_view_name = "array"
         elif compact_view and latest_contract_data is not None:
             # Mobile / slow-network view — prune ~20 audit + trust
             # fields.  ~90% byte reduction.  Additive: a frontend

--- a/server.py
+++ b/server.py
@@ -339,6 +339,22 @@ _OVERLAY_RESPONSE_CACHE: dict = {}
 # dict needs no extra synchronization.
 _OVERLAY_ENCODE_LOCKS: dict = {}
 _OVERLAY_RESPONSE_CACHE_MAX = 32
+# ``POST /api/rankings/overrides`` response memo.  Nearly every client
+# posts the identical stock body ({"tep_multiplier": 1.15} — the
+# /settings default), so one cached entry serves the whole user base
+# between scrapes.  Same shape as the overlay cache above:
+# ``key -> (raw_bytes, gzip_bytes, version)`` where ``version`` is the
+# ``latest_data_etag`` generation the entry was built from.  Key =
+# (canonical body JSON hash, delta_view, league key, sleeper_matches) —
+# everything that can alter the response body.  Entries whose version
+# no longer matches are rebuilt in place (one generation per slot);
+# ``_prime_latest_payload`` clears the dict outright on scrape
+# promotion.  The leagueAdjusted path is deliberately NOT cached (its
+# factors come from the gameplan module with its own freshness) but
+# still builds off the event loop.
+_OVERRIDES_RESPONSE_CACHE: dict = {}
+_OVERRIDES_ENCODE_LOCKS: dict = {}
+_OVERRIDES_RESPONSE_CACHE_MAX = 16
 latest_data_source: dict = {
     "type": "",
     "path": "",
@@ -1684,6 +1700,10 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
     latest_compact_data_bytes = None
     latest_compact_data_gzip_bytes = None
     latest_compact_data_etag = None
+    # A new contract generation invalidates every memoized overrides
+    # response (they are versioned on ``latest_data_etag``, but clearing
+    # eagerly also frees the multi-MB byte payloads immediately).
+    _OVERRIDES_RESPONSE_CACHE.clear()
     if not data:
         return
     try:
@@ -2801,6 +2821,28 @@ async def _serialize_overlaid_response(request, scrubbed, headers, cache_key, ov
     return Response(content=raw, media_type="application/json", headers=headers)
 
 
+def _overrides_encode_lock(cache_key) -> asyncio.Lock:
+    """Per-key single-flight lock for the overrides response memo."""
+    lock = _OVERRIDES_ENCODE_LOCKS.get(cache_key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _OVERRIDES_ENCODE_LOCKS[cache_key] = lock
+    return lock
+
+
+def _evict_overrides_cache_if_oversized(keep_key) -> None:
+    """Bound the overrides memo.  Key space is normally tiny (one stock
+    body × active leagues); the cap only guards against a client
+    spraying distinct bodies.  Held locks are preserved for the same
+    reason as ``_evict_overlay_cache_if_oversized``."""
+    if len(_OVERRIDES_RESPONSE_CACHE) < _OVERRIDES_RESPONSE_CACHE_MAX:
+        return
+    for k in [k for k in _OVERRIDES_RESPONSE_CACHE if k != keep_key]:
+        del _OVERRIDES_RESPONSE_CACHE[k]
+    for k in [k for k, lk in _OVERRIDES_ENCODE_LOCKS.items() if not lk.locked()]:
+        del _OVERRIDES_ENCODE_LOCKS[k]
+
+
 # ── API ROUTES ──────────────────────────────────────────────────────────
 @app.get("/api/data")
 async def get_data(request: Request):
@@ -3526,11 +3568,28 @@ async def post_rankings_overrides(request: Request):
         # field, which would return a market board labelled as adjusted.
         valuation_note = "league_adjusted_requires_delta_view"
 
-    try:
+    # Snapshot the shared globals ONCE on the event loop.  The worker
+    # thread below must not re-read them mid-build: a concurrent scrape
+    # promotion swaps them, and a build that saw two generations would
+    # emit a chimera payload.
+    data_snapshot = latest_data
+    source_snapshot = latest_data_source
+    contract_version = latest_data_etag
+
+    def _build_response_bytes() -> tuple[bytes, bytes]:
+        """Full pipeline rebuild + meta stamping + JSON/gzip encode.
+
+        Runs on a worker thread — this is multiple seconds of CPU on a
+        real contract and previously blocked the whole event loop.  The
+        raw bytes reproduce ``JSONResponse.render`` exactly
+        (``ensure_ascii=False, allow_nan=False, separators=(",", ":")``)
+        so memoizing bytes instead of returning JSONResponse is
+        wire-invisible.
+        """
         if delta_view:
             contract_payload = build_rankings_delta_payload(
-                latest_data,
-                data_source=latest_data_source,
+                data_snapshot,
+                data_source=source_snapshot,
                 source_overrides=overrides if overrides else None,
                 tep_multiplier=tep_multiplier,
                 tep_native_multiplier=tep_native_multiplier,
@@ -3538,12 +3597,91 @@ async def post_rankings_overrides(request: Request):
             )
         else:
             contract_payload = build_api_data_contract(
-                latest_data,
-                data_source=latest_data_source,
+                data_snapshot,
+                data_source=source_snapshot,
                 source_overrides=overrides if overrides else None,
                 tep_multiplier=tep_multiplier,
                 tep_native_multiplier=tep_native_multiplier,
             )
+
+        if warnings:
+            contract_payload.setdefault("warnings", []).extend(warnings)
+
+        # Stamp meta fields so the frontend can assert compatibility:
+        # ``leagueKey`` = resolved league; ``scoringProfile`` = which
+        # rules the pipeline used; ``sleeperDataReady`` = whether the
+        # ``sleeper`` block can be trusted for this league.  When the
+        # loaded contract was built for a different league (same scoring
+        # profile though — we'd have 503'd above if profiles differed),
+        # null the sleeper block so callers don't render the wrong
+        # league's teams.
+        if isinstance(contract_payload, dict):
+            meta = contract_payload.setdefault("meta", {})
+            meta["leagueKey"] = league_cfg.key
+            meta["scoringProfile"] = league_cfg.scoring_profile
+            meta["sleeperDataReady"] = sleeper_matches
+            if not sleeper_matches:
+                contract_payload["sleeper"] = None
+                meta["sleeperLoadedLeagueKey"] = loaded_league or None
+            # Always stamp which lens produced this board. A client that
+            # asked for leagueAdjusted and silently got market is the
+            # failure mode this whole change exists to remove, so the
+            # answer travels with the payload instead of being inferred.
+            meta["valuationMode"] = "leagueAdjusted" if valuation_factors else "market"
+            if valuation_note:
+                meta["valuationNote"] = valuation_note
+                contract_payload.setdefault("warnings", []).append(valuation_note)
+
+        raw = json.dumps(
+            contract_payload,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        gz = gzip.compress(raw, compresslevel=5)
+        return raw, gz
+
+    # ── Response memo ────────────────────────────────────────────────
+    # Cache key: everything that can change the response body.  The
+    # canonical body JSON covers overrides + tep knobs + any unknown
+    # keys (which produce per-body warnings).  ``valuation_mode``
+    # requests are excluded: their factors come from the gameplan
+    # module whose freshness this cache cannot see.  Entries are
+    # versioned on ``latest_data_etag`` (the contract generation) and
+    # rebuilt in place when stale; ``_prime_latest_payload`` clears the
+    # whole dict on scrape promotion.
+    cacheable = not want_league_adjusted and contract_version is not None
+    cache_key = None
+    if cacheable:
+        canonical_body = json.dumps(
+            body, sort_keys=True, separators=(",", ":"), default=str
+        )
+        cache_key = (
+            "overrides",
+            hashlib.sha1(canonical_body.encode("utf-8")).hexdigest(),
+            delta_view,
+            league_cfg.key,
+            sleeper_matches,
+        )
+
+    try:
+        if cache_key is None:
+            raw, gz = await run_in_threadpool(_build_response_bytes)
+        else:
+            entry = _OVERRIDES_RESPONSE_CACHE.get(cache_key)
+            if entry is not None and entry[2] != contract_version:
+                entry = None
+            if entry is None:
+                async with _overrides_encode_lock(cache_key):
+                    entry = _OVERRIDES_RESPONSE_CACHE.get(cache_key)
+                    if entry is not None and entry[2] != contract_version:
+                        entry = None
+                    if entry is None:
+                        raw, gz = await run_in_threadpool(_build_response_bytes)
+                        entry = (raw, gz, contract_version)
+                        _evict_overrides_cache_if_oversized(cache_key)
+                        _OVERRIDES_RESPONSE_CACHE[cache_key] = entry
+            raw, gz, _ = entry
     except Exception as exc:
         log.exception("Failed to rebuild contract with overrides: %s", exc)
         return JSONResponse(
@@ -3554,39 +3692,16 @@ async def post_rankings_overrides(request: Request):
             },
         )
 
-    if warnings:
-        contract_payload.setdefault("warnings", []).extend(warnings)
-
-    # Stamp meta fields so the frontend can assert compatibility:
-    # ``leagueKey`` = resolved league; ``scoringProfile`` = which
-    # rules the pipeline used; ``sleeperDataReady`` = whether the
-    # ``sleeper`` block can be trusted for this league.  When the
-    # loaded contract was built for a different league (same scoring
-    # profile though — we'd have 503'd above if profiles differed),
-    # null the sleeper block so callers don't render the wrong
-    # league's teams.
-    if isinstance(contract_payload, dict):
-        meta = contract_payload.setdefault("meta", {})
-        meta["leagueKey"] = league_cfg.key
-        meta["scoringProfile"] = league_cfg.scoring_profile
-        meta["sleeperDataReady"] = sleeper_matches
-        if not sleeper_matches:
-            contract_payload["sleeper"] = None
-            meta["sleeperLoadedLeagueKey"] = loaded_league or None
-        # Always stamp which lens produced this board. A client that
-        # asked for leagueAdjusted and silently got market is the
-        # failure mode this whole change exists to remove, so the
-        # answer travels with the payload instead of being inferred.
-        meta["valuationMode"] = "leagueAdjusted" if valuation_factors else "market"
-        if valuation_note:
-            meta["valuationNote"] = valuation_note
-            contract_payload.setdefault("warnings", []).append(valuation_note)
-
     headers = {
         "Cache-Control": "no-store",
         "X-Payload-View": "rankings-overrides-delta" if delta_view else "rankings-overrides",
+        "Vary": "Accept-Encoding",
     }
-    return JSONResponse(content=contract_payload, headers=headers)
+    accept_encoding = (request.headers.get("accept-encoding") or "").lower()
+    if "gzip" in accept_encoding and gz:
+        headers["Content-Encoding"] = "gzip"
+        return Response(content=gz, media_type="application/json", headers=headers)
+    return Response(content=raw, media_type="application/json", headers=headers)
 
 
 # Cache of Sleeper league ``name`` fields.  Refreshed every

--- a/server.py
+++ b/server.py
@@ -448,6 +448,28 @@ def _reset_news_service_for_tests(svc: NewsService | None = None) -> None:
         _news_service = svc
 
 
+# Memo for the full-contract scans below (~2,000-row walks that were
+# re-run on every /api/terminal and /api/news request).  Key: the
+# contract generation (``latest_data_etag``) — a scrape promotion mints
+# a new etag, which invalidates every entry implicitly.  Values are
+# shared references: CALLERS MUST TREAT THEM AS READ-ONLY (they already
+# do — the news service only reads names/meta).  No caching while the
+# etag is None (mid-prime / startup).
+_LIVE_CONTRACT_SCAN_MEMO: dict[str, tuple[str, Any]] = {}
+
+
+def _live_contract_scan(kind: str, builder):
+    etag = latest_data_etag
+    if not etag:
+        return builder()
+    hit = _LIVE_CONTRACT_SCAN_MEMO.get(kind)
+    if hit is not None and hit[0] == etag:
+        return hit[1]
+    val = builder()
+    _LIVE_CONTRACT_SCAN_MEMO[kind] = (etag, val)
+    return val
+
+
 def _live_player_names() -> list[str]:
     """Return every player name visible in the live contract.
 
@@ -455,19 +477,25 @@ def _live_player_names() -> list[str]:
     players; returning an empty list when the contract hasn't
     loaded yet degrades gracefully — headlines still surface,
     they just arrive with empty ``players[]``.
+
+    Memoized per contract generation — treat the result as read-only.
     """
-    contract = latest_contract_data or {}
-    rows = contract.get("playersArray") or []
-    names: list[str] = []
-    for row in rows:
-        if not isinstance(row, dict):
-            continue
-        for key in ("displayName", "name", "canonicalName", "fullName"):
-            v = row.get(key)
-            if isinstance(v, str) and v.strip():
-                names.append(v.strip())
-                break
-    return names
+
+    def _build() -> list[str]:
+        contract = latest_contract_data or {}
+        rows = contract.get("playersArray") or []
+        names: list[str] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            for key in ("displayName", "name", "canonicalName", "fullName"):
+                v = row.get(key)
+                if isinstance(v, str) and v.strip():
+                    names.append(v.strip())
+                    break
+        return names
+
+    return _live_contract_scan("player_names", _build)
 
 
 # How many top-board players get per-player ESPN news coverage.
@@ -553,39 +581,45 @@ def _live_player_meta() -> dict[str, dict[str, str | None]]:
     can be told apart on per-player surfaces.  ``team`` is sparsely
     populated until the next scrape cycle — null when absent;
     position is always available on contract rows.
+
+    Memoized per contract generation — treat the result as read-only.
     """
-    contract = latest_contract_data or {}
-    rows = contract.get("playersArray") or []
-    meta: dict[str, dict[str, str | None]] = {}
-    for row in rows:
-        if not isinstance(row, dict):
-            continue
-        name = ""
-        for key in ("displayName", "name", "canonicalName", "fullName"):
-            v = row.get(key)
-            if isinstance(v, str) and v.strip():
-                name = v.strip()
-                break
-        if not name:
-            continue
-        position = row.get("position")
-        team = row.get("team")
-        entry = {
-            "position": position.strip()
-            if isinstance(position, str) and position.strip()
-            else None,
-            "team": team.strip().upper() if isinstance(team, str) and team.strip() else None,
-        }
-        prior = meta.get(name)
-        if prior is None:
-            meta[name] = entry
-        elif prior != entry:
-            # Two contract rows share the EXACT display string with
-            # different identities — an exact-name lookup can't
-            # attribute a mention safely, so stamp nothing rather
-            # than the wrong player's identity.
-            meta[name] = {"position": None, "team": None}
-    return meta
+
+    def _build() -> dict[str, dict[str, str | None]]:
+        contract = latest_contract_data or {}
+        rows = contract.get("playersArray") or []
+        meta: dict[str, dict[str, str | None]] = {}
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            name = ""
+            for key in ("displayName", "name", "canonicalName", "fullName"):
+                v = row.get(key)
+                if isinstance(v, str) and v.strip():
+                    name = v.strip()
+                    break
+            if not name:
+                continue
+            position = row.get("position")
+            team = row.get("team")
+            entry = {
+                "position": position.strip()
+                if isinstance(position, str) and position.strip()
+                else None,
+                "team": team.strip().upper() if isinstance(team, str) and team.strip() else None,
+            }
+            prior = meta.get(name)
+            if prior is None:
+                meta[name] = entry
+            elif prior != entry:
+                # Two contract rows share the EXACT display string with
+                # different identities — an exact-name lookup can't
+                # attribute a mention safely, so stamp nothing rather
+                # than the wrong player's identity.
+                meta[name] = {"position": None, "team": None}
+        return meta
+
+    return _live_contract_scan("player_meta", _build)
 
 
 # R-9: Lightweight metrics counters
@@ -1471,9 +1505,32 @@ def _build_source_health_snapshot(data: dict | None) -> dict:
     }
 
 
+# 30s memo for the disk-probing observability helpers below.  They
+# glob + stat dozens of files per call, run on the event loop, and are
+# hit by /api/status (polled by /settings + tools pages) and
+# /api/health (polled every 60s by StaleDataBanner on EVERY page).
+# Pure observability data: key = helper name, TTL-only invalidation,
+# results treated as read-only, ≤30s staleness is invisible for
+# freshness ages measured in hours.
+_DISK_PROBE_MEMO: dict[str, tuple[float, Any]] = {}
+_DISK_PROBE_TTL_SEC = 30.0
+
+
+def _disk_probe_memo(kind: str, builder):
+    now = time.time()
+    hit = _DISK_PROBE_MEMO.get(kind)
+    if hit is not None and (now - hit[0]) < _DISK_PROBE_TTL_SEC:
+        return hit[1]
+    val = builder()
+    _DISK_PROBE_MEMO[kind] = (now, val)
+    return val
+
+
 def _per_source_freshness() -> dict[str, dict]:
     """Per-source ``{lastFetched, ageHours}`` for every source registered
     in ``_SOURCE_CSV_PATHS``.
+
+    Memoized 30s (see ``_DISK_PROBE_MEMO``) — treat as read-only.
 
     Freshness signal preference, in order:
 
@@ -1499,47 +1556,51 @@ def _per_source_freshness() -> dict[str, dict]:
     the output entirely.  Returns ``{}`` if the source registry can't
     be loaded.
     """
-    try:
-        from src.api.data_contract import _SOURCE_CSV_PATHS
-    except Exception:  # pragma: no cover
-        return {}
-    repo_root = Path(__file__).resolve().parent
-    state_dir = repo_root / "data" / "scrape_state"
-    out: dict[str, dict] = {}
-    now_epoch = time.time()
-    for src_key, entry in _SOURCE_CSV_PATHS.items():
-        csv_rel = entry if isinstance(entry, str) else (entry or {}).get("path")
-        if not csv_rel:
-            continue
-        csv_path = repo_root / csv_rel
 
-        # Prefer the stamp content over CSV mtime; fall back when the
-        # stamp is missing or unparseable.
-        stamp_path = state_dir / f"{src_key}_last_success"
-        last_epoch: float | None = None
+    def _build() -> dict[str, dict]:
         try:
-            stamp_text = stamp_path.read_text().strip()
-        except OSError:
-            stamp_text = ""
-        if stamp_text:
-            try:
-                last_epoch = float(stamp_text)
-            except ValueError:
-                last_epoch = None
-        if last_epoch is None:
-            try:
-                last_epoch = csv_path.stat().st_mtime
-            except OSError:
+            from src.api.data_contract import _SOURCE_CSV_PATHS
+        except Exception:  # pragma: no cover
+            return {}
+        repo_root = Path(__file__).resolve().parent
+        state_dir = repo_root / "data" / "scrape_state"
+        out: dict[str, dict] = {}
+        now_epoch = time.time()
+        for src_key, entry in _SOURCE_CSV_PATHS.items():
+            csv_rel = entry if isinstance(entry, str) else (entry or {}).get("path")
+            if not csv_rel:
                 continue
+            csv_path = repo_root / csv_rel
 
-        age_hours = max(0.0, (now_epoch - last_epoch) / 3600.0)
-        out[src_key] = {
-            "lastFetched": datetime.fromtimestamp(last_epoch, tz=timezone.utc).isoformat(
-                timespec="seconds"
-            ),
-            "ageHours": round(age_hours, 2),
-        }
-    return out
+            # Prefer the stamp content over CSV mtime; fall back when the
+            # stamp is missing or unparseable.
+            stamp_path = state_dir / f"{src_key}_last_success"
+            last_epoch: float | None = None
+            try:
+                stamp_text = stamp_path.read_text().strip()
+            except OSError:
+                stamp_text = ""
+            if stamp_text:
+                try:
+                    last_epoch = float(stamp_text)
+                except ValueError:
+                    last_epoch = None
+            if last_epoch is None:
+                try:
+                    last_epoch = csv_path.stat().st_mtime
+                except OSError:
+                    continue
+
+            age_hours = max(0.0, (now_epoch - last_epoch) / 3600.0)
+            out[src_key] = {
+                "lastFetched": datetime.fromtimestamp(last_epoch, tz=timezone.utc).isoformat(
+                    timespec="seconds"
+                ),
+                "ageHours": round(age_hours, 2),
+            }
+        return out
+
+    return _disk_probe_memo("per_source_freshness", _build)
 
 
 def _backup_freshness() -> dict:
@@ -1552,7 +1613,13 @@ def _backup_freshness() -> dict:
     within a day of a silent backup failure — the exact gap that let
     backups die unnoticed for ~2 weeks before the P0 fix.  Never raises;
     returns null age when no backup is found.
+
+    Memoized 30s (see ``_DISK_PROBE_MEMO``) — treat as read-only.
     """
+    return _disk_probe_memo("backup_freshness", _backup_freshness_uncached)
+
+
+def _backup_freshness_uncached() -> dict:
     result = {
         "newestBackupAgeHours": None,
         "newestBackupPath": None,
@@ -1698,33 +1765,72 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
         latest_compact_data_etag
     global contract_health
     global served_source_coverage
-    served_source_coverage = {}
-    latest_data_bytes = None
-    latest_data_gzip_bytes = None
-    latest_data_etag = None
-    latest_contract_data = None
-    latest_runtime_data = None
-    latest_runtime_data_bytes = None
-    latest_runtime_data_gzip_bytes = None
-    latest_runtime_data_etag = None
-    latest_startup_data = None
-    latest_startup_data_bytes = None
-    latest_startup_data_gzip_bytes = None
-    latest_startup_data_etag = None
-    latest_array_data = None
-    latest_array_data_bytes = None
-    latest_array_data_gzip_bytes = None
-    latest_array_data_etag = None
-    latest_compact_data = None
-    latest_compact_data_bytes = None
-    latest_compact_data_gzip_bytes = None
-    latest_compact_data_etag = None
-    # A new contract generation invalidates every memoized overrides
-    # response (they are versioned on ``latest_data_etag``, but clearing
-    # eagerly also frees the multi-MB byte payloads immediately).
-    _OVERRIDES_RESPONSE_CACHE.clear()
+
+    def _swap_to_empty() -> None:
+        """Publish the 'no payload' generation (falsy data / failed
+        build).  Plain reference assignments, no I/O — near-atomic."""
+        global latest_contract_data, latest_data_bytes, latest_data_gzip_bytes, latest_data_etag
+        global \
+            latest_runtime_data, \
+            latest_runtime_data_bytes, \
+            latest_runtime_data_gzip_bytes, \
+            latest_runtime_data_etag
+        global \
+            latest_startup_data, \
+            latest_startup_data_bytes, \
+            latest_startup_data_gzip_bytes, \
+            latest_startup_data_etag
+        global \
+            latest_array_data, \
+            latest_array_data_bytes, \
+            latest_array_data_gzip_bytes, \
+            latest_array_data_etag
+        global \
+            latest_compact_data, \
+            latest_compact_data_bytes, \
+            latest_compact_data_gzip_bytes, \
+            latest_compact_data_etag
+        global served_source_coverage
+        served_source_coverage = {}
+        latest_data_bytes = None
+        latest_data_gzip_bytes = None
+        latest_data_etag = None
+        latest_contract_data = None
+        latest_runtime_data = None
+        latest_runtime_data_bytes = None
+        latest_runtime_data_gzip_bytes = None
+        latest_runtime_data_etag = None
+        latest_startup_data = None
+        latest_startup_data_bytes = None
+        latest_startup_data_gzip_bytes = None
+        latest_startup_data_etag = None
+        latest_array_data = None
+        latest_array_data_bytes = None
+        latest_array_data_gzip_bytes = None
+        latest_array_data_etag = None
+        latest_compact_data = None
+        latest_compact_data_bytes = None
+        latest_compact_data_gzip_bytes = None
+        latest_compact_data_etag = None
+        # A new contract generation invalidates every memoized overrides
+        # response (they are versioned on ``latest_data_etag``, but clearing
+        # eagerly also frees the multi-MB byte payloads immediately).
+        _OVERRIDES_RESPONSE_CACHE.clear()
+        # Draft-capital results price picks off the live contract on the
+        # non-default-league path — drop them with the old generation.
+        _DRAFT_CAPITAL_CACHE.clear()
+
     if not data:
+        _swap_to_empty()
         return
+
+    # ── Stage 1: compute the ENTIRE new generation into locals.
+    # This function is offloaded to a worker thread at the scrape-
+    # completion call site, so requests can interleave with the
+    # multi-second build.  No global is touched until every variant is
+    # encoded; the publish happens in the tight swap at the end.  (The
+    # previous reset-globals-first shape was only safe because the
+    # whole build used to block the event loop.)
     try:
         contract_payload = build_api_data_contract(data, data_source=latest_data_source)
         contract_report = validate_api_data_contract(contract_payload)
@@ -1791,9 +1897,7 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
                 meta_block["scoringProfile"] = _default_cfg.scoring_profile
         except Exception:  # noqa: BLE001
             pass
-        latest_contract_data = contract_payload
-        contract_health = contract_report
-        served_source_coverage = _compute_served_source_coverage(contract_payload)
+        new_coverage = _compute_served_source_coverage(contract_payload)
 
         # Post-scrape overlay warm — for every ACTIVE league
         # (including the default league the scraper just built for),
@@ -1828,9 +1932,8 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
         raw = json.dumps(contract_payload, ensure_ascii=False, separators=(",", ":")).encode(
             "utf-8"
         )
-        latest_data_bytes = raw
-        latest_data_gzip_bytes = gzip.compress(raw, compresslevel=5)
-        latest_data_etag = hashlib.sha1(raw).hexdigest()
+        full_gzip = gzip.compress(raw, compresslevel=5)
+        full_etag = hashlib.sha1(raw).hexdigest()
 
         # Runtime payload: keep canonical top-level data shape used by the live UI,
         # but remove heavyweight contract array duplication to reduce parse/transfer cost.
@@ -1840,10 +1943,8 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
         runtime_raw = json.dumps(runtime_payload, ensure_ascii=False, separators=(",", ":")).encode(
             "utf-8"
         )
-        latest_runtime_data = runtime_payload
-        latest_runtime_data_bytes = runtime_raw
-        latest_runtime_data_gzip_bytes = gzip.compress(runtime_raw, compresslevel=5)
-        latest_runtime_data_etag = hashlib.sha1(runtime_raw).hexdigest()
+        runtime_gzip = gzip.compress(runtime_raw, compresslevel=5)
+        runtime_etag = hashlib.sha1(runtime_raw).hexdigest()
 
         # Array payload: full contract minus the LEGACY ``players`` dict.
         # ``playersArray`` and the dict are parallel encodings; the array
@@ -1858,10 +1959,8 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
         array_raw = json.dumps(array_payload, ensure_ascii=False, separators=(",", ":")).encode(
             "utf-8"
         )
-        latest_array_data = array_payload
-        latest_array_data_bytes = array_raw
-        latest_array_data_gzip_bytes = gzip.compress(array_raw, compresslevel=5)
-        latest_array_data_etag = hashlib.sha1(array_raw).hexdigest()
+        array_gzip = gzip.compress(array_raw, compresslevel=5)
+        array_etag = hashlib.sha1(array_raw).hexdigest()
 
         # Startup payload: same contract shape, but strips heavyweight fields
         # not needed for first screen render so first data-visible is faster.
@@ -1869,16 +1968,18 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
         startup_raw = json.dumps(startup_payload, ensure_ascii=False, separators=(",", ":")).encode(
             "utf-8"
         )
-        latest_startup_data = startup_payload
-        latest_startup_data_bytes = startup_raw
-        latest_startup_data_gzip_bytes = gzip.compress(startup_raw, compresslevel=5)
-        latest_startup_data_etag = hashlib.sha1(startup_raw).hexdigest()
+        startup_gzip = gzip.compress(startup_raw, compresslevel=5)
+        startup_etag = hashlib.sha1(startup_raw).hexdigest()
 
         # Compact payload: mobile / slow-network view (~90% smaller).
         # Precompute bytes + gzip + etag here so ``?view=compact`` serves
         # from the same fast path as the other views instead of running
         # ``compact_contract`` + ``json.dumps`` + gzip per request on the
         # event loop.
+        compact_payload = None
+        compact_raw = None
+        compact_gzip = None
+        compact_etag = None
         try:
             from src.api.compact_view import compact_contract
 
@@ -1886,15 +1987,22 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
             compact_raw = json.dumps(
                 compact_payload, ensure_ascii=False, separators=(",", ":")
             ).encode("utf-8")
-            latest_compact_data = compact_payload
-            latest_compact_data_bytes = compact_raw
-            latest_compact_data_gzip_bytes = gzip.compress(compact_raw, compresslevel=5)
-            latest_compact_data_etag = hashlib.sha1(compact_raw).hexdigest()
+            compact_gzip = gzip.compress(compact_raw, compresslevel=5)
+            compact_etag = hashlib.sha1(compact_raw).hexdigest()
         except Exception as exc:  # noqa: BLE001
             # Non-fatal: the endpoint falls back to on-demand compaction
             # when the precomputed compact payload is unavailable.
+            compact_payload = None
+            compact_raw = None
+            compact_gzip = None
+            compact_etag = None
             log.warning("compact payload precompute failed: %s", exc)
     except Exception as e:
+        # Failed build: publish the empty generation (same end state as
+        # before — /api/data 503s, health invalid).  This also covers a
+        # mid-encode failure, which previously could leave a contract
+        # object published with no bytes behind it.
+        _swap_to_empty()
         contract_health = {
             "ok": False,
             "status": "invalid",
@@ -1907,6 +2015,38 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
             "playerCount": 0,
         }
         log.error(f"Failed to pre-serialize latest payload: {e}")
+        return
+
+    # ── Stage 2: tight swap — publish the new generation.  Plain
+    # reference assignments only; concurrent readers see the old
+    # generation or the new one, never a torn one (each individual
+    # response is built from ONE consistent (bytes, etag) pair grabbed
+    # in a single statement server-side).
+    latest_contract_data = contract_payload
+    contract_health = contract_report
+    served_source_coverage = new_coverage
+    latest_data_bytes = raw
+    latest_data_gzip_bytes = full_gzip
+    latest_data_etag = full_etag
+    latest_runtime_data = runtime_payload
+    latest_runtime_data_bytes = runtime_raw
+    latest_runtime_data_gzip_bytes = runtime_gzip
+    latest_runtime_data_etag = runtime_etag
+    latest_array_data = array_payload
+    latest_array_data_bytes = array_raw
+    latest_array_data_gzip_bytes = array_gzip
+    latest_array_data_etag = array_etag
+    latest_startup_data = startup_payload
+    latest_startup_data_bytes = startup_raw
+    latest_startup_data_gzip_bytes = startup_gzip
+    latest_startup_data_etag = startup_etag
+    latest_compact_data = compact_payload
+    latest_compact_data_bytes = compact_raw
+    latest_compact_data_gzip_bytes = compact_gzip
+    latest_compact_data_etag = compact_etag
+    # Old-generation memoized responses go with the old etag.
+    _OVERRIDES_RESPONSE_CACHE.clear()
+    _DRAFT_CAPITAL_CACHE.clear()
 
 
 def load_from_disk() -> dict | None:
@@ -2264,7 +2404,16 @@ async def run_scraper(trigger: str = "manual") -> dict | None:
             # (``_prime_latest_payload`` called in the lifespan hook)
             # leaves is_fresh_scrape=False so the history log stays
             # read-only until a real scrape lands.
-            _prime_latest_payload(result, is_fresh_scrape=True)
+            #
+            # Offloaded to the threadpool: the contract build + 5×
+            # multi-MB json/gzip encodes are seconds of CPU that used
+            # to freeze the event loop at every scrape end.  The
+            # function computes into locals and publishes via a tight
+            # reference-assignment swap, so interleaved requests keep
+            # serving the OLD generation until the new one is fully
+            # encoded.  (The lifespan call site stays inline — it runs
+            # before the port binds, so there is nothing to block.)
+            await run_in_threadpool(_prime_latest_payload, result, is_fresh_scrape=True)
 
             _mark_scrape_success(elapsed, player_count, site_count, total_sites)
 
@@ -4081,7 +4230,11 @@ async def get_status():
             "idMappingCoverage": _id_mapping_coverage_safe(),
             "nflDataProvider": _nfl_data_provider_status_safe(),
             "normalizationHealth": _normalization_health_safe(),
-        }
+        },
+        # Observability payload — the disk-probe helpers behind it are
+        # memoized 30s server-side; let pollers (settings page, tools)
+        # reuse it browser-side for the same window.
+        headers={"Cache-Control": "private, max-age=15, stale-while-revalidate=30"},
     )
 
 
@@ -4450,12 +4603,17 @@ async def get_news(request: Request):
 
     svc = _get_news_service()
     try:
-        aggregated = await run_in_threadpool(
-            svc.aggregate,
-            player_names=_live_player_names(),
-            team_names=team_names or None,
-            player_meta=_live_player_meta(),
-        )
+        # One callable so the two full-contract scans run on the worker
+        # thread too — as call arguments they'd execute on the event
+        # loop before the threadpool hop.
+        def _aggregate():
+            return svc.aggregate(
+                player_names=_live_player_names(),
+                team_names=team_names or None,
+                player_meta=_live_player_meta(),
+            )
+
+        aggregated = await run_in_threadpool(_aggregate)
     except Exception as exc:
         log.warning("/api/news aggregation failed: %s", exc)
         # Signal "temporarily unavailable" — the frontend surfaces an
@@ -5710,18 +5868,25 @@ async def post_trade_suggestions(request: Request):
     contract, valuation_mode, valuation_note = await _valuation_scoped_contract(
         request, body, league_cfg
     )
-    pool = build_asset_pool_from_contract(
-        contract,
-        ktc_top_n=ktc_top_n,
-    )
 
-    try:
-        result = generate_suggestions_from_pool(
+    # Pool build + suggestion generation are heavy CPU passes over the
+    # full playersArray × league rosters — run them on a worker thread
+    # exactly like /api/trade/finder already does, instead of stalling
+    # the event loop for every concurrent request.
+    def _generate():
+        pool = build_asset_pool_from_contract(
+            contract,
+            ktc_top_n=ktc_top_n,
+        )
+        return generate_suggestions_from_pool(
             roster_names=roster,
             pool=pool,
             league_rosters=league_rosters,
             ktc_top_n=ktc_top_n,
         )
+
+    try:
+        result = await run_in_threadpool(_generate)
     except Exception as e:
         log.error(f"Trade suggestion generation failed: {e}")
         return JSONResponse(
@@ -6528,6 +6693,14 @@ DRAFT_TOTAL_BUDGET = 1200  # $100 × 12 teams
 
 # Cache for KTC live data: {"rookies": [...], "fetched_at": timestamp}
 _ktc_cache = {"rookies": None, "fetched_at": 0}
+
+# /api/draft-capital result cache — see the endpoint for the full
+# cache contract (key = league key, TTL 300s, ?refresh=1 busts,
+# cleared on scrape promotion because the non-default path prices
+# picks off the live contract).
+_DRAFT_CAPITAL_CACHE: dict[str, tuple[float, dict]] = {}
+_DRAFT_CAPITAL_TTL_SEC = 300.0
+_DRAFT_CAPITAL_LOCKS: dict[str, asyncio.Lock] = {}
 _KTC_CACHE_TTL = 6 * 3600  # 6 hours
 
 
@@ -6807,6 +6980,42 @@ def _vendor_dollars_for_rookies(
     return _dollars_by_vendor("ktcRaw"), _dollars_by_vendor("idpRaw")
 
 
+# mtime-keyed cache of the Draft Data workbook.  The workbook was
+# re-parsed by openpyxl on EVERY /api/draft-capital request (twice per
+# request, in fact — spine read + full parse).  Key: (path, mtime_ns,
+# size); invalidation: file replacement (the only way the sheet
+# changes); no TTL.  Cached workbooks are never close()d — data_only
+# workbooks are fully materialized in memory after load.
+_DRAFT_WB_CACHE: dict[str, tuple[tuple, Any]] = {}
+_DRAFT_WB_LOCK = threading.Lock()
+
+
+def _load_draft_workbook():
+    """Return the (cached) Draft Data workbook, or None if unavailable."""
+    try:
+        import openpyxl
+    except ImportError:
+        return None
+    if not DRAFT_DATA_XLSX.exists():
+        return None
+    try:
+        stat = DRAFT_DATA_XLSX.stat()
+        key = (str(DRAFT_DATA_XLSX), stat.st_mtime_ns, stat.st_size)
+    except OSError:
+        return None
+    with _DRAFT_WB_LOCK:
+        cached = _DRAFT_WB_CACHE.get("wb")
+        if cached and cached[0] == key:
+            return cached[1]
+        try:
+            wb = openpyxl.load_workbook(DRAFT_DATA_XLSX, data_only=True)
+        except Exception as exc:  # noqa: BLE001
+            logging.warning(f"Could not open {DRAFT_DATA_XLSX}: {exc}")
+            return None
+        _DRAFT_WB_CACHE["wb"] = (key, wb)
+        return wb
+
+
 def _read_sheet_spine_and_floor(n: int = 72) -> tuple[list[float], int]:
     """Return (spine[E2:E_n+1], r5_bonus_total) from the workbook so
     ``_rookie_dollars_from_values`` faithfully matches the sheet's
@@ -6818,17 +7027,14 @@ def _read_sheet_spine_and_floor(n: int = 72) -> tuple[list[float], int]:
     unreadable so callers don't blow up.
     """
     try:
-        import openpyxl
-
-        if not DRAFT_DATA_XLSX.exists():
+        wb = _load_draft_workbook()
+        if wb is None:
             return [1.0] * n, 0
-        wb = openpyxl.load_workbook(DRAFT_DATA_XLSX, data_only=True)
         ws = wb["Draft Data"]
         spine: list[float] = []
         for r in range(2, 2 + n):
             v = ws.cell(r, 5).value  # E = column 5
             spine.append(float(v) if v is not None else 1.0)
-        wb.close()
     except Exception:
         return [1.0] * n, 0
     return spine, n  # R5 bonus = +$1 × 12 picks = $12 total floor add
@@ -6990,19 +7196,8 @@ def _parse_draft_xlsx():
         O30:R42  — standings (slot → original owner)
         T63:U74  — team totals (authoritative)
     """
-    try:
-        import openpyxl
-    except ImportError:
-        logging.warning("openpyxl not installed — falling back to CSV")
-        return None
-
-    if not DRAFT_DATA_XLSX.exists():
-        return None
-
-    try:
-        wb = openpyxl.load_workbook(DRAFT_DATA_XLSX, data_only=True)
-    except Exception as e:
-        logging.warning(f"Could not open {DRAFT_DATA_XLSX}: {e}")
+    wb = _load_draft_workbook()
+    if wb is None:
         return None
 
     ws = wb["Draft Data"]
@@ -7063,7 +7258,7 @@ def _parse_draft_xlsx():
         if team and val is not None:
             workbook_team_totals[str(team).strip()] = float(val)
 
-    wb.close()
+    # NOTE: no wb.close() — the workbook is shared via _DRAFT_WB_CACHE.
     return pick_dollars, workbook_picks, slot_to_original_owner, workbook_team_totals, pick_values_l
 
 
@@ -7876,32 +8071,71 @@ async def get_draft_capital(request: Request, refresh: str = ""):
             },
         )
 
+    # ── Result cache ─────────────────────────────────────────────
+    # This endpoint used to run ~4s of synchronous work — an openpyxl
+    # parse plus up to six blocking Sleeper calls — directly on the
+    # event loop, per request, with /draft calling it three times per
+    # page load.  Cache: key = league key; TTL = 300s (same freshness
+    # class as the Sleeper overlay: pick ownership moves on trades,
+    # which the 15-min overlay already bounds — 5 min here is
+    # strictly fresher); invalidation = ``?refresh=1`` (which also
+    # busts the KTC cache, as before) or TTL expiry; stale data can
+    # be shown for ≤5 min, matching the rest of the Sleeper-derived
+    # surfaces.  Per-league asyncio single-flight so concurrent
+    # misses (the /draft triple-fetch) coalesce onto one build, which
+    # itself runs in the threadpool — never on the loop.
+    now = time.time()
+    cache_slot = _DRAFT_CAPITAL_CACHE.get(league_cfg.key)
+    if not refresh and cache_slot and (now - cache_slot[0]) < _DRAFT_CAPITAL_TTL_SEC:
+        return JSONResponse(
+            content=cache_slot[1],
+            headers={"Cache-Control": "private, max-age=60, stale-while-revalidate=300"},
+        )
+
     if refresh:
         _ktc_cache["fetched_at"] = 0  # invalidate cache
-    try:
+
+    def _compute():
         if is_default_league:
             # Workbook path — rich per-pick values pinned to League A's
             # rookie pool.
-            result = _fetch_draft_capital(league_cfg.key)
-        else:
-            # Sleeper-derived fallback for non-default leagues.
-            # Uses the canonical contract's pick values (Hill-curve-
-            # calibrated) + Sleeper's traded_picks.  Clearly labeled
-            # in the UI so users see "Sleeper-derived" vs.
-            # "workbook-calibrated".
-            from src.api.draft_capital_fallback import build_sleeper_derived
+            return _fetch_draft_capital(league_cfg.key)
+        # Sleeper-derived fallback for non-default leagues.
+        # Uses the canonical contract's pick values (Hill-curve-
+        # calibrated) + Sleeper's traded_picks.  Clearly labeled
+        # in the UI so users see "Sleeper-derived" vs.
+        # "workbook-calibrated".
+        from src.api.draft_capital_fallback import build_sleeper_derived
 
-            result = build_sleeper_derived(
-                league_cfg.sleeper_league_id,
-                latest_contract_data or {},
-                current_season=datetime.now(timezone.utc).year,
-                num_teams=league_cfg.roster_settings.get("teamCount", 12)
-                if hasattr(league_cfg, "roster_settings")
-                else 12,
-            )
-        if isinstance(result, dict):
-            result["leagueKey"] = league_cfg.key
-        return JSONResponse(content=result)
+        return build_sleeper_derived(
+            league_cfg.sleeper_league_id,
+            latest_contract_data or {},
+            current_season=datetime.now(timezone.utc).year,
+            num_teams=league_cfg.roster_settings.get("teamCount", 12)
+            if hasattr(league_cfg, "roster_settings")
+            else 12,
+        )
+
+    lock = _DRAFT_CAPITAL_LOCKS.get(league_cfg.key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _DRAFT_CAPITAL_LOCKS[league_cfg.key] = lock
+    try:
+        async with lock:
+            # Re-check after the wait — a concurrent request may have
+            # populated the slot while we queued.
+            cache_slot = _DRAFT_CAPITAL_CACHE.get(league_cfg.key)
+            if not refresh and cache_slot and (time.time() - cache_slot[0]) < _DRAFT_CAPITAL_TTL_SEC:
+                result = cache_slot[1]
+            else:
+                result = await run_in_threadpool(_compute)
+                if isinstance(result, dict):
+                    result["leagueKey"] = league_cfg.key
+                    _DRAFT_CAPITAL_CACHE[league_cfg.key] = (time.time(), result)
+        return JSONResponse(
+            content=result,
+            headers={"Cache-Control": "private, max-age=60, stale-while-revalidate=300"},
+        )
     except Exception as e:
         logging.error(f"Draft capital computation failed: {e}")
         return JSONResponse(
@@ -9951,25 +10185,34 @@ async def get_terminal(request: Request):
                 )
 
     try:
-        payload = await run_in_threadpool(
-            _terminal.build_terminal_payload,
-            contract,
-            resolved_team=resolved_team,
-            window_days=window_days,
-            news_items=_terminal.gather_news_items(
+        # ONE callable so every heavy piece runs on the worker thread.
+        # Python evaluates call arguments eagerly, so the previous
+        # ``run_in_threadpool(build, ..., news_items=gather_news_items(...))``
+        # shape executed the news aggregation (up to ~11 RSS providers)
+        # and two full-contract scans ON THE EVENT LOOP before the
+        # threadpool hop — stalling every concurrent request.
+        def _build_terminal():
+            news_items = _terminal.gather_news_items(
                 lambda: _get_news_service(),
                 _live_player_names(),
                 (resolved_team or {}).get("name") if resolved_team else None,
                 player_meta=_live_player_meta(),
-            ),
-            user_state=user_state,
-            public_mode=not authed,
-            # Scope dismissals to the active league so a dismissal
-            # on league A doesn't silence the same player's signal
-            # on league B.  See terminal.build_terminal_payload +
-            # user_kv.active_dismissals docstrings.
-            league_key=league_cfg.key if league_cfg else None,
-        )
+            )
+            return _terminal.build_terminal_payload(
+                contract,
+                resolved_team=resolved_team,
+                window_days=window_days,
+                news_items=news_items,
+                user_state=user_state,
+                public_mode=not authed,
+                # Scope dismissals to the active league so a dismissal
+                # on league A doesn't silence the same player's signal
+                # on league B.  See terminal.build_terminal_payload +
+                # user_kv.active_dismissals docstrings.
+                league_key=league_cfg.key if league_cfg else None,
+            )
+
+        payload = await run_in_threadpool(_build_terminal)
     except Exception as exc:
         log.exception("/api/terminal build failed: %s", exc)
         return JSONResponse(

--- a/server.py
+++ b/server.py
@@ -3849,9 +3849,7 @@ async def post_rankings_overrides(request: Request):
     cacheable = not want_league_adjusted and contract_version is not None
     cache_key = None
     if cacheable:
-        canonical_body = json.dumps(
-            body, sort_keys=True, separators=(",", ":"), default=str
-        )
+        canonical_body = json.dumps(body, sort_keys=True, separators=(",", ":"), default=str)
         cache_key = (
             "overrides",
             hashlib.sha1(canonical_body.encode("utf-8")).hexdigest(),
@@ -8125,7 +8123,11 @@ async def get_draft_capital(request: Request, refresh: str = ""):
             # Re-check after the wait — a concurrent request may have
             # populated the slot while we queued.
             cache_slot = _DRAFT_CAPITAL_CACHE.get(league_cfg.key)
-            if not refresh and cache_slot and (time.time() - cache_slot[0]) < _DRAFT_CAPITAL_TTL_SEC:
+            if (
+                not refresh
+                and cache_slot
+                and (time.time() - cache_slot[0]) < _DRAFT_CAPITAL_TTL_SEC
+            ):
                 result = cache_slot[1]
             else:
                 result = await run_in_threadpool(_compute)

--- a/src/api/sleeper_overlay.py
+++ b/src/api/sleeper_overlay.py
@@ -56,6 +56,22 @@ log = logging.getLogger(__name__)
 _CACHE: dict[str, dict[str, Any]] = {}
 _CACHE_LOCK = threading.Lock()
 _CACHE_TTL_SEC = 15 * 60
+# Stale-serve ceiling: an expired-but-present overlay is served
+# immediately (with a background refresh kicked off) up to this age.
+# Past it, the request blocks on a single-flighted rebuild.  Sign-off:
+# rosters/trades may briefly render up to 30 min old instead of 15 —
+# a freshness-window widening on an already-15-min-stale live overlay,
+# never a computation change.  Rankings/values are unaffected (they
+# come from the scrape pipeline, not this overlay).
+_STALE_SERVE_MAX_SEC = 2 * _CACHE_TTL_SEC
+# Per-league build locks: a cold overlay build is ~50-100 Sleeper
+# round-trips, and before these locks concurrent expirees each
+# launched their own storm.  Exactly one builder per league now runs
+# at a time; the rest wait and read its result.
+_BUILD_LOCKS: dict[str, threading.Lock] = {}
+# League ids with a background refresh in flight (stale-serve path) so
+# repeat stale hits don't stack refresh threads.
+_REFRESHING: set[str] = set()
 _HTTP_TIMEOUT_SEC = 8.0
 _USER_AGENT = "brisket-sleeper-overlay/1.0"
 
@@ -152,20 +168,67 @@ def _http_get_json(url: str) -> Any:
         return None
 
 
-def _walk_league_chain(root_league_id: str, max_depth: int = 2) -> list[str]:
+class _BuildFetcher:
+    """Build-scoped URL memo + parallel prefetch for one overlay build.
+
+    A single overlay build touches several Sleeper URLs more than once:
+    the league-chain walk runs for both the trades AND waivers builders,
+    rosters/users are fetched by the teams block and again by the
+    per-league rid lookup, and — the big one — the 19 weekly
+    ``/transactions/{week}`` feeds are iterated by BOTH builders (they
+    read the same feed with different type filters).  Memoizing by URL
+    within one build halves the round-trips with zero freshness change,
+    because every duplicate was previously fetched milliseconds apart
+    anyway.
+
+    ``prefetch`` issues a set of URLs concurrently (bounded pool) so
+    the serial per-week walk turns into one parallel round-trip wave.
+
+    Resolves ``_http_get_json`` late (module-global lookup at call
+    time) so tests that monkeypatch it keep working — including
+    through the prefetch pool's worker threads.
+    """
+
+    def __init__(self) -> None:
+        self._results: dict[str, Any] = {}
+        self._lock = threading.Lock()
+
+    def get(self, url: str) -> Any:
+        with self._lock:
+            if url in self._results:
+                return self._results[url]
+        val = _http_get_json(url)
+        with self._lock:
+            return self._results.setdefault(url, val)
+
+    def prefetch(self, urls: list[str], max_workers: int = 8) -> None:
+        from concurrent.futures import ThreadPoolExecutor
+
+        with self._lock:
+            pending = list(dict.fromkeys(u for u in urls if u not in self._results))
+        if not pending:
+            return
+        with ThreadPoolExecutor(
+            max_workers=max_workers, thread_name_prefix="sleeper-prefetch"
+        ) as ex:
+            list(ex.map(self.get, pending))
+
+
+def _walk_league_chain(root_league_id: str, max_depth: int = 2, getter=None) -> list[str]:
     """Walk backwards through previous_league_id so trade history
     covers multiple seasons when the ``/transactions`` endpoint
     only returns current-season trades.  Mirrors the scraper's
     ``_league_chain_ids`` helper (Dynasty Scraper.py ~line 1109)
     but capped at 2 levels to keep the overlay fetch fast.
     """
+    fetch = getter or _http_get_json
     out: list[str] = []
     seen: set[str] = set()
     cur = str(root_league_id or "").strip()
     while cur and cur not in seen and len(out) < max_depth:
         seen.add(cur)
         out.append(cur)
-        info = _http_get_json(f"https://api.sleeper.app/v1/league/{cur}")
+        info = fetch(f"https://api.sleeper.app/v1/league/{cur}")
         if not isinstance(info, dict):
             break
         prev = info.get("previous_league_id") or info.get("previous_league")
@@ -203,6 +266,7 @@ def _build_pick_ownership(
     roster_ids: list[int],
     num_rounds: int = 6,
     num_years: int = 3,
+    getter=None,
 ) -> dict[int, list[dict[str, Any]]]:
     """Return ``{rosterId: [pickDetail, ...]}`` — which future picks
     each roster currently owns based on the league's
@@ -231,7 +295,9 @@ def _build_pick_ownership(
             for rid in roster_ids:
                 ownership[(year, rnd, rid)] = rid
 
-    traded = _http_get_json(f"https://api.sleeper.app/v1/league/{sleeper_league_id}/traded_picks")
+    traded = (getter or _http_get_json)(
+        f"https://api.sleeper.app/v1/league/{sleeper_league_id}/traded_picks"
+    )
     if isinstance(traded, list):
         for tp in traded:
             if not isinstance(tp, dict):
@@ -271,6 +337,7 @@ def _build_pick_ownership(
 def _build_teams_block(
     sleeper_league_id: str,
     id_to_player: dict[str, str] | None,
+    getter=None,
 ) -> list[dict[str, Any]] | None:
     """Assemble the ``sleeper.teams`` array for one league.
 
@@ -286,8 +353,9 @@ def _build_teams_block(
     This is what unblocks /api/draft-capital + angle-finder for
     non-default leagues.
     """
-    rosters = _http_get_json(f"https://api.sleeper.app/v1/league/{sleeper_league_id}/rosters")
-    users = _http_get_json(f"https://api.sleeper.app/v1/league/{sleeper_league_id}/users")
+    fetch = getter or _http_get_json
+    rosters = fetch(f"https://api.sleeper.app/v1/league/{sleeper_league_id}/rosters")
+    users = fetch(f"https://api.sleeper.app/v1/league/{sleeper_league_id}/users")
     if not isinstance(rosters, list) or not isinstance(users, list):
         return None
 
@@ -296,7 +364,7 @@ def _build_teams_block(
     # FAAB.  When the league call fails (rare) we still emit the
     # block — faabRemaining just falls back to None and the
     # frontend renders "—" instead of a number.
-    league_info = _http_get_json(f"https://api.sleeper.app/v1/league/{sleeper_league_id}")
+    league_info = fetch(f"https://api.sleeper.app/v1/league/{sleeper_league_id}")
     league_settings = league_info.get("settings") if isinstance(league_info, dict) else None
     league_faab_budget = None
     if isinstance(league_settings, dict):
@@ -339,7 +407,7 @@ def _build_teams_block(
                 roster_ids.append(int(r["roster_id"]))
             except (TypeError, ValueError):
                 continue
-    pick_ownership = _build_pick_ownership(sleeper_league_id, roster_ids)
+    pick_ownership = _build_pick_ownership(sleeper_league_id, roster_ids, getter=getter)
 
     teams: list[dict[str, Any]] = []
     for r in rosters:
@@ -413,6 +481,7 @@ def _safe_int(v: Any) -> int | None:
 
 def _league_rid_lookup(
     target_league_id: str,
+    getter=None,
 ) -> tuple[dict[Any, str], dict[Any, str]]:
     """Per-league roster lookup: ``(rid_to_name, rid_to_owner_id)``.
 
@@ -429,10 +498,11 @@ def _league_rid_lookup(
     coercing first.  Empty maps on any fetch failure (the trade
     builder degrades gracefully).
     """
+    fetch = getter or _http_get_json
     rid_to_name: dict[Any, str] = {}
     rid_to_owner: dict[Any, str] = {}
-    rosters = _http_get_json(f"https://api.sleeper.app/v1/league/{target_league_id}/rosters")
-    users = _http_get_json(f"https://api.sleeper.app/v1/league/{target_league_id}/users")
+    rosters = fetch(f"https://api.sleeper.app/v1/league/{target_league_id}/rosters")
+    users = fetch(f"https://api.sleeper.app/v1/league/{target_league_id}/users")
     if not isinstance(rosters, list):
         return rid_to_name, rid_to_owner
     user_map: dict[str, str] = {}
@@ -470,6 +540,7 @@ def _league_rid_lookup(
 def _league_draft_slot_lookup(
     target_league_id: str,
     rosters: list[dict[str, Any]] | None = None,
+    getter=None,
 ) -> dict[tuple[int, int], int]:
     """Build ``{(season, origin_roster_id): slot}`` for trade-history
     pick labels.
@@ -493,8 +564,9 @@ def _league_draft_slot_lookup(
     still resolve through ``buildPickLookupCandidates`` on the
     frontend, just less precisely.
     """
+    fetch = getter or _http_get_json
     out: dict[tuple[int, int], int] = {}
-    drafts = _http_get_json(f"https://api.sleeper.app/v1/league/{target_league_id}/drafts")
+    drafts = fetch(f"https://api.sleeper.app/v1/league/{target_league_id}/drafts")
     if not isinstance(drafts, list):
         return out
 
@@ -504,7 +576,7 @@ def _league_draft_slot_lookup(
     owner_to_rid: dict[str, int] = {}
     rs = rosters
     if rs is None:
-        rs_resp = _http_get_json(f"https://api.sleeper.app/v1/league/{target_league_id}/rosters")
+        rs_resp = fetch(f"https://api.sleeper.app/v1/league/{target_league_id}/rosters")
         rs = rs_resp if isinstance(rs_resp, list) else []
     for r in rs or []:
         if not isinstance(r, dict):
@@ -524,7 +596,7 @@ def _league_draft_slot_lookup(
 
         # Try the DETAIL endpoint first (slot_to_roster_id usually
         # lands here even when the LIST endpoint's copy is empty).
-        detail = _http_get_json(f"https://api.sleeper.app/v1/draft/{draft_id}")
+        detail = fetch(f"https://api.sleeper.app/v1/draft/{draft_id}")
         detail_dict = detail if isinstance(detail, dict) else {}
 
         # draft_order: { user_id: slot } — needs owner_id → roster_id.
@@ -736,6 +808,7 @@ def _build_waivers_block(
     sleeper_league_id: str,
     window_days: int = 365,
     id_to_player: dict[str, str] | None = None,
+    getter=None,
 ) -> list[dict[str, Any]]:
     """Sister to ``_build_trades_block`` — collects ``waiver`` and
     ``free_agent`` transactions across the league chain (same depth-2
@@ -766,8 +839,9 @@ def _build_waivers_block(
     typically reused from the loaded contract.  When absent, player
     labels fall back to the raw Sleeper id.
     """
+    fetch = getter or _http_get_json
     cutoff_ms = _utc_now_ms() - int(window_days) * 24 * 3600 * 1000
-    chain = _walk_league_chain(sleeper_league_id, max_depth=2)
+    chain = _walk_league_chain(sleeper_league_id, max_depth=2, getter=getter)
     if not chain:
         return []
 
@@ -777,11 +851,11 @@ def _build_waivers_block(
     seen: set[str] = set()
 
     for lid in chain:
-        rid_to_name, rid_to_owner = _league_rid_lookup(lid)
+        rid_to_name, rid_to_owner = _league_rid_lookup(lid, getter=getter)
 
         for week in range(0, 19):
             url = f"https://api.sleeper.app/v1/league/{lid}/transactions/{week}"
-            txs = _http_get_json(url)
+            txs = fetch(url)
             if not isinstance(txs, list):
                 continue
             for tx in txs:
@@ -869,6 +943,7 @@ def _build_trades_block(
     sleeper_league_id: str,
     window_days: int = 365,
     id_to_player: dict[str, str] | None = None,
+    getter=None,
 ) -> list[dict[str, Any]]:
     """Fetch the rolling trade history for the league chain and
     PROCESS each trade into the same shape the offline scraper bakes
@@ -896,8 +971,9 @@ def _build_trades_block(
     """
     import datetime as _dt
 
+    fetch = getter or _http_get_json
     cutoff_ms = _utc_now_ms() - int(window_days) * 24 * 3600 * 1000
-    chain = _walk_league_chain(sleeper_league_id, max_depth=2)
+    chain = _walk_league_chain(sleeper_league_id, max_depth=2, getter=getter)
     if not chain:
         return []
 
@@ -914,12 +990,13 @@ def _build_trades_block(
         # roster identity (a roster_id can change human ownership
         # across seasons).  The rosters fetch is reused by the
         # draft-slot lookup so we don't pay the round-trip twice.
-        rosters_resp = _http_get_json(f"https://api.sleeper.app/v1/league/{lid}/rosters")
+        rosters_resp = fetch(f"https://api.sleeper.app/v1/league/{lid}/rosters")
         rosters_list = rosters_resp if isinstance(rosters_resp, list) else []
-        rid_to_name, rid_to_owner = _league_rid_lookup(lid)
+        rid_to_name, rid_to_owner = _league_rid_lookup(lid, getter=getter)
         draft_slot_by_origin = _league_draft_slot_lookup(
             lid,
             rosters=rosters_list,
+            getter=getter,
         )
         # League size drives Early/Mid/Late tier bucketing for
         # future-year picks.  Default to 12-team when the rosters
@@ -933,7 +1010,7 @@ def _build_trades_block(
         # trades that happened before week 1.
         for week in range(0, 19):
             url = f"https://api.sleeper.app/v1/league/{lid}/transactions/{week}"
-            txs = _http_get_json(url)
+            txs = fetch(url)
             if not isinstance(txs, list):
                 continue
             for tx in txs:
@@ -1039,8 +1116,8 @@ def _normalize_ts_ms(v: Any) -> int:
     return n
 
 
-def _fetch_league_name(sleeper_league_id: str) -> str | None:
-    info = _http_get_json(f"https://api.sleeper.app/v1/league/{sleeper_league_id}")
+def _fetch_league_name(sleeper_league_id: str, getter=None) -> str | None:
+    info = (getter or _http_get_json)(f"https://api.sleeper.app/v1/league/{sleeper_league_id}")
     if not isinstance(info, dict):
         return None
     name = info.get("name")
@@ -1077,35 +1154,147 @@ def fetch_sleeper_overlay(
     be loaded).  Partial fetches are acceptable — e.g. trades
     empty but teams populated.
 
-    Caches per ``sleeper_league_id`` for 15 minutes.  Pass
-    ``force_refresh=True`` to bust the cache (used by tests).
+    Caching (documented for the perf audit):
+      * key: ``sleeper_league_id``.
+      * fresh TTL: 15 min (``_CACHE_TTL_SEC``) — unchanged.
+      * stale-serve window: 15-30 min (``_STALE_SERVE_MAX_SEC``).  An
+        expired entry is served immediately and exactly ONE daemon
+        thread refreshes it in the background (``_REFRESHING`` guard),
+        so no user request ever blocks on the ~50-100-call rebuild
+        while a usable overlay exists.
+      * single-flight: the blocking build path (cold cache, or stale
+        beyond 30 min) holds a per-league lock, so concurrent misses
+        coalesce onto one upstream storm instead of N.
+      * invalidation: ``force_refresh=True`` (tests + the background
+        refresher) rebuilds unconditionally;
+        ``invalidate_overlay_cache`` drops entries.
     """
     sleeper_league_id = str(sleeper_league_id or "").strip()
     if not sleeper_league_id:
         return None
 
-    now = time.time()
     if not force_refresh:
+        now = time.time()
         with _CACHE_LOCK:
             cached = _CACHE.get(sleeper_league_id)
-            if cached and (now - float(cached.get("_cached_at") or 0)) < _CACHE_TTL_SEC:
+        if cached:
+            age = now - float(cached.get("_cached_at") or 0)
+            if age < _CACHE_TTL_SEC:
+                return dict(cached["payload"])
+            if age < _STALE_SERVE_MAX_SEC:
+                _kick_overlay_background_refresh(
+                    sleeper_league_id,
+                    id_to_player=id_to_player,
+                    trade_window_days=trade_window_days,
+                )
                 return dict(cached["payload"])
 
-    teams = _build_teams_block(sleeper_league_id, id_to_player)
+    lock = _overlay_build_lock(sleeper_league_id)
+    with lock:
+        # Re-check under the lock: another thread may have completed
+        # the build while we waited.
+        if not force_refresh:
+            with _CACHE_LOCK:
+                cached = _CACHE.get(sleeper_league_id)
+            if cached and (time.time() - float(cached.get("_cached_at") or 0)) < _CACHE_TTL_SEC:
+                return dict(cached["payload"])
+        return _build_overlay_and_cache(
+            sleeper_league_id,
+            id_to_player=id_to_player,
+            trade_window_days=trade_window_days,
+        )
+
+
+def _overlay_build_lock(sleeper_league_id: str) -> threading.Lock:
+    with _CACHE_LOCK:
+        lock = _BUILD_LOCKS.get(sleeper_league_id)
+        if lock is None:
+            lock = threading.Lock()
+            _BUILD_LOCKS[sleeper_league_id] = lock
+        return lock
+
+
+def _kick_overlay_background_refresh(
+    sleeper_league_id: str,
+    *,
+    id_to_player: dict[str, str] | None,
+    trade_window_days: int,
+) -> None:
+    """Start (at most) one daemon refresh for a stale-served league."""
+    with _CACHE_LOCK:
+        if sleeper_league_id in _REFRESHING:
+            return
+        _REFRESHING.add(sleeper_league_id)
+
+    def _run() -> None:
+        try:
+            fetch_sleeper_overlay(
+                sleeper_league_id=sleeper_league_id,
+                id_to_player=id_to_player,
+                trade_window_days=trade_window_days,
+                force_refresh=True,
+            )
+        except Exception as exc:  # noqa: BLE001 — background best-effort
+            log.warning("overlay background refresh failed for %s: %s", sleeper_league_id, exc)
+        finally:
+            with _CACHE_LOCK:
+                _REFRESHING.discard(sleeper_league_id)
+
+    threading.Thread(
+        target=_run, daemon=True, name=f"overlay-refresh-{sleeper_league_id}"
+    ).start()
+
+
+def _build_overlay_and_cache(
+    sleeper_league_id: str,
+    *,
+    id_to_player: dict[str, str] | None,
+    trade_window_days: int,
+) -> dict[str, Any] | None:
+    """The actual ~league-chain-wide build.  Uses a build-scoped URL
+    memo (``_BuildFetcher``) plus one parallel prefetch wave for the
+    weekly transaction feeds + per-league lookups, cutting a cold
+    build from ~100 sequential round-trips to ~2 short parallel waves.
+    Output is byte-identical to the sequential build: the memo only
+    dedupes URLs that were fetched multiple times per build, and the
+    builders still consume weeks in order."""
+    fetcher = _BuildFetcher()
+
+    # Wave 1: the chain walk (1-2 calls, inherently sequential).
+    chain = _walk_league_chain(sleeper_league_id, max_depth=2, getter=fetcher.get)
+
+    # Wave 2: everything whose URL is known up front, in parallel —
+    # per-league rosters/users/league/drafts/traded_picks and the
+    # 19 weekly transaction feeds per chain league that BOTH the
+    # trades and waivers builders consume.
+    prefetch_urls: list[str] = []
+    for lid in chain or [sleeper_league_id]:
+        base = f"https://api.sleeper.app/v1/league/{lid}"
+        prefetch_urls.extend(
+            [f"{base}/rosters", f"{base}/users", base, f"{base}/drafts"]
+        )
+        prefetch_urls.extend(f"{base}/transactions/{week}" for week in range(0, 19))
+    root_base = f"https://api.sleeper.app/v1/league/{sleeper_league_id}"
+    prefetch_urls.append(f"{root_base}/traded_picks")
+    fetcher.prefetch(prefetch_urls)
+
+    teams = _build_teams_block(sleeper_league_id, id_to_player, getter=fetcher.get)
     if teams is None:
         # Hard fetch failure — nothing useful to return.
         return None
 
-    league_name = _fetch_league_name(sleeper_league_id) or ""
+    league_name = _fetch_league_name(sleeper_league_id, getter=fetcher.get) or ""
     trades = _build_trades_block(
         sleeper_league_id,
         window_days=trade_window_days,
         id_to_player=id_to_player,
+        getter=fetcher.get,
     )
     waivers = _build_waivers_block(
         sleeper_league_id,
         window_days=trade_window_days,
         id_to_player=id_to_player,
+        getter=fetcher.get,
     )
 
     cutoff_dt = _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(days=int(trade_window_days))
@@ -1127,7 +1316,7 @@ def fetch_sleeper_overlay(
     }
 
     with _CACHE_LOCK:
-        _CACHE[sleeper_league_id] = {"payload": dict(payload), "_cached_at": now}
+        _CACHE[sleeper_league_id] = {"payload": dict(payload), "_cached_at": time.time()}
     return payload
 
 

--- a/src/api/sleeper_overlay.py
+++ b/src/api/sleeper_overlay.py
@@ -1240,9 +1240,7 @@ def _kick_overlay_background_refresh(
             with _CACHE_LOCK:
                 _REFRESHING.discard(sleeper_league_id)
 
-    threading.Thread(
-        target=_run, daemon=True, name=f"overlay-refresh-{sleeper_league_id}"
-    ).start()
+    threading.Thread(target=_run, daemon=True, name=f"overlay-refresh-{sleeper_league_id}").start()
 
 
 def _build_overlay_and_cache(
@@ -1270,9 +1268,7 @@ def _build_overlay_and_cache(
     prefetch_urls: list[str] = []
     for lid in chain or [sleeper_league_id]:
         base = f"https://api.sleeper.app/v1/league/{lid}"
-        prefetch_urls.extend(
-            [f"{base}/rosters", f"{base}/users", base, f"{base}/drafts"]
-        )
+        prefetch_urls.extend([f"{base}/rosters", f"{base}/users", base, f"{base}/drafts"])
         prefetch_urls.extend(f"{base}/transactions/{week}" for week in range(0, 19))
     root_base = f"https://api.sleeper.app/v1/league/{sleeper_league_id}"
     prefetch_urls.append(f"{root_base}/traded_picks")

--- a/src/news/service.py
+++ b/src/news/service.py
@@ -27,6 +27,7 @@ logic testable without stubbing HTTP.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import threading
 import time
@@ -40,7 +41,13 @@ from .providers import available_provider_names, build_provider
 
 log = logging.getLogger(__name__)
 
-DEFAULT_CACHE_TTL_S = 180  # 3 minutes — rate-limit-safe for all providers
+# 10 minutes (was 3).  Aggregated RSS feeds rarely update faster, and
+# every TTL expiry used to run the full provider sweep inline on a user
+# request — raising the TTL cuts that slow path to a third of its old
+# frequency.  Approved freshness tradeoff: headlines may be up to
+# 10 min old.  (``FAILURE_CACHE_TTL_S`` below is unchanged — outages
+# still retry quickly.)
+DEFAULT_CACHE_TTL_S = 600
 # Hard freshness cutoff: every surface (news tab, popups, chips)
 # must only show news from the last week, so the drop happens HERE
 # at aggregation — not per consumer.  Items whose timestamp cannot
@@ -302,7 +309,12 @@ class NewsService:
         # the param.  Instead the unfiltered aggregate is cached once
         # per known-names universe and filters are projected onto a
         # copy on the way out.
-        cache_key = tuple(known_names)
+        #
+        # The key is a sha1 of the joined names rather than a
+        # ~2,000-element string tuple: same universe ⇒ same key, but
+        # hashing a 40-char digest per request beats hashing (and
+        # keeping alive) thousands of strings per cache entry.
+        cache_key = hashlib.sha1("\n".join(known_names).encode("utf-8")).hexdigest()
 
         # Cold-cache single-flight: exactly one thread (the "leader")
         # refreshes a given key; concurrent callers wait on the
@@ -412,18 +424,19 @@ class NewsService:
         and converted into a ``ProviderRunResult(ok=False)`` so
         the aggregate response can still succeed on the survivors.
 
-        Run order follows registration order (priority).  We do
-        this sequentially rather than in a thread pool because
-        the worst-case total latency is small (2 providers × 5s
-        timeout = 10s cap, but realistic steady state is
-        sub-second) and keeping it sequential avoids another
-        dependency on a shared thread pool.
+        Providers run CONCURRENTLY in a bounded pool: the registry has
+        grown to ~6 enabled providers at a 5s timeout each, so a cold
+        refresh on the sequential path could stall a user request for
+        up to ~30s (the old "2 providers × 5s" rationale had gone
+        stale).  Results are collected back in registration order so
+        item ordering, dedupe preference, and ``providerRuns`` output
+        are byte-identical to the sequential implementation.
         """
-        all_items: List[NewsItem] = []
-        runs: List[ProviderRunResult] = []
-        for provider in self._providers:
+
+        def _run_one(provider) -> tuple[List[NewsItem], ProviderRunResult]:
             run = ProviderRunResult(name=provider.name, label=provider.label)
             started = time.monotonic()
+            items_out: List[NewsItem] = []
             try:
                 items = provider.fetch(
                     player_names=known_names,
@@ -432,7 +445,7 @@ class NewsService:
                 if not isinstance(items, list):
                     items = list(items or [])
                 run.count = len(items)
-                all_items.extend(items)
+                items_out = items
             except Exception as exc:  # defensive — providers
                 # shouldn't raise, but if they do we isolate the
                 # failure here rather than 500-ing the route.
@@ -441,6 +454,23 @@ class NewsService:
                 run.error = f"{type(exc).__name__}: {exc}"
             finally:
                 run.elapsed_ms = int((time.monotonic() - started) * 1000)
+            return items_out, run
+
+        providers = list(self._providers)
+        if len(providers) <= 1:
+            results = [_run_one(p) for p in providers]
+        else:
+            from concurrent.futures import ThreadPoolExecutor
+
+            with ThreadPoolExecutor(
+                max_workers=min(6, len(providers)), thread_name_prefix="news-provider"
+            ) as ex:
+                results = list(ex.map(_run_one, providers))
+
+        all_items: List[NewsItem] = []
+        runs: List[ProviderRunResult] = []
+        for items, run in results:
+            all_items.extend(items)
             runs.append(run)
         return all_items, runs
 

--- a/tests/api/test_array_view.py
+++ b/tests/api/test_array_view.py
@@ -59,9 +59,7 @@ def array_env(tmp_path, monkeypatch):
 
     monkeypatch.setattr(server, "_is_authenticated", lambda request: True)
     # Keep the live Sleeper overlay out of these tests.
-    monkeypatch.setattr(
-        server._sleeper_overlay, "fetch_sleeper_overlay", lambda **kwargs: None
-    )
+    monkeypatch.setattr(server._sleeper_overlay, "fetch_sleeper_overlay", lambda **kwargs: None)
 
     yield
 
@@ -77,9 +75,7 @@ def _install_views(monkeypatch):
     full_payload = {
         "meta": {"leagueKey": "main"},
         "players": {"Josh Allen": {"rankDerivedValue": 9200}},
-        "playersArray": [
-            {"displayName": "Josh Allen", "rankDerivedValue": 9200}
-        ],
+        "playersArray": [{"displayName": "Josh Allen", "rankDerivedValue": 9200}],
         "sleeper": {"teams": []},
     }
     full_raw = json.dumps(full_payload, ensure_ascii=False, separators=(",", ":")).encode()
@@ -97,9 +93,7 @@ def _install_views(monkeypatch):
     monkeypatch.setattr(server, "latest_array_data", array_payload)
     monkeypatch.setattr(server, "latest_array_data_bytes", array_raw)
     monkeypatch.setattr(server, "latest_array_data_gzip_bytes", _gzip.compress(array_raw))
-    monkeypatch.setattr(
-        server, "latest_array_data_etag", _hashlib.sha1(array_raw).hexdigest()
-    )
+    monkeypatch.setattr(server, "latest_array_data_etag", _hashlib.sha1(array_raw).hexdigest())
     return full_payload
 
 

--- a/tests/api/test_array_view.py
+++ b/tests/api/test_array_view.py
@@ -1,0 +1,165 @@
+"""Tests for the ``?view=array`` desktop payload of ``GET /api/data``.
+
+The full contract carries TWO parallel encodings of every player: the
+legacy ``players`` dict and ``playersArray`` (~5.8MB + ~6.6MB of a
+~12MB payload).  ``playersArray`` is strictly richer and is the branch
+the frontend materializer (``buildRows``) prefers whenever present, so
+desktop clients request ``view=array`` — the full contract minus the
+legacy dict — and cut wire/parse cost roughly in half with zero field
+loss.
+
+Pinned here:
+    1. ``view=array`` serves the precomputed array payload: no
+       ``players`` dict, ``playersArray`` intact and identical to the
+       full view's, ``X-Payload-View: array``.
+    2. ``view=desktop`` is an accepted alias.
+    3. The array payload is byte-stable with its own ETag (304 support
+       comes from the shared fast path).
+    4. Unknown views still fall back to the full payload.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+import server
+from src.api import league_registry
+
+
+@pytest.fixture
+def array_env(tmp_path, monkeypatch):
+    path = tmp_path / "registry.json"
+    path.write_text(
+        json.dumps(
+            {
+                "defaultLeagueKey": "main",
+                "leagues": [
+                    {
+                        "key": "main",
+                        "displayName": "Main",
+                        "sleeperLeagueId": "L-MAIN",
+                        "active": True,
+                        "rosterSettings": {"teamCount": 12},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    from src.api import user_kv
+
+    monkeypatch.setattr(user_kv, "USER_KV_PATH", tmp_path / "user_kv.sqlite")
+    user_kv._SETUP_DONE.clear()
+
+    monkeypatch.setattr(server, "_is_authenticated", lambda request: True)
+    # Keep the live Sleeper overlay out of these tests.
+    monkeypatch.setattr(
+        server._sleeper_overlay, "fetch_sleeper_overlay", lambda **kwargs: None
+    )
+
+    yield
+
+    league_registry.reload_registry()
+
+
+def _install_views(monkeypatch):
+    """Install a full payload + its derived array payload the way
+    ``_prime_latest_payload`` does (dict copy minus ``players``)."""
+    import gzip as _gzip
+    import hashlib as _hashlib
+
+    full_payload = {
+        "meta": {"leagueKey": "main"},
+        "players": {"Josh Allen": {"rankDerivedValue": 9200}},
+        "playersArray": [
+            {"displayName": "Josh Allen", "rankDerivedValue": 9200}
+        ],
+        "sleeper": {"teams": []},
+    }
+    full_raw = json.dumps(full_payload, ensure_ascii=False, separators=(",", ":")).encode()
+
+    array_payload = dict(full_payload)
+    array_payload.pop("players", None)
+    array_payload["payloadView"] = "array"
+    array_raw = json.dumps(array_payload, ensure_ascii=False, separators=(",", ":")).encode()
+
+    monkeypatch.setattr(server, "latest_data", {"players": {}})
+    monkeypatch.setattr(server, "latest_contract_data", full_payload)
+    monkeypatch.setattr(server, "latest_data_bytes", full_raw)
+    monkeypatch.setattr(server, "latest_data_gzip_bytes", _gzip.compress(full_raw))
+    monkeypatch.setattr(server, "latest_data_etag", _hashlib.sha1(full_raw).hexdigest())
+    monkeypatch.setattr(server, "latest_array_data", array_payload)
+    monkeypatch.setattr(server, "latest_array_data_bytes", array_raw)
+    monkeypatch.setattr(server, "latest_array_data_gzip_bytes", _gzip.compress(array_raw))
+    monkeypatch.setattr(
+        server, "latest_array_data_etag", _hashlib.sha1(array_raw).hexdigest()
+    )
+    return full_payload
+
+
+def test_array_view_drops_only_the_legacy_dict(array_env, monkeypatch):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        full_payload = _install_views(monkeypatch)
+        res = c.get("/api/data?view=array")
+    assert res.status_code == 200, res.text
+    assert res.headers["X-Payload-View"] == "array"
+    body = res.json()
+    assert "players" not in body
+    assert body["playersArray"] == full_payload["playersArray"]
+    assert body["payloadView"] == "array"
+
+
+def test_desktop_alias(array_env, monkeypatch):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_views(monkeypatch)
+        res = c.get("/api/data?view=desktop")
+    assert res.status_code == 200
+    assert res.headers["X-Payload-View"] == "array"
+
+
+def test_array_view_supports_304(array_env, monkeypatch):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_views(monkeypatch)
+        first = c.get("/api/data?view=array")
+        etag = first.headers.get("etag")
+        assert etag
+        second = c.get("/api/data?view=array", headers={"If-None-Match": etag})
+    assert second.status_code == 304
+
+
+def test_unknown_view_serves_full(array_env, monkeypatch):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_views(monkeypatch)
+        res = c.get("/api/data?view=banana")
+    assert res.status_code == 200
+    assert res.headers["X-Payload-View"] == "full"
+    assert "players" in res.json()
+
+
+def test_prime_builds_array_variant_from_real_pipeline(array_env, monkeypatch, tmp_path):
+    """End-to-end: run the real ``_prime_latest_payload`` on the small
+    pipeline fixture and assert the array variant is the full payload
+    minus ``players`` — nothing else may differ."""
+    from tests.api.test_source_overrides import _fixture_raw_payload
+
+    # Rank-history stamping writes under data/; isolate it.
+    monkeypatch.setattr(server, "RANK_HISTORY_ENABLED", False, raising=False)
+    server._prime_latest_payload(_fixture_raw_payload())
+    try:
+        full = server.latest_contract_data
+        arr = server.latest_array_data
+        assert full is not None and arr is not None
+        assert "players" in full
+        assert "players" not in arr
+        expected = dict(full)
+        expected.pop("players")
+        expected["payloadView"] = "array"
+        assert arr == expected
+    finally:
+        server._prime_latest_payload(None)

--- a/tests/api/test_overrides_response_cache.py
+++ b/tests/api/test_overrides_response_cache.py
@@ -1,0 +1,174 @@
+"""Tests for the ``POST /api/rankings/overrides`` response memo.
+
+The endpoint used to rebuild the full ranking pipeline synchronously on
+the event loop for every request — and since the frontend's stock
+settings post a body on every page load, that meant one multi-second
+pipeline run per page view.  ``server._OVERRIDES_RESPONSE_CACHE``
+memoizes the encoded response bytes keyed on (canonical body, view,
+league, sleeper-match) and versioned on ``latest_data_etag``.
+
+Pinned here:
+    1. Two identical POSTs → one pipeline build, byte-identical bodies.
+    2. Distinct bodies → distinct slots (no cross-body bleed).
+    3. A new contract generation (etag change) → rebuild.
+    4. ``_prime_latest_payload`` clears the memo outright.
+    5. leagueAdjusted requests bypass the cache (rebuilt every time).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+import server
+from src.api import league_registry
+from tests.api.test_source_overrides import _fixture_raw_payload
+
+
+@pytest.fixture
+def overrides_env(tmp_path, monkeypatch):
+    """Single-league registry + stub contract + clean memo."""
+    path = tmp_path / "registry.json"
+    path.write_text(
+        json.dumps(
+            {
+                "defaultLeagueKey": "main",
+                "leagues": [
+                    {
+                        "key": "main",
+                        "displayName": "Main",
+                        "sleeperLeagueId": "L-MAIN",
+                        "active": True,
+                        "rosterSettings": {"teamCount": 12},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    from src.api import user_kv
+
+    monkeypatch.setattr(user_kv, "USER_KV_PATH", tmp_path / "user_kv.sqlite")
+    user_kv._SETUP_DONE.clear()
+
+    monkeypatch.setattr(server, "_is_authenticated", lambda request: True)
+
+    server._OVERRIDES_RESPONSE_CACHE.clear()
+    server._OVERRIDES_ENCODE_LOCKS.clear()
+
+    yield
+
+    server._OVERRIDES_RESPONSE_CACHE.clear()
+    server._OVERRIDES_ENCODE_LOCKS.clear()
+    league_registry.reload_registry()
+
+
+def _install_data(monkeypatch, etag: str = "etag-gen-1"):
+    """Install the raw fixture payload + a contract meta stamped for
+    the registry's ``main`` league.  Must run inside the TestClient
+    context (same rationale as test_league_routing)."""
+    monkeypatch.setattr(server, "latest_data", _fixture_raw_payload())
+    monkeypatch.setattr(
+        server,
+        "latest_contract_data",
+        {"meta": {"leagueKey": "main"}},
+    )
+    monkeypatch.setattr(server, "latest_data_etag", etag)
+
+
+def _count_builds(monkeypatch):
+    """Wrap the delta builder with a call counter."""
+    calls = {"n": 0}
+    real = server.build_rankings_delta_payload
+
+    def counting(*args, **kwargs):
+        calls["n"] += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(server, "build_rankings_delta_payload", counting)
+    return calls
+
+
+STOCK_BODY = {"tep_multiplier": 1.15}
+
+
+def test_identical_posts_build_once_and_match_bytes(overrides_env, monkeypatch):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_data(monkeypatch)
+        calls = _count_builds(monkeypatch)
+
+        r1 = c.post("/api/rankings/overrides?view=delta", json=STOCK_BODY)
+        r2 = c.post("/api/rankings/overrides?view=delta", json=STOCK_BODY)
+
+    assert r1.status_code == 200, r1.text
+    assert r2.status_code == 200, r2.text
+    assert calls["n"] == 1, "second identical POST must be served from the memo"
+    assert r1.content == r2.content
+    assert r1.headers["X-Payload-View"] == "rankings-overrides-delta"
+    assert r1.headers["Cache-Control"] == "no-store"
+
+
+def test_distinct_bodies_get_distinct_slots(overrides_env, monkeypatch):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_data(monkeypatch)
+        calls = _count_builds(monkeypatch)
+
+        r1 = c.post("/api/rankings/overrides?view=delta", json={"tep_multiplier": 1.15})
+        r2 = c.post("/api/rankings/overrides?view=delta", json={"tep_multiplier": 1.30})
+
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert calls["n"] == 2
+    assert r1.content != r2.content
+
+
+def test_new_contract_generation_invalidates(overrides_env, monkeypatch):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_data(monkeypatch, etag="etag-gen-1")
+        calls = _count_builds(monkeypatch)
+
+        r1 = c.post("/api/rankings/overrides?view=delta", json=STOCK_BODY)
+        assert r1.status_code == 200
+        assert calls["n"] == 1
+
+        # Simulate a scrape promotion: same raw data, new generation.
+        monkeypatch.setattr(server, "latest_data_etag", "etag-gen-2")
+        r2 = c.post("/api/rankings/overrides?view=delta", json=STOCK_BODY)
+        assert r2.status_code == 200
+
+    assert calls["n"] == 2, "stale-generation entry must be rebuilt"
+
+
+def test_prime_latest_payload_clears_memo(overrides_env):
+    server._OVERRIDES_RESPONSE_CACHE[("overrides", "x", True, "main", False)] = (
+        b"raw",
+        b"gz",
+        "etag-gen-1",
+    )
+    # Falsy data → prime resets globals (incl. our memo) and returns.
+    server._prime_latest_payload(None)
+    assert server._OVERRIDES_RESPONSE_CACHE == {}
+
+
+def test_league_adjusted_requests_bypass_cache(overrides_env, monkeypatch):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_data(monkeypatch)
+        calls = _count_builds(monkeypatch)
+        monkeypatch.setattr(
+            server._gameplan,
+            "get_league_adjusted_values",
+            lambda *a, **k: {"factors": {"QB": 1.1}},
+        )
+
+        body = {"tep_multiplier": 1.15, "valuation_mode": "leagueAdjusted"}
+        r1 = c.post("/api/rankings/overrides?view=delta", json=body)
+        r2 = c.post("/api/rankings/overrides?view=delta", json=body)
+
+    assert r1.status_code == 200, r1.text
+    assert r2.status_code == 200, r2.text
+    assert calls["n"] == 2, "leagueAdjusted path must not be memoized"
+    assert not server._OVERRIDES_RESPONSE_CACHE, "no slot may be written for leagueAdjusted"

--- a/tests/api/test_per_source_freshness.py
+++ b/tests/api/test_per_source_freshness.py
@@ -18,6 +18,7 @@ import server as srv
 
 
 def test_per_source_freshness_returns_dict_with_known_sources():
+    srv._DISK_PROBE_MEMO.clear()  # helper is 30s-memoized; probe fresh
     out = srv._per_source_freshness()
     assert isinstance(out, dict)
     # KTC always has a CSV in the live repo; this confirms the
@@ -34,6 +35,7 @@ def test_per_source_freshness_returns_dict_with_known_sources():
 
 
 def test_freshness_records_have_consistent_age_window():
+    srv._DISK_PROBE_MEMO.clear()  # helper is 30s-memoized; probe fresh
     out = srv._per_source_freshness()
     if not out:
         pytest.skip("no CSV sources present in this checkout")
@@ -55,6 +57,7 @@ def test_per_source_freshness_returns_empty_when_repo_missing(monkeypatch, tmp_p
     bogus = tmp_path / "fake_repo_root"
     bogus.mkdir()
     monkeypatch.setattr(srv, "__file__", str(bogus / "server.py"))
+    srv._DISK_PROBE_MEMO.clear()  # helper is 30s-memoized; probe fresh
     out = srv._per_source_freshness()
     assert out == {}
 
@@ -79,6 +82,9 @@ def _redirect_repo_root(monkeypatch, tmp_path, source_key: str, csv_rel: str):
     from src.api import data_contract as dc
 
     monkeypatch.setattr(dc, "_SOURCE_CSV_PATHS", {source_key: csv_rel})
+    # The helper is 30s-memoized in production; each redirected test
+    # needs a fresh probe of its own fake repo root.
+    srv._DISK_PROBE_MEMO.clear()
     return csv_path, stamp_path
 
 

--- a/tests/api/test_sleeper_overlay_concurrency.py
+++ b/tests/api/test_sleeper_overlay_concurrency.py
@@ -1,0 +1,184 @@
+"""Concurrency + staleness tests for the Sleeper overlay cache.
+
+A cold overlay build is ~50-100 Sleeper round-trips.  Before the
+single-flight/stale-serve work, every request after the 15-min TTL
+expiry paid that storm inline (~8-12s), and N concurrent expirees each
+launched their own.  Pinned here:
+
+    1. Concurrent cold fetches coalesce onto ONE build (single-flight).
+    2. Within one build, a URL is fetched at most once (build memo) —
+       the trades and waivers builders share the weekly feeds.
+    3. A stale entry (15-30 min) is served immediately while exactly
+       one background refresh runs.
+    4. A stale entry past the 30-min ceiling blocks and rebuilds.
+    5. Output parity: the memoized/prefetched build returns the same
+       trades/waivers the sequential builders produce.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from src.api import sleeper_overlay
+
+_FIXED_TS = int(time.time() * 1000)
+
+LEAGUE = "L100"
+
+
+def _fake_sleeper(calls):
+    """Minimal but complete fake Sleeper API.  Records every URL."""
+
+    def fake(url: str):
+        calls.append(url)
+        if url.endswith("/rosters"):
+            return [
+                {"roster_id": 1, "owner_id": "u1", "players": ["1111"]},
+                {"roster_id": 2, "owner_id": "u2", "players": ["2222"]},
+            ]
+        if url.endswith("/users"):
+            return [
+                {"user_id": "u1", "display_name": "Alpha"},
+                {"user_id": "u2", "display_name": "Beta"},
+            ]
+        if url.endswith("/traded_picks"):
+            return []
+        if url.endswith("/drafts"):
+            return []
+        if "/transactions/" in url:
+            week = int(url.rsplit("/", 1)[1])
+            if week == 3:
+                return [
+                    {
+                        "type": "trade",
+                        "status": "complete",
+                        "status_updated": _FIXED_TS,
+                        "transaction_id": "t1",
+                        "roster_ids": [1, 2],
+                        "adds": {"1111": 2, "2222": 1},
+                        "drops": {"1111": 1, "2222": 2},
+                        "draft_picks": [],
+                    },
+                    {
+                        "type": "waiver",
+                        "status": "complete",
+                        "status_updated": _FIXED_TS,
+                        "transaction_id": "w1",
+                        "roster_ids": [1],
+                        "adds": {"3333": 1},
+                        "drops": {},
+                        "settings": {"waiver_bid": 7},
+                    },
+                ]
+            return []
+        # League meta (no previous league → chain depth 1).
+        return {"name": "Fake League", "settings": {"waiver_budget": 100}}
+
+    return fake
+
+
+def _reset():
+    sleeper_overlay.invalidate_overlay_cache()
+    with sleeper_overlay._CACHE_LOCK:
+        sleeper_overlay._BUILD_LOCKS.clear()
+        sleeper_overlay._REFRESHING.clear()
+
+
+def test_concurrent_cold_fetches_single_flight(monkeypatch):
+    _reset()
+    calls: list[str] = []
+    monkeypatch.setattr(sleeper_overlay, "_http_get_json", _fake_sleeper(calls))
+
+    results = [None] * 6
+    threads = [
+        threading.Thread(
+            target=lambda i=i: results.__setitem__(
+                i,
+                sleeper_overlay.fetch_sleeper_overlay(
+                    sleeper_league_id=LEAGUE, id_to_player={"1111": "P One"}
+                ),
+            )
+        )
+        for i in range(6)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert all(r is not None for r in results)
+    assert all(r["leagueId"] == LEAGUE for r in results)
+    # Single-flight + per-build memo: each unique URL fetched exactly
+    # once across ALL six concurrent requests.
+    rosters_calls = [u for u in calls if u.endswith("/rosters")]
+    week3_calls = [u for u in calls if u.endswith("/transactions/3")]
+    assert len(rosters_calls) == 1, calls
+    assert len(week3_calls) == 1, calls
+
+
+def test_stale_entry_served_instantly_with_one_background_refresh(monkeypatch):
+    _reset()
+    calls: list[str] = []
+    monkeypatch.setattr(sleeper_overlay, "_http_get_json", _fake_sleeper(calls))
+
+    stale_payload = {"leagueId": LEAGUE, "leagueName": "Stale", "teams": [{"name": "Old"}]}
+    with sleeper_overlay._CACHE_LOCK:
+        sleeper_overlay._CACHE[LEAGUE] = {
+            "payload": dict(stale_payload),
+            "_cached_at": time.time() - (16 * 60),  # 16 min: stale, within ceiling
+        }
+
+    got = sleeper_overlay.fetch_sleeper_overlay(sleeper_league_id=LEAGUE)
+    assert got["leagueName"] == "Stale", "stale entry must be served immediately"
+
+    # Second stale hit while refresh may be in flight must not stack a
+    # second refresher (the _REFRESHING guard) and still serves data.
+    got2 = sleeper_overlay.fetch_sleeper_overlay(sleeper_league_id=LEAGUE)
+    assert got2 is not None
+
+    # Wait for the background refresh to land.
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        with sleeper_overlay._CACHE_LOCK:
+            entry = sleeper_overlay._CACHE.get(LEAGUE)
+            refreshing = LEAGUE in sleeper_overlay._REFRESHING
+        if entry and entry["payload"].get("leagueName") == "Fake League" and not refreshing:
+            break
+        time.sleep(0.05)
+    else:
+        raise AssertionError("background refresh never replaced the stale entry")
+
+
+def test_stale_past_ceiling_blocks_and_rebuilds(monkeypatch):
+    _reset()
+    calls: list[str] = []
+    monkeypatch.setattr(sleeper_overlay, "_http_get_json", _fake_sleeper(calls))
+
+    with sleeper_overlay._CACHE_LOCK:
+        sleeper_overlay._CACHE[LEAGUE] = {
+            "payload": {"leagueId": LEAGUE, "leagueName": "Ancient", "teams": []},
+            "_cached_at": time.time() - (31 * 60),  # past the 30-min ceiling
+        }
+
+    got = sleeper_overlay.fetch_sleeper_overlay(sleeper_league_id=LEAGUE)
+    assert got["leagueName"] == "Fake League", "past the ceiling the build must block"
+
+
+def test_memoized_build_matches_sequential_builders(monkeypatch):
+    _reset()
+    calls: list[str] = []
+    fake = _fake_sleeper(calls)
+    monkeypatch.setattr(sleeper_overlay, "_http_get_json", fake)
+
+    id_map = {"1111": "P One", "2222": "P Two", "3333": "P Three"}
+    seq_trades = sleeper_overlay._build_trades_block(LEAGUE, id_to_player=id_map)
+    seq_waivers = sleeper_overlay._build_waivers_block(LEAGUE, id_to_player=id_map)
+
+    overlay = sleeper_overlay.fetch_sleeper_overlay(
+        sleeper_league_id=LEAGUE, id_to_player=id_map, force_refresh=True
+    )
+    assert overlay["trades"] == seq_trades
+    assert overlay["waivers"] == seq_waivers
+    assert overlay["meta"]["tradeCount"] == 1
+    assert overlay["meta"]["waiverCount"] == 1


### PR DESCRIPTION
# Sitewide performance audit — fix the ~10s page loads

Full-stack audit + fix pass. Every bottleneck was traced to a specific line before changing anything, every cache ships with a documented contract (key / TTL / invalidation / staleness — see the new section in `docs/performance-optimization.md`), and **zero valuation semantics changed** — the overrides delta is byte-identical to the pre-change capture (modulo wall-clock freshness stamps) and the new desktop view is row-for-row identical to the full board over all 1,073 rows.

## Root causes found (in impact order)

1. **Every page load re-ran the full ranking pipeline server-side — twice.** The stock `tepMultiplier: 1.15` default makes every user "customized", so every `fetchDynastyData` POSTs `/api/rankings/overrides`, which rebuilt the whole pipeline synchronously **on the event loop**, uncached — and the data hook mounts twice per page (AppShell + page).
2. **Cold Sleeper overlay rebuild = ~90 sequential HTTP calls inline on `/api/data`** whenever its 15-min TTL expired (~7 of 8 windows, since the warm-behind only runs on the 2h scrape), with no single-flight — concurrent expirees each launched their own storm.
3. **Desktop production downloaded the full ~11.8 MB contract**: `preferredDataView()` returned `"delta"`, which is not a valid GET view, so the param was dropped and the server served `view=full`.
4. **Event-loop blockers**: `/api/draft-capital` (~4 s of openpyxl + six blocking Sleeper calls per request, ×3 per /draft load), `/api/terminal` + `/api/news` evaluating the news aggregation + two full-contract scans as *arguments to* `run_in_threadpool` (i.e. on the loop) with ~6 RSS providers fetched sequentially, `/api/trade/suggestions` CPU on the loop, `/api/status` disk globs per request, and `_prime_latest_payload` freezing the loop for seconds after every scrape.
5. **No client-side dedup** and `cache: "no-store"` defeating the backend's working ETag/304 path; the service worker wrote the multi-MB private contract to CacheStorage on every navigation for zero read benefit.

## What changed (one commit per phase)

- **`_OVERRIDES_RESPONSE_CACHE`** (server): memoized overrides responses, keyed sha1(canonical body) + view + league + sleeper-match, versioned on `latest_data_etag`, per-key single-flight, whole build+encode in one threadpool callable. leagueAdjusted bypasses the memo but still builds off-loop.
- **Client data layer**: 30s TTL + in-flight dedup for the base contract and the merged override result; `cache: "no-cache"` unlocks the backend's 304 path (always revalidates through `_private_api_gate`, so no replay after logout — the previously-rejected attempt used `"default"`, which is a different mode); invalidation on league switch + `auth:changed`.
- **`?view=array`**: fifth precomputed `/api/data` variant — full contract minus the legacy `players` dict (a parallel encoding of `playersArray`). 11.83→6.45 MB raw, 1.18 MB→674 KB gzip, row-parity pinned by test. Desktop requests it; `app`/`compact` were rejected for desktop because they drop tier/confidence/audit fields 20+ desktop surfaces render.
- **Sleeper overlay**: per-league single-flight, stale-serve ≤30 min with exactly one background refresher (approved freshness tradeoff; rankings/values unaffected), build-scoped URL memo (trades + waivers read the same 19 weekly feeds), parallel prefetch wave. Cold build: 51 unique calls, output parity with the sequential builders pinned by test.
- **Event-loop unblocking**: terminal/news arg-evaluation fix + contract-generation memo for the row scans; news providers fetch concurrently + TTL 180→600 s (approved) + cheap cache key; trade/suggestions threadpooled; draft-capital result cache (300 s, `?refresh=1` busts) + mtime-keyed workbook cache + threadpool + single-flight; status/health disk probes memoized 30 s; `_prime_latest_payload` restructured to compute-into-locals + tight-swap publish and offloaded at the scrape call site.
- **Perceived performance**: route-level `loading.jsx` for 12 routes, preconnect to sleepercdn, SW `NEVER_CACHE` for the contract (v7 bump), `/rankings` `displayRows` memoized, `useTerminal` `skip` option kills the discarded `ownerId:""` duplicate fetch, `/tools/trade-coverage` 4-wide worker pool instead of 12 sequential awaits.

## Measured (prod-topology harness: `next build` + `next start` + nginx-standin, real data)

| Metric | Before | After |
|---|---|---|
| `POST /api/rankings/overrides` (stock body) | 0.75–0.93 s **every call** | **4 ms** (one 0.73 s build per scrape generation) |
| Desktop contract wire | 11.83 MB / 1.18 MB gzip | 6.45 MB / 674 KB, then 304s |
| `/api/terminal` | 7.8 s cold / 20 ms warm | 1.4 s cold / 20 ms warm |
| `/api/draft-capital` | 3.9–4.1 s **every request, on the loop** | 2.6–3.2 s cold (threadpooled) / **5 ms** warm |
| `/trade` settle / LCP | 13.5 s / 12.4 s | **1.7 s / 0.7 s** |
| `/draft` settle | 11.4 s | **1.6 s** |
| `/rankings` usable | 6.9 s | **1.1 s** |
| `/` LCP | 2.7 s | 0.8 s |
| Client-side nav re-downloads | full contract + pipeline rebuild each nav | served from 30 s memo / 304 |

## Validation

- Full pytest suite: **5,312 passed, 0 failed** (25 pre-existing skips), including 3 new test files (overrides memo, array-view parity, overlay concurrency).
- Frontend vitest: **1,378 passed** across both projects, including new dedup/TTL tests; `next build` green with all per-page bundle budgets passing.
- E2E `critical-smoke`: 18/18 against the self-boot topology. `signed-in-smoke`: 8/9 — the one failure is an environment artifact (the spec clicks the *first* listbox assuming a single-league registry; this environment has two leagues, so it opened the league switcher).
- Zero-data-change oracles: overrides delta byte-identical to the pre-change golden capture except time-derived freshness stamps; `buildRows(full)` vs `buildRows(array)` identical over 1,073 rows.

## Deliberately NOT done (with rationale, documented in the ledger)

- Changing the `tepMultiplier` default to `null` (changes TE values — ADR-015 basis curve).
- uvicorn multi-worker (module-global contract caches + in-process scheduler are single-process by design).
- Serving `view=app`/`compact` to desktop (drops rendered fields), RSC migration, CSS/design-system restructure, rankings virtualization (visible-row changes), nginx `proxy_cache` on `/api/` (not validatable in this environment; the single-process backend now serves warm hits in single-digit ms anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeQ4SkH9khPRx2b3WunSTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeQ4SkH9khPRx2b3WunSTA)_