### PR TITLE
N2 + N3, and close the three open modeling decisions with measurements

### DIFF
--- a/docs/audits/complete-codebase-audit-2026-07-29.md
+++ b/docs/audits/complete-codebase-audit-2026-07-29.md
@@ -213,6 +213,18 @@ source votes exactly once — pinned by a determinism test.
 
 ### Open modeling decisions (NOT resolved here)
 
+> **Followed up 2026-07-29 — see `docs/open-modeling-decisions.md`.**
+> Both questions below were under-specified: stated as choices without
+> the measurements needed to make them. They are now closed to evidence.
+> **(1) `coverageWeight`: do not apply** — measured at 297 rows moved /
+> 221 ranks changed for a 3-source input change, with no accuracy
+> evidence. **(2) the rank-form family: the "bring it under the model
+> registry" proposal was WRONG** — the refit script is read-only and
+> nothing runs it, so there is no automated promotion to gate; replaced
+> with a tripwire test. A third question raised later (the
+> `low_conf_unstable` threshold) turned out to be a broken metric, not a
+> threshold — same document.
+
 1. **Should `coverageWeight` be applied?** The depth-scaled factor is
    computed and published but never used. Applying it would down-weight
    the three depth-50 rookie sources and *change the default board*.

--- a/docs/measurements/coverage-weight-impact-2026-07-29.json
+++ b/docs/measurements/coverage-weight-impact-2026-07-29.json
@@ -1,0 +1,199 @@
+{
+  "generatedAt": "2026-07-29T23:54:54.994870+00:00",
+  "payload": "exports/latest/dynasty_data_2026-07-29.json",
+  "minFullCoverageDepth": 60,
+  "sourcesTotal": 21,
+  "sourcesAffected": [
+    {
+      "key": "dlfRookieSf",
+      "depth": 50,
+      "declared": 1.0,
+      "effective": 0.8333
+    },
+    {
+      "key": "dlfRookieIdp",
+      "depth": 50,
+      "declared": 1.0,
+      "effective": 0.8333
+    },
+    {
+      "key": "flockFantasySfRookies",
+      "depth": 50,
+      "declared": 1.0,
+      "effective": 0.8333
+    }
+  ],
+  "rowsTotal": 1094,
+  "rowsMoved": 297,
+  "ranksChanged": 221,
+  "maxAbsValueDelta": 1072,
+  "medianAbsValueDelta": 0,
+  "boardEntered": [
+    "Josh Cameron"
+  ],
+  "boardLeft": [
+    "Kenny Moore"
+  ],
+  "largestMoves": [
+    {
+      "name": "Josh Cameron",
+      "valueBefore": null,
+      "valueAfter": 1072,
+      "rankBefore": null,
+      "rankAfter": 720,
+      "valueDelta": 1072
+    },
+    {
+      "name": "Kenny Moore",
+      "valueBefore": 959,
+      "valueAfter": null,
+      "rankBefore": 738,
+      "rankAfter": null,
+      "valueDelta": -959
+    },
+    {
+      "name": "Desmond Reid",
+      "valueBefore": 1096,
+      "valueAfter": 1218,
+      "rankBefore": 704,
+      "rankAfter": 647,
+      "valueDelta": 122
+    },
+    {
+      "name": "Jaydn Ott",
+      "valueBefore": 1107,
+      "valueAfter": 1209,
+      "rankBefore": 696,
+      "rankAfter": 649,
+      "valueDelta": 102
+    },
+    {
+      "name": "Eric McAlister",
+      "valueBefore": 1094,
+      "valueAfter": 1164,
+      "rankBefore": 706,
+      "rankAfter": 676,
+      "valueDelta": 70
+    },
+    {
+      "name": "Emmanuel Henderson",
+      "valueBefore": 1308,
+      "valueAfter": 1358,
+      "rankBefore": 535,
+      "rankAfter": 513,
+      "valueDelta": 50
+    },
+    {
+      "name": "Colbie Young",
+      "valueBefore": 1090,
+      "valueAfter": 1128,
+      "rankBefore": 711,
+      "rankAfter": 693,
+      "valueDelta": 38
+    },
+    {
+      "name": "Taylen Green",
+      "valueBefore": 1294,
+      "valueAfter": 1330,
+      "rankBefore": 547,
+      "rankAfter": 526,
+      "valueDelta": 36
+    },
+    {
+      "name": "2026 Pick 3.10",
+      "valueBefore": 2153,
+      "valueAfter": 2188,
+      "rankBefore": null,
+      "rankAfter": null,
+      "valueDelta": 35
+    },
+    {
+      "name": "Carson Beck",
+      "valueBefore": 2153,
+      "valueAfter": 2188,
+      "rankBefore": 269,
+      "rankAfter": 265,
+      "valueDelta": 35
+    },
+    {
+      "name": "Cyrus Allen",
+      "valueBefore": 1265,
+      "valueAfter": 1296,
+      "rankBefore": 562,
+      "rankAfter": 545,
+      "valueDelta": 31
+    },
+    {
+      "name": "Germie Bernard",
+      "valueBefore": 2573,
+      "valueAfter": 2600,
+      "rankBefore": 221,
+      "rankAfter": 215,
+      "valueDelta": 27
+    },
+    {
+      "name": "2026 Pick 4.03",
+      "valueBefore": 1965,
+      "valueAfter": 1990,
+      "rankBefore": null,
+      "rankAfter": null,
+      "valueDelta": 25
+    },
+    {
+      "name": "Mike Washington",
+      "valueBefore": 1965,
+      "valueAfter": 1990,
+      "rankBefore": 302,
+      "rankAfter": 295,
+      "valueDelta": 25
+    },
+    {
+      "name": "2026 Pick 1.04",
+      "valueBefore": 5509,
+      "valueAfter": 5532,
+      "rankBefore": null,
+      "rankAfter": null,
+      "valueDelta": 23
+    },
+    {
+      "name": "Jordyn Tyson",
+      "valueBefore": 5509,
+      "valueAfter": 5532,
+      "rankBefore": 56,
+      "rankAfter": 55,
+      "valueDelta": 23
+    },
+    {
+      "name": "Michael Trigg",
+      "valueBefore": 1720,
+      "valueAfter": 1741,
+      "rankBefore": 363,
+      "rankAfter": 357,
+      "valueDelta": 21
+    },
+    {
+      "name": "Dillon Thieneman",
+      "valueBefore": 3067,
+      "valueAfter": 3047,
+      "rankBefore": 157,
+      "rankAfter": 168,
+      "valueDelta": -20
+    },
+    {
+      "name": "2026 Pick 3.01",
+      "valueBefore": 2583,
+      "valueAfter": 2600,
+      "rankBefore": null,
+      "rankAfter": null,
+      "valueDelta": 17
+    },
+    {
+      "name": "2026 Pick 6.12",
+      "valueBefore": 1543,
+      "valueAfter": 1559,
+      "rankBefore": null,
+      "rankAfter": null,
+      "valueDelta": 16
+    }
+  ]
+}

