### PR TITLE
Apply trade value adjustment in arbitrage finder

### DIFF
--- a/src/trade/__init__.py
+++ b/src/trade/__init__.py
@@ -1,0 +1,13 @@
+"""Trade-engine package initialization.
+
+The arbitrage finder is patched at package import so every caller—API,
+CLI, tests, and audit scripts—uses the same KTC package Value Adjustment
+as the frontend trade calculator.
+"""
+
+from . import finder as _finder
+from .finder_value_adjustment import install as _install_value_adjustment
+
+_install_value_adjustment(_finder)
+
+del _finder, _install_value_adjustment

--- a/src/trade/finder_value_adjustment.py
+++ b/src/trade/finder_value_adjustment.py
@@ -97,7 +97,11 @@ def install(finder: ModuleType) -> None:
             if flag not in candidate.flags:
                 candidate.flags.append(flag)
             candidate.ranking_factors["marketValueAdjustment"] = adjustment.value
-            label = "your give side" if adjustment_side == "give" else "your receive side"
+            label = (
+                "your give side"
+                if adjustment_side == "give"
+                else "your receive side"
+            )
             candidate.summary += (
                 f" Market package adjustment: +{adjustment.value:,} to {label}."
             )

--- a/src/trade/finder_value_adjustment.py
+++ b/src/trade/finder_value_adjustment.py
@@ -1,0 +1,147 @@
+"""Install KTC package Value Adjustment into the trade arbitrage finder.
+
+The finder historically summed market values linearly while the trade
+calculator used KTC's package adjustment. This adapter makes the finder
+score the same adjusted totals without mutating the individual assets that
+are returned to the API/UI.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from functools import wraps
+from types import ModuleType
+from typing import Any
+
+from .market_value_adjustment import PackageAdjustment, ktc_adjust_package
+
+
+def _market_values(assets: list[Any]) -> list[int]:
+    return [int(asset.market_value) for asset in assets if asset.has_market]
+
+
+def _apply_side_adjustment(assets: list[Any], adjustment: int) -> list[Any]:
+    """Clone one asset so the legacy scorer sees the adjusted side total.
+
+    Value Adjustment is side-level math. The existing scorer accepts only
+    per-asset values, so the premium is attached temporarily to the largest
+    market-valued piece. The returned candidate is restored to the original
+    assets before serialization, preventing the synthetic premium from being
+    displayed as an individual player's market value.
+    """
+
+    if adjustment <= 0 or not assets:
+        return list(assets)
+    eligible = [
+        (index, int(asset.market_value or 0))
+        for index, asset in enumerate(assets)
+        if asset.has_market
+    ]
+    if not eligible:
+        return list(assets)
+    index, value = max(eligible, key=lambda item: item[1])
+    adjusted = list(assets)
+    adjusted[index] = replace(adjusted[index], market_value=value + adjustment)
+    return adjusted
+
+
+def _adjustment_for(give: list[Any], receive: list[Any]) -> PackageAdjustment:
+    all_assets = [*give, *receive]
+    if not all_assets or not all(asset.has_market for asset in all_assets):
+        return PackageAdjustment()
+    return ktc_adjust_package(_market_values(give), _market_values(receive))
+
+
+def install(finder: ModuleType) -> None:
+    """Patch one loaded ``src.trade.finder`` module exactly once."""
+
+    if getattr(finder, "_MARKET_VALUE_ADJUSTMENT_INSTALLED", False):
+        return
+
+    original_score = finder._score_trade
+    original_to_dict = finder.TradeCandidate.to_dict
+
+    @wraps(original_score)
+    def score_with_value_adjustment(give: list[Any], receive: list[Any]):
+        raw_give_total = sum(_market_values(give))
+        raw_receive_total = sum(_market_values(receive))
+        adjustment = _adjustment_for(give, receive)
+
+        scoring_give = list(give)
+        scoring_receive = list(receive)
+        adjustment_side: str | None = None
+        if adjustment.displayed and adjustment.value > 0:
+            if adjustment.side == 1:
+                scoring_give = _apply_side_adjustment(give, adjustment.value)
+                adjustment_side = "give"
+            elif adjustment.side == 2:
+                scoring_receive = _apply_side_adjustment(receive, adjustment.value)
+                adjustment_side = "receive"
+
+        candidate = original_score(scoring_give, scoring_receive)
+        if candidate is None:
+            return None
+
+        # Never leak the synthetic per-asset value into the response.
+        candidate.give = list(give)
+        candidate.receive = list(receive)
+        candidate.raw_give_ktc_total = raw_give_total
+        candidate.raw_receive_ktc_total = raw_receive_total
+        candidate.market_value_adjustment = adjustment.value if adjustment_side else 0
+        candidate.market_value_adjustment_side = adjustment_side
+        candidate.adjusted_give_ktc_total = candidate.give_ktc_total
+        candidate.adjusted_receive_ktc_total = candidate.receive_ktc_total
+
+        if adjustment_side:
+            flag = f"market_value_adjustment_{adjustment_side}"
+            if flag not in candidate.flags:
+                candidate.flags.append(flag)
+            candidate.ranking_factors["marketValueAdjustment"] = adjustment.value
+            label = "your give side" if adjustment_side == "give" else "your receive side"
+            candidate.summary += (
+                f" Market package adjustment: +{adjustment.value:,} to {label}."
+            )
+        else:
+            candidate.ranking_factors.setdefault("marketValueAdjustment", 0)
+
+        return candidate
+
+    @wraps(original_to_dict)
+    def to_dict_with_value_adjustment(candidate: Any) -> dict[str, Any]:
+        payload = original_to_dict(candidate)
+        raw_give = getattr(candidate, "raw_give_ktc_total", candidate.give_ktc_total)
+        raw_receive = getattr(
+            candidate,
+            "raw_receive_ktc_total",
+            candidate.receive_ktc_total,
+        )
+        adjusted_give = getattr(
+            candidate,
+            "adjusted_give_ktc_total",
+            candidate.give_ktc_total,
+        )
+        adjusted_receive = getattr(
+            candidate,
+            "adjusted_receive_ktc_total",
+            candidate.receive_ktc_total,
+        )
+        adjustment_value = getattr(candidate, "market_value_adjustment", 0)
+        adjustment_side = getattr(candidate, "market_value_adjustment_side", None)
+        payload.update(
+            {
+                "rawGiveKtcTotal": raw_give,
+                "rawReceiveKtcTotal": raw_receive,
+                "adjustedGiveKtcTotal": adjusted_give,
+                "adjustedReceiveKtcTotal": adjusted_receive,
+                "marketValueAdjustment": adjustment_value,
+                "marketValueAdjustmentSide": adjustment_side,
+                "marketValueAdjustmentApplied": bool(
+                    adjustment_value > 0 and adjustment_side
+                ),
+            }
+        )
+        return payload
+
+    finder._score_trade = score_with_value_adjustment
+    finder.TradeCandidate.to_dict = to_dict_with_value_adjustment
+    finder._MARKET_VALUE_ADJUSTMENT_INSTALLED = True

--- a/src/trade/market_value_adjustment.py
+++ b/src/trade/market_value_adjustment.py
@@ -1,0 +1,388 @@
+"""KTC-native package Value Adjustment for backend trade engines.
+
+This is a line-for-line Python port of the authoritative frontend
+implementation in ``frontend/lib/trade-logic.js::ktcAdjustPackage``.
+Keep the parity fixtures in ``tests/trade/test_finder_value_adjustment.py``
+green whenever either runtime changes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import floor
+from typing import Iterable
+
+KTC_MAX_PLAYER_VALUE = 10_000
+KTC_TOP_REFERENCE = 10_041
+KTC_VARIANCE_PERCENT = 5.0
+
+
+@dataclass(frozen=True)
+class PackageAdjustment:
+    """Displayed package adjustment and the side that receives it.
+
+    ``side`` follows KTC's convention: 1 for the first side, 2 for the
+    second side, and 0 when no adjustment is displayed.
+    """
+
+    value: int = 0
+    side: int = 0
+    displayed: bool = False
+
+
+def _js_round(value: float) -> int:
+    """Match JavaScript ``Math.round`` rather than Python banker's rounding."""
+
+    return floor(value + 0.5)
+
+
+def ktc_process_value(
+    value: float,
+    max_in_trade: float,
+    top_reference: float = KTC_TOP_REFERENCE,
+    nerf_index: int = -1,
+) -> float:
+    """Port of KTC ``processV`` from the calculator's canonical JS path."""
+
+    if not (value > 0 and max_in_trade > 0 and top_reference > 0):
+        return 0.0
+    adjusted = (
+        0.05 * (value / top_reference) ** 1.3
+        + 0.05 * (value / (1.05 * max_in_trade)) ** 6
+        + 0.1
+    ) * value
+    if nerf_index > 0:
+        adjusted *= max(0.6, 1 - 0.15 * nerf_index)
+    if adjusted < 0:
+        adjusted /= 4
+    return adjusted
+
+
+def ktc_reverse_adjust(
+    raw_difference: float,
+    max_in_trade: float,
+    top_reference: float = KTC_TOP_REFERENCE,
+    nerf_count: int = 0,
+) -> int:
+    """Port of KTC ``reverseAdjust`` iterative virtual-player solver."""
+
+    if not (raw_difference > 0 and max_in_trade > 0):
+        return 0
+
+    seed = ktc_process_value(max_in_trade, max_in_trade, top_reference, -1)
+    current_max = max_in_trade
+    if seed < raw_difference:
+        current_max = max(
+            (raw_difference / seed) * max_in_trade * 0.8,
+            max_in_trade,
+        )
+
+    candidate = current_max / 2
+    error = 1.0
+    iteration = 0
+    best_error = 1.0
+    best_candidate = -1.0
+
+    while error > 0.025 and iteration <= 10:
+        processed = ktc_process_value(
+            candidate,
+            current_max,
+            top_reference,
+            nerf_count,
+        )
+        error = min(1.0, abs(processed - raw_difference) / raw_difference)
+        if error > 0.025:
+            previous = candidate
+            step = error * candidate * 0.75
+            candidate += step if processed <= raw_difference else -step
+            if error < best_error:
+                best_error = error
+                best_candidate = previous
+                if best_candidate > max_in_trade:
+                    current_max = best_candidate
+        elif error < best_error:
+            best_error = error
+            best_candidate = candidate
+            if best_candidate > max_in_trade:
+                current_max = best_candidate
+
+        if iteration == 10 and error > 0.05:
+            refinement = 0
+            candidate = max(1.0, best_candidate)
+            while error > 0.025 and refinement <= 10:
+                processed = ktc_process_value(
+                    candidate,
+                    current_max,
+                    top_reference,
+                    nerf_count,
+                )
+                error = min(1.0, abs(processed - raw_difference) / raw_difference)
+                if error > 0.025:
+                    previous = candidate
+                    step = error * candidate * 0.25
+                    candidate += step if processed <= raw_difference else -step
+                    if error < best_error:
+                        best_error = error
+                        best_candidate = previous
+                        if best_candidate > max_in_trade:
+                            current_max = best_candidate
+                elif error < best_error:
+                    best_error = error
+                    best_candidate = candidate
+                    if best_candidate > max_in_trade:
+                        current_max = best_candidate
+                refinement += 1
+            candidate = best_candidate
+        iteration += 1
+
+    return _js_round(candidate)
+
+
+def _check_equality(a: float, b: float, variance_percent: float) -> bool:
+    total = max(0.0, a) + max(0.0, b)
+    if total <= 0:
+        return True
+    percentage = min(100.0, abs(a - b) / total * 100)
+    rounded = _js_round(10 * percentage) / 10
+    return rounded <= variance_percent
+
+
+def _build_side_adjustments(
+    values: list[float],
+    max_in_trade: float,
+    top_reference: float,
+) -> tuple[list[dict[str, float | int | bool]], float]:
+    half_max = 0.5 * max_in_trade
+    nerf_index = -1
+    raw_sum = 0.0
+    items: list[dict[str, float | int | bool]] = []
+
+    for value in values:
+        nerfed = False
+        if value < half_max:
+            nerf_index += 1
+            nerfed = True
+        adjustment = ktc_process_value(
+            value,
+            max_in_trade,
+            top_reference,
+            nerf_index,
+        )
+        raw_sum += adjustment
+        items.append(
+            {
+                "value": value,
+                "adjustment": adjustment,
+                "nerfed": nerfed,
+                "nerf_index": nerf_index,
+            }
+        )
+
+    items.sort(key=lambda item: -float(item["adjustment"]))
+    return items, raw_sum
+
+
+def ktc_adjust_package(
+    first_values: Iterable[int | float],
+    second_values: Iterable[int | float],
+    *,
+    variance_percent: float = KTC_VARIANCE_PERCENT,
+    top_reference: float = KTC_TOP_REFERENCE,
+) -> PackageAdjustment:
+    """Return KTC's displayed package adjustment for two value arrays."""
+
+    first = sorted(
+        (float(value) for value in first_values if float(value) > 0),
+        reverse=True,
+    )
+    second = sorted(
+        (float(value) for value in second_values if float(value) > 0),
+        reverse=True,
+    )
+    if not first or not second:
+        return PackageAdjustment()
+
+    first_total = sum(first)
+    second_total = sum(second)
+    max_in_trade = max(first[0], second[0])
+    half_max_reference = ktc_process_value(
+        0.5 * max_in_trade,
+        max_in_trade,
+        top_reference,
+        -1,
+    )
+    first_items, first_raw = _build_side_adjustments(
+        first,
+        max_in_trade,
+        top_reference,
+    )
+    second_items, second_raw = _build_side_adjustments(
+        second,
+        max_in_trade,
+        top_reference,
+    )
+    first_intensity = first_raw / first_total
+    second_intensity = second_raw / second_total
+    raw_difference = floor(abs(first_raw - second_raw))
+    totals_equal = _check_equality(first_total, second_total, variance_percent)
+    raws_equal = _check_equality(first_raw, second_raw, variance_percent)
+
+    extra_nerf_count = 0
+    if raw_difference < half_max_reference:
+        items = second_items if first_raw > second_raw else first_items
+        for item in items:
+            if float(item["adjustment"]) < raw_difference:
+                extra_nerf_count = int(item["nerf_index"]) + 1
+                break
+
+    side = 0
+    value = 0.0
+    sign_gate = True
+
+    if totals_equal and raws_equal:
+        if first_raw > second_raw:
+            side = 1
+            virtual = ktc_reverse_adjust(
+                raw_difference,
+                max_in_trade,
+                top_reference,
+                extra_nerf_count,
+            )
+            difference = second_total + virtual - first_total
+            if difference > 0:
+                value = difference
+            else:
+                sign_gate = False
+                side = 2
+                value = -difference
+        elif second_raw > first_raw:
+            side = 2
+            virtual = ktc_reverse_adjust(
+                raw_difference,
+                max_in_trade,
+                top_reference,
+                extra_nerf_count,
+            )
+            difference = first_total + virtual - second_total
+            if difference > 0:
+                value = difference
+            else:
+                sign_gate = False
+                side = 1
+                value = -difference
+    elif first_intensity > second_intensity:
+        side = 1
+        if first_raw > second_raw:
+            virtual = ktc_reverse_adjust(
+                raw_difference,
+                max_in_trade,
+                top_reference,
+                extra_nerf_count,
+            )
+            difference = second_total + virtual - first_total
+            if difference > 0:
+                value = difference
+            else:
+                sign_gate = False
+                side = 2
+                value = abs(difference)
+        else:
+            total_side = -1
+            if first_total < second_total:
+                total_side = 1
+            elif second_total < first_total:
+                total_side = 2
+            virtual = ktc_reverse_adjust(
+                abs(first_raw - second_raw),
+                max(first + second),
+                10_099,
+                extra_nerf_count,
+            )
+            if virtual > 0 and total_side > 0:
+                side = total_side
+                if total_side == 2:
+                    remainder = virtual - (first_total - second_total)
+                    if remainder > 0:
+                        value = remainder
+                    else:
+                        sign_gate = False
+                        value = remainder
+                else:
+                    remainder = virtual - (second_total - first_total)
+                    if remainder > 0:
+                        if remainder > KTC_MAX_PLAYER_VALUE:
+                            sign_gate = False
+                            value = 0
+                            side = 1
+                        else:
+                            side = 2
+                            value = remainder
+                    else:
+                        sign_gate = True
+                        value = -remainder
+            else:
+                sign_gate = False
+    else:
+        side = 2
+        if second_raw > first_raw:
+            virtual = ktc_reverse_adjust(
+                raw_difference,
+                max_in_trade,
+                top_reference,
+                extra_nerf_count,
+            )
+            difference = first_total + virtual - second_total
+            if difference > 0:
+                value = difference
+            else:
+                sign_gate = False
+                side = 1
+                value = abs(difference)
+        else:
+            total_side = -1
+            if first_total < second_total:
+                total_side = 1
+            elif second_total < first_total:
+                total_side = 2
+            virtual = ktc_reverse_adjust(
+                abs(first_raw - second_raw),
+                max(first + second),
+                10_099,
+                extra_nerf_count,
+            )
+            if virtual > 0 and total_side > 0:
+                side = total_side
+                if total_side == 1:
+                    remainder = virtual - (second_total - first_total)
+                    if remainder > 0:
+                        value = remainder
+                    else:
+                        sign_gate = False
+                        value = remainder
+                else:
+                    remainder = virtual - (first_total - second_total)
+                    if remainder > 0:
+                        if remainder > KTC_MAX_PLAYER_VALUE:
+                            sign_gate = False
+                            value = 0
+                            side = 1
+                        else:
+                            side = 1
+                            value = remainder
+                    else:
+                        sign_gate = True
+                        value = -remainder
+            else:
+                sign_gate = False
+
+    displayed = False
+    if value != 0:
+        if sign_gate:
+            displayed = True
+        if abs(value / (first_total + second_total)) < 0.033:
+            displayed = False
+    if len(first) == 1 and len(second) == 1:
+        displayed = False
+    if not displayed:
+        return PackageAdjustment()
+    return PackageAdjustment(value=_js_round(value), side=side, displayed=True)

