### PR TITLE
fix(deps): declare tzdata on Windows; promote Hill scope masters v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,19 @@
 # Settings → Advanced Security. This configures the version-update
 # PRs once that is on.
 #
-# Why this matters here specifically: requirements.txt carries 76
-# dependency lines and ZERO `==` pins, so every install resolves
-# whatever is current at the time. That makes an unnoticed breaking
-# release a production incident with no diff to point at, and it means
-# nothing was watching for CVEs in the runtime deps.
+# Why this matters here specifically: requirements.txt declares 10
+# direct dependencies, every one of them a `~=` compatible-release
+# pin (e.g. `fastapi~=0.135.0` accepts 0.135.x). So the minor is
+# locked but the patch floats, and the ~50 transitive dependencies
+# those pull in are not constrained at all — there is no lockfile.
+# An unnoticed breaking patch release therefore lands with no diff to
+# point at, and until this file existed nothing was watching for CVEs
+# in the runtime graph.
+#
+# (An earlier version of this comment said "76 dependency lines and
+# ZERO `==` pins". 76 is the file's total line count including
+# comments, and `~=` *is* pinning — just not exact. Corrected
+# 2026-07-29.)
 #
 # Grouping is deliberate. Ungrouped, four ecosystems on a weekly
 # cadence open enough PRs to bury the repo, and each one costs an

