### PR TITLE
fix(deps): fastapi ~=0.141.1, with the route-introspection fix it needs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@
 # original PR pins to match what production + dev are actually
 # running on 2026-04-24 — the narrower pins were authored three
 # days earlier and fell behind the live env.
-fastapi~=0.135.0
+fastapi~=0.141.1
 uvicorn~=0.52.0
 
 # HTTP client used by scrapers, Sleeper client, news providers, etc.

--- a/tests/consensus_edge/test_endpoint.py
+++ b/tests/consensus_edge/test_endpoint.py
@@ -15,6 +15,32 @@ from src.api import feature_flags
 REPO = Path(__file__).resolve().parents[2]
 
 
+def _registered_paths(app) -> set[str]:
+    """Route paths as FastAPI itself publishes them.
+
+    Deliberately reads the OpenAPI schema rather than walking
+    ``app.routes``.  ``app.routes`` is an internal representation and its
+    shape changes: through FastAPI 0.135 an ``include_router`` call left
+    plain routes in the list, so ``{r.path for r in app.routes}`` worked.
+    On 0.141 it leaves an ``_IncludedRouter`` wrapper instead, which has
+    no ``.path`` — so that expression raises ``AttributeError``, and the
+    wrapped routes are not reachable via ``.routes`` or ``.router``
+    either (the attribute is ``original_router``).
+
+    Chasing that attribute would just re-break on the next refactor.
+    ``app.openapi()["paths"]`` is the public, supported answer to "what
+    routes does this app expose", and it reported all five
+    consensus-edge paths correctly on both versions.
+
+    One limit worth naming: this cannot see routes registered with
+    ``include_in_schema=False``.  None of the routes asserted here are,
+    and the HTTP-level tests below are the stronger check regardless —
+    they kept passing throughout the 0.141 upgrade, which is how we knew
+    the routes were fine and only the introspection was broken.
+    """
+    return set((app.openapi().get("paths") or {}).keys())
+
+
 class _Base(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -72,7 +98,7 @@ class TestFlagDefault(_Base):
         self.assertTrue(service.SELL_SIDE_VALIDATION["note"])
 
     def test_routes_are_registered(self):
-        paths = {r.path for r in server.app.routes}
+        paths = _registered_paths(server.app)
         self.assertIn("/api/consensus-edge/players", paths)
         self.assertIn("/api/consensus-edge/top", paths)
         self.assertIn("/api/consensus-edge/methodology", paths)


### PR DESCRIPTION
Supersedes **#637**. Closes it as a standalone — that PR bumps `fastapi` alone and **would land `main` red.**

## Why #637 can't merge as-is

Its CI passed on **2026-07-29** — six days before `tests/consensus_edge/` existed (#697, merged 08-04). Its green tick certified nothing about the tree it would merge into. Verified locally against current `main`, `fastapi 0.141.1` alone fails:

```
tests/consensus_edge/test_endpoint.py::TestFlagDefault::test_routes_are_registered
>   paths = {r.path for r in server.app.routes}
E   AttributeError: '_IncludedRouter' object has no attribute 'path'
```

## What actually changed

FastAPI 0.141 changed what `include_router` leaves in `app.routes`. Through 0.135 it appended the routes themselves; now it appends an `_IncludedRouter` wrapper with no `.path`. The wrapped routes aren't reachable via `.routes` or `.router` either — the attribute is `original_router`.

**This is introspection-only.** No production code iterates `app.routes` (checked across `server.py` and `src/`), and the nine other tests in that file — including ones exercising the routes over HTTP — passed throughout. The routes register and serve correctly on 0.141; only the test's *reading* of them broke.

## Why `openapi()` rather than chasing `original_router`

`app.openapi()["paths"]` is FastAPI's public, supported answer to "what routes does this app expose". Following `original_router` would just re-break at the next internal refactor — this is the second shape that list has had.

Confirmed the schema reports all five consensus-edge paths, and the helper passes on **both 0.135.4 and 0.141.1** — so it isn't coupled to the bump and would have been correct before it.

Documented limit, in the docstring: `openapi()` can't see `include_in_schema=False` routes. None of the asserted routes are, and the HTTP-level tests remain the stronger check.

Worth noting `tests/sharp/test_service_route_registration.py` already used `getattr(route, "path", None)` defensively and didn't break — but only because it builds its own app rather than reading `server.app`, so it never saw the wrapper.

## Verification

| check | result |
|---|---|
| full suite, this branch, fastapi 0.141.1 | **5695 passed, 0 failed** |
| same helper on fastapi 0.135.4 | consensus_edge 10 passed |
| `ruff format --check` / `ruff check` | clean |

## Related

The other three Dependabot Python bumps were verified in the same combined local run and merged separately — `main` already carries them: **#636** beautifulsoup4 4.15.0, **#638** uvicorn 0.52.0, **#640** requests 2.34.2.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrVJELpwtdym5DuC8NPYe5)_