### PR TITLE
Fix the silently-stale percentile-constant guard (D16)

### DIFF
--- a/docs/audits/complete-codebase-audit-2026-07-29.md
+++ b/docs/audits/complete-codebase-audit-2026-07-29.md
@@ -368,7 +368,49 @@ corrected instead.
 | D13 | ~205 pytest cases are `livedata`-advisory (`continue-on-error`) | Medium | Includes the primary blend test | Small | Re-litigate per module |
 | D14 | ADR numbers collide across two DECISIONS files (two ADR-008s) | Low | Ambiguous citations | Small | No |
 | D15 | `_sites` / `_marketConfidence` divisor is 8.0, a fossil of the pre-scope-reduction ~10-site scraper era; confidence is structurally capped at 0.594 | Low | No board impact (`market_conf` only multiplies the scraper composite, never `rankDerivedValue`); reaches live code only via `finder.py`'s degraded fallback | Small | Fix when the scraper is next touched — measured multipliers in `docs/open-modeling-decisions.md` §3 |
-| D16 | `tests/canonical/test_ktc_reconciliation.py`: 9 cases failing on `main`, invisible because the module is auto-marked `livedata` | Medium | A guard that was supposed to catch curve drift is stale and silent — `PINNED_DELTAS` were baselined against since-promoted percentile constants | Small | Re-baseline as part of the next percentile-master promotion; promotion currently re-baselines nothing |
+| D16 | `tests/canonical/test_ktc_reconciliation.py`: 10 cases failing on `main`, invisible because the module is auto-marked `livedata` | Medium | A guard that was supposed to catch curve drift is stale and silent — `PINNED_DELTAS` were baselined against since-promoted percentile constants | Small | **FIXED 2026-07-30** — see below |
+
+### D16 — fixed 2026-07-30
+
+Two problems, and only one of them was the stale numbers.
+
+**The pins were re-baselined.** All 10 cases were failing (not 9 — the
+first count came from a partial run; rank 1 fails only on the band, which
+happened to be in tolerance). Nine failed the exact `ours == pinned_ours`
+pin because `HILL_PERCENTILE_C/S` were promoted after the 2026-04-20
+baseline; ranks 24 and 50 also failed the divergence band.
+
+**The structural problem was that nothing could ever have caught it.**
+`scripts/model_registry.py apply` rewrites the constants and stops —
+deliberately, because ADR-008 prohibits the refit path from rewriting its
+own guards. But that leaves every downstream expectation to go stale
+silently, and this one is `livedata`-marked, so CI runs it
+`continue-on-error`. A guard that quietly rots after every promotion is
+not much better than one rewritten by the thing it guards.
+
+The marking is *correct* and pinned in place by
+`test_refit_path_characterisation.py::TestTheLivedataMarkingIsPreserved`
+(a KTC row-count dip once stalled every open PR), and that test also
+requires the module keep both its assertions. So the fix could not be a
+restructure of that file. Instead:
+
+`tests/canonical/test_hill_percentile_constants_tripwire.py` — a
+deterministic, **non-`livedata`, blocking** tripwire on the eight
+percentile constants, mirroring the rank-form tripwire. Four tests:
+
+- pins the eight constants; a promotion fails here, loudly, in the hard
+  tier, with a four-step follow-up checklist in the message
+- pins what the OFFENSE master *produces* at ten ranks — catches a
+  formula or `_PERCENTILE_REFERENCE_N` change the constants would miss
+- asserts the registry's **regex** reader (`hill_masters.read_committed_constants`,
+  the same path `apply` writes through) agrees with the values Python
+  imports. Nothing else checked that; a divergence would have the registry
+  promoting numbers the engine does not use
+- **cross-checks `PINNED_DELTAS` against these values**, so the advisory
+  guard's staleness is detectable from the blocking tier. Mutation-tested:
+  reverting one pin fails this test
+
+Net effect: the next promotion cannot silently stale either guard.
 
 ### D2 was wrong — recorded so it is not re-raised
 
