### PR TITLE
Clear the 37 ruff errors, and fix the three that were not lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,24 @@ select = ["E", "F", "W"]
 # pre-existing lines, none of them defects.
 ignore = ["E501"]
 
+[tool.ruff.lint.per-file-ignores]
+# E741 (ambiguous name `l`) is not enforced in the KTC VA port. That module
+# is a declared VERBATIM transliteration of KTC's minified client-side
+# algorithm (`keeptradecut.com/js/site.min.js`) via
+# `frontend/lib/trade-logic.js`, and its parity with the JS is pinned by
+# `tests/trade/test_ktc_va_python_port.py` over a 139-trade fixture to ±1.
+#
+# The single-letter names are the MINIFIER's, kept so the port can be diffed
+# line-for-line against its source. Renaming only `l` — the sole letter E741
+# objects to — would break that correspondence while leaving `n`, `d`, `u`,
+# `o` and `p` untouched, making the file harder to verify, not easier.
+#
+# Scoped per-FILE rather than per-line on purpose: the exemption is a
+# property of the whole module (it is a transliteration), so a letter added
+# during a future re-sync with the JS is covered too. Every other E741 in
+# the repo was renamed rather than exempted.
+"src/trade/ktc_va.py" = ["E741"]
+
 [tool.ruff.format]
 # Black-compatible defaults (double quotes, magic trailing comma).
 # No overrides — deterministic output is what makes the CI check safe

--- a/scripts/audit_identity.py
+++ b/scripts/audit_identity.py
@@ -25,7 +25,7 @@ REPO = Path(__file__).resolve().parents[1]
 if str(REPO) not in sys.path:
     sys.path.insert(0, str(REPO))
 
-from src.api.data_contract import build_api_data_contract
+from src.api.data_contract import build_api_data_contract  # noqa: E402 — must follow the sys.path bootstrap above
 
 
 def _load_payload(json_path: str | None) -> dict:

--- a/scripts/backtest_alpha_lambda_joint.py
+++ b/scripts/backtest_alpha_lambda_joint.py
@@ -81,12 +81,12 @@ def sweep_2d(snapshots) -> list[dict]:
     results: list[dict] = []
     try:
         for a in ALPHA_GRID:
-            for l in LAMBDA_GRID:
+            for lam in LAMBDA_GRID:
                 data_contract._ALPHA_SHRINKAGE = a
-                data_contract._MAD_PENALTY_LAMBDA = l
+                data_contract._MAD_PENALTY_LAMBDA = lam
                 boards = [build_board(raw) for _, raw in snapshots]
                 vw = stability_vw(boards)
-                results.append({"alpha": a, "lambda": l, "vw": vw})
+                results.append({"alpha": a, "lambda": lam, "vw": vw})
     finally:
         data_contract._ALPHA_SHRINKAGE = orig_a
         data_contract._MAD_PENALTY_LAMBDA = orig_l
@@ -121,15 +121,15 @@ def render(snapshots, results) -> str:
     lines.append("")
     lines.append("## Heatmap (rows = α, cols = λ)")
     lines.append("")
-    header = "| α \\ λ | " + " | ".join(f"{l:.2f}" for l in LAMBDA_GRID) + " |"
+    header = "| α \\ λ | " + " | ".join(f"{lam:.2f}" for lam in LAMBDA_GRID) + " |"
     sep = "|---:|" + "|".join(["---:" for _ in LAMBDA_GRID]) + "|"
     lines.append(header)
     lines.append(sep)
     for a in ALPHA_GRID:
         row_vals = []
-        for l in LAMBDA_GRID:
-            v = next(r["vw"] for r in results if r["alpha"] == a and r["lambda"] == l)
-            marker = " ★" if (a, l) == (best["alpha"], best["lambda"]) else ""
+        for lam in LAMBDA_GRID:
+            v = next(r["vw"] for r in results if r["alpha"] == a and r["lambda"] == lam)
+            marker = " ★" if (a, lam) == (best["alpha"], best["lambda"]) else ""
             row_vals.append(f"{v:.3f}{marker}")
         lines.append(f"| **{a:.2f}** | " + " | ".join(row_vals) + " |")
     lines.append("")

