### PR TITLE
Unblock production deploys: anchor the FAAB analytics fixture to now

### DIFF
--- a/tests/api/test_faab_recommend_endpoint.py
+++ b/tests/api/test_faab_recommend_endpoint.py
@@ -24,8 +24,15 @@ from fastapi.testclient import TestClient
 import server
 from src.api import league_registry
 
+# Captured at import time — BEFORE the fixture stubs the module
+# attribute — so the fast-path tripwire test can restore the real
+# implementation.
+from src.api.sleeper_overlay import fetch_sleeper_teams_overlay as _REAL_TEAMS_OVERLAY
+from src.trade import faab_contention
+
 # The analytics snapshot's freshness stamp, anchored to NOW rather than
-# to a literal date.
+# to a literal date.  (Defined below the imports on purpose: a statement
+# above them makes them E402 "import not at top of file".)
 #
 # ``faab_contention.stale_inputs`` compares this against the real wall
 # clock (``STALENESS_MAX_AGE_S["leagueAnalytics"]`` is 7 days), so a
@@ -39,12 +46,6 @@ from src.api import league_registry
 # ``STALENESS_MAX_AGE_S`` (the tightest is trending at 3h) while still
 # exercising the real not-stale path.
 _SNAPSHOT_GENERATED_AT = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
-
-# Captured at import time — BEFORE the fixture stubs the module
-# attribute — so the fast-path tripwire test can restore the real
-# implementation.
-from src.api.sleeper_overlay import fetch_sleeper_teams_overlay as _REAL_TEAMS_OVERLAY
-from src.trade import faab_contention
 
 # The v1 response keys — the frozen backward-compat surface.
 V1_KEYS = {

--- a/tests/api/test_faab_recommend_endpoint.py
+++ b/tests/api/test_faab_recommend_endpoint.py
@@ -16,12 +16,29 @@ All Sleeper/analytics/intel inputs are stubbed — no live network.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi.testclient import TestClient
 
 import server
 from src.api import league_registry
+
+# The analytics snapshot's freshness stamp, anchored to NOW rather than
+# to a literal date.
+#
+# ``faab_contention.stale_inputs`` compares this against the real wall
+# clock (``STALENESS_MAX_AGE_S["leagueAnalytics"]`` is 7 days), so a
+# hardcoded timestamp does not pin behaviour — it pins a countdown. The
+# previous literal, 2026-07-25T11:00Z, silently expired at
+# 2026-08-01T11:00Z and took the deploy pipeline's unit gate with it:
+# the last green production deploy ran at 10:25Z that morning and every
+# run afterwards failed, with no code change in between.
+#
+# One hour old keeps it comfortably inside every ceiling in
+# ``STALENESS_MAX_AGE_S`` (the tightest is trending at 3h) while still
+# exercising the real not-stale path.
+_SNAPSHOT_GENERATED_AT = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
 
 # Captured at import time — BEFORE the fixture stubs the module
 # attribute — so the fast-path tripwire test can restore the real
@@ -205,7 +222,7 @@ def _install_snapshot(monkeypatch, league_id, summary=None):
 
     snap = types.SimpleNamespace(
         root_league_id=league_id,
-        generated_at="2026-07-25T11:00:00+00:00",
+        generated_at=_SNAPSHOT_GENERATED_AT,
     )
     monkeypatch.setattr(server.public_snapshot_store, "load_snapshot", lambda: snap)
     if summary is not None:
@@ -580,7 +597,7 @@ def test_matching_league_snapshot_consumed_normally(faab_env, monkeypatch):
             {"addPlayerName": "Hot Pickup", "teamOwnerId": "me"},
         )
     payload = res.json()
-    assert payload["inputsAsOf"]["leagueAnalytics"] == "2026-07-25T11:00:00+00:00"
+    assert payload["inputsAsOf"]["leagueAnalytics"] == _SNAPSHOT_GENERATED_AT
     assert "leagueAnalytics" not in payload["staleInputs"]
     contention = payload["contention"]
     per = {r["ownerId"]: r for r in contention["perOpponent"]}


### PR DESCRIPTION
**Production has not deployed since 2026-08-01T10:25Z.** Every `Deploy Production` run since 11:50Z has failed, so `Deploy To Production` is skipped and nothing merged after that point — including the player-only Sharp Tracker (#691) — has reached production.

The cause is a time bomb in a test fixture, not a regression.

## Root cause

`test_matching_league_snapshot_consumed_normally` installs an analytics snapshot stamped `2026-07-25T11:00:00+00:00` and asserts `leagueAnalytics` is **not** stale. `faab_contention.stale_inputs` compares that against the real wall clock, and `STALENESS_MAX_AGE_S["leagueAnalytics"]` is **7 days**:

```
2026-07-25T11:00Z + 7d = 2026-08-01T11:00Z
```

| | |
|---|---|
| Last green production deploy | **10:25Z**, 2026-08-01 |
| First red | **11:50Z**, 2026-08-01 |

An exact match. The only commits in that window are automated data refreshes — **zero code changes**. The fixture simply expired, and it would never have self-healed.

## Not caused by #691

The Sharp Tracker player-only change is frontend-only (`page.jsx` + a frontend test) and cannot reach this code path. The same failure reproduces on `main` at `c93123eba`, a data-refresh commit ten hours *after* #691 merged, and reproduces locally on a clean checkout of `main`.

The `Background public_league refresh failed … upstream unreachable` warning in the CI log is a **red herring** — it appears on green runs too, and the live-data suite passed 294 tests in the same job, so the runner's network was fine.

## The fix

Anchor the fixture an hour behind `now`, so the test pins **behaviour** rather than a countdown.

The assertion is unchanged — it still asserts the snapshot is consumed and is not stale, which is the real product behaviour. Only the coupling to wall-clock goes, and that was never the thing under test. Nothing is skipped, xfailed, or weakened.

Deliberately untouched:

- **`STALENESS_MAX_AGE_S`** — the 7-day ceiling is a real product decision and the endpoint behaved correctly throughout. The bug was in the fixture, not the rule.
- **`test_inputs_as_of_and_stale_inputs_reflect_stubbed_sources`** and the trending `fetchedAt` literal, which exercise the *stale* path on purpose.
- The `rosters` not-stale assertion, which already uses a runtime stamp from a live teams fetch.

## Sweep for the same class of bug

`tests/trade/test_faab_contention.py::test_stale_inputs_flags_missing_and_old` covers the same function but passes `now=now.timestamp()` explicitly, so it is hermetic and immune. That was the only other not-stale assertion, and it demonstrates the correct pattern — the endpoint test was exposed precisely because it goes through HTTP, where `stale_inputs` is called without a `now` override.

## Tests

```
tests/api/test_faab_recommend_endpoint.py    16 passed
python -m ruff format --check .              768 files, clean
```

The `-x` hard gate has stopped at this failure since Aug 1, leaving 319 tests deselected and unrun. This PR is what lets the suite reach completion again.

## Follow-up noted, not fixed here

Running this test locally makes a real call to `api.sleeper.app` (a background `public_league` refresh escapes the fixture's stubs), despite the module docstring stating "All Sleeper/analytics/intel inputs are stubbed — no live network." It degrades gracefully and does not fail the test, so it is out of scope for a deploy-unblock, but it makes the unit gate network-dependent and is worth closing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Z5Atvg4QRT5Dz7aVu9qc3

---
_Generated by [Claude Code](https://claude.ai/code/session_018Z5Atvg4QRT5Dz7aVu9qc3)_