@@ -623,11 +665,13 @@ pipeline.
    write-up: `docs/legacy-rank-curve-backtest.md` 2026-07-30 addendum.
 
    Uncovered while doing it: `tests/canonical/test_ktc_reconciliation.py`
-   has **9 cases failing on `main`** — its `PINNED_DELTAS` were baselined
+   had **10 cases failing on `main`** — its `PINNED_DELTAS` were baselined
    against percentile constants that have since been promoted, and it is
    auto-marked `livedata` so CI never blocks on it. Confirmed at a clean
-   HEAD, so it predates this work. Registered as debt (D16 below);
-   re-baselining it is a percentile-master decision, not a rank-form one.
+   HEAD, so it predated this work. Registered as D16 and **fixed
+   2026-07-30** (see the D16 note in §8): pins re-baselined, plus a new
+   deterministic blocking tripwire on the percentile constants so the next
+   promotion cannot silently stale either guard.
 7. **BDVM end-to-end validation** once a projection snapshot exists.
 
 **Medium priority**

--- a/tests/canonical/test_hill_percentile_constants_tripwire.py
+++ b/tests/canonical/test_hill_percentile_constants_tripwire.py
@@ -1,0 +1,230 @@
+"""Tripwire on the eight percentile-form master Hill constants.
+
+2026-07-30, audit debt D16.
+
+WHY THIS IS NEEDED WHEN THE MODEL REGISTRY ALREADY EXISTS
+=========================================================
+The registry governs how a challenger BECOMES a champion: fit → score
+against held-out boards → record → a human runs
+``scripts/model_registry.py promote`` + ``apply``.  That machinery is
+sound and ADR-008 (``docs/roster-trade-intelligence/DECISIONS.md``) is
+why it exists.
+
+What it does not do is tell anyone what ELSE has to move when the
+constants change.  ``apply`` rewrites
+``src/canonical/player_valuation.py`` and stops.  Deliberately — the
+whole point of ADR-008 is that the refit path must not rewrite its own
+guards.  But the consequence is that every downstream expectation goes
+stale silently, and one of them did:
+
+``tests/canonical/test_ktc_reconciliation.py`` — the only test that
+pinned what these constants produce — had **all 10 of its cases failing
+on `main`** as of 2026-07-30.  Its pins were baselined 2026-04-20;
+``HILL_PERCENTILE_C/S`` were promoted since.  Nobody saw it because
+``tests/conftest.py`` auto-marks that module ``livedata``, so CI runs it
+``continue-on-error``.
+
+So the guard existed, was failing, and was invisible.  That is ADR-008's
+third failure mode ("the guard is not even run") returning by a different
+route: the old refit made the guard unfalsifiable by rewriting it, and
+removing that rewrite left it merely unmaintained.
+
+WHY A SEPARATE MODULE RATHER THAN FIXING THAT ONE
+=================================================
+Two constraints, both already pinned by
+``tests/model_registry/test_refit_path_characterisation.py``:
+
+* ``test_ktc_reconciliation.py`` must STAY ``livedata``-marked
+  (``TestTheLivedataMarkingIsPreserved``).  Un-marking it re-introduces
+  the PR-stalling failures the marking was added to prevent — a KTC
+  row-count dip once blocked every open PR.
+* It must keep both of its assertions
+  (``test_the_guard_still_has_real_assertions_to_make``).
+
+Both are right.  A test that reads ``CSVs/site_raw/ktc.csv`` cannot be a
+blocking gate, so drift in these constants was always going to be
+invisible in the hard tier without a check that reads no live data at
+all.  This is that check: deterministic, hard-gating, and it names the
+other places to update when it fires.
+
+Same shape as ``test_rank_form_constants_tripwire.py`` — deliberately a
+dumb equality assertion.  Every other test imports these symbolically
+(right, so a legitimate promotion does not break them) and that is
+exactly why none of them notices a change.
+"""
+
+from __future__ import annotations
+
+from src.canonical.player_valuation import (
+    HILL_GLOBAL_PERCENTILE_C,
+    HILL_GLOBAL_PERCENTILE_S,
+    HILL_PERCENTILE_C,
+    HILL_PERCENTILE_S,
+    HILL_ROOKIE_PERCENTILE_C,
+    HILL_ROOKIE_PERCENTILE_S,
+    IDP_HILL_PERCENTILE_C,
+    IDP_HILL_PERCENTILE_S,
+    percentile_to_value,
+)
+
+# Promoted values as of 2026-07-30.  These are the LIVE board's step-3
+# curve constants — the single most load-bearing numbers in the repo.
+_PINNED = {
+    "HILL_GLOBAL_PERCENTILE_C": 0.1120,
+    "HILL_GLOBAL_PERCENTILE_S": 0.725,
+    "HILL_PERCENTILE_C": 0.1100,
+    "HILL_PERCENTILE_S": 1.110,
+    "IDP_HILL_PERCENTILE_C": 0.0830,
+    "IDP_HILL_PERCENTILE_S": 1.110,
+    "HILL_ROOKIE_PERCENTILE_C": 0.1530,
+    "HILL_ROOKIE_PERCENTILE_S": 0.885,
+}
+
+# What the OFFENSE master produces at key ranks, at the live reference N.
+# Pinned separately from the constants because this is the number users
+# actually see, and because it catches a change to the FORMULA or to
+# ``_PERCENTILE_REFERENCE_N`` that leaves the constants untouched.
+_PINNED_OFFENSE_VALUES = {
+    1: 9999,
+    5: 9481,
+    12: 8561,
+    24: 7242,
+    50: 5314,
+    100: 3419,
+    150: 2481,
+    200: 1931,
+    300: 1322,
+    400: 996,
+}
+
+_GUIDANCE = """
+The percentile-form master Hill constants changed.
+
+If this is a PROMOTION (scripts/model_registry.py promote + apply), it is
+expected — and there are FOUR follow-ups, which is the whole reason this
+tripwire exists.  ``apply`` does none of them, by design: ADR-008
+prohibits the refit path from rewriting its own guards.
+
+  1. Update _PINNED and _PINNED_OFFENSE_VALUES in this file.
+
+  2. Re-baseline PINNED_DELTAS in
+     tests/canonical/test_ktc_reconciliation.py.  Both columns move: the
+     exact ``ours`` value AND the pct-diff band centre.  That file is
+     livedata-marked so it will NOT fail your PR — it will just go
+     quietly stale, which is precisely what happened between 2026-04-20
+     and 2026-07-30 (all 10 cases red on main, unnoticed).
+
+  3. Re-run the rank-form drift check.  A promotion reshapes the board's
+     rank->value relation, so the reconstruction curves go stale too:
+         python scripts/check_rank_form_drift.py --verbose
+     Measured precedent: the 2026-07-29 pre-promotion board refit to
+     68.8/0.929, the post-promotion board to 65.2/0.905.  If it reports
+     drift, follow its output (and remember the frontend mirror in
+     frontend/lib/value-history.js).
+
+  4. Record the promotion in config/model_registry/ if the registry CLI
+     did not already.
+
+If this is NOT a promotion: revert it.  These constants determine every
+displayed value on the board, and nothing should be hand-editing them —
+the refit driver cannot write files (pinned by
+tests/model_registry/test_refit_path_characterisation.py).
+"""
+
+
+def test_percentile_constants_are_unchanged():
+    actual = {
+        "HILL_GLOBAL_PERCENTILE_C": HILL_GLOBAL_PERCENTILE_C,
+        "HILL_GLOBAL_PERCENTILE_S": HILL_GLOBAL_PERCENTILE_S,
+        "HILL_PERCENTILE_C": HILL_PERCENTILE_C,
+        "HILL_PERCENTILE_S": HILL_PERCENTILE_S,
+        "IDP_HILL_PERCENTILE_C": IDP_HILL_PERCENTILE_C,
+        "IDP_HILL_PERCENTILE_S": IDP_HILL_PERCENTILE_S,
+        "HILL_ROOKIE_PERCENTILE_C": HILL_ROOKIE_PERCENTILE_C,
+        "HILL_ROOKIE_PERCENTILE_S": HILL_ROOKIE_PERCENTILE_S,
+    }
+    drifted = {k: (v, actual[k]) for k, v in _PINNED.items() if actual[k] != v}
+    assert not drifted, f"{_GUIDANCE}\nChanged (pinned -> actual): " + ", ".join(
+        f"{k}: {was} -> {now}" for k, (was, now) in sorted(drifted.items())
+    )
+
+
+def test_the_offense_curve_still_produces_the_pinned_values():
+    """Catches a formula or reference-N change the constants would miss."""
+    from src.api.data_contract import _PERCENTILE_REFERENCE_N
+
+    denom = max(1, _PERCENTILE_REFERENCE_N - 1)
+    drifted = []
+    for rank, expected in _PINNED_OFFENSE_VALUES.items():
+        actual = int(percentile_to_value((rank - 1) / denom))
+        if actual != expected:
+            drifted.append(f"rank {rank}: {expected} -> {actual}")
+    assert not drifted, f"{_GUIDANCE}\nChanged: " + ", ".join(drifted)
+
+
+def test_the_committed_source_matches_the_imported_values():
+    """The registry reads these constants by REGEX out of the source file
+    (``hill_masters.read_committed_constants``), and ``apply`` writes them
+    the same way.  If the regex and the Python parser ever disagree — a
+    duplicated assignment, a value written as ``1.11e0``, a constant moved
+    behind a conditional — the registry would report and promote numbers
+    the engine does not use.  Nothing else checks that they agree.
+    """
+    from src.model_registry.hill_masters import read_committed_constants
+
+    committed = read_committed_constants()
+    for name, pinned in _PINNED.items():
+        assert name in committed, f"{name} is no longer regex-readable by the registry"
+        assert committed[name] == pinned, (
+            f"registry reads {name}={committed[name]} but the module imports {pinned} — "
+            "the regex in hill_masters.py and the Python value have diverged"
+        )
+
+
+def test_the_livedata_guard_is_pinned_to_the_same_numbers():
+    """The link that was missing, made mechanical.
+
+    ``test_ktc_reconciliation.py``'s ``PINNED_DELTAS`` holds the same
+    curve values this file pins.  Because that module is
+    ``livedata``-marked it cannot block a PR, so its staleness has to be
+    detectable from the hard tier — otherwise the next promotion repeats
+    2026-04-20 → 07-30 exactly.
+
+    Parses rather than imports: importing the module would execute its
+    module-level KTC CSV load, coupling this hard gate to a live file.
+    """
+    import re
+    from pathlib import Path
+
+    path = (
+        Path(__file__).resolve().parents[2] / "tests" / "canonical" / "test_ktc_reconciliation.py"
+    )
+    text = path.read_text(encoding="utf-8")
+    # Anchor on the ASSIGNMENT, not the first mention of the name: that
+    # file's docstring and comments talk about ``PINNED_DELTAS`` several
+    # times before defining it, and a naive ``split`` lands in prose and
+    # silently parses nothing.
+    match = re.search(
+        r"^PINNED_DELTAS[^=]*=\s*\[(?P<body>.*?)^\]",
+        text,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert match, f"could not locate the PINNED_DELTAS assignment in {path.name}"
+    pinned_there = {
+        int(rank): int(ours)
+        for rank, ours in re.findall(r"\(\s*(\d+)\s*,\s*(\d+)\s*,", match.group("body"))
+    }
+    assert pinned_there, f"could not parse PINNED_DELTAS out of {path.name}"
+
+    stale = {
+        rank: (pinned_there[rank], expected)
+        for rank, expected in _PINNED_OFFENSE_VALUES.items()
+        if rank in pinned_there and pinned_there[rank] != expected
+    }
+    assert not stale, (
+        "test_ktc_reconciliation.py::PINNED_DELTAS is stale — it is "
+        "livedata-marked so it will not fail your PR on its own. Re-baseline "
+        "it (see step 2 of the guidance in this module). Stale ranks "
+        "(theirs -> should be): "
+        + ", ".join(f"{r}: {t} -> {e}" for r, (t, e) in sorted(stale.items()))
+    )

--- a/tests/canonical/test_ktc_reconciliation.py
+++ b/tests/canonical/test_ktc_reconciliation.py
@@ -37,10 +37,10 @@ REPO = Path(__file__).resolve().parents[2]
 if str(REPO) not in sys.path:
     sys.path.insert(0, str(REPO))
 
-from src.canonical.player_valuation import (
+from src.canonical.player_valuation import (  # noqa: E402
     percentile_to_value,  # kept for shape invariants
 )
-from src.api.data_contract import _PERCENTILE_REFERENCE_N
+from src.api.data_contract import _PERCENTILE_REFERENCE_N  # noqa: E402
 
 
 KTC_CSV = REPO / "CSVs" / "site_raw" / "ktc.csv"
@@ -103,17 +103,42 @@ def _load_ktc_players_sorted() -> list[tuple[str, int]]:
 # A structural KTC tail shift larger than these bands is a signal, not
 # a regression — break CI, investigate, re-baseline the affected ranks.
 # ──────────────────────────────────────────────────────────────────────
+#
+# RE-BASELINED 2026-07-30 (audit debt D16).  The previous baseline dated
+# from 2026-04-20 and had gone stale: `HILL_PERCENTILE_C/S` were promoted
+# through the model registry since, so `_ours(rank)` no longer matched the
+# pinned `ours` at 9 of these 10 ranks, and the bands at ranks 24 and 50
+# had drifted out too.  **All 10 cases were failing on `main`** and nobody
+# saw it, because this module is auto-marked `livedata` (see
+# `_LIVEDATA_MODULES` in tests/conftest.py) so CI runs it
+# `continue-on-error`.
+#
+# That is the third of ADR-008's three failure modes showing up from the
+# other side.  The old auto-refit used to rewrite these pins, which made
+# the guard unfalsifiable; removing that rewrite left the pins simply
+# UNMAINTAINED, because promotion (`scripts/model_registry.py apply`)
+# re-baselines nothing.  A guard that silently goes stale after every
+# promotion is not much better than one that is rewritten by the thing it
+# guards.
+#
+# The structural half of that gap is fixed by
+# `tests/canonical/test_hill_percentile_constants_tripwire.py`: it pins the
+# eight percentile constants deterministically, needs no live data, is NOT
+# livedata-marked, and therefore BLOCKS.  Its failure message tells the
+# operator to re-baseline this file too.  This module keeps only the part
+# that genuinely needs `ktc.csv` — the divergence band — and stays
+# advisory, which is correct for a data-coupled assertion.
 PINNED_DELTAS: list[tuple[int, int, float, float]] = [
     (1, 9999, 0.0, 3.0),
-    (5, 9587, 3.2, 3.0),
-    (12, 8768, 14.2, 3.0),
-    (24, 7502, 17.5, 3.0),
-    (50, 5535, 4.5, 3.0),
-    (100, 3525, -0.9, 5.0),
-    (150, 2523, -10.7, 5.0),
-    (200, 1939, -20.6, 10.0),
-    (300, 1300, -18.6, 10.0),
-    (400, 963, -2.7, 10.0),
+    (5, 9481, 2.2, 3.0),
+    (12, 8561, 12.3, 3.0),
+    (24, 7242, 13.5, 3.0),
+    (50, 5314, 0.4, 3.0),
+    (100, 3419, -3.3, 5.0),
+    (150, 2481, -11.8, 5.0),
+    (200, 1931, -20.4, 10.0),
+    (300, 1322, -16.5, 10.0),
+    (400, 996, 0.0, 10.0),
 ]
 
 


### PR DESCRIPTION
`tests/canonical/test_ktc_reconciliation.py` had **all 10 of its cases failing on `main`** — confirmed at a clean HEAD, so it predates this branch. Nine failed the exact `ours == pinned_ours` pin because `HILL_PERCENTILE_C/S` were promoted after the 2026-04-20 baseline; ranks 24 and 50 also failed the divergence band. Nobody saw it because `conftest.py` auto-marks the module `livedata`, so CI runs it `continue-on-error`.

(The audit first recorded 9 failures. 10 is right — rank 1 fails only on the band, which happened to sit inside tolerance.)

## The stale numbers were the smaller half

Nothing could ever have caught this. `scripts/model_registry.py apply` rewrites the constants and stops — deliberately, because ADR-008 prohibits the refit path from rewriting its own guards. But that leaves every downstream expectation to rot silently after a promotion, and this one rots *invisibly*. A guard that quietly goes stale after every promotion isn't much better than one rewritten by the thing it guards; it's ADR-008's third failure mode ("the guard is not even run") arriving by a different route.

The `livedata` marking is **correct** and is pinned in place by `test_refit_path_characterisation.py::TestTheLivedataMarkingIsPreserved` — a KTC row-count dip once stalled every open PR — and that same file requires the module keep both of its assertions. So the fix could not be a restructure of it. A test that reads `CSVs/site_raw/ktc.csv` cannot be a blocking gate, which means drift in these constants was always going to be invisible in the hard tier without a check that reads no live data at all.

## What shipped

**1. `PINNED_DELTAS` re-baselined** — both columns move: the exact `ours` value and the pct-diff band centre.

**2. `tests/canonical/test_hill_percentile_constants_tripwire.py`** — deterministic, **not** `livedata`-marked, therefore blocking. Mirrors the rank-form tripwire. Four checks:

- **pins the eight percentile constants** — a promotion now fails loudly in the hard tier, with a four-step follow-up checklist in the message (update these pins, re-baseline the KTC pins, re-run the rank-form drift check, record the promotion). `apply` does none of those, by design.
- **pins what the OFFENSE master *produces*** at ten ranks — catches a formula or `_PERCENTILE_REFERENCE_N` change that leaves the constants untouched.
- **asserts the registry's regex reader agrees with Python.** `hill_masters.read_committed_constants` pulls these values out of the source file by regex, and `apply` writes them the same way. Nothing checked that the regex and the imported value agree — a divergence (duplicated assignment, a value written `1.11e0`, a constant moved behind a conditional) would have the registry reporting and promoting numbers the engine does not use.
- **cross-checks `PINNED_DELTAS`** against those values, so the advisory guard's staleness is detectable from the blocking tier. It anchors on the *assignment* rather than the first mention of the name — that file's prose names `PINNED_DELTAS` several times before defining it, and a naive split parses nothing and passes vacuously.

Mutation-tested: reverting one KTC pin to its stale value fails the cross-check.

**Net effect:** the next promotion cannot silently stale either guard.

Also adds `# noqa: E402` on two pre-existing module-level imports in the KTC test, per repo convention — the changed-files ruff gate lints them now that this PR touches the file.

## Verification

| gate | result |
|---|---|
| `pytest -m "not livedata"` (hard gate) | **5268 passed** (was 5264) |
| `pytest -m livedata` (advisory tier) | **294 passed, 0 failed** — it had **10 failures** before this |
| `ruff format --check .` | 719 files already formatted |
| `ruff check` (changed files) | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RXRPXt7MhjKTgq5V8GuqZ

---
_Generated by [Claude Code](https://claude.ai/code/session_018RXRPXt7MhjKTgq5V8GuqZ)_