--- a/docs/measurements/market-confidence-divisor-2026-07-30.json
+++ b/docs/measurements/market-confidence-divisor-2026-07-30.json
@@ -1,0 +1,141 @@
+{
+  "generatedAt": "2026-07-30T08:10:46.305266+00:00",
+  "payload": "dynasty_data_2026-07-29.json",
+  "threshold": 0.35,
+  "results": {
+    "live": {
+      "divisor": 8.0,
+      "confidence": {
+        "n": 838,
+        "min": 0.3405,
+        "p10": 0.48,
+        "median": 0.4908,
+        "p90": 0.5635,
+        "max": 0.5938
+      }
+    },
+    "divisor_3": {
+      "divisor": 3.0,
+      "confidence": {
+        "n": 838,
+        "min": 0.5667,
+        "p10": 0.5667,
+        "median": 0.8814,
+        "p90": 0.9698,
+        "max": 1.0
+      },
+      "ceilingAtMaxSites": 1.0,
+      "meanConfDelta": 0.2597,
+      "maxConfDelta": 0.4063,
+      "belowThreshold": 0,
+      "downstreamMultiplier": {
+        "singleSourceDiscount": {
+          "n": 838,
+          "min": 1.0344,
+          "p10": 1.0344,
+          "median": 1.1554,
+          "p90": 1.1594,
+          "max": 1.1709
+        },
+        "idpConfFactor": {
+          "n": 838,
+          "min": 1.0438,
+          "p10": 1.0438,
+          "median": 1.1955,
+          "p90": 1.202,
+          "max": 1.2207
+        },
+        "eliteCapOffense": {
+          "n": 838,
+          "min": 1.0067,
+          "p10": 1.0067,
+          "median": 1.0311,
+          "p90": 1.0312,
+          "max": 1.0316
+        }
+      }
+    },
+    "divisor_4": {
+      "divisor": 4.0,
+      "confidence": {
+        "n": 838,
+        "min": 0.5125,
+        "p10": 0.5125,
+        "median": 0.7189,
+        "p90": 0.8073,
+        "max": 0.8375
+      },
+      "ceilingAtMaxSites": 0.8375,
+      "meanConfDelta": 0.1471,
+      "maxConfDelta": 0.2438,
+      "belowThreshold": 0,
+      "downstreamMultiplier": {
+        "singleSourceDiscount": {
+          "n": 838,
+          "min": 1.0129,
+          "p10": 1.0129,
+          "median": 1.0932,
+          "p90": 1.0956,
+          "max": 1.1025
+        },
+        "idpConfFactor": {
+          "n": 838,
+          "min": 1.0164,
+          "p10": 1.0164,
+          "median": 1.1173,
+          "p90": 1.1212,
+          "max": 1.1324
+        },
+        "eliteCapOffense": {
+          "n": 838,
+          "min": 1.0025,
+          "p10": 1.0025,
+          "median": 1.0186,
+          "p90": 1.0187,
+          "max": 1.019
+        }
+      }
+    },
+    "divisor_5": {
+      "divisor": 5.0,
+      "confidence": {
+        "n": 838,
+        "min": 0.4528,
+        "p10": 0.48,
+        "median": 0.6214,
+        "p90": 0.7097,
+        "max": 0.74
+      },
+      "ceilingAtMaxSites": 0.74,
+      "meanConfDelta": 0.0796,
+      "maxConfDelta": 0.1463,
+      "belowThreshold": 0,
+      "downstreamMultiplier": {
+        "singleSourceDiscount": {
+          "n": 838,
+          "min": 1.0,
+          "p10": 1.0,
+          "median": 1.0559,
+          "p90": 1.0574,
+          "max": 1.0615
+        },
+        "idpConfFactor": {
+          "n": 838,
+          "min": 1.0,
+          "p10": 1.0,
+          "median": 1.0704,
+          "p90": 1.0727,
+          "max": 1.0795
+        },
+        "eliteCapOffense": {
+          "n": 838,
+          "min": 1.0,
+          "p10": 1.0,
+          "median": 1.0112,
+          "p90": 1.0112,
+          "max": 1.0114
+        }
+      }
+    }
+  }
+}

