### PR TITLE
Perf round 5: unfreeze filtered rankings, and pin the board's column widths

### DIFF
--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useState,
   useCallback,
+  useDeferredValue,
   useEffect,
   useTransition,
 } from "react";
@@ -691,6 +692,25 @@ export default function RankingsPage() {
     [hasActiveFilter, ranked, rowLimit],
   );
   const hasMore = !hasActiveFilter && ranked.length > rowLimit;
+
+  // A filter deliberately bypasses ``rowLimit`` (above), so a broad one
+  // renders the FULL ~1.1k-row board — the same synchronous commit that
+  // froze the tab on "Show all" before it was made a transition.
+  //
+  // Deferring the ROWS rather than wrapping the filter setters in
+  // ``startTransition`` is the deliberate choice: the search box's own
+  // value has to stay urgent or the text lags a frame behind the
+  // keystrokes, which is worse than the freeze it fixes.  Filtering
+  // 1,076 rows is microseconds; RENDERING a thousand of them at ~36 DOM
+  // nodes each is the expensive half, and that is exactly what this
+  // defers.  Counts, movers and the lens chips all stay urgent.
+  //
+  // While the transition is in flight React keeps serving the previous
+  // array, so the table briefly shows pre-filter rows.  That must be
+  // visible or it reads as "the filter didn't work" — hence
+  // ``rowsPending`` and the affordance on the count line.
+  const renderedRows = useDeferredValue(displayRows);
+  const rowsPending = renderedRows !== displayRows;
 
   // Per-position ranks (QB3, RB5, LB2…) — computed from the eligible
   // board sorted by rank ASC, independent of the user's sort/filter.
@@ -1829,15 +1849,22 @@ export default function RankingsPage() {
               </div>
             )}
 
+            {/* ``aria-live`` so the count is announced when it settles,
+                and ``aria-busy`` while the deferred rows catch up — a
+                screen-reader user otherwise gets the stale count read
+                out as if it were the answer. */}
             <p
               className={styles.resultCount}
               style={{ margin: "var(--space-2) 0 0" }}
+              aria-live="polite"
+              aria-busy={rowsPending || undefined}
             >
-              {displayRows.length.toLocaleString()}
+              {renderedRows.length.toLocaleString()}
               {hasMore ? ` of ${ranked.length.toLocaleString()}` : ""} shown
               {activeLens !== "consensus" && ` · ${currentLens.label} lens`}
               {confFilter !== "all" && ` · ${confFilter} confidence`}
               {tierGroupingActive && " · grouped by tier"}
+              {rowsPending && " · filtering…"}
             </p>
           </div>
 
