### PR TITLE
Cut the /rankings first-load waterfall: parallel fetches + shared rows

### DIFF
--- a/frontend/__tests__/dynasty-data-dedup.test.js
+++ b/frontend/__tests__/dynasty-data-dedup.test.js
@@ -19,6 +19,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   fetchDynastyData,
+  prefetchBaseContract,
   _resetBaseContractCache,
   _resetValuationOverlayCache,
 } from "@/lib/dynasty-data.js";
@@ -174,5 +175,62 @@ describe("contract data layer dedup + TTL", () => {
     const [url, opts] = globalThis.fetch.mock.calls[0];
     expect(String(url)).toMatch(/\/api\/dynasty-data/);
     expect(opts?.cache).toBe("no-cache");
+  });
+
+  it("override path fires base GET and overrides POST concurrently", async () => {
+    // Make the base fetch slow; assert the POST is already on the wire
+    // before the base resolves (they used to run serially, putting an
+    // extra round-trip on every first page view).
+    let resolveBase;
+    const urls = [];
+    globalThis.fetch = vi.fn((url) => {
+      urls.push(String(url));
+      if (String(url).includes("/api/rankings/overrides")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => structuredClone(DELTA_PAYLOAD),
+        });
+      }
+      return new Promise((resolve) => {
+        resolveBase = () =>
+          resolve({ ok: true, json: async () => structuredClone(BASE_PAYLOAD) });
+      });
+    });
+
+    const resultPromise = fetchDynastyData({ tepMultiplier: 1.15 });
+    // Give microtasks a chance to dispatch both requests.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(
+      urls.some((u) => u.includes("/api/rankings/overrides")),
+      "overrides POST must start before the base GET resolves",
+    ).toBe(true);
+    resolveBase();
+    const result = await resultPromise;
+    expect(result.source).toBe("backend:override:delta");
+  });
+
+  it("prefetchBaseContract shares its in-flight request with the real fetch", async () => {
+    prefetchBaseContract();
+    const result = await fetchDynastyData();
+    expect(result.ok).toBe(true);
+    const gets = globalThis.fetch.mock.calls
+      .map(([u]) => String(u))
+      .filter((u) => u.includes("/api/dynasty-data"));
+    expect(gets).toHaveLength(1);
+  });
+
+  it("prefetchBaseContract swallows failures and leaves the path retryable", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 401, text: async () => "no" })
+      .mockResolvedValue({
+        ok: true,
+        json: async () => structuredClone(BASE_PAYLOAD),
+      });
+    prefetchBaseContract();
+    // Let the rejected prefetch settle without surfacing.
+    await new Promise((r) => setTimeout(r, 0));
+    const result = await fetchDynastyData();
+    expect(result.ok).toBe(true);
   });
 });

--- a/frontend/__tests__/site-overrides.test.js
+++ b/frontend/__tests__/site-overrides.test.js
@@ -589,6 +589,27 @@ describe("mergeRankingsDelta — runtime-view base (no playersArray)", () => {
   });
 });
 
