### PR TITLE
fix(frontend): derive bundle budgets from disk, and refuse to pass blind

### DIFF
--- a/frontend/scripts/check-bundle-sizes.mjs
+++ b/frontend/scripts/check-bundle-sizes.mjs
@@ -39,7 +39,32 @@ const DIST_DIR_NAME = process.env.NEXT_DIST_DIR || ".next";
 const NEXT_DIR = path.isAbsolute(DIST_DIR_NAME)
   ? DIST_DIR_NAME
   : path.join(ROOT, DIST_DIR_NAME);
-const MANIFEST = path.join(NEXT_DIR, "app-build-manifest.json");
+// Where the app-router page chunks live.  Derived from DISK, not from
+// ``app-build-manifest.json``, because that manifest is gone.
+//
+// Next 16 does not emit it at all — under either builder.  Worse, no
+// Next 16 manifest maps an app-router page key to its chunks:
+// ``build-manifest.json``'s ``pages`` holds only the legacy pages-router
+// ``/_app``, and ``app-path-routes-manifest.json`` maps page keys to
+// ROUTE paths, not chunk files.  Reading any of those would hand this
+// script an object whose ``pages[pageKey]`` is undefined, every page
+// would log "no chunks — skipped", and the gate would PASS while
+// measuring nothing.  That silent-pass is the failure mode this
+// rewrite exists to prevent; see assertGateIsMeasuring() below.
+//
+// The on-disk layout, by contrast, is identical across Next 15 and
+// Next 16 --webpack, and maps 1:1 from the page key (verified against
+// real builds of both on 2026-08-04):
+//
+//     /page           -> static/chunks/app/page-<hash>.js
+//     /rankings/page  -> static/chunks/app/rankings/page-<hash>.js
+//
+// Under Next 16's DEFAULT builder (Turbopack) there is no such layout —
+// chunks are flat and content-hashed (``static/chunks/1de9myc15dqxx.js``)
+// with nothing tying a file to a route. Per-page attribution is simply
+// not available there, so this script refuses loudly rather than
+// reporting a pass it cannot justify.
+const APP_CHUNK_DIR = path.join(NEXT_DIR, "static", "chunks", "app");
 
 // Per-page budgets in KB (raw on-disk size of the page-specific
 // JS chunks, NOT gzipped).  Values are intentionally a little
@@ -83,44 +108,94 @@ function fmtKb(bytes) {
   return `${(bytes / 1024).toFixed(1)} KB`;
 }
 
-function pageChunks(manifest, pageKey) {
-  const chunks = manifest.pages[pageKey] || [];
-  // Page-specific = chunks emitted under ``app/<route>/`` only.  The
-  // shared framework / common chunks are amortised across every
-  // page and don't represent an incremental cost for this page.
-  return chunks.filter((c) => c.startsWith("static/chunks/app/"));
+// Page key -> that page's own chunk files, resolved on disk.
+//
+// ``/rankings/page`` becomes ``<app>/rankings/page-*.js``: the key
+// minus its leading slash, with a hash suffix.  Only chunks under
+// ``static/chunks/app/`` count — shared framework/common chunks are
+// amortised across every page and are not an incremental cost here.
+// That is the same set the old manifest filter produced; verified
+// against a real Next 15 build where every page key mapped to exactly
+// the file this derives.
+function pageChunks(pageKey) {
+  const rel = pageKey.replace(/^\//, "");
+  const dir = path.join(APP_CHUNK_DIR, path.dirname(rel));
+  const base = path.basename(rel);
+  let entries;
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+  // ``page-<hash>.js`` — anchored so ``/page`` cannot also swallow
+  // ``page-legacy-*.js`` or a sibling route sharing the prefix.
+  const re = new RegExp(`^${base.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}-[^/]+\\.js$`);
+  return entries.filter((e) => re.test(e)).map((e) => path.join(dir, e));
+}
+
+// Refuse to report success when the gate could not actually measure.
+//
+// Every earlier version of this script degraded silently when its
+// assumption about Next's output broke: a missing page logged
+// "no chunks — skipped" and the run still exited 0.  That is fine for
+// ONE removed route and catastrophic when the layout changes wholesale,
+// which is exactly what Next 16 + Turbopack does.  If nothing resolved,
+// something structural is wrong and a green tick would be a lie.
+function assertGateIsMeasuring(resolvedCount) {
+  if (resolvedCount > 0) return;
+  console.error(
+    "[check-bundle-sizes] resolved chunks for ZERO of the " +
+      `${Object.keys(BUDGETS_KB).length} budgeted pages under ${APP_CHUNK_DIR}.\n` +
+      "\n" +
+      "Refusing to pass: this gate cannot measure anything, and exiting 0\n" +
+      "would report a budget check that never ran.\n" +
+      "\n" +
+      "Most likely cause: the build used Turbopack, which emits a flat,\n" +
+      "content-hashed chunk layout with no per-route attribution. Next 16\n" +
+      "makes Turbopack the default builder. Build with ``next build\n" +
+      "--webpack`` to restore the per-route layout this gate reads, or\n" +
+      "replace this script with a Turbopack-native measurement.",
+  );
+  process.exit(2);
 }
 
 function main() {
-  if (!fs.existsSync(MANIFEST)) {
+  if (!fs.existsSync(NEXT_DIR)) {
     console.error(
-      `[check-bundle-sizes] manifest not found at ${MANIFEST}.\n` +
+      `[check-bundle-sizes] build output not found at ${NEXT_DIR}.\n` +
         "Run ``npm run build`` first.",
     );
     process.exit(2);
   }
-  const manifest = JSON.parse(fs.readFileSync(MANIFEST, "utf-8"));
+  if (!fs.existsSync(APP_CHUNK_DIR)) {
+    console.error(
+      `[check-bundle-sizes] no app-router chunk dir at ${APP_CHUNK_DIR}.\n` +
+        "\n" +
+        "Under Next 16 the default builder is Turbopack, which emits a flat,\n" +
+        "content-hashed chunk layout and no per-route attribution — this gate\n" +
+        "cannot measure it. Build with ``next build --webpack``, or replace\n" +
+        "this script with a Turbopack-native measurement.",
+    );
+    process.exit(2);
+  }
   const failures = [];
   const lines = [];
+  let resolvedCount = 0;
 
   for (const [pageKey, budgetKb] of Object.entries(BUDGETS_KB)) {
-    const chunks = pageChunks(manifest, pageKey);
+    const chunks = pageChunks(pageKey);
     if (chunks.length === 0) {
       // Page may not exist (e.g. removed) — skip silently rather
       // than fail.  ``--strict`` flag below would change this.
       lines.push(`  ${pageKey.padEnd(22)} (no chunks — skipped)`);
       continue;
     }
+    resolvedCount += 1;
     let totalBytes = 0;
-    for (const chunk of chunks) {
-      const fullPath = path.join(NEXT_DIR, chunk);
-      try {
-        totalBytes += fs.statSync(fullPath).size;
-      } catch {
-        // Chunk listed in manifest but not on disk — should not
-        // happen on a clean build, but skip to avoid spurious
-        // failures.
-      }
+    for (const fullPath of chunks) {
+      // Paths come from readdir, so a stat failure here means the file
+      // vanished mid-run rather than a stale manifest entry.
+      totalBytes += fs.statSync(fullPath).size;
     }
     const totalKb = totalBytes / 1024;
     const overshoot = totalKb - budgetKb;
@@ -138,6 +213,7 @@ function main() {
 
   console.log("[check-bundle-sizes] per-page chunk sizes:");
   for (const line of lines) console.log(line);
+  assertGateIsMeasuring(resolvedCount);
 
   if (failures.length > 0) {
     console.error(


### PR DESCRIPTION
Unblocks the Next 16 security upgrade (#658) and closes a silent-pass hole in the gate itself.

## Why #658 fails today

Its build **succeeds**. `check-bundle-sizes.mjs` is what exits 2:

```
[check-bundle-sizes] manifest not found at .next/app-build-manifest.json
```

Next 16 doesn't emit that file under either builder. I verified this by building a real Next 16.2.12 app rather than inferring it: **no Next 16 manifest maps an app-router page key to its chunks at all.** `build-manifest.json`'s `pages` holds only the legacy pages-router `/_app`; `app-path-routes-manifest.json` maps page keys to *route paths*, not chunk files.

## The trap this avoids

The obvious fix — point the script at a different manifest — is **worse than the failure**. `manifest.pages[pageKey]` would be `undefined` for every page, each would log `(no chunks — skipped)`, and the gate would **exit 0 having measured nothing.**

A bundle budget that always passes is worse than one that's broken loudly. That's the same failure shape as the four defects in #653.

## What changed

Chunks now resolve from **disk** rather than from a manifest. The layout maps 1:1 from the page key and is identical on Next 15 and Next 16 `--webpack`:

```
/page           →  static/chunks/app/page-<hash>.js
/rankings/page  →  static/chunks/app/rankings/page-<hash>.js
```

Two loud refusals replace the silent skip:

- **no `static/chunks/app/` at all** → exit 2, naming Turbopack as the likely cause and `--webpack` as the fix
- **zero budgeted pages resolve** → exit 2 rather than reporting a check that never ran

A *single* missing page still skips quietly — that's the case the behaviour was written for (a route was removed).

## Verification — against real builds, not assumption

| scenario | result |
|---|---|
| **Real app, Next 15 — old vs new script** | **byte-identical output across all 14 budgeted pages** |
| Minimal app, Next 15.5.22 (default) | passes |
| Minimal app, Next 16.2.12 `--webpack` | passes |
| Minimal app, Next 16.2.12 (default/Turbopack) | **exit 2** with the explanatory message |
| Budgeted pages that don't exist | **exit 2** instead of skipping all |

The first row is the one that matters: this is a faithful replacement, not a reinterpretation. Same build, same numbers, down to the byte.

## What #658 still needs — this is necessary but not sufficient

Next 16 defaults to Turbopack, whose flat content-hashed chunks (`static/chunks/1de9myc15dqxx.js`) carry no route attribution. So the Next 16 PR must **also** build with `--webpack`.

That flag **cannot be added here**: Next 15.5.12 doesn't accept it, so adding it now would break the build immediately. It has to land inside the upgrade PR.

The longer-term choice — stay on `--webpack`, or write a Turbopack-native measurement — is deliberately left open. This change only ensures the gate keeps telling the truth either way.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrVJELpwtdym5DuC8NPYe5)_