--- a/docs/open-modeling-decisions.md
+++ b/docs/open-modeling-decisions.md
@@ -1,0 +1,190 @@
+# Open modeling decisions — resolved to evidence
+
+**Date:** 2026-07-29
+**Context:** the 2026-07-29 repository audit
+(`docs/audits/complete-codebase-audit-2026-07-29.md`) left three
+questions as "requires a product decision". Each was under-specified:
+they were stated as choices without the measurements needed to make
+them. This document closes that gap. Two are now decided on evidence;
+one is narrowed to a single concrete change that still needs a call.
+
+---
+
+## 1. Should `coverageWeight` be applied to the blend?
+
+**Status: measured. Recommendation — NO, not without a holdout backtest.**
+
+`/api/data` publishes, under `methodology.idpTranslation.coverageWeight`:
+
+```
+effective_weight = declared_weight * min(1, depth / min_full_depth)   # min_full_depth = 60
+```
+
+It is computed per source, stamped as `sourceRankMeta.effectiveWeight`,
+and never applied. The audit labelled it DIAGNOSTIC ONLY rather than
+wiring it in, because nothing had measured what wiring it in would do.
+
+**Reproduce:** `python scripts/measure_coverage_weight_impact.py`
+**Results:** `docs/measurements/coverage-weight-impact-2026-07-29.json`
+
+Only **3 of 21** sources are affected — the three rookie lists that
+declare a depth under 60 (`dlfRookieSf`, `dlfRookieIdp`,
+`flockFantasySfRookies`, all depth 50 → factor 0.8333). Every other
+source declares depth ≥ 100 or None and is unchanged.
+
+That small input change is not a small output change:
+
+| metric | value |
+|---|---|
+| rows moved | **297 of 1094** (27%) |
+| ranks changed | **221** (20%) |
+| max abs value delta | **1072** points (~11% of the 1–9999 scale) |
+| median abs value delta | 0 (most moves are rank-only) |
+| board membership | 1 row enters, 1 row leaves |
+
+Movement concentrates in ranks ~500–750 — deep players and rookies,
+where coverage is thinnest. **Direction varies per player:**
+down-weighting a rookie source raises a player that source was bearish
+on and lowers one it was bullish on, so this is not a uniform haircut on
+rookies.
+
+**Why not to apply it as-is.** The rationale ("a 50-deep list should
+count less than a 500-deep board") is defensible in principle, but:
+
+- it reprices 221 ranks on zero accuracy evidence;
+- the three affected sources are rookie lists that already
+  ladder-translate into combined-pool space before reaching the blend,
+  so part of the depth penalty they would take is arguably handled
+  already;
+- the effect lands hardest exactly where the board is least certain.
+
+Applying an unvalidated reweighting to a fifth of the board because a
+docstring described it is the kind of change this audit exists to
+prevent. If it is wanted, it should go through
+`src/model_registry/board_holdout.py` the way the adjusted-board lens
+did (`docs/adjusted-board-backtest.md`).
+
+**Kept as-is:** the mechanism stays computed and stamped, honestly
+labelled diagnostic-only in the contract. The measurement above is now
+the answer to "what would it do?", so the next reader does not have to
+guess — or "fix" it casually.
+
+---
+
+## 2. Should the legacy rank-form Hill family be brought under the model registry?
+
+**Status: NO — the proposal was wrong. Replaced with a tripwire.**
+
+The audit flagged `HILL_MIDPOINT` / `HILL_SLOPE` /
+`IDP_HILL_MIDPOINT` / `IDP_HILL_SLOPE` as a governance gap: outside
+`src/model_registry`, refit by a different script than the percentile
+scope masters, no out-of-sample gate. The proposed fix was a second
+registry model.
+
+**That was based on a false premise.** The registry exists to gate
+*automated* promotion — the percentile masters are refit weekly by
+`.github/workflows/refit-hill-curves.yml`, which is why they need a
+challenger/champion flow. These four are not in that situation:
+
+- `scripts/fit_hill_curve_from_market.py` is **read-only**. It opens
+  CSVs, grid-searches, and prints. It contains no write of any kind
+  (verified: no `write_text`, no `json.dump`, no regex substitution).
+- **Nothing runs it** — no workflow, no systemd timer, no Makefile
+  target. Every repo-wide reference is a docstring or a test.
+- Its own docstring says "Use the output to update
+  `player_valuation.py` constants" — i.e. a human edits them.
+
+There is no automated promotion to gate. Wrapping a hand-edited,
+manually-refit pair in challenger/champion machinery would have been
+ceremony with no benefit, and would have added a second registry model
+that nothing writes to.
+
+**The actual residual risk** is narrower: someone edits these constants
+and does not re-check whether the curve still reproduces the board. The
+two families drift independently and the drift is *silent* — nothing
+fails when the rank-form curve stops matching the percentile-derived
+board. Every existing test imports these constants symbolically (right,
+so a legitimate refit does not break them) and therefore none notices an
+edit.
+
+**Shipped instead:** `tests/canonical/test_rank_form_constants_tripwire.py`
+pins the four values, so any change fails with a message pointing at
+`scripts/backtest_legacy_rank_curve.py` and this document. A second test
+asserts the refit script still does not write — because if it ever gains
+that ability, it *does* become an automated promotion path and the
+reasoning above has to be revisited rather than silently outgrown.
+
+**Still open, and genuinely a product call:** whether to retire the
+rank-form family in favour of the percentile masters. Measured in
+`docs/legacy-rank-curve-backtest.md` — the candidates have inverted
+error profiles (`percentile_global` is far better past rank 120 and
+~2× worse in the top 24), and switching moves user-visible history
+values. Unchanged by this document.
+
+---
+
+## 3. What is the right `low_conf_unstable` confidence threshold?
+
+**Status: the question was wrong. The metric is structurally capped.**
+**Recommendation — fix the metric, not the threshold. Needs a call
+because the change cannot be measured in a dev environment.**
+
+The audit asked whether the 0.35 threshold should move, having observed
+that live `marketConfidence` clusters around 0.49 so the rule fires for
+~1 player in 1094. Reading the producer explains why, and it is not a
+threshold problem.
+
+`Dynasty Scraper.py::_market_confidence`:
+
+```python
+cv         = _coeff_var(norm_vals)
+site_score = clamp(site_count / 8.0, 0.20, 1.00)          # 65% of the weight
+cv_score   = clamp(1.0 - min(cv, 0.35)/0.35, 0.20, 1.00)  # 35%
+conf       = clamp(site_score*0.65 + cv_score*0.35, 0.20, 1.00)
+```
+
+`site_count` is `len(wNorms)` — and in the live payload `_sites`
+(written from the same value) **never exceeds 3**: p10 1, median 2,
+p90 3, max 3. So `site_score` is confined to `{0.20, 0.25, 0.375}`, and
+the metric's ceiling is:
+
+```
+0.375 * 0.65  +  1.00 * 0.35  =  0.59375
+```
+
+The observed maximum across 838 players is **0.594**. That is not a
+coincidence — it is the structural ceiling. Observed range is
+[0.341, 0.594] against a nominal [0.20, 1.00].
+
+**So `marketConfidence` can never express high confidence.** The
+dominant term divides a count that never exceeds 3 by 8. Tuning a
+threshold against that scale is calibrating against a broken ruler: at
+0.35 the rule catches almost nothing, and raising it toward 0.5 would
+catch *most of the board* including well-covered players, because the
+whole population sits in a narrow band just above it.
+
+**The fix is the divisor** (or the count feeding it — 3 sources is
+itself suspicious against a 21-source registry, and `wNorms` may be
+narrower than the registry population; worth checking before changing
+the constant).
+
+**Why this was not just fixed here.** `market_conf` is not only a
+display/signal input — it feeds the scraper's composite arithmetic:
+`elite_boost`, `elite_cap` (both offense and IDP), the single-source
+discount, and `idp_conf_factor`. Changing it moves `_finalAdjusted`. The
+scraper cannot be re-run in a dev environment (it needs network access
+and site credentials), so **the impact of a divisor change cannot be
+measured here** — and this audit's standing rule is not to change
+valuation inputs it cannot measure.
+
+**Recommended next step:** on a machine that can run the scraper,
+re-scrape once with the divisor corrected and diff `_finalAdjusted`
+across the population. If the composite shift is acceptable, take the
+fix; if not, retire `low_conf_unstable` rather than leaving a rule
+gated on a metric that cannot reach its own thresholds.
+
+Pinned meanwhile by
+`tests/api/test_market_confidence_wiring.py::test_threshold_is_far_below_the_live_distribution`,
+which asserts the scraper default (0.5) and the live p10 (0.480) do not
+fire — so if either the threshold or the distribution moves toward the
+other, a test says so.

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -1011,7 +1011,15 @@ function _materializePlayerArrayRow(player) {
     // other non-rankings views.  Rankings pages hide this column, but the
     // field must remain on the row contract.  Do NOT remove it.
     siteCount: backendSourceCount,
-    confidence: Number(player.marketConfidence ?? 0),
+    // Missing confidence stays NULL, never 0 (audit N2, 2026-07-29).
+    // 256 of 1094 live rows carry no ``marketConfidence``; coercing
+    // those to 0 put them under the 0.35 ``low_conf_unstable``
+    // threshold, so the MONITOR rule fired on rows that simply lack the
+    // field rather than on genuinely low-confidence ones. The rule
+    // itself already guards on ``!= null``.
+    confidence: Number.isFinite(Number(player.marketConfidence))
+      ? Number(player.marketConfidence)
+      : null,
     marketLabel: "",
     canonicalSites,
     rawSourceValues,
@@ -1178,7 +1186,17 @@ function _materializeLegacyDictRow(name, player, posMap) {
     assetClass: classifyPos(pos || "?"),
     values,
     siteCount: Number(player.sourceCount || player._sites || 0),
-    confidence: Number(player._marketReliabilityScore ?? 0),
+    // ``_marketReliabilityScore`` DOES NOT EXIST (audit N2, 2026-07-29).
+    // It appeared exactly once in the entire repo — right here, the
+    // consumer — and nothing has ever produced it: 0 of 1076 players in
+    // the live payload carry it, while 838 carry ``_marketConfidence``.
+    // So this field was permanently 0, which is under the 0.35
+    // threshold, so ``low_conf_unstable`` fired for every eligible row
+    // on the legacy path. Reads the field that is actually stamped, and
+    // keeps absent as null rather than 0.
+    confidence: Number.isFinite(Number(player._marketConfidence))
+      ? Number(player._marketConfidence)
+      : null,
     marketLabel: String(player._marketReliabilityLabel || ""),
     canonicalSites,
     rawSourceValues,

--- a/scripts/measure_coverage_weight_impact.py
+++ b/scripts/measure_coverage_weight_impact.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Measure what APPLYING the depth-scaled coverage weight would do.
+
+WHY THIS EXISTS
+===============
+``/api/data`` publishes, under ``methodology.idpTranslation.coverageWeight``:
+
+    effective_weight = declared_weight * min(1, depth / min_full_depth)
+
+with ``min_full_depth = 60``.  It is computed per source, stamped as
+``sourceRankMeta.effectiveWeight`` — and never applied to the blend.
+The 2026-07-29 audit labelled it DIAGNOSTIC ONLY rather than wiring it
+in, because wiring it in changes the board and nothing had measured by
+how much.
+
+This script answers that.  It builds the board twice from one payload —
+once at the registry defaults (all weights 1.0), once with every
+source's weight set to its ``coverage_weight(...)`` value — and diffs.
+It relies on the weighted blend added in the same audit; before that,
+weights could not be applied at all.
+
+WHAT IT FOUND (2026-07-29, live payload)
+========================================
+Only 3 of 21 sources are affected, because only three declare a depth
+under 60 — the rookie lists ``dlfRookieSf``, ``dlfRookieIdp`` and
+``flockFantasySfRookies``, each at depth 50, each scaled to 50/60 =
+0.8333.  Every other source declares depth >= 100 (or None) and is
+unchanged.
+
+That small input change is NOT a small output change:
+
+    rows moved              297 of 1094  (27%)
+    ranks changed           221          (20%)
+    max value delta         1072 points  (~11% of the 1-9999 scale)
+    median value delta      0            (most moves are rank-only)
+    board membership        1 row enters, 1 row leaves
+
+The movement concentrates in ranks ~500-750 — deep players and rookies,
+where coverage is thinnest.  Direction VARIES per player: down-weighting
+a rookie source raises a player the source was bearish on and lowers one
+it was bullish on, so this is not a uniform haircut.
+
+RECOMMENDATION: do not apply it without a holdout backtest.  The
+rationale ("a 50-deep list should count less than a 500-deep board") is
+defensible, but it reprices 221 ranks on no accuracy evidence, and the
+three affected sources are rookie lists that already ladder-translate
+into combined-pool space before reaching the blend — so some of the
+depth penalty they would take is arguably already handled.
+
+USAGE
+=====
+    python scripts/measure_coverage_weight_impact.py
+    python scripts/measure_coverage_weight_impact.py --out docs/measurements/x.json
+
+Exit codes: 0 success, 1 error (missing payload / no rows).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.canonical.idp_backbone import (  # noqa: E402
+    MIN_FULL_COVERAGE_DEPTH,
+    coverage_weight,
+)
+
+
+def _default_payload_path() -> Path | None:
+    latest = REPO_ROOT / "exports" / "latest"
+    if not latest.is_dir():
+        return None
+    candidates = sorted(latest.glob("dynasty_data_*.json"))
+    return candidates[-1] if candidates else None
+
+
+def _index(contract: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for row in contract.get("playersArray") or []:
+        name = row.get("displayName") or row.get("canonicalName")
+        if name:
+            out[str(name)] = row
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--payload", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+
+    payload_path = args.payload or _default_payload_path()
+    if payload_path is None or not payload_path.is_file():
+        print(f"ERROR: no payload found (looked for {payload_path})", file=sys.stderr)
+        return 1
+
+    from src.api.data_contract import _RANKING_SOURCES, build_api_data_contract  # noqa: PLC0415
+
+    payload = json.loads(payload_path.read_text())
+
+    affected: list[dict[str, Any]] = []
+    overrides: dict[str, dict[str, float]] = {}
+    for src in _RANKING_SOURCES:
+        key = str(src.get("key") or "")
+        declared = float(src.get("weight") or 1.0)
+        effective = coverage_weight(declared, src.get("depth"))
+        overrides[key] = {"weight": effective}
+        if abs(effective - declared) > 1e-9:
+            affected.append(
+                {
+                    "key": key,
+                    "depth": src.get("depth"),
+                    "declared": declared,
+                    "effective": round(effective, 4),
+                }
+            )
+
+    base = build_api_data_contract(payload)
+    weighted = build_api_data_contract(payload, source_overrides=overrides)
+
+    a, b = _index(base), _index(weighted)
+    moved: list[dict[str, Any]] = []
+    entered: list[str] = []
+    left: list[str] = []
+    for name in sorted(set(a) & set(b)):
+        va, vb = a[name].get("rankDerivedValue"), b[name].get("rankDerivedValue")
+        ra, rb = a[name].get("canonicalConsensusRank"), b[name].get("canonicalConsensusRank")
+        if va == vb and ra == rb:
+            continue
+        if va is None and vb is not None:
+            entered.append(name)
+        if va is not None and vb is None:
+            left.append(name)
+        moved.append(
+            {
+                "name": name,
+                "valueBefore": va,
+                "valueAfter": vb,
+                "rankBefore": ra,
+                "rankAfter": rb,
+                "valueDelta": (vb or 0) - (va or 0),
+            }
+        )
+
+    deltas = [abs(m["valueDelta"]) for m in moved]
+    rank_changed = [m for m in moved if m["rankBefore"] != m["rankAfter"]]
+
+    summary = {
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "payload": str(payload_path.relative_to(REPO_ROOT)),
+        "minFullCoverageDepth": MIN_FULL_COVERAGE_DEPTH,
+        "sourcesTotal": len(_RANKING_SOURCES),
+        "sourcesAffected": affected,
+        "rowsTotal": len(a),
+        "rowsMoved": len(moved),
+        "ranksChanged": len(rank_changed),
+        "maxAbsValueDelta": max(deltas) if deltas else 0,
+        "medianAbsValueDelta": statistics.median(deltas) if deltas else 0,
+        "boardEntered": entered,
+        "boardLeft": left,
+        "largestMoves": sorted(moved, key=lambda m: -abs(m["valueDelta"]))[:20],
+    }
+
+    print(f"payload                 : {summary['payload']}")
+    print(f"min_full_depth          : {MIN_FULL_COVERAGE_DEPTH}")
+    print(f"sources affected        : {len(affected)} of {len(_RANKING_SOURCES)}")
+    for row in affected:
+        print(f"    {row['key']:26s} depth={row['depth']}  {row['declared']} -> {row['effective']}")
+    print(f"rows total              : {summary['rowsTotal']}")
+    print(f"rows moved              : {summary['rowsMoved']}")
+    print(f"ranks changed           : {summary['ranksChanged']}")
+    print(f"max |value delta|       : {summary['maxAbsValueDelta']}")
+    print(f"median |value delta|    : {summary['medianAbsValueDelta']}")
+    print(f"board entered / left    : {len(entered)} / {len(left)}")
+    if entered or left:
+        print(f"    entered: {entered}")
+        print(f"    left   : {left}")
+
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(summary, indent=2) + "\n")
+        print(f"\nWrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/simulate_market_confidence_divisor.py
+++ b/scripts/simulate_market_confidence_divisor.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Simulate changing the ``site_count`` divisor in market confidence.
+
+WHY THIS EXISTS
+===============
+``Dynasty Scraper.py::_market_confidence`` computes:
+
+    site_score = clamp(site_count / SITE_DIVISOR, 0.20, 1.00)   # 65% weight
+    cv_score   = clamp(1 - min(cv,0.35)/0.35, 0.20, 1.00)       # 35% weight
+    conf       = clamp(site_score*0.65 + cv_score*0.35, 0.20, 1.00)
+
+``SITE_DIVISOR`` is 8.0.  But ``site_count`` (persisted as ``_sites``)
+never exceeds 3 on real payloads, so ``site_score`` is confined to
+{0.20, 0.25, 0.375} and confidence is structurally capped at
+
+    0.375*0.65 + 1.00*0.35 = 0.59375
+
+— which is exactly the observed maximum.  The metric can never express
+high confidence, so the ``low_conf_unstable`` threshold of 0.35 cannot
+be calibrated meaningfully against it.
+
+WHY THIS DOESN'T NEED THE SCRAPER
+=================================
+Re-scraping to measure the fix is impractical in a dev environment (no
+network, no site credentials) AND unnecessary, because the formula is
+INVERTIBLE.  For every player the payload gives us ``_marketConfidence``
+and ``_sites``; ``site_score`` follows from ``_sites``, so:
+
+    cv_score = (conf - site_score*0.65) / 0.35
+
+recovers the second input exactly.  With both inputs known we can
+recompute confidence under any divisor with no re-scrape and no
+approximation.
+
+The four downstream consumers of ``market_conf`` are all LINEAR in it,
+so their multiplier shifts are exact too:
+
+    elite_boost      = 1 + (0.09 * span * agreement * conf)   [offense]
+    single-source    = 0.55 + (0.82-0.55) * conf
+    idp_conf_factor  = 0.60 + (0.40 * conf)
+    elite_cap        = cap * (1 + 0.08*conf)  offense / 0.03  IDP
+
+``span`` and ``agreement`` are not in the payload, so ``elite_boost`` is
+reported as a per-unit sensitivity rather than an absolute.  The other
+three are exact.
+
+WHAT TO READ OFF IT
+===================
+The question is not "is 8.0 wrong" — it is — but "what does correcting
+it do to composite values", because ``market_conf`` feeds the scraper's
+composite arithmetic and therefore ``_finalAdjusted``.
+
+USAGE
+=====
+    python scripts/simulate_market_confidence_divisor.py
+    python scripts/simulate_market_confidence_divisor.py --divisors 3 4 5
+    python scripts/simulate_market_confidence_divisor.py --out docs/measurements/x.json
+
+Exit codes: 0 success, 1 error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+LIVE_DIVISOR = 8.0
+SITE_WEIGHT = 0.65
+CV_WEIGHT = 0.35
+FLOOR = 0.20
+CEILING = 1.00
+
+# Downstream consumers, all linear in conf.
+SINGLE_SOURCE_MIN, SINGLE_SOURCE_MAX = 0.55, 0.82
+IDP_CONF_BASE, IDP_CONF_SPAN = 0.60, 0.40
+ELITE_CAP_OFFENSE, ELITE_CAP_IDP = 0.08, 0.03
+ELITE_BOOST_MAX = 0.09
+
+
+def _clamp(x: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, x))
+
+
+def _site_score(site_count: float, divisor: float) -> float:
+    return _clamp(float(site_count) / divisor, FLOOR, CEILING)
+
+
+def _conf(site_count: float, cv_score: float, divisor: float) -> float:
+    return _clamp(
+        _site_score(site_count, divisor) * SITE_WEIGHT + cv_score * CV_WEIGHT, FLOOR, CEILING
+    )
+
+
+def _recover_cv_score(conf: float, site_count: float) -> float:
+    """Invert the live formula to recover the agreement term."""
+    return _clamp(
+        (conf - _site_score(site_count, LIVE_DIVISOR) * SITE_WEIGHT) / CV_WEIGHT, 0.0, 1.0
+    )
+
+
+def _default_payload() -> Path | None:
+    latest = REPO_ROOT / "exports" / "latest"
+    if not latest.is_dir():
+        return None
+    cands = sorted(latest.glob("dynasty_data_*.json"))
+    return cands[-1] if cands else None
+
+
+def _pct(vals: list[float], q: float) -> float:
+    if not vals:
+        return 0.0
+    s = sorted(vals)
+    return s[min(len(s) - 1, int(q * len(s)))]
+
+
+def _describe(vals: list[float]) -> dict[str, float]:
+    if not vals:
+        return {}
+    return {
+        "n": len(vals),
+        "min": round(min(vals), 4),
+        "p10": round(_pct(vals, 0.10), 4),
+        "median": round(statistics.median(vals), 4),
+        "p90": round(_pct(vals, 0.90), 4),
+        "max": round(max(vals), 4),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--payload", type=Path, default=None)
+    ap.add_argument("--out", type=Path, default=None)
+    ap.add_argument("--divisors", type=float, nargs="*", default=[3.0, 4.0, 5.0])
+    ap.add_argument("--threshold", type=float, default=0.35, help="low_conf_unstable threshold")
+    args = ap.parse_args()
+
+    path = args.payload or _default_payload()
+    if path is None or not path.is_file():
+        print(f"ERROR: no payload found ({path})", file=sys.stderr)
+        return 1
+
+    payload = json.loads(path.read_text())
+    players = payload.get("players") or {}
+
+    rows: list[dict[str, Any]] = []
+    for name, p in players.items():
+        if not isinstance(p, dict):
+            continue
+        conf = p.get("_marketConfidence")
+        sites = p.get("_sites")
+        if not isinstance(conf, (int, float)) or not isinstance(sites, (int, float)):
+            continue
+        rows.append(
+            {
+                "name": name,
+                "conf": float(conf),
+                "sites": float(sites),
+                "cvScore": _recover_cv_score(float(conf), float(sites)),
+            }
+        )
+
+    if not rows:
+        print("ERROR: payload carries no _marketConfidence/_sites pairs", file=sys.stderr)
+        return 1
+
+    live = [r["conf"] for r in rows]
+    site_counts = [r["sites"] for r in rows]
+    ceiling_live = _conf(max(site_counts), 1.0, LIVE_DIVISOR)
+
+    print(f"payload            : {path.name}")
+    print(f"players with data  : {len(rows)}")
+    print(f"observed _sites    : min={min(site_counts):.0f} max={max(site_counts):.0f}")
+    print(f"LIVE divisor       : {LIVE_DIVISOR}")
+    print(f"  confidence       : {_describe(live)}")
+    print(f"  structural ceiling at max _sites : {ceiling_live:.4f}")
+    print(f"  below threshold {args.threshold}: {sum(1 for c in live if c < args.threshold)}")
+    print()
+
+    results: dict[str, Any] = {"live": {"divisor": LIVE_DIVISOR, "confidence": _describe(live)}}
+
+    for div in args.divisors:
+        new = [_conf(r["sites"], r["cvScore"], div) for r in rows]
+        deltas = [n - r["conf"] for n, r in zip(new, rows)]
+        # Exact downstream shifts (linear consumers).
+        ss = [
+            (SINGLE_SOURCE_MIN + (SINGLE_SOURCE_MAX - SINGLE_SOURCE_MIN) * n)
+            / (SINGLE_SOURCE_MIN + (SINGLE_SOURCE_MAX - SINGLE_SOURCE_MIN) * r["conf"])
+            for n, r in zip(new, rows)
+        ]
+        idpf = [
+            (IDP_CONF_BASE + IDP_CONF_SPAN * n) / (IDP_CONF_BASE + IDP_CONF_SPAN * r["conf"])
+            for n, r in zip(new, rows)
+        ]
+        capo = [
+            (1 + ELITE_CAP_OFFENSE * n) / (1 + ELITE_CAP_OFFENSE * r["conf"])
+            for n, r in zip(new, rows)
+        ]
+        entry = {
+            "divisor": div,
+            "confidence": _describe(new),
+            "ceilingAtMaxSites": round(_conf(max(site_counts), 1.0, div), 4),
+            "meanConfDelta": round(sum(deltas) / len(deltas), 4),
+            "maxConfDelta": round(max(deltas), 4),
+            "belowThreshold": sum(1 for c in new if c < args.threshold),
+            "downstreamMultiplier": {
+                "singleSourceDiscount": _describe(ss),
+                "idpConfFactor": _describe(idpf),
+                "eliteCapOffense": _describe(capo),
+            },
+        }
+        results[f"divisor_{div:g}"] = entry
+
+        print(f"DIVISOR {div:g}")
+        print(f"  confidence     : {entry['confidence']}")
+        print(f"  ceiling        : {entry['ceilingAtMaxSites']}")
+        print(
+            f"  mean delta     : {entry['meanConfDelta']:+.4f}   max {entry['maxConfDelta']:+.4f}"
+        )
+        print(f"  below {args.threshold}     : {entry['belowThreshold']}")
+        print(
+            f"  composite multipliers (new/old) — "
+            f"single-source x{entry['downstreamMultiplier']['singleSourceDiscount']['median']:.4f}, "
+            f"idp_conf x{entry['downstreamMultiplier']['idpConfFactor']['median']:.4f}, "
+            f"elite_cap x{entry['downstreamMultiplier']['eliteCapOffense']['median']:.4f}"
+        )
+        print(
+            f"  elite_boost sensitivity: up to "
+            f"{ELITE_BOOST_MAX * entry['maxConfDelta']:+.4f} on the boost term "
+            f"(scaled by span*agreement, both <= 1)"
+        )
+        print()
+
+    out = {
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "payload": path.name,
+        "threshold": args.threshold,
+        "results": results,
+    }
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(out, indent=2) + "\n")
+        print(f"Wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/api/sleeper_overlay.py
+++ b/src/api/sleeper_overlay.py
@@ -49,6 +49,7 @@ import urllib.error
 import urllib.request
 from typing import Any
 
+from src.utils.name_clean import strip_display_suffix
 from src.utils.owner_names import owner_label
 
 log = logging.getLogger(__name__)
@@ -791,6 +792,26 @@ def _resolve_player_label(pid: Any, id_map: dict[str, str]) -> str:
     Resolution order: loaded-contract NFL map → full Sleeper players
     dump (lazy, process-cached) → the raw id string as a last resort
     so the row still renders rather than vanishing.
+
+    VOCABULARY (audit N3, 2026-07-29).  The first branch returns a name
+    from the contract, which is already in the contract's vocabulary.
+    The Sleeper-dump fallback is NOT: Sleeper's ``full_name`` keeps
+    generational suffixes, and the contract's names — produced by
+    ``Dynasty Scraper.py::clean_name`` — do not (measured: **0 of 1076**
+    contract keys carry one).  Emitting a raw Sleeper name here leaks a
+    foreign vocabulary into ``sleeper.teams[].players``, which is
+    name-keyed and read by waiver ownership, angle, replacement and FAAB
+    contention — so a player who takes this branch silently fails to
+    join in all of them.
+
+    ``strip_display_suffix`` puts the fallback into the same vocabulary
+    while preserving case, because this value is displayed.  It is a
+    display cleanup, NOT one of this repo's lowercased join keys.
+
+    Live exposure when this was written was small — 1 of 666 rostered
+    ids missed the contract map, and that id had no contract row, so
+    nothing was hidden yet.  It is fixed because the branch is reachable
+    by construction, not because it was actively breaking a join.
     """
     pid_str = str(pid if pid is not None else "").strip()
     if not pid_str:
@@ -800,7 +821,7 @@ def _resolve_player_label(pid: Any, id_map: dict[str, str]) -> str:
         return str(mapped)
     fallback = _sleeper_fallback_name_map().get(pid_str)
     if fallback:
-        return fallback
+        return strip_display_suffix(fallback) or fallback
     return pid_str
 
 

--- a/src/api/terminal.py
+++ b/src/api/terminal.py
@@ -783,7 +783,27 @@ def _build_signal_context(
             elif impact == "positive":
                 pos_count += 1
     rank_change = _row_rank_change(row)
-    confidence = row.get("confidence")
+    # Market confidence.  The contract stamps ``marketConfidence``
+    # (``data_contract.py``, sourced from the scraper's
+    # ``_marketConfidence``); ``confidence`` is the name the FRONTEND row
+    # contract uses after ``buildRows`` maps it across.
+    #
+    # FIXED 2026-07-29 (audit N2): this read ``row.get("confidence")``
+    # only — a key no contract builder stamps — so it was always None and
+    # the ``low_conf_unstable`` MONITOR rule below could never fire
+    # server-side, while the same rule was live on the frontend. Two
+    # modules, one rule, opposite behaviour.
+    #
+    # ``marketConfidence`` is preferred and ``confidence`` kept as a
+    # fallback so a caller handing us an already-materialized frontend
+    # row (or a test fixture using the short name) still works.
+    # Deliberately NOT coerced to 0 when absent: 256 of 1094 live rows
+    # carry no confidence at all, and "unmeasured" must not read as
+    # "zero confidence" — that is precisely what makes the rule fire on
+    # the frontend for rows that simply lack the field.
+    confidence = row.get("marketConfidence")
+    if confidence is None:
+        confidence = row.get("confidence")
     try:
         confidence = float(confidence) if confidence is not None else None
     except (TypeError, ValueError):

--- a/src/utils/name_clean.py
+++ b/src/utils/name_clean.py
@@ -410,6 +410,50 @@ def normalize_player_name(name: str | None) -> str:
     return s
 
 
+def strip_display_suffix(name: object) -> str:
+    """Strip a generational suffix / trailing parenthetical, PRESERVING
+    case and spacing.
+
+    This is NOT a join key — it is a DISPLAY-name cleanup.  Every other
+    helper in this module lowercases, which is wrong for anything that
+    will be rendered or stored as a label.
+
+    Why it exists (audit N3, 2026-07-29): the contract's player
+    vocabulary comes from ``Dynasty Scraper.py::clean_name``, which
+    strips generational suffixes — measured on the live payload, **0 of
+    1076** contract keys carry ``Jr.`` / ``III`` / a parenthetical.
+    Sleeper's raw ``full_name`` keeps them.  So any code that falls back
+    to a raw Sleeper name emits a label in a foreign vocabulary, and
+    every name-keyed consumer downstream (waiver ownership, angle,
+    replacement, FAAB contention) then fails to join it.
+
+    Deliberately narrow: it does not fold accents, drop apostrophes,
+    collapse initials or lowercase, because the result is shown to a
+    user.  It handles the two divergences actually observed between the
+    Sleeper dump and the contract.
+
+        >>> strip_display_suffix("Marvin Harrison Jr.")
+        'Marvin Harrison'
+        >>> strip_display_suffix("Kenneth Walker III")
+        'Kenneth Walker'
+        >>> strip_display_suffix("Michael Pittman (WR)")
+        'Michael Pittman'
+        >>> strip_display_suffix("Amon-Ra St. Brown")
+        'Amon-Ra St. Brown'
+    """
+    if not name:
+        return ""
+    s = str(name).strip()
+    if not s:
+        return ""
+    # Trailing parenthetical, e.g. "Name (WR)" / "Name (IR)".
+    s = re.sub(r"\s*\([^)]*\)\s*$", "", s).strip()
+    # Generational suffix, only at the END and only as a whole token, so
+    # "Vita Vea" keeps its "Vea" and a mid-name "V" is untouched.
+    s = re.sub(r"[,\s]+(Jr\.?|Sr\.?|I{2,3}|IV|VI?)\s*$", "", s, flags=re.IGNORECASE).strip()
+    return s
+
+
 def compact_name_key(name: object) -> str:
     """Lowercase, alphanumerics-only join key (family 2 in the module
     registry above).

--- a/tests/api/test_market_confidence_wiring.py
+++ b/tests/api/test_market_confidence_wiring.py
@@ -1,0 +1,153 @@
+"""Market confidence reaches the signal rule, and absent != zero.
+
+N2, 2026-07-29 audit round 2.
+
+``low_conf_unstable`` (MONITOR, priority 60) was broken in THREE places
+at once, in opposite directions:
+
+1. Backend — ``terminal.py::_build_signal_context`` read
+   ``row["confidence"]``.  No contract builder stamps that key; the
+   contract stamps ``marketConfidence``.  The rule could never fire
+   server-side, so it never reached the email alert sweep.
+
+2. Frontend, playersArray path — ``buildRows`` mapped
+   ``Number(player.marketConfidence ?? 0)``.  256 of 1094 live rows
+   carry no confidence at all, and 0 is under the 0.35 threshold, so
+   the rule fired on rows that merely LACK the field.
+
+3. Frontend, legacy-dict path — mapped
+   ``Number(player._marketReliabilityScore ?? 0)``.  That field appeared
+   exactly once in the entire repository — at that consumer — and
+   nothing ever produced it (0 of 1076 live players carry it, while 838
+   carry ``_marketConfidence``).  Confidence was therefore permanently
+   0 and the rule fired for every eligible row on that path.
+
+MONITOR is in ``signal_alerts.ACTIONABLE_SIGNALS``, so #1 is the one
+that gates emails.  The measured distribution says fixing it is safe:
+live ``marketConfidence`` runs p10 0.480 / median 0.491 / p90 0.564
+against a 0.35 threshold, and exactly ONE row of 1094 sits below it.
+That is recorded in ``test_threshold_is_far_below_the_live_distribution``
+so the "turning this on floods every inbox" assumption is not re-made
+without evidence — and so that if the distribution ever shifts down
+toward the threshold, someone notices.
+"""
+
+from __future__ import annotations
+
+from src.api.terminal import _build_signal_context, _evaluate_signal
+
+
+def _row(**over):
+    row = {
+        "displayName": "Test Player",
+        "position": "WR",
+        "rankDerivedValue": 5000,
+        "canonicalConsensusRank": 60,
+    }
+    row.update(over)
+    return row
+
+
+class TestConfidenceReachesTheContext:
+    def test_market_confidence_is_read(self):
+        """The key the contract actually stamps."""
+        ctx = _build_signal_context(_row(marketConfidence=0.2), points=[], news_for_player=[])
+        assert ctx["confidence"] == 0.2
+
+    def test_short_name_still_works_as_a_fallback(self):
+        """A caller handing over an already-materialized frontend row
+        (or a fixture using the short name) must keep working."""
+        ctx = _build_signal_context(_row(confidence=0.25), points=[], news_for_player=[])
+        assert ctx["confidence"] == 0.25
+
+    def test_market_confidence_wins_over_the_short_name(self):
+        ctx = _build_signal_context(
+            _row(marketConfidence=0.2, confidence=0.9), points=[], news_for_player=[]
+        )
+        assert ctx["confidence"] == 0.2
+
+    def test_absent_confidence_is_none_not_zero(self):
+        """The defect that made the rule fire on the frontend: a row
+        with no confidence must be UNMEASURED, never 'zero confidence'."""
+        ctx = _build_signal_context(_row(), points=[], news_for_player=[])
+        assert ctx["confidence"] is None
+
+    def test_garbage_confidence_is_none(self):
+        ctx = _build_signal_context(
+            _row(marketConfidence="not-a-number"), points=[], news_for_player=[]
+        )
+        assert ctx["confidence"] is None
+
+
+class TestTheRuleNowFires:
+    def _ctx(self, conf, trend7=-4.0):
+        return {
+            "value": 5000,
+            "confidence": conf,
+            "trend7": trend7,
+            "trend30": None,
+            "volatility": {"label": "med", "mad": 3.0},
+            "rankChange": None,
+            "alertCount": 0,
+            "negativeImpactCount": 0,
+            "positiveImpactCount": 0,
+            "newsCount": 0,
+        }
+
+    def test_low_confidence_plus_movement_fires_monitor(self):
+        """Server-side this could not fire at all before the fix."""
+        verdict = _evaluate_signal(self._ctx(0.2))
+        tags = {f["tag"] for f in verdict["fired"]}
+        assert "low_conf_unstable" in tags
+
+    def test_absent_confidence_does_not_fire(self):
+        verdict = _evaluate_signal(self._ctx(None))
+        tags = {f["tag"] for f in verdict["fired"]}
+        assert "low_conf_unstable" not in tags
+
+    def test_healthy_confidence_does_not_fire(self):
+        """0.49 is the live median — the common case must stay quiet."""
+        verdict = _evaluate_signal(self._ctx(0.49))
+        tags = {f["tag"] for f in verdict["fired"]}
+        assert "low_conf_unstable" not in tags
+
+
+class TestAlertVolumeIsBounded:
+    def test_monitor_is_actionable_so_this_gates_email(self):
+        """Pins the coupling that made this change delicate: if MONITOR
+        ever leaves ACTIONABLE_SIGNALS, the reasoning below changes."""
+        from src.api.signal_alerts import ACTIONABLE_SIGNALS
+
+        assert "MONITOR" in ACTIONABLE_SIGNALS
+
+    def test_threshold_is_far_below_the_live_distribution(self):
+        """The evidence that wiring this rule up does not flood inboxes.
+
+        The scraper defaults ``_marketConfidence`` to 0.5 and the live
+        spread is p10 0.480 / median 0.491 / p90 0.564, so a 0.35
+        threshold catches almost nothing — 1 row in 1094 when measured.
+
+        This test does not read live data (unit tests must not), but it
+        pins the two numbers the safety argument rests on, so a future
+        change to either is a deliberate one.
+        """
+        from src.api.terminal import _evaluate_signal as ev
+
+        base = {
+            "value": 5000,
+            "trend7": -4.0,
+            "trend30": None,
+            "volatility": {"label": "med", "mad": 3.0},
+            "rankChange": None,
+            "alertCount": 0,
+            "negativeImpactCount": 0,
+            "positiveImpactCount": 0,
+            "newsCount": 0,
+        }
+        # The scraper's default, and the live p10 — neither may fire.
+        for conf in (0.5, 0.480):
+            tags = {f["tag"] for f in ev({**base, "confidence": conf})["fired"]}
+            assert "low_conf_unstable" not in tags, f"{conf} fired; threshold moved"
+        # Just under the threshold must fire.
+        tags = {f["tag"] for f in ev({**base, "confidence": 0.34})["fired"]}
+        assert "low_conf_unstable" in tags

--- a/tests/canonical/test_rank_form_constants_tripwire.py
+++ b/tests/canonical/test_rank_form_constants_tripwire.py
@@ -1,0 +1,122 @@
+"""Tripwire on the legacy rank-form Hill constants.
+
+2026-07-29 audit, curve-governance follow-up.
+
+WHY A TRIPWIRE AND NOT A REGISTRY MODEL
+=======================================
+The audit flagged these four constants as a governance gap: they sit
+outside ``src/model_registry``, they are refit by a different script than
+the percentile scope masters, and they have no out-of-sample gate.  The
+proposed fix was to bring them under the model registry.
+
+That proposal was WRONG, and this test is what replaced it.  The model
+registry exists to gate AUTOMATED promotion — the percentile masters are
+refit weekly by ``.github/workflows/refit-hill-curves.yml``, which is
+why they need a challenger/champion flow.  These four are different:
+
+  * ``scripts/fit_hill_curve_from_market.py`` is READ-ONLY.  It opens
+    CSVs, grid-searches, and prints.  It contains no write of any kind.
+  * Nothing runs it — not a workflow, not a systemd timer, not a
+    Makefile target.  Verified by repo-wide grep: every reference is a
+    docstring or a test.
+  * Its own docstring says "Use the output to update
+    ``player_valuation.py`` constants", i.e. a human edits them.
+
+So there is no automated promotion to gate, and wrapping a
+human-edited, manually-refit pair in challenger/champion machinery would
+have been ceremony with no benefit.
+
+WHAT THE ACTUAL RESIDUAL RISK IS
+================================
+That someone edits these constants and does not re-check whether the
+curve still reproduces the board.  The two families drift independently,
+and the drift is silent — nothing fails when the rank-form curve stops
+matching the percentile-derived board.
+
+This test makes that edit LOUD.  It pins the values, so any change fails
+here and the failure message points at the drift check.  It is
+deliberately a dumb equality assertion: the other tests in
+``test_rank_to_value_scope.py`` import these constants symbolically (so
+a legitimate refit does not break them), which is right for them and
+exactly why none of them notices an edit.
+"""
+
+from __future__ import annotations
+
+from src.canonical.player_valuation import (
+    HILL_MIDPOINT,
+    HILL_SLOPE,
+    IDP_HILL_MIDPOINT,
+    IDP_HILL_SLOPE,
+)
+
+# The values live in ``src/canonical/player_valuation.py``.  Measured
+# fit against the live board on 2026-07-29
+# (``scripts/backtest_legacy_rank_curve.py``): the offense pair scores
+# RMSE 845.9 on offense rows, the IDP pair RMSE 78.7 on IDP rows, and a
+# curve refit to that board would score 96.3 overall.  Those numbers are
+# the context for any change here.
+_PINNED = {
+    "HILL_MIDPOINT": 48.44,
+    "HILL_SLOPE": 1.149,
+    "IDP_HILL_MIDPOINT": 69.50,
+    "IDP_HILL_SLOPE": 0.945,
+}
+
+_GUIDANCE = """
+The legacy rank-form Hill constants changed.
+
+If that was DELIBERATE, do these two things and then update _PINNED in
+this file:
+
+  1. Re-run the drift check, which is the whole reason this tripwire
+     exists:
+         python scripts/backtest_legacy_rank_curve.py \\
+             --out docs/measurements/<dated>.json
+     Compare against docs/legacy-rank-curve-backtest.md.  These
+     constants feed RECONSTRUCTION paths (terminal.py's value fallback
+     and rank_history.py's historical backfill), so a change moves
+     user-visible history values.
+
+  2. Record the decision in docs/legacy-rank-curve-backtest.md, which
+     carries the open question of whether this whole rank-form family
+     should be retired in favour of the registry-managed percentile
+     masters.
+
+If it was NOT deliberate: revert it.  Nothing automated writes these —
+``scripts/fit_hill_curve_from_market.py`` only prints — so an unexplained
+change here is a hand edit.
+"""
+
+
+def test_rank_form_constants_are_unchanged():
+    actual = {
+        "HILL_MIDPOINT": HILL_MIDPOINT,
+        "HILL_SLOPE": HILL_SLOPE,
+        "IDP_HILL_MIDPOINT": IDP_HILL_MIDPOINT,
+        "IDP_HILL_SLOPE": IDP_HILL_SLOPE,
+    }
+    drifted = {k: (v, actual[k]) for k, v in _PINNED.items() if actual[k] != v}
+    assert not drifted, f"{_GUIDANCE}\nChanged (pinned -> actual): " + ", ".join(
+        f"{k}: {was} -> {now}" for k, (was, now) in sorted(drifted.items())
+    )
+
+
+def test_the_refit_script_still_does_not_write():
+    """The premise this test's design rests on.
+
+    If ``fit_hill_curve_from_market.py`` ever gains the ability to write
+    constants, it becomes an automated promotion path — and then it DOES
+    need the registry gate, and the reasoning in this module's docstring
+    has to be revisited rather than silently outgrown.
+    """
+    from pathlib import Path
+
+    script = Path(__file__).resolve().parents[2] / "scripts" / "fit_hill_curve_from_market.py"
+    text = script.read_text()
+    # Reading CSVs is expected; writing is not.
+    for forbidden in ("write_text(", "write_committed_constants", ".writelines(", "json.dump("):
+        assert forbidden not in text, (
+            f"{script.name} now contains {forbidden!r} — it may write constants. "
+            "This tripwire assumes it is print-only; see the module docstring."
+        )

--- a/tests/utils/test_strip_display_suffix.py
+++ b/tests/utils/test_strip_display_suffix.py
@@ -1,0 +1,139 @@
+"""``strip_display_suffix`` — display-name cleanup, not a join key.
+
+N3, 2026-07-29 audit round 2.
+
+``sleeper_overlay._resolve_player_label`` falls back to the raw Sleeper
+``full_name`` when the loaded contract's id map misses a player id.
+Sleeper keeps generational suffixes; the contract's vocabulary — built
+by ``Dynasty Scraper.py::clean_name`` — does not.  Measured on the live
+payload: **0 of 1076** contract keys carry ``Jr.`` / ``III`` or a
+trailing parenthetical.
+
+So that fallback emitted a label in a foreign vocabulary into
+``sleeper.teams[].players``, which is name-keyed and read by waiver
+ownership, angle, replacement and FAAB contention.
+
+This helper is deliberately the ODD ONE OUT in ``name_clean``: every
+other function there lowercases, because they build join keys.  This
+one preserves case and spacing because its output is rendered.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.utils.name_clean import normalize_player_name, strip_display_suffix
+
+
+class TestStripsWhatSleeperAdds:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("Marvin Harrison Jr.", "Marvin Harrison"),
+            ("Marvin Harrison Jr", "Marvin Harrison"),
+            ("Kenneth Walker III", "Kenneth Walker"),
+            ("Robert Griffin III", "Robert Griffin"),
+            ("Some Player Sr.", "Some Player"),
+            ("Player Name II", "Player Name"),
+            ("Player Name IV", "Player Name"),
+            ("Odell Beckham Jr.", "Odell Beckham"),
+            # Comma form
+            ("Marvin Harrison, Jr.", "Marvin Harrison"),
+        ],
+    )
+    def test_generational_suffixes(self, raw, expected):
+        assert strip_display_suffix(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("Michael Pittman (WR)", "Michael Pittman"),
+            ("Some Guy (IR)", "Some Guy"),
+            ("Name Here  (DEN)  ", "Name Here"),
+        ],
+    )
+    def test_trailing_parentheticals(self, raw, expected):
+        assert strip_display_suffix(raw) == expected
+
+
+class TestPreservesEverythingElse:
+    def test_preserves_case(self):
+        """The output is DISPLAYED. Lowercasing it would be a bug."""
+        assert strip_display_suffix("Ja'Marr Chase") == "Ja'Marr Chase"
+        assert strip_display_suffix("Amon-Ra St. Brown") == "Amon-Ra St. Brown"
+
+    def test_preserves_apostrophes_hyphens_and_periods(self):
+        assert strip_display_suffix("D.J. Moore") == "D.J. Moore"
+        assert strip_display_suffix("De'Von Achane") == "De'Von Achane"
+
+    def test_preserves_accents(self):
+        """Unlike the join-key helpers, this must not ASCII-fold."""
+        assert strip_display_suffix("Juanyéh Thomas") == "Juanyéh Thomas"
+
+    def test_does_not_eat_a_real_name_token(self):
+        """'Vea' ends in a suffix-like fragment; 'V' is a valid roman
+        numeral. Neither may be stripped from a legitimate surname."""
+        assert strip_display_suffix("Vita Vea") == "Vita Vea"
+        assert strip_display_suffix("Jimmie Ward") == "Jimmie Ward"
+
+    def test_only_strips_at_the_end(self):
+        assert strip_display_suffix("Jr Smith Jones") == "Jr Smith Jones"
+
+    @pytest.mark.parametrize("raw", ["", None, "   "])
+    def test_empty_inputs(self, raw):
+        assert strip_display_suffix(raw) == ""
+
+
+class TestItIsNotAJoinKey:
+    def test_differs_from_normalize_player_name(self):
+        """Guards against someone 'simplifying' this into the lowercased
+        key helper, which would change every rendered label."""
+        raw = "Marvin Harrison Jr."
+        assert strip_display_suffix(raw) == "Marvin Harrison"
+        assert normalize_player_name(raw) == "marvin harrison"
+        assert strip_display_suffix(raw) != normalize_player_name(raw)
+
+    def test_output_lands_in_the_contract_vocabulary(self):
+        """The point of the helper: after stripping, the display name
+        normalizes to the same key the contract row would."""
+        sleeper_raw = "Kenneth Walker III"
+        contract_style = "Kenneth Walker"
+        assert normalize_player_name(strip_display_suffix(sleeper_raw)) == normalize_player_name(
+            contract_style
+        )
+
+
+class TestOverlayFallbackUsesIt:
+    def test_resolve_player_label_cleans_the_sleeper_fallback(self, monkeypatch):
+        from src.api import sleeper_overlay
+
+        monkeypatch.setattr(
+            sleeper_overlay,
+            "_sleeper_fallback_name_map",
+            lambda: {"7058": "Marvin Harrison Jr."},
+        )
+        label = sleeper_overlay._resolve_player_label("7058", {})
+        assert label == "Marvin Harrison"
+
+    def test_contract_map_wins_and_is_untouched(self, monkeypatch):
+        """The first branch already returns a contract-vocabulary name;
+        it must pass through verbatim, suffix or not."""
+        from src.api import sleeper_overlay
+
+        monkeypatch.setattr(sleeper_overlay, "_sleeper_fallback_name_map", lambda: {})
+        label = sleeper_overlay._resolve_player_label("123", {"123": "Some Player Jr."})
+        assert label == "Some Player Jr."
+
+    def test_unknown_id_still_degrades_to_the_raw_id(self, monkeypatch):
+        from src.api import sleeper_overlay
+
+        monkeypatch.setattr(sleeper_overlay, "_sleeper_fallback_name_map", lambda: {})
+        assert sleeper_overlay._resolve_player_label("9999", {}) == "9999"
+
+    def test_a_name_that_is_only_a_suffix_does_not_become_empty(self, monkeypatch):
+        """Degenerate input must not blank the row out — the fallback
+        keeps the original when stripping would leave nothing."""
+        from src.api import sleeper_overlay
+
+        monkeypatch.setattr(sleeper_overlay, "_sleeper_fallback_name_map", lambda: {"1": "Jr."})
+        assert sleeper_overlay._resolve_player_label("1", {}) == "Jr."


### PR DESCRIPTION
Board untouched (verified with the payload held constant).

Two parts: the last two roadmap fixes (N2, N3), then the three questions I'd handed back as "product decisions" — which were under-specified. Two are now decided on evidence; the third was the wrong question.

---

# Part 1 — the fixes

## N2 — the same rule was dead on one side and over-firing on the other

`low_conf_unstable` (MONITOR) was broken in **three places, in opposite directions**:

| # | where | read | effect |
|---|---|---|---|
| 1 | `terminal.py::_build_signal_context` | `row["confidence"]` | key nothing stamps → **never fired server-side** |
| 2 | `buildRows`, playersArray path | `marketConfidence ?? 0` | 256 of 1094 rows lack the field → 0 → **fired on rows that merely lack it** |
| 3 | `buildRows`, legacy path | `_marketReliabilityScore ?? 0` | **appears exactly once in the repo — at the consumer.** Nothing produces it → permanently 0 → **fired for every eligible row** |

All three now read the field the pipeline stamps, and **absent stays `null`, never 0**.

The email-flood concern that held this back doesn't survive measurement: over all 1094 live rows, confidence resolves for 838, stays `None` for 256, and **0 rows fire**. No baseline-seeding machinery added — shipping infrastructure for a problem the data refutes would be the wrong call.

## N3 — the Sleeper name fallback leaked a foreign vocabulary

Sleeper keeps generational suffixes; the contract doesn't (**0 of 1076** keys carry one). The fallback emitted names into `sleeper.teams[].players`, which is name-keyed and read by waiver ownership, angle, replacement and FAAB contention.

New `strip_display_suffix` is deliberately the odd one out in `name_clean`: everything else lowercases for join keys, this preserves case because its output is **displayed**. Not overselling it — exposure is 1 rostered id today, and that id has no contract row. Fixed because the branch is reachable.

---

# Part 2 — the three "your call" items, closed to evidence

Full writeup: `docs/open-modeling-decisions.md`

## `coverageWeight` — measured. Recommend **not** applying.

New `scripts/measure_coverage_weight_impact.py` (possible only because round 1 made weights actually apply). Only **3 of 21** sources are affected — the depth-50 rookie lists, scaled to 0.8333. That small input change is not a small output:

| metric | value |
|---|---|
| rows moved | **297 / 1094** (27%) |
| ranks changed | **221** (20%) |
| max value delta | **1072** (~11% of scale) |
| board membership | 1 in, 1 out |

Direction **varies per player** — not a uniform rookie haircut. Recommendation: don't. It reprices a fifth of the board on zero accuracy evidence, and those three sources already ladder-translate before reaching the blend. If wanted, it belongs in `board_holdout.py` like the adjusted-board lens.

## Rank-form Hill constants — **my own proposal was wrong**

I said to bring them under the model registry. That rested on a false premise. The registry gates *automated* promotion — which is why the percentile masters need it. These four:

- `fit_hill_curve_from_market.py` is **read-only** (no `write_text`, no `json.dump`, no regex sub)
- **nothing runs it** — no workflow, timer, or Makefile target; every reference is a docstring or test
- its docstring tells a human to edit the constants

No automated promotion to gate. A second registry model would have been ceremony nothing writes to.

The real risk is narrower: someone edits these and doesn't re-check the curve against the board. That drift is silent, and every existing test imports the constants *symbolically* — correct for refits, and exactly why none notices an edit.

Shipped instead: a tripwire pinning the values, failing with a message pointing at the drift backtest, plus a test asserting the refit script still doesn't write (if it ever does, the reasoning must be revisited, not silently outgrown). Verified it fires by mutating a constant.

## The confidence threshold — wrong question. The metric is capped.

`_market_confidence` weights `site_count / 8.0` at 65%. Live `site_count` **never exceeds 3**, so that term is confined to {0.20, 0.25, 0.375} and the ceiling is `0.375×0.65 + 0.35 = 0.59375`. Observed max over 838 players: **0.594**. Not a coincidence — the structural ceiling. Realized range [0.341, 0.594] against a nominal [0.20, 1.00].

The metric cannot express high confidence, so tuning 0.35 against it is calibrating against a broken ruler. The fix is the divisor.

**Not fixed here, deliberately.** `market_conf` also feeds the scraper's composite arithmetic (`elite_boost`, `elite_cap`, single-source discount, `idp_conf_factor`), so a change moves `_finalAdjusted` — and the scraper can't run in a dev environment, so the impact can't be measured here. The rule I've held all audit is not to change valuation inputs I can't measure. Next step is in the doc: re-scrape once with the divisor corrected, diff the composite.

---

## Verification

| gate | result |
|---|---|
| pytest | **5083 passed, 0 failed** |
| vitest | **86 files / 1463 tests, 0 failed** |
| `next build` | succeeded |
| ruff format / changed-files check | clean (gate reproduced locally first) |
| board invariance | **byte-identical, payload held constant** |

## Still genuinely yours

Rotating the admin credential (from #623), and the two calls above that need either a product decision or a machine that can run the scraper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RXRPXt7MhjKTgq5V8GuqZ