--- a/scripts/backtest_scoring_adjustment.py
+++ b/scripts/backtest_scoring_adjustment.py
@@ -19,7 +19,7 @@ ROOT = os.path.dirname(SCRIPT_DIR)
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 
-from src.scoring.backtest import run_scoring_backtest
+from src.scoring.backtest import run_scoring_backtest  # noqa: E402 — must follow the sys.path bootstrap above
 
 
 def resolve_latest_json() -> str | None:

--- a/scripts/collect_ktc_va.py
+++ b/scripts/collect_ktc_va.py
@@ -261,7 +261,6 @@ async def _add_player(page, team_idx: int, player_name: str, *, timeout: int = 1
     # Verify the player row landed in the team list.  This is the
     # check we should have had from day one — clicking the wrong
     # element succeeds silently otherwise (see bug history pre-#288).
-    list_loc = page.locator(f"#{list_id}")
     try:
         # Wait up to 3s for at least one direct child to appear.
         await page.wait_for_function(

--- a/scripts/export_player_map.py
+++ b/scripts/export_player_map.py
@@ -28,10 +28,10 @@ _REPO = Path(__file__).resolve().parents[1]
 if str(_REPO) not in sys.path:
     sys.path.insert(0, str(_REPO))
 
-from scripts._shared import _repo_root, _latest as _latest_file, _normalize_name
+from scripts._shared import _repo_root, _latest as _latest_file, _normalize_name  # noqa: E402 — must follow the sys.path bootstrap above
 
 
-from src.utils.name_clean import NICKNAME_MAP, POSITION_ALIASES as POS_MAP  # noqa: F401
+from src.utils.name_clean import NICKNAME_MAP, POSITION_ALIASES as POS_MAP  # noqa: F401,E402
 
 
 def build_player_map(legacy_path: Path) -> dict:

--- a/scripts/fetch_dynasty_daddy.py
+++ b/scripts/fetch_dynasty_daddy.py
@@ -215,11 +215,8 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
 
-    # Position breakdown diagnostics.
-    pos_counts: dict[str, int] = {}
-    for r in rows:
-        # Value-only CSV doesn't carry position — count from parse step.
-        pass
+    # No position breakdown: the value-only CSV carries no position, so
+    # the diagnostic that used to loop here could never populate.
     print(f"[fetch_dynasty_daddy] total={len(rows)} rows with positive sf_trade_value")
 
     if args.dry_run:

--- a/scripts/generate_test_seeds.py
+++ b/scripts/generate_test_seeds.py
@@ -24,7 +24,7 @@ _REPO = Path(__file__).resolve().parents[1]
 if str(_REPO) not in sys.path:
     sys.path.insert(0, str(_REPO))
 
-from scripts._shared import _repo_root
+from scripts._shared import _repo_root  # noqa: E402 — must follow the sys.path bootstrap above
 
 
 def load_ktc_players(repo: Path) -> list[tuple[str, int]]:

--- a/scripts/identity_resolve.py
+++ b/scripts/identity_resolve.py
@@ -17,7 +17,7 @@ def _bootstrap_path(repo: Path) -> None:
         sys.path.insert(0, str(repo))
 
 
-from scripts._shared import _latest
+from scripts._shared import _latest  # noqa: E402 — must follow the sys.path bootstrap above
 
 
 def main() -> int:

--- a/scripts/inspect_anomalies.py
+++ b/scripts/inspect_anomalies.py
@@ -24,7 +24,7 @@ REPO = Path(__file__).resolve().parents[1]
 if str(REPO) not in sys.path:
     sys.path.insert(0, str(REPO))
 
-from src.api.data_contract import build_api_data_contract
+from src.api.data_contract import build_api_data_contract  # noqa: E402 — must follow the sys.path bootstrap above
 
 
 def _load_payload(json_path: str | None) -> dict:

--- a/scripts/validate_ingest.py
+++ b/scripts/validate_ingest.py
@@ -17,7 +17,7 @@ def _bootstrap_path(repo: Path) -> None:
         sys.path.insert(0, str(repo))
 
 
-from scripts._shared import _latest
+from scripts._shared import _latest  # noqa: E402 — must follow the sys.path bootstrap above
 
 
 def _second_latest(path: Path, pattern: str) -> Path | None:

--- a/src/api/team_assignment.py
+++ b/src/api/team_assignment.py
@@ -260,7 +260,11 @@ def _score_player(
       - IDP starter (T5): depth-chart-based, only when league has IDP
     """
     weights = config["weights"]
-    thresholds = config["thresholds"]
+    # config["thresholds"] is deliberately not read here — see the T3
+    # comment below: those keys are forward-looking, documented as
+    # position-rank-based for a future canonicalConsensusRank drop-in.
+    # The one threshold in live use, assignmentMinPoints, is read where
+    # it is applied.
     pos = _normalize_position(meta.get("position"))
     if not pos:
         return 0, []

--- a/src/public_league/awards.py
+++ b/src/public_league/awards.py
@@ -1515,7 +1515,6 @@ def _rivalry_of_the_year(
     if not pair_scores:
         return None
 
-    best_key: tuple[str, str] | None = None
     best_score = -1.0
     best_row: dict[str, Any] | None = None
     for key, rec in pair_scores.items():
@@ -1530,7 +1529,6 @@ def _rivalry_of_the_year(
         rec["rivalryIndex"] = score
         if score > best_score:
             best_score = score
-            best_key = key
             best_row = rec
 
     if best_row is None:

--- a/src/public_league/draft.py
+++ b/src/public_league/draft.py
@@ -95,7 +95,6 @@ def _pick_ownership_map(snapshot: PublicLeagueSnapshot) -> dict[str, list[dict[s
     if current is None:
         return {}
 
-    num_teams = current.num_teams or max(1, len(current.rosters))
     settings = current.league.get("settings") or {}
     try:
         draft_rounds = int(settings.get("draft_rounds") or 0)

--- a/src/public_league/metrics.py
+++ b/src/public_league/metrics.py
@@ -242,16 +242,16 @@ def playoff_placement(bracket: list[dict[str, Any]]) -> dict[int, int]:
             place = int(p)
         except (TypeError, ValueError):
             continue
-        w = m.get("w")
-        l = m.get("l")
-        if w is not None:
+        winner_rid = m.get("w")
+        loser_rid = m.get("l")
+        if winner_rid is not None:
             try:
-                placement.setdefault(int(w), place)
+                placement.setdefault(int(winner_rid), place)
             except (TypeError, ValueError):
                 pass
-        if l is not None:
+        if loser_rid is not None:
             try:
-                placement.setdefault(int(l), place + 1)
+                placement.setdefault(int(loser_rid), place + 1)
             except (TypeError, ValueError):
                 pass
     return placement
@@ -315,9 +315,9 @@ def season_runner_up(season: SeasonSnapshot) -> int | None:
     # Fallback: loser of the final matchup.
     final = final_playoff_matchup(season.winners_bracket)
     if final is not None:
-        l = final.get("l")
+        loser_rid = final.get("l")
         try:
-            return int(l) if l is not None else None
+            return int(loser_rid) if loser_rid is not None else None
         except (TypeError, ValueError):
             return None
     return None

--- a/src/public_league/sleeper_client.py
+++ b/src/public_league/sleeper_client.py
@@ -22,6 +22,7 @@ Network layer:
 from __future__ import annotations
 
 import logging
+import os as _os
 import threading
 from typing import Any
 
@@ -38,8 +39,6 @@ SLEEPER_BASE = "https://api.sleeper.app/v1"
 # so ops can raise or lower without a code change.  Every section
 # module iterates ``snapshot.seasons`` so this constant is the single
 # knob that controls horizon.
-import os as _os
-
 try:
     PUBLIC_MAX_SEASONS = max(1, int(_os.getenv("PUBLIC_MAX_SEASONS", "3")))
 except ValueError:

--- a/src/public_league/weekly_recap.py
+++ b/src/public_league/weekly_recap.py
@@ -439,8 +439,6 @@ def _summary(recap: dict[str, Any], seed: int) -> str:
     # 100-pt threshold = "low" baseline; tuned for SF + TEP fantasy
     # scoring where 110-150 is a typical pace.
     if matchups and len(top) >= 2:
-        sides_total = len(top) + sum(2 for _ in matchups[len(top) :])
-        side_count = max(1, len(top) + 2 * max(0, len(matchups) - len(top) // 2))
         avg_side = scored_total / max(1, 2 * len(matchups))
         if avg_side >= 130:
             above = sum(1 for s in top if s["points"] >= 150)

--- a/src/ros/championship.py
+++ b/src/ros/championship.py
@@ -91,8 +91,6 @@ def _simulate_bracket(
                 finishes[owner] = i
         return finishes
 
-    bye_set = set(field[:bye_seeds])
-
     # Round 1: byes auto-advance; remaining seeds play in
     # higher-seed-vs-lower-seed pairs.
     advancing_to_semis: list[str] = list(field[:bye_seeds])

--- a/src/scoring/scoring_delta.py
+++ b/src/scoring/scoring_delta.py
@@ -100,8 +100,8 @@ def compare_to_baseline(
     out: List[ScoringRule] = []
     for key in keys:
         b = float(baseline.get(key, 0.0) or 0.0)
-        l = float(league.get(key, 0.0) or 0.0)
-        d = l - b
+        league_val = float(league.get(key, 0.0) or 0.0)
+        d = league_val - b
         if abs(d) < 1e-9:
             continue
         meta = RULE_META.get(key, {})
@@ -110,7 +110,7 @@ def compare_to_baseline(
                 key=key,
                 category=str(meta.get("category", "other")),
                 baseline_value=b,
-                league_value=l,
+                league_value=league_val,
                 delta=d,
                 relevant_buckets=list(meta.get("buckets", [])),
                 rule_type=str(meta.get("rule_type", "linear")),

--- a/tests/api/test_admin_endpoints.py
+++ b/tests/api/test_admin_endpoints.py
@@ -187,7 +187,7 @@ def test_guest_pass_login_creates_time_bounded_session(monkeypatch, tmp_path):
     """End-to-end: admin mints a pass → guest logs in with the
     plaintext token → /api/auth/status returns authenticated."""
     _authed_admin(monkeypatch)
-    db = _isolate_guest_pass_db(monkeypatch, tmp_path)
+    _isolate_guest_pass_db(monkeypatch, tmp_path)  # called for isolation; return unused
     # Force a known admin password so the login fall-through is the
     # only path that admits the guest token.
     monkeypatch.setattr(server, "JASON_LOGIN_USERNAME", "admin")

--- a/tests/api/test_identity_validation.py
+++ b/tests/api/test_identity_validation.py
@@ -134,16 +134,17 @@ class TestIdpToOffenseContamination(unittest.TestCase):
 class TestCrossUniverseCollision(unittest.TestCase):
     """Same name appearing in both offense and IDP should be flagged."""
 
-    def test_same_name_offense_and_idp_both_flagged(self):
-        # Two players with the same name but different positions
-        payload = _payload_with_players(
-            _make_player("Zzz James Williams", "WR", ktc=7000),
-            _make_player("Zzz James Williams", "LB", idp=3000),
-        )
-        # dict keys collide → only one survives in players dict.
-        # But if the scraper produces different entries, they'd have
-        # different canonical names.  Test the validation function directly.
-        pass
+    # ``test_same_name_offense_and_idp_both_flagged`` was here and is gone.
+    #
+    # Its whole body was a payload build followed by `pass` — no assertion
+    # of any kind — while its name claimed the collision was "both_flagged".
+    # It reported PASSED for testing nothing, which is worse than absent
+    # coverage: it occupied the slot where the real check would go.
+    #
+    # Its own trailing comment explains why it was abandoned (payload dict
+    # keys collide, so only one player survives that route) and points at
+    # the replacement: test the validation function directly. That is
+    # exactly what the test below does, so no coverage is lost here.
 
     def test_collision_detection_via_validation_function(self):
         """Directly test _validate_and_quarantine_rows with crafted rows.

--- a/tests/api/test_signal_state_migration.py
+++ b/tests/api/test_signal_state_migration.py
@@ -125,6 +125,13 @@ def test_migration_preserves_newer_entries_on_conflict(kv):
     )
     result = mig.migrate_user("alice", default_league_key="dynasty_main", path=kv)
     # Already-migrated state detected → skipped (legacy cleaned).
+    # This assertion was missing: the comment above stated the expected
+    # action and nothing checked it, so a regression that migrated instead
+    # of skipping would have passed. Every other test in this file pins
+    # result["action"] (see :32, :54, :69, :79); this one captured the
+    # diagnostic and dropped it.
+    assert result["action"] == "skipped"
+    assert result["reason"] == "already_migrated"
     # But both entries should now live in the bucket.
     state = user_kv.get_user_state("alice", path=kv)
     bucket = state["signalAlertStateByLeague"]["dynasty_main"]

--- a/tests/api/test_source_history.py
+++ b/tests/api/test_source_history.py
@@ -123,7 +123,7 @@ def test_retention_trims_to_max_snapshots(path):
             max_snapshots=180,
         )
     with path.open("r", encoding="utf-8") as f:
-        lines = [json.loads(l) for l in f if l.strip()]
+        lines = [json.loads(line) for line in f if line.strip()]
     assert len(lines) == 180
 
 

--- a/tests/canonical/test_calibration.py
+++ b/tests/canonical/test_calibration.py
@@ -11,7 +11,7 @@ REPO = Path(__file__).resolve().parents[2]
 if str(REPO) not in sys.path:
     sys.path.insert(0, str(REPO))
 
-from src.canonical.calibration import (
+from src.canonical.calibration import (  # noqa: E402 — must follow the sys.path bootstrap above
     calibrate_canonical_values,
     get_calibration_params,
     UNIVERSE_SCALES,

--- a/tests/nfl_data/test_usage_windows.py
+++ b/tests/nfl_data/test_usage_windows.py
@@ -82,6 +82,11 @@ def test_spike_produces_positive_zscore():
     final = [w for w in windows if w.week == 5][0]
     # With exactly-equal history, SD is 0 → z is None.  So insert a
     # small variance and re-check.
+    #
+    # That first half was stated and never checked — `final` was computed
+    # and dropped, so a regression that produced a z-score from zero
+    # variance would have gone unnoticed. Assert it.
+    assert final.snap_pct_z is None
     rows[0]["snap_pct"] = 0.32
     rows[1]["snap_pct"] = 0.28
     rows[2]["snap_pct"] = 0.30

--- a/tests/ros/test_aggregate.py
+++ b/tests/ros/test_aggregate.py
@@ -177,7 +177,6 @@ class TestAggregate(unittest.TestCase):
 
     def test_confidence_grows_with_source_count(self):
         rows1 = [("A", "QB", 1)]
-        rows3 = [("A", "QB", 1)] * 1  # same player from one source
         # 1-source confidence
         s1 = aggregate([_snapshot("only", 1.0, rows1, 1)], league=_LEAGUE)[0]["confidence"]
         # 4-source confidence (saturates at 4)

--- a/tests/trade/test_correlation_matrix.py
+++ b/tests/trade/test_correlation_matrix.py
@@ -52,8 +52,6 @@ def test_different_teams_same_pos_group():
 
 
 def test_different_everything_zero():
-    axes = [_ax("BUF", "QB"), _ax("KC", "RB", group="offense")]
-    mat = cm.build_matrix(axes)
     # Same group offense but — wait, the rule says same_group → 0.15.
     # If we want to ensure "different everything" is zero, we need
     # different groups.  QB + DL.
@@ -82,7 +80,6 @@ def test_cholesky_succeeds_on_pd_matrix():
 
 def test_cholesky_fails_on_non_pd():
     # Correlation 0.999 × off-diagonal with many entries can fail PD.
-    mat = [[1.0, 0.99, 0.99], [0.99, 1.0, 0.99], [0.99, 0.99, 1.0]]
     # This particular matrix IS positive definite — all eigenvalues > 0.
     # A better example: negative determinant.
     # 2x2 with rho > 1 explicitly breaks.


### PR DESCRIPTION
`ruff check .` reported **37 errors** — 15 F841, 12 E741, 10 E402 — across `src/` (15), `scripts/` (13) and `tests/` (9).

None had ever blocked anything: `pr-validation.yml` lints **changed files, blocking**; `deploy.yml` lints the repo **report-only**. Nobody had changed these files.

Triaged **by class**, because the three classes don't mean the same thing and two of them must not be auto-fixed.

---

## E402 (10) — nine must not be reordered

Every one is an import sitting below a deliberate `sys.path` bootstrap:

```python
REPO = Path(__file__).resolve().parents[1]
sys.path.insert(0, str(REPO))

from src.api.data_contract import build_api_data_contract   # E402
```

The ordering is *required*. Exempted **per-line** with the reason — not per-file — so a genuinely misplaced import added to the same file later still gets flagged.

**The tenth was not a bootstrap.** `src/public_league/sleeper_client.py` had a stray `import os as _os` roughly fifteen lines below the import block, used twice further down. That one is **moved, not exempted**.

## E741 (12) — renamed 7, exempted 5

Renamed where the letter meant something: `l` → `lam` (it *is* lambda, from `LAMBDA_GRID`), `l` → `loser_rid` (Sleeper's bracket loser roster id — it gets `place + 1`), `l` → `league_val`, `l` → `line`.

The other five are in **`src/trade/ktc_va.py`**, exempted per-**file**. That module declares itself a *verbatim transliteration* of KTC's minified client-side algorithm, with parity to the JS port pinned by a 139-trade fixture to ±1. The single-letter names are **the minifier's**, kept so the port can be diffed against its source. Renaming only `l` — the sole letter E741 objects to — would break that correspondence while leaving `n`, `d`, `u`, `o`, `p` untouched, making the file *harder* to verify. Per-file because the exemption is a property of the whole module, so a letter added in a future re-sync is covered too.

## F841 (15) — three of these were not dead code

Assigned-but-unused is ambiguous: dead scaffolding, **or a value that was meant to be used**. Reading each one found three of the second kind, and they are **fixed, not deleted**:

- **`test_signal_state_migration.py`** captured `result` and never asserted on it — while its own comment stated the expected outcome (*"Already-migrated state detected → skipped"*). Every other test in that file pins `result["action"]` (`:32`, `:54`, `:69`, `:79`). A regression that migrated instead of skipping would have passed. **Assertion added.**
- **`test_usage_windows.py`** computed `final`, commented *"With exactly-equal history, SD is 0 → z is None"*, and never checked it. **Assertion added.**
- **`test_identity_validation.py::test_same_name_offense_and_idp_both_flagged`** had a body of one payload build and `pass` — **no assertion of any kind** — reporting green for testing nothing. **Deleted**; its own trailing comment points at the next test, which is the real coverage.

The other twelve are inert and deleted: a duplicate locator whose actual check is the `wait_for_function` below it; an abandoned diagnostic whose loop body was `pass`; a forward-looking config read (the T3 comment in `team_assignment.py` documents those keys as unused pending a `canonicalConsensusRank` drop-in); a `best_key` that `best_row` already carries; a `num_teams` in a function that iterates rosters directly; two abandoned denominators; a set duplicating the list on the next line; and four leftovers from first attempts that the surrounding comments narrate being abandoned.

---

## Verification

- `ruff check .` → **0 errors**
- `ruff format --check .` → clean, 804 files
- `pytest -m "not livedata"` → **5,683 passed, 25 skipped**, one failure that is **not from this change**:

```
tests/consensus_edge/test_endpoint.py::TestFlagDefault::test_routes_are_registered
AttributeError: '_IncludedRouter' object has no attribute 'path'
```

That file is not in this diff, and **the same test fails identically on `origin/main` with none of these changes applied** — verified by checking out main and running it. It is environment skew: this container has fastapi **0.141.1** installed while `requirements.txt` pins **~=0.135.0**, and 0.141 puts `_IncludedRouter` objects in `app.routes`. CI runs the pin, so CI is unaffected, and #702 ("fastapi ~=0.141.1, with the route-introspection fix it needs") is the in-flight fix for when the pin moves.

## One thing this deliberately does not do

Ruff caught a mistake of mine on the way — the `lam` rename missed a use and surfaced as F821 undefined-name. That is the argument for the follow-on: `deploy.yml`'s repo-wide `ruff check .` is still **report-only**, so this re-rots unless it is made blocking. A report-only gate nobody reads is itself a §6.15 guard that cannot fire. Flipping it is a policy change and is left to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKhaEruQrSLhWKZPEGmEEm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKhaEruQrSLhWKZPEGmEEm)_