### PR TITLE
fix: four silent-degradation defects found on production

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -664,8 +664,57 @@ ensure_systemd_service() {
     fi
   fi
 
-  if [[ "${backend_present}" == "true" && "${frontend_present}" == "true" && "${force_reinstall}" != "true" ]]; then
+  # Timer units are NOT covered by the two checks above, and for a long
+  # time nothing checked them at all.
+  #
+  # This early return used to fire whenever the backend and frontend
+  # units existed — and since both have existed since the original
+  # bootstrap, the installer never ran again on any deploy. Every timer
+  # added to the repo after that point therefore never existed in
+  # production. Measured on the live box 2026-07-30: the repo shipped
+  # nine timer pairs and only two (dlf-fetch, idpshow-fetch, both
+  # predating the bootstrap) were installed. The BDVM refresh had never
+  # run once — `journalctl -u dynasty-bdvm-refresh` was empty and
+  # `data/bdvm/` did not exist — so `/api/bdvm/*` served nothing while
+  # the deploy reported success every time. Signal alerts, custom
+  # alerts, player context, sharp discovery and reception depth were
+  # equally absent.
+  #
+  # So the presence check is now derived from what the repo actually
+  # ships rather than from two hardcoded unit names. Note this runs the
+  # installer WITHOUT FORCE_SERVICE_INSTALL, so existing units are left
+  # alone and no service is restarted — the installer only fills gaps.
+  local missing_timers=""
+  local timer_template timer_unit
+  shopt -s nullglob
+  for timer_template in "${APP_DIR}"/deploy/systemd/*.timer.template; do
+    timer_unit="$(basename "${timer_template}" .template)"
+    # Templates are named dynasty-*; installed units use SERVICE_NAME.
+    timer_unit="${SERVICE_NAME}-${timer_unit#dynasty-}"
+    # The alert timers install only when the token is present, matching
+    # install-systemd-service.sh. Without this they would read as
+    # permanently missing and run the installer on every deploy.
+    case "${timer_unit}" in
+      *-signal-alerts.timer | *-custom-alerts.timer)
+        if [[ ! -f "${APP_DIR}/.env" ]] ||
+          ! grep -Eq '^[[:space:]]*SIGNAL_ALERT_CRON_TOKEN=.+$' "${APP_DIR}/.env"; then
+          continue
+        fi
+        ;;
+    esac
+    if ! sudo -n "${SYSTEMCTL_BIN}" cat "${timer_unit}" >/dev/null 2>&1; then
+      missing_timers="${missing_timers} ${timer_unit}"
+    fi
+  done
+  shopt -u nullglob
+
+  if [[ "${backend_present}" == "true" && "${frontend_present}" == "true" &&
+    "${force_reinstall}" != "true" && -z "${missing_timers}" ]]; then
     return 0
+  fi
+
+  if [[ -n "${missing_timers}" ]]; then
+    warn "Timer units missing from this host:${missing_timers}. Running installer to add them."
   fi
 
   local installer_script

--- a/scripts/fetch_idpshow.py
+++ b/scripts/fetch_idpshow.py
@@ -283,14 +283,32 @@ def _write_csv(path: Path, rows: list[dict]) -> int:
     return len(rows_sorted)
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    """Entry point.  ``argv`` MUST be accepted, not just for symmetry.
+
+    ``server.py``'s in-scrape refresh calls ``main([])`` — the same shape
+    it uses for the other three fetchers, all of which already take
+    ``argv``.  This one did not, so every scrape raised
+    ``TypeError: main() takes 0 positional arguments but 1 was given``,
+    which ``server.py:2323`` caught and logged as a WARNING
+    (``idpshow_fetch_exception``).  The in-scrape IDP Show refresh was
+    therefore dead in production while looking merely noisy; observed
+    live 2026-07-30.
+
+    Note that simply dropping the argument would NOT have fixed it:
+    ``parse_args(None)`` reads ``sys.argv[1:]``, which under uvicorn is
+    the *server's* argv, so argparse would exit on unrecognised flags.
+    Threading ``argv`` through is the fix, and it matches
+    ``fetch_dynasty_nerds`` / ``fetch_fantasypros_offense`` /
+    ``fetch_fantasypros_idp``.
+    """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Scrape but don't write the CSV.",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if not SESSION_PATH.exists():
         print(

--- a/scripts/migrate_intel_ledger.py
+++ b/scripts/migrate_intel_ledger.py
@@ -2,9 +2,30 @@
 """Migrate existing intel JSON snapshots into the normalized ledger.
 
 Idempotent: the crawler's deterministic ``eventId`` is the ledger's
-``movement_id``, so re-running this inserts nothing the second time.
-Safe to run against production while the service is up — it only
-inserts, never mutates or deletes existing rows.
+``movement_id``, so re-running this inserts nothing the second time
+(the insert is ``INSERT OR IGNORE`` against a PRIMARY KEY).
+
+Safe to run against production while the service is up.  The import
+itself only inserts and never mutates existing rows — but note that
+this script is NOT purely additive: after importing it calls
+``ledger.prune()``, which issues
+``DELETE FROM asset_movements WHERE ts < cutoff`` at
+``MOVEMENT_RETENTION_DAYS`` (400) and then deletes any transaction left
+with no movements.  On a ledger whose oldest row is well inside the
+horizon that removes nothing, and the returned report says so via
+``prunedBeyondRetention`` — but it is a delete, so back the file up
+first:
+
+    cp -a data/intel/ledger.sqlite3 data/intel/ledger.sqlite3.bak
+
+(An earlier version of this docstring claimed the script "never
+mutates or deletes existing rows", which was false for the prune step.
+Corrected 2026-07-30.)
+
+Note also that ``--dry-run`` reports ``eventsInSnapshot`` — what the
+snapshots CONTAIN, not what would be inserted.  It never consults the
+ledger, so the number is an upper bound: the real run drops both
+already-present rows and rows missing a required id.
 
     python scripts/migrate_intel_ledger.py            # all snapshots
     python scripts/migrate_intel_ledger.py --league default

--- a/scripts/refresh_bdvm_projections.py
+++ b/scripts/refresh_bdvm_projections.py
@@ -182,6 +182,16 @@ def main() -> int:
 
     wrote_any = False
     hard_error = False
+    # Tracked separately from ``wrote_any`` because the two mean very
+    # different things operationally.  The baseline stage is a
+    # RECONSTRUCTED PROXY (realized production re-scored under this
+    # league's rules) and it essentially always writes; clay and idpshow
+    # are the only real forward-looking projection sources.  Without this
+    # distinction the final log line read "done: snapshot(s) written" on
+    # a box where both real sources had failed — which is what happened
+    # on production 2026-07-30, where poppler was missing and the IDP
+    # Show header format had changed.
+    real_source_wrote = False
 
     if args.skip_baseline:
         log("baseline stage skipped by flag")
@@ -207,6 +217,7 @@ def main() -> int:
         )
         if rc == 0:
             wrote_any = True
+            real_source_wrote = True
         elif rc == 1:
             log(
                 "WARN: clay guide unavailable (CDN 404 / poppler missing?); "
@@ -233,9 +244,13 @@ def main() -> int:
             )
             if rc == 0:
                 wrote_any = True
+                real_source_wrote = True
             elif rc == 1:
                 log(
-                    "WARN: idpshow returned no usable data (expired cookies / paywall?). "
+                    "WARN: idpshow returned no usable data (expired cookies, paywall, "
+                    "OR a changed column layout — check the report's unmappedColumns "
+                    "before re-minting cookies; a header-format change presents "
+                    "identically here). "
                     "Previously merged real records stay on the board via the baseline "
                     f"carry-forward; {REMINT_HINT}."
                 )
@@ -244,7 +259,26 @@ def main() -> int:
                 hard_error = True
 
     if wrote_any:
-        log("done: snapshot(s) written")
+        if real_source_wrote:
+            log("done: snapshot(s) written, including at least one REAL source")
+        else:
+            # Deliberately still exit 0: the snapshot IS valid and the
+            # board prices from it, every record carries is_proxy=True,
+            # and the UI badges those rows. Turning this into a non-zero
+            # exit would mark the systemd unit failed every week until an
+            # operator installs poppler and mints cookies, which trains
+            # people to ignore a red unit — worse than a precise log line.
+            #
+            # If a louder signal is wanted, the right place is
+            # /api/status (a projectionSourceMix field), not the exit
+            # code. Left as an explicit decision rather than an
+            # accident; raised with the owner 2026-07-30.
+            log(
+                "done: PROXY-ONLY snapshot written — no real projection source "
+                "landed (clay and idpshow both failed above). Every record is "
+                "is_proxy=True: this is backward-looking realized production, "
+                "not a forward projection."
+            )
         return 0
     if hard_error:
         log("done: hard error and nothing written")

--- a/src/bdvm/idpshow_projections.py
+++ b/src/bdvm/idpshow_projections.py
@@ -143,8 +143,30 @@ class IdpShowParseError(ValueError):
     pass
 
 
+# A leading "Projected " / "Proj " on a stat header carries no meaning
+# here — this whole module parses a projection sheet, so every column is
+# projected by definition.  Stripped before alias lookup.
+#
+# Why: measured 2026-07-30 on the live sheet, every stat header arrived
+# prefixed ("Projected Solo Tackles", "Projected Sacks", "Projected
+# TFL", ...).  None matched, so ``statColumns`` came back EMPTY, the
+# table was rejected as ``not_a_projection_table``, and the caller
+# reported it as "expired cookies / paywall?" — a misdiagnosis, since
+# the cookies were valid and the right table had been fetched.
+#
+# Safe by construction: stripping only ever widens what matches, and it
+# cannot collide with the two aliases that already spell the prefix out
+# ("projected points" -> "points", "proj pts" -> "pts"), both of which
+# still resolve to ``fpts``.  ``_squeeze`` is used for headers only
+# (one call site), so player names and position values are untouched.
+_PROJECTED_PREFIX = re.compile(r"^(?:projected|proj)\s+")
+
+
 def _squeeze(header: str) -> str:
-    return re.sub(r"[^a-z0-9/ ]+", "", str(header or "").strip().lower()).replace("  ", " ").strip()
+    cleaned = (
+        re.sub(r"[^a-z0-9/ ]+", "", str(header or "").strip().lower()).replace("  ", " ").strip()
+    )
+    return _PROJECTED_PREFIX.sub("", cleaned).strip()
 
 
 def _num(v: Any) -> float | None:

--- a/tests/bdvm/test_idpshow_projected_header_prefix.py
+++ b/tests/bdvm/test_idpshow_projected_header_prefix.py
@@ -1,0 +1,93 @@
+"""The IDP Show sheet prefixes every stat header with "Projected ".
+
+Measured against production on 2026-07-30.  The fetcher retrieved the
+correct table and then mapped **zero** stat columns, because
+``_HEADER_ALIASES`` holds ``"solo tackles"`` / ``"sacks"`` / ``"tfl"``
+while the sheet ships ``"Projected Solo Tackles"`` /
+``"Projected Sacks"`` / ``"Projected TFL"``.  With ``statColumns``
+empty the table failed the ``usable`` gate and was rejected as
+``not_a_projection_table``.
+
+The visible symptom was worse than the cause: the caller
+(``scripts/refresh_bdvm_projections.py``) reported
+*"idpshow returned no usable data (expired cookies / paywall?)"* and told
+the operator to re-mint cookies.  The cookies were valid and had been
+staged successfully — a header-format change was being reported as an
+auth failure, sending the operator after the wrong thing entirely.
+
+These are the exact headers observed in the production report's
+``unmappedColumns``.
+"""
+
+from __future__ import annotations
+
+from src.bdvm.idpshow_projections import _HEADER_ALIASES, _STAT_FIELDS, _squeeze
+
+# Verbatim from the live 2026-07-30 report.
+LIVE_STAT_HEADERS = [
+    "Projected Fantasy Points",
+    "Projected Total Snaps",
+    "Projected Solo Tackles",
+    "Projected Assists",
+    "Projected Sacks",
+    "Projected QB Hits",
+    "Projected TFL",
+    "Projected INT",
+    "Projected FR",
+    "Projected FF",
+    "Projected PD",
+]
+
+
+def _semantics(headers: list[str]) -> set[str]:
+    out: set[str] = set()
+    for col in headers:
+        semantic = _HEADER_ALIASES.get(_squeeze(col))
+        if semantic is not None:
+            out.add(semantic)
+    return out
+
+
+def test_prefixed_stat_headers_map_to_stat_fields() -> None:
+    mapped = _semantics(LIVE_STAT_HEADERS)
+    stat_cols = mapped & _STAT_FIELDS
+    assert len(stat_cols) >= 2, (
+        "Prefixed stat headers map to no stat fields, so the table would be "
+        f"rejected as not_a_projection_table. Mapped: {sorted(mapped)}. "
+        "_squeeze() must strip a leading 'Projected '/'Proj ' before the "
+        "alias lookup."
+    )
+    # The live sheet carries nine scored categories plus a points column.
+    assert len(stat_cols) == 9, f"expected 9 stat columns, got {sorted(stat_cols)}"
+    assert "fpts" in mapped, "'Projected Fantasy Points' must resolve to fpts"
+
+
+def test_unscored_column_stays_unmapped() -> None:
+    """ "Projected Total Snaps" is not a scored category.
+
+    Stripping the prefix must not accidentally alias it onto
+    ``"total"`` -> ``def_tackles``, which would invent tackle production
+    out of a snap count.
+    """
+    assert _squeeze("Projected Total Snaps") == "total snaps"
+    assert _HEADER_ALIASES.get("total snaps") is None
+    assert _HEADER_ALIASES.get(_squeeze("Projected Total")) == "def_tackles"
+
+
+def test_no_regression_on_aliases_that_spell_the_prefix_out() -> None:
+    """Two aliases already included the word, and must still resolve.
+
+    ``"projected points"`` and ``"proj pts"`` predate this fix; after
+    stripping they become ``"points"`` and ``"pts"``, both of which are
+    themselves aliases for ``fpts``. If either stopped resolving, the
+    strip would have broken a working path to fix a broken one.
+    """
+    for header in ("Projected Points", "Proj Pts", "Points", "FPTS", "Pts/G"):
+        semantic = _HEADER_ALIASES.get(_squeeze(header))
+        assert semantic in ("fpts", "fpg"), f"{header!r} no longer resolves (got {semantic!r})"
+
+
+def test_bare_headers_are_unaffected() -> None:
+    """A sheet without the prefix must behave exactly as before."""
+    bare = ["Solo Tackles", "Sacks", "TFL", "INT", "FF", "FR", "PD", "QB Hits", "Assists"]
+    assert len(_semantics(bare) & _STAT_FIELDS) == 9

--- a/tests/scripts/test_fetcher_main_argv_contract.py
+++ b/tests/scripts/test_fetcher_main_argv_contract.py
@@ -1,0 +1,110 @@
+"""Every fetcher ``server.py`` calls in-scrape must accept ``argv``.
+
+``server.py``'s scrape path refreshes four sources by importing the
+fetcher module and calling ``main([...])`` with an explicit argument
+list.  Three of the four declared ``main(argv=None)``.  The fourth,
+``fetch_idpshow``, declared bare ``main()`` — so the call raised
+``TypeError: main() takes 0 positional arguments but 1 was given`` on
+EVERY scrape.
+
+That did not fail loudly.  ``server.py:2323`` wraps the call in
+``except Exception`` and records a ``idpshow_fetch_exception`` WARNING,
+so the in-scrape IDP Show refresh was dead in production while the only
+symptom was one warning line in the journal.  It went unnoticed because
+the standalone ``dynasty-idpshow-fetch.timer`` runs the same script as a
+subprocess and kept the ``idpShow`` freshness stamp looking current —
+the broken path and the working path fed the same file.
+
+Observed live 2026-07-30 on the production journal.
+
+Two properties are pinned here, because either one alone is
+insufficient:
+
+1. every fetcher's ``main`` accepts a positional ``argv`` — otherwise
+   the call raises; and
+2. ``server.py`` passes a list literal to each — otherwise ``main``
+   falls through to ``parse_args(None)``, which reads the *server's*
+   ``sys.argv`` under uvicorn and exits on unrecognised flags.
+
+Dropping the argument at the call site would satisfy (1) and silently
+break (2), which is why both are asserted.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SERVER_PY = REPO_ROOT / "server.py"
+
+# Module name -> the argv list server.py passes it.
+FETCHERS: dict[str, str] = {
+    "fetch_dynasty_nerds": '["--mirror-data-dir"]',
+    "fetch_fantasypros_offense": '["--mirror-data-dir"]',
+    "fetch_fantasypros_idp": '["--mirror-data-dir"]',
+    "fetch_idpshow": "[]",
+}
+
+
+@pytest.mark.parametrize("module_name", sorted(FETCHERS))
+def test_main_accepts_argv(module_name: str) -> None:
+    mod = importlib.import_module(f"scripts.{module_name}")
+    main = getattr(mod, "main", None)
+    assert main is not None, f"scripts/{module_name}.py has no main()"
+
+    sig = inspect.signature(main)
+    positional = [
+        p
+        for p in sig.parameters.values()
+        if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD, p.VAR_POSITIONAL)
+    ]
+    assert positional, (
+        f"scripts/{module_name}.py::main{sig} accepts no positional argument, "
+        f"but server.py calls it as main({FETCHERS[module_name]}). That raises "
+        "TypeError, which server.py catches and downgrades to a warning — so "
+        "the fetch silently stops running. Use main(argv: list[str] | None = None) "
+        "and pass argv to parse_args()."
+    )
+
+
+@pytest.mark.parametrize("module_name", sorted(FETCHERS))
+def test_argv_is_threaded_into_parse_args(module_name: str) -> None:
+    """``parse_args()`` with no argument reads ``sys.argv`` — wrong here.
+
+    Under uvicorn that is the server's own argv, so argparse would exit
+    on flags meant for the server rather than the fetcher.
+    """
+    src = (REPO_ROOT / "scripts" / f"{module_name}.py").read_text(encoding="utf-8")
+    bare = re.search(r"parse_args\(\s*\)", src)
+    assert bare is None, (
+        f"scripts/{module_name}.py calls parse_args() with no argument. "
+        "It must be parse_args(argv) so an in-process caller controls the "
+        "arguments instead of inheriting the server's sys.argv."
+    )
+
+
+@pytest.mark.parametrize("module_name", sorted(FETCHERS))
+def test_server_passes_a_list_literal(module_name: str) -> None:
+    """The call site must keep passing an explicit list.
+
+    A future edit to ``main()`` alone cannot restore correctness if the
+    caller stops passing argv, so the contract is pinned from both ends.
+    """
+    src = SERVER_PY.read_text(encoding="utf-8")
+    # server.py imports these as `from scripts import X as _alias`.
+    alias = re.search(
+        rf"from scripts import {re.escape(module_name)} as (\w+)",
+        src,
+    )
+    assert alias, f"server.py no longer imports scripts.{module_name}"
+    call = re.search(rf"{re.escape(alias.group(1))}\.main\(\s*\[", src)
+    assert call, (
+        f"server.py calls {alias.group(1)}.main() without a list literal. "
+        "Pass an explicit argv list so the fetcher does not parse the "
+        "server's sys.argv."
+    )


### PR DESCRIPTION
Four places where something was broken while every signal an operator could see said "fine". Unrelated mechanisms, identical shape, so they're fixed together. All four were found by walking production, not by reading code.

---

## 1. `scripts/fetch_idpshow.py` — `main()` rejected its own caller

`server.py:2311` calls `_idpshow_fetch.main([])`, the same shape it uses for the other three in-scrape fetchers. This one declared bare `main()`, so **every scrape raised**:

```
[WARNING] [Scrape] idpshow_fetch_exception — IDP Show fetch raised:
          main() takes 0 positional arguments but 1 was given
```

`server.py:2323` catches that and downgrades it to a warning, so the in-scrape IDP Show refresh was dead in production with one journal line as the only symptom.

| fetcher | signature | caller passes |
|---|---|---|
| `fetch_dynasty_nerds` | `main(argv=None)` | `["--mirror-data-dir"]` ✓ |
| `fetch_fantasypros_offense` | `main(argv=None)` | `["--mirror-data-dir"]` ✓ |
| `fetch_fantasypros_idp` | `main(argv=None)` | `["--mirror-data-dir"]` ✓ |
| **`fetch_idpshow`** | **`main()`** | `[]` ✗ |

**Why it hid for so long:** `dynasty-idpshow-fetch.timer` runs the same script as a subprocess and kept the `idpShow` freshness stamp current. The broken path and the working path fed the same file, so freshness monitoring couldn't see it.

**Why the obvious fix is wrong:** dropping the argument gives `parse_args(None)`, which reads `sys.argv[1:]` — under uvicorn that's the *server's* argv, and argparse would exit on unrecognised flags. `argv` is threaded through instead.

`tests/scripts/test_fetcher_main_argv_contract.py` pins it **from both ends** — that `main` accepts `argv`, and that `server.py` keeps passing a list literal — because either half can be satisfied while the pair stays broken.

## 2. `src/bdvm/idpshow_projections.py` — a header change reported as an auth failure

The live sheet now prefixes every stat header with `Projected `. None matched `_HEADER_ALIASES`, so `statColumns` came back **empty**, and the table was rejected as `not_a_projection_table` — despite the fetch succeeding and returning the right table:

```json
"unmappedColumns": ["Projected Fantasy Points", "Projected Solo Tackles",
                    "Projected Sacks", "Projected TFL", "Projected INT", ...],
"statColumns": [],
"reason": "not_a_projection_table"
```

The operator-facing message was then actively misleading — *"expired cookies / paywall? … mint cookies"* — when the cookies were valid and had been staged successfully in the same run.

`_squeeze()` now strips a leading `Projected `/`Proj ` before alias lookup. Measured against the real headers: **9 stat categories plus `fpts`**, `usable: True`. Stripping only widens what matches and cannot collide with the two aliases that already spelled the prefix out (`"projected points"` → `"points"`, `"proj pts"` → `"pts"`, both still → `fpts`). `_squeeze` has one call site and is header-only, so player names and position values are untouched.

## 3. `deploy/deploy.sh` — the guard that skipped six timer pairs

`ensure_systemd_service` returned early whenever `dynasty.service` **and** `dynasty-frontend.service` both existed. Both have existed since the original bootstrap, so `install-systemd-service.sh` never ran again on any deploy — and **every timer added to the repo since then never existed in production.**

Measured on the live host: the repo ships **nine** timer pairs; **two** were installed (`dlf-fetch`, `idpshow-fetch`, both predating the bootstrap).

`dynasty-bdvm-refresh` had **never run once** — empty journal, no `data/bdvm/` directory at all — so `/api/bdvm/*` served nothing since the BDVM feature merged, while every deploy reported success. Signal alerts, custom alerts, player context, sharp discovery and reception depth were equally absent. Backups (`riskit-backup.*`) were the one lucky exception; those had been enabled at bootstrap.

The presence check is now derived from the `*.timer.template` files the repo ships, mapping template basename → `${SERVICE_NAME}-<suffix>`. Two details that matter:

- The alert timers are excluded unless `SIGNAL_ALERT_CRON_TOKEN` is in `.env`, mirroring `install-systemd-service.sh:262` — otherwise they'd read as permanently missing and run the installer on every deploy.
- The installer runs **without** `FORCE_SERVICE_INSTALL`, so existing units are left alone and **nothing is restarted**. It fills gaps only.

Verified by exercising the detection logic against the real template set with a stubbed `systemctl`, reproducing exactly the four units genuinely missing on the live host, and confirming the alert timers appear only once the token is present.

## 4. Two reports that overstated what they knew

- **`refresh_bdvm_projections.py`** logged `done: snapshot(s) written` whenever *any* stage wrote. The baseline stage is a reconstructed proxy and essentially always writes, so a box with no poppler and no cookies reported success forever. Real-source success is now tracked separately and the proxy-only case says so explicitly.

  **Exit stays 0, deliberately.** The snapshot is valid, every record carries `is_proxy: true`, and the UI badges those rows — a permanently-red weekly unit trains people to ignore it. Recorded as a decision in-code, with the note that `/api/status` is the right home for a louder signal.

- **`migrate_intel_ledger.py`**'s docstring claimed it *"never mutates or deletes existing rows"*. It calls `ledger.prune()` at line 74 — a `DELETE` at `MOVEMENT_RETENTION_DAYS=400`. Corrected, with the backup command and a note that `--dry-run`'s `eventsInSnapshot` is an upper bound rather than an insert plan.

---

## Not included

Splitting `IngestResult.movements_skipped` into duplicate vs rejected. Its docstring also overstates — *"Rows already present — the dedup hit count"* — while the property is `seen - inserted`, which absorbs validation rejects too.

Left out because it's misleading rather than masking: verified on production that the ledger is complete. 250 snapshot events resolve to 218 distinct movements, and the 32-row gap is genuine cross-snapshot overlap (the snapshots are manager-centric and span 24 leagues, so shared-league trades and waivers get crawled twice — the per-type overlaps sum to exactly 32). It also changes a dataclass contract several tests read, so it belongs in its own change.

## Verification

- `pytest tests/ -q -m "not livedata"` → **5228 passed, 0 failed** (up 16 from the new tests)
- `ruff format --check .` → 712 files already formatted
- `ruff check` → clean on every touched file
- `bash -n deploy/deploy.sh` → clean
- Both new test files verified by **negative control** — reverting each fix makes exactly the intended assertions fail, and only those

Local run was Python 3.11; `Validate PR` is the authoritative gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrVJELpwtdym5DuC8NPYe5)_