+// URL-routing fetch mock.  The base GET and the overrides POST start
+// CONCURRENTLY (the POST never needed the base payload), so ordered
+// ``mockResolvedValueOnce`` queues would hand the base payload to
+// whichever request happens to dispatch first.  Route responses by URL
+// instead; multiple delta responses are consumed FIFO (the last one
+// sticks for any further POSTs).
+function routeFetchMock({ base, deltas = [] }) {
+  const deltaQueue = [...deltas];
+  return vi.fn(async (url) => {
+    if (String(url).includes("/api/rankings/overrides")) {
+      if (deltaQueue.length > 1) return deltaQueue.shift();
+      return deltaQueue[0] ?? { ok: false, status: 503, json: async () => ({}) };
+    }
+    return base;
+  });
+}
+
+function callsMatching(fetchMock, pattern) {
+  return fetchMock.mock.calls.filter(([url]) => pattern.test(String(url)));
+}
+
 describe("fetchDynastyData — routes overrides to backend endpoint", () => {
   const realFetch = globalThis.fetch;
 
@@ -619,9 +640,8 @@ describe("fetchDynastyData — routes overrides to backend endpoint", () => {
   });
 
   it("POSTs to /api/rankings/overrides?view=delta when the map is customized", async () => {
-    // First call: /api/dynasty-data (base contract load).
-    globalThis.fetch
-      .mockResolvedValueOnce({
+    globalThis.fetch = routeFetchMock({
+      base: {
         ok: true,
         json: async () => ({
           ok: true,
@@ -641,38 +661,45 @@ describe("fetchDynastyData — routes overrides to backend endpoint", () => {
             ],
           },
         }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          mode: "delta",
-          rankingsOverride: {
-            isCustomized: true,
-            enabledSources: ["idpTradeCalc"],
-            received: { ktcSfTep: { include: false } },
-          },
-          rankingsDelta: {
-            playerKey: "displayName",
-            players: [
-              {
-                id: "Player A",
-                canonicalConsensusRank: 1,
-                rankDerivedValue: 9700,
-                sourceRanks: { idpTradeCalc: 1 },
-              },
-            ],
-            activePlayerIds: ["Player A"],
-          },
-        }),
-      });
+      },
+      deltas: [
+        {
+          ok: true,
+          json: async () => ({
+            mode: "delta",
+            rankingsOverride: {
+              isCustomized: true,
+              enabledSources: ["idpTradeCalc"],
+              received: { ktcSfTep: { include: false } },
+            },
+            rankingsDelta: {
+              playerKey: "displayName",
+              players: [
+                {
+                  id: "Player A",
+                  canonicalConsensusRank: 1,
+                  rankDerivedValue: 9700,
+                  sourceRanks: { idpTradeCalc: 1 },
+                },
+              ],
+              activePlayerIds: ["Player A"],
+            },
+          }),
+        },
+      ],
+    });
     const result = await fetchDynastyData({
       siteOverrides: { ktcSfTep: { include: false } },
     });
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
-    const [url1] = globalThis.fetch.mock.calls[0];
-    const [url2, opts2] = globalThis.fetch.mock.calls[1];
-    expect(String(url1)).toMatch(/\/api\/dynasty-data/);
-    expect(String(url2)).toMatch(/\/api\/rankings\/overrides\?view=delta/);
+    const baseCalls = callsMatching(globalThis.fetch, /\/api\/dynasty-data/);
+    const postCalls = callsMatching(
+      globalThis.fetch,
+      /\/api\/rankings\/overrides\?view=delta/,
+    );
+    expect(baseCalls).toHaveLength(1);
+    expect(postCalls).toHaveLength(1);
+    const [, opts2] = postCalls[0];
     expect(opts2?.method).toBe("POST");
     expect(opts2?.headers?.["Content-Type"]).toBe("application/json");
     const body = JSON.parse(opts2.body);
@@ -683,8 +710,8 @@ describe("fetchDynastyData — routes overrides to backend endpoint", () => {
   });
 
   it("reuses the cached base contract for a second override fetch", async () => {
-    globalThis.fetch
-      .mockResolvedValueOnce({
+    globalThis.fetch = routeFetchMock({
+      base: {
         ok: true,
         json: async () => ({
           ok: true,
@@ -703,43 +730,46 @@ describe("fetchDynastyData — routes overrides to backend endpoint", () => {
             ],
           },
         }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          mode: "delta",
-          rankingsOverride: { isCustomized: true },
-          rankingsDelta: {
-            playerKey: "displayName",
-            players: [
-              {
-                id: "Player A",
-                canonicalConsensusRank: 1,
-                rankDerivedValue: 9600,
-              },
-            ],
-            activePlayerIds: ["Player A"],
-          },
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          mode: "delta",
-          rankingsOverride: { isCustomized: true },
-          rankingsDelta: {
-            playerKey: "displayName",
-            players: [
-              {
-                id: "Player A",
-                canonicalConsensusRank: 1,
-                rankDerivedValue: 9500,
-              },
-            ],
-            activePlayerIds: ["Player A"],
-          },
-        }),
-      });
+      },
+      deltas: [
+        {
+          ok: true,
+          json: async () => ({
+            mode: "delta",
+            rankingsOverride: { isCustomized: true },
+            rankingsDelta: {
+              playerKey: "displayName",
+              players: [
+                {
+                  id: "Player A",
+                  canonicalConsensusRank: 1,
+                  rankDerivedValue: 9600,
+                },
+              ],
+              activePlayerIds: ["Player A"],
+            },
+          }),
+        },
+        {
+          ok: true,
+          json: async () => ({
+            mode: "delta",
+            rankingsOverride: { isCustomized: true },
+            rankingsDelta: {
+              playerKey: "displayName",
+              players: [
+                {
+                  id: "Player A",
+                  canonicalConsensusRank: 1,
+                  rankDerivedValue: 9500,
+                },
+              ],
+              activePlayerIds: ["Player A"],
+            },
+          }),
+        },
+      ],
+    });
 
     await fetchDynastyData({ siteOverrides: { ktcSfTep: { include: false } } });
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
@@ -747,27 +777,33 @@ describe("fetchDynastyData — routes overrides to backend endpoint", () => {
     const result2 = await fetchDynastyData({
       siteOverrides: { ktcSfTep: { weight: 2.0 } },
     });
+    // Second call: base served from the in-memory cache, so only ONE
+    // more network call (the second override POST).
     expect(globalThis.fetch).toHaveBeenCalledTimes(3);
-    const [url3] = globalThis.fetch.mock.calls[2];
-    expect(String(url3)).toMatch(/\/api\/rankings\/overrides\?view=delta/);
+    expect(
+      callsMatching(globalThis.fetch, /\/api\/rankings\/overrides\?view=delta/),
+    ).toHaveLength(2);
     expect(result2.data.playersArray[0].rankDerivedValue).toBe(9500);
   });
 
   it("falls through to base contract when the override endpoint fails", async () => {
-    globalThis.fetch
-      .mockResolvedValueOnce({
+    globalThis.fetch = routeFetchMock({
+      base: {
         ok: true,
         json: async () => ({
           ok: true,
           source: "backend",
           data: fixture(),
         }),
-      })
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 503,
-        json: async () => ({ error: "unavailable" }),
-      });
+      },
+      deltas: [
+        {
+          ok: false,
+          status: 503,
+          json: async () => ({ error: "unavailable" }),
+        },
+      ],
+    });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const result = await fetchDynastyData({
       siteOverrides: { ktcSfTep: { include: false } },
@@ -912,15 +948,20 @@ describe("fetchDynastyData — tepMultiplier routes overrides to backend", () =>
   });
 
   it("routes to override endpoint when only tepMultiplier is customized", async () => {
-    globalThis.fetch
-      .mockResolvedValueOnce(baseMock())
-      .mockResolvedValueOnce(deltaTepMock(4550));
+    globalThis.fetch = routeFetchMock({
+      base: baseMock(),
+      deltas: [deltaTepMock(4550)],
+    });
 
     const result = await fetchDynastyData({ tepMultiplier: 1.15 });
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
-    const [url2, opts2] = globalThis.fetch.mock.calls[1];
-    expect(String(url2)).toMatch(/\/api\/rankings\/overrides\?view=delta/);
+    const postCalls = callsMatching(
+      globalThis.fetch,
+      /\/api\/rankings\/overrides\?view=delta/,
+    );
+    expect(postCalls).toHaveLength(1);
+    const [, opts2] = postCalls[0];
     expect(opts2.method).toBe("POST");
     const body = JSON.parse(opts2.body);
     expect(body.tep_multiplier).toBe(1.15);
@@ -932,9 +973,10 @@ describe("fetchDynastyData — tepMultiplier routes overrides to backend", () =>
   });
 
   it("routes to override endpoint with BOTH siteOverrides and tepMultiplier", async () => {
-    globalThis.fetch
-      .mockResolvedValueOnce(baseMock())
-      .mockResolvedValueOnce(deltaTepMock(4400));
+    globalThis.fetch = routeFetchMock({
+      base: baseMock(),
+      deltas: [deltaTepMock(4400)],
+    });
 
     await fetchDynastyData({
       siteOverrides: { ktcSfTep: { include: false } },
@@ -942,7 +984,10 @@ describe("fetchDynastyData — tepMultiplier routes overrides to backend", () =>
     });
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
-    const [, opts2] = globalThis.fetch.mock.calls[1];
+    const [, opts2] = callsMatching(
+      globalThis.fetch,
+      /\/api\/rankings\/overrides\?view=delta/,
+    )[0];
     const body = JSON.parse(opts2.body);
     // siteOverrides map fields flow through
     expect(body.ktcSfTep).toEqual({ include: false });
@@ -951,20 +996,25 @@ describe("fetchDynastyData — tepMultiplier routes overrides to backend", () =>
   });
 
   it("cache key: changing tepMultiplier between fetches re-issues the override request", async () => {
-    globalThis.fetch
-      .mockResolvedValueOnce(baseMock())
-      .mockResolvedValueOnce(deltaTepMock(4500))
-      .mockResolvedValueOnce(deltaTepMock(4600));
+    globalThis.fetch = routeFetchMock({
+      base: baseMock(),
+      deltas: [deltaTepMock(4500), deltaTepMock(4600)],
+    });
 
     await fetchDynastyData({ tepMultiplier: 1.15 });
     await fetchDynastyData({ tepMultiplier: 1.25 });
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+    const postCalls = callsMatching(
+      globalThis.fetch,
+      /\/api\/rankings\/overrides\?view=delta/,
+    );
+    expect(postCalls).toHaveLength(2);
     // First override call (1.15)
-    const body1 = JSON.parse(globalThis.fetch.mock.calls[1][1].body);
+    const body1 = JSON.parse(postCalls[0][1].body);
     expect(body1.tep_multiplier).toBe(1.15);
     // Second override call (1.25)
-    const body2 = JSON.parse(globalThis.fetch.mock.calls[2][1].body);
+    const body2 = JSON.parse(postCalls[1][1].body);
     expect(body2.tep_multiplier).toBe(1.25);
   });
 });

--- a/frontend/components/useDynastyData.js
+++ b/frontend/components/useDynastyData.js
@@ -1,8 +1,32 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { buildRows, fetchDynastyData, getSiteKeys } from "@/lib/dynasty-data";
+import {
+  buildRows,
+  fetchDynastyData,
+  getSiteKeys,
+  prefetchBaseContract,
+} from "@/lib/dynasty-data";
 import { useSettings } from "@/components/useSettings";
+
+// Shared materialization cache: the hook is mounted by AppShell AND by
+// the page component, and after the fetch-layer dedup both instances
+// hold the SAME contract object — but each still paid its own
+// ``buildRows`` pass (~1,100 row objects + a sort, twice per page).
+// Keyed by contract object identity; consumers already treat rows as
+// immutable (the "pure materializer" rule — pages sort/filter copies),
+// so sharing one array is safe.  WeakMap so a replaced contract frees
+// its rows with it.
+const _rowsByContract = new WeakMap();
+
+function buildRowsShared(rawData) {
+  if (!rawData || typeof rawData !== "object") return buildRows(rawData || {});
+  const hit = _rowsByContract.get(rawData);
+  if (hit) return hit;
+  const rows = buildRows(rawData);
+  _rowsByContract.set(rawData, rows);
+  return rows;
+}
 
 export function useDynastyData() {
   // Read user-level source overrides from settings so per-source
@@ -78,6 +102,15 @@ export function useDynastyData() {
     };
   }, []);
 
+  // Warm the base-contract download immediately on mount.  The base
+  // payload does not depend on settings (only the overrides POST
+  // does), so there is no reason for the page's largest download to
+  // sit behind the settings-hydration gate below — the real fetch
+  // joins this in-flight request instead of starting from zero.
+  useEffect(() => {
+    prefetchBaseContract();
+  }, []);
+
   useEffect(() => {
     let active = true;
     // Do not fetch on the hydration pass.  ``useSettings`` serves
@@ -85,7 +118,9 @@ export function useDynastyData() {
     // request the DEFAULT board — market lens, no source overrides, the
     // default TE multiplier — and then immediately re-request the real
     // one, having rendered the wrong numbers in between.  Two round
-    // trips, and the first one wins the first paint.
+    // trips, and the first one wins the first paint.  (The BASE
+    // contract is settings-independent and is prefetched above; only
+    // the overrides POST waits for hydration.)
     //
     // ``loading`` is already true from its initial state, so the page
     // keeps showing its skeleton rather than an empty board; the delay
@@ -171,7 +206,7 @@ export function useDynastyData() {
 
   const rows = useMemo(() => {
     try {
-      return buildRows(rawData || {});
+      return buildRowsShared(rawData);
     } catch (e) {
       console.error("[useDynastyData] buildRows crashed:", e);
       return [];

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -2036,7 +2036,6 @@ export async function fetchDynastyData(opts = {}) {
   // cached base contract.  The backend bakes TEP into every TE's
   // rankDerivedValue stamp before producing the delta, so the
   // frontend never needs to multiply on render.
-  const base = await _fetchBaseContract();
 
   // Build the POST body: start from the siteOverrides map (legacy
   // shape) and stamp the tep_multiplier field on top only when the
@@ -2062,29 +2061,31 @@ export async function fetchDynastyData(opts = {}) {
 
   // Merged-result memo: the double-mounted hook fires two identical
   // override requests per page; serve the second from memory.  Key =
-  // POST body + active league; validity additionally requires the SAME
-  // base contract object (a new base generation or league switch
-  // yields a different reference) and the shared 30s TTL.  Only
-  // successful merges are cached — a fallback-to-base result must stay
-  // retryable.
+  // POST body + active league; a cached VALUE is additionally pinned
+  // to the base contract object it was merged onto (a new base
+  // generation or league switch yields a different reference) and the
+  // shared 30s TTL.  Only successful merges are cached — a
+  // fallback-to-base result must stay retryable.
   const overrideKey = `${JSON.stringify(body)}|${_readActiveLeagueKey()}`;
   if (
     _cachedOverrideResult &&
     _cachedOverrideResult.key === overrideKey &&
-    _cachedOverrideResult.base === base &&
+    _cachedOverrideResult.base === _cachedBaseContract &&
+    _cachedBaseContract &&
+    Date.now() - _cachedBaseContractAt < _BASE_CONTRACT_TTL_MS &&
     Date.now() - _cachedOverrideResult.at < _BASE_CONTRACT_TTL_MS
   ) {
     return _cachedOverrideResult.value;
   }
-  if (
-    _inflightOverrideResult &&
-    _inflightOverrideResult.key === overrideKey &&
-    _inflightOverrideResult.base === base
-  ) {
+  if (_inflightOverrideResult && _inflightOverrideResult.key === overrideKey) {
     return _inflightOverrideResult.promise;
   }
-  const promise = _postOverridesAndMerge(base, body, overrideKey);
-  _inflightOverrideResult = { key: overrideKey, base, promise };
+  // Base fetch and overrides POST run CONCURRENTLY — the POST never
+  // needed the base payload (only the merge does), yet they used to
+  // run serially, putting a full extra round-trip on the critical
+  // path of every first page view.
+  const promise = _postOverridesAndMerge(_fetchBaseContract(), body, overrideKey);
+  _inflightOverrideResult = { key: overrideKey, promise };
   try {
     return await promise;
   } finally {
@@ -2094,15 +2095,31 @@ export async function fetchDynastyData(opts = {}) {
   }
 }
 
-async function _postOverridesAndMerge(base, body, overrideKey) {
+async function _postOverridesAndMerge(basePromise, body, overrideKey) {
+  // Kick the POST off immediately (it never needed the base payload)
+  // and hold its failure in-band so the two error semantics stay
+  // exactly what they were on the serial path:
+  //   * base fetch failure → THROWS out of fetchDynastyData (the page
+  //     shows its error state);
+  //   * overrides POST failure → falls back to the base contract.
+  const postPromise = fetch(`${RANKINGS_OVERRIDES_URL}?view=delta`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    cache: "no-store",
+  }).catch((err) => {
+    if (typeof console !== "undefined" && console.warn) {
+      console.warn(
+        "[dynasty-data] /api/rankings/overrides request failed:",
+        err?.message || err,
+      );
+    }
+    return null;
+  });
+  const base = await basePromise;
   try {
-    const overrideRes = await fetch(`${RANKINGS_OVERRIDES_URL}?view=delta`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-      cache: "no-store",
-    });
-    if (overrideRes.ok) {
+    const overrideRes = await postPromise;
+    if (overrideRes && overrideRes.ok) {
       const deltaPayload = await overrideRes.json();
       if (
         deltaPayload &&
@@ -2134,7 +2151,7 @@ async function _postOverridesAndMerge(base, body, overrideKey) {
         };
         return passthrough;
       }
-    } else if (typeof console !== "undefined" && console.warn) {
+    } else if (overrideRes && typeof console !== "undefined" && console.warn) {
       console.warn(
         `[dynasty-data] /api/rankings/overrides returned ${overrideRes.status}; ` +
           "falling through to base contract.",
@@ -2143,7 +2160,7 @@ async function _postOverridesAndMerge(base, body, overrideKey) {
   } catch (err) {
     if (typeof console !== "undefined" && console.warn) {
       console.warn(
-        "[dynasty-data] /api/rankings/overrides request failed:",
+        "[dynasty-data] /api/rankings/overrides response handling failed:",
         err?.message || err,
       );
     }
@@ -2151,4 +2168,26 @@ async function _postOverridesAndMerge(base, body, overrideKey) {
 
   // Override endpoint failed — return the base contract unchanged.
   return base;
+}
+
+/**
+ * Warm the base-contract cache without waiting for settings hydration.
+ *
+ * The base contract does not depend on user settings — only the
+ * overrides POST does — yet the data hook's fetch effect gates on
+ * ``settingsHydrated``, so the largest download of the page used to
+ * start only after the settings store + auth probe settled.  Calling
+ * this from the hook's mount effect starts the download immediately;
+ * the real ``fetchDynastyData`` call then hits the in-flight promise
+ * (or the fresh cache) instead of the network.  Errors are swallowed:
+ * this is purely advisory warming, and the real fetch surfaces them.
+ */
+export function prefetchBaseContract() {
+  try {
+    const p = _fetchBaseContract();
+    if (p && typeof p.catch === "function") p.catch(() => {});
+    return p;
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
Follow-up to #620, prompted by "/rankings still takes a long time to load."

**First, the main explanation:** the production deploy of #620 (`Deploy Production` run #1973) was still in progress when that was observed — production was running pre-merge code at the time. This PR additionally removes the three serial costs that remained on the /rankings first-load critical path even with #620 deployed.

## Changes

1. **Base contract GET ∥ overrides POST.** The two requests ran serially even though the POST never needed the base payload (only the client-side merge does). They now start concurrently — measured on the wire within 30 ms of each other, where the POST previously waited out a full GET round-trip (674 KB) first. Error semantics preserved exactly: a base-fetch failure still throws (page error state); a POST failure still falls back to the base contract.
2. **Base contract prefetch on hook mount.** The page's largest download sat behind the settings-hydration gate although the base payload does not depend on settings (only the POST body does). `prefetchBaseContract()` starts it immediately; the gated real fetch joins the in-flight request. Failures are swallowed and never cached, so the real fetch's error handling is untouched.
3. **Shared `buildRows` across hook instances.** AppShell and the page component each materialized their own ~1,100-row array from the *same* contract object. A `WeakMap` keyed on contract identity now shares one array. Safe because consumers already treat rows as immutable per the pure-materializer rule — verified there are no in-place row mutations anywhere in `app/`/`components/`.

## Tests

- `site-overrides.test.js`: the ordered `mockResolvedValueOnce` queues encoded the incidental serial dispatch order, not the pinned contract (*which request gets which response*) — replaced with URL-routed mocks.
- New tests pin the concurrency (POST on the wire before the base resolves), prefetch request-sharing, and prefetch failure-swallowing.
- Full frontend suite: 1,381 passed; production build green with all bundle budgets passing.

## Measured (local prod build)

/rankings usable ≈ 950 ms warm (one-time cold contract-generation encode aside); GET and POST start within 30 ms of each other vs fully serial before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeQ4SkH9khPRx2b3WunSTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeQ4SkH9khPRx2b3WunSTA)_