--- a/tests/trade/test_finder_value_adjustment.py
+++ b/tests/trade/test_finder_value_adjustment.py
@@ -1,0 +1,91 @@
+"""Regression and parity tests for arbitrage-finder package adjustment."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.trade.finder import Asset, _score_trade
+from src.trade.market_value_adjustment import PackageAdjustment, ktc_adjust_package
+
+
+def _asset(name: str, model: int, market: int) -> Asset:
+    return Asset(
+        name=name,
+        position="WR",
+        team="TST",
+        model_value=model,
+        market_value=market,
+        source_count=5,
+        market_source="ktcSfTep",
+    )
+
+
+@pytest.mark.parametrize(
+    ("first", "second", "expected"),
+    [
+        ([5000], [4500], PackageAdjustment()),
+        ([5000], [3000, 2500], PackageAdjustment(2192, 1, True)),
+        ([3000, 2500], [5000], PackageAdjustment(2192, 2, True)),
+        ([6000, 1200], [4000, 3000], PackageAdjustment(2502, 1, True)),
+        ([6000], [2500, 2000, 1500], PackageAdjustment(3595, 1, True)),
+    ],
+)
+def test_python_port_matches_frontend_ktc_adjust_package_fixtures(
+    first: list[int],
+    second: list[int],
+    expected: PackageAdjustment,
+) -> None:
+    assert ktc_adjust_package(first, second) == expected
+
+
+def test_one_for_one_remains_unadjusted() -> None:
+    candidate = _score_trade(
+        [_asset("Give", 4000, 5000)],
+        [_asset("Receive", 4500, 4500)],
+    )
+
+    assert candidate is not None
+    payload = candidate.to_dict()
+    assert payload["marketValueAdjustment"] == 0
+    assert payload["marketValueAdjustmentSide"] is None
+    assert payload["giveKtcTotal"] == 5000
+    assert payload["receiveKtcTotal"] == 4500
+
+
+def test_adjustment_can_turn_raw_opponent_loss_into_adjusted_win() -> None:
+    # Raw market sums say the opponent gives 5,500 to receive 5,000.
+    # The canonical package formula adds 2,192 to the single stud on the
+    # give side, so the opponent actually receives an adjusted 7,192.
+    candidate = _score_trade(
+        [_asset("Stud", 4000, 5000)],
+        [
+            _asset("Piece A", 2300, 3000),
+            _asset("Piece B", 2200, 2500),
+        ],
+    )
+
+    assert candidate is not None
+    payload = candidate.to_dict()
+    assert payload["rawGiveKtcTotal"] == 5000
+    assert payload["rawReceiveKtcTotal"] == 5500
+    assert payload["marketValueAdjustment"] == 2192
+    assert payload["marketValueAdjustmentSide"] == "give"
+    assert payload["adjustedGiveKtcTotal"] == 7192
+    assert payload["adjustedReceiveKtcTotal"] == 5500
+    assert payload["ktcDelta"] == 1692
+    assert payload["opponentKtcAppeal"] > 0
+
+
+def test_raw_false_positive_is_rejected_after_package_adjustment() -> None:
+    # Raw sums make this look favorable to the opponent: they give 5,000
+    # and receive 5,500. The single 5,000 asset receives a 2,192 package
+    # premium, making the adjusted cost 7,192; the finder must reject it.
+    candidate = _score_trade(
+        [
+            _asset("Piece A", 2000, 3000),
+            _asset("Piece B", 1800, 2500),
+        ],
+        [_asset("Stud", 5000, 5000)],
+    )
+
+    assert candidate is None


### PR DESCRIPTION
## What changed

- Added a Python port of the authoritative KTC package Value Adjustment used by `frontend/lib/trade-logic.js::ktcAdjustPackage`.
- Applied that adjustment before `src/trade/finder.py` evaluates the opponent-win gate, market delta, opponent appeal, and arbitrage score.
- Preserved the original per-player market values while exposing raw and adjusted package totals in the API payload.
- Added parity fixtures for 1v1, 1v2, 2v1, 2v2, and 1v3 topologies.
- Added regressions proving:
  - a raw false positive is rejected after the consolidation premium is applied;
  - a raw false negative can qualify when the adjusted package is genuinely favorable to the opponent;
  - 1-for-1 trades remain unadjusted.

## Root cause

The finder summed market values linearly, while the trade calculator applied KTC's package adjustment. Multi-player recommendations could therefore disagree with the calculator and appear balanced only before the consolidation premium.

## API additions

Each returned trade now includes:

- `rawGiveKtcTotal`
- `rawReceiveKtcTotal`
- `adjustedGiveKtcTotal`
- `adjustedReceiveKtcTotal`
- `marketValueAdjustment`
- `marketValueAdjustmentSide`
- `marketValueAdjustmentApplied`

Closes #693