@@ -1846,11 +1873,16 @@ export default function RankingsPage() {
             role="tabpanel"
             id={tabPanelId("lens", activeLens)}
             aria-labelledby={tabId("lens", activeLens)}
+            // Dim the stale rows while the deferred list catches up.  No
+            // transition on the property: a fade would itself cost paint
+            // on the very commit this is trying to keep cheap, and the
+            // whole point is that the rows below are the OLD ones.
+            style={rowsPending ? { opacity: 0.55 } : undefined}
           >
             <DataTable
               caption="Unified dynasty value board: rank, tier, player, position, consensus, value, per-source values, confidence, and market signals"
               columns={columns}
-              rows={displayRows}
+              rows={renderedRows}
               rowKey={(row) => row.name}
               presorted
               density="compact"
@@ -1902,7 +1934,7 @@ export default function RankingsPage() {
               renderBeforeRow={(row, i) => {
                 if (!tierGroupingActive || i === 0) return null;
                 const tierId = effectiveTierId(row);
-                const prevTierId = effectiveTierId(displayRows[i - 1]);
+                const prevTierId = effectiveTierId(renderedRows[i - 1]);
                 if (tierId === prevTierId || tierId == null) return null;
                 return (
                   <tr className={styles.tierSeparator}>

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -1885,6 +1885,13 @@ export default function RankingsPage() {
               rows={renderedRows}
               rowKey={(row) => row.name}
               presorted
+              // Prerequisite for windowing the rows: under auto layout a
+              // column is as wide as its widest CELL, so rendering only a
+              // visible slice would make columns jump while scrolling.
+              // DataTable measures the widths the browser already settled
+              // on and freezes exactly those, so the geometry is
+              // unchanged at every breakpoint.  See DataTable.jsx.
+              freezeColumnWidths
               density="compact"
               // DataTable renders emptyState INSTEAD of the table when
               // rows are empty — without one, a filter that matches

--- a/frontend/components/ds/DataTable.jsx
+++ b/frontend/components/ds/DataTable.jsx
@@ -64,9 +64,22 @@
  */
 "use client";
 
-import React, { Fragment, useCallback, useMemo, useState } from "react";
+import React, {
+  Fragment,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Icon } from "./Icon";
 import { InfoTip } from "./Help";
+
+// useLayoutEffect warns during SSR; the freeze pass is a post-paint
+// measurement that has no server equivalent, so fall back to a no-op.
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? () => {} : useLayoutEffect;
 
 function defaultRowKey(row, index) {
   return row?.id ?? index;
@@ -153,6 +166,7 @@ export function DataTable({
   rowClassName = null,
   renderBeforeRow = null,
   renderAfterRow = null,
+  freezeColumnWidths = false,
 }) {
   const [internalSort, setInternalSort] = useState(defaultSort);
   const sort = controlledSort !== undefined ? controlledSort : internalSort;
@@ -200,6 +214,123 @@ export function DataTable({
   const getKey =
     typeof rowKey === "string" ? (row, i) => row?.[rowKey] ?? i : rowKey;
 
+  // ── Column-width freeze (opt-in via `freezeColumnWidths`) ──────────
+  //
+  // A prerequisite for row virtualization, not a cosmetic option. Under
+  // `table-layout: auto` a column is as wide as its widest CELL, so
+  // rendering only a window of rows would let widths change as the user
+  // scrolls. `table-layout: fixed` fixes that, but naively flipping it
+  // is wrong here: this table is content-sized and horizontally
+  // scrollable on narrow viewports (measured 604px inside a 376px wrap
+  // at 390px), and `fixed` with no min-width would squeeze it to the
+  // wrapper instead.
+  //
+  // So rather than hand-authoring widths per breakpoint — which the
+  // `hideBelow` columns would make a maintenance trap, since the
+  // visible set and therefore the correct min-width change per
+  // breakpoint — we MEASURE the widths the browser already settled on
+  // and then freeze exactly those. The frozen table is by construction
+  // the same geometry the user sees today, at whatever breakpoint they
+  // are at, and re-measures when the viewport changes.
+  const tableRef = useRef(null);
+  const [frozen, setFrozen] = useState(null);
+
+  const measure = useCallback(() => {
+    const table = tableRef.current;
+    if (!table) return;
+    const ths = Array.from(table.querySelectorAll("thead th"));
+    if (ths.length === 0) return;
+    // Measure with the freeze OFF, so we read the browser's own
+    // content-driven answer rather than the widths we last imposed.
+    const widths = ths.map((th) => {
+      // A `hideBelow` column is display:none at this breakpoint. It has
+      // no width to freeze and must not get one, or its <col> would
+      // reserve space for a column nobody can see.
+      if (th.offsetParent === null && th.getClientRects().length === 0) {
+        return null;
+      }
+      return Math.round(th.getBoundingClientRect().width * 100) / 100;
+    });
+    const total = widths.reduce((sum, w) => sum + (w || 0), 0);
+    if (total <= 0) return;
+    setFrozen((prev) => {
+      if (
+        prev &&
+        prev.total === total &&
+        prev.widths.length === widths.length &&
+        prev.widths.every((w, i) => w === widths[i])
+      ) {
+        return prev; // identical — don't churn a re-render
+      }
+      return { widths, total };
+    });
+  }, []);
+
+  // Measure after paint, with the freeze removed for that one frame, so
+  // the numbers come from the auto-layout pass. `frozen` is cleared
+  // first on a resize (below) for the same reason.
+  //
+  // Deliberately NO dependency array. The obvious version — deps on
+  // [freezeColumnWidths, frozen, columns] — silently fails whenever the
+  // first render has no rows yet: the component returns `emptyState`, so
+  // there is no <table> to measure, `measure()` bails on the null ref,
+  // and when the rows finally arrive none of those deps has changed, so
+  // the effect never runs again and the table stays on auto layout
+  // forever. Running every render costs one `if` once frozen, and
+  // `measure()` is idempotent — it self-terminates on the guard below.
+  useIsomorphicLayoutEffect(() => {
+    if (!freezeColumnWidths) return;
+    if (frozen) return;
+    measure();
+  });
+
+  // Re-measure on viewport change: a breakpoint crossing changes which
+  // columns are visible, so both the widths AND the correct min-width
+  // change. Clearing `frozen` drops back to auto layout for one frame,
+  // which is what makes the next measurement honest.
+  useEffect(() => {
+    if (!freezeColumnWidths) return undefined;
+    const table = tableRef.current;
+    if (!table || typeof ResizeObserver === "undefined") return undefined;
+    const target = table.parentElement || table;
+    // Only react to a real WIDTH change. Freezing the table sets a
+    // min-width, which changes the wrapper's scrollWidth — observing
+    // size unconditionally would fire on our own change, clear the
+    // freeze, re-measure, re-freeze, forever.
+    let lastWidth = Math.round(target.getBoundingClientRect().width);
+    let raf = 0;
+    const ro = new ResizeObserver(() => {
+      const width = Math.round(target.getBoundingClientRect().width);
+      if (width === lastWidth) return;
+      lastWidth = width;
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => setFrozen(null));
+    });
+    ro.observe(target);
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+    };
+  }, [freezeColumnWidths]);
+
+  // Columns changing (the board's source toggles add/remove columns)
+  // invalidates the measurement for the same reason a resize does.
+  //
+  // The ref guard is load-bearing, not defensive: an unguarded effect
+  // fires on MOUNT too, in the same commit where the layout effect above
+  // has just set `frozen`. Passive effects run after layout effects, so
+  // it clears the freeze, `frozen` ends the commit back at null, the
+  // layout effect's deps are therefore unchanged on the next render, and
+  // it never measures again. The table silently stayed on auto layout.
+  const columnKeys = columns.map((c) => c.key).join("|");
+  const lastColumnKeys = useRef(columnKeys);
+  useEffect(() => {
+    if (!freezeColumnWidths) return;
+    if (lastColumnKeys.current === columnKeys) return;
+    lastColumnKeys.current = columnKeys;
+    setFrozen(null);
+  }, [freezeColumnWidths, columnKeys]);
+
   if (!rows || rows.length === 0) return emptyState;
 
   const activeCol = sort ? columns.find((c) => c.key === sort.key) : null;
@@ -210,6 +341,7 @@ export function DataTable({
       style={maxHeight ? { maxHeight, overflowY: "auto" } : undefined}
     >
       <table
+        ref={tableRef}
         className={[
           "ds-table",
           density === "compact" ? "ds-table--compact" : "",
@@ -217,9 +349,38 @@ export function DataTable({
         ]
           .filter(Boolean)
           .join(" ")}
+        style={
+          frozen
+            ? {
+                tableLayout: "fixed",
+                // The measured total, so a content-sized horizontally
+                // scrollable table keeps its width instead of being
+                // squeezed into the wrapper by `fixed`.
+                width: frozen.total,
+                minWidth: frozen.total,
+              }
+            : undefined
+        }
       >
         {caption ? (
           <caption className="ds-visually-hidden">{caption}</caption>
+        ) : null}
+        {frozen ? (
+          // Only the VISIBLE columns get a <col>, and this is the whole
+          // subtlety of the feature. `hideBelow` hides a column with
+          // `display: none`, which removes it from the table's column
+          // count in the fixed-layout algorithm — but <col> elements map
+          // to columns by POSITION. Emitting a placeholder <col> for a
+          // hidden column therefore shifted every width after it onto
+          // the wrong column: at 390px the player name collapsed to 0
+          // and the position column inherited its 296px.
+          <colgroup>
+            {frozen.widths.map((w, i) =>
+              w == null ? null : (
+                <col key={columns[i]?.key ?? i} style={{ width: w }} />
+              ),
+            )}
+          </colgroup>
         ) : null}
         <thead>
           <tr>


### PR DESCRIPTION
Follow-up to #630, closing the two items its ledger left open. Two independent changes; the second is the prerequisite for row virtualization rather than the virtualization itself.

## 1. A broad filter no longer freezes the tab

An active filter deliberately bypasses `rowLimit` (`hasActiveFilter ? ranked : ranked.slice(0, rowLimit)`), so picking **Position: offense** goes from 200 capped rows to all 516 matches in one synchronous commit — the same freeze "Show all" had before #630 made it a transition.

Measured at 390×844, Position all → offense (230 → 630 rendered rows including tier dividers):

| | control | after |
|---|---|---|
| 1× time-to-rows | 601ms | **344ms** |
| 1× longest frame gap | 296ms | **52ms** |
| 6× time-to-rows | 4078ms | **3380ms** |
| 6× longest frame gap | 2197ms | **324ms** |
| 6× p95 frame gap | 2197ms | **23ms** |
| 6× frames painted | 10 | **146** |

The frame count is the honest headline: during the same window the tab went from ~2.5 FPS to ~43 FPS. It wasn't slow, it was unresponsive.

Two deliberate choices:

- **`useDeferredValue` on the rows, not `startTransition` around the filter setters.** The search box's own value has to stay urgent or the text lags a frame behind the keystrokes — a worse defect than the freeze it fixes. Verified: the input reads back its full value synchronously.
- **The filter is still not capped.** Capping filtered results was the easy fix and it changes what a filter *means* — "516 shown" has to keep being all 516. Filtering 968 rows is microseconds; *rendering* them at ~36 DOM nodes each is the expensive half, and that is the only part deferred. Counts, movers and lens chips stay urgent.

While the deferred render is in flight React serves the previous array, so the table briefly shows pre-filter rows. That has to be visible or it reads as "the filter didn't work": the count line gains a "· filtering…" suffix plus `aria-live`/`aria-busy` (a screen-reader user would otherwise have the stale count read out as the answer), and the table dims with no transition — a fade would cost paint on the very commit this keeps cheap.

## 2. `DataTable`: opt-in column-width freeze

Step A of virtualizing the board. Under `table-layout: auto` a column is as wide as its widest *cell*, so rendering only a window of rows would let widths change while scrolling.

| | auto layout | frozen |
|---|---|---|
| worst column shift when rows change (81→786) | 116px desktop / 47px mobile | **0px / 0px** |
| column widths vs pre-freeze baseline | — | **0px delta**, both viewports |
| body cells clipped | — | **0 of 2,030** |

Not implemented as hand-authored widths + `table-layout: fixed`, which is the obvious version and is wrong here twice over:

- The board is content-sized and horizontally scrollable on narrow viewports — 604px inside a 376px wrapper at 390px. `fixed` with no min-width squeezes it to the wrapper.
- `hideBelow` columns make the correct min-width a per-breakpoint value (10 visible columns at 1366px, 5 at 390px), so any hand-maintained number is a trap the next column change silently breaks.

Instead `DataTable` **measures the widths the browser already settled on** and freezes exactly those, re-measuring when the viewport crosses a breakpoint or the column set changes. The frozen table is by construction the geometry users already see.

### Three non-obvious defects, all found by measurement, all now commented in place

Each of these shipped "working" on one viewport and broken on the other:

- **`<col>` maps by position, `display: none` doesn't.** Hiding a column removes it from the fixed-layout algorithm, but `<col>` elements still map to columns positionally — so a placeholder `<col>` for a hidden column shifted every width after it onto the wrong column. At 390px the player name collapsed to 0px and the position column inherited its 296px. Only visible columns get a `<col>`.
- **The measure effect deliberately has no dependency array.** With deps it silently failed whenever the first render had no rows: the component returns `emptyState`, there's no `<table>` to measure, and when rows arrived no dep had changed, so it never retried and the table stayed on auto layout forever.
- **The columns-changed effect needs a ref guard.** Unguarded it also fires on *mount*, in the same commit where the layout effect just set the freeze. Passive effects run after layout effects, so it cleared the freeze, `frozen` ended the commit back at null, and the layout effect's deps were unchanged on the next render — dead.

### Verification

Full-page pixel diff, 15 routes × 2 viewports. The board is visually identical at both — inspected side by side, including full player names on mobile. The residual 0.44% on `/rankings` and `/finder` is sub-pixel glyph re-rasterization in the Confidence and Edge columns (96% of it within one antialiasing step); no content moved or clipped, and the row-height set is unchanged. `/finder` moves because it renders the same board.

1,526 frontend tests pass.

## Not in this PR

**Step B — windowing the rows — is deliberately not here.** Scroll is still 13 FPS at 1× and 2–3 FPS at 4–6× with 1,095 rows; a width freeze doesn't reduce DOM size. Step A is landed separately so the geometry change can be reviewed on its own before windowing is built on top of it.

Also still open from #630's ledger: `app/sitemap.js` fetches the 2MB aggregate contract (crawler-only path), and first-paint JS remains the biggest lever on slow devices — on a 6× throttled CPU the budget is script 1301–1829ms vs layout 310–417ms vs style recalc 255–321ms.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeQ4SkH9khPRx2b3WunSTA)_