--- a/config/model_registry/hill_scope_masters.json
+++ b/config/model_registry/hill_scope_masters.json
@@ -1,7 +1,7 @@
 {
   "modelId": "hill_scope_masters",
   "schemaVersion": 1,
-  "updatedAt": "2026-07-28T09:08:00.219932+00:00",
+  "updatedAt": "2026-07-29T23:27:58.024727+00:00",
   "championVersion": 1,
   "versions": [
     {
@@ -29,14 +29,14 @@
         "YahooBoone": "sha256:8687353a0fcbb9ee"
       },
       "holdout": {
-        "criterion": 849.8254,
+        "criterion": 819.7335,
         "criterionName": "mean_per_source_rmse",
         "criterionUnits": "points on the 0-9999 value scale (lower is better)",
         "perSource": {
-          "FantasyCalc": 852.6106,
+          "FantasyCalc": 803.4113,
           "FantasyNavigator": 1185.153,
-          "OTCFFB": 1104.867,
-          "PFKDynasty": 256.6712
+          "OTCFFB": 1033.9634,
+          "PFKDynasty": 256.4063
         },
         "perSourceRows": {
           "FantasyCalc": 399,
@@ -71,7 +71,8 @@
       "qualified": true,
       "confidence": "measured",
       "notes": [
-        "seeded, not validated: these constants were live before the registry existed and carry no out-of-sample score"
+        "seeded: these constants were live before the registry existed, so they were never FIT against a holdout — but they have since been SCORED against one",
+        "holdout re-scored 2026-07-29 against that day's boards (849.8 -> 819.7). The prior figure was measured 2026-07-26 and was NOT comparable to challenger v2's 2026-07-28 score: promotion.py requires a PAIRED comparison because the criterion's absolute level drifts ~68 points week to week, so comparing across snapshot dates reads market drift as model quality."
       ],
       "promotedAt": "2026-07-26T20:14:13.267338+00:00",
       "retiredAt": null

--- a/config/model_registry/hill_scope_masters.json
+++ b/config/model_registry/hill_scope_masters.json
@@ -1,8 +1,8 @@
 {
   "modelId": "hill_scope_masters",
   "schemaVersion": 1,
-  "updatedAt": "2026-07-29T23:27:58.024727+00:00",
-  "championVersion": 1,
+  "updatedAt": "2026-07-29T23:35:35.519561+00:00",
+  "championVersion": 2,
   "versions": [
     {
       "modelId": "hill_scope_masters",
@@ -19,7 +19,7 @@
       },
       "fittedAt": "unknown",
       "producer": "seeded from committed constants in player_valuation.py",
-      "status": "champion",
+      "status": "retired",
       "trainingInputs": {
         "DraftSharks": "sha256:c37dc3fb4b127a2d",
         "DynastyDaddy": "sha256:5b9d328ae8f51887",
@@ -71,11 +71,11 @@
       "qualified": true,
       "confidence": "measured",
       "notes": [
-        "seeded: these constants were live before the registry existed, so they were never FIT against a holdout — but they have since been SCORED against one",
+        "seeded: these constants were live before the registry existed, so they were never FIT against a holdout \u2014 but they have since been SCORED against one",
         "holdout re-scored 2026-07-29 against that day's boards (849.8 -> 819.7). The prior figure was measured 2026-07-26 and was NOT comparable to challenger v2's 2026-07-28 score: promotion.py requires a PAIRED comparison because the criterion's absolute level drifts ~68 points week to week, so comparing across snapshot dates reads market drift as model quality."
       ],
       "promotedAt": "2026-07-26T20:14:13.267338+00:00",
-      "retiredAt": null
+      "retiredAt": "2026-07-29T23:35:35.519297+00:00"
     },
     {
       "modelId": "hill_scope_masters",
@@ -92,7 +92,7 @@
       },
       "fittedAt": "2026-07-28T09:08:00.219336+00:00",
       "producer": "scripts/fit_hill_curve_percentile.py @ 3df9cc4",
-      "status": "challenger",
+      "status": "champion",
       "trainingInputs": {
         "DraftSharks": "sha256:d474c81d2f6ce808",
         "DynastyDaddy": "sha256:4d2cd2d87560557f",
@@ -143,8 +143,10 @@
       },
       "qualified": true,
       "confidence": "measured",
-      "notes": [],
-      "promotedAt": null,
+      "notes": [
+        "promoted: held-out win: +38.5 paired on 2026-07-29 boards (819.7 -> 781.2), improving all four holdout sources with no sign flips; downstream contract diff over 1093 rows shows top-100 median 2.4% / max 4.4% and max top-150 rank displacement 46 slots"
+      ],
+      "promotedAt": "2026-07-29T23:35:35.519297+00:00",
       "retiredAt": null
     }
   ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,28 @@ beautifulsoup4~=4.14.0
 # subscribed devices.
 pywebpush~=2.0
 
+# tzdata: required on Windows ONLY, and load-bearing there.
+#
+# ``src/nfl_data/freshness.py:25`` evaluates
+# ``ZoneInfo("America/New_York")`` at MODULE IMPORT TIME, and
+# ``src/news/usage_signals.py`` imports that module.  On Linux and
+# macOS ``zoneinfo`` reads the operating system's tz database
+# (``/usr/share/zoneinfo``) and needs nothing extra.  Windows ships no
+# such database, so CPython's ``zoneinfo`` falls back to this PyPI
+# package — and without it the import raises
+# ``ZoneInfoNotFoundError``, not a soft warning.
+#
+# Why this went unnoticed until 2026-07-29: every workflow runs on
+# ``ubuntu-latest``, so CI could never surface it, while CLAUDE.md
+# calls Windows the primary dev platform.  The practical effect was
+# that ``python -m pytest tests/`` could not even be COLLECTED on
+# Windows (3 collection errors, whole run interrupted), and any
+# Windows process touching news usage signals died on import.
+#
+# The environment marker keeps it off Linux/macOS installs, so the
+# production dependency graph is unchanged.
+tzdata~=2026.1; sys_platform == "win32"
+
 # nfl_data_py: deliberately NOT in this manifest.
 #
 # nfl_data_py 0.3.x pins pandas<2.0, which forces pandas-1.5.3 to

--- a/src/canonical/player_valuation.py
+++ b/src/canonical/player_valuation.py
@@ -92,23 +92,23 @@ IDP_HILL_SLOPE: float = 0.945
 # (currently IDPTradeCalc only; the only source with dual-universe
 # coverage).  Used for the anchor source's contributions to every
 # player, regardless of position.
-HILL_GLOBAL_PERCENTILE_C: float = 0.1130
-HILL_GLOBAL_PERCENTILE_S: float = 0.870
+HILL_GLOBAL_PERCENTILE_C: float = 0.1120
+HILL_GLOBAL_PERCENTILE_S: float = 0.725
 #
 # OFFENSE master — fit from offense-only value sources (KTC,
 # DynastyDaddy, DynastyNerds).  Used for every offense-scope source's
 # contributions (KTC, DLF SF, Dynasty Nerds, FantasyPros SF, Dynasty
 # Daddy, Flock Fantasy, FootballGuys SF, Yahoo/Boone, DraftSharks,
 # DLF Rookie SF).
-HILL_PERCENTILE_C: float = 0.1180
-HILL_PERCENTILE_S: float = 1.170
+HILL_PERCENTILE_C: float = 0.1100
+HILL_PERCENTILE_S: float = 1.110
 #
 # IDP master — fit from IDPTradeCalc's IDP slice (the only value-
 # based IDP source).  Used for every IDP-scope source's contributions
 # (DLF IDP, FantasyPros IDP, FootballGuys IDP, DLF Rookie IDP,
 # DraftSharks IDP).
-IDP_HILL_PERCENTILE_C: float = 0.0930
-IDP_HILL_PERCENTILE_S: float = 0.970
+IDP_HILL_PERCENTILE_C: float = 0.0830
+IDP_HILL_PERCENTILE_S: float = 1.110
 #
 # ROOKIE master — fit from KTC + IDPTC rookie slices of the latest
 # snapshot.
@@ -132,8 +132,8 @@ IDP_HILL_PERCENTILE_S: float = 0.970
 # Keep the constants — the refit workflow maintains them, and routing
 # the curve is a live option — but do not read this block as a
 # description of current behaviour.
-HILL_ROOKIE_PERCENTILE_C: float = 0.1280
-HILL_ROOKIE_PERCENTILE_S: float = 0.865
+HILL_ROOKIE_PERCENTILE_C: float = 0.1530
+HILL_ROOKIE_PERCENTILE_S: float = 0.885
 
 # Display scale
 DISPLAY_SCALE_MAX: int = 9999

--- a/tests/nfl_data/test_windows_tzdata_declared.py
+++ b/tests/nfl_data/test_windows_tzdata_declared.py
@@ -1,0 +1,82 @@
+"""``tzdata`` must stay declared for Windows, and CI cannot notice if it goes.
+
+``src/nfl_data/freshness.py`` evaluates ``ZoneInfo("America/New_York")``
+at module import time and ``src/news/usage_signals.py`` imports it.  On
+Linux and macOS ``zoneinfo`` reads the OS tz database and needs nothing
+extra; Windows ships none, so CPython falls back to the ``tzdata`` PyPI
+package.  Without it the import raises ``ZoneInfoNotFoundError``.
+
+This is a STATIC manifest check rather than a behavioural one on
+purpose.  Every workflow runs ``ubuntu-latest``, where the import
+succeeds whether or not ``tzdata`` is installed — so a behavioural test
+would pass on the exact platform that cannot detect the problem.  That
+blind spot is what let the gap survive: measured 2026-07-29, a Windows
+``python -m pytest tests/`` aborted with 3 collection errors and ran
+nothing at all, while CI stayed green.
+
+If this test fails, do not delete it.  Restore the declaration in
+``requirements.txt`` instead, or Windows development breaks silently
+again.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REQUIREMENTS = REPO_ROOT / "requirements.txt"
+
+# Matches e.g. ``tzdata~=2026.1; sys_platform == "win32"`` with flexible
+# whitespace, quote style, and version-specifier operator.
+_TZDATA_LINE = re.compile(
+    r"""^\s*tzdata\s*             # package name
+        (?:[~>=<!]=[^;]+)?        # optional version specifier
+        \s*;\s*                   # environment-marker separator
+        sys_platform\s*==\s*      # the marker we require
+        ['"]win32['"]\s*$""",
+    re.VERBOSE,
+)
+
+
+def _declared_lines() -> list[str]:
+    text = REQUIREMENTS.read_text(encoding="utf-8")
+    return [
+        line
+        for line in text.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def test_tzdata_is_declared_for_win32() -> None:
+    matches = [line for line in _declared_lines() if _TZDATA_LINE.match(line)]
+    assert matches, (
+        "requirements.txt must declare tzdata with a win32 environment "
+        "marker, e.g.\n\n"
+        '    tzdata~=2026.1; sys_platform == "win32"\n\n'
+        "Without it, ZoneInfo('America/New_York') raises "
+        "ZoneInfoNotFoundError on Windows at import time and the test "
+        "suite cannot be collected there. CI runs Linux and will not "
+        "reproduce the failure."
+    )
+    assert len(matches) == 1, f"tzdata declared more than once: {matches!r}"
+
+
+def test_tzdata_marker_keeps_it_off_linux() -> None:
+    """The marker is what protects the production dependency graph.
+
+    Production is Linux, where the OS tz database already answers the
+    lookup.  An unmarked ``tzdata`` would install there too — harmless
+    but untrue to why the package is present, and it would quietly
+    become a runtime dependency nobody could justify from the code.
+    """
+    unmarked = [
+        line
+        for line in _declared_lines()
+        if re.match(r"^\s*tzdata\s*(?:[~>=<!]=\S+)?\s*$", line)
+    ]
+    assert not unmarked, (
+        "tzdata is declared without an environment marker "
+        f"({unmarked!r}); it must be constrained to "
+        'sys_platform == "win32" so Linux/macOS installs are unchanged.'
+    )

--- a/tests/nfl_data/test_windows_tzdata_declared.py
+++ b/tests/nfl_data/test_windows_tzdata_declared.py
@@ -42,9 +42,7 @@ _TZDATA_LINE = re.compile(
 def _declared_lines() -> list[str]:
     text = REQUIREMENTS.read_text(encoding="utf-8")
     return [
-        line
-        for line in text.splitlines()
-        if line.strip() and not line.lstrip().startswith("#")
+        line for line in text.splitlines() if line.strip() and not line.lstrip().startswith("#")
     ]
 
 
@@ -71,9 +69,7 @@ def test_tzdata_marker_keeps_it_off_linux() -> None:
     become a runtime dependency nobody could justify from the code.
     """
     unmarked = [
-        line
-        for line in _declared_lines()
-        if re.match(r"^\s*tzdata\s*(?:[~>=<!]=\S+)?\s*$", line)
+        line for line in _declared_lines() if re.match(r"^\s*tzdata\s*(?:[~>=<!]=\S+)?\s*$", line)
     ]
     assert not unmarked, (
         "tzdata is declared without an environment marker "


### PR DESCRIPTION
Two independent changes, reviewable separately. Commit 1 is a dependency fix; commits 2–3 are a model promotion.

---

# 1. `tzdata` on Windows — `bd2ea18` / `f7ade39`

## What

Declares `tzdata~=2026.1; sys_platform == "win32"` in `requirements.txt`, pins it with a static test, and corrects a wrong number in the `dependabot.yml` header.

## Why

`src/nfl_data/freshness.py:25` evaluates `ZoneInfo("America/New_York")` at **module import time**, and `src/news/usage_signals.py` imports that module. Linux and macOS answer the lookup from the OS tz database (`/usr/share/zoneinfo`). **Windows ships none**, so CPython's `zoneinfo` falls back to the `tzdata` PyPI package — which was declared in neither `requirements.txt` nor `requirements-dev.txt`.

Measured on a clean Windows 3.12.10 venv, `python -m pytest tests/ -q -m "not livedata"` **aborted during collection and ran zero tests**:

```
ERROR tests/news/test_usage_signal_calibration.py - ZoneInfoNotFoundError
ERROR tests/news/test_usage_signals.py            - ZoneInfoNotFoundError
ERROR tests/nfl_data/test_freshness.py            - ZoneInfoNotFoundError
!!!!!!!!!!!!!!! Interrupted: 3 errors during collection !!!!!!!!!!!!!!!
319 deselected, 3 errors in 30.82s
```

Two things worth calling out:

- **This is not test-only breakage.** `src/` is production code, so any Windows process reaching news usage signals died on the same import — relevant because `start_dynasty.bat` exists and `CLAUDE.md` calls Windows the primary dev platform.
- **CI could never catch it.** Every workflow runs `ubuntu-latest`, where the import succeeds regardless.

Confirmed fixed on the same machine: with `tzdata` installed the suite collects and runs, **5191 passed** (the 10 remaining failures are unrelated Windows-portability issues — `sleep`, `os.symlink`, `os.fchmod`, and a path-separator comparison — tracked separately).

## How

- `requirements.txt` — adds the dependency behind a `sys_platform == "win32"` marker, so the Linux production dependency graph is **unchanged**.
- `tests/nfl_data/test_windows_tzdata_declared.py` — a **static manifest** check, deliberately not behavioural. On Linux the import succeeds whether or not `tzdata` is installed, so a behavioural test would pass on the only platform CI runs.
- `.github/dependabot.yml` — the header claimed requirements.txt carried *"76 dependency lines and ZERO `==` pins"*. 76 is the file's total line count including comments; there are **10 direct dependencies** and they are `~=` compatible-release pins. Corrected, with a note recording what was wrong.

---

# 2. Hill scope masters v2 — `9c07887` / `15d5682`

Closes #613. This is the human promotion step ADR-008 (`docs/roster-trade-intelligence/DECISIONS.md`) reserves for a person: the weekly refit workflow scores a challenger and stops.

## The issue's comparison was not paired

Issue #613 scored champion v1 at 826.7; the registry had 849.8 from 2026-07-26; challenger v2's 787.8 came from 2026-07-28. `src/model_registry/promotion.py` is explicit that this must be paired — its docstring records that re-scoring one *fixed* curve against 30 consecutive FantasyCalc snapshots gave 584.90–653.04, a 68-point range. Across-date comparison reads market drift as model quality.

Both curves re-scored against the **same** 2026-07-29 boards:

| | criterion | FantasyCalc | FantasyNavigator | OTCFFB | PFKDynasty |
|---|---|---|---|---|---|
| champion v1 (c=.118 s=1.17) | 819.7 | 803.4 | 1185.2 | 1034.0 | 256.4 |
| challenger v2 (c=.110 s=1.11) | **781.2** | 754.6 | 1148.5 | 978.4 | 243.4 |

**+38.5 against the 25-point margin, improving all four holdout sources with no sign flips.** `9c07887` updates v1's stored score to the same-day measurement so `validate` is paired going forward.

## The ungated constants were measured, not assumed

Only `HILL_PERCENTILE_C/S` (OFFENSE) is gated out of sample. In curve-isolation arithmetic the ungated IDP change looks severe — −15% at p20, −27% at p50, −34% at p90.

**That is the wrong unit of analysis.** Rebuilding the full `/api/data` contract from the live payload under both constant sets and diffing 1,093 rows:

| band | n | median Δ | p90 | max |
|---|---|---|---|---|
| ranks 1–150 | 150 | 2.4% | 3.7% | 13.6% |
| ranks 151–400 | 234 | 0.8% | 4.4% | 15.7% |
| ranks 401–1200 | 314 | 2.5% | 11.9% | 33.5% |

IDP median across the whole asset class is **0.0%** — α-shrinkage pulls IDP rows toward the value-direct IDPTC anchor and count-aware blending dilutes the single rank→Hill vote.

Rank order is stable where it matters: 93 rows move one slot, 55 move two, top-150 max displacement is 46 slots, and every displacement over 100 slots sits at rank #490 or deeper. `ROOKIE` is fitted but `routed=False` in `data_contract.py`, so its change is inert.

## Two caveats, recorded rather than buried

1. The GLOBAL and IDP pairs are **live but ungated**. Their downstream effect was measured and is small, but "measured once" is weaker than "gated by a test" — a standing ADR-008 limitation, not something this PR introduces.
2. Largest top-150 movers are **Ernest Jones** (#146, −13.6%) and **Jihaad Campbell** (#134, −11.6%), both IDP near the top-150 gate `suggestions.py` and `finder.py` filter on. A couple of borderline IDP assets can enter or leave those engines' universes.

## Rollback

Two commands, with v1's params stored verbatim in the registry rather than reconstructed:

```
python3 scripts/model_registry.py rollback --reason "..."
python3 scripts/model_registry.py apply
```

---

# Verification

Run against the merged state of this branch:

- `pytest tests/ -q -m "not livedata"` → **5212 passed, 0 failed**
- `ruff format --check .` → 710 files already formatted
- `ruff check` → clean
- New `tzdata` tests verified by negative control (deleting the declaration makes them fail)

The local run was on Python 3.11; `Validate PR` is the authoritative gate.

# Not included

The 35 open Dependabot alerts (17 high / 14 moderate / 4 low) and the 14 open Dependabot PRs are a separate matter and untouched here.