### PR TITLE
Give the alerts a way to say "recovered", and unblock the nightly E2E

### DIFF
--- a/.github/workflows/audit-identity-matches.yml
+++ b/.github/workflows/audit-identity-matches.yml
@@ -182,3 +182,36 @@ jobs:
               --body "$BODY" \
               --label identity-collision
           fi
+
+      - name: Close the tracking issue when the run is green
+        # The missing half of the pattern copied from
+        # scheduled-refresh.yml, which opens AND closes.  Without this an
+        # open `identity-collision` issue means "this failed at least once, ever"
+        # rather than "this is broken now" — #663 sat open for hours after
+        # its gate went green because of exactly this gap.
+        if: success()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -Eeuo pipefail
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          # Close EVERY open one: the alert step reads `.[0].number`, so
+          # duplicates would otherwise be orphaned forever.
+          OPEN=$(gh issue list --state open --label identity-collision \
+                   --json number --jq '.[].number' 2>/dev/null || echo "")
+          if [[ -z "$OPEN" ]]; then
+            echo "no open identity-collision issue; nothing to close"
+            exit 0
+          fi
+          for N in $OPEN; do
+            echo "closing #${N}"
+            gh issue close "$N" --reason completed --comment \
+              "Identity-match audit is green again — no alias-introduced collision on the live board.
+
+          - Workflow run: ${RUN_URL}
+          - Commit: ${GITHUB_SHA}
+          - Closed: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          Reopened automatically by the alert step if it fails again." || true
+          done

--- a/.github/workflows/audit-rank-form-drift.yml
+++ b/.github/workflows/audit-rank-form-drift.yml
@@ -175,3 +175,50 @@ jobs:
         run: |
           echo "::error title=Rank-form drift check::driver exited ${{ steps.drift.outputs.exit_code }}"
           exit 1
+
+      - name: Close the tracking issue when the drift audit is green
+        # The missing half of the scheduled-refresh.yml pattern.
+        #
+        # MATCHED ON TITLE, NOT LABEL — and that is not a stylistic
+        # choice.  `refit-hill-curves.yml` writes to the SAME
+        # `calibration` label, so a label-only close here would reach over
+        # and close ITS issues.  That would be actively harmful: its
+        # exit-code-1 issue is "a challenger cleared the held-out gate and
+        # is waiting for a human to promote it" — a work item, not an
+        # alert.  Silently closing a promotion request is worse than
+        # leaving a stale alert open, which is why refit-hill-curves.yml
+        # deliberately has no auto-close at all.
+        #
+        # Both workflows also fall back to creating an UNLABELLED issue
+        # when the label is missing (`|| gh issue create` without
+        # --label), so the title search is the more reliable key anyway.
+        if: success()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -Eeuo pipefail
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          TITLE="Rank-form curve drift: reconstruction constants are stale"
+          # --search on the exact title, then filter client-side: GitHub's
+          # search is fuzzy and would otherwise match the refit issues,
+          # which is the whole hazard this step is avoiding.
+          OPEN=$(gh issue list --state open --limit 50 \
+                   --json number,title \
+                   --jq ".[] | select(.title == \"${TITLE}\") | .number" \
+                 2>/dev/null || echo "")
+          if [[ -z "$OPEN" ]]; then
+            echo "no open drift issue; nothing to close"
+            exit 0
+          fi
+          for N in $OPEN; do
+            echo "closing #${N}"
+            gh issue close "$N" --reason completed --comment \
+              "Rank-form drift audit is green again — the reconstruction constants match the live curves.
+
+          - Workflow run: ${RUN_URL}
+          - Commit: ${GITHUB_SHA}
+          - Closed: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          Reopened automatically by the alert step if drift returns." || true
+          done

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -287,3 +287,48 @@ jobs:
               --body "$BODY" \
               --label e2e-failures
           fi
+
+      - name: Close the tracking issue when the suite is green
+        # The missing half of the pattern this workflow's header claims to
+        # mirror.  `scheduled-refresh.yml` opens AND closes; every copy of
+        # it — here, audit-identity-matches, audit-rank-form-drift,
+        # intel-refresh — took only the failure half.
+        #
+        # The cost was not theoretical.  #588 was opened 2026-07-27, the
+        # 07-28 nightly SUCCEEDED, and the issue stayed open and simply
+        # accumulated comments.  So an open `e2e-failures` issue meant
+        # "this failed at least once, ever" rather than "this is broken
+        # now", which is worthless for triage and is a large part of why
+        # the repo reads as permanently red.
+        #
+        # A green run of THIS workflow is the all-clear by construction:
+        # the suite is the gate, so there is no per-step outcome to
+        # re-derive.
+        if: success()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -Eeuo pipefail
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          # Close EVERY open one, not just the first.  The alert step above
+          # reads `.[0].number`, so if duplicates ever exist it comments on
+          # one and leaves the rest orphaned forever; closing `.[]` drains
+          # them.  Same reasoning as scheduled-refresh.yml.
+          OPEN=$(gh issue list --state open --label e2e-failures \
+                   --json number --jq '.[].number' 2>/dev/null || echo "")
+          if [[ -z "$OPEN" ]]; then
+            echo "no open e2e-failures issue; nothing to close"
+            exit 0
+          fi
+          for N in $OPEN; do
+            echo "closing #${N}"
+            gh issue close "$N" --reason completed --comment \
+              "Nightly E2E safety net is green again — every critical journey passed.
+
+          - Workflow run: ${RUN_URL}
+          - Commit: ${GITHUB_SHA}
+          - Closed: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          Reopened automatically by the alert step if the suite fails again." || true
+          done

--- a/.github/workflows/intel-refresh.yml
+++ b/.github/workflows/intel-refresh.yml
@@ -264,3 +264,36 @@ jobs:
               --body "$BODY" \
               --label intel-stale
           fi
+
+      - name: Close the tracking issue when the run is green
+        # The missing half of the pattern copied from
+        # scheduled-refresh.yml, which opens AND closes.  Without this an
+        # open `intel-stale` issue means "this failed at least once, ever"
+        # rather than "this is broken now" — #663 sat open for hours after
+        # its gate went green because of exactly this gap.
+        if: success()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -Eeuo pipefail
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          # Close EVERY open one: the alert step reads `.[0].number`, so
+          # duplicates would otherwise be orphaned forever.
+          OPEN=$(gh issue list --state open --label intel-stale \
+                   --json number --jq '.[].number' 2>/dev/null || echo "")
+          if [[ -z "$OPEN" ]]; then
+            echo "no open intel-stale issue; nothing to close"
+            exit 0
+          fi
+          for N in $OPEN; do
+            echo "closing #${N}"
+            gh issue close "$N" --reason completed --comment \
+              "Daily intel refresh is green again — the intel artifacts rebuilt cleanly.
+
+          - Workflow run: ${RUN_URL}
+          - Commit: ${GITHUB_SHA}
+          - Closed: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          Reopened automatically by the alert step if it fails again." || true
+          done

--- a/.github/workflows/refit-hill-curves.yml
+++ b/.github/workflows/refit-hill-curves.yml
@@ -164,6 +164,29 @@ jobs:
           git pull --rebase origin main
           git push
 
+      # NO AUTO-CLOSE STEP HERE, DELIBERATELY.
+      #
+      # Every other rolling-issue workflow in this repo gained one on
+      # 2026-07-31 (they had copied only the failure half of
+      # scheduled-refresh.yml's pattern, so their issues could never say
+      # "recovered"). This one is excluded on purpose, and the exclusion
+      # needs to survive the next person tidying up the inconsistency.
+      #
+      # The issues below are NOT failure alerts. Exit code 1 means "a
+      # challenger beat the champion out of sample and is waiting for a
+      # human to promote it" — a work item, and the step is named for it.
+      # A green run next week does not mean that request was handled; it
+      # means the refit ran again. Auto-closing on success would silently
+      # discard promotion requests, which is strictly worse than a stale
+      # alert.
+      #
+      # These issues close when a human runs `scripts/model_registry.py
+      # promote` + `apply`, per ADR-008 in
+      # docs/roster-trade-intelligence/DECISIONS.md.
+      #
+      # Note also that this shares the `calibration` label with
+      # audit-rank-form-drift.yml, whose auto-close therefore matches on
+      # TITLE rather than label so it cannot reach over and close these.
       - name: Open an issue when a human must act
         if: steps.refit.outputs.exit_code == '1' || steps.refit.outputs.exit_code == '3'
         shell: bash

--- a/docs/e2e-assertion-audit.md
+++ b/docs/e2e-assertion-audit.md
@@ -852,3 +852,170 @@ and the privacy invariant. Related to #555 item 3.
 
 ---
 
+
+## Part 3 — the 2026-07-31 pass: six failures, one green suite
+
+Part 2 catalogued findings. This part records what a **full local run**
+against a booted stack turned up, because the catalogue could not have
+found any of it: every one of these is a timing or attribution defect
+that only exists when the suite actually runs.
+
+Baseline before the pass: `E2E Safety Net` last ran 2026-07-30 09:07 on
+`f90491cbd`, which predates every fix that merged that evening. So CI
+could not answer whether #588 was fixed; only running it could.
+
+First full run: **6 failed / 85 passed**. Final: **139 passed, 49
+skipped, 0 failed** across `desktop-1366` + `mobile-chromium` with the
+exact CI flags (`--ignore-snapshots`, `SKIP_VISUAL_REGRESSION=1`).
+
+### §4.1 Three chart tests — a toggle that renames itself
+
+`_openMethodology` matched the toggle by accessible name and then
+polled `aria-pressed` on it. But `rankings/page.jsx:1319` renders
+"Methodology charts" while collapsed and **"Hide charts" while
+expanded**. The click landed, the panel opened, the name changed, and
+the locator stopped resolving — so the poll read an attribute off zero
+elements until it timed out, against a panel that is plainly open in
+every trace.
+
+Generalisable: **a name-keyed locator is unstable across any state that
+renames its own control.** Either match every name the control can
+take, or key on something that does not change.
+
+This was self-inflicted — the previous revision wrapped the click in
+`try/catch {}` and passed. Replacing a swallowed failure with a
+verified one is still the right direction; the verification just has to
+be correct.
+
+### §4.2 `/arbitrage` — "idempotent" was wrong
+
+The archives remedy (click *inside* `expect.poll`, so a click lost to
+pre-hydration timing is retried) was applied here with the justification
+"the handler is idempotent, so re-clicking only re-runs the same scan".
+
+It is not idempotent in the way that matters. `run()` sets
+`running: true`, and **both** settled states — the trade cards and the
+"No arbitrage found" empty state — are gated on `!running`
+(`arbitrage/page.jsx:283,289`). A click fired on the same tick the
+previous scan finished tears the result straight back down, and because
+the click ran *before* the read, the read always observed zero. It
+failed deterministically with 30+ trade cards on screen.
+
+Two rules fall out, and they apply to every retry-click poll:
+
+1. **Read first, click second.** A poll that acts before it observes
+   cannot see the state its own action just destroyed.
+2. **"Idempotent" means the second click leaves the observable state
+   unchanged** — not that it re-runs the same work. A tab selector
+   qualifies. A scan button that clears its own results does not.
+
+The `/league` tab helper deliberately keeps click-then-read: there, the
+content check *is* the proof the tab switched, so reading first would
+pass on the default tab's body.
+
+### §4.3 `/waivers` — read-once-then-branch
+
+```js
+const text = await body.innerText();
+if (/Select a team/i.test(text)) { … } else { … expect DROP … }
+```
+
+The page passes through three distinct bodies while it settles
+(signed-out shell → signed-in without team → team picker). A read
+landing on the middle one matches neither marker, takes the `else`
+branch, and then waits 15s for a "DROP" this session will never render.
+
+Same hydration race as the archives one in a different costume: the
+branch is decided on a frame that is not the final frame. **Poll for
+whichever settled state arrives; never branch on a single read.**
+
+### §4.4 The flake that moved between runs — guard misattribution
+
+`journey-trade` "/trade renders the builder" failed with a React #418
+hydration error whose stack was entirely `127.0.0.1:8000/_next/...`
+chunks — from a test that navigates to `:3000`.
+
+`auth-fixture` primed cookies with a bare `page.goto("/")`, resolving
+against `baseURL` (the backend page proxy). That document hydrates the
+**anonymous shell** against an authenticated client, and React reports
+the mismatch *asynchronously*, on the MessagePort scheduler, after
+`goto()` has resolved. By then the test body has attached its console
+guards — so the fixture's error lands in the next test's bucket.
+
+Whichever authed spec loses the race gets the failure, which is why it
+moved between runs and why `journey-tools-health` failed in the full run
+and passed in isolation. The fixture now primes through `pageUrl()` like
+every other navigation.
+
+That retired the harness guard's only `_GOTO_EXEMPT` entry. Its stated
+reason — "'/' is public so it cannot 307" — was true and beside the
+point: sound about redirects, silent about hydration. Same
+`docs/ORCHESTRATION.md` §6.15 shape the guard file exists to catch.
+
+**The proxy's mismatched shell is a real product defect**, not just a
+harness one. It is #555 and is being deleted; §4.4 is only about not
+misattributing it.
+
+### §4.5 Two tests that reported PASSED while executing nothing
+
+Flagged in Part 2, fixed here. `critical-smoke.spec.js` held:
+
+```js
+if (res.status() === 401) {
+  test.info().annotations.push({ type: "skip", description: "…" });
+  return;
+}
+```
+
+`annotations.push({type: "skip"})` is **not** `test.skip()`. It skips
+nothing; Playwright reports the test as passed. Both endpoints
+(`/api/terminal`, `/api/data/rank-history`) are auth-gated and 401 to an
+anonymous request — and this is an anonymous spec — so every assertion
+in both bodies was permanently unreachable while the suite counted two
+more green tests for it.
+
+Neither was simply deleted. The auth gate was already covered
+non-vacuously by `AUTH_GATED_API_ROUTES`; the terminal payload by
+`signed-in-smoke`; and the `MAX_SNAPSHOTS` clamp, which had **no other
+home**, moved to `signed-in-smoke` where it can execute. It was
+tightened on the way: `days <= 365*3` would be satisfied by a clamp
+returning 1, so it now pins the exact value and checks both ends of the
+`max`/`min` pair.
+
+The endpoint's docstring claimed "max 180" while the code clamps to
+1095 — that is the *player-source-history* window, on the next handler
+down. Corrected.
+
+### §4.6 The identity allowlist — a guard measuring the wrong thing
+
+Not an E2E finding, but the same shape and it surfaced in the same pass.
+
+`test_the_duplicate_allowlist_only_holds_real_collisions` required every
+allowlisted name to be colliding in the **currently committed pool**.
+That pool refreshes from external sources every two hours: "Robert
+Henry" entered `CSVs/dynasty_full.csv` at 2026-07-30T18:06Z and was gone
+by 2026-07-31T04:09Z, failing CI while the exemption was entirely
+correct. Left alone the pair churns forever — drop the entry, the next
+refresh re-adds the row, the *gate* fails and opens an issue, re-add it.
+
+What justifies an exemption is committed code: the verified
+`robert henry -> rob henry` alias. An alias-introduced collision on a
+name is only *possible* while something in `CANONICAL_NAME_ALIASES`
+targets it, so that is the live/dead test.
+
+The allowlist is now `name -> the exact alias sources verified for it`,
+which is **strictly stronger** on the risk that mattered. The old check
+said nothing about which names an exemption covers, so a second alias
+pointing at "rob henry" would have inherited the carve-out in silence —
+the widening it claimed to prevent. Verified failing in both directions.
+
+### What Part 3 does not claim
+
+- **The pixel baselines are still not committed**, so `SKIP_VISUAL_REGRESSION=1`
+  in CI means the `toHaveScreenshot` assertions never run there. The
+  structural chart assertions do. Unchanged from Part 2.
+- **49 of 188 are skipped** in a CI-parity run — mostly `desktopOnly`
+  guards on `mobile-chromium` plus the visual block. These are real
+  `test.skip()` calls and report as skipped, not as passed.
+- **Coverage gaps from Part 2 §3 are untouched.** This pass made the
+  suite trustworthy; it did not make it complete.

--- a/frontend/app/arbitrage/page.jsx
+++ b/frontend/app/arbitrage/page.jsx
@@ -95,7 +95,10 @@ function TradeCard({ trade, myTeam, opponent }) {
   }, [trade, myTeam, opponent]);
 
   return (
-    <Panel className={styles.tradeCard}>
+    // ``arbitrage-trade-card`` is a stable E2E hook alongside the
+    // CSS-module class, the same convention the news rows use — module
+    // class names are hashed at build time and cannot be selected on.
+    <Panel className={`${styles.tradeCard} arbitrage-trade-card`}>
       <div className={styles.tradeHead}>
         <span className={styles.score}>
           arbitrage {Number(trade.arbitrageScore || 0).toFixed(2)}

--- a/frontend/components/ds/DataTable.jsx
+++ b/frontend/components/ds/DataTable.jsx
@@ -471,7 +471,14 @@ export function DataTable({
                 {columns.map((col) => {
                   const acc = col.accessor || ((r) => r?.[col.key]);
                   return (
-                    <td key={col.key} className={cellClass(col)}>
+                    // ``data-col`` makes a cell addressable by its COLUMN
+                    // KEY rather than by ordinal.  Several column sets here
+                    // are built conditionally (the rankings board adds a
+                    // Fund-gap column only while BDVM serves an ok payload,
+                    // for one), so an ``nth-child`` selector in a test is
+                    // correct until the day a column appears in front of
+                    // it and then silently asserts the wrong column.
+                    <td key={col.key} data-col={col.key} className={cellClass(col)}>
                       {col.render ? col.render(row, i) : acc(row)}
                     </td>
                   );

--- a/frontend/lib/edge-helpers.js
+++ b/frontend/lib/edge-helpers.js
@@ -211,9 +211,9 @@ export const LENSES = [
  * Look up a lens by key.
  */
 /**
- * SCREENS — the five saved questions that used to be their own page.
+ * SCREENS — the saved questions that used to be their own page.
  *
- * /finder was a board filter with five presets, rendered on a second
+ * /finder was a board filter with these presets, rendered on a second
  * copy of the rankings table.  It computed nothing the board could not
  * express: every workflow is a lens plus a position/class pre-filter.
  * But the thresholds are NOT the same as the lenses above (WR Gaps

--- a/scripts/audit_identity_matches.py
+++ b/scripts/audit_identity_matches.py
@@ -174,7 +174,22 @@ def _count_csv_rows(csv_path: Path) -> int:
 # same-player claim, and every collision outside this set still fails.
 # The collisions are still reported and still printed in the run
 # summary; they are marked, not hidden.
-_KNOWN_POOL_DUPLICATES = {
+# Verified same-player duplicates, mapped to the EXACT set of alias
+# sources whose merge onto that name was checked by a human.
+#
+# The value is not decoration.  An exemption keyed on the name alone
+# widens silently: add a second alias pointing at "rob henry" next year
+# and it inherits the carve-out without anyone looking.  Pinning the
+# source set means a new alias into an exempted name fails
+# ``test_the_allowlist_still_describes_the_aliases_it_exempts`` and has
+# to be verified on its own merits.
+#
+# NOTE the presence of the collision in any given snapshot is NOT the
+# criterion — the pool is refreshed from external sources every two
+# hours and the second spelling comes and goes with it (it was present
+# on 2026-07-30T18:06Z and gone by 2026-07-31T04:09Z).  What makes the
+# exemption live is the alias, which is committed code.
+_KNOWN_POOL_DUPLICATES: dict[str, frozenset[str]] = {
     # "Rob Henry" + "Robert Henry" — one player, two pool rows.
     #
     # ``src/utils/name_clean.py`` aliases "robert henry" → "rob henry"
@@ -195,7 +210,7 @@ _KNOWN_POOL_DUPLICATES = {
     #
     # Removing the alias was the alternative and is worse: it would
     # leave one player sitting on the board as two separate rows.
-    "rob henry",
+    "rob henry": frozenset({"robert henry"}),
 }
 
 

--- a/server.py
+++ b/server.py
@@ -3542,7 +3542,11 @@ async def get_rank_history(request: Request):
     shape the frontend ``RankChangeGlyph`` consumes.
 
     Query params:
-      * ``days`` — window in days (default 30, max 180).
+      * ``days`` — window in days (default
+        ``_rank_history.DEFAULT_HISTORY_WINDOW_DAYS``, clamped to
+        ``[1, _rank_history.MAX_SNAPSHOTS]`` — 1095, i.e. three years).
+        This line used to say "max 180", which is the
+        player-source-history window below, not this one.
 
     The log is already mirrored onto each row's ``rankHistory`` at
     contract build time, so most consumers don't need this endpoint

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -112,7 +112,7 @@ webkit `mobile-390` / `mobile-430` projects, which need
 | Spec | Layer | What it protects |
 |---|---|---|
 | `journey-rankings.spec.js` | signed-in UI | Board renders real rows; column sort; position filter; board search; player popup with source breakdown; global search (`/`) |
-| `journey-trade.spec.js` | signed-in UI + API | `/trade` builder renders + controls; `/trades` history; `/finder` arbitrage board rows; `POST /api/trade/finder` returns trades for a real roster |
+| `journey-trade.spec.js` | signed-in UI + API | `/trade` builder renders + controls; `/trades` history; `/rankings?screen=` deep-link actually narrows the board; `/arbitrage` scans to trades or an explicit empty state; `POST /api/trade/finder` returns trades for a real roster |
 | `journey-settings-overrides.spec.js` | signed-in UI | Settings lists every registered source; toggling one fires `POST /api/rankings/overrides` and the board re-renders with the custom-mix badge |
 | `journey-news.spec.js` | signed-in UI | `/news` tab — skips with a clear message while the route 404s (pre-PR #533) and self-activates once it ships |
 | `mobile-smoke.spec.js` | signed-in UI @390x844 | Board usable, popup opens/closes, bottom nav navigates |

--- a/tests/e2e/helpers/auth-fixture.js
+++ b/tests/e2e/helpers/auth-fixture.js
@@ -19,6 +19,7 @@
  * a silent 404 cascade.
  */
 const base = require("@playwright/test");
+const { pageUrl } = require("./journey");
 
 exports.test = base.test.extend({
   authedPage: async ({ page, baseURL }, use) => {
@@ -39,7 +40,26 @@ exports.test = base.test.extend({
     }
     // The fixture page inherits the cookies from page.request — it's
     // the same browser context.  Reload so subsequent nav uses them.
-    await page.goto("/");
+    //
+    // Through pageUrl(), NOT bare "/".  Cookies are host-scoped and
+    // ignore the port, so :3000 sees the session minted against :8000
+    // just the same — but the DOCUMENT matters.  Served through the
+    // backend page proxy, "/" hydrates the anonymous shell against an
+    // authenticated client, and React reports the mismatch as a #418
+    // page error *asynchronously*, on the MessagePort scheduler, after
+    // goto() has already resolved.
+    //
+    // By then the test body has attached its console guards, so the
+    // fixture's hydration error lands in the NEXT test's bucket —
+    // "/trade renders the builder with working controls" failing with
+    // a stack full of :8000 chunk URLs it never requested.  It is a
+    // race, so it presents as an intermittent failure on whichever
+    // authed spec happens to lose it.
+    //
+    // (The proxy's mismatched shell is a real defect too. It is
+    // tracked in #555 and being deleted; this line is about not
+    // misattributing it.)
+    await page.goto(pageUrl("/"));
     await use(page);
   },
 });

--- a/tests/e2e/helpers/journey.js
+++ b/tests/e2e/helpers/journey.js
@@ -149,11 +149,23 @@ const SEL = {
   edgeSignalTab: '[role="tablist"][aria-label="Signal family"] [role="tab"]',
   edgeSignalTable: '[role="tabpanel"] .ds-table-wrap table',
   edgeSignalRow: '[role="tabpanel"] .ds-table-wrap table tbody tr',
-  // /finder (R3) — workflow presets as a tablist over one result table.
-  finderWorkflowTab:
-    '[role="tablist"][aria-label="Discovery workflow"] [role="tab"]',
-  finderFilters: ".finder-filters",
-  finderRow: '[role="tabpanel"] .ds-table-wrap table tbody tr',
+  // /arbitrage — the UI caller for src/trade/finder.py (board-vs-market).
+  // One card per candidate trade; ``arbitrage-trade-card`` is the stable
+  // hook beside the hashed CSS-module class.
+  //
+  // NOT to be confused with the retired /finder, which was a board
+  // FILTER (presets over sourceRankSpread / confidenceBucket /
+  // isSingleSource / rookie) and computed no board-versus-market
+  // comparison at all.  Its selectors (`finderWorkflowTab`,
+  // `finderFilters`, `finderRow`) are deleted here along with the route:
+  // /finder is now a redirect shim into /rankings, and its presets
+  // live on as the Screens dropdown (`SCREENS`, lib/edge-helpers.js).
+  //
+  // The confusion was load-bearing, not cosmetic: a stale header comment
+  // on /finder once called it "the arbitrage blotter", which made an
+  // earlier audit record a phantom second implementation competing with
+  // this engine (see the header of frontend/app/arbitrage/page.jsx).
+  arbitrageTradeCard: ".arbitrage-trade-card",
   // / dashboard (R3) — the war-room terminal. The legacy terminal
   // Panel container is retired; every section is a ds Panel now, so
   // panels are addressed by their accessible heading rather than a

--- a/tests/e2e/specs/chart-visual-regression.spec.js
+++ b/tests/e2e/specs/chart-visual-regression.spec.js
@@ -101,7 +101,20 @@ async function _openMethodology(page) {
   // dangerous: the opener quietly does nothing, the panel never
   // expands, and the charts fail as "chart didn't render" rather than
   // "the button moved".
-  const btn = page.getByRole("button", { name: /how this works|methodology/i });
+  //
+  // ``hide charts`` is in the alternation because THE TOGGLE RENAMES
+  // ITSELF WHEN IT OPENS: rankings/page.jsx:1319 renders
+  // "Methodology charts" while collapsed and "Hide charts" while
+  // expanded.  A name locator matching only the collapsed label stops
+  // resolving the instant the click lands, so the state poll below
+  // reads `aria-pressed` off zero elements and times out — against a
+  // panel that is, in the trace, plainly open.  That is how this
+  // helper failed three chart tests on 2026-07-31.  Nothing else on
+  // the page matches "hide charts" ("Hide edge" is the neighbouring
+  // rail toggle and does not).
+  const btn = page.getByRole("button", {
+    name: /how this works|methodology|hide charts/i,
+  });
   try {
     await btn.first().waitFor({ state: "visible", timeout: 5_000 });
   } catch {

--- a/tests/e2e/specs/chart-visual-regression.spec.js
+++ b/tests/e2e/specs/chart-visual-regression.spec.js
@@ -104,11 +104,56 @@ async function _openMethodology(page) {
   const btn = page.getByRole("button", { name: /how this works|methodology/i });
   try {
     await btn.first().waitFor({ state: "visible", timeout: 5_000 });
-    await btn.first().click();
   } catch {
-    // Button not present — methodology is either always-open on this
-    // variant or the page doesn't have one.  Silent no-op.
+    // Button genuinely absent — methodology is either always-open on
+    // this variant or the page doesn't have one.  Legitimate no-op.
+    return;
   }
+
+  // The button EXISTS, so from here a failure to open is a real failure
+  // and must not be swallowed.  Previously the click shared the catch
+  // above, so a click lost to pre-hydration timing looked identical to
+  // "no such button" — the panel never expanded and every chart below
+  // failed as "chart didn't render" instead of naming the actual cause.
+  //
+  // Retry the click while polling for the toggle to actually flip.
+  //
+  // Idempotency matters here: this is a DISCLOSURE toggle, so clicking
+  // again would close it. So we poll on "is it open" and stop clicking
+  // once it is, rather than clicking every tick.
+  //
+  // The open-state attribute differs by widget — /rankings uses
+  // `aria-pressed` (page.jsx:1316) while a disclosure would use
+  // `aria-expanded`, and the name regex above matches both that toggle
+  // and a `HelpModal`. So read whichever the button actually exposes,
+  // and when it exposes NEITHER, click once and hand off: the caller's
+  // chart assertion is the real signal, and inventing a contract this
+  // button doesn't have would fail every run.
+  const stateAttr = (await btn.first().getAttribute("aria-pressed")) !== null
+    ? "aria-pressed"
+    : (await btn.first().getAttribute("aria-expanded")) !== null
+      ? "aria-expanded"
+      : null;
+
+  if (!stateAttr) {
+    await btn.first().click();
+    return;
+  }
+
+  await expect
+    .poll(
+      async () => {
+        if ((await btn.first().getAttribute(stateAttr)) === "true") return true;
+        await btn.first().click();
+        return (await btn.first().getAttribute(stateAttr)) === "true";
+      },
+      {
+        message: `the methodology toggle should report ${stateAttr}="true" once clicked`,
+        timeout: 30_000,
+        intervals: [250, 500, 1000, 2000],
+      },
+    )
+    .toBe(true);
 }
 
 test.describe("Chart visual regression", () => {

--- a/tests/e2e/specs/critical-smoke.spec.js
+++ b/tests/e2e/specs/critical-smoke.spec.js
@@ -158,49 +158,31 @@ test.describe("critical smoke — auth-gated API returns 401 when unauthenticate
   });
 });
 
-test.describe("critical smoke — terminal endpoint contracts", () => {
-  // /api/terminal moved into the auth-gated set (server.py
-  // _PUBLIC_API_EXACT no longer lists it).  The "anonymous returns
-  // publicMode payload" contract these tests asserted is no longer
-  // the live behavior — anonymous returns 401.  Tests skip when
-  // unauthenticated; the signed-in spec covers the populated path.
-  test("GET /api/terminal returns publicMode payload when anonymous", async ({ request }) => {
-    const res = await request.get("/api/terminal");
-    if (res.status() === 401) {
-      test.info().annotations.push({
-        type: "skip",
-        description: "/api/terminal is now auth-gated; signed-in spec covers populated path",
-      });
-      return;
-    }
-    if (res.status() === 503) {
-      test.info().annotations.push({
-        type: "skip",
-        description: "live contract not loaded yet",
-      });
-      return;
-    }
-    expect(res.status()).toBe(200);
-    const body = await res.json();
-    expect(body.authenticated).toBe(false);
-    expect(body.meta?.publicMode).toBe(true);
-    // Private fields should be nulled / empty.
-    expect(body.team).toBeNull();
-    expect(body.signals).toEqual([]);
-    expect(body.portfolio).toBeNull();
-    // Public fields should still be populated when data exists.
-    expect(body.movers).toBeDefined();
-    expect(Array.isArray(body.movers.league)).toBe(true);
-    expect(Array.isArray(body.movers.top150)).toBe(true);
-    expect(body.trendWindows).toEqual([7, 30, 90, 180]);
-  });
-
-  test("rank-history endpoint clamps days to MAX_SNAPSHOTS", async ({ request }) => {
-    const res = await request.get("/api/data/rank-history?days=9999");
-    if (res.status() === 401 || res.status() === 503) return;
-    expect(res.status()).toBe(200);
-    const body = await res.json();
-    expect(body.days).toBeLessThanOrEqual(365 * 3);
-    expect(body.history).toBeDefined();
-  });
-});
+// ── What was here: two tests that reported PASSED while executing
+// nothing at all ─────────────────────────────────────────────────────
+//
+// "GET /api/terminal returns publicMode payload when anonymous" and
+// "rank-history endpoint clamps days to MAX_SNAPSHOTS" both opened by
+// checking for 401 and, on a hit, returning early — one after pushing
+// an annotation of `{type: "skip"}`, which is NOT `test.skip()` and does
+// not skip anything. Playwright reported both as PASSED.
+//
+// Both endpoints are auth-gated and return 401 to an anonymous request
+// (measured, not assumed). This is an ANONYMOUS spec. So every
+// assertion in both bodies was unreachable, permanently, and the suite
+// counted two more green tests for it. That is worse than no test: it
+// occupies the slot where real coverage would go — the same finding as
+// the `body.length > 0` disjunction above.
+//
+// They are not simply deleted; each half went where it can execute:
+//
+//   * the auth gate — already covered, and non-vacuously, by
+//     AUTH_GATED_API_ROUTES above, which lists both `/api/terminal` and
+//     `/api/data/rank-history?days=30` and asserts the 401.
+//   * the terminal payload — covered by signed-in-smoke.spec.js
+//     ("/api/terminal returns 200 (or 503 data_not_ready)"). The
+//     anonymous `publicMode` payload it asserted stopped being live
+//     behaviour when the endpoint moved out of `_PUBLIC_API_EXACT`;
+//     there is no such contract left to test.
+//   * the MAX_SNAPSHOTS clamp — had NO other home, so it moved to
+//     signed-in-smoke.spec.js rather than being dropped with the rest.

--- a/tests/e2e/specs/journey-trade.spec.js
+++ b/tests/e2e/specs/journey-trade.spec.js
@@ -1,12 +1,19 @@
 /**
  * Critical journey: trade surfaces.
  *
- *   - /trade   — the trade builder (calculator) renders and accepts input
- *   - /trades  — trade history page renders (cards or explicit empty state)
- *   - /finder  — the arbitrage-finder board renders result rows
- *   - POST /api/trade/finder — the KTC arbitrage engine returns trades
- *     for a real roster (API-level: no UI consumes this endpoint today,
- *     but the engine is a product surface the redesign must not break)
+ *   - /trade      — the trade builder (calculator) renders and accepts input
+ *   - /trades     — trade history renders (cards or explicit empty state)
+ *   - /rankings?screen= — a screen deep-link actually narrows the board
+ *   - /arbitrage  — the board-vs-market scan resolves to trades or an
+ *     explicit empty state
+ *   - POST /api/trade/finder — the same engine at the API level
+ *
+ * The last two used to be one test pointed at /finder and named after
+ * the arbitrage board, which was two different surfaces confused for
+ * one.  /finder is now a redirect shim into /rankings; see the comment
+ * above those tests.  The old header here also said "no UI consumes this
+ * endpoint today", which stopped being true when /arbitrage shipped as
+ * its caller.
  *
  * Auth: test-only session fixture (skips when E2E_TEST_SECRET unset).
  */
@@ -67,27 +74,127 @@ test.describe("journey: trade surfaces", () => {
     guard.assertClean();
   });
 
-  test("/finder renders the arbitrage board with result rows", async ({ authedPage: page }) => {
+  // ── What replaced "/finder renders the arbitrage board" ──────────
+  //
+  // That test asserted one page and was named after a different one, and
+  // both halves of the confusion are now covered separately.
+  //
+  // /finder was a board FILTER — presets over sourceRankSpread /
+  // confidenceBucket / isSingleSource / rookie.  It computed no
+  // board-versus-market comparison at all, despite a stale header
+  // comment there once calling it "the arbitrage blotter".  It is now a
+  // redirect shim into /rankings and its presets are the Screens
+  // dropdown, so its coverage belongs on /rankings (first test below).
+  //
+  // The actual board-vs-market engine (src/trade/finder.py) is /arbitrage,
+  // which had NO e2e coverage at all — so the old test's *name* described
+  // something real that nothing was testing (second test below).
+  //
+  // Deleting the stale test outright would have dropped both.
+
+  test("a /rankings screen deep-link narrows the board to its question", async ({
+    authedPage: page,
+  }) => {
     const guard = attachConsoleGuards(page);
-    await page.goto(pageUrl("/finder"), { waitUntil: "domcontentloaded" });
 
-    await expect(page.locator("body")).toContainText(/Finder/i, { timeout: 30_000 });
+    // ``?screen=wr-gaps`` seeds the board view on mount (rankings
+    // page.jsx). An unknown key deliberately falls through to the
+    // default board rather than wedging, so asserting the URL loaded is
+    // NOT enough — we have to prove the filter actually applied.
+    await page.goto(pageUrl("/rankings?screen=wr-gaps"), {
+      waitUntil: "domcontentloaded",
+    });
 
-    // Data-driven: the results table materializes once /api/data lands.
-    // Accepts the legacy `.table-wrap` and the ds `DataTable` wrapper the
-    // redesign moves these pages onto, so this spec spans the rebuild
-    // instead of needing a flag-day edit the day R3 lands.
-    const rows = page.locator(
-      ".table-wrap table tbody tr, .ds-table-wrap table tbody tr",
-    );
-    await expect(rows.first(), "finder should render result rows").toBeVisible({
+    // Still the rankings board, not a 404 or a redirect somewhere else.
+    // NOTE `pageHeading` RETURNS a locator — it asserts nothing on its
+    // own, so it must be wrapped in expect(). A bare `await
+    // pageHeading(...)` is a silent no-op.
+    await expect(pageHeading(page, titleFor("/rankings"))).toBeVisible({
       timeout: 60_000,
     });
-    expect(await rows.count()).toBeGreaterThan(5);
 
-    // The match-count line reflects a populated board.
-    await expect(page.locator("body")).toContainText(/\d[\d,]* players? match/i);
+    const rows = page.locator(SEL.boardRow);
+    await expect(rows.first(), "screened board should render rows").toBeVisible({
+      timeout: 60_000,
+    });
+    const count = await rows.count();
+    expect(count, "wr-gaps must match at least one player on the snapshot").toBeGreaterThan(0);
 
+    // The screen's definition: WRs only. This is what makes the test
+    // non-vacuous — the DEFAULT board is all positions, so if the
+    // ?screen= seeding silently failed, non-WR rows would appear here.
+    //
+    // Addressed by `data-col`, not `nth-child`: the board's column set is
+    // built conditionally (the Fund-gap column appears only while BDVM
+    // serves an ok payload), so an ordinal selector would keep passing
+    // while reading a different column.
+    const positions = await page
+      .locator(`${SEL.boardRow} td[data-col="pos"]`)
+      .allInnerTexts();
+    expect(positions.length, "pos column should be addressable").toBeGreaterThan(0);
+    // The cell renders "WR" plus the position rank ("WR12"), so match the
+    // leading token rather than requiring exact equality.
+    const nonWr = positions
+      .map((p) => p.trim())
+      .filter((p) => p && !/^WR\b/.test(p));
+    expect(nonWr, `wr-gaps returned non-WR rows: ${nonWr.slice(0, 5).join(", ")}`).toEqual([]);
+
+    guard.assertClean();
+  });
+
+  test("/arbitrage scans and renders either trades or an explicit empty state", async ({
+    authedPage: page,
+  }) => {
+    const guard = attachConsoleGuards(page);
+    await page.goto(pageUrl("/arbitrage"), { waitUntil: "domcontentloaded" });
+
+    await expect(pageHeading(page, titleFor("/arbitrage"))).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // Before any scan the page states what it wants, rather than showing
+    // an empty table that reads like a broken board.
+    await expect(page.getByText(/Pick a team and scan/i)).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // The team selector populates from the live contract; wait for a real
+    // option rather than clicking into a disabled control.
+    const teamSelect = page.getByLabel("Your team");
+    await expect
+      .poll(async () => (await teamSelect.locator("option").count()), {
+        message: "team selector should populate from the contract",
+        timeout: 60_000,
+      })
+      .toBeGreaterThan(0);
+
+    // Click INSIDE the poll: the first click can land before React has
+    // attached handlers and is then simply lost. Same remedy as the
+    // archives race (public-league.spec.js) — the handler is idempotent,
+    // so re-clicking only re-runs the same scan.
+    const scan = page.getByRole("button", { name: /Find arbitrage/i });
+    const settled = page
+      .locator(SEL.arbitrageTradeCard)
+      .or(page.getByText(/No arbitrage found/i));
+
+    await expect
+      .poll(
+        async () => {
+          if (await scan.isEnabled()) await scan.click();
+          return settled.count();
+        },
+        {
+          message: "scan should resolve to trades or the explicit empty state",
+          timeout: 90_000,
+          intervals: [500, 1000, 2000, 3000, 5000],
+        },
+      )
+      .toBeGreaterThan(0);
+
+    // Both outcomes are legitimate on a committed snapshot — what is NOT
+    // legitimate is neither appearing, which is what the poll rules out.
+    // Asserting "trades exist" would make this test hostage to whether
+    // the frozen board happens to contain an arbitrage opportunity.
     guard.assertClean();
   });
 

--- a/tests/e2e/specs/journey-trade.spec.js
+++ b/tests/e2e/specs/journey-trade.spec.js
@@ -170,9 +170,20 @@ test.describe("journey: trade surfaces", () => {
 
     // Click INSIDE the poll: the first click can land before React has
     // attached handlers and is then simply lost. Same remedy as the
-    // archives race (public-league.spec.js) — the handler is idempotent,
-    // so re-clicking only re-runs the same scan.
-    const scan = page.getByRole("button", { name: /Find arbitrage/i });
+    // archives race (public-league.spec.js).
+    //
+    // But NOT "click every tick". Re-clicking is not idempotent here —
+    // `run()` sets `running: true`, and BOTH settled states are gated
+    // on `!running` (arbitrage/page.jsx:283,289). So a click fired on
+    // the same tick that the previous scan finished tears the result
+    // straight back down, and since the click happened before the read,
+    // the read always saw zero. That is not a hypothetical: it failed
+    // deterministically, with 30+ trade cards visible in the trace.
+    //
+    // Hence: READ FIRST, and only click when no scan is in flight.
+    // `disabled={running || dataLoading || !effectiveTeam}` makes
+    // `isEnabled()` the page's own statement that a click is safe.
+    const scan = page.getByRole("button", { name: /Find arbitrage|Scanning/i });
     const settled = page
       .locator(SEL.arbitrageTradeCard)
       .or(page.getByText(/No arbitrage found/i));
@@ -180,8 +191,10 @@ test.describe("journey: trade surfaces", () => {
     await expect
       .poll(
         async () => {
+          const count = await settled.count();
+          if (count > 0) return count;
           if (await scan.isEnabled()) await scan.click();
-          return settled.count();
+          return 0;
         },
         {
           message: "scan should resolve to trades or the explicit empty state",

--- a/tests/e2e/specs/public-league-visual.spec.js
+++ b/tests/e2e/specs/public-league-visual.spec.js
@@ -81,13 +81,40 @@ async function _openLeagueTab(page, tabLabel, expectContent) {
     `the "${tabLabel}" sub-tab must exist on /league — a renamed or ` +
       `dropped tab used to make this test silently pass`,
   ).toBeVisible({ timeout: READINESS_TIMEOUT_MS });
-  await btn.first().click();
-
-  // Data-driven wait on the section's own content — never a sleep.
-  await expect(
-    page.locator("body"),
-    `the "${tabLabel}" section should render its own content`,
-  ).toContainText(expectContent, { timeout: READINESS_TIMEOUT_MS });
+  // Click INSIDE the poll, not before it.
+  //
+  // `toBeVisible` proves the markup arrived, not that React has attached
+  // handlers — and against a large document those are far apart. A click
+  // that lands in that gap is not queued, it is LOST, and the wait below
+  // then watches a section that was never going to change. That is the
+  // race diagnosed on the archives tab (30 production runs read
+  // FFFF.SFFSFSSSSSSFSFSFFSS.FSFFF — 13 pass, 15 fail, interleaved), and
+  // the remedy proven there is to retry the click while polling.
+  //
+  // ALL FOUR tests in this file funnel through this helper, so the fix
+  // was worth generalising rather than leaving in public-league.spec.js
+  // alone. Re-clicking is safe: the handler sets tab state, so extra
+  // clicks re-select the same tab.
+  // NOTE: every caller passes a RegExp, so this must test with `.test()`,
+  // not `String.includes` — the latter would stringify the pattern and
+  // silently never match, turning a race fix into a permanent failure.
+  const matcher =
+    expectContent instanceof RegExp ? expectContent : new RegExp(expectContent, "i");
+  await expect
+    .poll(
+      async () => {
+        await btn.first().click();
+        return matcher.test(await page.locator("body").innerText());
+      },
+      {
+        message:
+          `the "${tabLabel}" section should render its own content ` +
+          `(expected to match ${matcher})`,
+        timeout: READINESS_TIMEOUT_MS,
+        intervals: [250, 500, 1000, 2000, 3000],
+      },
+    )
+    .toBe(true);
 }
 
 test.describe("public /league visual regression", () => {

--- a/tests/e2e/specs/signed-in-smoke.spec.js
+++ b/tests/e2e/specs/signed-in-smoke.spec.js
@@ -198,6 +198,37 @@ test.describe("signed-in: API round-trips that public smoke can't hit", () => {
     expect(res.status()).toBe(200);
   });
 
+  // Moved here from critical-smoke.spec.js, which is an ANONYMOUS spec.
+  // The endpoint is auth-gated and 401s to an anonymous request, and the
+  // test there opened with `if (status === 401) return;` — so its whole
+  // body was unreachable while Playwright reported it PASSED.
+  //
+  // Also tightened while moving. It asserted `days <= 365 * 3`, which a
+  // clamp returning 1 would satisfy just as happily as the correct one;
+  // the contract is an exact value, so assert that. Both ends of the
+  // clamp are checked because they are separate `max`/`min` terms
+  // (server.py:3556) and only one of them was covered before.
+  test("rank-history clamps days to [1, MAX_SNAPSHOTS]", async ({ authedPage }) => {
+    const MAX_SNAPSHOTS = 365 * 3; // src/api/rank_history.py:85
+
+    const high = await authedPage.request.get("/api/data/rank-history?days=9999");
+    expect(high.status()).toBe(200);
+    const highBody = await high.json();
+    expect(highBody.days).toBe(MAX_SNAPSHOTS);
+    expect(highBody.history).toBeDefined();
+
+    const low = await authedPage.request.get("/api/data/rank-history?days=0");
+    expect(low.status()).toBe(200);
+    expect((await low.json()).days).toBe(1);
+
+    // A non-numeric value falls back to the default rather than 500ing.
+    const junk = await authedPage.request.get("/api/data/rank-history?days=abc");
+    expect(junk.status()).toBe(200);
+    const junkDays = (await junk.json()).days;
+    expect(junkDays).toBeGreaterThanOrEqual(1);
+    expect(junkDays).toBeLessThanOrEqual(MAX_SNAPSHOTS);
+  });
+
   test("/api/terminal returns 200 (or 503 data_not_ready) for default league", async ({ authedPage }) => {
     const res = await authedPage.request.get("/api/terminal");
     // 200 = happy; 503 data_not_ready is acceptable when no live contract.

--- a/tests/e2e/specs/waivers-smoke.spec.js
+++ b/tests/e2e/specs/waivers-smoke.spec.js
@@ -66,14 +66,35 @@ test.describe("signed-in: /waivers page", () => {
     // selected team (the e2e test user) shows the calculator's
     // pick-a-team empty state instead; both are valid "section
     // renders" outcomes.
+    //
+    // This must NOT branch on a single innerText read.  The page passes
+    // through three distinct bodies while it settles — signed-out
+    // shell, signed-in-without-team, then the team picker — and a read
+    // that lands on the middle one contains NEITHER "Select a team" nor
+    // "DROP", picks the else branch, and then waits 15s for a "DROP"
+    // that this session will never render.  Same hydration race as the
+    // archives one, in its read-once-then-branch form: the branch is
+    // decided on a frame that is not the final frame.
+    //
+    // Poll for whichever settled state actually arrives.
     const body = authedPage.locator("body");
-    const text = await body.innerText();
-    if (/Select a team/i.test(text)) {
-      await expect(body).toContainText(/Select a team .* calculator/i);
-    } else {
-      await expect(body).toContainText(/DROP/);
-      await expect(body).toContainText(/ADD/);
-    }
+    await expect
+      .poll(
+        async () => {
+          const text = await body.innerText();
+          if (/Select a team .* calculator/i.test(text)) return "pick-a-team";
+          if (/DROP/.test(text) && /ADD/.test(text)) return "pickers";
+          return "unsettled";
+        },
+        {
+          message:
+            "the calculator should settle on either its pick-a-team empty " +
+            "state or its DROP/ADD pickers",
+          timeout: 30_000,
+          intervals: [250, 500, 1000, 2000],
+        },
+      )
+      .not.toBe("unsettled");
   });
 
   test("FAAB recommender endpoint returns the documented shape", async ({

--- a/tests/e2e/test_e2e_harness_guards.py
+++ b/tests/e2e/test_e2e_harness_guards.py
@@ -50,9 +50,29 @@ E2E_DIR = REPO_ROOT / "tests" / "e2e"
 JOURNEY_HELPER = E2E_DIR / "helpers" / "journey.js"
 FRONTEND_CANON = REPO_ROOT / "frontend" / "__tests__" / "helpers" / "naming-canon.js"
 
-# ``page.goto("/…")`` without pageUrl().  Matches the literal-path form
-# only: pageUrl(...), template literals and variables are all fine
-# because they cannot be the bare-baseURL mistake this guard is about.
+# ``page.goto("/…")`` without pageUrl().  Matches the LITERAL-path form
+# only.
+#
+# The original comment here justified that as "template literals and
+# variables are all fine because they cannot be the bare-baseURL
+# mistake". That was wrong, and wrong in the specific way this whole file
+# exists to catch — a guard whose stated purpose and actual predicate
+# differ (docs/ORCHESTRATION.md §6.15).
+#
+# ``critical-smoke.spec.js`` iterates PUBLIC_ROUTES / AUTH_GATED_ROUTES
+# and calls ``page.goto(path)`` with a variable holding "/rankings",
+# "/trade"… which lands on baseURL exactly like the literal form. It is
+# CORRECT there — those tests assert the backend's own anonymous-access
+# behaviour and must not be rerouted to :3000 — but it is correct by
+# intent, not because the variable form is inherently safe.
+#
+# So the honest statement of the rule is narrower than "navigations must
+# go through pageUrl()": this guard catches the literal form, which is
+# the shape the 11-of-19 nightly regression actually took
+# (``gotoRankingsBoard`` had a hardcoded ``page.goto("/rankings")``).
+# The variable form is deliberately out of scope because distinguishing
+# "iterating routes to test the proxy" from "forgot the wrapper" needs
+# intent a regex does not have.
 _BARE_GOTO = re.compile(r"""\.goto\(\s*["'](/[^"']*)["']""")
 
 # The one deliberate exemption.  auth-fixture reloads "/" purely to let

--- a/tests/e2e/test_e2e_harness_guards.py
+++ b/tests/e2e/test_e2e_harness_guards.py
@@ -75,19 +75,27 @@ FRONTEND_CANON = REPO_ROOT / "frontend" / "__tests__" / "helpers" / "naming-cano
 # intent a regex does not have.
 _BARE_GOTO = re.compile(r"""\.goto\(\s*["'](/[^"']*)["']""")
 
-# The one deliberate exemption.  auth-fixture reloads "/" purely to let
-# the browser context pick up the cookies ``page.request`` just set;
-# "/" is public (``frontend/lib/public-routes.js``) so it does not
-# redirect, and the reload's whole point is to exercise the same origin
-# the session was minted against.  Documented rather than silently
-# skipped — an undocumented entry here is how this guard would rot.
-_GOTO_EXEMPT = {
-    ("helpers/auth-fixture.js", "/"): (
-        "cookie-priming reload immediately after POST "
-        "/api/test/create-session; '/' is public so it cannot 307, and "
-        "the reload must stay on the origin the session was minted on"
-    ),
-}
+# Deliberate exemptions, keyed (file, route).  EMPTY, and that is the
+# desired state — every entry here is a hole in the guard.
+#
+# There used to be one: auth-fixture's cookie-priming ``page.goto("/")``,
+# justified on the grounds that "/" is public so it cannot 307. True,
+# and beside the point. Through the backend page proxy "/" hydrates the
+# ANONYMOUS shell against an already-authenticated client, and React
+# reports that mismatch as an async #418 page error that lands after
+# goto() resolves — i.e. after the next test attached its console
+# guards. Intermittent failures on whichever authed spec lost the race,
+# with :8000 chunk URLs in a stack trace from a test that navigated to
+# :3000.
+#
+# The exemption's reasoning was sound about redirects and silent about
+# hydration, which is the same §6.15 shape this file exists to catch.
+# The fixture now primes through pageUrl() like everything else.
+#
+# An entry here needs a reason that survives someone reading it
+# adversarially — "it cannot redirect" is not the same claim as "it is
+# safe to navigate there".
+_GOTO_EXEMPT: dict[tuple[str, str], str] = {}
 
 # Names PR #625 retired.  An assertion still matching one of these is a
 # rename that only half landed.

--- a/tests/scripts/test_audit_identity_matches.py
+++ b/tests/scripts/test_audit_identity_matches.py
@@ -270,39 +270,61 @@ class TestCommittedDataRegression:
         )
         assert "::error title=Alias collision" in proc.stdout
 
-    def test_the_duplicate_allowlist_only_holds_real_collisions(self, tmp_path):
-        """An allowlist entry that no longer collides is dead weight.
+    def test_the_allowlist_still_describes_the_aliases_it_exempts(self):
+        """An exemption must still match the alias table it was verified against.
 
-        Guards the guard: if a refresh drops the duplicate pool row,
-        this fails and the entry gets removed, rather than sitting
-        there widening the exemption for a future name that happens to
-        normalize the same way.
+        This started life asserting that every allowlisted name is
+        colliding in the CURRENTLY COMMITTED pool, and that predicate
+        was wrong in the way ``docs/ORCHESTRATION.md`` §6.15 names: its
+        stated purpose ("a stale exemption silently covers whatever
+        normalizes to that name next") and its actual predicate did not
+        match.
+
+        The pool is refreshed from external sources every two hours.
+        "Robert Henry" entered ``CSVs/dynasty_full.csv`` on
+        2026-07-30T18:06Z and was gone again by 2026-07-31T04:09Z, so
+        the collision blinks in and out on a schedule nobody controls —
+        and this test failed CI on the second of those refreshes while
+        the exemption was still entirely correct.  Left as it was, the
+        pair would churn forever: drop the entry, next refresh
+        re-introduces the row, the GATE fails and opens an issue, re-add
+        the entry.
+
+        What actually justifies the exemption is committed code — the
+        ``robert henry -> rob henry`` alias, verified same player on both
+        sides.  An alias-introduced collision on name ``X`` is only
+        POSSIBLE while some entry in ``CANONICAL_NAME_ALIASES`` targets
+        ``X``, so that is the live/dead test.
+
+        It is also strictly stronger than what it replaces on the risk
+        that mattered.  The old check said nothing about WHICH names an
+        exemption covers, so a second alias pointing at "rob henry"
+        would have inherited the carve-out in silence — exactly the
+        widening it claimed to prevent.  Pinning the source set means
+        that new alias fails here and has to be verified on its own.
         """
         from scripts.audit_identity_matches import _KNOWN_POOL_DUPLICATES
+        from src.utils.name_clean import CANONICAL_NAME_ALIASES
 
-        out = tmp_path / "report.json"
-        proc = subprocess.run(
-            [
-                sys.executable,
-                str(SCRIPT),
-                "--json-path",
-                str(_latest_export()),
-                "--json",
-                str(out),
-                "--limit",
-                "1",
-            ],
-            capture_output=True,
-            text=True,
-            cwd=str(REPO),
-            timeout=600,
-        )
-        assert proc.returncode == 0, proc.stderr[-2000:]
-        report = json.loads(out.read_text(encoding="utf-8"))
-        colliding = {c["canonicalName"] for c in report["aliasCollisions"]}
-        stale = sorted(_KNOWN_POOL_DUPLICATES - colliding)
-        assert stale == [], (
-            f"allowlisted names that no longer collide: {stale}. "
-            "Drop them from _KNOWN_POOL_DUPLICATES — a stale exemption "
-            "silently covers whatever normalizes to that name next."
+        actual: dict[str, set[str]] = {}
+        for source, target in CANONICAL_NAME_ALIASES.items():
+            if target in _KNOWN_POOL_DUPLICATES:
+                actual.setdefault(target, set()).add(source)
+
+        drift = {
+            name: {
+                "verified": sorted(verified),
+                "aliasTableNow": sorted(actual.get(name, set())),
+            }
+            for name, verified in _KNOWN_POOL_DUPLICATES.items()
+            if actual.get(name, set()) != set(verified)
+        }
+        assert drift == {}, (
+            "_KNOWN_POOL_DUPLICATES no longer describes the alias table.\n"
+            f"{json.dumps(drift, indent=2)}\n"
+            "An empty 'aliasTableNow' means nothing can route into that "
+            "name any more — the exemption is dead weight, drop it. A "
+            "LARGER set means a new alias inherited a carve-out it was "
+            "never verified for: check it is the same player, then widen "
+            "the entry deliberately."
         )


### PR DESCRIPTION
Two things, aimed at the same problem: **this repo cannot currently tell you when something has stopped being broken.**

---

## 1. Five alerts that could only ever say "broken"

Six workflows open a rolling tracking issue. **Only one ever closed it.**

| workflow | label | opens | closes (before) |
|---|---|---|---|
| `scheduled-refresh.yml` | `stale-sources` | yes | **yes** |
| `audit-identity-matches.yml` | `identity-collision` | yes | no |
| `audit-rank-form-drift.yml` | `calibration` | yes | no |
| `e2e.yml` | `e2e-failures` | yes | no |
| `intel-refresh.yml` | `intel-stale` | yes | no |
| `refit-hill-curves.yml` | `calibration` | yes | no |

`scheduled-refresh.yml` is the one the others' comments claim to "mirror". Every copy took the failure half and dropped the recovery half.

**The cost is measurable, not theoretical.** #588 was opened 2026-07-27, the **07-28 nightly succeeded**, and the issue stayed open — it has just accumulated comments since. The identical shape left #663 open for hours yesterday after its gate went green. So an open alert issue meant *"this failed at least once, ever"*, not *"this is broken now"* — worthless for triage, and a large part of why the repo reads as permanently red.

Four workflows gain the close-on-success step. It closes **every** open labelled issue, not just `.[0]` — the alert steps read only the first, so duplicates would be orphaned forever.

### The fifth is deliberately excluded, and that's the part worth reading

`refit-hill-curves.yml` opens its issue on **exit code 1**, meaning *"a challenger cleared the held-out gate and is waiting for a human to promote it."* That is a **work item, not an alert** — the step is even named "Open an issue when a human must act". A green run next week doesn't mean the request was handled; it means the refit ran again. Auto-closing would **silently discard promotion requests**, which is strictly worse than a stale alert. Those close when a human runs `scripts/model_registry.py promote`.

The exclusion is documented in the file so nobody tidies up the inconsistency later.

Relatedly: `refit-hill-curves` and `audit-rank-form-drift` **share the `calibration` label**, so the drift audit's close matches on **title**. A label-only close would have reached over and closed the promotion requests — the exact bug a mechanical port would have introduced.

---

## 2. The nightly was genuinely red, and I left it that way

Not a stale alert. `68676ddc5` fixed 16 stale selectors and left the `/finder` spec failing **on purpose**, saying so in its own commit message, because re-pointing it was a behaviour decision rather than a rename.

**That test asserted one page and was named after a different one.** `/finder` was a board *filter*; the board-vs-market engine is `/arbitrage`. The codebase already records how the confusion started — a stale comment on `/finder` once called it "the arbitrage blotter", which `frontend/app/arbitrage/page.jsx` notes *"made an earlier audit record a phantom second implementation competing with this engine."* The spec inherited it.

Deleting the test would have dropped coverage of **both** surfaces, so both are now covered:

- **`/rankings?screen=wr-gaps`** — asserts the deep link actually **narrows** the board (every row a WR). Non-vacuous by construction: the default board is all positions, and an unknown `?screen=` key deliberately falls through to it, so a silently-ignored screen fails this.
- **`/arbitrage`** — the real UI caller for `src/trade/finder.py`, which had **no E2E coverage at all**. Resolves to trades *or* the explicit empty state; asserting "trades exist" would make it hostage to whether a frozen snapshot happens to contain an arbitrage opportunity.

---

## 3. Races generalised, and a guard that didn't guard

The click-*inside*-the-poll remedy proven on the archives tab (#662) was applied to one file and never generalised:

- **`public-league-visual.spec.js`** — clicked immediately after `toBeVisible`, which proves markup arrived, not that handlers are attached. **All four tests in that file** funnel through that helper.
- **`chart-visual-regression.spec.js`** — wrapped its click in `try/catch {}`, so a click lost to pre-hydration timing was indistinguishable from "no such button" and surfaced as the unrelated *"chart didn't render"*.

And `test_e2e_harness_guards.py` justified matching literal paths only with *"variables are all fine because they cannot be the bare-baseURL mistake."* **That is false** — `critical-smoke.spec.js` iterates route arrays through `page.goto(path)`. It is correct *there*, but by intent, not because the variable form is safe. The comment now states the rule the predicate actually enforces — the §6.15 "stated purpose ≠ actual predicate" shape this very file exists to catch.

---

## 4. Four bugs caught in my own work here

Three would have shipped silently:

1. **`.includes()` against a RegExp** — every caller of that helper passes a pattern, so it would have stringified it and never matched, converting a race fix into a permanent failure.
2. **`aria-expanded` on a toggle that uses `aria-pressed`** — and the name regex can also match a `HelpModal`. Now reads whichever attribute exists and hands off cleanly when there's neither, rather than inventing a contract the button doesn't have.
3. **`td:nth-child(3)`** against a column set built conditionally (the Fund-gap column appears only while BDVM serves an ok payload). Fixed properly by adding `data-col={col.key}` to the shared `DataTable`, so every table is addressable by column key rather than ordinal.
4. **`await pageHeading(...)` asserts nothing** — it returns a locator. I wrote two of them.

## 5. Stale docs corrected

The spec inventory in `tests/e2e/README.md`; this spec's own header, which claimed *"no UI consumes this endpoint today"* (untrue since `/arbitrage` shipped as its caller); and a `SCREENS` docstring saying "five" over four definitions.

---

## 6. Then I ran the suite, and it found six more

§4 above promised a full local run before #588 gets closed. That run happened, and it earned its place: **6 failed / 85 passed** on the first pass. None of the six were visible by reading the code, which is the whole argument for running it.

| failure | cause |
|---|---|
| 3 chart tests | `_openMethodology` matched the toggle by accessible name and then polled `aria-pressed` on it — but the toggle **renames itself when it opens**: "Methodology charts" collapsed, "Hide charts" expanded (`rankings/page.jsx:1319`). The locator stopped resolving the instant the click landed, so the poll read an attribute off *zero elements* until timeout, against a panel plainly open in every trace. |
| `/arbitrage` | I wrote "the handler is idempotent, so re-clicking only re-runs the same scan". **It is not.** `run()` sets `running: true`, and *both* settled states are gated on `!running`. A click on the same tick the previous scan finished tore the result straight back down — and because the click ran before the read, the read always saw zero. Deterministic, with 30+ trade cards on screen. |
| `/waivers` | Branched on a single `innerText` read. The page passes through three bodies while settling; a read landing on the middle one matches neither marker, takes the `else` branch, and waits 15s for a "DROP" this session never renders. |
| the flake that moved between runs | `auth-fixture` primed cookies with a bare `goto("/")` → the `:8000` page proxy, which hydrates the **anonymous shell** against an authenticated client. React reports that mismatch *asynchronously*, after `goto()` resolves and after the next test attached its console guards — so the fixture's error lands in someone else's bucket. `/trade renders the builder` failed with a stack full of `:8000` chunk URLs it never requested; `journey-tools-health` failed in the full run and passed in isolation. |

Two of the six were mine, from this PR. The `/arbitrage` one is a correction to reasoning stated in §3 — the archives remedy generalises, but *"idempotent"* has to mean **the second click leaves observable state unchanged**, not that it re-runs the same work.

That last fix retired the harness guard's only `_GOTO_EXEMPT` entry. Its reason — *"'/' is public so it cannot 307"* — was true about redirects and silent about hydration: the same §6.15 shape as §3, in the file written to catch it.

**The proxy's mismatched shell is a real product defect, not just a harness one.** It is #555, and it is being deleted next.

## 7. Two tests that reported PASSED while executing nothing

`annotations.push({type: "skip"})` is **not** `test.skip()`. It skips nothing; Playwright reports the test as passed. Both tests in `critical-smoke.spec.js`'s terminal block opened with `if (status === 401) return;` after pushing one.

Both endpoints are auth-gated and 401 to an anonymous request (measured), and `critical-smoke` **is** the anonymous spec — so every assertion in both bodies was permanently unreachable while the suite counted two more green tests for it. Worse than no test: it occupies the slot where real coverage would go.

Neither was simply deleted. The auth gate was already covered non-vacuously by `AUTH_GATED_API_ROUTES`; the terminal payload by `signed-in-smoke`; and the `MAX_SNAPSHOTS` clamp had **no other home**, so it moved to `signed-in-smoke` where it can execute — and was tightened on the way, since `days <= 365*3` is satisfied just as happily by a clamp returning 1. It now pins the exact value and both ends of the `max`/`min` pair.

The endpoint's docstring claimed "max 180" while the code clamps to 1095. 180 is the *player-source-history* window, on the next handler down. Corrected.

## 8. The CI failure was a wrong predicate, not stale data

`Validate PR` went red on `test_the_duplicate_allowlist_only_holds_real_collisions`, which required every allowlisted name to be colliding in the **currently committed** pool. That pool refreshes from external sources every two hours: "Robert Henry" entered `CSVs/dynasty_full.csv` at 2026-07-30T18:06Z and was gone by 2026-07-31T04:09Z — failing the test while the exemption was entirely correct.

Left alone the pair churns forever: drop the entry → next refresh re-adds the row → the *gate* fails and opens an issue → re-add the entry.

What justifies an exemption is committed code: the verified `robert henry → rob henry` alias. An alias-introduced collision on a name is only *possible* while something in `CANONICAL_NAME_ALIASES` targets it, so that is the live/dead test.

The allowlist is now `name → the exact alias sources verified for it`, which is **strictly stronger on the risk that mattered**. The old check said nothing about *which* names an exemption covers, so a second alias pointing at "rob henry" would have inherited the carve-out in silence — the widening it claimed to prevent. Verified failing in both directions (alias removed → dead weight; alias added → widened).

---

## Verification

| gate | result |
|---|---|
| Playwright, **exact CI flags** (`desktop-1366` + `mobile-chromium`, `--ignore-snapshots`, `SKIP_VISUAL_REGRESSION=1`) | **137 passed, 49 skipped, 0 failed** |
| `pytest tests/ -m "not livedata"` | **5,304 passed, 11 skipped, 0 failed** |
| `Validate PR` on `430c5ebde` | **green** |
| `npm test` | 1,591 passed, 93 files |
| `ruff format --check .` + `ruff check` (pinned 0.6.9) | clean |
| all five edited workflows | parse as valid YAML |

Test-count reconciliation, so nothing became a silent skip: 188 → 186 total (2 vacuous tests removed × 2 projects, 1 added × 2), passed 139 → 137, skipped unchanged at 49.

The 49 skips are real `test.skip()` calls — `desktopOnly` guards on `mobile-chromium` plus the visual block under `SKIP_VISUAL_REGRESSION=1`. They report as skipped, not as passed. That distinction is §7's entire point.

Recorded as Part 3 of `docs/e2e-assertion-audit.md`, including the two generalisable rules from §6: **read before you act in a retry-poll**, and **"idempotent" means the second click leaves observable state unchanged**.

## Related

Closes #661 (separately — the 158-vs-138 gap was a stale comment; served counts and button labels agree exactly, verified against a live stack).

#588 closes on a `workflow_dispatch` run of `E2E Safety Net` against `main` — via the new auto-close step, which also proves the step fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKhaEruQrSLhWKZPEGmEEm