### PR TITLE
Retire low_conf_unstable; re-tune the rank-form Hill curves and alarm on their drift

### DIFF
--- a/.github/workflows/audit-rank-form-drift.yml
+++ b/.github/workflows/audit-rank-form-drift.yml
@@ -1,0 +1,177 @@
+name: Audit Rank-Form Curve Drift
+
+# Surveillance of the legacy rank-form Hill constants
+# (``HILL_MIDPOINT`` / ``HILL_SLOPE``, ``IDP_HILL_MIDPOINT`` /
+# ``IDP_HILL_SLOPE`` in src/canonical/player_valuation.py).
+#
+# WHY THIS CRON EXISTS
+# --------------------
+# Those constants reconstruct a value from a rank for terminal.py's value
+# fallback, rank_history.py's historical backfill, and the frontend
+# team-value / derived-rank charts.  When they stop matching the board,
+# NOTHING FAILS — a reconstruction path returning a wrong-but-plausible
+# number renders a perfectly normal-looking chart.  That is how the
+# pre-2026-07-30 offense pair sat at RMSE 821.7 against an achievable
+# 89.8 (a ~9x error on every reconstructed offense value) without anyone
+# noticing.
+#
+# WHY TUESDAY 07:41
+# -----------------
+# Deliberately AFTER refit-hill-curves.yml (Tue 06:17).  A
+# percentile-master promotion is the thing that actually moves these
+# constants — the masters are step 3 of the live pipeline, so a new pair
+# reshapes the board's rank→value relation and the rank-form
+# approximation of it goes stale.  Measured: the 2026-07-29
+# pre-promotion board refit to 68.8/0.929, the post-promotion board to
+# 65.2/0.905.  Market churn, by contrast, does not move them at all: 16
+# archived snapshots spanning 2026-07-16 → 07-30 all refit to the same
+# values.  So this check follows promotions, not data.
+#
+# WHY IT OPENS AN ISSUE INSTEAD OF A PULL REQUEST
+# -----------------------------------------------
+# ADR-008 (docs/roster-trade-intelligence/DECISIONS.md) prohibits a model
+# autonomously rewriting production constants, and its sharpest finding
+# is the one that applies here: the old auto-refit path was green BY
+# CONSTRUCTION because it rewrote the very test that guarded it.  An
+# automated fix that patched player_valuation.py and also re-baselined
+# test_rank_form_constants_tripwire.py would rebuild that exact
+# circularity — a PR that cannot fail its own guard.
+#
+# So the automation computes the fix and hands it over.  The script
+# prints the constants to write and the three files to write them in; a
+# human applies them, which makes the tripwire fail, and updating the
+# pins is the deliberate recorded act.  The refit-hill-curves.yml comment
+# "ONLY the registry. Never player_valuation.py, never the reconciliation
+# pins" is the standing rule and this workflow keeps it.
+#
+# Exit codes from scripts/check_rank_form_drift.py:
+#   0  within tolerance                        -> green, job summary only
+#   1  error (missing/unreadable snapshot)     -> RED
+#   2  drift detected                          -> RED + issue
+
+on:
+  schedule:
+    # Tuesday 07:41 UTC — after refit-hill-curves.yml (06:17) so a
+    # promotion landing that morning is measured the same day, and off
+    # the top of the hour.
+    - cron: "41 7 * * 2"
+  workflow_dispatch:
+    inputs:
+      threshold:
+        description: "Excess-RMSE budget per scope before drift is reported"
+        required: false
+        type: string
+        default: "25"
+
+concurrency:
+  group: audit-rank-form-drift
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    name: Rank-form drift check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip check
+          python scripts/check_env.py --runtime
+
+      - name: Check for a snapshot
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          SNAPSHOT=$(ls -t exports/latest/dynasty_data_*.json 2>/dev/null | head -1 || true)
+          if [ -z "${SNAPSHOT}" ]; then
+            # Same reasoning as audit-dropped-sources.yml: a missing
+            # snapshot means the export pipeline is broken, and a silent
+            # 0 would make "the audit did not run" look identical to
+            # "the curve is healthy" in GitHub's UI.
+            echo "::error title=Missing snapshot::no dynasty_data_*.json in exports/latest/ — data-refresh pipeline may be broken"
+            exit 1
+          fi
+          echo "Using snapshot: ${SNAPSHOT}"
+
+      - name: Run drift check
+        id: drift
+        shell: bash
+        continue-on-error: true
+        env:
+          THRESHOLD: ${{ github.event.inputs.threshold || '25' }}
+        run: |
+          set -Eeuo pipefail
+          set +e
+          python scripts/check_rank_form_drift.py \
+            --threshold "${THRESHOLD}" \
+            --json-out /tmp/rank_form_drift.json \
+            --verbose | tee /tmp/rank_form_drift.txt
+          code=${PIPESTATUS[0]}
+          set -e
+          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+          echo "Driver exited ${code}"
+
+      - name: Job summary
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          {
+            echo "## Rank-form curve drift"
+            echo
+            if [[ "${{ steps.drift.outputs.exit_code }}" == "0" ]]; then
+              echo "Committed constants still reproduce the board within budget."
+            elif [[ "${{ steps.drift.outputs.exit_code }}" == "2" ]]; then
+              echo "**Drift detected** — see the opened issue."
+            else
+              echo "**Check errored** (exit ${{ steps.drift.outputs.exit_code }})."
+            fi
+            echo
+            echo '```'
+            cat /tmp/rank_form_drift.txt 2>/dev/null || echo "(no output captured)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open or update an issue on drift
+        if: ${{ steps.drift.outputs.exit_code == '2' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          TITLE="Rank-form curve drift: reconstruction constants are stale"
+          BODY=$(printf '%s\n\n```\n%s\n```\n\nWhy this matters: these constants feed RECONSTRUCTION paths (terminal.py value fallback, rank_history.py historical backfill, and the frontend team-value / derived-rank charts). Nothing fails when they drift — the charts just render wrong numbers.\n\nThis issue is deliberately not a pull request. See ADR-008 and the header of `.github/workflows/audit-rank-form-drift.yml`: an automated patch that also re-baselined the guard tests would be green by construction, which is the exact defect ADR-008 documents.\n\nRun: %s\n' \
+            "The weekly drift check found the committed rank-form Hill constants no longer reproduce the served board. The constants to write, and the three files to write them in, are in the output below." \
+            "$(cat /tmp/rank_form_drift.txt)" \
+            "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}")
+          EXISTING=$(gh issue list --state open --label calibration \
+            --search "in:title Rank-form curve drift" --json number --jq '.[0].number' || true)
+          if [[ -n "${EXISTING}" && "${EXISTING}" != "null" ]]; then
+            gh issue comment "${EXISTING}" --body "${BODY}"
+          else
+            gh issue create --title "${TITLE}" --body "${BODY}" --label calibration \
+              || gh issue create --title "${TITLE}" --body "${BODY}"
+          fi
+
+      - name: Fail loudly on drift or error
+        if: ${{ steps.drift.outputs.exit_code != '0' }}
+        shell: bash
+        run: |
+          echo "::error title=Rank-form drift check::driver exited ${{ steps.drift.outputs.exit_code }}"
+          exit 1

--- a/docs/audits/complete-codebase-audit-2026-07-29.md
+++ b/docs/audits/complete-codebase-audit-2026-07-29.md
@@ -224,6 +224,13 @@ source votes exactly once — pinned by a determinism test.
 > with a tripwire test. A third question raised later (the
 > `low_conf_unstable` threshold) turned out to be a broken metric, not a
 > threshold — same document.
+>
+> **Closed 2026-07-30.** `low_conf_unstable` is **retired** from both
+> engines. `_sites` maxes at 3 because the scraper runs a deliberate
+> two-source model (`SITES` has KTC + IDPTradeCalc on, ten others off),
+> and every candidate divisor moves confidence *away* from the 0.35
+> threshold — 0 players below it at divisors 3, 4 and 5 — so no
+> recalibration could rescue the rule.
 
 1. **Should `coverageWeight` be applied?** The depth-scaled factor is
    computed and published but never used. Applying it would down-weight
@@ -549,6 +556,14 @@ pipeline.
 > (three merges, three live defects fixed). The follow-up also surfaced
 > **three NEW items**, listed under "Must complete" — they are bigger
 > than the ones they replaced.
+>
+> **Status update 2026-07-30.** **N1 done** (`signal-engine.js` now uses
+> `buildHistoryLookup`, so the frontend engine actually sees history).
+> **N2 resolved by retirement, not repair** — the metric, not the wiring,
+> was the problem; see `docs/open-modeling-decisions.md` §3. **N3 done**
+> (`sleeper_overlay` raw `full_name` fallback). Item 1 (rotate the admin
+> password) is still an owner action. Item 6 — the legacy-curve decision
+> — is in progress: re-tune plus drift automation.
 
 **Must complete before major new features**
 1. **Rotate the admin password** if not already done since April (C6).
@@ -567,6 +582,19 @@ pipeline.
    `ACTIONABLE_SIGNALS` — so fixing it naively would email every user at
    once on the first sweep. It needs the silent baseline-seeding pass
    that `bdvm_signal_alerts.py` already models.
+
+   **RESOLVED 2026-07-30 — retired, not repaired.** The wiring was fixed
+   on 2026-07-29; with the plumbing correct the *metric* proved to be
+   the defect. `marketConfidence` is structurally capped at 0.59375
+   because the scraper's `site_count / 8.0` term is a fossil of a
+   ~10-site era and only three dash keys exist under today's two-source
+   `SITES` map. Every candidate divisor pushes the population above
+   0.35 rather than toward it, so no threshold makes the rule sound. The
+   rule is gone from both engines and from the parity fixture's rule
+   registry; the confidence number survives as a diagnostic.
+   `tests/api/test_market_confidence_wiring.py::TestTheRuleIsRetired`
+   asserts no surviving rule's verdict changes with confidence, so a
+   reinstatement under another tag fails a test.
 4. **Decide the `coverageWeight` question** (§3.1). It is now honestly
    labelled, but leaving a published formula unapplied indefinitely
    invites the next reader to "fix" it and move every value.

--- a/docs/audits/complete-codebase-audit-2026-07-29.md
+++ b/docs/audits/complete-codebase-audit-2026-07-29.md
@@ -367,6 +367,8 @@ corrected instead.
 | D12 | mypy configured, never run; ruff check changed-files-only | Low | Type debt accumulates unseen | Medium | No |
 | D13 | ~205 pytest cases are `livedata`-advisory (`continue-on-error`) | Medium | Includes the primary blend test | Small | Re-litigate per module |
 | D14 | ADR numbers collide across two DECISIONS files (two ADR-008s) | Low | Ambiguous citations | Small | No |
+| D15 | `_sites` / `_marketConfidence` divisor is 8.0, a fossil of the pre-scope-reduction ~10-site scraper era; confidence is structurally capped at 0.594 | Low | No board impact (`market_conf` only multiplies the scraper composite, never `rankDerivedValue`); reaches live code only via `finder.py`'s degraded fallback | Small | Fix when the scraper is next touched — measured multipliers in `docs/open-modeling-decisions.md` §3 |
+| D16 | `tests/canonical/test_ktc_reconciliation.py`: 9 cases failing on `main`, invisible because the module is auto-marked `livedata` | Medium | A guard that was supposed to catch curve drift is stale and silent — `PINNED_DELTAS` were baselined against since-promoted percentile constants | Small | Re-baseline as part of the next percentile-master promotion; promotion currently re-baselines nothing |
 
 ### D2 was wrong — recorded so it is not re-raised
 
@@ -605,6 +607,27 @@ pipeline.
    One function; hardens five consumers at once.
 6. **Legacy-curve decision** (§3.2) using the committed backtest.
    Depends on 4 only in the sense that both are curve-governance calls.
+
+   **DONE 2026-07-30 — re-tuned, kept, and alarmed.** Migration to the
+   percentile masters turned out not to be a live option (they are 5-8x
+   worse everywhere on the current board; they model the blend's *input*,
+   not its output). The old rank-form constants were fit to retail source
+   boards rather than to our board and scored RMSE 821.8 on offense rows;
+   re-tuned to 65.4/0.910 (offense) and 64.6/0.900 (IDP) they score
+   89.8/76.2, which is the achievable floor. Drift is now watched by
+   `scripts/check_rank_form_drift.py` +
+   `.github/workflows/audit-rank-form-drift.yml`, which opens an issue
+   rather than a PR per ADR-008, and the alarm itself is tested. A third
+   copy of these constants in `frontend/lib/value-history.js` (wrong on
+   all three values) was found and pinned by a parity test. Full
+   write-up: `docs/legacy-rank-curve-backtest.md` 2026-07-30 addendum.
+
+   Uncovered while doing it: `tests/canonical/test_ktc_reconciliation.py`
+   has **9 cases failing on `main`** — its `PINNED_DELTAS` were baselined
+   against percentile constants that have since been promoted, and it is
+   auto-marked `livedata` so CI never blocks on it. Confirmed at a clean
+   HEAD, so it predates this work. Registered as debt (D16 below);
+   re-baselining it is a percentile-master decision, not a rank-form one.
 7. **BDVM end-to-end validation** once a projection snapshot exists.
 
 **Medium priority**

--- a/docs/legacy-rank-curve-backtest.md
+++ b/docs/legacy-rank-curve-backtest.md
@@ -123,3 +123,175 @@ script above after any curve change; it is the regression check.
 
 Deliberately not decided inside an audit fix, per the guardrail that
 questionable formulas be flagged rather than silently rewritten.
+
+---
+
+# Addendum — 2026-07-30: the family was re-tuned, not retired
+
+**Script:** `scripts/backtest_legacy_rank_curve.py` (now fits per scope)
+**Drift check:** `scripts/check_rank_form_drift.py`
+**Results:** `docs/measurements/legacy-rank-curve-2026-07-30.json`
+
+## The decision
+
+Re-tune the rank-form constants against **our board**, keep the family,
+and put a drift alarm on it. Both migration options above are off the
+table for a reason that only became visible on re-measurement.
+
+| constant | was | now |
+|---|---|---|
+| `HILL_MIDPOINT` | 48.44 | **65.4** |
+| `HILL_SLOPE` | 1.149 | **0.910** |
+| `IDP_HILL_MIDPOINT` | 69.50 | **64.6** |
+| `IDP_HILL_SLOPE` | 0.945 | **0.900** |
+
+Measured on the 2026-07-30 board (740 ranked rows: 420 offense, 292 IDP,
+28 picks):
+
+| candidate | overall RMSE | IDP | offense | pick |
+|---|---|---|---|---|
+| `legacy_scope` — **re-tuned** | **83.8** | 76.2 | 89.8 | 64.7 |
+| best-fit per scope (floor) | 83.4 | 76.2 | 89.8 | 47.6 |
+| best-fit single curve | 84.0 | 76.4 | 90.1 | 61.9 |
+| `legacy_scope` — old constants | 644.9 | 89.5 | 821.8 | 882.9 |
+| `percentile_global` | 410.1 | 459.0 | 380.6 | 276.5 |
+| `percentile_scope` | 691.8 | 835.0 | 575.5 | 639.0 |
+
+Offense reconstruction error drops **821.8 → 89.8**, a ~9× improvement on
+every reconstructed offense value. IDP improves 89.5 → 76.2.
+
+## Three things the first pass got wrong
+
+**1. The old constants were fit to the wrong target.**
+`scripts/fit_hill_curve_from_market.py` fits retail *source* boards —
+"what shape does KTC publish". These constants have to answer "what does
+*our* board pay at rank r", which is the output of the entire pipeline
+after blending, TE basis conversion, α-shrinkage, the single-source
+haircut, the corridor clamp and pick tethering. Those are different
+questions, and the 821.8 RMSE is the size of the difference. Fitting
+against `rankDerivedValue` is the correct target and that is what the
+backtest script does.
+
+**2. "The error profiles are inverted" no longer holds.**
+The 2026-07-29 table showed `percentile_global` beating the legacy family
+overall (238 vs 670) while being ~2× worse in the top 24, which is what
+made the migration question genuinely hard. On the current board the
+percentile candidates are 5–8× worse *everywhere* (410 and 692 against
+83.8). The reason is structural, not a data shift: **the percentile
+masters are an INPUT stage to the blend, not a model of its output.**
+Translating them into rank space cannot answer this question, so
+migrating the reconstruction paths onto them is not a live option.
+
+**3. The offense/IDP split is much weaker than its comment claimed.**
+The old rationale — dynasty IDP markets price differently from offense —
+is a true statement about retail IDP boards and an irrelevant one here.
+`canonicalConsensusRank` is a single **global** ordinal over the whole
+board, so offense, IDP and pick rows all lie on one rank→value relation
+by construction. Fitting per scope buys 84.0 → 83.4 RMSE (0.7%), and the
+two fitted pairs are nearly identical (65.4/0.910 vs 64.6/0.900). The old
+IDP pair scored well on IDP rows largely by coincidence: it happened to
+sit near the global optimum while the offense pair did not.
+
+The split is kept because `rank_history.py` already routes by scope and
+the numbers are marginally better, but it should not be read as evidence
+of two economies. If ranks ever become scope-local, re-fit and revisit.
+
+## The re-tune is at the floor
+
+83.8 against an achievable 83.4 means **there is no headroom left in this
+curve family.** The residual ~84 RMSE is irreducible scatter: the board
+is not a pure function of rank, because post-blend stages (pick
+tethering, the two-way boost, the corridor clamp) move individual rows
+off any smooth curve. A further refit cannot help; only a
+reconstruction that uses more than the rank could.
+
+## Stability: what moves these constants
+
+Fit against 16 archived snapshots spanning **2026-07-16 → 07-30**
+(`exports/archive/`, every 8th export):
+
+| scope | midpoint range | slope range |
+|---|---|---|
+| offense | 65.4 (65.6 once) | 0.910 throughout |
+| idp | 64.4 – 64.6 | 0.900 throughout |
+| pick | 61.8 – 62.8 | 0.869 – 0.880 |
+
+Market churn does **not** move them, and the reason matters: the board's
+rank→value relation *is* a Hill curve, so churn only permutes which
+player sits at which rank.
+
+What does move them is a **percentile-master promotion**. The masters are
+step 3 of the live pipeline, so a new pair reshapes the board and the
+rank-form approximation goes stale. Measured directly: the 2026-07-29
+pre-promotion board refit to **68.8 / 0.929**, the post-promotion board
+to **65.2 / 0.905**.
+
+That is a useful finding on its own — it means the right cadence for this
+check is "after a promotion", not "daily".
+
+## The drift alarm
+
+`scripts/check_rank_form_drift.py`, run weekly by
+`.github/workflows/audit-rank-form-drift.yml` (Tue 07:41 UTC, after
+`refit-hill-curves.yml` at 06:17).
+
+The metric is **excess RMSE** = RMSE(committed constants) −
+RMSE(refit optimum), per scope, budget 25.0 on the display scale. Not
+parameter delta: parameters are partially redundant, so a curve can move
+its numbers and still reproduce the board, while a small move near a
+steep optimum can matter more than a large one on a plateau. Excess RMSE
+measures the thing that actually matters — whether the committed curve
+still reproduces the board.
+
+Calibration of the 25.0 budget, on real data:
+
+| constants | excess RMSE | verdict |
+|---|---|---|
+| the new pair (offense) | +0.0 | ok |
+| the new pair (IDP) | +0.0 | ok |
+| old IDP pair (69.50/0.945) | +13.3 | ok — near the optimum by luck |
+| old offense pair (48.44/1.149) | **+731.9** | drift |
+| a promotion-sized move (68.8/0.929) | over budget | drift |
+
+**It opens an issue, not a pull request, and that is deliberate.**
+ADR-008 (`docs/roster-trade-intelligence/DECISIONS.md`) prohibits a model
+autonomously rewriting production constants; its sharpest finding is that
+the old auto-refit path was green *by construction* because it rewrote
+the very test that guarded it. An automated patch that fixed
+`player_valuation.py` and also re-baselined
+`test_rank_form_constants_tripwire.py` would rebuild exactly that
+circularity. So the automation computes the fix and prints the constants
+plus the three files to write them in; a human applies them, the tripwire
+fails, and updating the pins is the deliberate recorded act.
+
+The alarm is itself tested — `tests/canonical/test_rank_form_drift_check.py`
+proves it fires on the pre-re-tune pair and on a promotion-sized move,
+because an alarm that cannot fire reads identically to a healthy system.
+
+## The third copy of these constants
+
+`frontend/lib/value-history.js` mirrors the offense pair for the terminal
+team-value chart and the derived rank-history line. On 2026-07-30 it
+still read `K = 45, EXP = 1.1, CEIL = 9999` — three values wrong at once
+(the backend pair was 48.44 / 1.149, and `1 + 9999/(…)` puts rank 1 at
+**10000** rather than 9999). Its own comment flagged the drift risk and
+deferred the fix to a follow-up that never happened.
+
+Now `RANK_FORM_CURVE` in that file is the single place the numbers appear,
+and `tests/api/test_rank_form_frontend_parity.py` parses it and fails if
+it disagrees with Python — including a formula check across twelve ranks,
+so a divergence in the arithmetic (not just the constants) also fails.
+
+## Pre-existing failure found while doing this
+
+`tests/canonical/test_ktc_reconciliation.py` has **9 failing cases on
+`main`**, unrelated to this change and confirmed by running it at a clean
+HEAD. Its `PINNED_DELTAS` were baselined against percentile constants
+that have since been promoted, so `_ours(rank)` no longer matches. It is
+auto-marked `livedata` by `tests/conftest.py`, so CI runs it
+`continue-on-error` and the staleness is invisible.
+
+This is ADR-008's circularity showing up from the other side: the guard
+whose pins the old refit used to rewrite is now simply stale, because
+promotion re-baselines nothing. Not fixed here — re-baselining it is a
+percentile-master decision, not a rank-form one — and registered as debt.

--- a/docs/measurements/legacy-rank-curve-2026-07-30.json
+++ b/docs/measurements/legacy-rank-curve-2026-07-30.json
@@ -1,0 +1,658 @@
+{
+  "generatedAt": "2026-07-30T08:50:33.227662+00:00",
+  "payload": "exports/latest/dynasty_data_2026-07-30.json",
+  "rowCount": 740,
+  "scopeCounts": {
+    "idp": 292,
+    "offense": 420,
+    "pick": 28
+  },
+  "percentileReferenceN": 500,
+  "liveConstants": {
+    "legacyOffense": {
+      "midpoint": 65.4,
+      "slope": 0.91
+    },
+    "legacyIdp": {
+      "midpoint": 64.6,
+      "slope": 0.9
+    },
+    "percentileOffense": {
+      "c": 0.11,
+      "s": 1.11
+    },
+    "percentileIdp": {
+      "c": 0.083,
+      "s": 1.11
+    },
+    "percentileGlobal": {
+      "c": 0.112,
+      "s": 0.725
+    }
+  },
+  "refitRankForm": {
+    "midpoint": 65.2,
+    "slope": 0.905
+  },
+  "refitRankFormPerScope": {
+    "idp": {
+      "midpoint": 64.6,
+      "slope": 0.9,
+      "n": 292
+    },
+    "offense": {
+      "midpoint": 65.4,
+      "slope": 0.91,
+      "n": 420
+    },
+    "pick": {
+      "midpoint": 62.2,
+      "slope": 0.874,
+      "n": 28
+    }
+  },
+  "results": {
+    "legacy_offense": {
+      "overall": {
+        "n": 740,
+        "rmse": 84.1,
+        "mae": 60.5,
+        "medianAbsErr": 48.0,
+        "maxAbsErr": 438.0,
+        "meanSignedErr": -11.7
+      },
+      "byScope": {
+        "idp": {
+          "n": 292,
+          "rmse": 77.0,
+          "mae": 62.8,
+          "medianAbsErr": 57.5,
+          "maxAbsErr": 235.0,
+          "meanSignedErr": -3.8
+        },
+        "offense": {
+          "n": 420,
+          "rmse": 89.8,
+          "mae": 59.9,
+          "medianAbsErr": 41.5,
+          "maxAbsErr": 438.0,
+          "meanSignedErr": -17.8
+        },
+        "pick": {
+          "n": 28,
+          "rmse": 64.7,
+          "mae": 45.9,
+          "medianAbsErr": 24.5,
+          "maxAbsErr": 155.0,
+          "meanSignedErr": -2.6
+        }
+      },
+      "byRankBand": {
+        "1-24": {
+          "n": 24,
+          "rmse": 254.5,
+          "mae": 215.0,
+          "medianAbsErr": 201.0,
+          "maxAbsErr": 438.0,
+          "meanSignedErr": -214.1
+        },
+        "25-60": {
+          "n": 36,
+          "rmse": 92.7,
+          "mae": 78.6,
+          "medianAbsErr": 74.5,
+          "maxAbsErr": 194.0,
+          "meanSignedErr": 39.4
+        },
+        "61-120": {
+          "n": 60,
+          "rmse": 75.4,
+          "mae": 60.0,
+          "medianAbsErr": 58.5,
+          "maxAbsErr": 147.0,
+          "meanSignedErr": 38.9
+        },
+        "121-250": {
+          "n": 130,
+          "rmse": 95.3,
+          "mae": 75.7,
+          "medianAbsErr": 71.5,
+          "maxAbsErr": 211.0,
+          "meanSignedErr": 13.0
+        },
+        "251-500": {
+          "n": 250,
+          "rmse": 25.2,
+          "mae": 19.2,
+          "medianAbsErr": 13.5,
+          "maxAbsErr": 67.0,
+          "meanSignedErr": -11.2
+        },
+        "501+": {
+          "n": 240,
+          "rmse": 84.0,
+          "mae": 77.2,
+          "medianAbsErr": 67.0,
+          "maxAbsErr": 235.0,
+          "meanSignedErr": -25.6
+        }
+      }
+    },
+    "legacy_scope": {
+      "overall": {
+        "n": 740,
+        "rmse": 83.8,
+        "mae": 59.4,
+        "medianAbsErr": 44.5,
+        "maxAbsErr": 438.0,
+        "meanSignedErr": -8.9
+      },
+      "byScope": {
+        "idp": {
+          "n": 292,
+          "rmse": 76.2,
+          "mae": 60.0,
+          "medianAbsErr": 48.0,
+          "maxAbsErr": 247.0,
+          "meanSignedErr": 3.4
+        },
+        "offense": {
+          "n": 420,
+          "rmse": 89.8,
+          "mae": 59.9,
+          "medianAbsErr": 41.5,
+          "maxAbsErr": 438.0,
+          "meanSignedErr": -17.8
+        },
+        "pick": {
+          "n": 28,
+          "rmse": 64.7,
+          "mae": 45.9,
+          "medianAbsErr": 24.5,
+          "maxAbsErr": 155.0,
+          "meanSignedErr": -2.6
+        }
+      },
+      "byRankBand": {
+        "1-24": {
+          "n": 24,
+          "rmse": 254.5,
+          "mae": 215.0,
+          "medianAbsErr": 201.0,
+          "maxAbsErr": 438.0,
+          "meanSignedErr": -214.1
+        },
+        "25-60": {
+          "n": 36,
+          "rmse": 89.5,
+          "mae": 75.5,
+          "medianAbsErr": 74.5,
+          "maxAbsErr": 194.0,
+          "meanSignedErr": 35.4
+        },
+        "61-120": {
+          "n": 60,
+          "rmse": 76.5,
+          "mae": 61.1,
+          "medianAbsErr": 58.5,
+          "maxAbsErr": 154.0,
+          "meanSignedErr": 36.3
+        },
+        "121-250": {
+          "n": 130,
+          "rmse": 94.2,
+          "mae": 74.6,
+          "medianAbsErr": 71.5,
+          "maxAbsErr": 211.0,
+          "meanSignedErr": 12.3
+        },
+        "251-500": {
+          "n": 250,
+          "rmse": 23.4,
+          "mae": 17.9,
+          "medianAbsErr": 14.0,
+          "maxAbsErr": 67.0,
+          "meanSignedErr": -8.2
+        },
+        "501+": {
+          "n": 240,
+          "rmse": 84.6,
+          "mae": 75.9,
+          "medianAbsErr": 64.5,
+          "maxAbsErr": 247.0,
+          "meanSignedErr": -18.4
+        }
+      }
+    },
+    "percentile_offense": {
+      "overall": {
+        "n": 740,
+        "rmse": 566.6,
+        "mae": 528.3,
+        "medianAbsErr": 589.0,
+        "maxAbsErr": 842.0,
+        "meanSignedErr": -527.2
+      },
+      "byScope": {
+        "idp": {
+          "n": 292,
+          "rmse": 545.8,
+          "mae": 498.5,
+          "medianAbsErr": 583.0,
+          "maxAbsErr": 839.0,
+          "meanSignedErr": -498.3
+        },
+        "offense": {
+          "n": 420,
+          "rmse": 575.5,
+          "mae": 542.5,
+          "medianAbsErr": 594.5,
+          "maxAbsErr": 842.0,
+          "meanSignedErr": -540.7
+        },
+        "pick": {
+          "n": 28,
+          "rmse": 639.0,
+          "mae": 624.8,
+          "medianAbsErr": 652.5,
+          "maxAbsErr": 808.0,
+          "meanSignedErr": -624.8
+        }
+      },
+      "byRankBand": {
+        "1-24": {
+          "n": 24,
+          "rmse": 112.0,
+          "mae": 91.5,
+          "medianAbsErr": 81.5,
+          "maxAbsErr": 213.0,
+          "meanSignedErr": -61.7
+        },
+        "25-60": {
+          "n": 36,
+          "rmse": 232.2,
+          "mae": 198.4,
+          "medianAbsErr": 194.0,
+          "maxAbsErr": 399.0,
+          "meanSignedErr": -197.0
+        },
+        "61-120": {
+          "n": 60,
+          "rmse": 564.8,
+          "mae": 561.2,
+          "medianAbsErr": 565.5,
+          "maxAbsErr": 721.0,
+          "meanSignedErr": -561.2
+        },
+        "121-250": {
+          "n": 130,
+          "rmse": 720.0,
+          "mae": 713.3,
+          "medianAbsErr": 747.0,
+          "maxAbsErr": 842.0,
+          "meanSignedErr": -713.3
+        },
+        "251-500": {
+          "n": 250,
+          "rmse": 650.0,
+          "mae": 649.0,
+          "medianAbsErr": 659.0,
+          "maxAbsErr": 766.0,
+          "meanSignedErr": -649.0
+        },
+        "501+": {
+          "n": 240,
+          "rmse": 423.9,
+          "mae": 387.2,
+          "medianAbsErr": 396.0,
+          "maxAbsErr": 596.0,
+          "meanSignedErr": -386.9
+        }
+      }
+    },
+    "percentile_scope": {
+      "overall": {
+        "n": 740,
+        "rmse": 691.8,
+        "mae": 639.0,
+        "medianAbsErr": 648.5,
+        "maxAbsErr": 1432.0,
+        "meanSignedErr": -637.9
+      },
+      "byScope": {
+        "idp": {
+          "n": 292,
+          "rmse": 835.0,
+          "mae": 779.1,
+          "medianAbsErr": 789.5,
+          "maxAbsErr": 1432.0,
+          "meanSignedErr": -779.1
+        },
+        "offense": {
+          "n": 420,
+          "rmse": 575.5,
+          "mae": 542.5,
+          "medianAbsErr": 594.5,
+          "maxAbsErr": 842.0,
+          "meanSignedErr": -540.7
+        },
+        "pick": {
+          "n": 28,
+          "rmse": 639.0,
+          "mae": 624.8,
+          "medianAbsErr": 652.5,
+          "maxAbsErr": 808.0,
+          "meanSignedErr": -624.8
+        }
+      },
+      "byRankBand": {
+        "1-24": {
+          "n": 24,
+          "rmse": 112.0,
+          "mae": 91.5,
+          "medianAbsErr": 81.5,
+          "maxAbsErr": 213.0,
+          "meanSignedErr": -61.7
+        },
+        "25-60": {
+          "n": 36,
+          "rmse": 387.8,
+          "mae": 283.9,
+          "medianAbsErr": 228.0,
+          "maxAbsErr": 1136.0,
+          "meanSignedErr": -282.6
+        },
+        "61-120": {
+          "n": 60,
+          "rmse": 704.6,
+          "mae": 653.5,
+          "medianAbsErr": 571.0,
+          "maxAbsErr": 1432.0,
+          "meanSignedErr": -653.5
+        },
+        "121-250": {
+          "n": 130,
+          "rmse": 923.5,
+          "mae": 887.9,
+          "medianAbsErr": 790.5,
+          "maxAbsErr": 1233.0,
+          "meanSignedErr": -887.9
+        },
+        "251-500": {
+          "n": 250,
+          "rmse": 741.9,
+          "mae": 731.7,
+          "medianAbsErr": 674.0,
+          "maxAbsErr": 1021.0,
+          "meanSignedErr": -731.7
+        },
+        "501+": {
+          "n": 240,
+          "rmse": 540.6,
+          "mae": 511.9,
+          "medianAbsErr": 482.0,
+          "maxAbsErr": 796.0,
+          "meanSignedErr": -511.9
+        }
+      }
+    },
+    "percentile_global": {
+      "overall": {
+        "n": 740,
+        "rmse": 410.1,
+        "mae": 356.2,
+        "medianAbsErr": 304.5,
+        "maxAbsErr": 1104.0,
+        "meanSignedErr": 238.0
+      },
+      "byScope": {
+        "idp": {
+          "n": 292,
+          "rmse": 459.0,
+          "mae": 403.7,
+          "medianAbsErr": 321.0,
+          "maxAbsErr": 941.0,
+          "meanSignedErr": 384.0
+        },
+        "offense": {
+          "n": 420,
+          "rmse": 380.6,
+          "mae": 329.8,
+          "medianAbsErr": 298.0,
+          "maxAbsErr": 1104.0,
+          "meanSignedErr": 137.8
+        },
+        "pick": {
+          "n": 28,
+          "rmse": 276.5,
+          "mae": 257.9,
+          "medianAbsErr": 282.0,
+          "maxAbsErr": 546.0,
+          "meanSignedErr": 218.6
+        }
+      },
+      "byRankBand": {
+        "1-24": {
+          "n": 24,
+          "rmse": 862.8,
+          "mae": 828.5,
+          "medianAbsErr": 879.0,
+          "maxAbsErr": 1104.0,
+          "meanSignedErr": -827.6
+        },
+        "25-60": {
+          "n": 36,
+          "rmse": 471.3,
+          "mae": 446.8,
+          "medianAbsErr": 398.0,
+          "maxAbsErr": 816.0,
+          "meanSignedErr": -446.8
+        },
+        "61-120": {
+          "n": 60,
+          "rmse": 178.7,
+          "mae": 151.3,
+          "medianAbsErr": 140.5,
+          "maxAbsErr": 305.0,
+          "meanSignedErr": -108.1
+        },
+        "121-250": {
+          "n": 130,
+          "rmse": 162.2,
+          "mae": 158.9,
+          "medianAbsErr": 152.5,
+          "maxAbsErr": 253.0,
+          "meanSignedErr": 158.9
+        },
+        "251-500": {
+          "n": 250,
+          "rmse": 296.0,
+          "mae": 295.2,
+          "medianAbsErr": 297.5,
+          "maxAbsErr": 334.0,
+          "meanSignedErr": 295.2
+        },
+        "501+": {
+          "n": 240,
+          "rmse": 545.3,
+          "mae": 517.1,
+          "medianAbsErr": 508.0,
+          "maxAbsErr": 941.0,
+          "meanSignedErr": 517.1
+        }
+      }
+    },
+    "refit_rank_form": {
+      "overall": {
+        "n": 740,
+        "rmse": 84.0,
+        "mae": 58.3,
+        "medianAbsErr": 41.0,
+        "maxAbsErr": 450.0,
+        "meanSignedErr": -6.6
+      },
+      "byScope": {
+        "idp": {
+          "n": 292,
+          "rmse": 76.4,
+          "mae": 60.5,
+          "medianAbsErr": 51.0,
+          "maxAbsErr": 244.0,
+          "meanSignedErr": 3.5
+        },
+        "offense": {
+          "n": 420,
+          "rmse": 90.1,
+          "mae": 57.8,
+          "medianAbsErr": 36.0,
+          "maxAbsErr": 450.0,
+          "meanSignedErr": -14.3
+        },
+        "pick": {
+          "n": 28,
+          "rmse": 61.9,
+          "mae": 43.6,
+          "medianAbsErr": 28.0,
+          "maxAbsErr": 157.0,
+          "meanSignedErr": 3.0
+        }
+      },
+      "byRankBand": {
+        "1-24": {
+          "n": 24,
+          "rmse": 266.7,
+          "mae": 228.9,
+          "medianAbsErr": 214.0,
+          "maxAbsErr": 450.0,
+          "meanSignedErr": -228.0
+        },
+        "25-60": {
+          "n": 36,
+          "rmse": 89.2,
+          "mae": 73.8,
+          "medianAbsErr": 63.5,
+          "maxAbsErr": 209.0,
+          "meanSignedErr": 27.4
+        },
+        "61-120": {
+          "n": 60,
+          "rmse": 75.2,
+          "mae": 59.5,
+          "medianAbsErr": 56.5,
+          "maxAbsErr": 146.0,
+          "meanSignedErr": 35.8
+        },
+        "121-250": {
+          "n": 130,
+          "rmse": 94.3,
+          "mae": 73.7,
+          "medianAbsErr": 66.0,
+          "maxAbsErr": 213.0,
+          "meanSignedErr": 17.6
+        },
+        "251-500": {
+          "n": 250,
+          "rmse": 22.4,
+          "mae": 17.6,
+          "medianAbsErr": 14.0,
+          "maxAbsErr": 58.0,
+          "meanSignedErr": -3.0
+        },
+        "501+": {
+          "n": 240,
+          "rmse": 81.7,
+          "mae": 72.9,
+          "medianAbsErr": 60.0,
+          "maxAbsErr": 244.0,
+          "meanSignedErr": -17.0
+        }
+      }
+    },
+    "refit_rank_form_per_scope": {
+      "overall": {
+        "n": 740,
+        "rmse": 83.4,
+        "mae": 59.1,
+        "medianAbsErr": 44.0,
+        "maxAbsErr": 438.0,
+        "meanSignedErr": -8.8
+      },
+      "byScope": {
+        "idp": {
+          "n": 292,
+          "rmse": 76.2,
+          "mae": 60.0,
+          "medianAbsErr": 48.0,
+          "maxAbsErr": 247.0,
+          "meanSignedErr": 3.4
+        },
+        "offense": {
+          "n": 420,
+          "rmse": 89.8,
+          "mae": 59.9,
+          "medianAbsErr": 41.5,
+          "maxAbsErr": 438.0,
+          "meanSignedErr": -17.8
+        },
+        "pick": {
+          "n": 28,
+          "rmse": 47.6,
+          "mae": 37.6,
+          "medianAbsErr": 29.0,
+          "maxAbsErr": 111.0,
+          "meanSignedErr": -1.8
+        }
+      },
+      "byRankBand": {
+        "1-24": {
+          "n": 24,
+          "rmse": 254.5,
+          "mae": 215.0,
+          "medianAbsErr": 201.0,
+          "maxAbsErr": 438.0,
+          "meanSignedErr": -214.1
+        },
+        "25-60": {
+          "n": 36,
+          "rmse": 86.5,
+          "mae": 71.8,
+          "medianAbsErr": 73.0,
+          "maxAbsErr": 194.0,
+          "meanSignedErr": 31.5
+        },
+        "61-120": {
+          "n": 60,
+          "rmse": 76.5,
+          "mae": 61.0,
+          "medianAbsErr": 61.0,
+          "maxAbsErr": 154.0,
+          "meanSignedErr": 33.5
+        },
+        "121-250": {
+          "n": 130,
+          "rmse": 93.4,
+          "mae": 74.1,
+          "medianAbsErr": 71.5,
+          "maxAbsErr": 211.0,
+          "meanSignedErr": 11.3
+        },
+        "251-500": {
+          "n": 250,
+          "rmse": 23.5,
+          "mae": 18.3,
+          "medianAbsErr": 14.0,
+          "maxAbsErr": 67.0,
+          "meanSignedErr": -6.8
+        },
+        "501+": {
+          "n": 240,
+          "rmse": 84.2,
+          "mae": 75.5,
+          "medianAbsErr": 64.0,
+          "maxAbsErr": 247.0,
+          "meanSignedErr": -17.9
+        }
+      }
+    }
+  }
+}

--- a/docs/open-modeling-decisions.md
+++ b/docs/open-modeling-decisions.md
@@ -125,9 +125,13 @@ values. Unchanged by this document.
 
 ## 3. What is the right `low_conf_unstable` confidence threshold?
 
-**Status: the question was wrong. The metric is structurally capped.**
-**Recommendation — fix the metric, not the threshold. Needs a call
-because the change cannot be measured in a dev environment.**
+**RESOLVED 2026-07-30 — the rule is retired.** The question was wrong:
+the metric is structurally capped, and every candidate repair pushes
+confidence *away* from the threshold rather than toward it. Kept here
+(rather than deleted) because the underlying metric is still broken and
+the next person to reach for `marketConfidence` needs to know that.
+
+### The original question
 
 The audit asked whether the 0.35 threshold should move, having observed
 that live `marketConfidence` clusters around 0.49 so the rule fires for
@@ -163,28 +167,106 @@ threshold against that scale is calibrating against a broken ruler: at
 catch *most of the board* including well-covered players, because the
 whole population sits in a narrow band just above it.
 
-**The fix is the divisor** (or the count feeding it — 3 sources is
-itself suspicious against a 21-source registry, and `wNorms` may be
-narrower than the registry population; worth checking before changing
-the constant).
+### Why `_sites` maxes at 3 (measured 2026-07-30)
 
-**Why this was not just fixed here.** `market_conf` is not only a
-display/signal input — it feeds the scraper's composite arithmetic:
-`elite_boost`, `elite_cap` (both offense and IDP), the single-source
-discount, and `idp_conf_factor`. Changing it moves `_finalAdjusted`. The
-scraper cannot be re-run in a dev environment (it needs network access
-and site credentials), so **the impact of a divisor change cannot be
-measured here** — and this audit's standing rule is not to change
-valuation inputs it cannot measure.
+The suspicion above — "3 sources is itself suspicious against a
+21-source registry" — checks out, and the answer is that `_sites` is not
+a registry-coverage count at all.
 
-**Recommended next step:** on a machine that can run the scraper,
-re-scrape once with the divisor corrected and diff `_finalAdjusted`
-across the population. If the composite shift is acceptable, take the
-fix; if not, retire `low_conf_unstable` rather than leaving a rule
-gated on a metric that cannot reach its own thresholds.
+The composite loop (`Dynasty Scraper.py`, `for name, pdata in
+players_json.items()`) accumulates `wNorms` by iterating the *scraper's
+own* per-player dash keys. The scraper's `SITES` toggle map has exactly
+**two entries enabled** — `KTC: True` and `IDPTradeCalc: True`; the
+other ten are `False`, labelled *"disabled in scope reduction"*, with a
+matching comment elsewhere reading *"No rank-based sites in the
+two-source model"*. Those two scrapers emit three numeric dash keys
+between them, confirmed on the live payload:
 
-Pinned meanwhile by
-`tests/api/test_market_confidence_wiring.py::test_threshold_is_far_below_the_live_distribution`,
-which asserts the scraper default (0.5) and the live p10 (0.480) do not
-fire — so if either the threshold or the distribution moves toward the
-other, a test says so.
+| dash key | players carrying it | in `_canonicalSiteValues` |
+|---|---|---|
+| `idpTradeCalc` | 898 | 814 |
+| `ktc` | 590 | 464 |
+| `ktcSfTep` | 464 | 464 |
+
+So `len(wNorms) ∈ {1,2,3}` by construction. The other 18 registry
+sources are fetched by `scripts/fetch_*.py` and merged **downstream** in
+`src/api/data_contract.py`, which never recomputes `_sites` or
+`_marketConfidence`. `_sites` therefore measures scraper-composite
+coverage only, and always did — it was never the board's source count.
+(The board's own count is `sourceCount`, from the 21-source blend.)
+
+The `/ 8.0` divisor is a fossil of the pre-scope-reduction era when
+~10 `SITES` were on.
+
+### Why no divisor rescues the rule
+
+`scripts/simulate_market_confidence_divisor.py` recomputes confidence
+under any divisor without re-scraping, by inverting the live formula
+(`cv_score = (conf - site_score*0.65) / 0.35` recovers the second input
+exactly from the payload's `_marketConfidence` + `_sites`). Result:
+
+| divisor | confidence range | players below 0.35 |
+|---|---|---|
+| 8.0 (live) | 0.341 – 0.594 | 1 |
+| 5 | 0.356 – 1.000 | **0** |
+| 4 | 0.393 – 1.000 | **0** |
+| 3 | 0.567 – 1.000 | **0** |
+
+Every correction moves the population *up*, so a rule that fires below
+0.35 gets strictly deader, not healthier. There is no divisor at which
+this rule becomes well-calibrated.
+
+### The decision
+
+`low_conf_unstable` is removed from both engines
+(`src/api/terminal.py::_evaluate_signal` and
+`frontend/lib/signal-engine.js`), from the shared parity fixture's rule
+registry, and from the alert path. MONITOR is in
+`signal_alerts.ACTIONABLE_SIGNALS`, so the rule gated email on a gauge
+whose range is an artifact of how many scrapers happen to be enabled —
+that is the specific thing worth not shipping.
+
+The confidence *number* survives as a diagnostic on both signal
+contexts, so a future rule built on a repaired metric has the plumbing
+in place.
+
+Pinned by `tests/api/test_market_confidence_wiring.py`:
+`TestConfidenceReachesTheContext` keeps the 2026-07-29 plumbing fixes
+honest, and `TestTheRuleIsRetired` asserts that **no** surviving rule's
+verdict changes with confidence — so a reinstatement under a different
+tag fails a test rather than landing quietly.
+
+### Still open (deliberately not done here)
+
+**The divisor itself is still 8.0.** Correcting it is a separate
+decision with a separate risk profile, and it is *not* a board change:
+`market_conf` only ever multiplies the scraper's `composite`
+(`elite_boost`, `elite_cap`, the single-source discount,
+`idp_conf_factor`), never `canonical_site_values`, so
+`rankDerivedValue` is untouched by it. What it does move is
+`_finalAdjusted`. Measured multiplier shifts on the composite, median
+across the population:
+
+| divisor | single-source discount | `idp_conf_factor` | `elite_cap` (offense) |
+|---|---|---|---|
+| 5 | ×1.056 | ×1.070 | ×1.011 |
+| 4 | ×1.093 | ×1.117 | ×1.019 |
+| 3 | ×1.155 | ×1.196 | ×1.031 |
+
+The blast radius is narrower than it looks, but it is not zero — be
+precise about which `finalAdjusted` a consumer reads:
+
+* `values.finalAdjusted` on a `playersArray` row is **overwritten with
+  `rankDerivedValue`** whenever the board priced the row
+  (`data_contract.py`, "Stamp rankDerivedValue into the values bundle").
+  So `public_activity_valuation.py`, `league_intel/values.py` and
+  `/draft`'s fallback chain all see the board value, not the composite.
+* The raw legacy key `_finalAdjusted` still carries the scraper
+  composite, and `src/trade/finder.py` is the one live reader
+  (lines 451 and 946) — both on its **degraded/legacy** path, after
+  `finder.py` was moved onto the canonical board on 2026-07-27.
+
+With `low_conf_unstable` gone there is no signal-path pressure to change
+the divisor either. Honest status: a fossil constant whose only live
+reach is the finder's fallback path, worth fixing when the scraper is
+next touched, not worth a speculative re-scrape now.

--- a/docs/open-modeling-decisions.md
+++ b/docs/open-modeling-decisions.md
@@ -1,12 +1,22 @@
 # Open modeling decisions — resolved to evidence
 
-**Date:** 2026-07-29
+**Date:** 2026-07-29, updated 2026-07-30
 **Context:** the 2026-07-29 repository audit
 (`docs/audits/complete-codebase-audit-2026-07-29.md`) left three
 questions as "requires a product decision". Each was under-specified:
 they were stated as choices without the measurements needed to make
-them. This document closes that gap. Two are now decided on evidence;
-one is narrowed to a single concrete change that still needs a call.
+them. This document closes that gap.
+
+**Status as of 2026-07-30 — all three are decided:**
+
+| # | question | outcome |
+|---|---|---|
+| 1 | apply `coverageWeight`? | **No.** Measured: 297 rows / 221 ranks move for a 3-source input change, with no accuracy evidence either way. Stays DIAGNOSTIC ONLY. |
+| 2 | retire the legacy rank-form curves? | **No — re-tuned and kept**, with a tested drift alarm. Migration turned out not to be a live option; the old constants were fit to the wrong target. |
+| 3 | re-threshold `low_conf_unstable`? | **No — rule retired.** The metric is structurally capped; no threshold makes it sound. |
+
+Only #1 remains reversible-on-new-evidence (a holdout backtest would
+settle it); #2 and #3 are closed.
 
 ---
 
@@ -114,12 +124,44 @@ asserts the refit script still does not write — because if it ever gains
 that ability, it *does* become an automated promotion path and the
 reasoning above has to be revisited rather than silently outgrown.
 
-**Still open, and genuinely a product call:** whether to retire the
-rank-form family in favour of the percentile masters. Measured in
-`docs/legacy-rank-curve-backtest.md` — the candidates have inverted
-error profiles (`percentile_global` is far better past rank 120 and
-~2× worse in the top 24), and switching moves user-visible history
-values. Unchanged by this document.
+**RESOLVED 2026-07-30 — re-tuned and kept, with a drift alarm.** The
+question above was "retire the rank-form family in favour of the
+percentile masters?", and the 2026-07-29 answer was "hard, because the
+error profiles are inverted". Re-measuring closed it:
+
+* **Migration is not a live option.** On the current board the percentile
+  candidates are 5–8× worse *everywhere* (410 and 692 RMSE against 83.8),
+  not better-past-120-and-worse-in-the-top-24. The reason is structural:
+  the percentile masters are an **input stage to the blend**, not a model
+  of its output, so translating them into rank space cannot answer "what
+  does our board pay at rank r".
+* **The old constants were fit to the wrong target.** They came from
+  `fit_hill_curve_from_market.py`, which fits retail *source* boards.
+  Against `rankDerivedValue` the offense pair scored RMSE 821.8 — a ~9×
+  error on every reconstructed offense value. Re-tuned to 65.4 / 0.910
+  (offense) and 64.6 / 0.900 (IDP), it scores 89.8 / 76.2, which **is**
+  the achievable floor for this curve family (83.8 overall vs 83.4 for a
+  free fit). No headroom left; the residual is post-blend scatter.
+* **The drift surface is now watched, and the alarm is tested.**
+  `scripts/check_rank_form_drift.py` +
+  `.github/workflows/audit-rank-form-drift.yml` (Tue 07:41 UTC, after
+  the refit workflow) measure *excess RMSE over the achievable floor*
+  per scope, budget 25.0. It opens an issue rather than a PR, because an
+  automated patch that also re-baselined the guard tests would recreate
+  precisely the by-construction-green circularity ADR-008 documents.
+  `tests/canonical/test_rank_form_drift_check.py` proves the alarm fires.
+* **Bonus finding: the real drift driver is percentile-master
+  promotion, not market churn.** 16 snapshots over two weeks all refit to
+  the same constants; the 2026-07-29 pre-promotion board refit to
+  68.8 / 0.929 and the post-promotion board to 65.2 / 0.905. That is why
+  the check runs after the refit workflow rather than daily.
+* **A third copy existed.** `frontend/lib/value-history.js` still held
+  `K = 45, EXP = 1.1, CEIL = 9999` — wrong on all three, with rank 1 at
+  10000 instead of 9999 — behind a comment that flagged the risk and
+  deferred the fix. Now a single `RANK_FORM_CURVE` object, pinned against
+  Python by `tests/api/test_rank_form_frontend_parity.py`.
+
+Full write-up: `docs/legacy-rank-curve-backtest.md` (2026-07-30 addendum).
 
 ---
 

--- a/frontend/__tests__/signal-engine-parity.test.js
+++ b/frontend/__tests__/signal-engine-parity.test.js
@@ -84,7 +84,9 @@ describe("signal-engine parity fixture integrity", () => {
   it("loads a non-trivial shared fixture", () => {
     expect(Array.isArray(FIXTURE.cases)).toBe(true);
     expect(FIXTURE.cases.length).toBeGreaterThanOrEqual(40);
-    expect(FIXTURE.rules).toHaveLength(10);
+    // 10 until 2026-07-30, when `low_conf_unstable` was retired — see
+    // the retirement note in frontend/lib/signal-engine.js.
+    expect(FIXTURE.rules).toHaveLength(9);
   });
 
   it("has unique case ids", () => {

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -1015,8 +1015,11 @@ function _materializePlayerArrayRow(player) {
     // 256 of 1094 live rows carry no ``marketConfidence``; coercing
     // those to 0 put them under the 0.35 ``low_conf_unstable``
     // threshold, so the MONITOR rule fired on rows that simply lack the
-    // field rather than on genuinely low-confidence ones. The rule
-    // itself already guards on ``!= null``.
+    // field rather than on genuinely low-confidence ones.
+    // That rule was retired 2026-07-30, so nothing consumes this for a
+    // verdict any more — but absent-is-not-zero is the right contract for
+    // a measurement regardless, and this is the row field the terminal
+    // signal context reads.
     confidence: Number.isFinite(Number(player.marketConfidence))
       ? Number(player.marketConfidence)
       : null,
@@ -1193,7 +1196,8 @@ function _materializeLegacyDictRow(name, player, posMap) {
     // So this field was permanently 0, which is under the 0.35
     // threshold, so ``low_conf_unstable`` fired for every eligible row
     // on the legacy path. Reads the field that is actually stamped, and
-    // keeps absent as null rather than 0.
+    // keeps absent as null rather than 0. (That rule was retired
+    // 2026-07-30; reading the real field is still correct.)
     confidence: Number.isFinite(Number(player._marketConfidence))
       ? Number(player._marketConfidence)
       : null,

--- a/frontend/lib/signal-engine.js
+++ b/frontend/lib/signal-engine.js
@@ -118,18 +118,14 @@ const RULES = [
       `High volatility (MAD ${c.volatility.mad.toFixed(1)}) — market can't settle on a price.`,
     tag: "high_vol",
   },
-  {
-    id: "monitor.low_conf_unstable",
-    signal: SIGNALS.MONITOR,
-    priority: 60,
-    test: (c) =>
-      c.confidence != null &&
-      c.confidence < 0.35 &&
-      (c.volatility?.label === "med" || Math.abs(c.trend7 ?? 0) >= 2),
-    reason: (c) =>
-      `Low market confidence (${(c.confidence * 100).toFixed(0)}%) plus recent movement.`,
-    tag: "low_conf_unstable",
-  },
+  // RETIRED 2026-07-30: `monitor.low_conf_unstable` (MONITOR, priority 60)
+  // lived here. It tested `confidence < 0.35`, but `marketConfidence` is
+  // structurally capped at 0.59375 and runs p10 0.480 / median 0.491 /
+  // p90 0.564 live — the scraper's `site_count / 8.0` term dates from a
+  // ~10-site era and only three dash keys exist today. See the full
+  // rationale on the Python side (`src/api/terminal.py::_evaluate_signal`),
+  // which is the authority; this engine mirrors it and the two are pinned
+  // together by `tests/fixtures/signal_parity_cases.json`.
 
   // ── STRONG HOLD ─────────────────────────────────────────────────
   {
@@ -248,6 +244,9 @@ export function buildContext({ row, historyPoints, newsItems }) {
     value: Number(row?.rankDerivedValue || row?.values?.full || 0),
     rank: Number(row?.canonicalConsensusRank) || null,
     rankChange: Number.isFinite(row?.rankChange) ? row.rankChange : null,
+    // Diagnostic only since 2026-07-30 — no rule reads it (see the
+    // retirement note on `monitor.low_conf_unstable` above). Kept on the
+    // context to stay shape-identical to the Python builder.
     confidence: Number.isFinite(row?.confidence) ? row.confidence : null,
     trend7,
     trend30,

--- a/frontend/lib/value-history.js
+++ b/frontend/lib/value-history.js
@@ -304,49 +304,76 @@ export function buildHistoryLookup(history) {
 }
 
 /**
- * Cheap Hill-curve approximation matching the canonical backend
- * formula in src/canonical/player_valuation.py.  Used for the
- * team-value series so the frontend can sum values from a rank
- * series without a second API call per history point.
+ * The rank-form Hill curve, mirrored from the backend.
  *
- * Backend constants (k=45, exponent=1.10, floor=1, ceiling=9999)
- * are duplicated here.  If they drift backend-side, the team chart
- * goes out of calibration until this is retuned — flagged for the
- * follow-up step that pulls these constants from the contract's
- * ``methodology`` or ``hillCurves`` field.
+ * SINGLE SOURCE OF TRUTH for this file's two curve functions, and the
+ * only place the constants appear. It mirrors
+ * `src/canonical/player_valuation.py`:
+ *
+ *     HILL_MIDPOINT -> midpoint
+ *     HILL_SLOPE    -> slope
+ *     span 9998     -> span   (so rank 1 == 9999 exactly, as it does
+ *                              in Python's `rank_to_value`)
+ *
+ * Kept as a mirror rather than read from the contract because the two
+ * consumers are chart components that receive a rank series, not the
+ * contract, and threading it through four call sites to fetch two
+ * numbers is not worth the coupling.
+ *
+ * The drift risk that WAS real here is now covered by a test instead of
+ * a comment: `tests/api/test_rank_form_frontend_parity.py` parses this
+ * object and fails if it disagrees with the Python constants.
+ *
+ * Before 2026-07-30 these were `K = 45`, `EXP = 1.1`, `CEIL = 9999`,
+ * with a comment noting the drift risk and deferring the fix. All three
+ * were wrong: the backend pair was 48.44 / 1.149 at the time, and
+ * `1 + 9999/(...)` puts rank 1 at 10000 rather than 9999. The chart had
+ * been quietly off-calibration on both axes.
+ */
+export const RANK_FORM_CURVE = {
+  midpoint: 65.4,
+  slope: 0.91,
+  span: 9998,
+};
+
+/**
+ * Cheap Hill-curve reconstruction matching the backend's
+ * `rank_to_value`. Used for the team-value series so the frontend can
+ * sum values from a rank series without a second API call per history
+ * point.
+ *
+ * RECONSTRUCTION ONLY — like its Python counterpart, this is not a
+ * valuation path. It answers "what would the board have said at this
+ * rank" for history points that persisted a rank but no value.
  */
 export function valueFromRank(rank) {
   const r = Number(rank);
   if (!Number.isFinite(r) || r <= 0) return 0;
-  const K = 45;
-  const EXP = 1.1;
-  const CEIL = 9999;
-  return Math.round(1 + CEIL / (1 + Math.pow((r - 1) / K, EXP)));
+  const { midpoint, slope, span } = RANK_FORM_CURVE;
+  return Math.round(1 + span / (1 + Math.pow((r - 1) / midpoint, slope)));
 }
 
 /**
- * Closed-form inverse of {@link valueFromRank}.  Given a blended
- * value on the 1..(1+CEIL) Hill scale, return the rank that produces
- * it.  Solving ``v = 1 + CEIL / (1 + ((r-1)/K)^EXP)`` for r:
- *   r = 1 + K * (CEIL/(v-1) - 1)^(1/EXP)
+ * Closed-form inverse of {@link valueFromRank}. Given a blended value on
+ * the 1..(1+span) Hill scale, return the rank that produces it. Solving
+ * ``v = 1 + span / (1 + ((r-1)/midpoint)^slope)`` for r:
+ *   r = 1 + midpoint * (span/(v-1) - 1)^(1/slope)
  *
  * Used to DERIVE a rank-history line for historical snapshots that
  * persisted a value but not a rank (per-source ranks only began
- * persisting 2026-04-29 while value history goes back further).  Same
- * K/EXP/CEIL as valueFromRank so derived ranks are exactly consistent
- * with the curve the rest of the app uses.  Returns null when the
- * value is outside the curve's invertible domain.
+ * persisting 2026-04-29 while value history goes back further). Reads
+ * the same `RANK_FORM_CURVE` so derived ranks are exactly consistent
+ * with the curve the rest of the app uses. Returns null when the value
+ * is outside the curve's invertible domain.
  */
 export function rankFromValue(value) {
   const v = Number(value);
-  const K = 45;
-  const EXP = 1.1;
-  const CEIL = 9999;
+  const { midpoint, slope, span } = RANK_FORM_CURVE;
   if (!Number.isFinite(v) || v <= 1) return null;
-  if (v >= 1 + CEIL) return 1; // saturated → top rank
-  const base = CEIL / (v - 1) - 1; // > 0 for 1 < v < 1+CEIL
+  if (v >= 1 + span) return 1; // saturated → top rank
+  const base = span / (v - 1) - 1; // > 0 for 1 < v < 1+span
   if (!(base > 0)) return 1;
-  const r = 1 + K * Math.pow(base, 1 / EXP);
+  const r = 1 + midpoint * Math.pow(base, 1 / slope);
   if (!Number.isFinite(r)) return null;
   return Math.max(1, Math.round(r));
 }

--- a/scripts/backtest_legacy_rank_curve.py
+++ b/scripts/backtest_legacy_rank_curve.py
@@ -224,6 +224,31 @@ def _fit_rank_form(rows: list[dict[str, Any]]) -> tuple[float, float]:
     return round(best[1], 4), round(best[2], 4)
 
 
+def _fit_rank_form_per_scope(rows: list[dict[str, Any]]) -> dict[str, dict[str, float]]:
+    """Fit a separate rank-form curve per scope.
+
+    The live code carries TWO pairs (``HILL_*`` and ``IDP_HILL_*``) and
+    ``rank_history.py`` routes by scope, so the honest question is whether
+    the scopes actually WANT different curves.  They largely do not, and
+    the reason is structural: ``canonicalConsensusRank`` is a single
+    GLOBAL ordinal over the whole board, so offense, IDP and pick rows all
+    lie on one rank→value relation by construction.  Splitting the fit
+    measures how much the sub-populations deviate from it, not two
+    genuinely different economies.
+
+    ``pick`` is fit and reported for completeness; no live path routes
+    picks to their own rank-form pair.
+    """
+    out: dict[str, dict[str, float]] = {}
+    for scope in sorted({r["scope"] for r in rows}):
+        subset = [r for r in rows if r["scope"] == scope]
+        if len(subset) < 20:
+            continue
+        mid, slope = _fit_rank_form(subset)
+        out[scope] = {"midpoint": mid, "slope": slope, "n": len(subset)}
+    return out
+
+
 def _metrics(errors: list[float]) -> dict[str, float | int]:
     if not errors:
         return {"n": 0}
@@ -282,6 +307,7 @@ def main() -> int:
     results: dict[str, Any] = {name: _evaluate(rows, fn) for name, fn in candidates.items()}
 
     refit: dict[str, Any] | None = None
+    refit_scope: dict[str, dict[str, float]] | None = None
     if not args.skip_fit:
         mid, slope = _fit_rank_form(rows)
         refit = {"midpoint": mid, "slope": slope}
@@ -289,9 +315,25 @@ def main() -> int:
             rows, lambda r, _s, m=mid, sl=slope: float(rank_to_value(r, midpoint=m, slope=sl))
         )
 
+        refit_scope = _fit_rank_form_per_scope(rows)
+        if refit_scope:
+
+            def _per_scope(rank: float, scope: str) -> float:
+                pair = refit_scope.get(scope) or {"midpoint": mid, "slope": slope}
+                return float(rank_to_value(rank, midpoint=pair["midpoint"], slope=pair["slope"]))
+
+            results["refit_rank_form_per_scope"] = _evaluate(rows, _per_scope)
+
     payload_out = {
         "generatedAt": datetime.now(timezone.utc).isoformat(),
-        "payload": str(payload_path.relative_to(REPO_ROOT)),
+        # ``--payload`` may point outside the repo (e.g. a snapshot
+        # extracted to a temp dir for a stability sweep), so
+        # ``relative_to`` is best-effort rather than assumed.
+        "payload": str(
+            payload_path.relative_to(REPO_ROOT)
+            if payload_path.is_relative_to(REPO_ROOT)
+            else payload_path
+        ),
         "rowCount": len(rows),
         "scopeCounts": {
             scope: sum(1 for r in rows if r["scope"] == scope)
@@ -306,6 +348,7 @@ def main() -> int:
             "percentileGlobal": {"c": HILL_GLOBAL_PERCENTILE_C, "s": HILL_GLOBAL_PERCENTILE_S},
         },
         "refitRankForm": refit,
+        "refitRankFormPerScope": refit_scope,
         "results": results,
     }
 
@@ -317,6 +360,13 @@ def main() -> int:
     print(f"Percentile reference N: {_PERCENTILE_REFERENCE_N}")
     if refit:
         print(f"Best-fit rank-form curve on this board: {refit}")
+    if refit_scope:
+        print("Best-fit rank-form curve per scope:")
+        for scope, pair in refit_scope.items():
+            print(
+                f"  {scope:8s} midpoint={pair['midpoint']:8.4f} "
+                f"slope={pair['slope']:6.4f}  (n={int(pair['n'])})"
+            )
     print("\nOverall RMSE (lower = reproduces the live board more closely):")
     for name, rmse in ranked:
         overall = results[name]["overall"]

--- a/scripts/check_rank_form_drift.py
+++ b/scripts/check_rank_form_drift.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Alarm when the legacy rank-form Hill constants drift off the board.
+
+WHAT DRIFTS, AND WHY IT IS SILENT
+=================================
+``HILL_MIDPOINT`` / ``HILL_SLOPE`` and ``IDP_HILL_MIDPOINT`` /
+``IDP_HILL_SLOPE`` in ``src/canonical/player_valuation.py`` reconstruct a
+value from a rank.  Two live paths use them — ``terminal.py``'s value
+fallback and ``rank_history.py``'s historical backfill — plus the
+frontend mirror in ``value-history.js``.
+
+Nothing fails when they stop matching the board.  A reconstruction path
+returning a wrong-but-plausible number produces a chart that renders
+fine, and that is exactly how the pre-2026-07-30 pair went unnoticed at
+RMSE 821.8 on offense rows against a floor of 89.8 — a ~9x error on
+every reconstructed offense value.
+
+WHAT MOVES THEM
+===============
+Not market churn.  16 archived snapshots spanning 2026-07-16 → 07-30 all
+refit to offense 65.4 / 0.910 and IDP 64.4-64.6 / 0.900, because the
+board's rank→value relation IS a Hill curve — churn only permutes which
+player sits at which rank.
+
+What moves them is a **percentile-master promotion**.  The masters are
+step 3 of the live pipeline, so promoting a new pair reshapes the board's
+rank→value relation and the rank-form approximation of it goes stale.
+Measured: the pre-promotion board of 2026-07-29 refit to 68.8 / 0.929,
+the post-promotion board to 65.2 / 0.905.  So this check belongs
+downstream of ``scripts/model_registry.py apply``, and the workflow that
+runs it fires on the same weekly cadence as the refit.
+
+THE METRIC
+==========
+Parameter delta is the wrong alarm — a curve can move its parameters and
+still reproduce the board (the two are partially redundant), and a small
+parameter move near a steep optimum can matter more than a large one on
+a plateau.  What matters is whether the COMMITTED curve still reproduces
+the board, so the metric is:
+
+    excess RMSE = RMSE(committed constants) − RMSE(refit optimum)
+
+per scope, on the served board's ranked rows.  Zero means the committed
+curve is optimal; the default threshold of 25.0 (on the 1–9999 display
+scale) is the point at which a reconstructed history value is off by
+enough to be visible on a chart.  For reference, the committed pair
+scored an excess of 0.4 when it was set on 2026-07-30, and the pair it
+replaced scored 732.
+
+WHY THIS DOES NOT AUTO-COMMIT
+=============================
+ADR-008 (``docs/roster-trade-intelligence/DECISIONS.md``) prohibits a
+model autonomously rewriting production constants, and its sharpest
+finding is worth re-reading before automating anything here: the old
+refit path was green **by construction** because it rewrote the very
+test that guarded it.
+
+An auto-fix that patched ``player_valuation.py`` *and* re-baselined
+``test_rank_form_constants_tripwire.py`` / ``test_player_valuation.py``
+would recreate that exact circularity — a PR that cannot fail its own
+guard.  So this script computes the fix and hands it over: it prints the
+constants to write and the files to write them in, and the workflow opens
+an issue.  The human edit then makes the tripwire fail, and updating the
+pins is the deliberate, recorded act.  That is the whole design.
+
+USAGE
+=====
+    python scripts/check_rank_form_drift.py
+    python scripts/check_rank_form_drift.py --verbose
+    python scripts/check_rank_form_drift.py --threshold 15
+    python scripts/check_rank_form_drift.py --json-out /tmp/drift.json
+
+Exit codes:
+    0  within tolerance
+    1  error (no payload, no ranked rows, unreadable snapshot)
+    2  drift detected — a human should act
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.canonical.player_valuation import (  # noqa: E402
+    HILL_MIDPOINT,
+    HILL_SLOPE,
+    IDP_HILL_MIDPOINT,
+    IDP_HILL_SLOPE,
+)
+
+DEFAULT_THRESHOLD = 25.0
+
+# scope -> (constant name pair, committed values).  ``pick`` is fit and
+# reported but has no committed pair: ``rank_to_value_for_scope`` routes
+# picks to the offense curve deliberately (the board prices them by
+# tethering, not by a rank curve), so a pick-only fit is diagnostic.
+_COMMITTED: dict[str, tuple[tuple[str, str], tuple[float, float]]] = {
+    "offense": (("HILL_MIDPOINT", "HILL_SLOPE"), (HILL_MIDPOINT, HILL_SLOPE)),
+    "idp": (("IDP_HILL_MIDPOINT", "IDP_HILL_SLOPE"), (IDP_HILL_MIDPOINT, IDP_HILL_SLOPE)),
+}
+
+
+def _load_backtest_module() -> ModuleType:
+    """Import the backtest script as a module.
+
+    It is a script, not a package member, so this is the same importlib
+    pattern ``audit-dropped-sources.yml`` uses.  Reusing it keeps ONE
+    grid-search and ONE definition of "which rows count" — duplicating
+    either here is how the two would end up disagreeing about drift.
+    """
+    path = REPO_ROOT / "scripts" / "backtest_legacy_rank_curve.py"
+    spec = importlib.util.spec_from_file_location("backtest_legacy_rank_curve", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _rmse(rows: list[dict[str, Any]], midpoint: float, slope: float) -> float:
+    total = 0.0
+    for row in rows:
+        rank = max(1.0, float(row["rank"]))
+        pred = 1.0 + 9998.0 / (1.0 + ((rank - 1.0) / midpoint) ** slope)
+        total += (pred - float(row["value"])) ** 2
+    return math.sqrt(total / len(rows))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--payload", type=Path, default=None, help="raw scraper payload JSON")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=DEFAULT_THRESHOLD,
+        help=f"excess-RMSE budget per scope before drift is reported (default {DEFAULT_THRESHOLD})",
+    )
+    parser.add_argument("--json-out", type=Path, default=None, help="write the verdict here")
+    parser.add_argument("--verbose", action="store_true", help="print per-scope detail")
+    args = parser.parse_args()
+
+    try:
+        backtest = _load_backtest_module()
+    except Exception as exc:  # pragma: no cover - import-time failure
+        print(f"ERROR: could not load the backtest module: {exc}", file=sys.stderr)
+        return 1
+
+    payload_path = args.payload or backtest._default_payload_path()
+    if payload_path is None or not Path(payload_path).is_file():
+        print(f"ERROR: no payload found (looked for {payload_path})", file=sys.stderr)
+        return 1
+
+    try:
+        rows = backtest._load_rows(Path(payload_path))
+    except Exception as exc:
+        print(f"ERROR: could not build a contract from {payload_path}: {exc}", file=sys.stderr)
+        return 1
+    if not rows:
+        print("ERROR: payload produced no ranked+valued rows", file=sys.stderr)
+        return 1
+
+    per_scope = backtest._fit_rank_form_per_scope(rows)
+
+    scopes: dict[str, Any] = {}
+    drifted: list[str] = []
+    for scope, (names, committed) in _COMMITTED.items():
+        subset = [r for r in rows if r["scope"] == scope]
+        if not subset:
+            scopes[scope] = {"n": 0, "note": "no rows of this scope on the board"}
+            continue
+        fit = per_scope.get(scope)
+        committed_rmse = _rmse(subset, committed[0], committed[1])
+        if fit is None:
+            scopes[scope] = {
+                "n": len(subset),
+                "committed": {"midpoint": committed[0], "slope": committed[1]},
+                "committedRmse": round(committed_rmse, 1),
+                "note": "too few rows to refit; no comparison made",
+            }
+            continue
+        best_rmse = _rmse(subset, fit["midpoint"], fit["slope"])
+        excess = committed_rmse - best_rmse
+        entry = {
+            "n": len(subset),
+            "constantNames": list(names),
+            "committed": {"midpoint": committed[0], "slope": committed[1]},
+            "refit": {"midpoint": fit["midpoint"], "slope": fit["slope"]},
+            "committedRmse": round(committed_rmse, 1),
+            "refitRmse": round(best_rmse, 1),
+            "excessRmse": round(excess, 1),
+            "drifted": bool(excess > args.threshold),
+        }
+        scopes[scope] = entry
+        if entry["drifted"]:
+            drifted.append(scope)
+
+    verdict = {
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "payload": Path(payload_path).name,
+        "rowCount": len(rows),
+        "threshold": args.threshold,
+        "scopes": scopes,
+        "pickDiagnostic": per_scope.get("pick"),
+        "drifted": drifted,
+        "status": "drift" if drifted else "ok",
+    }
+
+    print(f"payload   : {Path(payload_path).name}  ({len(rows)} ranked rows)")
+    print(f"threshold : {args.threshold:.1f} excess RMSE per scope\n")
+    for scope, entry in scopes.items():
+        if "excessRmse" not in entry:
+            print(f"{scope:8s} {entry.get('note')}")
+            continue
+        flag = "DRIFT" if entry["drifted"] else "ok"
+        print(
+            f"{scope:8s} {flag:5s} committed "
+            f"{entry['committed']['midpoint']:.4g}/{entry['committed']['slope']:.4g} "
+            f"rmse={entry['committedRmse']:.1f}   refit "
+            f"{entry['refit']['midpoint']:.4g}/{entry['refit']['slope']:.4g} "
+            f"rmse={entry['refitRmse']:.1f}   excess={entry['excessRmse']:+.1f}"
+        )
+    if args.verbose and per_scope.get("pick"):
+        pick = per_scope["pick"]
+        print(
+            f"\npick     (diagnostic only, routed to the offense curve) "
+            f"best fit {pick['midpoint']:.4g}/{pick['slope']:.4g} on n={int(pick['n'])}"
+        )
+
+    if drifted:
+        print("\nDRIFT DETECTED. To fix, edit these THREE places together:\n")
+        print("  1. src/canonical/player_valuation.py")
+        for scope in drifted:
+            entry = scopes[scope]
+            mid_name, slope_name = entry["constantNames"]
+            print(f"       {mid_name}: float = {entry['refit']['midpoint']}")
+            print(f"       {slope_name}: float = {entry['refit']['slope']}")
+        if "offense" in drifted:
+            off = scopes["offense"]["refit"]
+            print("\n  2. frontend/lib/value-history.js — RANK_FORM_CURVE")
+            print(f"       midpoint: {off['midpoint']},")
+            print(f"       slope: {off['slope']},")
+        else:
+            print("\n  2. frontend/lib/value-history.js — no change (it mirrors")
+            print("     the OFFENSE pair only)")
+        print("\n  3. tests/canonical/test_rank_form_constants_tripwire.py — _PINNED")
+        print("     and tests/canonical/test_player_valuation.py spot values.")
+        print(
+            "\nThose two test files are deliberately NOT rewritten by this "
+            "script: see the 'WHY THIS DOES NOT AUTO-COMMIT' note in its "
+            "docstring, and ADR-008."
+        )
+
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(verdict, indent=2) + "\n")
+        print(f"\nWrote {args.json_out}")
+
+    return 2 if drifted else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/simulate_market_confidence_divisor.py
+++ b/scripts/simulate_market_confidence_divisor.py
@@ -19,6 +19,32 @@ never exceeds 3 on real payloads, so ``site_score`` is confined to
 high confidence, so the ``low_conf_unstable`` threshold of 0.35 cannot
 be calibrated meaningfully against it.
 
+WHY ``_sites`` MAXES AT 3 (measured 2026-07-30)
+===============================================
+It is not a registry-coverage count.  The composite loop accumulates
+``wNorms`` from the SCRAPER's own per-player dash keys, and the
+scraper's ``SITES`` toggle map has exactly two entries enabled — ``KTC``
+and ``IDPTradeCalc``, the rest ``False`` and labelled "disabled in scope
+reduction".  Those two emit three numeric dash keys between them
+(``ktc``, ``ktcSfTep``, ``idpTradeCalc``), so ``len(wNorms) ∈ {1,2,3}``
+by construction.  The other 18 registry sources are fetched by
+``scripts/fetch_*.py`` and merged downstream in
+``src/api/data_contract.py``, which never recomputes ``_sites``.  The
+``/ 8.0`` divisor is a fossil of the pre-scope-reduction ~10-site era.
+
+OUTCOME (2026-07-30)
+====================
+The rule this was measured for is **RETIRED**, because the table this
+script prints shows every candidate divisor pushing confidence UP: zero
+players fall below 0.35 at divisors 3, 4 or 5, so there is no divisor at
+which a "fires below 0.35" rule becomes well-calibrated.  See
+``docs/open-modeling-decisions.md`` §3.
+
+The script is kept because the divisor itself is still 8.0 and the
+composite-multiplier columns below are the measurement anyone correcting
+it will need.  ``--threshold`` now just annotates the output; no live
+rule reads it.
+
 WHY THIS DOESN'T NEED THE SCRAPER
 =================================
 Re-scraping to measure the fix is impractical in a dev environment (no
@@ -138,7 +164,12 @@ def main() -> int:
     ap.add_argument("--payload", type=Path, default=None)
     ap.add_argument("--out", type=Path, default=None)
     ap.add_argument("--divisors", type=float, nargs="*", default=[3.0, 4.0, 5.0])
-    ap.add_argument("--threshold", type=float, default=0.35, help="low_conf_unstable threshold")
+    ap.add_argument(
+        "--threshold",
+        type=float,
+        default=0.35,
+        help="annotation only — the retired low_conf_unstable rule's threshold",
+    )
     args = ap.parse_args()
 
     path = args.payload or _default_payload()

--- a/src/api/terminal.py
+++ b/src/api/terminal.py
@@ -788,19 +788,19 @@ def _build_signal_context(
     # ``_marketConfidence``); ``confidence`` is the name the FRONTEND row
     # contract uses after ``buildRows`` maps it across.
     #
-    # FIXED 2026-07-29 (audit N2): this read ``row.get("confidence")``
-    # only — a key no contract builder stamps — so it was always None and
-    # the ``low_conf_unstable`` MONITOR rule below could never fire
-    # server-side, while the same rule was live on the frontend. Two
-    # modules, one rule, opposite behaviour.
+    # DIAGNOSTIC ONLY since 2026-07-30.  No signal rule reads it — the
+    # ``low_conf_unstable`` MONITOR rule that did was RETIRED (see
+    # ``_evaluate_signal``).  It is still surfaced on the context so the
+    # number stays inspectable in ``/api/terminal`` payloads, and so a
+    # future rule built on a *repaired* confidence metric has the plumbing
+    # already in place.
     #
     # ``marketConfidence`` is preferred and ``confidence`` kept as a
     # fallback so a caller handing us an already-materialized frontend
     # row (or a test fixture using the short name) still works.
     # Deliberately NOT coerced to 0 when absent: 256 of 1094 live rows
-    # carry no confidence at all, and "unmeasured" must not read as
-    # "zero confidence" — that is precisely what makes the rule fire on
-    # the frontend for rows that simply lack the field.
+    # carry no confidence at all, and "unmeasured" must never read as
+    # "zero confidence".
     confidence = row.get("marketConfidence")
     if confidence is None:
         confidence = row.get("confidence")
@@ -853,7 +853,6 @@ def _evaluate_signal(ctx: dict[str, Any]) -> dict[str, Any]:
     mad = (ctx.get("volatility") or {}).get("mad")
     value = ctx.get("value") or 0
     rank_change = ctx.get("rankChange")
-    conf = ctx.get("confidence")
     alert = ctx.get("alertCount") or 0
     neg = ctx.get("negativeImpactCount") or 0
     pos = ctx.get("positiveImpactCount") or 0
@@ -905,17 +904,35 @@ def _evaluate_signal(ctx: dict[str, Any]) -> dict[str, Any]:
         )
     if vol_label == "high":
         add(62, "MONITOR", "high_vol", f"High volatility (MAD {float(mad or 0):.1f}).")
-    if (
-        conf is not None
-        and conf < 0.35
-        and (vol_label == "med" or (trend7 is not None and abs(trend7) >= 2))
-    ):
-        add(
-            60,
-            "MONITOR",
-            "low_conf_unstable",
-            f"Low market confidence ({conf * 100:.0f}%) plus recent movement.",
-        )
+    # RETIRED 2026-07-30: ``low_conf_unstable`` (MONITOR, priority 60).
+    #
+    # The rule tested ``confidence < 0.35``, but the metric it read cannot
+    # produce a value near that threshold.  ``_marketConfidence`` comes from
+    # ``Dynasty Scraper.py::_market_confidence``:
+    #
+    #     site_score = clamp(site_count / 8.0, 0.20, 1.00)   # 65% weight
+    #     cv_score   = clamp(1 - min(cv,0.35)/0.35, 0.20, 1.00)  # 35% weight
+    #
+    # The 8.0 divisor dates from an era when ~10 scraper SITES were enabled.
+    # Today ``SITES`` has exactly two on (KTC + IDPTradeCalc), yielding at
+    # most three numeric dash keys per player (``ktc``, ``ktcSfTep``,
+    # ``idpTradeCalc``), so ``site_count`` is confined to {1,2,3},
+    # ``site_score`` to {0.20, 0.25, 0.375}, and confidence is structurally
+    # capped at 0.375*0.65 + 1.00*0.35 = 0.59375 — the observed live maximum.
+    # Measured live distribution: p10 0.480 / median 0.491 / p90 0.564, with
+    # exactly ONE of 1094 rows under 0.35.
+    #
+    # So the rule was, in practice, a near-dead branch gated on a broken
+    # gauge, and MONITOR is in ``signal_alerts.ACTIONABLE_SIGNALS`` — it
+    # gates email.  Every candidate divisor pushes confidence UP (measured
+    # by ``scripts/simulate_market_confidence_divisor.py``: 0 players below
+    # 0.35 at divisors 3, 4 and 5), so no recalibration rescues it either.
+    #
+    # Retired rather than re-thresholded: picking a new cut-off against a
+    # gauge whose range is an artifact of how many scrapers happen to be
+    # enabled would be fitting to noise.  The confidence number itself
+    # survives on the context as a diagnostic.  Reinstate only on top of a
+    # confidence metric that spans its own range.
     if value >= 7000 and (trend30 is not None and trend30 >= 0) and vol_label in ("low", "med"):
         add(
             50,

--- a/src/canonical/player_valuation.py
+++ b/src/canonical/player_valuation.py
@@ -51,33 +51,56 @@ TIER_MIN_SIZE: int = 3  # minimum players in a tier before allowing split
 
 # Rank-form value curve — Hill-style, rank 1 always = 9999
 # value = 1 + 9998 / (1 + ((rank - 1) / midpoint)^slope)
-# Mirrors the JS rankToValue in frontend/lib/dynasty-data.js.
 #
-# Constants are the simple mean of per-source Hill-curve fits across
-# the four value-emitting market sources — KTC, IDPTradeCalc,
-# DynastyNerds (SF TEP), DynastyDaddy (SF) — each normalised so its
-# top player = 9999 before fitting. Re-run
-# ``scripts/fit_hill_curve_from_market.py`` when the community's
-# dropoff shape drifts from ours and update the constants here.
-HILL_MIDPOINT: float = 48.44  # rank at which value decay inflects
-HILL_SLOPE: float = 1.149  # controls steepness of decay
+# RECONSTRUCTION-ONLY.  Nothing on the live valuation path evaluates
+# these; the board is built by the percentile-form scope masters below.
+# The only consumers answer "what would the board have said for this
+# rank?" when a real value is missing — see ``rank_to_value_for_scope``.
+#
+# RE-TUNED 2026-07-30.  Previously 48.44 / 1.149, being the mean of
+# per-source Hill fits from ``scripts/fit_hill_curve_from_market.py``
+# (four value-emitting market sources, each normalised so its top player
+# = 9999).  That is the wrong target for a reconstruction curve: fitting
+# individual retail SOURCE boards answers "what shape does KTC publish",
+# while these constants have to answer "what does OUR board pay at rank
+# r" — the output of the whole pipeline, after blending, TE basis
+# conversion, shrinkage, the single-source haircut, the corridor clamp
+# and pick tethering.  Measured against the live board the old pair
+# scored RMSE 821.8 on offense rows; the values below score 89.8.
+#
+# Fit by ``scripts/backtest_legacy_rank_curve.py``, per scope, against
+# ``rankDerivedValue`` on the served board.  The fit is structurally
+# stable — 16 archived snapshots spanning 2026-07-16 → 07-30 returned
+# offense midpoint 65.4 (once 65.6) / slope 0.910 and IDP 64.4-64.6 /
+# 0.900 — because the board's rank→value relation IS a Hill curve, so
+# market churn only permutes which player sits at which rank.
+#
+# What DOES move them is a percentile-master promotion: the pre-promotion
+# board of 2026-07-29 fit at 68.8 / 0.929, the post-promotion board at
+# 65.2 / 0.905.  That is what ``scripts/check_rank_form_drift.py`` and
+# ``.github/workflows/audit-rank-form-drift.yml`` watch for.
+HILL_MIDPOINT: float = 65.4  # rank at which value decay inflects
+HILL_SLOPE: float = 0.910  # controls steepness of decay
 
-# IDP-specific Hill curve.  Dynasty IDP markets price differently from
-# offense: the #1 LB is nowhere near 2x the #2 the way the #1 QB is,
-# and values decay more slowly through the long tail (mid-/deep-
-# roster IDP players are more fungible than the equivalent offensive
-# skill-position players).  Fit via
-# ``scripts/fit_hill_curve_from_market.py --universe idp`` against
-# IDPTradeCalc's raw IDP slice of its combined offense+IDP pool — the
-# retail IDP authority whose per-rank values the blend should
-# reproduce at the Hill step, BEFORE any per-position IDP calibration
-# multiplier is applied.  Previous fit anchored on FantasyPros IDP
-# ``normalizedValue`` which produced values ~600-1,000 below IDPTC
-# across the top-250 IDP rows; the new fit is RMSE ~170 across 376
-# IDP rows in the live snapshot.  Re-run the fit and update these
-# constants when the IDPTC dropoff shape drifts.
-IDP_HILL_MIDPOINT: float = 69.50
-IDP_HILL_SLOPE: float = 0.945
+# IDP-specific rank-form curve.  Kept as a separate pair because
+# ``rank_history.py`` routes by scope and the IDP sub-population does fit
+# marginally better on its own numbers (RMSE 76.2 vs 76.4 for one shared
+# curve).  Note how SMALL that gap is, and why: ``canonicalConsensusRank``
+# is a single GLOBAL ordinal over the whole board, so offense, IDP and
+# pick rows all lie on one rank→value relation by construction.  The
+# pre-2026-07-30 rationale here — that "dynasty IDP markets price
+# differently from offense", fit against IDPTradeCalc's raw IDP slice —
+# describes a real property of retail IDP BOARDS, but it is not what this
+# constant measures.  Against our own board the two scopes want
+# effectively the same curve, and the old IDP pair (69.50 / 0.945) scored
+# well on IDP rows largely by coincidence: it sat near the global optimum
+# while the offense pair did not.
+#
+# Do not read the offense/IDP split here as evidence of two economies.
+# If a future change makes ranks scope-local rather than global, re-fit
+# and revisit.
+IDP_HILL_MIDPOINT: float = 64.6
+IDP_HILL_SLOPE: float = 0.900
 
 # Final Framework step 2-3: percentile-input Hill curves, one per scope.
 #
@@ -309,24 +332,36 @@ def rank_to_value_for_scope(rank: float, scope: str) -> int:
     ``data_contract.py::_compute_unified_rankings``; this is only for
     rows where that output is unavailable.
 
-    CALIBRATION (measured 2026-07-29,
-    ``scripts/backtest_legacy_rank_curve.py``, 740 ranked rows of the
-    live board, results in ``docs/measurements/``):
+    CALIBRATION (re-measured 2026-07-30 after the constants were re-tuned,
+    ``scripts/backtest_legacy_rank_curve.py``, 740 ranked rows of the live
+    board, results in ``docs/measurements/``):
 
         candidate                overall RMSE   idp    offense   pick
-        legacy_offense (was)         840.4     826.5    845.9   887.8
-        legacy_scope   (this)        670.3      78.7    845.9   887.8
-        percentile_global            238.4     164.9    278.8   193.4
-        best-fit rank-form            96.3      65.6    113.5    68.7
+        legacy_scope   (this)         83.8      76.2     89.8     64.7
+        best-fit per scope            83.4      76.2     89.8     47.6
+        best-fit single curve         84.0      76.4     90.1     61.9
+        percentile_global            410.1     459.0    380.6    276.5
+        percentile_scope             691.8     835.0    575.5    639.0
 
-    Routing by scope is a strict improvement and costs nothing — it uses
-    constants that already exist — so it is applied here.  Whether this
-    whole legacy rank-form family should be REPLACED (by the
-    registry-managed percentile masters, or by a refit) is an open
-    modeling decision, deliberately not taken inside an audit fix: the
-    candidates have inverted error profiles (percentile_global is far
-    better past rank 120 but ~2x worse in the top 24), and switching
-    changes user-visible history values.  See the audit report.
+    For contrast, the SAME table on the same board before the re-tune:
+
+        legacy_scope (old 48.44/1.149 + 69.50/0.945)
+                                     644.9      89.5    821.8    882.9
+
+    Two conclusions worth keeping:
+
+    * The re-tuned pair now sits ON the achievable floor (83.8 vs 83.4),
+      so there is no headroom left in this curve family.  The remaining
+      ~84 RMSE is irreducible scatter — the board is not a pure function
+      of rank, because post-blend stages (pick tethering, the two-way
+      boost, the corridor clamp) move individual rows off the curve.
+    * The percentile masters are NOT a drop-in replacement, and the
+      2026-07-29 note that they had "inverted error profiles" is
+      superseded: on the current board they are 5-8x worse everywhere.
+      They are an INPUT stage to the blend, not a model of its output,
+      so translating them into rank space does not answer this question.
+      Retiring the rank-form family in their favour is off the table
+      until something better than a refit exists.
     """
     if str(scope).lower() == "idp":
         return int(rank_to_value(float(rank), midpoint=IDP_HILL_MIDPOINT, slope=IDP_HILL_SLOPE))

--- a/tests/api/test_market_confidence_wiring.py
+++ b/tests/api/test_market_confidence_wiring.py
@@ -1,9 +1,9 @@
-"""Market confidence reaches the signal rule, and absent != zero.
+"""Market confidence reaches the signal context — and no rule reads it.
 
-N2, 2026-07-29 audit round 2.
+History, because both halves matter:
 
-``low_conf_unstable`` (MONITOR, priority 60) was broken in THREE places
-at once, in opposite directions:
+**2026-07-29 (audit N2).**  ``low_conf_unstable`` (MONITOR, priority 60)
+was broken in THREE places at once, in opposite directions:
 
 1. Backend — ``terminal.py::_build_signal_context`` read
    ``row["confidence"]``.  No contract builder stamps that key; the
@@ -18,23 +18,39 @@ at once, in opposite directions:
 3. Frontend, legacy-dict path — mapped
    ``Number(player._marketReliabilityScore ?? 0)``.  That field appeared
    exactly once in the entire repository — at that consumer — and
-   nothing ever produced it (0 of 1076 live players carry it, while 838
-   carry ``_marketConfidence``).  Confidence was therefore permanently
-   0 and the rule fired for every eligible row on that path.
+   nothing ever produced it, so confidence was permanently 0 and the
+   rule fired for every eligible row on that path.
 
-MONITOR is in ``signal_alerts.ACTIONABLE_SIGNALS``, so #1 is the one
-that gates emails.  The measured distribution says fixing it is safe:
-live ``marketConfidence`` runs p10 0.480 / median 0.491 / p90 0.564
-against a 0.35 threshold, and exactly ONE row of 1094 sits below it.
-That is recorded in ``test_threshold_is_far_below_the_live_distribution``
-so the "turning this on floods every inbox" assumption is not re-made
-without evidence — and so that if the distribution ever shifts down
-toward the threshold, someone notices.
+All three plumbing defects were fixed then, and the fixes are what this
+file still pins.
+
+**2026-07-30 — the rule itself is RETIRED.**  With the plumbing correct,
+the metric turned out to be the problem.  ``_marketConfidence`` is
+computed by ``Dynasty Scraper.py::_market_confidence`` with a
+``site_count / 8.0`` term inherited from an era when ~10 scraper
+``SITES`` were enabled.  Two are enabled today (KTC + IDPTradeCalc),
+which yields at most three numeric dash keys per player, so
+``site_score`` is confined to {0.20, 0.25, 0.375} and confidence is
+structurally capped at ``0.375*0.65 + 1.00*0.35 = 0.59375``.  Live
+distribution: p10 0.480 / median 0.491 / p90 0.564, one row of 1094
+below 0.35.  Every candidate divisor moves confidence UP
+(``scripts/simulate_market_confidence_divisor.py``: zero players below
+0.35 at divisors 3, 4 and 5), so no re-threshold rescues it.
+
+So: the context field stays (it is a real, inspectable number and the
+plumbing must not silently rot), and the rule is gone.  This file tests
+both facts — including, explicitly, that the rule does NOT come back
+without someone editing this test.
 """
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from src.api.terminal import _build_signal_context, _evaluate_signal
+
+_FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "signal_parity_cases.json"
 
 
 def _row(**over):
@@ -49,6 +65,10 @@ def _row(**over):
 
 
 class TestConfidenceReachesTheContext:
+    """The 2026-07-29 plumbing fixes.  Still load-bearing: the number is
+    surfaced in ``/api/terminal`` payloads and is the substrate any future
+    confidence rule would be built on."""
+
     def test_market_confidence_is_read(self):
         """The key the contract actually stamps."""
         ctx = _build_signal_context(_row(marketConfidence=0.2), points=[], news_for_player=[])
@@ -67,8 +87,8 @@ class TestConfidenceReachesTheContext:
         assert ctx["confidence"] == 0.2
 
     def test_absent_confidence_is_none_not_zero(self):
-        """The defect that made the rule fire on the frontend: a row
-        with no confidence must be UNMEASURED, never 'zero confidence'."""
+        """A row with no confidence must be UNMEASURED, never 'zero
+        confidence' — the distinction that made defect #2 above fire."""
         ctx = _build_signal_context(_row(), points=[], news_for_player=[])
         assert ctx["confidence"] is None
 
@@ -79,14 +99,17 @@ class TestConfidenceReachesTheContext:
         assert ctx["confidence"] is None
 
 
-class TestTheRuleNowFires:
-    def _ctx(self, conf, trend7=-4.0):
+class TestTheRuleIsRetired:
+    """The 2026-07-30 retirement, pinned from three directions so it
+    cannot be undone by accident in either engine."""
+
+    def _ctx(self, conf, trend7=-4.0, vol="med"):
         return {
             "value": 5000,
             "confidence": conf,
             "trend7": trend7,
             "trend30": None,
-            "volatility": {"label": "med", "mad": 3.0},
+            "volatility": {"label": vol, "mad": 3.0},
             "rankChange": None,
             "alertCount": 0,
             "negativeImpactCount": 0,
@@ -94,60 +117,46 @@ class TestTheRuleNowFires:
             "newsCount": 0,
         }
 
-    def test_low_confidence_plus_movement_fires_monitor(self):
-        """Server-side this could not fire at all before the fix."""
+    def test_low_confidence_no_longer_fires_anything(self):
+        """The exact input that used to produce the MONITOR verdict."""
         verdict = _evaluate_signal(self._ctx(0.2))
         tags = {f["tag"] for f in verdict["fired"]}
-        assert "low_conf_unstable" in tags
+        assert "low_conf_unstable" not in tags
+        assert tags == set(), f"unexpected rules fired: {sorted(tags)}"
+        assert verdict["signal"] == "HOLD"
 
-    def test_absent_confidence_does_not_fire(self):
-        verdict = _evaluate_signal(self._ctx(None))
-        tags = {f["tag"] for f in verdict["fired"]}
+    def test_zero_confidence_does_not_fire_either(self):
+        """0.0 is a measurement, not an absence — and neither one has a
+        rule to reach any more."""
+        tags = {f["tag"] for f in _evaluate_signal(self._ctx(0.0))["fired"]}
+        assert tags == set()
+
+    def test_no_surviving_rule_reads_confidence(self):
+        """Sweep the whole rule set: confidence must not change any
+        verdict.  Catches a reinstatement under a different tag."""
+        for conf in (None, 0.0, 0.1, 0.34, 0.35, 0.5, 0.9, 1.0):
+            for trend7 in (-4.0, 0.0, 4.0):
+                for vol in ("low", "med", "high"):
+                    with_conf = _evaluate_signal(self._ctx(conf, trend7=trend7, vol=vol))
+                    without = _evaluate_signal(self._ctx(None, trend7=trend7, vol=vol))
+                    assert [f["tag"] for f in with_conf["fired"]] == [
+                        f["tag"] for f in without["fired"]
+                    ], f"confidence {conf} changed the verdict (trend7={trend7}, vol={vol})"
+
+    def test_parity_fixture_no_longer_registers_the_rule(self):
+        """The shared fixture is the contract between the Python and JS
+        engines.  If the tag is back in its rule registry, one of the two
+        engines has been changed without the other."""
+        data = json.loads(_FIXTURE.read_text())
+        tags = {r["tag"] for r in data["rules"]}
         assert "low_conf_unstable" not in tags
 
-    def test_healthy_confidence_does_not_fire(self):
-        """0.49 is the live median — the common case must stay quiet."""
-        verdict = _evaluate_signal(self._ctx(0.49))
-        tags = {f["tag"] for f in verdict["fired"]}
-        assert "low_conf_unstable" not in tags
 
-
-class TestAlertVolumeIsBounded:
-    def test_monitor_is_actionable_so_this_gates_email(self):
-        """Pins the coupling that made this change delicate: if MONITOR
-        ever leaves ACTIONABLE_SIGNALS, the reasoning below changes."""
+class TestMonitorStillGatesEmail:
+    def test_monitor_is_actionable(self):
+        """Pins the coupling that made the retired rule delicate in the
+        first place: MONITOR verdicts send mail, so the surviving MONITOR
+        rules (``alert_present``, ``high_vol``) are email-gating too."""
         from src.api.signal_alerts import ACTIONABLE_SIGNALS
 
         assert "MONITOR" in ACTIONABLE_SIGNALS
-
-    def test_threshold_is_far_below_the_live_distribution(self):
-        """The evidence that wiring this rule up does not flood inboxes.
-
-        The scraper defaults ``_marketConfidence`` to 0.5 and the live
-        spread is p10 0.480 / median 0.491 / p90 0.564, so a 0.35
-        threshold catches almost nothing — 1 row in 1094 when measured.
-
-        This test does not read live data (unit tests must not), but it
-        pins the two numbers the safety argument rests on, so a future
-        change to either is a deliberate one.
-        """
-        from src.api.terminal import _evaluate_signal as ev
-
-        base = {
-            "value": 5000,
-            "trend7": -4.0,
-            "trend30": None,
-            "volatility": {"label": "med", "mad": 3.0},
-            "rankChange": None,
-            "alertCount": 0,
-            "negativeImpactCount": 0,
-            "positiveImpactCount": 0,
-            "newsCount": 0,
-        }
-        # The scraper's default, and the live p10 — neither may fire.
-        for conf in (0.5, 0.480):
-            tags = {f["tag"] for f in ev({**base, "confidence": conf})["fired"]}
-            assert "low_conf_unstable" not in tags, f"{conf} fired; threshold moved"
-        # Just under the threshold must fire.
-        tags = {f["tag"] for f in ev({**base, "confidence": 0.34})["fired"]}
-        assert "low_conf_unstable" in tags

--- a/tests/api/test_rank_form_frontend_parity.py
+++ b/tests/api/test_rank_form_frontend_parity.py
@@ -1,0 +1,129 @@
+"""Backend/frontend parity for the rank-form Hill curve constants.
+
+WHY THIS EXISTS
+===============
+``frontend/lib/value-history.js`` reconstructs a value from a rank for
+two charts — the terminal team-value series
+(``computeTeamValueSeries`` → ``valueFromRank``) and the derived
+rank-history line on the player popup (``rankFromValue``). It does that
+with its own copy of the backend's rank-form Hill constants, because
+its callers are chart components that hold a rank series rather than the
+contract.
+
+A mirrored constant with a comment saying "these might drift" is not a
+guard, and this pair proved it. On 2026-07-30 the mirror still read
+``K = 45, EXP = 1.1, CEIL = 9999`` while Python held
+``HILL_MIDPOINT = 48.44, HILL_SLOPE = 1.149`` and a span of 9998 — three
+values wrong at once, one of them (the span) putting rank 1 at 10000
+instead of 9999. Nothing failed. The comment had even flagged the risk
+and deferred the fix to a follow-up that never came.
+
+So the comment is replaced by this test. Same approach as
+``test_source_registry_parity.py``: parse the JS as text, no eval, and
+diff against the Python constants.
+
+WHAT IT DOES NOT COVER
+======================
+Only the rank-form pair. The percentile-form scope masters
+(``HILL_*_PERCENTILE_*``) are not mirrored in this file — the frontend
+reads those from the contract's ``hillCurves`` block, which is the right
+pattern and needs no static parity check.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+from src.canonical.player_valuation import (
+    HILL_MIDPOINT,
+    HILL_SLOPE,
+    rank_to_value,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JS_PATH = REPO_ROOT / "frontend" / "lib" / "value-history.js"
+
+# The backend span: ``value = 1 + 9998 / (1 + ...)``, so rank 1 == 9999.
+EXPECTED_SPAN = 9998
+
+
+def _parse_rank_form_curve() -> dict[str, float]:
+    """Pull the ``RANK_FORM_CURVE`` object literal out of the JS source."""
+    text = JS_PATH.read_text(encoding="utf-8")
+    match = re.search(
+        r"export\s+const\s+RANK_FORM_CURVE\s*=\s*\{(?P<body>.*?)\}\s*;",
+        text,
+        re.DOTALL,
+    )
+    if not match:
+        raise AssertionError(
+            f"could not find `export const RANK_FORM_CURVE = {{...}}` in {JS_PATH}. "
+            "If the constants moved, point this test at the new home rather "
+            "than deleting it — the drift it guards is silent."
+        )
+    body = match.group("body")
+    out: dict[str, float] = {}
+    for key in ("midpoint", "slope", "span"):
+        found = re.search(rf"\b{key}\s*:\s*(-?\d+(?:\.\d+)?)", body)
+        if not found:
+            raise AssertionError(f"RANK_FORM_CURVE is missing a numeric `{key}`: {body!r}")
+        out[key] = float(found.group(1))
+    return out
+
+
+class TestRankFormFrontendParity(unittest.TestCase):
+    def test_midpoint_matches_python(self) -> None:
+        js = _parse_rank_form_curve()
+        self.assertAlmostEqual(
+            js["midpoint"],
+            HILL_MIDPOINT,
+            places=6,
+            msg=(
+                f"frontend RANK_FORM_CURVE.midpoint={js['midpoint']} but "
+                f"HILL_MIDPOINT={HILL_MIDPOINT}. Update "
+                "frontend/lib/value-history.js to match; a re-tune has to move "
+                "both or the team-value chart goes out of calibration."
+            ),
+        )
+
+    def test_slope_matches_python(self) -> None:
+        js = _parse_rank_form_curve()
+        self.assertAlmostEqual(
+            js["slope"],
+            HILL_SLOPE,
+            places=6,
+            msg=(
+                f"frontend RANK_FORM_CURVE.slope={js['slope']} but "
+                f"HILL_SLOPE={HILL_SLOPE}. Update "
+                "frontend/lib/value-history.js to match."
+            ),
+        )
+
+    def test_span_puts_rank_one_at_9999(self) -> None:
+        """The bug that made rank 1 worth 10000 on the frontend."""
+        js = _parse_rank_form_curve()
+        self.assertEqual(js["span"], EXPECTED_SPAN)
+        self.assertEqual(round(1 + js["span"] / 1.0), rank_to_value(1))
+
+    def test_the_two_implementations_agree_numerically(self) -> None:
+        """Belt and braces: reimplement the JS arithmetic from the parsed
+        constants and compare against Python across the board's range.
+
+        Catches a divergence in the FORMULA, which matching constants
+        would not (e.g. a stray ``(r - 1)`` becoming ``r``).
+        """
+        js = _parse_rank_form_curve()
+        mid, slope, span = js["midpoint"], js["slope"], js["span"]
+        for rank in (1, 2, 3, 5, 10, 25, 50, 100, 200, 300, 500, 800):
+            js_value = round(1 + span / (1 + ((rank - 1) / mid) ** slope))
+            self.assertEqual(
+                js_value,
+                rank_to_value(rank),
+                msg=f"rank {rank}: JS mirror gives {js_value}, Python {rank_to_value(rank)}",
+            )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/api/test_rank_history.py
+++ b/tests/api/test_rank_history.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from src.api import rank_history
+from src.canonical.player_valuation import rank_to_value_for_scope
 
 
 def _contract_with(
@@ -251,11 +252,23 @@ class LoadHistory(unittest.TestCase):
             idp_val = series[_key("Idp Rookie", "idp")][-1]["val"]
             self.assertGreater(off_val, 0)
             self.assertGreater(idp_val, 0)
-            # IDP curve decays slower at rank 50 than offense — so an
-            # IDP player at rank 50 should outvalue an offense player
-            # at the same rank.  (Sanity check that the asset class
-            # actually gates which curve fills in the gap.)
-            self.assertGreater(idp_val, off_val)
+            # The claim under test is that the asset class GATES which
+            # curve fills the gap — so each value must equal what the
+            # scope-aware curve produces, and the two must differ.
+            #
+            # This used to assert ``idp_val > off_val``, on the rationale
+            # that "the IDP curve decays slower at rank 50".  That was
+            # true of the pre-2026-07-30 constants (IDP 69.50/0.945 vs
+            # offense 48.44/1.149) and is no longer: re-fitting both
+            # against our own board gave 64.6/0.900 and 65.4/0.910, which
+            # cross over.  The direction was never the property worth
+            # pinning — ``canonicalConsensusRank`` is a single global
+            # ordinal, so the two scopes lie on one relation and any
+            # ordering between them at a given rank is a coincidence of
+            # the fit.  See docs/legacy-rank-curve-backtest.md.
+            self.assertEqual(off_val, rank_to_value_for_scope(50, "offense"))
+            self.assertEqual(idp_val, rank_to_value_for_scope(50, "idp"))
+            self.assertNotEqual(off_val, idp_val)
 
     def test_corrupt_line_is_skipped(self) -> None:
         # A half-written final line must not break the reader.  We

--- a/tests/api/test_signal_engine_parity.py
+++ b/tests/api/test_signal_engine_parity.py
@@ -106,7 +106,9 @@ class TestSignalParityFixtureIntegrity(unittest.TestCase):
     def test_fixture_exists_and_is_non_trivial(self) -> None:
         self.assertTrue(FIXTURE_PATH.is_file(), f"missing fixture {FIXTURE_PATH}")
         self.assertGreaterEqual(len(FIXTURE["cases"]), 40)
-        self.assertEqual(len(FIXTURE["rules"]), 10)
+        # 10 until 2026-07-30, when ``low_conf_unstable`` was retired
+        # (see tests/api/test_market_confidence_wiring.py for why).
+        self.assertEqual(len(FIXTURE["rules"]), 9)
 
     def test_case_ids_are_unique(self) -> None:
         ids = [c["id"] for c in FIXTURE["cases"]]

--- a/tests/canonical/test_player_valuation.py
+++ b/tests/canonical/test_player_valuation.py
@@ -121,21 +121,27 @@ class TestBaseValueCurve:
         assert rank_to_value(1) == 9999
 
     def test_correct_spot_values(self):
-        # Hill curve fit to the simple mean of KTC / IDPTradeCalc /
-        # DynastyDaddy / DynastyNerds. Re-run
-        # ``scripts/fit_hill_curve_from_market.py`` to refresh the
-        # constants and update these expected values together.
+        # Re-baselined 2026-07-30 for the re-tuned rank-form constants
+        # (HILL_MIDPOINT 48.44 -> 65.4, HILL_SLOPE 1.149 -> 0.910).
+        #
+        # The previous baseline came from fitting retail SOURCE boards via
+        # ``scripts/fit_hill_curve_from_market.py``.  These constants exist
+        # to reconstruct OUR board from a rank, so they are now fit to
+        # ``rankDerivedValue`` by ``scripts/backtest_legacy_rank_curve.py``.
+        # If they change again, regenerate this dict from the constants
+        # rather than hand-editing it, and re-run the drift check
+        # (``scripts/check_rank_form_drift.py``).
         expected = {
             1: 9999,
-            2: 9885,
-            3: 9749,
-            5: 9460,
-            10: 8736,
-            25: 6914,
-            50: 4967,
-            100: 3055,
-            200: 1648,
-            500: 643,
+            2: 9781,
+            3: 9597,
+            5: 9270,
+            10: 8587,
+            25: 7134,
+            50: 5653,
+            100: 4068,
+            200: 2665,
+            500: 1360,
         }
         for rank, val in expected.items():
             assert (

--- a/tests/canonical/test_rank_form_constants_tripwire.py
+++ b/tests/canonical/test_rank_form_constants_tripwire.py
@@ -50,27 +50,41 @@ from src.canonical.player_valuation import (
     IDP_HILL_SLOPE,
 )
 
-# The values live in ``src/canonical/player_valuation.py``.  Measured
-# fit against the live board on 2026-07-29
-# (``scripts/backtest_legacy_rank_curve.py``): the offense pair scores
-# RMSE 845.9 on offense rows, the IDP pair RMSE 78.7 on IDP rows, and a
-# curve refit to that board would score 96.3 overall.  Those numbers are
-# the context for any change here.
+# The values live in ``src/canonical/player_valuation.py``.
+#
+# RE-BASELINED 2026-07-30.  The previous pins (48.44 / 1.149 and
+# 69.50 / 0.945) were fit against retail SOURCE boards, which is the
+# wrong target for a curve whose job is reconstructing OUR board: they
+# scored RMSE 821.8 on offense rows against ``rankDerivedValue``.  The
+# values below are the per-scope fit to the served board
+# (``scripts/backtest_legacy_rank_curve.py``) and score 89.8 offense /
+# 76.2 IDP, which IS the achievable floor for this curve family (83.8
+# overall vs 83.4 for a free fit).
+#
+# They are structurally stable: 16 archived snapshots spanning
+# 2026-07-16 -> 07-30 returned offense midpoint 65.4 (once 65.6) /
+# slope 0.910 and IDP 64.4-64.6 / 0.900.  Market churn does not move
+# them, because the board's rank->value relation IS a Hill curve and
+# churn only permutes which player sits at which rank.  A
+# percentile-master promotion DOES move them — that is what
+# ``scripts/check_rank_form_drift.py`` watches.
 _PINNED = {
-    "HILL_MIDPOINT": 48.44,
-    "HILL_SLOPE": 1.149,
-    "IDP_HILL_MIDPOINT": 69.50,
-    "IDP_HILL_SLOPE": 0.945,
+    "HILL_MIDPOINT": 65.4,
+    "HILL_SLOPE": 0.910,
+    "IDP_HILL_MIDPOINT": 64.6,
+    "IDP_HILL_SLOPE": 0.900,
 }
 
 _GUIDANCE = """
 The legacy rank-form Hill constants changed.
 
-If that was DELIBERATE, do these two things and then update _PINNED in
+If that was DELIBERATE, do these three things and then update _PINNED in
 this file:
 
   1. Re-run the drift check, which is the whole reason this tripwire
      exists:
+         python scripts/check_rank_form_drift.py --verbose
+     and the full comparison behind it:
          python scripts/backtest_legacy_rank_curve.py \\
              --out docs/measurements/<dated>.json
      Compare against docs/legacy-rank-curve-backtest.md.  These
@@ -78,14 +92,18 @@ this file:
      and rank_history.py's historical backfill), so a change moves
      user-visible history values.
 
-  2. Record the decision in docs/legacy-rank-curve-backtest.md, which
-     carries the open question of whether this whole rank-form family
-     should be retired in favour of the registry-managed percentile
-     masters.
+  2. Update the mirrored constants in
+     frontend/lib/value-history.js (RANK_FORM_CURVE).  They must move
+     together or the team-value chart and the derived rank-history line
+     go out of calibration with the backend.
+     tests/api/test_rank_form_frontend_parity.py fails if they diverge.
+
+  3. Record the decision in docs/legacy-rank-curve-backtest.md.
 
 If it was NOT deliberate: revert it.  Nothing automated writes these —
-``scripts/fit_hill_curve_from_market.py`` only prints — so an unexplained
-change here is a hand edit.
+``scripts/fit_hill_curve_from_market.py`` only prints, and
+``check_rank_form_drift.py`` opens an issue rather than committing — so
+an unexplained change here is a hand edit.
 """
 
 

--- a/tests/canonical/test_rank_form_drift_check.py
+++ b/tests/canonical/test_rank_form_drift_check.py
@@ -1,0 +1,142 @@
+"""Unit tests for the rank-form drift checker.
+
+``scripts/check_rank_form_drift.py`` is the automation the 2026-07-30
+re-tune added, and it has the same problem every alarm has: an alarm that
+cannot fire is indistinguishable from a healthy system.  The old offense
+pair sat at RMSE 821.7 against a floor of 89.8 for months with nothing
+complaining, so "the checker reports ok" is not evidence of anything
+until the checker is shown to also report drift.
+
+These tests run on synthetic rows — no live payload, no network — so they
+are a hard CI gate rather than ``livedata`` advisory.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.canonical.player_valuation import (  # noqa: E402
+    HILL_MIDPOINT,
+    HILL_SLOPE,
+    IDP_HILL_MIDPOINT,
+    IDP_HILL_SLOPE,
+    rank_to_value,
+)
+
+
+def _load(name: str) -> object:
+    path = REPO_ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+CHECK = _load("check_rank_form_drift")
+BACKTEST = _load("backtest_legacy_rank_curve")
+
+
+def _rows_on_curve(midpoint: float, slope: float, scope: str, n: int = 120) -> list[dict]:
+    """Synthetic rows lying exactly on a given rank-form curve."""
+    return [
+        {
+            "name": f"p{rank}",
+            "rank": float(rank),
+            "value": float(rank_to_value(rank, midpoint=midpoint, slope=slope)),
+            "scope": scope,
+        }
+        for rank in range(1, n + 1)
+    ]
+
+
+class TestRmse(unittest.TestCase):
+    def test_zero_on_the_generating_curve(self) -> None:
+        rows = _rows_on_curve(65.4, 0.91, "offense")
+        # Rounding to integers in ``rank_to_value`` leaves sub-1.0 noise.
+        self.assertLess(CHECK._rmse(rows, 65.4, 0.91), 1.0)
+
+    def test_large_when_the_curve_is_wrong(self) -> None:
+        rows = _rows_on_curve(65.4, 0.91, "offense")
+        self.assertGreater(CHECK._rmse(rows, 48.44, 1.149), 100.0)
+
+    def test_matches_the_production_formula(self) -> None:
+        """The checker reimplements the Hill arithmetic (it evaluates in
+        bulk).  If that copy diverges from ``rank_to_value``, every number
+        it reports is measured against the wrong curve."""
+        for rank in (1, 2, 5, 25, 100, 400):
+            row = [{"rank": float(rank), "value": float(rank_to_value(rank))}]
+            # Committed constants -> the residual is pure rounding.
+            self.assertLess(CHECK._rmse(row, HILL_MIDPOINT, HILL_SLOPE), 1.0, msg=f"rank {rank}")
+
+
+class TestCommittedMapping(unittest.TestCase):
+    def test_maps_to_the_real_constants(self) -> None:
+        """A rename in ``player_valuation.py`` must not silently orphan a
+        scope here — the checker would then report ``ok`` forever."""
+        self.assertEqual(
+            CHECK._COMMITTED["offense"][1],
+            (HILL_MIDPOINT, HILL_SLOPE),
+        )
+        self.assertEqual(
+            CHECK._COMMITTED["idp"][1],
+            (IDP_HILL_MIDPOINT, IDP_HILL_SLOPE),
+        )
+
+    def test_names_match_the_values(self) -> None:
+        import src.canonical.player_valuation as pv
+
+        for _scope, (names, values) in CHECK._COMMITTED.items():
+            for name, value in zip(names, values):
+                self.assertEqual(getattr(pv, name), value, msg=name)
+
+    def test_picks_are_not_gated(self) -> None:
+        """``rank_to_value_for_scope`` routes picks to the offense curve on
+        purpose, so a pick-only fit is diagnostic and must not raise an
+        alarm of its own."""
+        self.assertNotIn("pick", CHECK._COMMITTED)
+
+
+class TestTheAlarmCanFire(unittest.TestCase):
+    """The point of the file: drift is detected, and only real drift is."""
+
+    def _excess(self, rows: list[dict], committed: tuple[float, float]) -> float:
+        fit = BACKTEST._fit_rank_form_per_scope(rows)[rows[0]["scope"]]
+        return CHECK._rmse(rows, *committed) - CHECK._rmse(rows, fit["midpoint"], fit["slope"])
+
+    def test_committed_constants_score_near_zero_excess_on_their_own_curve(self) -> None:
+        rows = _rows_on_curve(HILL_MIDPOINT, HILL_SLOPE, "offense")
+        self.assertLess(self._excess(rows, (HILL_MIDPOINT, HILL_SLOPE)), CHECK.DEFAULT_THRESHOLD)
+
+    def test_the_pre_retune_offense_pair_would_have_fired(self) -> None:
+        """The regression this automation exists to catch. On the real
+        board the old pair scored +731.9 excess RMSE; on a synthetic board
+        generated from the current curve it must also blow the budget."""
+        rows = _rows_on_curve(HILL_MIDPOINT, HILL_SLOPE, "offense")
+        self.assertGreater(self._excess(rows, (48.44, 1.149)), CHECK.DEFAULT_THRESHOLD)
+
+    def test_a_percentile_master_promotion_sized_move_fires(self) -> None:
+        """The real drift SOURCE, measured: the 2026-07-29 board refit to
+        68.8/0.929 and the post-promotion board to 65.2/0.905. A shift of
+        that size must not slip under the threshold, or the alarm is
+        decorative."""
+        rows = _rows_on_curve(65.2, 0.905, "offense")
+        self.assertGreater(self._excess(rows, (68.8, 0.929)), CHECK.DEFAULT_THRESHOLD)
+
+    def test_the_idp_pair_is_checked_independently(self) -> None:
+        rows = _rows_on_curve(IDP_HILL_MIDPOINT, IDP_HILL_SLOPE, "idp")
+        self.assertLess(
+            self._excess(rows, (IDP_HILL_MIDPOINT, IDP_HILL_SLOPE)), CHECK.DEFAULT_THRESHOLD
+        )
+        self.assertGreater(self._excess(rows, (48.44, 1.149)), CHECK.DEFAULT_THRESHOLD)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/fixtures/signal_parity_cases.json
+++ b/tests/fixtures/signal_parity_cases.json
@@ -38,11 +38,6 @@
       "signal": "MONITOR"
     },
     {
-      "tag": "low_conf_unstable",
-      "priority": 60,
-      "signal": "MONITOR"
-    },
-    {
       "tag": "elite_stable",
       "priority": 50,
       "signal": "STRONG_HOLD"
@@ -636,7 +631,7 @@
     },
     {
       "id": "r7_conf_just_below_threshold",
-      "why": "confidence 0.34 with medium volatility.",
+      "why": "RETIRED RULE \u2014 low_conf_unstable was removed 2026-07-30 (marketConfidence is structurally capped at 0.59375, so the 0.35 threshold could not be calibrated). This case is kept inverted: the inputs that USED to fire it must now fire nothing, in both engines. Original: confidence 0.34 with medium volatility.",
       "ctx": {
         "name": "Parity Player",
         "pos": "RB",
@@ -656,16 +651,14 @@
         "newsCount": 0
       },
       "expected": {
-        "signal": "MONITOR",
-        "tag": "low_conf_unstable",
-        "firedTags": [
-          "low_conf_unstable"
-        ]
+        "signal": "HOLD",
+        "tag": "default_hold",
+        "firedTags": []
       }
     },
     {
       "id": "r7_conf_zero_is_not_missing",
-      "why": "confidence 0.0 is a measurement, not an absence \u2014 both engines must null-check explicitly rather than testing truthiness.",
+      "why": "RETIRED RULE \u2014 low_conf_unstable was removed 2026-07-30 (marketConfidence is structurally capped at 0.59375, so the 0.35 threshold could not be calibrated). This case is kept inverted: the inputs that USED to fire it must now fire nothing, in both engines. Original: confidence 0.0 is a measurement, not an absence \u2014 both engines must null-check explicitly rather than testing truthiness.",
       "ctx": {
         "name": "Parity Player",
         "pos": "RB",
@@ -685,16 +678,14 @@
         "newsCount": 0
       },
       "expected": {
-        "signal": "MONITOR",
-        "tag": "low_conf_unstable",
-        "firedTags": [
-          "low_conf_unstable"
-        ]
+        "signal": "HOLD",
+        "tag": "default_hold",
+        "firedTags": []
       }
     },
     {
       "id": "r7_conf_null_never_fires",
-      "why": "No confidence measurement must never produce a confidence verdict.",
+      "why": "Absent confidence produced no verdict even while the rule was live; it still must not, now that no rule reads confidence at all.",
       "ctx": {
         "name": "Parity Player",
         "pos": "RB",
@@ -721,7 +712,7 @@
     },
     {
       "id": "r7_trend7_abs_at_2_positive",
-      "why": "|trend7| exactly 2 on the rise satisfies the movement clause.",
+      "why": "RETIRED RULE \u2014 low_conf_unstable was removed 2026-07-30 (marketConfidence is structurally capped at 0.59375, so the 0.35 threshold could not be calibrated). This case is kept inverted: the inputs that USED to fire it must now fire nothing, in both engines. Original: |trend7| exactly 2 on the rise satisfies the movement clause.",
       "ctx": {
         "name": "Parity Player",
         "pos": "RB",
@@ -741,16 +732,14 @@
         "newsCount": 0
       },
       "expected": {
-        "signal": "MONITOR",
-        "tag": "low_conf_unstable",
-        "firedTags": [
-          "low_conf_unstable"
-        ]
+        "signal": "HOLD",
+        "tag": "default_hold",
+        "firedTags": []
       }
     },
     {
       "id": "r7_trend7_abs_at_2_negative",
-      "why": "|trend7| exactly 2 on the fall satisfies it too.",
+      "why": "RETIRED RULE \u2014 low_conf_unstable was removed 2026-07-30 (marketConfidence is structurally capped at 0.59375, so the 0.35 threshold could not be calibrated). This case is kept inverted: the inputs that USED to fire it must now fire nothing, in both engines. Original: |trend7| exactly 2 on the fall satisfies it too.",
       "ctx": {
         "name": "Parity Player",
         "pos": "RB",
@@ -770,11 +759,9 @@
         "newsCount": 0
       },
       "expected": {
-        "signal": "MONITOR",
-        "tag": "low_conf_unstable",
-        "firedTags": [
-          "low_conf_unstable"
-        ]
+        "signal": "HOLD",
+        "tag": "default_hold",
+        "firedTags": []
       }
     },
     {
@@ -1285,7 +1272,7 @@
     },
     {
       "id": "stack_all_bearish_rules",
-      "why": "Seven rules fire at once; the 100-priority RISK rule owns the verdict and the whole chain must come back in priority order.",
+      "why": "Six rules fire at once; the 100-priority RISK rule owns the verdict and the whole chain must come back in priority order.",
       "ctx": {
         "name": "Parity Player",
         "pos": "RB",
@@ -1313,8 +1300,7 @@
           "sustained_downtrend",
           "neg_news_high_vol",
           "alert_present",
-          "high_vol",
-          "low_conf_unstable"
+          "high_vol"
         ]
       }
     },
@@ -1351,30 +1337,30 @@
     },
     {
       "id": "stack_monitor_outranks_strong_hold",
-      "why": "MONITOR (60) beats STRONG_HOLD (50).",
+      "why": "MONITOR (65, alert_present) beats STRONG_HOLD (50). Rebuilt 2026-07-30 off alert_present: this case used to ride the retired low_conf_unstable rule, and high_vol cannot stand in because elite_stable requires low/med volatility.",
       "ctx": {
         "name": "Parity Player",
         "pos": "RB",
         "value": 9000,
         "rank": 50,
         "rankChange": null,
-        "confidence": 0.1,
         "trend7": 0,
         "trend30": 2,
         "volatility": {
           "mad": 3.0,
           "label": "med"
         },
-        "alertCount": 0,
+        "alertCount": 1,
         "negativeImpactCount": 0,
         "positiveImpactCount": 0,
-        "newsCount": 0
+        "newsCount": 1,
+        "confidence": null
       },
       "expected": {
         "signal": "MONITOR",
-        "tag": "low_conf_unstable",
+        "tag": "alert_present",
         "firedTags": [
-          "low_conf_unstable",
+          "alert_present",
           "elite_stable"
         ]
       }


### PR DESCRIPTION
Closes the last two open items from the 2026-07-29 audit round. Both were "needs a decision" items; both are now decided on measurement.

## 1. `low_conf_unstable` is retired

The rule fired on `marketConfidence < 0.35` plus recent movement. The 2026-07-29 round fixed three plumbing defects that had it dead server-side and misfiring on both frontend paths. With the plumbing correct, the **metric** turned out to be the defect.

**Why `_sites` maxes at 3** (the question left open last round): it is not a registry-coverage count. The scraper's composite loop builds `wNorms` from its own per-player dash keys, and `SITES` has exactly two entries enabled — `KTC` and `IDPTradeCalc`, the other ten `False` and labelled *"disabled in scope reduction"*. Those two emit three numeric dash keys between them (`ktc` 590 players, `ktcSfTep` 464, `idpTradeCalc` 898). The other 18 registered sources are fetched by `scripts/fetch_*.py` and merged downstream in `data_contract.py`, which never recomputes `_sites`.

**Why no threshold works:** `site_score = clamp(site_count / 8.0, …)` carries 65% of the weight, so confidence is structurally capped at 0.59375 — exactly the observed live maximum. Live spread is p10 0.480 / median 0.491 / p90 0.564, one row of 1094 under 0.35. Every candidate divisor pushes the population *up*, away from the threshold: **zero players below 0.35 at divisors 3, 4 and 5**. MONITOR is in `ACTIONABLE_SIGNALS`, so the rule gated email on a gauge whose range is an artifact of how many scrapers happen to be enabled.

Removed from `terminal.py::_evaluate_signal`, `frontend/lib/signal-engine.js`, and the shared parity fixture's rule registry. The four fixture cases built on it are kept and **inverted** — inputs that used to fire it must now fire nothing, in both engines. `TestTheRuleIsRetired` sweeps every rule across 72 (confidence, trend7, volatility) combinations asserting no verdict changes with confidence, so a reinstatement under a different tag fails a test.

The confidence number survives as a diagnostic on both signal contexts. The 8.0 divisor is deliberately not changed — it never touches `rankDerivedValue`, and its one live reader of raw `_finalAdjusted` is `finder.py`'s degraded fallback path. Measured multiplier shifts per divisor are recorded for whoever next touches the scraper (new debt item D15).

## 2. The rank-form Hill curves are re-tuned, kept, and alarmed

|  | was | now | offense RMSE | IDP RMSE |
|---|---|---|---|---|
| `HILL_MIDPOINT` / `HILL_SLOPE` | 48.44 / 1.149 | **65.4 / 0.910** | 821.8 → **89.8** | |
| `IDP_HILL_MIDPOINT` / `IDP_HILL_SLOPE` | 69.50 / 0.945 | **64.6 / 0.900** | | 89.5 → **76.2** |

These reconstruct a value from a rank for `terminal.py`'s value fallback, `rank_history.py`'s historical backfill, and the frontend team-value / derived-rank charts. Nothing fails when they drift — a reconstruction returning a wrong-but-plausible number renders a perfectly normal chart. That is how the offense pair sat at a ~9× error on every reconstructed offense value without complaint.

**The old constants were fit to the wrong target.** `fit_hill_curve_from_market.py` fits retail *source* boards ("what shape does KTC publish"). These have to answer "what does *our* board pay at rank r" — the output of the whole pipeline after blending, TE basis conversion, shrinkage, the single-source haircut, the corridor clamp and pick tethering. 821.8 RMSE is the size of that difference.

83.8 overall against an achievable floor of 83.4: **no headroom left in this curve family.** The residual is post-blend scatter, since pick tethering, the two-way boost and the corridor clamp move individual rows off any smooth curve.

**Migration to the percentile masters is off the table.** Last round said the choice was hard because the error profiles were inverted. On the current board the percentile candidates are 5–8× worse *everywhere* (410 and 692 vs 83.8), and the reason is structural: the masters are an **input stage** to the blend, not a model of its output.

**The offense/IDP split is weaker than its comment claimed.** `canonicalConsensusRank` is a single *global* ordinal, so all three scopes lie on one rank→value relation by construction. Fitting per scope buys 84.0 → 83.4 (0.7%) and the two pairs nearly coincide. The old IDP pair scored well on IDP rows largely by luck — it sat near the global optimum while the offense pair did not. The split is kept (`rank_history` already routes by scope) but documented as *not* evidence of two economies.

### A third copy existed, wrong on all three values

`frontend/lib/value-history.js` still read `K = 45, EXP = 1.1, CEIL = 9999`, behind a comment that flagged the drift risk and deferred the fix to a follow-up that never came. The backend pair was 48.44/1.149 at the time, and `1 + 9999/(…)` puts rank 1 at **10000** rather than 9999 — off on both axes. Now a single `RANK_FORM_CURVE` object, pinned by a new parity test that also reimplements the JS arithmetic across twelve ranks, so a divergence in the *formula* fails too.

### Drift automation

`scripts/check_rank_form_drift.py` + `.github/workflows/audit-rank-form-drift.yml` (Tue 07:41 UTC, after `refit-hill-curves.yml` at 06:17).

Metric is **excess RMSE over the per-scope refit optimum**, budget 25.0 — not parameter delta, since parameters are partially redundant and a small move near a steep optimum matters more than a large one on a plateau. Calibration on real data: new pairs +0.0, old IDP pair +13.3 (ok — near the optimum by luck), old offense pair **+731.9** (drift).

**It opens an issue, not a PR, deliberately.** ADR-008's sharpest finding is that the old auto-refit path was green *by construction* because it rewrote the very test that guarded it. An automated patch that fixed `player_valuation.py` and also re-baselined the tripwire would rebuild that circularity exactly. So the script computes the constants and names the three files to edit; a human applies them, the tripwire fails, and updating the pins is the deliberate recorded act. `tests/canonical/test_rank_form_drift_check.py` proves the alarm fires — an alarm that cannot fire reads identically to a healthy system.

**What actually moves these constants:** not market churn. 16 archived snapshots spanning 2026-07-16 → 07-30 all refit to the same values, because the board's rank→value relation *is* a Hill curve, so churn only permutes which player sits at which rank. What moves them is a percentile-master promotion — the 2026-07-29 pre-promotion board refit to 68.8/0.929, the post-promotion board to 65.2/0.905. Hence the cadence.

## Test changes that are behaviour changes, called out

- `test_rank_history.py`'s back-fill test asserted `idp_val > off_val` at rank 50. The curves now cross over. The direction was never the property worth pinning; it now asserts scope **gating** (each value equals `rank_to_value_for_scope`, and the two differ).
- Spot values in `test_player_valuation.py` and `_PINNED` in the tripwire re-baselined.
- Parity rule counts 10 → 9 in both engines' fixture-integrity tests.

## Found, not fixed

`tests/canonical/test_ktc_reconciliation.py` has **9 cases failing on `main`** — confirmed at a clean HEAD, so it predates this work. Its `PINNED_DELTAS` were baselined against percentile constants that have since been promoted, and `conftest.py` auto-marks the module `livedata` so CI runs it `continue-on-error` and the staleness is invisible. Registered as debt item D16; re-baselining is a percentile-master decision, not a rank-form one.

Also fixed a real bug found while sweeping snapshots: `backtest_legacy_rank_curve.py` crashed on a `--payload` outside the repo (`relative_to`), which blocked the stability measurement.

## Verification

| gate | result |
|---|---|
| `pytest -m "not livedata"` | **5264 passed**, 319 deselected, 108 subtests |
| `vitest` | **1526 passed** (89 files) |
| `ruff format --check .` | 718 files already formatted |
| `ruff check` (changed files) | clean |
| drift check on the live board | `ok`, +0.0 excess both scopes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RXRPXt7MhjKTgq5V8GuqZ

---
_Generated by [Claude Code](https://claude.ai/code/session_018RXRPXt7MhjKTgq5V8GuqZ)_