### PR TITLE
Scope the archives E2E assertion, and make its wait falsifiable

### DIFF
--- a/frontend/app/league/sections/archives.jsx
+++ b/frontend/app/league/sections/archives.jsx
@@ -104,7 +104,12 @@ function ArchivesSection({ data }) {
         {rows.length > filtered.length ? ` of ${rows.length}` : ""}
       </div>
 
-      <div className="table-wrap">
+      {/* `archives-table` is a stable E2E hook, in the style of the
+          SEL registry in tests/e2e/helpers/journey.js. `table-wrap`
+          alone is not addressable: ten other /league sections use it
+          (weekly, luck, power, draft, draft-capital, rivalries…), so a
+          page-wide `table tbody tr` count is not this table's count. */}
+      <div className="table-wrap archives-table">
         <ArchiveTable kind={kind} rows={filtered} />
       </div>
     </Card>

--- a/tests/e2e/specs/public-league.spec.js
+++ b/tests/e2e/specs/public-league.spec.js
@@ -223,15 +223,29 @@ test.describe("public /league page", () => {
     // nothing at all.  It also slept 500ms instead of waiting on data.
     // Assert the actual contract: applying a narrower filter must
     // reduce the row count, and clearing it must restore.
-    const rows = page.locator("table tbody tr");
+    // Scoped to the archives table. `table tbody tr` counted EVERY
+    // table on /league — weekly, luck, power, draft, draft-capital and
+    // rivalries all use `.table-wrap` too — so the number being
+    // asserted on was not this section's row count.
+    const rows = page.locator(".archives-table table tbody tr");
 
-    await page.getByRole("button", { name: /Matchups/i }).first().click();
+    // The kind buttons render their own count ("Matchups (138)"), so
+    // the expected row count is readable from the control itself.
+    // Waiting for THAT is falsifiable. The old wait was
+    // `.toBeGreaterThan(0)` immediately after the click, which the
+    // PRE-click trades table already satisfied — so it captured a
+    // stale count and the later comparison was against the wrong
+    // number. That is how this test reported 190 (the unfiltered
+    // trades total) while claiming to measure matchups.
+    const matchupsBtn = page.getByRole("button", { name: /^Matchups \(\d+\)$/ });
+    const declared = Number((await matchupsBtn.innerText()).match(/\((\d+)\)/)[1]);
+    await matchupsBtn.click();
     await expect
       .poll(() => rows.count(), {
-        message: "archives should list matchup rows",
+        message: `clicking Matchups should render its declared ${declared} rows`,
         timeout: 15_000,
       })
-      .toBeGreaterThan(0);
+      .toBe(Math.min(declared, 500)); // the section caps its render at 500
     const matchupRows = await rows.count();
 
     // Season filter is the narrowing control.  Pick the first specific
@@ -252,6 +266,21 @@ test.describe("public /league page", () => {
           timeout: 15_000,
         })
         .toBeLessThan(matchupRows);
+
+      // Stronger than "fewer rows": every surviving row must BE the
+      // selected season. A filter that drops rows for the wrong reason
+      // passes the count check and fails this one. Skipped when the
+      // filter legitimately empties the table (the live board has
+      // seasons with no matchups at all), because `every` on an empty
+      // list is vacuously true and would assert nothing.
+      const remaining = await rows.count();
+      if (remaining > 0) {
+        const seasons = await rows.locator("td:first-child").allInnerTexts();
+        expect(
+          seasons.every((s) => s.trim() === specific),
+          `rows left after selecting ${specific}: ${[...new Set(seasons.map((s) => s.trim()))].join(", ")}`,
+        ).toBe(true);
+      }
     } else {
       // No season control in this build — then the section-type
       // buttons are the only filter, so prove THOSE narrow: a


### PR DESCRIPTION
Follow-up to #657, driven by a measurement rather than a hunch.

After #657's conditional-hook fix deployed, I dispatched `Production E2E Smoke` (run [`30566288832`](https://github.com/jasonleetucker-code/riskittogetthebrisket/actions/runs/30566288832)) to check the claim rather than assume it:

| | before (`30535132618`) | after #657 | expected after this PR |
|---|---|---|---|
| archives spec | **2 failed** (desktop + mobile) | **1 failed** (mobile only) | 0 |
| suite | 2 failed / 30 passed | **1 failed / 31 passed** | 0 failed / 32 passed |

So the hook fix was **necessary and not sufficient**. Two harness defects were also in play — both identified during the audit and deliberately deferred — and this closes them.

## The row locator was not scoped

`page.locator("table tbody tr")` counted **every** table on `/league`. Ten other sections use `.table-wrap` too — weekly, luck, power, draft, draft-capital, rivalries — so the number under assertion was never this section's row count.

Adds an `archives-table` hook class, in the style of the `SEL` registry in `tests/e2e/helpers/journey.js`, and scopes the locator to it.

## The post-click wait could not fail

`.toBeGreaterThan(0)` fired immediately after clicking "Matchups", and the **pre-click trades table already satisfied it** — so the test captured a stale count before React committed, then compared against the wrong number.

That is the precise mechanism by which it reported exactly **190**: the unfiltered `trades` total, which is the component's default `kind` (`archives.jsx:11`). It never measured matchups at all.

The kind buttons render their own count — `Matchups (138)` — so the expected value is readable off the control. Waiting for the row count to equal the button's declared count is exact and falsifiable.

## The assertion is now stronger, not weaker

Beyond "fewer rows", every surviving row must **be** the selected season. A filter that drops rows for the wrong reason passes a count check and fails this one.

Deliberately skipped when the filter legitimately empties the table: `every` on an empty list is vacuously true and would assert nothing, and the live board really does have seasons with no matchups (2026 has 0, measured from `/api/public/league/archives`).

This matters because the whole point of #657 was that a suite which is red on renames and green on blank pages is untrustworthy in both directions. Fixing a red test by loosening it would have reproduced exactly that.

## Scope

Test-only, plus one `className`. No production logic, no valuation change. 1554 frontend tests, ruff clean across 723 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKhaEruQrSLhWKZPEGmEEm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKhaEruQrSLhWKZPEGmEEm)_