### PR TITLE
Fix Sharp market route registration in production

### DIFF
--- a/src/sharp/service.py
+++ b/src/sharp/service.py
@@ -137,6 +137,22 @@ def market_audit_payload(asset_id: str, **kwargs: Any) -> dict[str, Any]:
     return sharp_market.audit_payload(asset_id, **kwargs)
 
 
+def _server_app():
+    """Return the FastAPI app whether ``server.py`` was imported or executed.
+
+    Production starts the backend with ``python server.py``, which places the
+    module in ``sys.modules['__main__']`` rather than ``sys.modules['server']``.
+    Looking only for ``server`` silently skipped the market route registration
+    while the explicitly declared cohort endpoint continued to work.
+    """
+    for module_name in ("server", "__main__"):
+        module = sys.modules.get(module_name)
+        app = getattr(module, "app", None)
+        if app is not None:
+            return app
+    return None
+
+
 def _register_http_routes() -> None:
     """Register routes when this module is imported by ``server.py``.
 
@@ -144,8 +160,7 @@ def _register_http_routes() -> None:
     section. Keeping registration here avoids a second API application or
     a parallel FFPC router while preserving ``/api/sharp/cohort`` exactly.
     """
-    server_module = sys.modules.get("server")
-    app = getattr(server_module, "app", None)
+    app = _server_app()
     if app is None:
         return
     existing = {getattr(route, "path", None) for route in getattr(app, "routes", [])}

--- a/tests/sharp/test_service_route_registration.py
+++ b/tests/sharp/test_service_route_registration.py
@@ -1,0 +1,18 @@
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+
+from src.sharp import service
+
+
+def test_market_routes_register_when_server_executes_as_main(monkeypatch):
+    app = FastAPI()
+    monkeypatch.delitem(service.sys.modules, "server", raising=False)
+    monkeypatch.setitem(service.sys.modules, "__main__", SimpleNamespace(app=app))
+
+    service._register_http_routes()
+    service._register_http_routes()
+
+    paths = [getattr(route, "path", None) for route in app.routes]
+    assert paths.count("/api/sharp/market") == 1
+    assert paths.count("/api/sharp/market/audit") == 1


### PR DESCRIPTION
## Problem

The live Sharp Tracker loaded `/api/sharp/cohort` but `/api/sharp/market` returned 404 `Not Found`.

Production starts the backend with `python server.py`. In that mode the server module is registered as `__main__`, while `src/sharp/service.py` only searched `sys.modules['server']` before adding the market and audit routes. The explicit cohort route still existed, which is why the page showed cohort cards but no market table.

## Fix

- Resolve the FastAPI app from either `server` or `__main__`.
- Preserve idempotent route registration.
- Add a regression test that simulates the actual `python server.py` startup mode and verifies both Sharp market routes are registered exactly once.

This is intentionally narrow and does not alter Sharp scoring, FFPC ingestion, Sleeper ingestion, aggregation, or frontend behavior.