### PR TITLE
Six measured defects: IDP starter counts across four surfaces, the double-counted ROS board, and the 13s archives tab

### DIFF
--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -1603,7 +1603,26 @@ if SLEEPER_LEAGUE_ID:
     except Exception as e:  # defensive — it normally returns ([], {}) on failure
         print(f"  [Sleeper] fetch raised: {e}")
         SLEEPER_PLAYERS, SLEEPER_ROSTER_DATA = [], {}
-    if SLEEPER_ROSTER_DATA:
+    # A PARTIAL fetch is not a success.  ``fetch_sleeper_rosters`` makes
+    # two independent Sleeper calls: ``/rosters`` (teams) and ``/league``
+    # (name, scoring, roster_positions).  Only the second one carries
+    # ``rosterPositions``, and its request sits in a bare
+    # ``except Exception: pass`` with ``roster_positions`` pre-set to
+    # ``[]`` — so a single timeout or 5xx on that one endpoint returns a
+    # perfectly truthy dict with 12 teams and NO LINEUP.
+    #
+    # Treating that as success did real damage twice over: it overwrote
+    # ``data/sleeper_last_good.json`` with the degraded block, making it
+    # the fallback every later outage restores from, and it stamped
+    # success so the freshness watchdog stayed quiet about it.
+    # Downstream, a contract with teams but no lineup is exactly the
+    # input that makes /terminal fill an offence-only default lineup.
+    #
+    # ``rosterPositions`` is the discriminator because it is the field
+    # that only the league endpoint provides; ``teams`` alone cannot
+    # tell the two calls apart.
+    _missing_lineup = not (SLEEPER_ROSTER_DATA or {}).get("rosterPositions")
+    if SLEEPER_ROSTER_DATA and not _missing_lineup:
         # Live fetch produced the per-league block: persist it as the
         # last-good snapshot and stamp success so the freshness
         # watchdog can see a future outage.
@@ -1611,6 +1630,31 @@ if SLEEPER_LEAGUE_ID:
         _stamp_sleeper_success()
         if SLEEPER_PLAYERS:
             print(f"  Sample: {SLEEPER_PLAYERS[:5]}")
+    elif SLEEPER_ROSTER_DATA and _missing_lineup:
+        # Rosters arrived, the league endpoint did not.  Keep the live
+        # rosters (they are real and fresher than the cache) but splice
+        # the lineup back in from the last-good snapshot, and refuse to
+        # persist or stamp — a half-fetch must not become the artifact a
+        # future outage restores from.
+        print(
+            "  [Sleeper] WARNING: rosters fetched but the league endpoint "
+            "returned no roster_positions — NOT saving as last-good and "
+            "NOT stamping success.",
+            file=sys.stderr,
+        )
+        _cached_rd, _cache_age_h = _load_sleeper_snapshot()
+        _cached_slots = (_cached_rd or {}).get("rosterPositions") or []
+        if _cached_slots:
+            SLEEPER_ROSTER_DATA["rosterPositions"] = _cached_slots
+            _age_txt = f"{_cache_age_h:.1f}h old" if _cache_age_h is not None else "age unknown"
+            print(f"  [Sleeper] lineup slots restored from cache ({_age_txt})")
+        else:
+            print(
+                "  [Sleeper] no cached lineup either — the contract will "
+                "carry teams with no rosterPositions; starter views will "
+                "say so rather than guess.",
+                file=sys.stderr,
+            )
     else:
         # Sleeper outage / empty result.  Keep the league `sleeper`
         # block alive from the last-good committed snapshot instead of

--- a/config/leagues/default_superflex_idp.template.json
+++ b/config/leagues/default_superflex_idp.template.json
@@ -7,17 +7,19 @@
     "te_premium": 1.5,
     "ppr": 1.0
   },
+  "_starters_note": "Mirrors the live dynasty_main lineup in registry.json (corrected 2026-07-30). This block previously read DL 2 / LB 2 / DB 2 plus IDP_FLEX 2 — six IDP starters against the real nine, and the same wrong 2/2/2 table that was deleted from the frontend the same day. Nothing reads this template today, which is exactly why it was worth correcting: it is the shape someone copies when adding a league.",
   "starters": {
     "QB": 1,
     "RB": 2,
     "WR": 3,
-    "TE": 1,
+    "TE": 2,
     "FLEX": 2,
     "SFLEX": 1,
-    "DL": 2,
-    "LB": 2,
-    "DB": 2,
-    "IDP_FLEX": 2
+    "K": 1,
+    "DL": 3,
+    "LB": 3,
+    "DB": 3,
+    "IDP_FLEX": 0
   },
   "roster_size": 30,
   "taxi_size": 5,

--- a/frontend/__tests__/starter-slots.test.js
+++ b/frontend/__tests__/starter-slots.test.js
@@ -15,7 +15,12 @@
  * `sleeper.rosterPositions` on the live contract.
  */
 import { describe, expect, it } from "vitest";
-import { fillLineup, lineupPosition, lineupSlots } from "@/lib/starter-slots";
+import {
+  fillLineup,
+  lineupPosition,
+  lineupSlots,
+  slotsFromStarterCounts,
+} from "@/lib/starter-slots";
 import { computePortfolio } from "@/lib/portfolio-insights";
 import {
   buildAllTeamSummaries,
@@ -377,6 +382,54 @@ describe("an IDP-stacked roster starts 3 at EACH position, not 9 defenders", () 
   });
 });
 
+describe("slotsFromStarterCounts — the registry rung of the ladder", () => {
+  const DYNASTY_MAIN_STARTERS = {
+    QB: 1, RB: 2, WR: 3, TE: 2, FLEX: 2, SFLEX: 1, K: 1,
+    DL: 3, LB: 3, DB: 3, IDP_FLEX: 0,
+  };
+
+  it("expands the registry map into the league's 21 slots", () => {
+    const slots = slotsFromStarterCounts(DYNASTY_MAIN_STARTERS);
+    expect(slots).toHaveLength(21);
+    expect(slots.filter((s) => s === "DL")).toHaveLength(3);
+    expect(slots.filter((s) => s === "LB")).toHaveLength(3);
+    expect(slots.filter((s) => s === "DB")).toHaveLength(3);
+  });
+
+  it("maps the registry's SFLEX onto Sleeper's SUPER_FLEX", () => {
+    // FLEX_POOLS knows SUPER_FLEX, not SFLEX. Left unmapped, the slot
+    // falls to the strict pass, matches a position token nobody has and
+    // silently goes unfilled — one fewer starter and no error anywhere.
+    const slots = slotsFromStarterCounts(DYNASTY_MAIN_STARTERS);
+    expect(slots).toContain("SUPER_FLEX");
+    expect(slots).not.toContain("SFLEX");
+  });
+
+  it("drops zero-count slots such as this league's IDP_FLEX", () => {
+    expect(slotsFromStarterCounts(DYNASTY_MAIN_STARTERS)).not.toContain("IDP_FLEX");
+  });
+
+  it("returns [] for a missing or empty map so the caller can refuse", () => {
+    expect(slotsFromStarterCounts(null)).toEqual([]);
+    expect(slotsFromStarterCounts({})).toEqual([]);
+    expect(slotsFromStarterCounts(undefined)).toEqual([]);
+  });
+
+  it("fills the same lineup the live rosterPositions array does", () => {
+    const roster = squad([
+      ["QB", 3, 900], ["RB", 4, 800], ["WR", 5, 700], ["TE", 3, 600],
+      ["DL", 4, 500], ["LB", 4, 400], ["DB", 4, 300],
+    ]);
+    const opts = { assets: roster, positionOf: (p) => p.group };
+    const live = fillLineup({ ...opts, rosterPositions: DYNASTY_MAIN_SLOTS });
+    const registry = fillLineup({
+      ...opts,
+      rosterPositions: slotsFromStarterCounts(DYNASTY_MAIN_STARTERS),
+    });
+    expect(new Set(registry.starters)).toEqual(new Set(live.starters));
+  });
+});
+
 describe("computePortfolio (/terminal) fills on the resolved position", () => {
   it("starts 3 LB, 3 DL and 3 DB from an LB-heavy roster", () => {
     const players = [
@@ -403,6 +456,65 @@ describe("computePortfolio (/terminal) fills on the resolved position", () => {
     expect(lbStarters).toHaveLength(3);
     expect(starterNames.filter((n) => n.startsWith("DL"))).toHaveLength(3);
     expect(starterNames.filter((n) => n.startsWith("DB"))).toHaveLength(3);
+  });
+
+  it("falls back to the registry lineup, never to an offence-only literal", () => {
+    // The exact production shape: a contract that HAS teams but whose
+    // rosterPositions is empty, because the Sleeper rosters call
+    // succeeded and the league call timed out. The old 9-slot literal
+    // benched all 12 defenders here and reported it as a real split.
+    const players = [
+      ...Array.from({ length: 3 }, (_, i) => ({ name: `QB${i + 1}`, pos: "QB", v: 9000 - i })),
+      ...Array.from({ length: 4 }, (_, i) => ({ name: `RB${i + 1}`, pos: "RB", v: 8000 - i })),
+      ...Array.from({ length: 4 }, (_, i) => ({ name: `WR${i + 1}`, pos: "WR", v: 7000 - i })),
+      ...Array.from({ length: 3 }, (_, i) => ({ name: `TE${i + 1}`, pos: "TE", v: 6000 - i })),
+      ...Array.from({ length: 4 }, (_, i) => ({ name: `DL${i + 1}`, pos: "DE", v: 500 - i })),
+      ...Array.from({ length: 4 }, (_, i) => ({ name: `LB${i + 1}`, pos: "LB", v: 400 - i })),
+      ...Array.from({ length: 4 }, (_, i) => ({ name: `DB${i + 1}`, pos: "CB", v: 300 - i })),
+    ];
+    const rows = players.map((p) => ({
+      name: p.name, pos: p.pos, rankDerivedValue: p.v, values: { full: p.v }, raw: {},
+    }));
+    const args = {
+      rows,
+      selectedTeam: { players: players.map((p) => p.name), picks: [] },
+      history: {},
+    };
+    const rosterSettings = {
+      starters: { QB: 1, RB: 2, WR: 3, TE: 2, FLEX: 2, SFLEX: 1, K: 1, DL: 3, LB: 3, DB: 3 },
+    };
+
+    const p = computePortfolio({
+      ...args,
+      rawData: { sleeper: { rosterPositions: [] } },
+      rosterSettings,
+    });
+
+    const names = p.starterAssignments.map((a) => a.asset.name);
+    expect(names.filter((n) => n.startsWith("DL"))).toHaveLength(3);
+    expect(names.filter((n) => n.startsWith("LB"))).toHaveLength(3);
+    expect(names.filter((n) => n.startsWith("DB"))).toHaveLength(3);
+    // ...and it says where the lineup came from rather than implying live.
+    expect(p.lineupFromLeague).toBe(false);
+    expect(p.lineupKnown).toBe(true);
+  });
+
+  it("refuses outright when neither the contract nor the registry has a lineup", () => {
+    const rows = [
+      { name: "QB1", pos: "QB", rankDerivedValue: 9000, values: { full: 9000 }, raw: {} },
+      { name: "LB1", pos: "LB", rankDerivedValue: 400, values: { full: 400 }, raw: {} },
+    ];
+    const p = computePortfolio({
+      rows,
+      selectedTeam: { players: ["QB1", "LB1"], picks: [] },
+      rawData: { sleeper: { rosterPositions: [] } },
+      history: {},
+      rosterSettings: {},
+    });
+    expect(p.lineupKnown).toBe(false);
+    expect(p.lineupFromLeague).toBe(false);
+    expect(p.starterAssignments).toEqual([]);
+    expect(p.starterCount).toBe(0);
   });
 
   it("still buckets defenders under the collapsed IDP allocation group", () => {

--- a/frontend/__tests__/starter-slots.test.js
+++ b/frontend/__tests__/starter-slots.test.js
@@ -15,7 +15,8 @@
  * `sleeper.rosterPositions` on the live contract.
  */
 import { describe, expect, it } from "vitest";
-import { fillLineup, lineupSlots } from "@/lib/starter-slots";
+import { fillLineup, lineupPosition, lineupSlots } from "@/lib/starter-slots";
+import { computePortfolio } from "@/lib/portfolio-insights";
 import {
   buildAllTeamSummaries,
   buildPlayerMetaMap,
@@ -229,20 +230,127 @@ describe("fillLineup — no lineup supplied", () => {
   });
 });
 
-describe("fillLineup — collapsed IDP vocabulary (the /terminal caller)", () => {
-  it("still matches specific IDP slots via the generic IDP token", () => {
-    // portfolio-insights normalizes DB/LB/DL/... -> "IDP" before calling.
-    const roster = [
-      { name: "d1", pos: "IDP", value: 500 },
-      { name: "d2", pos: "IDP", value: 490 },
-      { name: "q1", pos: "QB", value: 900 },
-    ];
+describe("lineupPosition", () => {
+  it("keeps DL, LB and DB DISTINCT — the league starts 3 at each", () => {
+    expect(lineupPosition("DL")).toBe("DL");
+    expect(lineupPosition("LB")).toBe("LB");
+    expect(lineupPosition("DB")).toBe("DB");
+  });
+
+  it("resolves the family aliases onto those three", () => {
+    for (const p of ["DE", "DT", "EDGE", "NT"]) expect(lineupPosition(p)).toBe("DL");
+    for (const p of ["OLB", "ILB"]) expect(lineupPosition(p)).toBe("LB");
+    for (const p of ["CB", "S", "FS", "SS"]) expect(lineupPosition(p)).toBe("DB");
+  });
+
+  it("passes offense, K and DEF through so their slots still match", () => {
+    for (const p of ["QB", "RB", "WR", "TE", "DEF"]) expect(lineupPosition(p)).toBe(p);
+    expect(lineupPosition("PK")).toBe("K");
+  });
+
+  it("never returns the collapsed 'IDP' token", () => {
+    for (const p of ["DL", "DE", "DT", "EDGE", "NT", "LB", "OLB", "ILB", "DB", "CB", "S"]) {
+      expect(lineupPosition(p)).not.toBe("IDP");
+    }
+  });
+});
+
+describe("an IDP-stacked roster starts 3 at EACH position, not 9 defenders", () => {
+  // The defect this pins, in the shape that exposes it: 9 linebackers,
+  // all worth more than any lineman or back. Every defensive slot in
+  // FLEX_POOLS also accepts the generic "IDP" token, so filling on a
+  // collapsed vocabulary lets all 9 LBs claim the DL and DB slots too.
+  // The league has 3 LB slots. It starts 3 linebackers.
+  const stacked = [
+    ...Array.from({ length: 9 }, (_, i) => ({
+      name: `LB${i + 1}`,
+      real: "LB",
+      value: 900 - i,
+    })),
+    ...Array.from({ length: 3 }, (_, i) => ({
+      name: `DL${i + 1}`,
+      real: "DE",
+      value: 100 - i,
+    })),
+    ...Array.from({ length: 3 }, (_, i) => ({
+      name: `DB${i + 1}`,
+      real: "CB",
+      value: 50 - i,
+    })),
+  ];
+  const idpSlots = ["DL", "DL", "DL", "LB", "LB", "LB", "DB", "DB", "DB", "BN"];
+
+  it("credits exactly 3 LB when filled on the resolved position", () => {
     const f = fillLineup({
-      assets: roster,
-      rosterPositions: ["QB", "DL", "LB", "BN"],
-      positionOf: (p) => p.pos,
+      assets: stacked,
+      rosterPositions: idpSlots,
+      positionOf: (p) => lineupPosition(p.real),
     });
-    expect(f.starters).toHaveLength(3);
+    const counts = byGroup(f.starters.map((p) => ({ group: lineupPosition(p.real) })));
+    expect(counts.LB).toBe(3);
+    expect(counts.DL).toBe(3);
+    expect(counts.DB).toBe(3);
+    expect(f.starters).toHaveLength(9);
+  });
+
+  it("credits 9 LB when filled on the collapsed vocabulary — the bug", () => {
+    // Kept as an executable statement of WHY `lineupPos` exists. If this
+    // ever stops reproducing, the collapsed path is gone and this test
+    // and the two-field split in portfolio-insights can go with it.
+    const f = fillLineup({
+      assets: stacked,
+      rosterPositions: idpSlots,
+      positionOf: () => "IDP",
+    });
+    const lbStarters = f.starters.filter((p) => p.real === "LB");
+    expect(lbStarters).toHaveLength(9);
+    expect(f.starters.filter((p) => p.real === "DE")).toHaveLength(0);
+  });
+});
+
+describe("computePortfolio (/terminal) fills on the resolved position", () => {
+  it("starts 3 LB, 3 DL and 3 DB from an LB-heavy roster", () => {
+    const players = [
+      ...Array.from({ length: 9 }, (_, i) => ({ name: `LB${i + 1}`, pos: "LB", v: 900 - i })),
+      ...Array.from({ length: 3 }, (_, i) => ({ name: `DL${i + 1}`, pos: "DE", v: 100 - i })),
+      ...Array.from({ length: 3 }, (_, i) => ({ name: `DB${i + 1}`, pos: "CB", v: 50 - i })),
+    ];
+    const rows = players.map((p) => ({
+      name: p.name,
+      pos: p.pos,
+      rankDerivedValue: p.v,
+      values: { full: p.v },
+      raw: {},
+    }));
+    const portfolio = computePortfolio({
+      rows,
+      selectedTeam: { players: players.map((p) => p.name), picks: [] },
+      rawData: { sleeper: { rosterPositions: ["DL", "DL", "DL", "LB", "LB", "LB", "DB", "DB", "DB", "BN"] } },
+      history: {},
+    });
+
+    const starterNames = portfolio.starters.map((p) => p.name);
+    const lbStarters = starterNames.filter((n) => n.startsWith("LB"));
+    expect(lbStarters).toHaveLength(3);
+    expect(starterNames.filter((n) => n.startsWith("DL"))).toHaveLength(3);
+    expect(starterNames.filter((n) => n.startsWith("DB"))).toHaveLength(3);
+  });
+
+  it("still buckets defenders under the collapsed IDP allocation group", () => {
+    // `pos` stays collapsed on purpose — byPosition reports allocation
+    // against QB/RB/WR/TE/K/DEF/IDP/PICK, not per defensive position.
+    const rows = [
+      { name: "LB1", pos: "LB", rankDerivedValue: 900, values: { full: 900 }, raw: {} },
+      { name: "CB1", pos: "CB", rankDerivedValue: 800, values: { full: 800 }, raw: {} },
+    ];
+    const portfolio = computePortfolio({
+      rows,
+      selectedTeam: { players: ["LB1", "CB1"], picks: [] },
+      rawData: { sleeper: { rosterPositions: ["LB", "DB", "BN"] } },
+      history: {},
+    });
+    expect(portfolio.byPosition.IDP.count).toBe(2);
+    expect(portfolio.byPosition.IDP.value).toBe(1700);
   });
 });
 

--- a/frontend/__tests__/starter-slots.test.js
+++ b/frontend/__tests__/starter-slots.test.js
@@ -204,6 +204,52 @@ describe("fillLineup — dynasty_new (same scoring profile, different lineup)", 
   });
 });
 
+describe("assignments — slot order, so a display cap cannot eat the defense", () => {
+  // The shape that broke the terminal panel: offense values sit far above
+  // IDP on the blended board, so a VALUE-sorted starter list puts all 11
+  // offensive starters first and any top-N truncation removes the entire
+  // secondary. Measured on the real snapshot, the old `slice(0, 12)` left
+  // 11 of 12 teams showing zero defensive backs.
+  const roster = squad([
+    ["QB", 2, 9000], ["RB", 3, 8000], ["WR", 4, 7000], ["TE", 3, 6000],
+    ["DL", 4, 300], ["LB", 4, 200], ["DB", 4, 100],
+  ]);
+  const fill = () =>
+    fillLineup({
+      assets: roster,
+      rosterPositions: DYNASTY_MAIN_SLOTS,
+      positionOf: (p) => p.group,
+    });
+
+  it("returns one entry per FILLED slot, in the league's slot order", () => {
+    const { assignments } = fill();
+    expect(assignments).toHaveLength(20); // 21 slots, K unfillable
+    // The league's own slot array order, with the unfillable K dropped —
+    // NOT the two-pass fill order, and not value order.
+    expect(assignments.map((a) => a.slot)).toEqual([
+      "QB", "RB", "RB", "WR", "WR", "WR", "TE", "TE",
+      "FLEX", "FLEX", "SUPER_FLEX",
+      "DL", "DL", "DL", "LB", "LB", "LB", "DB", "DB", "DB",
+    ]);
+  });
+
+  it("keeps all three DB even though they are the 18th-20th most valuable", () => {
+    const { assignments, starters } = fill();
+    expect(assignments.filter((a) => a.slot === "DB")).toHaveLength(3);
+    // ...and this is why slot order is required: the value-sorted list
+    // puts every DB in the last three positions.
+    const dbIdx = starters
+      .map((p, i) => (p.group === "DB" ? i : -1))
+      .filter((i) => i >= 0);
+    expect(Math.min(...dbIdx)).toBeGreaterThanOrEqual(12);
+  });
+
+  it("assigns the same players as `starters`, only ordered differently", () => {
+    const { assignments, starters } = fill();
+    expect(new Set(assignments.map((a) => a.asset))).toEqual(new Set(starters));
+  });
+});
+
 describe("fillLineup — no lineup supplied", () => {
   const roster = squad([["QB", 2, 900], ["RB", 2, 800]]);
 
@@ -227,6 +273,29 @@ describe("fillLineup — no lineup supplied", () => {
     });
     expect(f.available).toBe(true);
     expect(f.starters).toHaveLength(2);
+  });
+
+  it("flags a fallback fill as such, distinctly from `available`", () => {
+    // `available` goes true again the moment a fallback applies, so it
+    // cannot answer "is this the league's lineup?". Collapsing the two is
+    // how /terminal's 9-slot offence-only default would get rendered as
+    // if it were an IDP league's starting nine.
+    const withLeague = fillLineup({
+      assets: roster,
+      rosterPositions: ["QB", "RB"],
+      positionOf: (p) => p.group,
+      fallbackSlots: ["QB", "RB"],
+    });
+    const withFallback = fillLineup({
+      assets: roster,
+      rosterPositions: null,
+      positionOf: (p) => p.group,
+      fallbackSlots: ["QB", "RB"],
+    });
+    expect(withLeague.available).toBe(true);
+    expect(withFallback.available).toBe(true);
+    expect(withLeague.usedFallback).toBe(false);
+    expect(withFallback.usedFallback).toBe(true);
   });
 });
 

--- a/frontend/__tests__/starter-slots.test.js
+++ b/frontend/__tests__/starter-slots.test.js
@@ -1,0 +1,296 @@
+/**
+ * Tests for lib/starter-slots.js and the two consumers that used to
+ * carry their own answer.
+ *
+ * There was NO coverage of any of this before 2026-07-30 — not of
+ * `STARTER_SLOTS`, `buildTeamValueBreakdown`, `buildAllTeamSummaries`,
+ * `scoreTeamTiers` or `splitStartersBench`. That is why a table saying
+ * this league starts 2 DL, 2 LB and 2 DB sat in the tree while the
+ * league started 3 of each, undercounting every team on /rosters and
+ * reordering the leaderboard. These tests exist so the next drift is
+ * caught by CI rather than by an audit.
+ *
+ * The lineup arrays below are the REAL ones, copied from
+ * config/leagues/registry.json and corroborated against
+ * `sleeper.rosterPositions` on the live contract.
+ */
+import { describe, expect, it } from "vitest";
+import { fillLineup, lineupSlots } from "@/lib/starter-slots";
+import {
+  buildAllTeamSummaries,
+  buildPlayerMetaMap,
+  buildTeamValueBreakdown,
+} from "@/lib/league-analysis";
+
+// dynasty_main — 12-team superflex TEP IDP. 21 lineup slots + 37 bench.
+const DYNASTY_MAIN_SLOTS = [
+  "QB", "RB", "RB", "WR", "WR", "WR", "TE", "TE",
+  "FLEX", "FLEX", "SUPER_FLEX", "K",
+  "DL", "DL", "DL", "LB", "LB", "LB", "DB", "DB", "DB",
+  ...Array(37).fill("BN"),
+];
+
+// dynasty_new — 10-team, no IDP, no K, TE 1. Same scoring profile,
+// completely different lineup: the reason a literal cannot be right.
+const DYNASTY_NEW_SLOTS = [
+  "QB", "RB", "RB", "WR", "WR", "WR", "TE", "FLEX", "FLEX", "SUPER_FLEX",
+  ...Array(14).fill("BN"),
+];
+
+/** n players of one group, values descending from `top`. */
+function squad(spec) {
+  const out = [];
+  for (const [group, count, top] of spec) {
+    for (let i = 0; i < count; i += 1) {
+      out.push({ name: `${group}${i + 1}`, group, value: top - i * 10 });
+    }
+  }
+  return out;
+}
+
+const byGroup = (players) =>
+  players.reduce((acc, p) => {
+    acc[p.group] = (acc[p.group] || 0) + 1;
+    return acc;
+  }, {});
+
+describe("lineupSlots", () => {
+  it("drops bench, IR and taxi and keeps the 21 starting slots", () => {
+    const slots = lineupSlots(DYNASTY_MAIN_SLOTS);
+    expect(slots).toHaveLength(21);
+    expect(slots).not.toContain("BN");
+    expect(slots.filter((s) => s === "DL")).toHaveLength(3);
+    expect(slots.filter((s) => s === "LB")).toHaveLength(3);
+    expect(slots.filter((s) => s === "DB")).toHaveLength(3);
+  });
+
+  it("is case-insensitive and drops IR/TAXI", () => {
+    expect(lineupSlots(["qb", "bn", "ir", "taxi", "rb"])).toEqual(["QB", "RB"]);
+  });
+
+  it("returns [] for a missing or empty array", () => {
+    expect(lineupSlots(null)).toEqual([]);
+    expect(lineupSlots([])).toEqual([]);
+  });
+});
+
+describe("fillLineup — dynasty_main", () => {
+  // Deep enough at every position to fill every slot with room to spare.
+  const roster = squad([
+    ["QB", 4, 900], ["RB", 6, 800], ["WR", 8, 700], ["TE", 4, 600],
+    ["DL", 6, 500], ["LB", 6, 400], ["DB", 6, 300],
+  ]);
+  const fill = () =>
+    fillLineup({
+      assets: roster,
+      rosterPositions: DYNASTY_MAIN_SLOTS,
+      positionOf: (p) => p.group,
+    });
+
+  it("starts THREE of each IDP position, not two", () => {
+    // The whole defect, in one assertion. The old table said 2/2/2.
+    const counts = byGroup(fill().starters);
+    expect(counts.DL).toBe(3);
+    expect(counts.LB).toBe(3);
+    expect(counts.DB).toBe(3);
+  });
+
+  it("fills 20 of 21 slots — K goes unfilled because kickers are not rostered here", () => {
+    // `buildPlayerMetaMap` drops pos === "K", so no asset can ever match
+    // the K slot. That is intended; it must not be papered over by
+    // adding K back to a slot table.
+    const f = fill();
+    expect(f.slotCount).toBe(21);
+    expect(f.starters).toHaveLength(20);
+    expect(f.unfilledSlots).toEqual(["K"]);
+  });
+
+  it("allocates FLEX and SUPER_FLEX by value rather than by a fixed guess", () => {
+    const counts = byGroup(fill().starters);
+    // 1 QB + 2 RB + 3 WR + 2 TE = 8 strict, then 2 FLEX (RB/WR/TE) and
+    // 1 SUPER_FLEX (QB-eligible) = 11 offensive starters.
+    const offense = counts.QB + counts.RB + counts.WR + counts.TE;
+    expect(offense).toBe(11);
+    // The 2nd QB is worth 890, above every remaining RB/WR/TE, so the
+    // superflex takes it. A fixed "+1 QB" table happens to agree here;
+    // the point is that this one is derived, not assumed.
+    expect(counts.QB).toBe(2);
+  });
+
+  it("takes the highest-valued eligible player for each slot", () => {
+    const names = fill().starters.map((p) => p.name);
+    expect(names).toContain("QB1");
+    expect(names).toContain("DL1");
+    expect(names).not.toContain("DL4"); // 4th DL: no slot for it
+  });
+
+  it("picks the best eligible player when the input is NOT pre-sorted", () => {
+    // Regression guard for two bugs caught in review, both of which
+    // produced a wrong answer that looked right.
+    //
+    // 1. `fillLineup` sorts by `valueFor`, defaulting to `p.value`. The
+    //    league-analysis callers hold player-meta entries whose value
+    //    field is `.meta`, so the default read undefined for every asset,
+    //    the sort became a no-op and slots filled in INSERTION order.
+    // 2. That option was first named `valueOf` — which every object
+    //    inherits from Object.prototype, so destructuring it out of the
+    //    options bag ALWAYS found a function and the default never
+    //    applied at all.
+    //
+    // Every other fixture in this file happens to be built in descending
+    // order, so all of them passed through both bugs. Shuffled input with
+    // a non-default value field is what actually catches them.
+    const shuffled = [
+      { name: "cheap", group: "QB", meta: 10 },
+      { name: "best", group: "QB", meta: 999 },
+      { name: "mid", group: "QB", meta: 500 },
+    ];
+    const f = fillLineup({
+      assets: shuffled,
+      rosterPositions: ["QB", "BN"],
+      positionOf: (p) => p.group,
+      valueFor: (p) => p.meta,
+    });
+    expect(f.starters.map((p) => p.name)).toEqual(["best"]);
+  });
+
+  it("treats a missing/NaN value as 0 rather than corrupting the sort", () => {
+    const f = fillLineup({
+      assets: [
+        { name: "unpriced", group: "QB" },
+        { name: "priced", group: "QB", value: 1 },
+      ],
+      rosterPositions: ["QB"],
+      positionOf: (p) => p.group,
+    });
+    expect(f.starters.map((p) => p.name)).toEqual(["priced"]);
+  });
+
+  it("reports slots a thin roster cannot fill", () => {
+    const thin = squad([["QB", 1, 900], ["DL", 1, 500]]);
+    const f = fillLineup({
+      assets: thin,
+      rosterPositions: DYNASTY_MAIN_SLOTS,
+      positionOf: (p) => p.group,
+    });
+    expect(f.starters).toHaveLength(2);
+    expect(f.unfilledSlots.filter((s) => s === "DL")).toHaveLength(2);
+    expect(f.unfilledSlots).toContain("RB");
+  });
+});
+
+describe("fillLineup — dynasty_new (same scoring profile, different lineup)", () => {
+  const roster = squad([
+    ["QB", 3, 900], ["RB", 5, 800], ["WR", 6, 700], ["TE", 3, 600],
+    ["DL", 3, 500], ["LB", 3, 400], ["DB", 3, 300],
+  ]);
+  const fill = fillLineup({
+    assets: roster,
+    rosterPositions: DYNASTY_NEW_SLOTS,
+    positionOf: (p) => p.group,
+  });
+
+  it("starts ONE TE, not two", () => {
+    expect(byGroup(fill.starters).TE).toBe(1);
+  });
+
+  it("starts no IDP at all", () => {
+    const counts = byGroup(fill.starters);
+    expect(counts.DL).toBeUndefined();
+    expect(counts.LB).toBeUndefined();
+    expect(counts.DB).toBeUndefined();
+    expect(fill.starters).toHaveLength(10);
+  });
+});
+
+describe("fillLineup — no lineup supplied", () => {
+  const roster = squad([["QB", 2, 900], ["RB", 2, 800]]);
+
+  it("refuses rather than inventing a lineup", () => {
+    const f = fillLineup({
+      assets: roster,
+      rosterPositions: null,
+      positionOf: (p) => p.group,
+    });
+    expect(f.available).toBe(false);
+    expect(f.starters).toEqual([]);
+    expect(f.bench).toHaveLength(4);
+  });
+
+  it("uses an explicit fallback only when the caller asks for one", () => {
+    const f = fillLineup({
+      assets: roster,
+      rosterPositions: null,
+      positionOf: (p) => p.group,
+      fallbackSlots: ["QB", "RB"],
+    });
+    expect(f.available).toBe(true);
+    expect(f.starters).toHaveLength(2);
+  });
+});
+
+describe("fillLineup — collapsed IDP vocabulary (the /terminal caller)", () => {
+  it("still matches specific IDP slots via the generic IDP token", () => {
+    // portfolio-insights normalizes DB/LB/DL/... -> "IDP" before calling.
+    const roster = [
+      { name: "d1", pos: "IDP", value: 500 },
+      { name: "d2", pos: "IDP", value: 490 },
+      { name: "q1", pos: "QB", value: 900 },
+    ];
+    const f = fillLineup({
+      assets: roster,
+      rosterPositions: ["QB", "DL", "LB", "BN"],
+      positionOf: (p) => p.pos,
+    });
+    expect(f.starters).toHaveLength(3);
+  });
+});
+
+describe("/rosters starters scope", () => {
+  const rows = [
+    ...squad([
+      ["QB", 3, 900], ["RB", 4, 800], ["WR", 5, 700], ["TE", 3, 600],
+      ["DL", 4, 500], ["LB", 4, 400], ["DB", 4, 300],
+    ]),
+  ].map((p) => ({
+    name: p.name,
+    pos: p.group,
+    values: { full: p.value },
+    raw: {},
+    team: "",
+  }));
+  const meta = buildPlayerMetaMap(rows);
+  const team = { name: "T", roster_id: 1, players: rows.map((r) => r.name), picks: [] };
+
+  it("counts the 3rd DL, LB and DB that the old table dropped", () => {
+    const withSlots = buildTeamValueBreakdown(
+      team, meta, rows, "starters", null, DYNASTY_MAIN_SLOTS,
+    );
+    // Old behaviour was top-2 per IDP group: 500+490, 400+390, 300+290.
+    const old = 500 + 490 + 400 + 390 + 300 + 290;
+    const now = withSlots.byGroup.DL + withSlots.byGroup.LB + withSlots.byGroup.DB;
+    expect(now).toBe(old + 480 + 380 + 280);
+  });
+
+  it("reports starterSlotsUnavailable instead of guessing", () => {
+    const b = buildTeamValueBreakdown(team, meta, rows, "starters", null, null);
+    expect(b.starterSlotsUnavailable).toBe(true);
+    expect(b.total).toBe(0);
+  });
+
+  it("does not set the flag on the non-starter scopes", () => {
+    for (const scope of ["full", "players"]) {
+      const b = buildTeamValueBreakdown(team, meta, rows, scope, null, null);
+      expect(b.starterSlotsUnavailable).toBe(false);
+      expect(b.total).toBeGreaterThan(0);
+    }
+  });
+
+  it("threads the lineup through buildAllTeamSummaries", () => {
+    const [summary] = buildAllTeamSummaries(
+      [team], meta, rows, "starters", null, DYNASTY_MAIN_SLOTS,
+    );
+    expect(summary.starterSlotsUnavailable).toBe(false);
+    expect(summary.total).toBeGreaterThan(0);
+  });
+});

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -4645,6 +4645,16 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   font-size: 0.64rem;
   color: var(--amber);
 }
+/* Shown above the starter/bench bar when the lineup did not come from
+   the league's live roster positions.  Amber, not red: the split is
+   still computed, just from the registry rather than the host. */
+.portfolio-lineup-note {
+  margin: 0 0 6px;
+  font-size: 0.64rem;
+  line-height: 1.35;
+  color: var(--amber);
+  max-width: 60ch;
+}
 .portfolio-split {
   flex: 1;
   min-width: 240px;

--- a/frontend/app/league/page.jsx
+++ b/frontend/app/league/page.jsx
@@ -125,8 +125,27 @@ export default async function LeagueRoute({ searchParams }) {
   // still fully server-rendered — which is what keeps crawlers and
   // shared links seeing real content instead of a spinner.  Everything
   // else loads when the visitor actually opens it.
+  //
+  // ``archives`` is the one exception (2026-07-30), and it is a size
+  // decision rather than a policy change.  At ~737 KB it is 8x the next
+  // largest section; inlining it into the RSC flight payload took this
+  // document from ~91 KB to ~960 KB, and that payload is what made
+  // hydration slow enough to race (#662).  The client already fetches
+  // sections it lacks — ``LeagueClient``'s lazy-section effect handles
+  // archives on a tab switch today, with an in-flight guard — and
+  // ``ArchivesSection`` is written for a null first render.  So SSR here
+  // bought nothing but bytes.
+  //
+  // What is genuinely given up: a crawler following ``?tab=archives``
+  // sees the shell rather than the table.  Archives is a waiver / draft /
+  // trade log, not the shareable surface; ``overview``, which carries the
+  // OG title and description, still server-renders on every tab.
   const landing = sectionForTab(normalizeTabKey(rawTab));
-  const wanted = landing && landing !== "overview" ? ["overview", landing] : ["overview"];
+  const ssrSkip = new Set(["archives"]);
+  const wanted =
+    landing && landing !== "overview" && !ssrSkip.has(landing)
+      ? ["overview", landing]
+      : ["overview"];
   const payloads = await Promise.all(wanted.map((s) => fetchSection(s)));
 
   let league = null;

--- a/frontend/app/league/sections/archives.jsx
+++ b/frontend/app/league/sections/archives.jsx
@@ -24,14 +24,19 @@ function ArchivesSection({ data }) {
   // <select> do nothing.
   //
   // That is the shape of the Production E2E Smoke failure this fixes.
-  // `public-league.spec.js:218` clicked "Matchups", then selected a
-  // season, and the row count stayed at exactly 190 through both — and
-  // 190 is the UNFILTERED `trades` total (the default `kind` below),
-  // matching no season-filtered subset of any dataset.  Measured from
-  // production 2026-07-30: trades 190 (2026:37, 2025:124, 2024:29),
-  // weeklyMatchups 138 (2026:0), waivers 1092, rookieDrafts 424,
-  // seasonResults 30.  The season filter below was never the bug — it
-  // had simply never run.
+  // `public-league.spec.js` clicked "Matchups", then selected a season,
+  // and the row count stayed at exactly 190 through both — and 190 is
+  // the UNFILTERED `trades` total (the default `kind` below), matching
+  // no season-filtered subset of any dataset.  Measured from production
+  // 2026-07-30: trades 190 (2026:37, 2025:124, 2024:29), weeklyMatchups
+  // 158, waivers 1092, rookieDrafts 494, seasonResults 30.  The season
+  // filter below was never the bug — it had simply never run.
+  //
+  // "Lazily loaded" above is now true on EVERY entry, not just a tab
+  // switch: `page.jsx` stopped server-rendering this section (it was
+  // ~737 KB of a ~960 KB document), so the first render has `data: null`
+  // even on a `?tab=archives` deep link.  The hook ordering here is what
+  // makes that safe.
   const rows = useMemo(() => (data ? data[kind] || [] : []), [data, kind]);
   const filtered = useMemo(() => {
     let out = rows;

--- a/frontend/app/rosters/page.jsx
+++ b/frontend/app/rosters/page.jsx
@@ -54,13 +54,33 @@ export default function RostersPage() {
   const sleeperTeams = rawData?.sleeper?.teams || [];
   const pickAliases = rawData?.pickAliases || null;
   const myTeam = settings.selectedTeam || "";
+  // The league's actual lineup slots, straight off the contract's
+  // leagueKey-stamped sleeper block.  This is what "Starters only"
+  // means — it is a per-league fact, not a constant, and the two live
+  // leagues run different lineups on the same scoring profile.
+  const rosterPositions = rawData?.sleeper?.rosterPositions || null;
 
   const playerMeta = useMemo(() => buildPlayerMetaMap(rows), [rows]);
 
   const teams = useMemo(
-    () => buildAllTeamSummaries(sleeperTeams, playerMeta, rows, assetScope, pickAliases),
-    [sleeperTeams, playerMeta, rows, assetScope, pickAliases],
+    () =>
+      buildAllTeamSummaries(
+        sleeperTeams,
+        playerMeta,
+        rows,
+        assetScope,
+        pickAliases,
+        rosterPositions,
+      ),
+    [sleeperTeams, playerMeta, rows, assetScope, pickAliases, rosterPositions],
   );
+
+  // Say so rather than guessing a lineup.  This board ranks 12 teams
+  // against each other, so an invented slot table doesn't just shift
+  // the totals — it reorders the leaderboard, and nothing on screen
+  // would indicate the order came from a guess.
+  const starterSlotsUnavailable =
+    assetScope === "starters" && teams.some((t) => t.starterSlotsUnavailable);
 
   // Sort by active group totals
   const sortedTeams = useMemo(() => {
@@ -90,8 +110,8 @@ export default function RostersPage() {
   );
 
   const teamTiers = useMemo(
-    () => scoreTeamTiers(sleeperTeams, playerMeta, rows, pickAliases),
-    [sleeperTeams, playerMeta, rows, pickAliases],
+    () => scoreTeamTiers(sleeperTeams, playerMeta, rows, pickAliases, rosterPositions),
+    [sleeperTeams, playerMeta, rows, pickAliases, rosterPositions],
   );
 
   function toggleGroup(g) {
@@ -151,6 +171,20 @@ export default function RostersPage() {
         />
 
         <ValueBasisNote contract={rawData} />
+
+        {/* "Starters only" needs the league's lineup-slot array, and
+            there is no honest default for it: this board ranks every
+            team against every other, so a guessed slot table reorders
+            the leaderboard rather than merely shifting the totals.
+            Say what is missing instead. */}
+        {starterSlotsUnavailable && (
+          <p className="ds-value-basis-note starter-slots-unavailable" role="note">
+            <strong>Starter totals unavailable.</strong> This league&rsquo;s lineup
+            slots aren&rsquo;t in the current data, so there is no way to say which
+            players start. Switch to &ldquo;Players only&rdquo; or &ldquo;Players +
+            Picks&rdquo; for a complete comparison.
+          </p>
+        )}
 
         {/* Position filter — toggle chips.  The previous 13x13 native
             checkbox + 11px label was impossible to tap on mobile.

--- a/frontend/components/terminal/PortfolioSummary.jsx
+++ b/frontend/components/terminal/PortfolioSummary.jsx
@@ -42,7 +42,9 @@ function formatPct(v) {
  *   - Positional allocation (value-weighted stack)
  *   - Age mix (value-weighted segments)
  *   - Volatility exposure (value-weighted segments)
- *   - Starting XI (top 10 starters as clickable chips)
+ *   - Starters (top 12 by value, as clickable chips).  Heading is
+ *     "Starters", not "Starting XI" — this league starts 21, and the 12
+ *     is a display cap on the chip row, not the lineup size.
  *
  * All numbers trace back to contract fields or named derived metrics.
  * No fake data, no filler chips.
@@ -325,7 +327,12 @@ export default function PortfolioSummary() {
                   onClick={() => openPlayerPopup?.(p.name)}
                   title={`${p.name} — ${formatValue(p.value)}`}
                 >
-                  <span className="portfolio-starter-pos">{p.pos}</span>
+                  {/* ``lineupPos`` (DL / LB / DB), not ``pos`` — the
+                      latter collapses every defender to a generic "IDP",
+                      so nine of these chips read the same token and you
+                      cannot see that the lineup is 3 DL + 3 LB + 3 DB.
+                      Falls back for any row built before lineupPos. */}
+                  <span className="portfolio-starter-pos">{p.lineupPos || p.pos}</span>
                   <span className="portfolio-starter-name">{p.name}</span>
                   <span className="portfolio-starter-value">{formatValue(p.value)}</span>
                 </button>

--- a/frontend/components/terminal/PortfolioSummary.jsx
+++ b/frontend/components/terminal/PortfolioSummary.jsx
@@ -53,7 +53,7 @@ function formatPct(v) {
  */
 export default function PortfolioSummary() {
   const { rows, rawData, openPlayerPopup } = useApp();
-  const { selectedTeam, idpEnabled, loading: teamLoading } = useTeam();
+  const { selectedTeam, idpEnabled, rosterSettings, loading: teamLoading } = useTeam();
   // IDP gating: skip the IDP positional bucket (and any IDP rows in
   // the positional stack) for leagues that don't support IDP.  The
   // portfolio computation still runs globally on the contract; we
@@ -82,8 +82,8 @@ export default function PortfolioSummary() {
   });
 
   const localPortfolio = useMemo(
-    () => computePortfolio({ rows, selectedTeam, rawData, history }),
-    [rows, selectedTeam, rawData, history],
+    () => computePortfolio({ rows, selectedTeam, rawData, history, rosterSettings }),
+    [rows, selectedTeam, rawData, history, rosterSettings],
   );
 
   // Merge: prefer server-computed sub-sections when present; fall
@@ -136,6 +136,7 @@ export default function PortfolioSummary() {
     benchCount,
     starterAssignments,
     lineupFromLeague,
+    lineupKnown,
     pickCount,
     pickValue,
     byPosition,
@@ -169,6 +170,18 @@ export default function PortfolioSummary() {
             </span>
           )}
         </div>
+        {/* The split bar is a claim about which players start, so it
+            must not present a guessed lineup as a measurement. Silence
+            here is what let a contract with teams but no rosterPositions
+            render 40.1% starters (offence-only, all 12 defenders
+            benched) as if it were the real 68.1%. */}
+        {!lineupFromLeague && (
+          <p className="portfolio-lineup-note" role="note">
+            {lineupKnown
+              ? "Lineup from league settings — the live roster positions weren't in this contract."
+              : "Lineup unknown for this league, so no starter/bench split can be computed."}
+          </p>
+        )}
         <div className="portfolio-split" aria-label="Starter vs bench value">
           <div className="portfolio-split-bar">
             <span
@@ -333,9 +346,7 @@ export default function PortfolioSummary() {
           <h3 className="portfolio-section-title">
             Starters{" "}
             <span className="portfolio-section-hint">
-              {lineupFromLeague
-                ? "click to open"
-                : "league lineup unavailable — showing a default"}
+              {lineupFromLeague ? "click to open" : "from league settings"}
             </span>
           </h3>
           <ul className="portfolio-starters">

--- a/frontend/components/terminal/PortfolioSummary.jsx
+++ b/frontend/components/terminal/PortfolioSummary.jsx
@@ -42,9 +42,11 @@ function formatPct(v) {
  *   - Positional allocation (value-weighted stack)
  *   - Age mix (value-weighted segments)
  *   - Volatility exposure (value-weighted segments)
- *   - Starters (top 12 by value, as clickable chips).  Heading is
- *     "Starters", not "Starting XI" — this league starts 21, and the 12
- *     is a display cap on the chip row, not the lineup size.
+ *   - Starters — EVERY filled lineup slot, in the league's own slot
+ *     order, as clickable chips.  Not a top-N by value: that ordering
+ *     put all the offense first, so a display cap silently removed the
+ *     defense (11 of 12 teams rendered zero DBs).  The chip shows the
+ *     SLOT, so 3 DL + 3 LB + 3 DB is legible.
  *
  * All numbers trace back to contract fields or named derived metrics.
  * No fake data, no filler chips.
@@ -132,7 +134,8 @@ export default function PortfolioSummary() {
     benchValue,
     starterCount,
     benchCount,
-    starters,
+    starterAssignments,
+    lineupFromLeague,
     pickCount,
     pickValue,
     byPosition,
@@ -312,27 +315,43 @@ export default function PortfolioSummary() {
         </div>
       </section>
 
-      {/* ── Starters list ── */}
-      {starters.length > 0 && (
+      {/* ── Starters list ──
+          Walks ``starterAssignments`` (SLOT order, the league's own),
+          not ``starters`` (value-descending), and renders every filled
+          slot rather than a top-N.
+
+          Both halves of that matter. This used to be
+          ``starters.slice(0, 12)``: 12 of 20 filled slots, taken from a
+          value-sorted list. IDP values sit far below offense on the
+          blended board, so the truncation ate the defense — measured on
+          the 2026-07-30 snapshot, 11 of 12 teams showed ZERO defensive
+          backs and most showed one or no linebackers, in a league that
+          starts three of each. The lineup is 20 players; showing it is
+          the panel's job. */}
+      {starterAssignments.length > 0 && (
         <section className="portfolio-section">
           <h3 className="portfolio-section-title">
-            Starters <span className="portfolio-section-hint">click to open</span>
+            Starters{" "}
+            <span className="portfolio-section-hint">
+              {lineupFromLeague
+                ? "click to open"
+                : "league lineup unavailable — showing a default"}
+            </span>
           </h3>
           <ul className="portfolio-starters">
-            {starters.slice(0, 12).map((p) => (
-              <li key={p.name}>
+            {starterAssignments.map(({ slot, asset: p }, i) => (
+              <li key={`${slot}-${p.name}-${i}`}>
                 <button
                   type="button"
                   className="portfolio-starter"
                   onClick={() => openPlayerPopup?.(p.name)}
-                  title={`${p.name} — ${formatValue(p.value)}`}
+                  title={`${slot} — ${p.name} — ${formatValue(p.value)}`}
                 >
-                  {/* ``lineupPos`` (DL / LB / DB), not ``pos`` — the
-                      latter collapses every defender to a generic "IDP",
-                      so nine of these chips read the same token and you
-                      cannot see that the lineup is 3 DL + 3 LB + 3 DB.
-                      Falls back for any row built before lineupPos. */}
-                  <span className="portfolio-starter-pos">{p.lineupPos || p.pos}</span>
+                  {/* The SLOT this player fills, which is what the lineup
+                      is made of. ``p.pos`` collapses every defender to a
+                      generic "IDP", so nine chips would read the same
+                      token and you could not see 3 DL + 3 LB + 3 DB. */}
+                  <span className="portfolio-starter-pos">{slot}</span>
                   <span className="portfolio-starter-name">{p.name}</span>
                   <span className="portfolio-starter-value">{formatValue(p.value)}</span>
                 </button>

--- a/frontend/lib/league-analysis.js
+++ b/frontend/lib/league-analysis.js
@@ -11,8 +11,7 @@ import {
   resolvePickRow,
   ktcAdjustPackage,
 } from "@/lib/trade-logic";
-import { normalizePos } from "@/lib/dynasty-data";
-import { fillLineup } from "@/lib/starter-slots";
+import { fillLineup, lineupPosition } from "@/lib/starter-slots";
 
 // ── Position Group Helpers ──────────────────────────────────────────────
 export const POS_GROUPS = ["QB", "RB", "WR", "TE", "DL", "LB", "DB", "PICKS"];
@@ -51,14 +50,20 @@ export const POS_GROUP_LABELS = {
 // was a single-league literal on a page that serves two leagues with
 // different lineups).
 
+/**
+ * Position → value-bucket group for this page's tables.
+ *
+ * Delegates to `lineupPosition` so the grouping a player is DISPLAYED
+ * under and the grouping used to fill a lineup slot cannot drift apart.
+ * The only difference is the tail: K and DEF are real lineup slots but
+ * not buckets on /rosters (`buildPlayerMetaMap` drops kickers before
+ * they reach here), so anything outside the seven value groups lands in
+ * "Other".
+ */
 export function posGroup(pos) {
   if (!pos) return "Other";
-  const p = normalizePos(pos);
-  if (["QB", "RB", "WR", "TE"].includes(p)) return p;
-  if (["DL", "DE", "DT", "EDGE", "NT"].includes(p)) return "DL";
-  if (["LB", "OLB", "ILB"].includes(p)) return "LB";
-  if (["DB", "CB", "S", "FS", "SS"].includes(p)) return "DB";
-  return "Other";
+  const g = lineupPosition(pos);
+  return PLAYER_GROUPS.includes(g) ? g : "Other";
 }
 
 // ── Timestamp Helpers ───────────────────────────────────────────────────

--- a/frontend/lib/league-analysis.js
+++ b/frontend/lib/league-analysis.js
@@ -12,10 +12,14 @@ import {
   ktcAdjustPackage,
 } from "@/lib/trade-logic";
 import { normalizePos } from "@/lib/dynasty-data";
+import { fillLineup } from "@/lib/starter-slots";
 
 // ── Position Group Helpers ──────────────────────────────────────────────
 export const POS_GROUPS = ["QB", "RB", "WR", "TE", "DL", "LB", "DB", "PICKS"];
 export const OFFENSE_GROUPS = ["QB", "RB", "WR", "TE"];
+// POS_GROUPS minus the synthetic "PICKS" bucket: the groups a real
+// player can land in, and therefore the ones that can fill a lineup slot.
+export const PLAYER_GROUPS = POS_GROUPS.filter((g) => g !== "PICKS");
 
 export const POS_GROUP_COLORS = {
   QB: "#e74c3c",
@@ -39,7 +43,13 @@ export const POS_GROUP_LABELS = {
   PICKS: "Draft Picks",
 };
 
-const STARTER_SLOTS = { QB: 2, RB: 3, WR: 4, TE: 2, DL: 2, LB: 2, DB: 2 };
+// Starter slots are NOT defined here.  They come from the league's own
+// ``sleeper.rosterPositions`` via ``lib/starter-slots.js`` — see that
+// module for why (short version: this file used to carry
+// `STARTER_SLOTS = { QB: 2, RB: 3, WR: 4, TE: 2, DL: 2, LB: 2, DB: 2 }`,
+// which started 2 of each IDP position in a league that starts 3, and
+// was a single-league literal on a page that serves two leagues with
+// different lineups).
 
 export function posGroup(pos) {
   if (!pos) return "Other";
@@ -589,15 +599,6 @@ export function buildPlayerMetaMap(rows) {
 }
 
 // ── Team Value Breakdown ────────────────────────────────────────────────
-function sumTopN(values, n) {
-  if (!Array.isArray(values) || n <= 0) return 0;
-  return values
-    .filter((v) => Number.isFinite(v) && v > 0)
-    .sort((a, b) => b - a)
-    .slice(0, n)
-    .reduce((s, v) => s + v, 0);
-}
-
 /**
  * Compute per-position-group value breakdown for a team.
  * @param {object} team - { players: string[], picks: string[] }
@@ -609,13 +610,25 @@ function sumTopN(values, n) {
  *   ("full" | "raw") meaning which value NUMBER to read.  Both use the
  *   key "full", so mixing them up runs clean and returns wrong totals.
  * @param {object} [pickAliases] - optional backend alias map
- * @returns {{ total, byGroup, playerDetails, pickDetails }}
+ * @param {string[]} [rosterPositions] - the league's Sleeper lineup-slot
+ *   array (`rawData.sleeper.rosterPositions`).  REQUIRED for the
+ *   "starters" scope; without it that scope reports
+ *   `starterSlotsUnavailable` instead of guessing a lineup.
+ * @returns {{ total, byGroup, playerDetails, pickDetails,
+ *   starterSlotsUnavailable }}
  */
-export function buildTeamValueBreakdown(team, playerMeta, rows, assetScope = "full", pickAliases = null) {
+export function buildTeamValueBreakdown(
+  team,
+  playerMeta,
+  rows,
+  assetScope = "full",
+  pickAliases = null,
+  rosterPositions = null,
+) {
   const byGroup = {};
   POS_GROUPS.forEach((g) => { byGroup[g] = 0; });
   const playerDetails = [];
-  const buckets = { QB: [], RB: [], WR: [], TE: [], DL: [], LB: [], DB: [] };
+  const lineupPool = [];
   let pickValue = 0;
   const pickDetails = [];
 
@@ -634,7 +647,7 @@ export function buildTeamValueBreakdown(team, playerMeta, rows, assetScope = "fu
     if (assetScope !== "starters") {
       if (byGroup[pm.group] !== undefined) byGroup[pm.group] += pm.meta;
     }
-    if (buckets[pm.group]) buckets[pm.group].push(pm.meta);
+    if (PLAYER_GROUPS.includes(pm.group)) lineupPool.push(pm);
   }
 
   // Resolve pick values using multi-candidate lookup so Sleeper labels
@@ -653,16 +666,32 @@ export function buildTeamValueBreakdown(team, playerMeta, rows, assetScope = "fu
     }
   }
 
+  // Starters: fill the league's ACTUAL lineup slots, then bucket the
+  // players that won a slot.  A per-group top-N cannot express this
+  // league — 3 of its 21 slots are FLEX/SUPER_FLEX, so "how many WRs
+  // start" depends on the rest of the roster, not a constant.
+  let starterSlotsUnavailable = false;
   if (assetScope === "starters") {
-    Object.keys(buckets).forEach((g) => {
-      byGroup[g] = sumTopN(buckets[g], STARTER_SLOTS[g] || 0);
+    const fill = fillLineup({
+      assets: lineupPool,
+      rosterPositions,
+      // The un-collapsed vocabulary: DL, LB and DB stay distinct, so a
+      // DL slot matches only defensive linemen.  This is the exact
+      // answer; /terminal's collapsed vocabulary credits the top N
+      // defenders regardless of whether the roster can fill each slot.
+      positionOf: (p) => p.group,
+      valueFor: (p) => p.meta,
     });
+    starterSlotsUnavailable = !fill.available;
+    for (const p of fill.starters) {
+      if (byGroup[p.group] !== undefined) byGroup[p.group] += p.meta;
+    }
   }
 
   byGroup.PICKS = assetScope === "full" ? pickValue : 0;
   const total = POS_GROUPS.reduce((s, g) => s + (byGroup[g] || 0), 0);
 
-  return { total, byGroup, playerDetails, pickDetails };
+  return { total, byGroup, playerDetails, pickDetails, starterSlotsUnavailable };
 }
 
 // ── Build All Team Summaries ────────────────────────────────────────────
@@ -670,9 +699,23 @@ export function buildTeamValueBreakdown(team, playerMeta, rows, assetScope = "fu
  * Build summary data for all teams in the league.
  * Returns sorted array of team objects with value breakdowns.
  */
-export function buildAllTeamSummaries(sleeperTeams, playerMeta, rows, assetScope = "full", pickAliases = null) {
+export function buildAllTeamSummaries(
+  sleeperTeams,
+  playerMeta,
+  rows,
+  assetScope = "full",
+  pickAliases = null,
+  rosterPositions = null,
+) {
   const teams = (sleeperTeams || []).map((team) => {
-    const breakdown = buildTeamValueBreakdown(team, playerMeta, rows, assetScope, pickAliases);
+    const breakdown = buildTeamValueBreakdown(
+      team,
+      playerMeta,
+      rows,
+      assetScope,
+      pickAliases,
+      rosterPositions,
+    );
     return {
       name: team.name,
       roster_id: team.roster_id,
@@ -682,6 +725,7 @@ export function buildAllTeamSummaries(sleeperTeams, playerMeta, rows, assetScope
       pickCount: Array.isArray(team.picks) ? team.picks.length : 0,
       players: breakdown.playerDetails,
       pickDetails: breakdown.pickDetails,
+      starterSlotsUnavailable: breakdown.starterSlotsUnavailable,
     };
   });
 
@@ -920,16 +964,33 @@ export function analyzeTradeTendencies(rawData, rows) {
 // ── Contender / Rebuilder Tiers ─────────────────────────────────────────
 /**
  * Score and tier all teams: contender / mid-tier / rebuilder.
- * Starter value = top 10 offensive players, weighted 70%.
+ * Starter value = the players who fill the league's lineup, weighted 70%.
  * Depth = total minus starters, weighted 20%.
  * Pick surplus penalized at -10% (rebuild signal).
+ *
+ * "Starter value" was the top 10 OFFENSIVE players, flat, until
+ * 2026-07-30.  In a league that starts 9 IDP alongside 12 offensive
+ * slots that read a defense-heavy contender as a rebuilder, and it was
+ * a second single-league constant on a page that serves two leagues
+ * with different lineups.  It now fills the real lineup via the shared
+ * `fillLineup`, across every group.  Weights are unchanged.
+ *
+ * @param {string[]} [rosterPositions] - the league's Sleeper lineup-slot
+ *   array.  Without it there is no lineup to fill and every team scores
+ *   as pure depth, so callers should pass it; `/rosters` does.
  */
-export function scoreTeamTiers(sleeperTeams, playerMeta, rows, pickAliases = null) {
+export function scoreTeamTiers(
+  sleeperTeams,
+  playerMeta,
+  rows,
+  pickAliases = null,
+  rosterPositions = null,
+) {
   const rowLookup = buildRowLookup(rows);
 
   const scored = (sleeperTeams || []).map((team) => {
     let totalValue = 0;
-    const topPlayers = [];
+    const lineupPool = [];
     let pickValue = 0;
 
     for (const pName of team.players || []) {
@@ -937,8 +998,8 @@ export function scoreTeamTiers(sleeperTeams, playerMeta, rows, pickAliases = nul
       const pm = playerMeta[(pName || "").toLowerCase()];
       if (!pm) continue;
       totalValue += pm.meta;
-      if (OFFENSE_GROUPS.includes(pm.group)) {
-        topPlayers.push(pm.meta);
+      if (PLAYER_GROUPS.includes(pm.group)) {
+        lineupPool.push(pm);
       }
     }
 
@@ -951,8 +1012,13 @@ export function scoreTeamTiers(sleeperTeams, playerMeta, rows, pickAliases = nul
       pickValue += val;
     }
 
-    topPlayers.sort((a, b) => b - a);
-    const starterValue = topPlayers.slice(0, 10).reduce((s, v) => s + v, 0);
+    const { starters } = fillLineup({
+      assets: lineupPool,
+      rosterPositions,
+      positionOf: (p) => p.group,
+      valueFor: (p) => p.meta,
+    });
+    const starterValue = starters.reduce((s, p) => s + p.meta, 0);
     const depthValue = totalValue - starterValue;
     const score = starterValue * 0.7 + depthValue * 0.2 + (pickValue > 0 ? -pickValue * 0.1 : 0);
 

--- a/frontend/lib/portfolio-insights.js
+++ b/frontend/lib/portfolio-insights.js
@@ -7,7 +7,7 @@ import {
   buildHistoryLookup,
 } from "@/lib/value-history";
 import { buildPickLookupCandidates } from "@/lib/trade-logic";
-import { fillLineup, lineupPosition } from "@/lib/starter-slots";
+import { fillLineup, lineupPosition, slotsFromStarterCounts } from "@/lib/starter-slots";
 
 /** First contract row matching any candidate key, or null. */
 function resolveByCandidates(byName, candidates) {
@@ -81,27 +81,29 @@ function pct(part, whole) {
   return Math.round((part / whole) * 1000) / 10;
 }
 
-// The lineup this module assumes when the contract gave us no
-// ``sleeper.rosterPositions``.  It is a 9-slot, non-IDP guess and it is
-// WRONG for both live leagues — it undercounts dynasty_main's 21-slot
-// lineup by 12.  It is kept only because /terminal's starter-share
-// panels are a defensive fallback that should degrade to a plausible
-// shape rather than to zero starters (see the module docstring above).
+// NO LITERAL FALLBACK LINEUP.  This used to hold a 9-slot offence-only
+// default used whenever the contract lacked ``sleeper.rosterPositions``,
+// justified as "degrade to a plausible shape".  It was neither plausible
+// nor necessary:
 //
-// /rosters deliberately does NOT take this route: it says so on screen
-// instead, because its starter board is a ranked comparison across 12
-// teams and a wrong lineup silently reorders it.
-const DEFAULT_FALLBACK_SLOTS = [
-  "QB",
-  "RB",
-  "RB",
-  "WR",
-  "WR",
-  "WR",
-  "TE",
-  "FLEX",
-  "SUPER_FLEX",
-];
+//   * Measured by running this module both ways on one 29-player roster,
+//     it produced 9 starters — QB2 RB3 WR3 TE1 and ZERO DL / LB / DB, all
+//     12 defenders benched — where the real lineup gives 20 starters
+//     including 3 / 3 / 3.  The split bar read 40.1% against a true
+//     68.1%.  Offense was wrong too (TE 1, not 2).
+//   * It was reachable in production, and stickily so.  ``fetch_sleeper_
+//     rosters`` gets teams and the lineup from two DIFFERENT Sleeper
+//     endpoints, and only the lineup call sits in a bare ``except: pass``
+//     with ``roster_positions`` pre-set to ``[]`` — so one timeout on
+//     that endpoint alone yields teams-present / lineup-empty.
+//   * And the league's real lineup was one destructure away the whole
+//     time: ``useTeam()`` already returns ``rosterSettings`` from
+//     ``/api/leagues``, and ``PortfolioSummary`` already calls it.
+//
+// So the ladder is now the same one BDVM already set
+// (``src/bdvm/league_config.py``) and that /rosters follows: live host
+// (``sleeper.rosterPositions``) → registry (``rosterSettings.starters``)
+// → refuse and say so.  Never a literal.
 
 /**
  * Starter / bench split for the terminal's portfolio panels.
@@ -118,14 +120,17 @@ const DEFAULT_FALLBACK_SLOTS = [
  * for.  ``pos`` is still what ``byPosition`` allocates against, which is
  * why both fields exist.
  */
-function splitStartersBench({ rosterValues, sleeperRosterPositions }) {
-  const { starters, bench, assignments, usedFallback } = fillLineup({
+function splitStartersBench({ rosterValues, sleeperRosterPositions, rosterSettings }) {
+  const { starters, bench, assignments, usedFallback, available } = fillLineup({
     assets: rosterValues,
     rosterPositions: sleeperRosterPositions,
     // ``|| p.pos`` only for callers that predate ``lineupPos``; every
     // row built by ``computePortfolio`` carries it.
     positionOf: (p) => p.lineupPos || p.pos,
-    fallbackSlots: DEFAULT_FALLBACK_SLOTS,
+    // Rung two of the ladder — the registry's own lineup, not a guess.
+    // Omitted entirely when the registry has nothing either, so
+    // ``available: false`` propagates and the panel says so.
+    fallbackSlots: slotsFromStarterCounts(rosterSettings?.starters),
   });
   return {
     starters,
@@ -134,11 +139,15 @@ function splitStartersBench({ rosterValues, sleeperRosterPositions }) {
     // is value-descending, and truncating that to fit a panel drops the
     // defense — IDP values sit far below offense on the blended board.
     starterAssignments: assignments,
-    // False only when the contract carried no lineup and we fell back to
-    // DEFAULT_FALLBACK_SLOTS, which has no IDP slots at all.  Surfaced so
-    // the panel can say so instead of showing an offence-only lineup as
-    // if it were the league's.
-    lineupFromLeague: !usedFallback,
+    // Which rung of the truth ladder produced this lineup, so the panel
+    // can be honest about it:
+    //   lineupFromLeague true        -> the league's live rosterPositions
+    //   false + lineupKnown true     -> the registry's rosterSettings
+    //   both false                   -> no lineup at all; nobody starts,
+    //                                   and the panel must say so rather
+    //                                   than render 0% as a measurement
+    lineupFromLeague: !usedFallback && available,
+    lineupKnown: available,
     starterCount: starters.length,
     benchCount: bench.length,
     starterValue: sumValue(starters),
@@ -156,8 +165,11 @@ function splitStartersBench({ rosterValues, sleeperRosterPositions }) {
  *                   the lineup-slot ARRAY, distinct from
  *                   sleeper.positions which is the player→position map)
  *   - history       rank-history map (name -> [{date, rank}])
+ *   - rosterSettings the registry's roster settings (from ``useTeam()``),
+ *                   used ONLY as the lineup fallback when the contract
+ *                   carries no rosterPositions
  */
-export function computePortfolio({ rows, selectedTeam, rawData, history }) {
+export function computePortfolio({ rows, selectedTeam, rawData, history, rosterSettings }) {
   const hasPlayers = !!selectedTeam?.players?.length;
   const hasPicks = !!selectedTeam?.picks?.length;
   if ((!hasPlayers && !hasPicks) || !Array.isArray(rows)) {
@@ -281,6 +293,7 @@ export function computePortfolio({ rows, selectedTeam, rawData, history }) {
   const starterSplit = splitStartersBench({
     rosterValues: lineupEligible,
     sleeperRosterPositions,
+    rosterSettings,
   });
   const picks = rosterValues.filter((p) => p.isPick);
   const pickValue = sumValue(picks);

--- a/frontend/lib/portfolio-insights.js
+++ b/frontend/lib/portfolio-insights.js
@@ -7,7 +7,7 @@ import {
   buildHistoryLookup,
 } from "@/lib/value-history";
 import { buildPickLookupCandidates } from "@/lib/trade-logic";
-import { fillLineup } from "@/lib/starter-slots";
+import { fillLineup, lineupPosition } from "@/lib/starter-slots";
 
 /** First contract row matching any candidate key, or null. */
 function resolveByCandidates(byName, candidates) {
@@ -107,20 +107,24 @@ const DEFAULT_FALLBACK_SLOTS = [
  * Starter / bench split for the terminal's portfolio panels.
  *
  * Thin wrapper over the shared ``fillLineup`` — see
- * ``lib/starter-slots.js`` for why the slot filling lives there.  The
- * position vocabulary handed in here is the COLLAPSED one
- * (``normalizePos``: DB/LB/DL/DE/DT/CB/S → "IDP"), so each of this
- * league's 9 defensive slots matches any defender and the split credits
- * the top 9 by value rather than 3 DL + 3 LB + 3 DB.  Totals coincide
- * for a normally-constructed roster; a team stacked at one IDP position
- * is over-credited.  /rosters passes the un-collapsed vocabulary and
- * gets the exact answer.
+ * ``lib/starter-slots.js`` for why the slot filling lives there.
+ *
+ * Fills on ``lineupPos`` (DL / LB / DB kept DISTINCT), never on ``pos``
+ * (every defender collapsed to "IDP").  The league starts 3 at each IDP
+ * position; filling on the collapsed field made every defensive slot
+ * match every defender, so the split credited the top 9 defenders by
+ * value.  Identical answer on a balanced roster, wrong on one stacked at
+ * a single IDP position — it counted starters the league has no slot
+ * for.  ``pos`` is still what ``byPosition`` allocates against, which is
+ * why both fields exist.
  */
 function splitStartersBench({ rosterValues, sleeperRosterPositions }) {
   const { starters, bench } = fillLineup({
     assets: rosterValues,
     rosterPositions: sleeperRosterPositions,
-    positionOf: (p) => p.pos,
+    // ``|| p.pos`` only for callers that predate ``lineupPos``; every
+    // row built by ``computePortfolio`` carries it.
+    positionOf: (p) => p.lineupPos || p.pos,
     fallbackSlots: DEFAULT_FALLBACK_SLOTS,
   });
   return {
@@ -171,12 +175,25 @@ export function computePortfolio({ rows, selectedTeam, rawData, history }) {
       continue;
     }
     const pos = normalizePos(row.pos);
+    // TWO position fields, deliberately, because they answer different
+    // questions:
+    //   ``pos``       collapses every defender to "IDP" — the value
+    //                 bucket this page reports allocation against
+    //                 (``byPosition``, POSITION_GROUPS).
+    //   ``lineupPos`` keeps DL / LB / DB DISTINCT — because the league
+    //                 starts 3 at EACH of those, not 9 defenders.
+    // Filling slots off the collapsed field made every defensive slot
+    // match every defender, so the split credited the top 9 by value; a
+    // roster stacked at one IDP position had players counted as starters
+    // that the league has no slot for.
+    const lineupPos = lineupPosition(row.pos);
     const value = Number(row.rankDerivedValue || row.values?.full || 0);
     const points = normalizePoints(lookupHistory(row.name, row.assetClass));
     const vol = computeVolatility(points, 30);
     rosterValues.push({
       name: row.name,
       pos,
+      lineupPos,
       value,
       age: row.age,
       isRookie: !!row.rookie,

--- a/frontend/lib/portfolio-insights.js
+++ b/frontend/lib/portfolio-insights.js
@@ -7,6 +7,7 @@ import {
   buildHistoryLookup,
 } from "@/lib/value-history";
 import { buildPickLookupCandidates } from "@/lib/trade-logic";
+import { fillLineup } from "@/lib/starter-slots";
 
 /** First contract row matching any candidate key, or null. */
 function resolveByCandidates(byName, candidates) {
@@ -50,53 +51,6 @@ function resolveByCandidates(byName, candidates) {
  * No randomness.  Every insight cites the metric that earned it.
  */
 
-// Which player positions can fill each Sleeper lineup slot.  Without
-// full coverage an unrecognized alias like WRRB_FLEX would fall
-// through the strict pass, never match any player, and push valid
-// starters onto the bench — skewing starter-share metrics.
-//
-// IDP slot pools include the generic "IDP" token because upstream
-// normalization collapses DB/LB/DL/DE/DT/CB/S → "IDP".
-const OFFENSE_FLEX = new Set(["RB", "WR", "TE"]);
-const WR_RB_FLEX_POOL = new Set(["RB", "WR"]);
-const WR_TE_FLEX_POOL = new Set(["WR", "TE"]);
-const SUPER_FLEX_POOL = new Set(["QB", "RB", "WR", "TE"]);
-const IDP_POOL = new Set(["IDP", "DL", "DE", "DT", "LB", "DB", "CB", "S"]);
-
-const FLEX_POOLS = {
-  // Offense: all known Sleeper aliases → the same pool.
-  FLEX:         OFFENSE_FLEX,
-  // RB/WR (no TE)
-  WR_RB_FLEX:   WR_RB_FLEX_POOL,
-  WRRB_FLEX:    WR_RB_FLEX_POOL,
-  RB_WR_FLEX:   WR_RB_FLEX_POOL,
-  RBWR_FLEX:    WR_RB_FLEX_POOL,
-  // WR/TE
-  REC_FLEX:     WR_TE_FLEX_POOL,
-  WR_TE_FLEX:   WR_TE_FLEX_POOL,
-  WRTE_FLEX:    WR_TE_FLEX_POOL,
-  WRT:          WR_TE_FLEX_POOL,
-  // Superflex (QB-eligible)
-  SUPER_FLEX:   SUPER_FLEX_POOL,
-  SUPERFLEX:    SUPER_FLEX_POOL,
-  Q_FLEX:       SUPER_FLEX_POOL,
-  QB_RB_WR_TE:  SUPER_FLEX_POOL,
-  // IDP — both specific slot names and flex aliases.
-  DL:           new Set(["IDP", "DL", "DE", "DT"]),
-  DE:           new Set(["IDP", "DE", "DL"]),
-  DT:           new Set(["IDP", "DT", "DL"]),
-  LB:           new Set(["IDP", "LB"]),
-  DB:           new Set(["IDP", "DB", "CB", "S"]),
-  CB:           new Set(["IDP", "CB", "DB"]),
-  S:            new Set(["IDP", "S", "DB"]),
-  IDP:          IDP_POOL,
-  IDP_FLEX:     IDP_POOL,
-  DB_LB:        IDP_POOL,
-  DL_LB:        IDP_POOL,
-  DL_DB:        IDP_POOL,
-  DEF_FLEX:     IDP_POOL,
-};
-
 const POSITION_GROUPS = ["QB", "RB", "WR", "TE", "K", "DEF", "IDP", "PICK"];
 
 function normalizePos(pos) {
@@ -127,56 +81,48 @@ function pct(part, whole) {
   return Math.round((part / whole) * 1000) / 10;
 }
 
-// Strict slots (no flex pool entry): these match a single
-// normalized player position token exactly.  K and DEF do not
-// collapse into a flex pool; their slots match same-named rosters
-// and nothing else.
-const STRICT_SLOT_REMAP = {
-  PK: "K",
-};
+// The lineup this module assumes when the contract gave us no
+// ``sleeper.rosterPositions``.  It is a 9-slot, non-IDP guess and it is
+// WRONG for both live leagues — it undercounts dynasty_main's 21-slot
+// lineup by 12.  It is kept only because /terminal's starter-share
+// panels are a defensive fallback that should degrade to a plausible
+// shape rather than to zero starters (see the module docstring above).
+//
+// /rosters deliberately does NOT take this route: it says so on screen
+// instead, because its starter board is a ranked comparison across 12
+// teams and a wrong lineup silently reorders it.
+const DEFAULT_FALLBACK_SLOTS = [
+  "QB",
+  "RB",
+  "RB",
+  "WR",
+  "WR",
+  "WR",
+  "TE",
+  "FLEX",
+  "SUPER_FLEX",
+];
 
 /**
- * Compute the strict starter / bench split using the league's
- * roster-positions array when present, falling back to a reasonable
- * default (1QB/2RB/3WR/1TE/1FLEX/1SF) otherwise.
+ * Starter / bench split for the terminal's portfolio panels.
  *
- * Two passes so flex slots fill AFTER strict-position slots have
- * already claimed the appropriate starters.  All slot-to-position
- * matching routes through FLEX_POOLS for anything flex-y, including
- * the IDP slot family (DL/LB/DB/IDP_FLEX/…) — those pools include
- * the generic "IDP" token so roster positions normalized upstream
- * still match specific-IDP lineup slots.
+ * Thin wrapper over the shared ``fillLineup`` — see
+ * ``lib/starter-slots.js`` for why the slot filling lives there.  The
+ * position vocabulary handed in here is the COLLAPSED one
+ * (``normalizePos``: DB/LB/DL/DE/DT/CB/S → "IDP"), so each of this
+ * league's 9 defensive slots matches any defender and the split credits
+ * the top 9 by value rather than 3 DL + 3 LB + 3 DB.  Totals coincide
+ * for a normally-constructed roster; a team stacked at one IDP position
+ * is over-credited.  /rosters passes the un-collapsed vocabulary and
+ * gets the exact answer.
  */
 function splitStartersBench({ rosterValues, sleeperRosterPositions }) {
-  const defaultSlots = ["QB", "RB", "RB", "WR", "WR", "WR", "TE", "FLEX", "SUPER_FLEX"];
-  const slots = Array.isArray(sleeperRosterPositions) && sleeperRosterPositions.length > 0
-    ? sleeperRosterPositions.filter((p) => {
-        const u = String(p).toUpperCase();
-        return u !== "BN" && u !== "IR" && u !== "TAXI";
-      })
-    : defaultSlots;
-
-  const pool = [...rosterValues].sort((a, b) => b.value - a.value);
-  const starterNames = new Set();
-
-  // First pass: strict position slots.
-  for (const slot of slots) {
-    const upper = STRICT_SLOT_REMAP[String(slot).toUpperCase()] ?? String(slot).toUpperCase();
-    if (FLEX_POOLS[upper]) continue;
-    const match = pool.find((p) => !starterNames.has(p.name) && p.pos === upper);
-    if (match) starterNames.add(match.name);
-  }
-  // Second pass: flex / IDP-family slots.
-  for (const slot of slots) {
-    const upper = STRICT_SLOT_REMAP[String(slot).toUpperCase()] ?? String(slot).toUpperCase();
-    const pool_ = FLEX_POOLS[upper];
-    if (!pool_) continue;
-    const match = pool.find((p) => !starterNames.has(p.name) && pool_.has(p.pos));
-    if (match) starterNames.add(match.name);
-  }
-
-  const starters = pool.filter((p) => starterNames.has(p.name));
-  const bench = pool.filter((p) => !starterNames.has(p.name));
+  const { starters, bench } = fillLineup({
+    assets: rosterValues,
+    rosterPositions: sleeperRosterPositions,
+    positionOf: (p) => p.pos,
+    fallbackSlots: DEFAULT_FALLBACK_SLOTS,
+  });
   return {
     starters,
     bench,

--- a/frontend/lib/portfolio-insights.js
+++ b/frontend/lib/portfolio-insights.js
@@ -119,7 +119,7 @@ const DEFAULT_FALLBACK_SLOTS = [
  * why both fields exist.
  */
 function splitStartersBench({ rosterValues, sleeperRosterPositions }) {
-  const { starters, bench } = fillLineup({
+  const { starters, bench, assignments, usedFallback } = fillLineup({
     assets: rosterValues,
     rosterPositions: sleeperRosterPositions,
     // ``|| p.pos`` only for callers that predate ``lineupPos``; every
@@ -130,6 +130,15 @@ function splitStartersBench({ rosterValues, sleeperRosterPositions }) {
   return {
     starters,
     bench,
+    // Slot-ordered, for anything that RENDERS the lineup.  ``starters``
+    // is value-descending, and truncating that to fit a panel drops the
+    // defense — IDP values sit far below offense on the blended board.
+    starterAssignments: assignments,
+    // False only when the contract carried no lineup and we fell back to
+    // DEFAULT_FALLBACK_SLOTS, which has no IDP slots at all.  Surfaced so
+    // the panel can say so instead of showing an offence-only lineup as
+    // if it were the league's.
+    lineupFromLeague: !usedFallback,
     starterCount: starters.length,
     benchCount: bench.length,
     starterValue: sumValue(starters),

--- a/frontend/lib/starter-slots.js
+++ b/frontend/lib/starter-slots.js
@@ -163,6 +163,55 @@ function normalizeSlot(slot) {
   return STRICT_SLOT_REMAP[upper] ?? upper;
 }
 
+// The order a lineup reads in, so `assignments` renders like the league's
+// own lineup card rather than in whatever order the registry map happened
+// to serialize.
+const SLOT_DISPLAY_ORDER = [
+  "QB", "RB", "WR", "TE", "FLEX", "SUPER_FLEX", "K", "DEF",
+  "DL", "LB", "DB", "IDP_FLEX",
+];
+
+// The registry spells superflex `SFLEX`; Sleeper spells it `SUPER_FLEX`,
+// which is the spelling FLEX_POOLS knows. Without this the slot falls
+// through to the strict pass, matches a position token nobody has, and
+// silently goes unfilled — one fewer starter, no error.
+const REGISTRY_SLOT_ALIASES = {
+  SFLEX: "SUPER_FLEX",
+  SUPERFLEX: "SUPER_FLEX",
+};
+
+/**
+ * Expand a registry `rosterSettings.starters` map into a slot array.
+ *
+ * `{QB: 1, RB: 2, ..., SFLEX: 1, DL: 3}` → `["QB","RB","RB",…,"SUPER_FLEX",…,"DL","DL","DL"]`,
+ * i.e. the same shape Sleeper's `rosterPositions` arrives in, so both can
+ * feed `fillLineup` unchanged.
+ *
+ * This is the SECOND rung of the truth ladder: live `rosterPositions`
+ * first, this next, and refusal after that — never a literal. See the
+ * module docstring.
+ */
+export function slotsFromStarterCounts(starters) {
+  if (!starters || typeof starters !== "object") return [];
+  const entries = Object.entries(starters)
+    .map(([slot, n]) => {
+      const upper = String(slot).toUpperCase();
+      return [REGISTRY_SLOT_ALIASES[upper] ?? upper, Number(n) || 0];
+    })
+    .filter(([, n]) => n > 0);
+  entries.sort((a, b) => {
+    const ia = SLOT_DISPLAY_ORDER.indexOf(a[0]);
+    const ib = SLOT_DISPLAY_ORDER.indexOf(b[0]);
+    // Unknown slots keep their relative order, after the known ones.
+    return (ia === -1 ? 999 : ia) - (ib === -1 ? 999 : ib);
+  });
+  const out = [];
+  for (const [slot, n] of entries) {
+    for (let i = 0; i < n; i += 1) out.push(slot);
+  }
+  return out;
+}
+
 /**
  * Fill a league's lineup slots greedily by value.
  *

--- a/frontend/lib/starter-slots.js
+++ b/frontend/lib/starter-slots.js
@@ -1,5 +1,7 @@
 "use client";
 
+import { normalizePos } from "@/lib/dynasty-data";
+
 /**
  * starter-slots — THE lineup-slot filler.
  *
@@ -104,6 +106,39 @@ export const FLEX_POOLS = {
 const STRICT_SLOT_REMAP = {
   PK: "K",
 };
+
+const DL_FAMILY = new Set(["DL", "DE", "DT", "EDGE", "NT"]);
+const LB_FAMILY = new Set(["LB", "OLB", "ILB"]);
+const DB_FAMILY = new Set(["DB", "CB", "S", "FS", "SS"]);
+
+/**
+ * A player position resolved to the token that fills a lineup slot.
+ *
+ * THE single position vocabulary for lineup purposes. Defensive players
+ * resolve to their FAMILY — DL, LB or DB, kept distinct — because this
+ * league starts 3 at each of those positions, not 9 defenders. Anything
+ * else (QB/RB/WR/TE/K/DEF) passes through `normalizePos` unchanged so a
+ * K slot still matches a kicker and a DEF slot a team defense.
+ *
+ * Keeping DL/LB/DB distinct is the whole point. `FLEX_POOLS.DL`, `.LB`
+ * and `.DB` each also contain the generic "IDP" token for backward
+ * compatibility, so a caller that hands in an IDP-collapsed vocabulary
+ * still matches *something* — but every defensive slot then matches
+ * every defender, and the fill degrades to "top N defenders by value".
+ * On a roster stacked at one IDP position that starts players the
+ * league has no slot for. Callers should resolve through here.
+ */
+export function lineupPosition(pos) {
+  const p = normalizePos(pos);
+  if (DL_FAMILY.has(p)) return "DL";
+  if (LB_FAMILY.has(p)) return "LB";
+  if (DB_FAMILY.has(p)) return "DB";
+  // ``normalizePos`` maps P -> K but not PK; portfolio-insights' local
+  // helper mapped PK and this must not lose it, or a kicker stops
+  // matching the league's K slot.
+  if (p === "PK") return "K";
+  return p;
+}
 
 // Slots that are not part of the starting lineup.
 const NON_LINEUP_SLOTS = new Set(["BN", "IR", "TAXI"]);

--- a/frontend/lib/starter-slots.js
+++ b/frontend/lib/starter-slots.js
@@ -209,46 +209,69 @@ export function fillLineup({
   const pool = scored.map((s) => s.asset);
   let slots = lineupSlots(rosterPositions);
   let available = slots.length > 0;
+  // Distinct from `available`, which goes true again once a fallback is
+  // applied. A caller that renders the lineup needs to know the
+  // difference between "this is the league's lineup" and "this is our
+  // guess at one" — collapsing them is how an offence-only default gets
+  // shown as if it were an IDP league's starting nine.
+  let usedFallback = false;
   if (!available) {
     if (!fallbackSlots) {
       return {
         starters: [],
         bench: pool,
+        assignments: [],
         slotCount: 0,
         unfilledSlots: [],
         available: false,
+        usedFallback: false,
       };
     }
     slots = lineupSlots(fallbackSlots);
     available = slots.length > 0;
+    usedFallback = available;
   }
 
   const claimed = new Set();
   const unfilledSlots = [];
+  // Slot -> asset, in the league's own slot order. `starters` below is
+  // value-descending, which is the wrong order for anything that renders
+  // a lineup: IDP values sit far below offense on the blended board, so
+  // truncating a value-sorted list to fit a panel eats the defense
+  // entirely. Callers that DISPLAY the lineup should walk `assignments`.
+  const assignments = slots.map((slot) => ({ slot: normalizeSlot(slot), asset: null }));
 
   // First pass: strict position slots.
-  for (const slot of slots) {
-    const upper = normalizeSlot(slot);
-    if (FLEX_POOLS[upper]) continue;
-    const match = pool.find((p) => !claimed.has(p) && positionOf(p) === upper);
-    if (match) claimed.add(match);
-    else unfilledSlots.push(upper);
-  }
+  assignments.forEach((a) => {
+    if (FLEX_POOLS[a.slot]) return;
+    const match = pool.find((p) => !claimed.has(p) && positionOf(p) === a.slot);
+    if (match) {
+      claimed.add(match);
+      a.asset = match;
+    } else {
+      unfilledSlots.push(a.slot);
+    }
+  });
   // Second pass: flex / IDP-family slots.
-  for (const slot of slots) {
-    const upper = normalizeSlot(slot);
-    const eligible = FLEX_POOLS[upper];
-    if (!eligible) continue;
+  assignments.forEach((a) => {
+    const eligible = FLEX_POOLS[a.slot];
+    if (!eligible) return;
     const match = pool.find((p) => !claimed.has(p) && eligible.has(positionOf(p)));
-    if (match) claimed.add(match);
-    else unfilledSlots.push(upper);
-  }
+    if (match) {
+      claimed.add(match);
+      a.asset = match;
+    } else {
+      unfilledSlots.push(a.slot);
+    }
+  });
 
   return {
     starters: pool.filter((p) => claimed.has(p)),
     bench: pool.filter((p) => !claimed.has(p)),
+    assignments: assignments.filter((a) => a.asset),
     slotCount: slots.length,
     unfilledSlots,
     available,
+    usedFallback,
   };
 }

--- a/frontend/lib/starter-slots.js
+++ b/frontend/lib/starter-slots.js
@@ -1,0 +1,219 @@
+"use client";
+
+/**
+ * starter-slots — THE lineup-slot filler.
+ *
+ * One implementation of "given a roster and a league's lineup slots,
+ * which players start?", shared by `portfolio-insights.js` (/terminal)
+ * and `league-analysis.js` (/rosters).
+ *
+ * WHY THIS MODULE EXISTS
+ *
+ * There were six answers to that question in the tree and two of them
+ * were wrong (audit 2026-07-30):
+ *
+ *   - `league-analysis.js` carried `STARTER_SLOTS = { QB: 2, RB: 3,
+ *     WR: 4, TE: 2, DL: 2, LB: 2, DB: 2 }` — a per-position top-N with
+ *     DL/LB/DB at 2 where the league starts 3 of each. It counted 17
+ *     slots against a real 20 (21 minus K, which never enters), dropping
+ *     the 3rd DL, 3rd LB and 3rd DB from every team on /rosters
+ *     "Starters only". Replaying both models over the 2026-07-30 roster
+ *     snapshot: every team undercounted, mean 10.1%, and because the
+ *     error is roster-dependent the leaderboard REORDERS — 7 of 12
+ *     teams move, including #2 <-> #4. (Measured on the snapshot's
+ *     `_finalAdjusted` composite, the closest offline proxy for the
+ *     served board; the exact percentages shift with the value scale,
+ *     the missing slots and the reordering do not.)
+ *   - It was also a single-league literal. Starter counts are
+ *     leagueKey-scoped (CLAUDE.md, "Rankings vs. league context"), and
+ *     the two live leagues share a scoring profile while running
+ *     completely different lineups: `dynasty_main` is 12-team IDP with
+ *     TE 2; `dynasty_new` is 10-team, no IDP, TE 1.
+ *
+ * TRUTH PRECEDENCE — live host first, registry second, never a literal.
+ * `sleeper.rosterPositions` is what the league actually runs and is
+ * already stamped per-league on the contract; `rosterSettings.starters`
+ * in the registry is operator-maintained and known to drift. That is
+ * the precedence the BDVM layer already set (`src/bdvm/league_config.py`),
+ * and this follows it rather than inventing a second convention.
+ *
+ * A per-position top-N cannot express this league's lineup anyway: 3 of
+ * its 21 slots are FLEX/SUPER_FLEX, so "how many WRs start" is not a
+ * constant — it depends on who else is on the roster. Hence a fill, not
+ * a count.
+ *
+ * VOCABULARY
+ *
+ * Callers supply `positionOf`, so this works on either position
+ * vocabulary in the tree: portfolio-insights collapses DB/LB/DL/DE/DT/
+ * CB/S → "IDP", while league-analysis's `posGroup` keeps DL/LB/DB
+ * distinct. Both resolve, because the IDP pools below carry the generic
+ * "IDP" token AND the specific ones. The distinct vocabulary is
+ * strictly better: with it, a DL slot matches only defensive linemen,
+ * where the collapsed vocabulary credits the top 9 defenders regardless
+ * of whether the roster can actually fill 3 DL + 3 LB + 3 DB.
+ */
+
+// Which player positions can fill each Sleeper lineup slot. Without
+// full coverage an unrecognized alias like WRRB_FLEX would fall
+// through the strict pass, never match any player, and push valid
+// starters onto the bench — skewing starter-share metrics.
+const OFFENSE_FLEX = new Set(["RB", "WR", "TE"]);
+const WR_RB_FLEX_POOL = new Set(["RB", "WR"]);
+const WR_TE_FLEX_POOL = new Set(["WR", "TE"]);
+const SUPER_FLEX_POOL = new Set(["QB", "RB", "WR", "TE"]);
+const IDP_POOL = new Set(["IDP", "DL", "DE", "DT", "LB", "DB", "CB", "S"]);
+
+export const FLEX_POOLS = {
+  // Offense: all known Sleeper aliases → the same pool.
+  FLEX: OFFENSE_FLEX,
+  // RB/WR (no TE)
+  WR_RB_FLEX: WR_RB_FLEX_POOL,
+  WRRB_FLEX: WR_RB_FLEX_POOL,
+  RB_WR_FLEX: WR_RB_FLEX_POOL,
+  RBWR_FLEX: WR_RB_FLEX_POOL,
+  // WR/TE
+  REC_FLEX: WR_TE_FLEX_POOL,
+  WR_TE_FLEX: WR_TE_FLEX_POOL,
+  WRTE_FLEX: WR_TE_FLEX_POOL,
+  WRT: WR_TE_FLEX_POOL,
+  // Superflex (QB-eligible)
+  SUPER_FLEX: SUPER_FLEX_POOL,
+  SUPERFLEX: SUPER_FLEX_POOL,
+  Q_FLEX: SUPER_FLEX_POOL,
+  QB_RB_WR_TE: SUPER_FLEX_POOL,
+  // IDP — both specific slot names and flex aliases.
+  DL: new Set(["IDP", "DL", "DE", "DT"]),
+  DE: new Set(["IDP", "DE", "DL"]),
+  DT: new Set(["IDP", "DT", "DL"]),
+  LB: new Set(["IDP", "LB"]),
+  DB: new Set(["IDP", "DB", "CB", "S"]),
+  CB: new Set(["IDP", "CB", "DB"]),
+  S: new Set(["IDP", "S", "DB"]),
+  IDP: IDP_POOL,
+  IDP_FLEX: IDP_POOL,
+  DB_LB: IDP_POOL,
+  DL_LB: IDP_POOL,
+  DL_DB: IDP_POOL,
+  DEF_FLEX: IDP_POOL,
+};
+
+// Strict slots (no flex pool entry): these match a single normalized
+// player position token exactly. K and DEF do not collapse into a flex
+// pool; their slots match same-named rosters and nothing else.
+const STRICT_SLOT_REMAP = {
+  PK: "K",
+};
+
+// Slots that are not part of the starting lineup.
+const NON_LINEUP_SLOTS = new Set(["BN", "IR", "TAXI"]);
+
+/**
+ * The starting-lineup slots from a Sleeper `rosterPositions` array.
+ * Returns [] for a missing or empty array — callers decide what an
+ * absent lineup means for them rather than inheriting a default from
+ * here (see `fillLineup`'s `available` flag).
+ */
+export function lineupSlots(sleeperRosterPositions) {
+  if (!Array.isArray(sleeperRosterPositions) || sleeperRosterPositions.length === 0) {
+    return [];
+  }
+  return sleeperRosterPositions
+    .map((p) => String(p).toUpperCase())
+    .filter((p) => !NON_LINEUP_SLOTS.has(p));
+}
+
+function normalizeSlot(slot) {
+  const upper = String(slot).toUpperCase();
+  return STRICT_SLOT_REMAP[upper] ?? upper;
+}
+
+/**
+ * Fill a league's lineup slots greedily by value.
+ *
+ * Two passes so flex slots fill AFTER strict-position slots have
+ * already claimed the appropriate starters. All slot-to-position
+ * matching routes through FLEX_POOLS for anything flex-y, including the
+ * IDP slot family (DL/LB/DB/IDP_FLEX/…).
+ *
+ * @param {object}   opts
+ * @param {object[]} opts.assets      - any shape; read only via the two
+ *   accessors below
+ * @param {string[]} opts.rosterPositions - the league's Sleeper slot array
+ * @param {Function} opts.positionOf  - asset → normalized position token
+ * @param {Function} [opts.valueFor]  - asset → number. Defaults to
+ *   `p.value`. PASS IT if your assets name the field something else:
+ *   `league-analysis`'s player-meta entries carry `.meta`, and a
+ *   `.value` default silently returns NaN for all of them, which makes
+ *   the sort a no-op and fills slots in insertion order instead of by
+ *   value. That is a wrong answer that looks like a right one.
+ * @param {string[]} [opts.fallbackSlots] - slots to use when
+ *   `rosterPositions` is absent. OMIT IT to get `available: false`
+ *   instead of an invented lineup — see below.
+ *
+ * @returns {{ starters, bench, slotCount, unfilledSlots, available }}
+ *   `available` is false when no lineup was supplied and no fallback
+ *   was given. In that state `starters` is empty and `bench` is
+ *   everything — deliberately, so a caller cannot mistake "we don't
+ *   know this league's lineup" for "this team starts nobody". The old
+ *   silent default here was a 9-slot non-IDP lineup, which undercounted
+ *   an IDP league by 12 slots without saying so.
+ */
+export function fillLineup({
+  assets,
+  rosterPositions,
+  positionOf,
+  valueFor = (p) => p?.value,
+  fallbackSlots = null,
+}) {
+  const scored = (assets || []).map((a) => {
+    const v = Number(valueFor(a));
+    return { asset: a, value: Number.isFinite(v) ? v : 0 };
+  });
+  scored.sort((a, b) => b.value - a.value);
+  const pool = scored.map((s) => s.asset);
+  let slots = lineupSlots(rosterPositions);
+  let available = slots.length > 0;
+  if (!available) {
+    if (!fallbackSlots) {
+      return {
+        starters: [],
+        bench: pool,
+        slotCount: 0,
+        unfilledSlots: [],
+        available: false,
+      };
+    }
+    slots = lineupSlots(fallbackSlots);
+    available = slots.length > 0;
+  }
+
+  const claimed = new Set();
+  const unfilledSlots = [];
+
+  // First pass: strict position slots.
+  for (const slot of slots) {
+    const upper = normalizeSlot(slot);
+    if (FLEX_POOLS[upper]) continue;
+    const match = pool.find((p) => !claimed.has(p) && positionOf(p) === upper);
+    if (match) claimed.add(match);
+    else unfilledSlots.push(upper);
+  }
+  // Second pass: flex / IDP-family slots.
+  for (const slot of slots) {
+    const upper = normalizeSlot(slot);
+    const eligible = FLEX_POOLS[upper];
+    if (!eligible) continue;
+    const match = pool.find((p) => !claimed.has(p) && eligible.has(positionOf(p)));
+    if (match) claimed.add(match);
+    else unfilledSlots.push(upper);
+  }
+
+  return {
+    starters: pool.filter((p) => claimed.has(p)),
+    bench: pool.filter((p) => !claimed.has(p)),
+    slotCount: slots.length,
+    unfilledSlots,
+    available,
+  };
+}

--- a/scripts/fetch_draftsharks_ros.py
+++ b/scripts/fetch_draftsharks_ros.py
@@ -5,9 +5,10 @@ dynasty Superflex page (a season-long valuation board used as a
 ROS proxy), this hits the actual ROS-specific pages:
 
   * ``/ros-rankings/superflex`` — combined offense + IDP ROS list
-  * ``/ros-rankings/idp``       — IDP-only ROS list (currently
-                                  redundant with the SF page; kept
-                                  for forward compat)
+  * ``/ros-rankings/idp``       — despite the name, NOT an IDP-only
+                                  list: a second FULL board over the
+                                  same universe, ranked for a
+                                  1QB format
 
 These pages render ~25 rows server-side and lazy-load the rest via
 JS scroll, so we need a real browser to capture the full ranked
@@ -17,13 +18,32 @@ Reuses the same ``draftsharks_session.json`` cookie store + login
 flow that ``fetch_draftsharks.py`` already established — no new
 auth dependency.
 
-Output: writes per-asset CSVs directly into ``data/ros/sources/``
-so the ROS orchestrator picks them up on the next scrape pass:
+Output: writes per-asset CSVs into ``CSVs/site_raw/`` (see
+``ROS_RAW_DIR`` below for why that path and not ``data/ros/sources/``),
+where the adapter ``src/ros/sources/draftsharks_ros.py`` reads them:
 
-  * ``data/ros/sources/draftSharksRosSf.csv``  (offense + IDP, position-tagged)
-  * ``data/ros/sources/draftSharksRosIdp.csv`` (IDP-only mirror; currently
-                                                a subset of the SF list filtered
-                                                to IDP positions)
+  * ``CSVs/site_raw/draftSharksRosSf.csv``  (offense + IDP, position-tagged)
+  * ``CSVs/site_raw/draftSharksRosIdp.csv`` (the ``/ros-rankings/idp``
+                                             page verbatim)
+
+WHAT THE IDP FILE ACTUALLY IS (measured 2026-07-30, corrected here —
+this docstring previously claimed it was "IDP-only … filtered to IDP
+positions", which it has never been).  Both files carry 978 rows over
+the *identical* 978 players — zero names unique to either side — and
+the SF board already contains all 424 IDP-family rows by itself.  What
+differs is the FORMAT: 974 of 978 players sit at a different rank, and
+the deltas are positional (RB −171, QB +104, WR +109), i.e. the idp
+page is a 1QB board.  ``jahmyr gibbs`` is 1 there against ``josh
+allen``'s 17; on the SF board those are 2 and 1.
+
+It is therefore kept as forward-compat / pagination overflow, NOT as a
+second opinion.  The adapter unions it name-first behind the SF board
+so it contributes only players the SF page did not list (today: zero).
+Do not restore the ``_IDP_FAMILIES`` filter to the success branch to
+"make the file match its name": ``_write_csv`` renumbers ``rank`` 1..N
+and stamps ``total_ranked = N``, so a filtered file would arrive on a
+424-player scale for players already carried at 978, and every one of
+them would still be excluded by the union — a file nothing reads.
 
 The CSV schema matches the ROS orchestrator's existing format
 (``canonicalName,sourceName,position,team,rank,total_ranked,projection``).
@@ -242,12 +262,17 @@ async def main_async() -> int:
     # which is how DS publishes their ROS list).  Position is preserved.
     n_sf = _write_csv(sf_csv, sf_rows)
 
-    # IDP CSV.  The SF-filter fallback is acceptable when the IDP
-    # page merely loaded empty, but a FAILED IDP fetch must NOT
-    # silently overwrite the last-good IDP CSV with a degraded
-    # SF-filtered board (this was a silent-degradation bug).  On
-    # failure: preserve last-good if it exists and fail loud; only
-    # fall back when there is no prior good CSV (genuine first run).
+    # IDP CSV — written verbatim from ``/ros-rankings/idp``, which is a
+    # full 1QB board rather than an IDP subset (see the module
+    # docstring).  The adapter unions it behind the SF board name-first,
+    # so it only ever contributes players the SF page did not list.
+    #
+    # The SF-filter fallback below is acceptable when the IDP page
+    # merely loaded empty, but a FAILED IDP fetch must NOT silently
+    # overwrite the last-good IDP CSV with a degraded SF-filtered board
+    # (this was a silent-degradation bug).  On failure: preserve
+    # last-good if it exists and fail loud; only fall back when there is
+    # no prior good CSV (genuine first run).
     idp_degraded = False
     if idp_page_failed and idp_csv.exists():
         print(

--- a/scripts/measure_te_demand_actuals.py
+++ b/scripts/measure_te_demand_actuals.py
@@ -36,30 +36,40 @@ from src.ros.lineup import RosterPlayer, optimize_lineup  # noqa: E402
 FIX = REPO / "tests/league_intel/fixtures/matchups_2025"
 META = json.loads((FIX / "players_meta.json").read_text())
 
-NEW = (
-    ["QB"]
-    + ["RB"] * 2
-    + ["WR"] * 3
-    + ["TE"] * 2
-    + ["FLEX"] * 2
-    + ["SUPER_FLEX"]
-    + ["K"]
-    + ["DL"] * 3
-    + ["LB"] * 3
-    + ["DB"] * 3
-)
-OLD = (
-    ["QB"]
-    + ["RB"] * 2
-    + ["WR"] * 3
-    + ["TE"]
-    + ["FLEX"] * 2
-    + ["SUPER_FLEX"]
-    + ["K"]
-    + ["DL"] * 2
-    + ["LB"] * 2
-    + ["DB"] * 2
-)
+
+def _slots(te_count: int) -> list[str]:
+    """This league's lineup with ONLY the TE count parameterised.
+
+    The two arms must differ in exactly one slot or the comparison
+    measures something other than TE premium.  They are built from one
+    expression for that reason: the OLD arm used to be written out
+    longhand and carried ``DL 2 / LB 2 / DB 2`` against NEW's 3/3/3, so
+    it quietly dropped a slot at each IDP position too — the same wrong
+    2/2/2 table that was deleted from the frontend on 2026-07-30, and a
+    direct contradiction of this module's own docstring claim that the
+    vectors are "measured symmetrically".
+
+    The IDP slots do not compete with TE for a slot (the eligibility
+    pools are disjoint), so this does not move the measured ratio — but
+    "it happened not to matter" is not a reason to leave an asymmetry in
+    a symmetric measurement.
+    """
+    return (
+        ["QB"]
+        + ["RB"] * 2
+        + ["WR"] * 3
+        + ["TE"] * te_count
+        + ["FLEX"] * 2
+        + ["SUPER_FLEX"]
+        + ["K"]
+        + ["DL"] * 3
+        + ["LB"] * 3
+        + ["DB"] * 3
+    )
+
+
+NEW = _slots(2)  # our league: 2 TE
+OLD = _slots(1)  # 1-TE reference
 
 
 def base_pos(pid: str) -> str:

--- a/server.py
+++ b/server.py
@@ -5867,7 +5867,16 @@ async def post_trade_suggestions(request: Request):
     from src.trade.suggestions import (
         build_asset_pool_from_contract,
         generate_suggestions_from_pool,
+        starter_needs_for_league,
     )
+
+    # Effective starter demand is a per-LEAGUE fact, not a constant: both
+    # live leagues share a scoring profile but ``dynasty_main`` starts
+    # 2 TE + 9 IDP while ``dynasty_new`` starts 1 TE and no IDP.  The
+    # engine has always accepted ``starter_needs``; nothing ever passed
+    # it, so every league got dynasty_main's lineup.  The derivation is
+    # a no-op for dynasty_main by construction.
+    starter_needs = starter_needs_for_league(getattr(league_cfg, "key", None))
 
     league_rosters = body.get("league_rosters")
     if league_rosters is not None and not isinstance(league_rosters, list):
@@ -5918,6 +5927,7 @@ async def post_trade_suggestions(request: Request):
             roster_names=roster,
             pool=pool,
             league_rosters=league_rosters,
+            starter_needs=starter_needs,
             ktc_top_n=ktc_top_n,
         )
 

--- a/server.py
+++ b/server.py
@@ -8551,23 +8551,48 @@ class PublicSnapshotUnavailable(RuntimeError):
 # naively, a burst of concurrent ``playoffOdds`` requests would each
 # launch an independent simulation and saturate the shared threadpool.
 #
-# So we single-flight + memoize ``playoffOdds`` only:
+# ``archives`` has the same SHAPE for a different reason (added
+# 2026-07-30).  It is the single most expensive builder in the contract:
+# ``src/public_league/archives.py`` rebuilds four other sections
+# (history, activity, draft, awards) before its own five walks, and
+# ``assert_public_payload_safe`` then recurses the whole ~800 KB result.
+# That is ~1.4s of GIL-bound Python per request, and it ran fresh on
+# EVERY request — measured 34.3s / 19.3s / 2.9s TTFB on production
+# against a ~0.53s baseline for every other section, because concurrent
+# requests each launched their own build and held an AnyIO worker token
+# for the duration.  The 2 MB aggregate contract is *faster* than this
+# 737 KB subset of it precisely because the aggregate is memoized
+# (``_store_public_contract_bytes``) and the section route threw the
+# identical work away.
+#
+# So we single-flight + memoize these two:
 #   * Coordination happens on the EVENT LOOP via a per-section
 #     ``asyncio.Lock`` (see ``_get_heavy_section_payload``), so waiters
 #     ``await`` on the loop instead of occupying AnyIO worker tokens.
 #     Exactly one request offloads the simulation to ``run_in_threadpool``;
 #     the rest wake to the cached result.
 #   * The result is keyed by the snapshot's identity + freshness
-#     (``root_league_id`` + ``generated_at``).  ``playoffOdds`` is derived
-#     purely from the snapshot (no external files), so that key is
-#     complete — a snapshot refresh mints a new ``generated_at`` and
-#     transparently invalidates the entry (bounded to one payload).
+#     (``root_league_id`` + ``generated_at``).  Both are derived purely
+#     from the snapshot (no external files), so that key is complete — a
+#     snapshot refresh mints a new ``generated_at`` and transparently
+#     invalidates the entry (bounded to one payload per section).
+#     Freshness is therefore unchanged by memoizing: the 300s SWR window
+#     on the snapshot still governs how old the data can be.
+#
+# One asymmetry worth knowing before adding a third key: the JSON route
+# passes ``activity_valuation`` and the CSV route does not, while the
+# cache key includes neither.  That is safe for both current members —
+# ``playoffOdds`` resolves through ``_LAZY_SECTION_BUILDERS`` and
+# ``archives`` through ``_SECTION_BUILDERS``, and neither branch of
+# ``build_section_payload`` forwards the kwarg (only ``activity`` and
+# the aggregate walk do).  A section that DOES consume it must not be
+# added here without putting it in the cache key.
 #
 # The file-backed ROS sections are deliberately NOT cached here: they are
 # cheap file reads in the common case, and caching them by snapshot
 # identity would hide fresh results the ROS publisher writes between
 # snapshot refreshes.  They read their artifact fresh on every request.
-_HEAVY_SECTION_KEYS = frozenset({"playoffOdds"})
+_HEAVY_SECTION_KEYS = frozenset({"playoffOdds", "archives"})
 _heavy_section_cache: dict = {}
 _heavy_section_async_locks: dict = {}
 
@@ -9366,10 +9391,24 @@ async def get_public_league_section_csv(
 
     try:
         snapshot = await run_in_threadpool(_get_public_snapshot, force_refresh=bool(refresh))
-        if section in _HEAVY_SECTION_KEYS:
-            # playoffOdds.csv: reuse the single-flighted / cached payload
-            # (heavy sections take no owner/kind qualifier), then serialize
-            # to CSV in the worker.
+        if section in _HEAVY_SECTION_KEYS and not kind and not owner:
+            # Reuse the single-flighted / cached payload, then serialize to
+            # CSV in the worker.
+            #
+            # The qualifier check is load-bearing, not defensive padding:
+            # this branch never FORWARDS a qualifier, which was invisible
+            # while ``playoffOdds`` (which takes none) was the only heavy
+            # section.  ``archives`` DOES take ``?kind=`` — and
+            # ``public_csv_export.export_section`` falls back to trades for
+            # a missing kind, so without this a request for
+            # ``archives.csv?kind=waivers`` would return a trades CSV with
+            # a 200 and nothing saying a qualifier had been ignored.  A
+            # qualified request drops to the uncached branch below, which
+            # honours it; that is the rarer path, and correctness beats the
+            # memo there.  ``owner`` is included for the same reason even
+            # though no heavy section reads it today — the predicate should
+            # match the stated rule, or the next section added here
+            # reintroduces the bug.
             payload = await _get_heavy_section_payload(snapshot, section)
 
             def _export():

--- a/src/league_intel/replacement.py
+++ b/src/league_intel/replacement.py
@@ -269,6 +269,31 @@ def measure_endogenous_starters(
         solution = optimize_lineup(_to_roster_players(players), starter_slots=starter_slots)
         per_pos: dict[str, list[float]] = {}
         for row in solution.starting_lineup:
+            # BY THE PLAYER'S NOMINAL POSITION, NOT BY THE SLOT — and that
+            # is deliberate, so read this before "fixing" it.
+            #
+            # It looks wrong on a hybrid: a DL/LB whom the optimizer slots
+            # at LB still counts as DL here, so on the live 12 rosters
+            # ``starters_per_team`` reads DL 2.667 / LB 3.250 / DB 3.083
+            # while the league plainly starts 3 at each.  The slot truth
+            # is real and is recorded — ``slot_fill`` below shows exactly
+            # 36 DL / 36 LB / 36 DB, 3 per team.
+            #
+            # But this count exists to INDEX A POOL, and the pool is keyed
+            # by nominal position: ``compute_scarcity`` builds ``by_pos``
+            # from ``normalize_base_position(player["position"])`` and
+            # then uses ``starters_n`` to find the median starter inside
+            # it.  Counting by slot instead would index a pool of
+            # nominal-DLs with a number derived from DL *slots* — the two
+            # stop denoting the same set the moment one hybrid moves, and
+            # ``lineupScarcity`` (the only live axis of the
+            # league-adjusted overlay) is computed off that index.
+            #
+            # The question this answers is "how many DL-pool bodies do
+            # lineups consume", which is what a replacement level needs.
+            # "How many DL slots does the league start" is a different
+            # question with a different answer, and ``slot_fill`` is where
+            # it lives.
             base = normalize_base_position(str(row.get("position") or ""))
             counts[base] = counts.get(base, 0) + 1
             per_pos.setdefault(base, []).append(float(row.get("rosValue") or 0.0))

--- a/src/league_intel/replacement.py
+++ b/src/league_intel/replacement.py
@@ -279,15 +279,28 @@ def measure_endogenous_starters(
             # is real and is recorded — ``slot_fill`` below shows exactly
             # 36 DL / 36 LB / 36 DB, 3 per team.
             #
-            # But this count exists to INDEX A POOL, and the pool is keyed
-            # by nominal position: ``compute_scarcity`` builds ``by_pos``
-            # from ``normalize_base_position(player["position"])`` and
-            # then uses ``starters_n`` to find the median starter inside
-            # it.  Counting by slot instead would index a pool of
-            # nominal-DLs with a number derived from DL *slots* — the two
-            # stop denoting the same set the moment one hybrid moves, and
-            # ``lineupScarcity`` (the only live axis of the
-            # league-adjusted overlay) is computed off that index.
+            # But these numbers exist to describe A POOL, and the pool is
+            # keyed by nominal position: ``compute_scarcity`` builds
+            # ``by_pos`` from ``normalize_base_position(player["position"])``.
+            # Two separate consumers depend on that correspondence, and it
+            # is worth naming them precisely rather than hand-waving at
+            # "scarcity" — a vague justification is what invites the next
+            # reader to re-open this:
+            #
+            #   * ``starters_per_team`` → ``starters_n`` → ``pool[:n]`` →
+            #     ``median_starter``, which feeds ``eliteSeparation`` and
+            #     ``starterSeparation``.  Slicing a pool of nominal-DLs
+            #     with a count derived from DL *slots* mismatches
+            #     numerator and denominator.
+            #   * ``marginal_starter_values`` → the ``starter``
+            #     replacement tier → ``lineupScarcity``, which IS the live
+            #     axis of the league-adjusted overlay.  Note it reaches
+            #     that axis through the MARGINALS, not through
+            #     ``starters_n`` — an earlier version of this comment said
+            #     otherwise and was wrong.
+            #
+            # Both are keyed nominally, so switching attribution to the
+            # slot breaks both.
             #
             # The question this answers is "how many DL-pool bodies do
             # lineups consume", which is what a replacement level needs.

--- a/src/ros/aggregate.py
+++ b/src/ros/aggregate.py
@@ -33,6 +33,7 @@ in ``src/ros/scrape.py`` and ``src/ros/api.py``.
 
 from __future__ import annotations
 
+import logging
 import statistics
 from dataclasses import dataclass, field
 from typing import Any, Iterable
@@ -42,6 +43,8 @@ from src.ros.parse import (
     rank_to_score,
 )
 
+
+LOG = logging.getLogger("ros.aggregate")
 
 VOLATILITY_THRESHOLD = 18.0  # 0-100 scale; stddev above this flags volatile
 DEFAULT_TIER_QUINTILES = 5
@@ -150,6 +153,17 @@ def aggregate(
         )
         if weight <= 0:
             continue
+        # One vote per (source, player).  ``weight`` above is computed once
+        # for the SOURCE, then added below once per ROW — so a source that
+        # lists the same player twice silently doubles that vendor's say.
+        # That is not hypothetical: the DraftSharks ROS adapter
+        # concatenated two of the vendor's own boards over an identical
+        # 978-player universe, taking 67.4% of the blend against an
+        # intended 50.8% and inflating ``sourceCount``/``confidence`` on
+        # 939 of 1084 players for a year (audit 2026-07-30).  The adapter
+        # is fixed; this guard is here so the next one cannot reintroduce
+        # it.  First row wins — adapters put their primary board first.
+        seen_in_source: set[str] = set()
         for row in snap.rows:
             if not row.canonical_name:
                 continue
@@ -167,6 +181,18 @@ def aggregate(
             score = rank_to_score(row.rank, row.total_ranked)
             if score <= 0:
                 continue
+            # Checked here rather than at the top of the loop so a row that
+            # scores 0 (and contributes nothing) cannot claim the slot and
+            # shut out a scoreable duplicate behind it.
+            if row.canonical_name in seen_in_source:
+                LOG.warning(
+                    "[ros] %s emitted %r more than once — keeping the first "
+                    "scoring row; a source gets one vote per player.",
+                    snap.source_key,
+                    row.canonical_name,
+                )
+                continue
+            seen_in_source.add(row.canonical_name)
             acc = accs.get(row.canonical_name)
             if acc is None:
                 acc = _PlayerAcc(
@@ -204,10 +230,17 @@ def aggregate(
         ros_value = acc.weighted_score_sum / acc.weight_sum
         stddev = statistics.pstdev(acc.raw_scores) if len(acc.raw_scores) > 1 else 0.0
         median_rank = statistics.median(acc.ranks) if acc.ranks else None
+        # DISTINCT sources, not rows.  ``sourceCount`` is the number the UI
+        # shows as "N sources agree" and the number ``ros-index.js`` breaks
+        # duplicate-row ties on, so counting rows lets one vendor's second
+        # board read as independent corroboration.  The per-source dedup
+        # above makes these equal today; this keeps them equal by
+        # construction rather than by the loop above staying correct.
+        source_count = len({c["sourceKey"] for c in acc.contributors})
         # Confidence: combines source count (saturates at 4),
         # agreement (1 - stddev/SD_REFERENCE), and freshness
         # (% of contributors not stale).
-        source_count_factor = min(1.0, len(acc.ranks) / 4.0)
+        source_count_factor = min(1.0, source_count / 4.0)
         agreement_factor = max(0.0, 1.0 - stddev / 30.0)
         freshness_factor = 1.0 - (acc.stale_count / acc.total_count) if acc.total_count else 0.0
         confidence = round(
@@ -219,7 +252,7 @@ def aggregate(
                 "canonicalName": acc.canonical_name,
                 "position": acc.position,
                 "rosValue": round(ros_value, 2),
-                "sourceCount": len(acc.ranks),
+                "sourceCount": source_count,
                 "sourceMinRank": min(acc.ranks),
                 "sourceMaxRank": max(acc.ranks),
                 "sourceMedianRank": float(median_rank) if median_rank is not None else None,

--- a/src/ros/sources/draftsharks_ros.py
+++ b/src/ros/sources/draftsharks_ros.py
@@ -148,6 +148,40 @@ def _read_dynasty_proxy_csv(path: Path) -> list[dict[str, Any]]:
     return rows
 
 
+def _union_primary_first(
+    primary: list[dict[str, Any]],
+    secondary: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], int]:
+    """Merge two boards under ONE source key without double-counting.
+
+    The primary board wins outright; a secondary row is merged only when
+    its name is ABSENT from the primary.  That is the whole invariant:
+    ``src/ros/aggregate.py`` adds the source's full weight per ROW with no
+    ``(source_key, player)`` guard, so one vendor listing a player on two
+    of its own boards counts that vendor's opinion twice.
+
+    Merging only unseen names is also what makes the two boards' separate
+    rank scales safe.  Each row carries its own ``total_ranked`` and
+    ``rank_to_score`` normalizes against it, which is correct for
+    genuinely disjoint boards (the dynasty proxies: 453 offense-only rows
+    and 411 IDP-only, one name in common) and would be wrong only for
+    overlapping ones — which is exactly the case this excludes.
+
+    Returns ``(rows, merged_from_secondary)``.
+    """
+    seen = {(r.get("sourceName") or "").strip().lower() for r in primary}
+    rows = list(primary)
+    merged = 0
+    for row in secondary:
+        name = (row.get("sourceName") or "").strip().lower()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        rows.append(row)
+        merged += 1
+    return rows, merged
+
+
 def scrape(src_meta: dict[str, Any]) -> ScrapeResult:
     """Read DraftSharks ROS data.
 
@@ -160,25 +194,54 @@ def scrape(src_meta: dict[str, Any]) -> ScrapeResult:
     Falls back to the dynasty Superflex + IDP CSVs as a season-long
     proxy when the ROS fetcher hasn't run yet (fresh checkout, ROS
     page outage, etc.).
+
+    The two files are UNIONED name-first, not concatenated (audit
+    2026-07-30).  ``/ros-rankings/idp`` is not an IDP-only mirror
+    despite its name: measured on the live files it is a second FULL
+    board over the identical 978-player universe (0 names unique to
+    either side) in a different format — a 1QB board, where
+    ``jahmyr gibbs`` is 1 and ``josh allen`` is 17 against the SF
+    board's 1 and 2.  Concatenating handed DraftSharks 67.4% of the
+    blend instead of 50.8%, inflated ``sourceCount``/``confidence`` on
+    939 of 1084 players, and systematically suppressed QB/LB in a
+    superflex IDP league.  Nothing is lost by collapsing: the SF board
+    already carries all 424 IDP-family rows itself.
     """
     started = datetime.now(timezone.utc).isoformat()
     key = str(src_meta.get("key") or "draftSharksRosSf")
 
-    # Prefer real ROS data when both CSVs are populated.
+    # Prefer real ROS data when the SF board is populated.
+    #
+    # The SF board is the one this source key claims to be
+    # (``is_superflex: True``, +10% format-match bonus in
+    # ``src/ros/aggregate.py``).  When it is missing we do NOT promote
+    # the idp file in its place — that file is a 1QB board, and serving
+    # it under a superflex key would pay a format-match bonus for a
+    # format mismatch.  Fall through to the dynasty proxies instead,
+    # which are genuinely superflex + genuinely disjoint (453
+    # offense-only rows vs 411 IDP-only, one name in common).
     sf_rows = _read_ros_csv(DS_ROS_SF_CSV)
     idp_rows = _read_ros_csv(DS_ROS_IDP_CSV)
     source_mode = "ros"
-    if not sf_rows and not idp_rows:
+    if not sf_rows:
+        if idp_rows:
+            LOG.warning(
+                "[ros] DraftSharks: SF ROS board empty but IDP board has "
+                "%d rows — declining to serve a 1QB board under a "
+                "superflex key; falling back to the dynasty proxies.",
+                len(idp_rows),
+            )
         sf_rows = _read_dynasty_proxy_csv(DS_DYNASTY_SF_CSV)
         idp_rows = _read_dynasty_proxy_csv(DS_DYNASTY_IDP_CSV)
         source_mode = "dynasty_proxy"
 
-    rows = sf_rows + idp_rows
+    rows, merged = _union_primary_first(sf_rows, idp_rows)
     LOG.info(
-        "[ros] DraftSharks: %d rows (sf=%d, idp=%d, mode=%s)",
+        "[ros] DraftSharks: %d rows (sf=%d, idp=%d -> merged=%d new, mode=%s)",
         len(rows),
         len(sf_rows),
         len(idp_rows),
+        merged,
         source_mode,
     )
 

--- a/src/trade/suggestions.py
+++ b/src/trade/suggestions.py
@@ -46,6 +46,106 @@ DEFAULT_STARTER_NEEDS: dict[str, int] = {
     "DB": 3,  # 3 DB
 }
 
+# Order flex slots are handed out in when converting a lineup to
+# effective demand.  RB before WR before TE matches how the constant
+# above was hand-derived, and is what makes the derivation reproduce it.
+_FLEX_ALLOCATION_ORDER: tuple[str, ...] = ("RB", "WR", "TE")
+
+# Slots that carry no dynasty trade demand.  ``K`` is deliberately
+# absent from the constant above and must stay absent from the derived
+# version: kickers carry no board value, so a "need" for one can never
+# be met or traded for.  ``BN``/``IR``/``TAXI`` are not lineup slots.
+_NON_DEMAND_SLOTS: frozenset[str] = frozenset({"K", "DEF", "BN", "IR", "TAXI"})
+
+
+def starter_needs_for_league(league_key: str | None = None) -> dict[str, int]:
+    """Effective starter demand per position for one league.
+
+    ``DEFAULT_STARTER_NEEDS`` above is not a slot count — it is a demand
+    model: base slots PLUS a hand-allocation of the flex slots, because
+    a superflex league genuinely wants a second startable QB even though
+    only one QB slot exists.  That model was correct and hardcoded, which
+    made it silently wrong for any other league.  The two live leagues
+    share a scoring profile but not a lineup (``dynasty_main`` starts
+    2 TE and 9 IDP; ``dynasty_new`` starts 1 TE and no IDP), and starter
+    counts are leagueKey-scoped per CLAUDE.md.
+
+    The allocation rule, stated once so it is auditable:
+
+    * every fixed positional slot contributes 1 to its own position;
+    * each ``SFLEX``/``SUPER_FLEX`` slot contributes 1 to ``QB`` — it is
+      the reason the format is called superflex;
+    * each ``FLEX`` slot contributes 1, round-robin over the league's
+      own ``flexEligible`` list in ``RB``, ``WR``, ``TE`` order;
+    * each ``IDP_FLEX`` slot contributes 1, round-robin over
+      ``idpFlexEligible``;
+    * ``K``/``DEF`` contribute nothing — see ``_NON_DEMAND_SLOTS``.
+
+    Applied to ``dynasty_main`` this reproduces ``DEFAULT_STARTER_NEEDS``
+    exactly, so the live league's suggestions are unchanged; pinned by
+    ``tests/league_intel/test_registry_consumers.py``.
+
+    Falls back to ``DEFAULT_STARTER_NEEDS`` when the registry has
+    nothing to say — an unknown key, or no roster settings — rather than
+    returning an empty demand map, which would read as "this roster
+    needs nobody" and silence every surplus/need suggestion.
+    """
+    starters: dict[str, Any] = {}
+    flex_eligible: list[str] = []
+    idp_flex_eligible: list[str] = []
+    try:
+        from src.api.league_registry import get_league_roster_settings
+
+        settings = get_league_roster_settings(league_key) or {}
+        starters = dict(settings.get("starters") or {})
+        flex_eligible = list(settings.get("flexEligible") or [])
+        idp_flex_eligible = list(settings.get("idpFlexEligible") or [])
+    except Exception:  # noqa: BLE001 — registry is optional for this module
+        starters = {}
+    if not starters:
+        return dict(DEFAULT_STARTER_NEEDS)
+
+    needs: dict[str, int] = {}
+
+    def _add(position: str, count: int = 1) -> None:
+        pos = str(position).upper()
+        if pos in _NON_DEMAND_SLOTS:
+            return
+        needs[pos] = needs.get(pos, 0) + count
+
+    def _round_robin(count: int, eligible: list[str], order: tuple[str, ...]) -> None:
+        pool = [p for p in order if p in {str(e).upper() for e in eligible}]
+        if not pool:
+            return
+        for i in range(int(count)):
+            _add(pool[i % len(pool)])
+
+    flex_count = 0
+    sflex_count = 0
+    idp_flex_count = 0
+    for slot, count in starters.items():
+        key = str(slot).upper()
+        n = int(count or 0)
+        if n <= 0:
+            continue
+        if key in ("FLEX", "WR_RB_FLEX", "REC_FLEX"):
+            flex_count += n
+        elif key in ("SFLEX", "SUPER_FLEX", "SUPERFLEX"):
+            sflex_count += n
+        elif key == "IDP_FLEX":
+            idp_flex_count += n
+        else:
+            _add(key, n)
+
+    # Superflex is a QB slot in everything but name.
+    if sflex_count:
+        _add("QB", sflex_count)
+    _round_robin(flex_count, flex_eligible, _FLEX_ALLOCATION_ORDER)
+    _round_robin(idp_flex_count, idp_flex_eligible, ("DL", "LB", "DB"))
+
+    return needs or dict(DEFAULT_STARTER_NEEDS)
+
+
 # Minimum display value to consider a player "rosterable" (not a throw-in)
 MIN_RELEVANT_VALUE = 500
 

--- a/tests/e2e/specs/public-league.spec.js
+++ b/tests/e2e/specs/public-league.spec.js
@@ -229,7 +229,7 @@ test.describe("public /league page", () => {
     // asserted on was not this section's row count.
     const rows = page.locator(".archives-table table tbody tr");
 
-    // The kind buttons render their own count ("Matchups (138)"), so
+    // The kind buttons render their own count ("Matchups (158)"), so
     // the expected row count is readable from the control itself.
     // Waiting for THAT is falsifiable. The old wait was
     // `.toBeGreaterThan(0)` immediately after the click, which the
@@ -243,14 +243,18 @@ test.describe("public /league page", () => {
     // Click INSIDE the poll, because the first one can land before
     // React has attached its handlers and is then simply lost.
     //
-    // `visitLeague` waits for the text "Public archives", which is in
-    // the SSR HTML — so it proves the markup arrived, not that the
-    // page is interactive. Against production that gap is real: the
-    // /league document is ~960 KB with the archives section (~737 KB)
-    // inlined in the RSC payload, so hydration takes long enough to
-    // race a test that clicks the moment the text appears.
+    // `visitLeague` waits for the text "Public archives". That wait has
+    // CHANGED MEANING as of 2026-07-30 and is now strictly stronger:
+    // the section is no longer server-rendered (it was ~737 KB of a
+    // ~960 KB document), so "Public archives" appears only once the
+    // client fetch has landed and the component has rendered with data
+    // — it waits on data, not on markup. Previously the string was in
+    // the SSR HTML, so it proved the markup arrived and nothing about
+    // interactivity, and against production that gap was real: a
+    // ~960 KB RSC payload takes long enough to hydrate to race a test
+    // that clicks the moment the text appears.
     //
-    // This is what made the suite ~46% flaky rather than broken.
+    // That gap is what made the suite ~46% flaky rather than broken.
     // Across 30 consecutive scheduled runs the results were
     // FFFF.SFFSFSSSSSSFSFSFFSS.FSFFF — 13 passes, 15 failures,
     // interleaved. A genuinely inert control fails every time; an

--- a/tests/league_intel/test_registry_consumers.py
+++ b/tests/league_intel/test_registry_consumers.py
@@ -228,6 +228,60 @@ class TestSuggestionsNeeds:
         assert DEFAULT_STARTER_NEEDS["LB"] == 3
         assert "K" not in DEFAULT_STARTER_NEEDS  # kickers not tradeable assets
 
+    # NOTE: every derived-needs test below takes ``real_registry``.  The
+    # global conftest points LEAGUE_REGISTRY_PATH at /nonexistent, and
+    # ``starter_needs_for_league`` falls back to DEFAULT_STARTER_NEEDS
+    # when the registry has nothing — so without the fixture the
+    # dynasty_main assertion passes by comparing the fallback to itself,
+    # and the dynasty_new one fails for the wrong reason.
+    def test_derived_needs_reproduce_the_constant_for_dynasty_main(self, real_registry):
+        """The derivation must be a NO-OP for the live league.
+
+        ``DEFAULT_STARTER_NEEDS`` was hand-derived: base slots plus an
+        allocation of the 3 flex slots as +1 QB / +1 RB / +1 WR.  If the
+        registry-driven version disagrees, it is the derivation that is
+        wrong, not the constant — this league's trade suggestions have
+        been computed against those numbers and are correct.
+        """
+        from src.trade.suggestions import DEFAULT_STARTER_NEEDS, starter_needs_for_league
+
+        derived = starter_needs_for_league("dynasty_main")
+        # Guard against the vacuous pass: prove the registry is actually
+        # loaded, so this is a real comparison and not fallback == fallback.
+        assert real_registry.get_league_roster_settings("dynasty_main").get("starters")
+        assert derived == DEFAULT_STARTER_NEEDS
+
+    def test_derived_needs_follow_the_league_not_the_scoring_profile(self, real_registry):
+        """dynasty_new shares the scoring profile and not the lineup.
+
+        Both leagues are ``superflex_tep15_ppr1``, but dynasty_new is
+        10-team, starts 1 TE and rosters no IDP.  Serving it
+        dynasty_main's demand model told it to chase a second TE and
+        nine defenders it cannot start.
+        """
+        from src.trade.suggestions import starter_needs_for_league
+
+        needs = starter_needs_for_league("dynasty_new")
+
+        assert needs["TE"] == 1, "dynasty_new starts one TE"
+        assert "DL" not in needs and "LB" not in needs and "DB" not in needs
+        # Superflex + 2 FLEX are allocated the same way in both leagues.
+        assert needs["QB"] == 2
+        assert needs["RB"] == 3
+        assert needs["WR"] == 4
+        assert "K" not in needs
+
+    def test_derived_needs_fall_back_rather_than_returning_nothing(self, real_registry):
+        """An unknown league must not read as 'this roster needs nobody'.
+
+        An empty demand map silences every surplus/need suggestion, which
+        looks identical to a roster with no holes.
+        """
+        from src.trade.suggestions import DEFAULT_STARTER_NEEDS, starter_needs_for_league
+
+        assert starter_needs_for_league("no_such_league") == DEFAULT_STARTER_NEEDS
+        assert starter_needs_for_league(None)
+
 
 # ── 6. server draft-capital teamCount read ────────────────────────────
 

--- a/tests/league_intel/test_replacement.py
+++ b/tests/league_intel/test_replacement.py
@@ -111,7 +111,25 @@ class TestEndogenousStarters:
         assert measured.slot_fill["FLEX"] == {"RB": 1}
         assert measured.starters_per_team.get("TE", 0.0) == 0.0
 
-    def test_hybrid_counts_toward_the_slot_it_actually_fills(self):
+    def test_hybrid_counts_against_its_own_position_pool_not_the_slot(self):
+        """A DL/LB slotted at LB still consumes a DL-pool body.
+
+        Renamed 2026-07-30.  This was
+        ``test_hybrid_counts_toward_the_slot_it_actually_fills``, whose
+        name asserted the OPPOSITE of its assertion — the hybrid fills the
+        LB slot, yet the assertion (correctly) counts it as DL.  Acting on
+        the name and switching the attribution to the slot breaks
+        ``compute_scarcity``: it builds ``by_pos`` from the players'
+        nominal positions and uses ``starters_n`` to index into it, so a
+        slot-derived count would index a pool it no longer denotes, and
+        ``lineupScarcity`` — the only live axis of the league-adjusted
+        overlay — is computed off that index.
+
+        ``starters_per_team`` answers "how many DL-pool bodies do lineups
+        consume".  "How many DL does the league start" is a different
+        question; ``slot_fill`` answers that one, and the test below pins
+        it.
+        """
         team = {
             "players": [
                 player("h", "DL", 50, fp=("DL", "LB")),
@@ -121,6 +139,37 @@ class TestEndogenousStarters:
         measured = measure_endogenous_starters([team], ["DL", "LB"])
         assert measured.starters_per_team["DL"] == 2.0
         assert measured.slot_fill["LB"] == {"DL": 1}
+
+    def test_fixed_slots_are_filled_exactly_as_many_times_as_they_exist(self):
+        """The league starts 3 at each IDP position — pinned on the slots.
+
+        This is the invariant a reader expects ``starters_per_team`` to
+        show and it deliberately does not (see above).  It belongs here,
+        on ``slot_fill``, where it is true regardless of how many hybrids
+        Sleeper labels one way and the optimizer slots another.
+        """
+        team = {
+            "players": [
+                player("h", "DL", 50, fp=("DL", "LB")),
+                player("d1", "DL", 40),
+                player("d2", "DL", 30),
+                player("d3", "DL", 20),
+                player("l1", "LB", 18),
+                player("l2", "LB", 16),
+                player("b1", "DB", 14),
+                player("b2", "DB", 12),
+                player("b3", "DB", 10),
+            ]
+        }
+        slots = ["DL"] * 3 + ["LB"] * 3 + ["DB"] * 3
+        measured = measure_endogenous_starters([team], slots)
+
+        for pos in ("DL", "LB", "DB"):
+            filled = sum(measured.slot_fill.get(pos, {}).values())
+            assert filled == 3, f"{pos} slots filled {filled} times, expected 3"
+        # ...and the hybrid is one of the bodies doing it, counted under
+        # its own position in the diagnostic.
+        assert measured.slot_fill["LB"].get("DL", 0) == 1
 
     def test_marginal_starter_is_the_weakest_started_at_the_position(self):
         measured = measure_endogenous_starters([make_team(0)], ["WR", "WR", "WR"])

--- a/tests/public_league/test_server_routes.py
+++ b/tests/public_league/test_server_routes.py
@@ -157,6 +157,90 @@ class PublicLeagueRouteTests(unittest.TestCase):
         # Both responses are identical (same cached payload).
         self.assertEqual(r1.json()["data"], r2.json()["data"])
 
+    def test_archives_section_is_single_flight_cached(self) -> None:
+        """archives must be memoized per snapshot, same as playoffOdds.
+
+        It is the most expensive builder in the contract — it rebuilds
+        history, activity, draft and awards before its own five walks,
+        and the safety walk then recurses the whole ~800 KB result. Run
+        fresh per request (which it was until 2026-07-30) that measured
+        1.8-34.3s TTFB on production against a ~0.53s baseline for every
+        other section, because concurrent requests each launched their
+        own build and held an AnyIO worker token for the duration.
+        """
+        import server
+
+        self.client.get("/api/public/league?refresh=1")
+        server._heavy_section_cache.clear()
+
+        calls = {"n": 0}
+        real = server.build_section_payload
+
+        def _counting(snapshot, section, **kw):
+            if section == "archives":
+                calls["n"] += 1
+            return real(snapshot, section, **kw)
+
+        server.build_section_payload = _counting
+        try:
+            r1 = self.client.get("/api/public/league/archives")
+            r2 = self.client.get("/api/public/league/archives")
+        finally:
+            server.build_section_payload = real
+
+        self.assertEqual(r1.status_code, 200)
+        self.assertEqual(r2.status_code, 200)
+        self.assertEqual(r1.json()["section"], "archives")
+        self.assertEqual(calls["n"], 1)
+        self.assertEqual(r1.json()["data"], r2.json()["data"])
+
+    def test_archives_stays_in_the_aggregate_contract(self) -> None:
+        """Memoizing is a ROUTING change, not a builder-registry change.
+
+        The tempting-looking alternative — moving archives into
+        ``_LAZY_SECTION_BUILDERS`` — drops it from the aggregate
+        contract, which is a public shape change, and would not touch
+        the per-request rebuild that was the actual cost.
+        """
+        import server
+        from src.public_league.public_contract import (
+            _LAZY_SECTION_BUILDERS,
+            _SECTION_BUILDERS,
+        )
+
+        self.assertIn("archives", server._HEAVY_SECTION_KEYS)
+        self.assertIn("archives", _SECTION_BUILDERS)
+        self.assertNotIn("archives", _LAZY_SECTION_BUILDERS)
+
+        r = self.client.get("/api/public/league?refresh=1")
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("archives", r.json()["sections"])
+
+    def test_archives_csv_honours_the_kind_qualifier(self) -> None:
+        """The regression the ``and not kind`` guard exists for.
+
+        The heavy-section CSV branch never forwards a qualifier, and
+        ``export_section`` falls back to trades when ``kind`` is absent.
+        Without the guard, adding archives to ``_HEAVY_SECTION_KEYS``
+        would make ``archives.csv?kind=waivers`` return a trades CSV
+        with a 200 and nothing saying the qualifier was dropped.
+        """
+        self.client.get("/api/public/league?refresh=1")
+
+        trades = self.client.get("/api/public/league/archives.csv")
+        waivers = self.client.get("/api/public/league/archives.csv?kind=waivers")
+
+        self.assertEqual(trades.status_code, 200)
+        self.assertEqual(waivers.status_code, 200)
+        trades_header = trades.text.splitlines()[0]
+        waivers_header = waivers.text.splitlines()[0]
+        self.assertNotEqual(
+            waivers_header,
+            trades_header,
+            "?kind=waivers silently returned the default trades export",
+        )
+        self.assertIn("waiver", waivers.headers.get("content-disposition", "").lower())
+
     def test_only_playoff_odds_is_cached(self) -> None:
         """Only ``playoffOdds`` (always-simulate, purely snapshot-derived)
         is cached.  The file-backed ROS sections are intentionally NOT

--- a/tests/ros/test_source_double_count.py
+++ b/tests/ros/test_source_double_count.py
@@ -1,0 +1,231 @@
+"""One vendor, one vote.
+
+Two guards, at two layers, for the same defect: from 2026-07-27 until
+2026-07-30 the DraftSharks ROS adapter concatenated two of the vendor's
+OWN boards under one source key.  The two files covered an identical
+978-player universe (zero names unique to either side) but ranked them
+for different formats, so every player was counted twice — DraftSharks
+took 67.4% of the blend against an intended 50.8%, ``sourceCount`` read
+2 where one vendor had spoken once, and ``confidence`` was inflated on
+939 of 1084 players.
+
+Layer 1 (``src/ros/sources/draftsharks_ros.py``) is the specific fix:
+union name-first instead of concatenating.
+Layer 2 (``src/ros/aggregate.py``) is the durable one: the aggregator
+adds a source's weight once per ROW, so it now refuses a repeat
+regardless of which adapter emits it.
+
+Both are tested here because either alone leaves the hole open — the
+adapter fix does nothing for the next adapter, and the aggregate guard
+does nothing about the adapter shipping rows nobody wanted.
+"""
+
+from __future__ import annotations
+
+import csv
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from src.ros.aggregate import RankedRow, SourceSnapshot, aggregate
+
+
+_LEAGUE = {
+    "is_superflex": True,
+    "is_2qb": False,
+    "is_te_premium": True,
+    "idp_enabled": True,
+}
+_NOW = datetime(2026, 7, 30, 12, 0, 0, tzinfo=timezone.utc)
+_FRESH = "2026-07-30T11:00:00+00:00"
+
+_ROS_HEADER = [
+    "canonicalName",
+    "sourceName",
+    "position",
+    "team",
+    "rank",
+    "total_ranked",
+    "projection",
+]
+
+
+def _write_ros_csv(path: Path, rows: list[tuple[str, str, int]], total: int) -> None:
+    with path.open("w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(_ROS_HEADER)
+        for name, pos, rank in rows:
+            w.writerow(["", name, pos, "FA", rank, total, ""])
+
+
+def _snapshot(key: str, rows: list[RankedRow], *, player_count: int) -> SourceSnapshot:
+    return SourceSnapshot(
+        source_key=key,
+        base_weight=1.0,
+        is_ros=True,
+        is_dynasty=False,
+        is_te_premium=False,
+        is_superflex=True,
+        is_2qb=False,
+        is_idp=False,
+        status="ok",
+        scraped_at=_FRESH,
+        player_count=player_count,
+        has_valid_cache=True,
+        rows=rows,
+    )
+
+
+class TestAdapterUnion(unittest.TestCase):
+    """``draftsharks_ros.scrape`` must emit each player at most once."""
+
+    def _scrape_with(self, sf, idp, *, sf_total=None, idp_total=None):
+        from src.ros.sources import draftsharks_ros as mod
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            sf_csv = root / "sf.csv"
+            idp_csv = root / "idp.csv"
+            _write_ros_csv(sf_csv, sf, sf_total if sf_total is not None else len(sf))
+            _write_ros_csv(idp_csv, idp, idp_total if idp_total is not None else len(idp))
+            with (
+                mock.patch.object(mod, "DS_ROS_SF_CSV", sf_csv),
+                mock.patch.object(mod, "DS_ROS_IDP_CSV", idp_csv),
+            ):
+                return mod.scrape({"key": "draftSharksRosSf"})
+
+    def test_fully_overlapping_boards_collapse_to_one_row_per_player(self):
+        """The live shape: same universe, different format, both full."""
+        sf = [("Josh Allen", "QB", 1), ("Jahmyr Gibbs", "RB", 2), ("Ja'Marr Chase", "WR", 3)]
+        # The /ros-rankings/idp page verbatim — same three players, 1QB order.
+        idp = [("Jahmyr Gibbs", "RB", 1), ("Ja'Marr Chase", "WR", 2), ("Josh Allen", "QB", 3)]
+
+        result = self._scrape_with(sf, idp)
+
+        self.assertEqual(result.status, "ok")
+        names = [r["sourceName"] for r in result.rows]
+        self.assertEqual(len(names), len(set(names)), f"duplicate players emitted: {names}")
+        self.assertEqual(len(result.rows), 3)
+        # The SF board wins outright — it is the board this source key
+        # claims to be (is_superflex=True, +10% format-match bonus).
+        by_name = {r["sourceName"]: r["rank"] for r in result.rows}
+        self.assertEqual(by_name["Josh Allen"], 1)
+        self.assertEqual(by_name["Jahmyr Gibbs"], 2)
+
+    def test_idp_only_players_absent_from_sf_are_merged(self):
+        """The documented forward-compat case still works."""
+        sf = [("Josh Allen", "QB", 1), ("Jahmyr Gibbs", "RB", 2)]
+        idp = [("Micah Parsons", "LB", 1), ("Josh Allen", "QB", 2)]
+
+        result = self._scrape_with(sf, idp)
+
+        by_name = {r["sourceName"]: r["rank"] for r in result.rows}
+        self.assertIn("Micah Parsons", by_name, "genuinely new coverage was dropped")
+        self.assertEqual(by_name["Josh Allen"], 1, "SF board should win the collision")
+        self.assertEqual(len(result.rows), 3)
+
+    def test_empty_sf_board_does_not_promote_the_1qb_board(self):
+        """An outage must not serve a 1QB board under a superflex key.
+
+        The source is registered ``is_superflex: True`` and paid a 1.10
+        format-match bonus for it.  With the SF page down, substituting
+        the idp page would pay that bonus for a format mismatch — so the
+        adapter falls through to the dynasty proxies instead, which are
+        genuinely superflex.
+        """
+        from src.ros.sources import draftsharks_ros as mod
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            sf_csv = root / "sf.csv"
+            idp_csv = root / "idp.csv"
+            _write_ros_csv(sf_csv, [], 0)
+            _write_ros_csv(idp_csv, [("Jahmyr Gibbs", "RB", 1)], 1)
+            missing = root / "nope.csv"
+            with (
+                mock.patch.object(mod, "DS_ROS_SF_CSV", sf_csv),
+                mock.patch.object(mod, "DS_ROS_IDP_CSV", idp_csv),
+                mock.patch.object(mod, "DS_DYNASTY_SF_CSV", missing),
+                mock.patch.object(mod, "DS_DYNASTY_IDP_CSV", missing),
+            ):
+                result = mod.scrape({"key": "draftSharksRosSf"})
+
+        # No dynasty proxies available either, so this legitimately fails
+        # rather than quietly shipping the wrong-format board.
+        self.assertEqual(result.status, "failed")
+        self.assertEqual(result.rows, [])
+
+
+class TestAggregateOneVotePerSource(unittest.TestCase):
+    """The durable guard: no adapter can double a source's weight."""
+
+    def test_duplicate_rows_from_one_source_do_not_double_its_weight(self):
+        dup = _snapshot(
+            "vendorA",
+            [
+                RankedRow(canonical_name="josh allen", position="QB", rank=1, total_ranked=10),
+                RankedRow(canonical_name="josh allen", position="QB", rank=9, total_ranked=10),
+            ],
+            player_count=10,
+        )
+        single = _snapshot(
+            "vendorA",
+            [RankedRow(canonical_name="josh allen", position="QB", rank=1, total_ranked=10)],
+            player_count=10,
+        )
+
+        with_dup = aggregate([dup], league=_LEAGUE, now_iso=_NOW.isoformat())
+        without = aggregate([single], league=_LEAGUE, now_iso=_NOW.isoformat())
+
+        self.assertEqual(len(with_dup), 1)
+        # The second row would have dragged the blend toward rank 9.
+        self.assertAlmostEqual(with_dup[0]["rosValue"], without[0]["rosValue"], places=6)
+        self.assertEqual(len(with_dup[0]["contributors"]), 1)
+
+    def test_source_count_counts_distinct_sources_not_rows(self):
+        """``sourceCount`` is shown as 'N sources' and breaks join ties."""
+        two_boards_one_vendor = _snapshot(
+            "vendorA",
+            [
+                RankedRow(canonical_name="josh allen", position="QB", rank=1, total_ranked=10),
+                RankedRow(canonical_name="josh allen", position="QB", rank=4, total_ranked=10),
+            ],
+            player_count=10,
+        )
+        other = _snapshot(
+            "vendorB",
+            [RankedRow(canonical_name="josh allen", position="QB", rank=2, total_ranked=10)],
+            player_count=10,
+        )
+
+        out = aggregate([two_boards_one_vendor, other], league=_LEAGUE, now_iso=_NOW.isoformat())
+
+        self.assertEqual(len(out), 1)
+        self.assertEqual(
+            out[0]["sourceCount"],
+            2,
+            "two vendors spoke; one of them twice — that is still two sources",
+        )
+
+    def test_a_zero_scoring_row_does_not_shut_out_a_scoring_duplicate(self):
+        """Dedup happens after scoring, so a dead row can't claim the slot."""
+        snap = _snapshot(
+            "vendorA",
+            [
+                # rank 0 -> rank_to_score returns <= 0 and the row is dropped.
+                RankedRow(canonical_name="josh allen", position="QB", rank=0, total_ranked=10),
+                RankedRow(canonical_name="josh allen", position="QB", rank=1, total_ranked=10),
+            ],
+            player_count=10,
+        )
+
+        out = aggregate([snap], league=_LEAGUE, now_iso=_NOW.isoformat())
+
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["sourceMinRank"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Six defects, each measured before and after. Nothing here touches `rankDerivedValue` or the valuation pipeline.

The IDP work grew mid-PR: the first fix was `/rosters`, and an exhaustive sweep of *every* surface that decides an IDP starter count then found three more — plus one place I got it wrong and reverted. All of it is below.

---

## 1. `/rosters` "Starters only" counted 17 slots against a real 20

`league-analysis.js` carried `STARTER_SLOTS = { QB: 2, RB: 3, WR: 4, TE: 2, DL: 2, LB: 2, DB: 2 }` — 2 of each IDP position in a league that starts **3**. The 3rd DL, 3rd LB and 3rd DB were dropped from every team.

Replaying both models over the 2026-07-30 roster snapshot: **12 of 12** teams undercounted, mean **10.1%**, and because the error is roster-dependent the leaderboard **reorders — 7 of 12 teams move**, including #2 ↔ #4.

It was also a **single-league literal on a page that serves two**. `dynasty_main` starts 2 TE + 9 IDP; `dynasty_new` starts 1 TE and no IDP. Replacing `DL: 2` with `DL: 3` would have been the same defect with better numbers.

**Ground truth, verified two ways:** registry `rosterSettings.starters` and the live host's `sleeper.rosterPositions` agree exactly — QB1 RB2 WR3 TE2 FLEX2 SFLEX1 K1 DL3 LB3 DB3, 21 slots.

A per-position top-N can't express this league anyway — 3 of 21 slots are FLEX/SUPER_FLEX, so "how many WRs start" depends on the rest of the roster. Hence a fill, not a count.

- New `frontend/lib/starter-slots.js` holds the greedy two-pass filler and the eligibility pools.
- **`scoreTeamTiers` was a fifth hardcode on the same page** — top 10 offensive players, flat, ignoring all 9 IDP starters. Now fills the real lineup; weights unchanged. Moves contender/rebuilder badges for defense-heavy rosters, which is the correction.
- `suggestions.py` grows `starter_needs_for_league`, feeding a `starter_needs` parameter that existed and went unused since the engine was written — so every league got dynasty_main's demand model. Reproduces `DEFAULT_STARTER_NEEDS` **exactly** for dynasty_main (pinned, so the live league is unchanged) while giving dynasty_new TE 1 and no IDP.

## 2. `/terminal` credited the top 9 defenders, not 3 at each position

`portfolio-insights.js` resolved positions through a local helper collapsing DB/LB/DL/DE/DT/CB/S → one `"IDP"` token, then filled slots off that. Every defensive slot matched every defender.

The starting lineup shown was **wrong for 10 of 12 teams**:

| team | shown | correct |
|---|---|---|
| MaKayla | DL6 LB3 **DB0** | DL3 LB3 DB3 |
| Brent | DL5 LB2 DB2 | DL3 LB3 DB3 |
| Blaine, Roy | DL5 LB3 DB1 | DL3 LB3 DB3 |
| Jason | DL2 LB5 DB2 | DL3 LB3 DB3 |
| Collin, jstuedle | DL4 LB4 DB1 | DL3 LB3 DB3 |
| Ed, Joey | DL4 LB3 DB2 | DL3 LB3 DB3 |
| Kich | DL4 LB2 DB3 | DL3 LB3 DB3 |
| Eric, Ty | DL3 LB3 DB3 | *(already right)* |

Six linemen and zero defensive backs, in a league that starts three of each. Each player now carries two position fields deliberately: `pos` stays collapsed for the allocation chart, `lineupPos` fills slots. `posGroup` delegates to the same resolver so display and fill can't drift apart — verified behaviour-identical across 34 position tokens.

## 3. The starter panel still didn't show 3 at each — the display cap ate the defense

Even with the math fixed, `PortfolioSummary` rendered `starters.slice(0, 12)` — 12 of 20 filled slots, from a **value-sorted** list. IDP values sit far below offense, so the truncation removed the defense wholesale: **11 of 12 teams showed zero DBs**.

`fillLineup` now also returns `assignments` — one entry per filled slot, in the league's own slot order — and the panel renders all 20, showing the **slot**, so 3 DL + 3 LB + 3 DB is legible.

## 4. A half-fetched Sleeper lineup became the cached truth

The root cause of the whole "missing lineup" class, and self-perpetuating.

`fetch_sleeper_rosters` makes two **independent** Sleeper calls: `/rosters` for teams, `/league` for `roster_positions`. Only the second sits in a bare `except Exception: pass` with `roster_positions` pre-set to `[]` — so one timeout on that endpoint returns a truthy dict with 12 teams and **no lineup**.

`if SLEEPER_ROSTER_DATA:` treated that as a clean fetch and did two harmful things: wrote the degraded block to `data/sleeper_last_good.json` — making it what every *later* outage restores from — and stamped success, so the freshness watchdog stayed quiet. A partial failure recorded as a full one, permanently.

Downstream, that contract shape is what made `/terminal` invent a lineup. Running the module both ways on one 29-player roster: **9 starters, 0 DL / 0 LB / 0 DB** — all 12 defenders benched — against a true 20 including 3/3/3. The split bar read **40.1%** where the real figure is **68.1%**.

- The scraper now discriminates on `rosterPositions`, splices the lineup back from cache, and refuses to persist or stamp.
- The offence-only literal is **deleted**, not patched: the real lineup was one destructure away (`useTeam()` already returns `rosterSettings`). The ladder is now live host → registry → refuse, matching BDVM and `/rosters`. `slotsFromStarterCounts` maps `SFLEX` → `SUPER_FLEX`, because `FLEX_POOLS` knows only the latter and an unmapped slot silently goes unfilled.
- The notice sits on the **split bar** too, not just the chip heading — the bar was the part rendering 40.1% in silence.
- `config/leagues/default_superflex_idp.template.json` declared `DL2 LB2 DB2 + IDP_FLEX2` — six IDP starters against nine. Nothing reads it, which is exactly why it was worth defusing: it's the shape someone copies when adding a league.

## 5. One ROS vendor's board was counted twice

`/ros-rankings/idp` is not an IDP-only mirror despite its name:

```
sf  rows 978  distinct names 978
idp rows 978  distinct names 978
only in sf: 0 | only in idp: 0 | common: 978
differing rank: 974
idp-family rows on SF board: 424   (on IDP board: 424)
```

Same universe, and the SF board already carries all 424 IDP rows — so **dedup costs zero coverage**, the hazard that had blocked this fix. What differs is the *format*: `josh allen` sf 1 → idp 17, `jahmyr gibbs` sf 2 → idp **1**, positional deltas RB −171 / QB +104 / WR +109. It's a **1QB board**, ingested under a key registered `is_superflex: True` and paid a 1.10 format-match bonus.

| source | before | after |
|---|---|---|
| **draftSharksRosSf** | **67.4%** | **50.8%** |
| fantasyProsRosSf | 13.1% | 19.8% |
| fantasyProsRosOverall | 11.1% | 16.7% |
| fantasyProsRosIdp | 5.0% | 7.6% |
| ffc2qbAdp | 3.4% | 5.1% |

939 of 1084 players carried ≥2 DraftSharks contributors. Adapter output goes 1880 rows → **978**, distinct names 978, **IDP coverage unchanged at 424**. Latent since the file first appeared — never right, not a regression.

`aggregate.py` makes it structural: one vote per `(source, player)`, and `sourceCount` counts distinct `sourceKey`s rather than rows.

**Confidence FALLS on 934 players** (mean 0.850 → 0.758). That's the honest number: one source is not four.

Dynasty valuation is untouched and enforced so — `tests/ros/test_isolation.py` asserts the `/api/data` contract is byte-identical across a `src.ros` import.

## 6. `/league?tab=archives` took 13 seconds

The cost is **TTFB on the section endpoint, not transfer**:

| endpoint | TTFB | bytes |
|---|---|---|
| `/api/public/league` (2 MB aggregate) | 0.52s | 2,005,439 |
| `/api/public/league/archives` | **34.3 / 19.3 / 2.9s**, steady 1.8–3.4s | 736,983 |
| every other section | ≈**0.53s** | — |

Not a cold rebuild (`cache_miss_cold_rebuild: 0`). `_HEAVY_SECTION_KEYS` held only `playoffOdds`, so archives ran a fresh `build_section_payload` on **every request** — the most expensive builder there is, rebuilding history, activity, draft and awards before its own five walks. The 2 MB aggregate is *faster* than this 737 KB subset of it because the aggregate is memoized and the section route threw the identical work away.

- Register archives as a heavy section, reusing the existing single-flight + per-snapshot memo. A **routing** change, not a builder-registry one: archives stays in the aggregate contract, pinned by a test.
- Stop server-rendering it into the RSC payload (~737 KB of a ~960 KB document). Given up deliberately: a crawler on `?tab=archives` sees the shell; `overview`, which carries the OG metadata, still SSRs on every tab.

**The regression this introduces, and its guard.** The heavy-section CSV branch never forwards a qualifier — invisible while playoffOdds (which takes none) was the only member. `archives.csv` *does* take `?kind=`, and `export_section` falls back to trades, so `?kind=waivers` would have returned a trades CSV with a 200 and no indication. Gated on `and not kind and not owner`, with a test **verified to fail** when the guard is removed.

---

## What I got wrong, and reverted

The sweep flagged `measure_endogenous_starters` for reporting DL 2.667 where the league starts 3, and I changed it to attribute a filled slot to the **slot** rather than the player's nominal position. `test_hybrid_counts_toward_the_slot_it_actually_fills` failed — and the test was right.

`compute_scarcity` builds its pool keyed by **nominal** position and indexes into it; a slot-derived count indexes a pool it no longer denotes. I'd have quietly repriced the league-adjusted board. Reverted, with the reasoning written down.

The genuine defect there was the **test name**, which asserted the opposite of its own assertion — the repo's documented "guard whose stated purpose and actual predicate differ" pattern. Renamed, and "3 at each" is now pinned where it's actually true: on `slot_fill`, which reads exactly **36/36/36 across 12 teams**. `lineupScarcity` confirmed back at its original values, so nothing is repriced.

*(A first version of that revert's justification claimed `lineupScarcity` is computed off `starters_n`. It isn't — verified at `replacement.py:635-642`; `lineupScarcity` reads the marginal-starter tier and `starters_n` feeds only `eliteSeparation`/`starterSeparation`. The conclusion held — both paths are nominal-keyed — but the comment now names the real mechanisms.)*

## Three bugs the new tests caught during review

All three produced a wrong answer that looked right:

1. The lineup filler's value accessor defaulted to `p.value` while the `league-analysis` callers carry `.meta` — the sort became a no-op and slots filled in **insertion order**.
2. That option was first named `valueOf`, inherited from `Object.prototype` — destructuring it **always** found a function, so the default never applied at all.
3. `normalizePos` maps `P` → `K` but not `PK`; folding the position helpers naively would have dropped kickers from the K slot.

Every fixture happened to be built in descending order and sailed through the first two. Shuffled input with a non-default value field is what catches them, and that case is pinned.

## Verification

- `pytest tests/` — **5,589 passed, 36 skipped, 0 failed**.
- `npm test` — **1,591 passed** (up from 1,554), 93 files.
- `npm run build:nocheck` green; `ruff format --check .` + `ruff check` clean under the pinned 0.6.9.
- Guard tests confirmed to **fail** with their guard removed: the CSV `kind` guard and the derived-starter-needs derivation.

**Pre-existing, not from this branch:** running `tests/league_intel tests/ros tests/trade tests/api` as a subset yields 10 TEP-derive failures. Verified **identical with every change here stashed** — ordering sensitivity in the suite, which the full `pytest tests/` ordering CI runs does not hit.

## Not in this PR, deliberately

- **Required status checks on `main`** — a repository *setting*, not a file. No commit can create it and the branch-protection API is 403 for this session. Settings → Rules → require `Validate PR` on `main`; add `E2E Safety Net` only after three consecutive green nights, since requiring a flaky check deadlocks every merge.
- **`/rosters` "Trade Targets" can never suggest an IDP need** — it iterates `OFFENSE_GROUPS` only. A real gap, but it changes what the card *recommends* rather than a starter count, so it belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKhaEruQrSLhWKZPEGmEEm