### PR TITLE
Fix the unbound variable that makes every production deploy roll back

### DIFF
--- a/deploy/install-systemd-service.sh
+++ b/deploy/install-systemd-service.sh
@@ -415,13 +415,6 @@ main() {
       bdvm_needs_install=true
     fi
 
-    if [[ "${sharprec_needs_install}" == "true" ]]; then
-    # --now arms the daily timer.  No initial kick: the discovery crawl
-    # kicked above must populate the sharp-eligible league list first,
-    # and the 04:50 slot already sequences this after it.
-    sudo -n "${SYSTEMCTL_BIN}" enable --now "${sharprec_service_name}.timer"
-    log "Enabled ${sharprec_service_name}.timer"
-  fi
   if [[ "${bdvm_needs_install}" == "true" ]]; then
       local tmp_bdvm_service tmp_bdvm_timer
       tmp_bdvm_service="$(mktemp)"


### PR DESCRIPTION
**`main` is currently undeployable.** Two consecutive deploys — run 2023 (#651) and run 2024 (#668) — failed and auto-rolled back. Production has been serving `0506e7a91` throughout: healthy, but carrying neither change.

## The failure

```
deploy/install-systemd-service.sh: line 418: sharprec_needs_install: unbound variable
[deploy][ERROR] Deployment failed at line 737 (exit code 1).
[deploy][WARN] AUTO_ROLLBACK enabled. Attempting rollback to 0506e7a91d3efecc81602b169f3587d072ccf438.
```

Line 418 reads `${sharprec_needs_install}` — a variable `main()` does not declare until **line 505**. Under `set -u` that aborts the script.

**Not a cross-scope bug.** Both lines are inside `main()`; the read simply executes ~90 lines before the assignment. That distinction matters for anyone grepping: the variable *is* in scope, it just has no value yet.

## Why it lay dormant until now

The installer only runs when a systemd unit is missing from the host. #651 added `sharp-records.timer`, so:

```
[deploy][WARN] Timer units missing from this host: ***-sharp-records.timer. Running installer to add them.
[systemd-bootstrap] Signal-alerts timer already installed; skipping.
[systemd-bootstrap] Custom-alerts timer already installed; skipping.
[systemd-bootstrap] Player-context timer already installed; skipping.
install-systemd-service.sh: line 418: sharprec_needs_install: unbound variable
```

And because the rollback reverts to a commit that predates the timer, **the unit is still missing on the next deploy** — so it re-fires every time. Self-perpetuating until fixed.

## The fix

The block at 418–424 is a **verbatim duplicate** of the legitimate one at 777–783 — including the `if [[ "${bdvm_needs_install}" == "true" ]]; then` line that follows it, which is duplicated too. A merge artifact, not a deliberate early enable.

Deleting the orphan is the entire fix. The real sharprec enable already exists at 777, correctly placed after the declaration.

Guarded rather than trusted: the deletion asserted the two blocks are byte-identical modulo whitespace before removing anything, so if they had diverged it would have aborted instead of silently dropping real logic.

## Verification

- `bash -n deploy/install-systemd-service.sh` — clean
- every remaining `sharprec_needs_install` reference (505, 511, 517, 520, 770) now **follows** the declaration at 505
- diff is 7 deletions, no additions, one file

## Note on the rollback machinery

This is the case auto-rollback exists for, and it worked exactly as designed — it caught a broken deploy twice and left production serving a known-good revision with all verification checks passing. Production was never at risk. Re-probed while diagnosing: `/api/health` 200, `/` 200, `/league` 200, `/rankings` 307 → `/login`, `/api/public/league` 2.0 MB.

Once this lands, #651 and #668 will both reach production on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKhaEruQrSLhWKZPEGmEEm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKhaEruQrSLhWKZPEGmEEm)_