### PR TITLE
Populate Sharp Tracker records and make the crawl truly resumable

### DIFF
--- a/.github/workflows/sharp-records-bootstrap.yml
+++ b/.github/workflows/sharp-records-bootstrap.yml
@@ -1,0 +1,118 @@
+name: Bootstrap Sharp Records
+
+on:
+  workflow_run:
+    workflows:
+      - Deploy Production
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      force_kick:
+        description: Run at least one records pass even if the cohort is already populated
+        required: false
+        default: false
+        type: boolean
+      max_passes:
+        description: Maximum immediate records passes while the cohort is still unqualified
+        required: false
+        default: "3"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-sharp-records-bootstrap
+  cancel-in-progress: false
+
+jobs:
+  bootstrap:
+    name: Install And Populate Sharp Records
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main')
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    environment: production
+
+    steps:
+      - name: Configure production SSH
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+          DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          for name in DEPLOY_HOST DEPLOY_USER DEPLOY_SSH_PRIVATE_KEY DEPLOY_KNOWN_HOSTS; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "::error title=Missing production SSH configuration::${name} is empty or unset."
+              exit 1
+            fi
+          done
+
+          DEPLOY_PORT_RESOLVED="${DEPLOY_PORT:-22}"
+          if ! [[ "${DEPLOY_PORT_RESOLVED}" =~ ^[0-9]+$ ]]; then
+            echo "::error title=Invalid SSH port::DEPLOY_PORT must be numeric."
+            exit 1
+          fi
+
+          install -d -m 700 "${HOME}/.ssh"
+          DEPLOY_KEY_FILE="${HOME}/.ssh/id_ed25519"
+          DEPLOY_KNOWN_HOSTS_FILE="${HOME}/.ssh/known_hosts"
+          printf '%s\n' "${DEPLOY_SSH_PRIVATE_KEY}" | sed 's/\r$//' > "${DEPLOY_KEY_FILE}"
+          printf '%s\n' "${DEPLOY_KNOWN_HOSTS}" | sed 's/\r$//' > "${DEPLOY_KNOWN_HOSTS_FILE}"
+          chmod 600 "${DEPLOY_KEY_FILE}"
+          chmod 644 "${DEPLOY_KNOWN_HOSTS_FILE}"
+
+          ssh-keygen -y -f "${DEPLOY_KEY_FILE}" >/dev/null
+          [[ -s "${DEPLOY_KNOWN_HOSTS_FILE}" ]] || {
+            echo "::error title=Empty known_hosts::DEPLOY_KNOWN_HOSTS produced an empty file."
+            exit 1
+          }
+
+          {
+            echo "DEPLOY_PORT_RESOLVED=${DEPLOY_PORT_RESOLVED}"
+            echo "DEPLOY_KEY_FILE=${DEPLOY_KEY_FILE}"
+            echo "DEPLOY_KNOWN_HOSTS_FILE=${DEPLOY_KNOWN_HOSTS_FILE}"
+          } >> "${GITHUB_ENV}"
+
+      - name: Install units and populate the Sharp cohort
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          PROD_APP_DIR: ${{ vars.PROD_APP_DIR || '/home/dynasty/trade-calculator' }}
+          PROD_VENV_DIR: ${{ vars.PROD_VENV_DIR || '/home/dynasty/.venvs/trade-calculator' }}
+          PROD_SERVICE_NAME: ${{ vars.PROD_SERVICE_NAME || 'dynasty' }}
+          FORCE_SHARP_RECORDS_KICK: ${{ github.event_name == 'workflow_dispatch' && inputs.force_kick || false }}
+          SHARP_BOOTSTRAP_MAX_PASSES: ${{ inputs.max_passes || '3' }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          printf -v REMOTE_COMMAND \
+            'APP_DIR=%q APP_USER=%q VENV_DIR=%q SERVICE_NAME=%q FORCE_SHARP_RECORDS_KICK=%q SHARP_BOOTSTRAP_MAX_PASSES=%q bash %q' \
+            "${PROD_APP_DIR}" \
+            "${DEPLOY_USER}" \
+            "${PROD_VENV_DIR}" \
+            "${PROD_SERVICE_NAME}" \
+            "${FORCE_SHARP_RECORDS_KICK}" \
+            "${SHARP_BOOTSTRAP_MAX_PASSES}" \
+            "${PROD_APP_DIR}/deploy/bootstrap-sharp-records.sh"
+
+          ssh \
+            -i "${DEPLOY_KEY_FILE}" \
+            -o BatchMode=yes \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="${DEPLOY_KNOWN_HOSTS_FILE}" \
+            -o ConnectTimeout=20 \
+            -o ServerAliveInterval=20 \
+            -o ServerAliveCountMax=6 \
+            -p "${DEPLOY_PORT_RESOLVED}" \
+            "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            "${REMOTE_COMMAND}"

--- a/deploy/bootstrap-sharp-records.sh
+++ b/deploy/bootstrap-sharp-records.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_APP_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+APP_DIR="${APP_DIR:-${DEFAULT_APP_DIR}}"
+APP_USER="${APP_USER:-$(id -un)}"
+VENV_DIR="${VENV_DIR:-${APP_DIR}/.venv}"
+SERVICE_NAME="${SERVICE_NAME:-dynasty}"
+FORCE_SHARP_RECORDS_KICK="${FORCE_SHARP_RECORDS_KICK:-false}"
+SHARP_BOOTSTRAP_MAX_PASSES="${SHARP_BOOTSTRAP_MAX_PASSES:-3}"
+
+SYSTEMCTL_BIN=""
+INSTALL_BIN=""
+JOURNALCTL_BIN=""
+TMP_DIR=""
+
+log() {
+  printf '[sharp-bootstrap] %s\n' "$*"
+}
+
+warn() {
+  printf '[sharp-bootstrap][WARN] %s\n' "$*" >&2
+}
+
+error() {
+  printf '[sharp-bootstrap][ERROR] %s\n' "$*" >&2
+}
+
+lower() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+resolve_binary() {
+  local candidate
+  for candidate in "$@"; do
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+escape_sed_replacement() {
+  printf '%s' "$1" | sed -e 's/[\\/&]/\\&/g'
+}
+
+render_unit() {
+  local template="$1"
+  local target="$2"
+  local rendered="${TMP_DIR}/$(basename "${target}")"
+
+  [[ -f "${template}" ]] || {
+    error "Missing Sharp Tracker systemd template: ${template}"
+    return 1
+  }
+
+  sed \
+    -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
+    -e "s/__APP_USER__/$(escape_sed_replacement "${APP_USER}")/g" \
+    -e "s/__APP_DIR__/$(escape_sed_replacement "${APP_DIR}")/g" \
+    -e "s/__VENV_DIR__/$(escape_sed_replacement "${VENV_DIR}")/g" \
+    "${template}" > "${rendered}"
+
+  sudo -n "${INSTALL_BIN}" -m 0644 "${rendered}" "${target}"
+  log "Installed $(basename "${target}")"
+}
+
+queue_field() {
+  local field="$1"
+  "${VENV_DIR}/bin/python" - "${field}" <<'PY'
+import sys
+
+from src.sharp.record_queue import queue_stats
+
+value = queue_stats().get(sys.argv[1])
+print(0 if value is None else value)
+PY
+}
+
+records_field() {
+  local field="$1"
+  "${VENV_DIR}/bin/python" - "${field}" <<'PY'
+import sys
+
+from src.sharp.records import records_coverage
+
+value = records_coverage().get(sys.argv[1])
+print(0 if value is None else value)
+PY
+}
+
+qualified_count() {
+  "${VENV_DIR}/bin/python" - <<'PY'
+from src.sharp import records
+from src.sharp import score as sharp_score
+
+scored = sharp_score.score_managers(records.build_manager_records())
+print(sum(1 for manager in scored if manager.qualified))
+PY
+}
+
+show_diagnostics() {
+  log "Current season-record coverage:"
+  "${VENV_DIR}/bin/python" "${APP_DIR}/scripts/crawl_sharp_records.py" --stats || true
+  log "Current Sharp Score tiers:"
+  "${VENV_DIR}/bin/python" "${APP_DIR}/scripts/crawl_sharp_records.py" --score || true
+  log "Recent records-crawler journal:"
+  sudo -n "${JOURNALCTL_BIN}" -u "${SERVICE_NAME}-sharp-records.service" -n 80 --no-pager || true
+}
+
+run_oneshot() {
+  local unit="$1"
+  log "Starting ${unit}"
+  sudo -n "${SYSTEMCTL_BIN}" reset-failed "${unit}" >/dev/null 2>&1 || true
+  if ! sudo -n "${SYSTEMCTL_BIN}" start "${unit}"; then
+    error "${unit} failed."
+    sudo -n "${JOURNALCTL_BIN}" -u "${unit}" -n 120 --no-pager || true
+    return 1
+  fi
+  if sudo -n "${SYSTEMCTL_BIN}" is-failed --quiet "${unit}"; then
+    error "${unit} entered a failed state."
+    sudo -n "${JOURNALCTL_BIN}" -u "${unit}" -n 120 --no-pager || true
+    return 1
+  fi
+  log "${unit} completed."
+}
+
+main() {
+  [[ -d "${APP_DIR}" ]] || { error "APP_DIR does not exist: ${APP_DIR}"; exit 1; }
+  [[ -x "${VENV_DIR}/bin/python" ]] || {
+    error "Python virtualenv is unavailable: ${VENV_DIR}/bin/python"
+    exit 1
+  }
+  [[ "${SHARP_BOOTSTRAP_MAX_PASSES}" =~ ^[1-9][0-9]*$ ]] || {
+    error "SHARP_BOOTSTRAP_MAX_PASSES must be a positive integer."
+    exit 1
+  }
+
+  SYSTEMCTL_BIN="$(resolve_binary /bin/systemctl /usr/bin/systemctl)" || {
+    error "systemctl was not found."
+    exit 1
+  }
+  INSTALL_BIN="$(resolve_binary /usr/bin/install /bin/install)" || {
+    error "install was not found."
+    exit 1
+  }
+  JOURNALCTL_BIN="$(resolve_binary /bin/journalctl /usr/bin/journalctl)" || {
+    error "journalctl was not found."
+    exit 1
+  }
+
+  cd "${APP_DIR}"
+  TMP_DIR="$(mktemp -d)"
+  trap 'rm -rf "${TMP_DIR:-}"' EXIT
+
+  local discovery_service="${SERVICE_NAME}-sharp-discovery.service"
+  local discovery_timer="${SERVICE_NAME}-sharp-discovery.timer"
+  local records_service="${SERVICE_NAME}-sharp-records.service"
+  local records_timer="${SERVICE_NAME}-sharp-records.timer"
+
+  # Re-render all four units on every run. This intentionally bypasses the
+  # generic installer's historical presence-check blind spot and guarantees
+  # that a changed timer template reaches production, even when the unit
+  # already exists.
+  render_unit \
+    "${APP_DIR}/deploy/systemd/dynasty-sharp-discovery.service.template" \
+    "/etc/systemd/system/${discovery_service}"
+  render_unit \
+    "${APP_DIR}/deploy/systemd/dynasty-sharp-discovery.timer.template" \
+    "/etc/systemd/system/${discovery_timer}"
+  render_unit \
+    "${APP_DIR}/deploy/systemd/dynasty-sharp-records.service.template" \
+    "/etc/systemd/system/${records_service}"
+  render_unit \
+    "${APP_DIR}/deploy/systemd/dynasty-sharp-records.timer.template" \
+    "/etc/systemd/system/${records_timer}"
+
+  sudo -n "${SYSTEMCTL_BIN}" daemon-reload
+  log "Reloaded systemd after installing Sharp Tracker units."
+  sudo -n "${SYSTEMCTL_BIN}" enable --now "${discovery_timer}"
+  sudo -n "${SYSTEMCTL_BIN}" enable --now "${records_timer}"
+  log "Enabled both Sharp Tracker timers."
+
+  local eligible
+  eligible="$(queue_field eligibleLeagues)"
+  if (( eligible == 0 )); then
+    warn "No sharp-eligible leagues are stored yet; running discovery first."
+    run_oneshot "${discovery_service}"
+    eligible="$(queue_field eligibleLeagues)"
+  fi
+
+  if (( eligible == 0 )); then
+    error "Discovery completed but produced no sharp-eligible leagues."
+    show_diagnostics
+    exit 1
+  fi
+  log "Sharp-eligible leagues available: ${eligible}"
+
+  local force passes qualified uncrawled complete_rows
+  force="$(lower "${FORCE_SHARP_RECORDS_KICK}")"
+  passes=0
+  qualified="$(qualified_count)"
+  uncrawled="$(queue_field uncrawledLeagues)"
+  complete_rows="$(records_field completedSeasonRows)"
+
+  log "Before bootstrap: completed_rows=${complete_rows}, uncrawled_leagues=${uncrawled}, qualified_managers=${qualified}"
+
+  # An empty or still-unqualified cohort receives immediate bounded passes.
+  # Every pass recomputes the persistent queue, so it advances to leagues
+  # the prior pass did not reach instead of re-reading the same prefix.
+  while (( passes < SHARP_BOOTSTRAP_MAX_PASSES )); do
+    if (( qualified > 0 )) && [[ "${force}" != "true" && "${force}" != "1" && "${force}" != "yes" ]]; then
+      break
+    fi
+    if (( passes > 0 && uncrawled == 0 )); then
+      break
+    fi
+
+    passes=$((passes + 1))
+    log "Running immediate Sharp records pass ${passes}/${SHARP_BOOTSTRAP_MAX_PASSES}."
+    run_oneshot "${records_service}"
+
+    qualified="$(qualified_count)"
+    uncrawled="$(queue_field uncrawledLeagues)"
+    complete_rows="$(records_field completedSeasonRows)"
+    log "After pass ${passes}: completed_rows=${complete_rows}, uncrawled_leagues=${uncrawled}, qualified_managers=${qualified}"
+
+    # FORCE means at least one pass, not an unbounded refresh loop.
+    force="false"
+  done
+
+  show_diagnostics
+
+  if (( complete_rows == 0 )); then
+    error "The records service ran but stored no completed-season rows."
+    exit 1
+  fi
+
+  if (( qualified == 0 )); then
+    warn "Historical records now exist, but no manager has cleared every Sharp Score gate yet."
+    warn "The enabled daily timer will continue through the fair queue until coverage expands."
+  else
+    log "Sharp Tracker is populated with ${qualified} qualified manager(s)."
+  fi
+}
+
+main "$@"

--- a/deploy/systemd/dynasty-sharp-records.timer.template
+++ b/deploy/systemd/dynasty-sharp-records.timer.template
@@ -13,6 +13,13 @@ Description=Daily Sharp Tracker season-records crawl for __SERVICE_NAME__
 # offseason, but the crawl is budgeted and resumable, so a daily pass
 # is really "keep chewing through the backlog" rather than "re-read
 # everything".
+#
+# Also run once 30 minutes after the timer is first activated. This is a
+# deployment safety net: enabling the timer just after 04:50 UTC must not
+# leave a brand-new Sharp Tracker empty until the following day. The
+# dedicated production bootstrap starts an empty records crawl immediately;
+# OnActiveSec covers manual installs and any future installer path.
+OnActiveSec=30min
 OnCalendar=*-*-* 04:50:00 UTC
 RandomizedDelaySec=900
 Persistent=true

--- a/frontend/app/market/sharp-tracker/page.jsx
+++ b/frontend/app/market/sharp-tracker/page.jsx
@@ -21,19 +21,28 @@ import { PageHeader, LoadingState, EmptyState } from "@/components/ui";
 // managers clear the eligibility bar, this page says exactly that
 // rather than showing a thin board dressed up as a market.
 
-const METHODOLOGY_VERSION = "sharp-v1";
+const METHODOLOGY_VERSION = "sharp-v2";
 
 function CohortStat({ label, value, note }) {
   return (
     <div style={{ minWidth: 150 }}>
-      <div className="muted" style={{ fontSize: "0.68rem", textTransform: "uppercase", letterSpacing: "0.04em" }}>
+      <div
+        className="muted"
+        style={{
+          fontSize: "0.68rem",
+          textTransform: "uppercase",
+          letterSpacing: "0.04em",
+        }}
+      >
         {label}
       </div>
       <div style={{ fontFamily: "var(--mono)", fontSize: "1.35rem", fontWeight: 700 }}>
         {value == null ? "—" : value.toLocaleString()}
       </div>
       {note ? (
-        <div className="muted" style={{ fontSize: "0.66rem" }}>{note}</div>
+        <div className="muted" style={{ fontSize: "0.66rem" }}>
+          {note}
+        </div>
       ) : null}
     </div>
   );
@@ -74,6 +83,23 @@ export default function SharpTrackerPage() {
 
   const cohort = data?.cohort || {};
   const building = !data || data.status !== "ok";
+  const managersWithRecords =
+    cohort.managersWithRecords ?? data?.records?.managersWithRecords ?? 0;
+  const discoveryHasManagers = (cohort.observableManagers || 0) > 0;
+  const recordsAreEmpty = discoveryHasManagers && managersWithRecords === 0;
+  const buildingTitle = recordsAreEmpty
+    ? "Historical manager records are being collected"
+    : "The sharp cohort is still being built";
+  const buildingMessage = recordsAreEmpty
+    ? "Manager discovery is working, but discovery alone cannot calculate a Sharp Score. " +
+      "The records crawler is now walking those leagues' completed seasons to collect wins, " +
+      "playoff results, championships, and finishes. The board opens as soon as enough of " +
+      "those managers have complete multi-season evidence."
+    : "Sleeper publishes no global directory of users or leagues, so a manager pool " +
+      "can only grow outward from leagues we already observe. Discovery and historical-record " +
+      "jobs advance that graph on a schedule, and this board opens once enough managers have " +
+      "the multi-season history needed to be scored. It will stay empty rather than show a " +
+      "handful of managers labelled as a market.";
 
   return (
     <section>
@@ -90,10 +116,31 @@ export default function SharpTrackerPage() {
 
       <div className="card" style={{ marginBottom: 12 }}>
         <div style={{ display: "flex", gap: 28, flexWrap: "wrap" }}>
-          <CohortStat label="Observable" value={cohort.observableManagers} note="managers seen in any crawled league" />
-          <CohortStat label="Evaluable" value={cohort.evaluableManagers} note="enough history to score" />
-          <CohortStat label="Qualified" value={cohort.qualifiedManagers} note="cleared the Sharp Score bar" />
-          <CohortStat label="Leagues" value={cohort.observedLeagues} note="dynasty + keeper only" />
+          <CohortStat
+            label="Observable"
+            value={cohort.observableManagers}
+            note="managers seen in any crawled league"
+          />
+          <CohortStat
+            label="Records"
+            value={managersWithRecords}
+            note="managers with historical season results"
+          />
+          <CohortStat
+            label="Evaluable"
+            value={cohort.evaluableManagers}
+            note="enough history to score"
+          />
+          <CohortStat
+            label="Qualified"
+            value={cohort.qualifiedManagers}
+            note="cleared the Sharp Score bar"
+          />
+          <CohortStat
+            label="Leagues"
+            value={cohort.observedLeagues}
+            note="all leagues reached by discovery"
+          />
         </div>
         <div className="muted" style={{ fontSize: "0.68rem", marginTop: 10 }}>
           Methodology {data?.methodologyVersion || METHODOLOGY_VERSION}
@@ -103,16 +150,7 @@ export default function SharpTrackerPage() {
 
       {building ? (
         <div className="card">
-          <EmptyState
-            title="The sharp cohort is still being built"
-            message={
-              "Sleeper publishes no global directory of users or leagues, so a manager pool " +
-              "can only grow outward from leagues we already observe. The discovery job walks " +
-              "that graph on a schedule, and this board opens once enough managers have the " +
-              "multi-season history needed to be scored. It will stay empty rather than show " +
-              "a handful of managers labelled as a market."
-            }
-          />
+          <EmptyState title={buildingTitle} message={buildingMessage} />
         </div>
       ) : null}
 
@@ -120,7 +158,10 @@ export default function SharpTrackerPage() {
         <div style={{ fontWeight: 600, marginBottom: 6, fontSize: "0.82rem" }}>
           What qualifies a manager as sharp
         </div>
-        <ul className="muted" style={{ fontSize: "0.72rem", lineHeight: 1.7, paddingLeft: 18, margin: 0 }}>
+        <ul
+          className="muted"
+          style={{ fontSize: "0.72rem", lineHeight: 1.7, paddingLeft: 18, margin: 0 }}
+        >
           <li>Multi-season record — win rate, playoff and championship rate, median finish</li>
           <li>Roster quality relative to their league&apos;s average, age- and depth-adjusted</li>
           <li>Consistency across several independent leagues, not one lucky season</li>

--- a/scripts/crawl_sharp_records.py
+++ b/scripts/crawl_sharp_records.py
@@ -16,6 +16,11 @@ Costs 4 Sleeper calls per league-season (league, rosters,
 winners_bracket for completed seasons, plus the chain hop). Idempotent:
 rows upsert on (league_id, season, user_id).
 
+The default league order is persistent and fair: leagues with no stored
+season rows are crawled first, then previously crawled leagues from oldest
+to newest. That makes repeated budgeted runs advance through the full graph
+instead of restarting at the same insertion-ordered prefix every day.
+
 Exit codes: 0 success, 1 failure, 2 budget exhausted with work left.
 """
 
@@ -29,10 +34,16 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from src.sharp import discovery, records  # noqa: E402
+from src.sharp import discovery, record_queue, records  # noqa: E402
 from src.sharp import score as sharp_score  # noqa: E402
 
 log = logging.getLogger("crawl_sharp_records")
+
+
+def _stats_payload() -> dict:
+    payload = records.records_coverage()
+    payload["queue"] = record_queue.queue_stats()
+    return payload
 
 
 def main() -> int:
@@ -59,7 +70,7 @@ def main() -> int:
 
     try:
         if args.stats:
-            print(json.dumps(records.records_coverage(), indent=2))
+            print(json.dumps(_stats_payload(), indent=2))
             return 0
 
         if args.score:
@@ -83,10 +94,15 @@ def main() -> int:
             kwargs["budget"] = args.budget
         if args.max_seasons is not None:
             kwargs["max_seasons"] = args.max_seasons
-        result = records.crawl_records(league_ids=args.leagues, **kwargs)
+
+        league_ids = args.leagues
+        if league_ids is None:
+            league_ids = record_queue.prioritized_league_ids()
+        result = records.crawl_records(league_ids=league_ids, **kwargs)
 
         payload = result.to_dict()
         payload["coverage"] = records.records_coverage()
+        payload["queue"] = record_queue.queue_stats()
         payload["sharpEligibleLeagues"] = len(discovery.sharp_eligible_league_ids())
         print(json.dumps(payload, indent=2))
         # Partial is normal on a large graph — the next run continues.

--- a/src/sharp/record_queue.py
+++ b/src/sharp/record_queue.py
@@ -1,0 +1,106 @@
+"""Fair, resumable ordering for the Sharp Tracker season-records crawl.
+
+The records crawler has a hard per-run Sleeper API budget.  Feeding it the
+same insertion-ordered league list every day means a large graph can spend
+that budget re-reading the same first leagues forever while later leagues
+never receive a first pass.  This module turns the discovered
+sharp-eligible leagues into a round-robin queue:
+
+* leagues with no stored season rows are first;
+* previously crawled leagues follow, oldest crawl first;
+* ties are stable by league id.
+
+``manager_seasons`` always receives a row for the current/root league when a
+crawl reaches its rosters, including in-season leagues.  Its latest
+``crawled_ms`` is therefore a durable, idempotent cursor without adding a
+second queue table or competing state machine.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+from src.intel import ledger
+
+
+def prioritize_league_ids(
+    league_ids: Iterable[str],
+    last_crawled_ms: Mapping[str, int | None],
+) -> list[str]:
+    """Return unique league ids in fair crawl order.
+
+    Uncrawled leagues sort before crawled leagues.  Among crawled leagues,
+    the oldest successful write sorts first so repeated budgeted runs rotate
+    through the full graph instead of restarting at the same prefix.
+    """
+
+    unique = {str(league_id).strip() for league_id in league_ids if str(league_id).strip()}
+
+    def key(league_id: str) -> tuple[int, int, str]:
+        raw = last_crawled_ms.get(league_id)
+        if raw is None:
+            return (0, 0, league_id)
+        try:
+            crawled = int(raw)
+        except (TypeError, ValueError):
+            return (0, 0, league_id)
+        return (1, crawled, league_id)
+
+    return sorted(unique, key=key)
+
+
+def _queue_inputs(*, ledger_path: Path | None = None) -> tuple[list[str], dict[str, int]]:
+    conn = ledger.connect(ledger_path)
+    try:
+        league_rows = conn.execute("SELECT league_id, settings_json FROM leagues").fetchall()
+        crawl_rows = conn.execute(
+            """
+            SELECT league_id, MAX(crawled_ms) AS last_crawled_ms
+              FROM manager_seasons
+             GROUP BY league_id
+            """
+        ).fetchall()
+    finally:
+        conn.close()
+
+    eligible: list[str] = []
+    for row in league_rows:
+        try:
+            settings = json.loads(row["settings_json"] or "{}")
+        except (TypeError, ValueError):
+            continue
+        if settings.get("sharpEligible"):
+            eligible.append(str(row["league_id"]))
+
+    last_crawled = {
+        str(row["league_id"]): int(row["last_crawled_ms"])
+        for row in crawl_rows
+        if row["last_crawled_ms"] is not None
+    }
+    return eligible, last_crawled
+
+
+def prioritized_league_ids(*, ledger_path: Path | None = None) -> list[str]:
+    """Return every sharp-eligible league in resumable crawl order."""
+
+    eligible, last_crawled = _queue_inputs(ledger_path=ledger_path)
+    return prioritize_league_ids(eligible, last_crawled)
+
+
+def queue_stats(*, ledger_path: Path | None = None) -> dict[str, Any]:
+    """Inspectable queue coverage for logs and operator diagnostics."""
+
+    eligible, last_crawled = _queue_inputs(ledger_path=ledger_path)
+    unique_eligible = {str(league_id) for league_id in eligible}
+    crawled = unique_eligible.intersection(last_crawled)
+    timestamps = [last_crawled[league_id] for league_id in crawled]
+    return {
+        "eligibleLeagues": len(unique_eligible),
+        "uncrawledLeagues": len(unique_eligible - crawled),
+        "crawledLeagues": len(crawled),
+        "oldestCrawlMs": min(timestamps) if timestamps else None,
+        "newestCrawlMs": max(timestamps) if timestamps else None,
+    }

--- a/src/sharp/record_queue.py
+++ b/src/sharp/record_queue.py
@@ -1,9 +1,9 @@
 """Fair, resumable ordering for the Sharp Tracker season-records crawl.
 
-The records crawler has a hard per-run Sleeper API budget.  Feeding it the
+The records crawler has a hard per-run Sleeper API budget. Feeding it the
 same insertion-ordered league list every day means a large graph can spend
 that budget re-reading the same first leagues forever while later leagues
-never receive a first pass.  This module turns the discovered
+never receive a first pass. This module turns the discovered
 sharp-eligible leagues into a round-robin queue:
 
 * leagues with no stored season rows are first;
@@ -11,7 +11,7 @@ sharp-eligible leagues into a round-robin queue:
 * ties are stable by league id.
 
 ``manager_seasons`` always receives a row for the current/root league when a
-crawl reaches its rosters, including in-season leagues.  Its latest
+crawl reaches its rosters, including in-season leagues. Its latest
 ``crawled_ms`` is therefore a durable, idempotent cursor without adding a
 second queue table or competing state machine.
 """
@@ -32,12 +32,18 @@ def prioritize_league_ids(
 ) -> list[str]:
     """Return unique league ids in fair crawl order.
 
-    Uncrawled leagues sort before crawled leagues.  Among crawled leagues,
+    Uncrawled leagues sort before crawled leagues. Among crawled leagues,
     the oldest successful write sorts first so repeated budgeted runs rotate
     through the full graph instead of restarting at the same prefix.
     """
 
-    unique = {str(league_id).strip() for league_id in league_ids if str(league_id).strip()}
+    unique: set[str] = set()
+    for league_id in league_ids:
+        if league_id is None:
+            continue
+        normalized = str(league_id).strip()
+        if normalized:
+            unique.add(normalized)
 
     def key(league_id: str) -> tuple[int, int, str]:
         raw = last_crawled_ms.get(league_id)

--- a/tests/deploy/test_sharp_records_bootstrap_wiring.py
+++ b/tests/deploy/test_sharp_records_bootstrap_wiring.py
@@ -1,0 +1,54 @@
+"""Sharp discovery is not enough: production must also collect records.
+
+The Sharp Tracker can show thousands of observable managers while remaining
+empty when the season-records unit is missing, never receives its first run,
+or repeatedly spends its budget on the same prefix of leagues.  These guards
+pin the production path that turns discovery coverage into scoreable history.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+_BOOTSTRAP = _REPO / "deploy" / "bootstrap-sharp-records.sh"
+_TIMER = _REPO / "deploy" / "systemd" / "dynasty-sharp-records.timer.template"
+_WORKFLOW = _REPO / ".github" / "workflows" / "sharp-records-bootstrap.yml"
+_CRAWLER = _REPO / "scripts" / "crawl_sharp_records.py"
+
+
+def test_bootstrap_installs_reloads_and_enables_both_sharp_timers() -> None:
+    body = _BOOTSTRAP.read_text(encoding="utf-8")
+    assert "dynasty-sharp-discovery.timer.template" in body
+    assert "dynasty-sharp-records.timer.template" in body
+    assert "daemon-reload" in body
+    assert 'enable --now "${discovery_timer}"' in body
+    assert 'enable --now "${records_timer}"' in body
+
+
+def test_bootstrap_can_immediately_start_the_records_service() -> None:
+    body = _BOOTSTRAP.read_text(encoding="utf-8")
+    assert 'run_oneshot "${records_service}"' in body
+    assert "SHARP_BOOTSTRAP_MAX_PASSES" in body
+    assert "completedSeasonRows" in body
+
+
+def test_records_timer_has_a_first_activation_safety_net() -> None:
+    body = _TIMER.read_text(encoding="utf-8")
+    assert "OnActiveSec=" in body
+    assert "OnCalendar=" in body
+    assert "Persistent=true" in body
+
+
+def test_production_deploy_success_triggers_the_bootstrap_workflow() -> None:
+    body = _WORKFLOW.read_text(encoding="utf-8")
+    assert "workflow_run:" in body
+    assert "Deploy Production" in body
+    assert "workflow_run.conclusion == 'success'" in body
+    assert "deploy/bootstrap-sharp-records.sh" in body
+
+
+def test_default_records_crawl_uses_the_persistent_fair_queue() -> None:
+    body = _CRAWLER.read_text(encoding="utf-8")
+    assert "record_queue.prioritized_league_ids()" in body
+    assert 'payload["queue"] = record_queue.queue_stats()' in body

--- a/tests/sharp/test_record_queue.py
+++ b/tests/sharp/test_record_queue.py
@@ -1,0 +1,30 @@
+from src.sharp.record_queue import prioritize_league_ids
+
+
+def test_uncrawled_leagues_are_prioritized_before_oldest_crawled() -> None:
+    assert prioritize_league_ids(
+        ["league-b", "league-a", "league-c", "league-d"],
+        {
+            "league-a": 200,
+            "league-b": 100,
+            "league-d": 300,
+        },
+    ) == ["league-c", "league-b", "league-a", "league-d"]
+
+
+def test_queue_deduplicates_strips_and_stably_orders_uncrawled_leagues() -> None:
+    assert prioritize_league_ids(
+        [" league-b ", "league-a", "league-b", "", "league-c"],
+        {},
+    ) == ["league-a", "league-b", "league-c"]
+
+
+def test_invalid_crawl_timestamp_is_treated_as_uncrawled() -> None:
+    assert prioritize_league_ids(
+        ["league-a", "league-b", "league-c"],
+        {
+            "league-a": "not-a-timestamp",
+            "league-b": 100,
+            "league-c": None,
+        },
+    ) == ["league-a", "league-c", "league-b"]


### PR DESCRIPTION
## Problem

Sharp discovery could reach thousands of managers and leagues while the tracker stayed at **0 evaluable / 0 qualified**. Discovery and scoring were separated correctly, but the production records pass had three gaps:

1. the records timer could be installed after its daily slot with no initial run;
2. Sharp unit installation did not have a dedicated, guaranteed daemon-reload/bootstrap path;
3. the supposedly resumable records crawler restarted from the same insertion-ordered league prefix every run, so a large graph could repeatedly spend its API budget on the same leagues forever.

## Fix

- Add a persistent fair records queue: uncrawled leagues first, then oldest-crawled first.
- Wire the default records crawl through that queue and expose queue coverage in `--stats` output.
- Add a bounded production bootstrap that:
  - re-renders all four Sharp systemd units,
  - runs `daemon-reload`,
  - enables both timers,
  - runs discovery first when necessary,
  - immediately runs up to three records passes while the cohort remains unqualified,
  - prints record, score, and journal diagnostics,
  - fails if the crawler still stores zero completed-season rows.
- Trigger that bootstrap after every successful `Deploy Production` run, with a manual-dispatch option.
- Add `OnActiveSec=30min` as a timer-level first-activation safety net.
- Show **Records** separately from **Observable**, **Evaluable**, and **Qualified** in the UI so discovery success is no longer mistaken for scoring coverage.
- Correct the fallback methodology label from `sharp-v1` to `sharp-v2`.
- Add queue and production-wiring regression tests.

## Expected production result

After deployment, the follow-up workflow installs/reloads the units and immediately starts the historical records pass. The Sharp Tracker should move from discovery-only counts to stored manager records, then evaluable and qualified managers. Future daily passes advance through the entire eligible graph instead of revisiting a fixed prefix.
