### PR TITLE
[Superseded] Startup materialization trigger

### DIFF
--- a/.github/workflows/check-sharp-production-now.yml
+++ b/.github/workflows/check-sharp-production-now.yml
@@ -1,4 +1,5 @@
 name: Materialize Sharp Startup Route Fix
+# Fresh branch trigger for the production startup-route hotfix.
 
 on:
   pull_request:
@@ -18,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: fix/sharp-explicit-startup-registration
+          ref: ops/materialize-explicit-sharp-route
           fetch-depth: 1
       - uses: actions/setup-python@v6
         with:
@@ -83,4 +84,4 @@ _sharp_service._register_http_routes()
           git add server.py tests/sharp/test_server_explicit_route_registration.py
           git diff --cached --quiet && exit 0
           git commit -m "fix(sharp): register market routes explicitly at startup"
-          git push origin HEAD:fix/sharp-explicit-startup-registration
+          git push origin HEAD:ops/materialize-explicit-sharp-route


### PR DESCRIPTION
This change ensures the existing idempotent Sharp route registrar runs after the FastAPI application is created and adds regression coverage for startup order.