### PR TITLE
Wire the pool-duplicate allowlist into the gate it was written for

### DIFF
--- a/scripts/audit_identity_matches.py
+++ b/scripts/audit_identity_matches.py
@@ -498,13 +498,35 @@ def main() -> int:
     if args.github_summary:
         _write_github_summary(report, collisions)
     if collisions and args.fail_on_collision:
+        # ``_KNOWN_POOL_DUPLICATES`` entries are REPORTED but do not fail
+        # the gate — that is the whole point of the set, and until now it
+        # was only half-implemented: ``build_report`` stamped
+        # ``knownPoolDuplicate`` on the row and this gate ignored the
+        # stamp, so the carve-out annotated the collision and still went
+        # red.  The set's own docstring says "every collision outside
+        # this set still fails", which only means anything if the ones
+        # inside it do not.  A guard whose stated purpose and actual
+        # predicate differ is the exact failure mode this repo keeps
+        # tripping over (docs/ORCHESTRATION.md §6.15).
+        #
+        # They stay visible as ::notice, never silently dropped.
+        blocking = [c for c in collisions if not c.get("knownPoolDuplicate")]
         for c in collisions:
             kind = "cross-family " if c.get("crossFamily") else ""
-            print(
-                f"::error title=Alias collision::{kind}'{c['canonicalName']}' "
-                f"merges {c['mergedNames']}"
-            )
-        return 1
+            if c.get("knownPoolDuplicate"):
+                print(
+                    f"::notice title=Known pool duplicate::{kind}"
+                    f"'{c['canonicalName']}' merges {c['mergedNames']} — "
+                    "verified same player, allow-listed in "
+                    "_KNOWN_POOL_DUPLICATES; not failing the gate"
+                )
+            else:
+                print(
+                    f"::error title=Alias collision::{kind}'{c['canonicalName']}' "
+                    f"merges {c['mergedNames']}"
+                )
+        if blocking:
+            return 1
     return 0
 
 

--- a/tests/scripts/test_audit_identity_matches.py
+++ b/tests/scripts/test_audit_identity_matches.py
@@ -188,6 +188,88 @@ class TestCommittedDataRegression:
         unexpected = [c for c in report["aliasCollisions"] if not c.get("knownPoolDuplicate")]
         assert unexpected == []
 
+    def test_gate_exits_zero_under_the_flag_ci_actually_passes(self, tmp_path):
+        """The CI invocation, verbatim — including ``--fail-on-collision``.
+
+        Every other end-to-end test here omits that flag, so none of them
+        exercised the GATE.  That gap is not hypothetical: the
+        ``_KNOWN_POOL_DUPLICATES`` carve-out landed on 2026-07-30 stamping
+        ``knownPoolDuplicate`` on the report while the gate ignored the
+        stamp, so the whole suite stayed green and
+        ``Audit Identity Matches`` went red on ``main`` anyway.  A test
+        that does not pass the flag cannot see that.
+        """
+        out = tmp_path / "report.json"
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--json-path",
+                str(_latest_export()),
+                "--json",
+                str(out),
+                "--limit",
+                "10",
+                "--fail-on-collision",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO),
+            timeout=600,
+        )
+        assert proc.returncode == 0, (
+            "identity audit gate failed:\n" + proc.stdout[-3000:] + proc.stderr[-2000:]
+        )
+        # Allow-listed collisions stay VISIBLE — marked, not hidden.
+        report = json.loads(out.read_text(encoding="utf-8"))
+        known = [c for c in report["aliasCollisions"] if c.get("knownPoolDuplicate")]
+        if known:
+            assert "::notice title=Known pool duplicate" in proc.stdout
+            assert "::error title=Alias collision" not in proc.stdout
+
+    def test_gate_still_fails_on_a_collision_outside_the_allowlist(self, tmp_path):
+        """The exemption must not become a blanket pass.
+
+        Feeds a payload whose pool carries two genuinely different
+        players that an alias merges, with the name absent from
+        ``_KNOWN_POOL_DUPLICATES``.  Exit MUST be 1.
+        """
+        # The same cross-family pair the unit test above uses: an alias
+        # merges a WR and a CB onto one canonical name, which is the
+        # vote-replication hazard this gate exists for.
+        assert "michael jackson" not in _mod._KNOWN_POOL_DUPLICATES
+        payload = {
+            "players": {
+                "Michael Jackson": {"pos": "WR", "_finalAdjusted": 5000},
+                "Mike Jackson": {"pos": "CB", "_finalAdjusted": 4000},
+            }
+        }
+        payload_path = tmp_path / "payload.json"
+        payload_path.write_text(json.dumps(payload), encoding="utf-8")
+
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--json-path",
+                str(payload_path),
+                "--json",
+                str(tmp_path / "r.json"),
+                "--limit",
+                "1",
+                "--fail-on-collision",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO),
+            timeout=600,
+        )
+        assert proc.returncode == 1, (
+            "an un-allow-listed cross-family collision did NOT fail the "
+            "gate:\n" + proc.stdout[-3000:]
+        )
+        assert "::error title=Alias collision" in proc.stdout
+
     def test_the_duplicate_allowlist_only_holds_real_collisions(self, tmp_path):
         """An allowlist entry that no longer collides is dead weight.
 


### PR DESCRIPTION
`Audit Identity Matches` has been **red on `main` since 19:09 today**, and the carve-out I added this morning is why.

## The defect

`_KNOWN_POOL_DUPLICATES` exists so a *verified* same-player pool duplicate is reported without failing the hard gate. The live instance: the 18:06 scheduled refresh added `Robert Henry` to `CSVs/dynasty_full.csv` alongside the existing `Rob Henry` — one player (RB, UTSA UDFA → WAS, age 24), two pool rows, merged by an alias that is working correctly.

The implementation stamped `knownPoolDuplicate` on the report row. **The gate never read the stamp.** It annotated the collision and still returned 1.

That is the same defect shape this repo keeps tripping over, and the set's own docstring advertises against it:

> Entries are NOT a way to quiet the check … **every collision outside this set still fails.**

Which only means anything if the ones *inside* it don't. A guard whose stated purpose and actual predicate differ — `docs/ORCHESTRATION.md` §6.15.

## The fix

The gate now partitions instead of failing on any collision:

- allow-listed → `::notice title=Known pool duplicate`, does not block
- everything else → `::error title=Alias collision`, returns 1

Collisions stay visible either way. Marked, not hidden — which is what the docstring promised.

## Why the suite didn't catch it

**Not one end-to-end test passed `--fail-on-collision`** — the flag CI actually runs with. Three tests invoke the script; all three omit it. So every one of them exercised the *report* and none of them exercised the *gate*. The half-done carve-out passed the full suite and went red in CI, which is precisely the gap.

Two tests added:

1. **The CI invocation verbatim**, flag included — asserts exit 0 and that an allow-listed collision surfaces as a notice rather than an error. **Verified to fail against the unfixed gate.**
2. **A cross-family WR/CB merge outside the allowlist must still exit 1**, so the exemption can't quietly widen into a blanket pass. This is the vote-replication hazard the whole check exists for (the name-only CSV join replicates a matched entry across every position group sharing a canonical name).

## Verification

Run end to end against the committed export:

```
!! ALIAS-INTRODUCED COLLISIONS: 1
::notice title=Known pool duplicate::cross-family 'rob henry' merges
  ['Rob Henry', 'Robert Henry'] — verified same player, allow-listed in
  _KNOWN_POOL_DUPLICATES; not failing the gate
EXIT=0
```

`tests/scripts/test_audit_identity_matches.py` — 11 passed. `ruff format --check .` and `ruff check` clean under the pinned 0.6.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKhaEruQrSLhWKZPEGmEEm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKhaEruQrSLhWKZPEGmEEm)_