### PR TITLE
Add Sharp Roster Percentage on the shared sharp cohort

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -823,6 +823,27 @@ which is why the timers are staggered:
 3. `scripts/crawl_sharp_rosters.py` (05:50) — finds what they currently
    OWN, which is what the roster-percentage board is made of
 
+Two things the roster pass depends on, both fixed rather than worked
+around:
+
+- `discovery.py` records a `league_memberships` row at USER-expansion
+  time as well as league-expansion time. It used to record one only when
+  a league was expanded, so leagues left on the frontier by the budget
+  had none — invisible to anything asking "which leagues does this
+  manager play in", which silently bounded the roster crawl to the
+  expanded subgraph.
+- The roster pass orders leagues through
+  `record_queue.prioritize_league_ids` (never-collected first, then
+  oldest), the same fair ordering the records crawl uses. Sorting by
+  league id meant a budget-capped run re-collected the same prefix
+  forever and never reached the tail.
+
+`server.py` calls `_sharp_service.register_http_routes()` explicitly
+after importing the module. The import-time side effect alone is not
+enough: anything that imports `src.sharp.service` before the app exists
+makes it a no-op, and the module cache means the later import re-runs
+nothing — `/api/sharp/market` then 404s with no other symptom.
+
 Roster observations live in `sharp_rosters` / `sharp_roster_assets` /
 `sharp_roster_asset_spans` / `sharp_roster_observations`
 (`src/sharp/roster_store.py`), created by a plain

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,8 @@ npm run regression                   # Full pipeline: preflight + tests
 | `/api/trade/suggestions` | POST | Roster-aware trade suggestions (reads live contract) |
 | `/api/trade/finder` | POST | KTC arbitrage finder |
 | `/api/leagues` | GET | Active league registry (stable `key` → `displayName` + roster settings; **no Sleeper IDs leaked**) |
+| `/api/sharp/roster-percentage` | GET | Sharp Roster Percentage board (global cohort — takes no `leagueKey`) |
+| `/api/sharp/roster-percentage/audit` | GET | Every roster behind one player's count, for manual verification |
 
 ### Rankings vs. league context — the core split
 
@@ -785,6 +787,58 @@ The `POST /api/rankings/overrides` endpoint supports two response views:
 Regression test: `tests/api/test_source_overrides.py::TestBuildRankingsDeltaPayload` pins the delta shape, byte-size bounds, and the invariant that every field in `_DELTA_PLAYER_FIELDS` round-trips through a manual merge identically to the full-contract path.
 
 See `tests/api/test_source_overrides.py` for the full contract spec.
+
+### The sharp cohort: one pool, many surfaces
+
+`src/sharp/cohort.py::cohort_members` is THE definition of "who is a
+sharp". Every sharp-powered surface resolves its manager pool through
+it, and none of them may keep a second list or add a qualification rule:
+
+| surface | module |
+|---|---|
+| Sharp Buy/Sell Tracker (`/market/sharp-tracker`) | `src/sharp/market.py` |
+| Sharp Roster Percentage (`/market/sharp-roster-percentage`) | `src/sharp/roster_percentage.py` |
+| roster collection pass | `src/sharp/roster_collect.py` |
+| activity crawl | `scripts/crawl_sharp_activity.py` |
+
+`market.py` re-exports `CohortMember`, `cohort_members`,
+`curated_members`, `provisional_members` and `load_ffpc_config`, so
+`sharp_market.cohort_members` still resolves and the monkeypatch seam
+existing tests use is preserved. Note the re-export is a
+`from ... import` binding taken at import time — a test that patches
+the cohort module before importing `market` captures the stub.
+
+Qualification is decided in `src/sharp/score.py` +
+`config/sharp/scoring_v2.json` over evidence from
+`src/sharp/platform_records.py`; league eligibility in
+`src/intel/league_filter.py` (dynasty only, ≥ 2 seasons). `cohort.py`
+only SELECTS and DEDUPLICATES.
+
+**Three sharp crawl passes, in order** — each depends on the one before,
+which is why the timers are staggered:
+
+1. `scripts/discover_sharp_graph.py` (04:20 UTC) — finds MANAGERS
+2. `scripts/crawl_sharp_records.py` (04:50) — finds their RESULTS, which
+   is what makes them scoreable
+3. `scripts/crawl_sharp_rosters.py` (05:50) — finds what they currently
+   OWN, which is what the roster-percentage board is made of
+
+Roster observations live in `sharp_rosters` / `sharp_roster_assets` /
+`sharp_roster_asset_spans` / `sharp_roster_observations`
+(`src/sharp/roster_store.py`), created by a plain
+`CREATE TABLE IF NOT EXISTS` that is deliberately NOT wired to
+`platform_ledger.PLATFORM_SCHEMA_VERSION` — bumping that re-runs the
+whole platform migration on every deployed ledger to add four additive
+tables.
+
+Counting rules are enforced by primary keys rather than by caller
+discipline: one row per roster, one row per (roster, player). The
+denominator is ROSTERS, not people — a sharp with five dynasty teams
+contributes five observations — and it is computed PER PLAYER, because a
+linebacker cannot be rostered in a league with no IDP slots. Full
+methodology and the known limitations (no general-dynasty ownership feed
+exists; FFPC contributes zero rosters until a roster-bearing URL is
+configured) are in `docs/sharp-roster-percentage/METHODOLOGY.md`.
 
 ### Adapter Pattern
 Pluggable source adapters (`src/adapters/base.py` defines the frozen contract). All adapters emit `RawAssetRecord` dataclasses with normalized fields.

--- a/deploy/install-systemd-service.sh
+++ b/deploy/install-systemd-service.sh
@@ -588,6 +588,56 @@ main() {
   fi
 
 
+  # ── Sharp roster collection timer ───────────────────────────────────
+  #
+  # The THIRD pass: what the cohort currently OWNS, which is what
+  # /market/sharp-roster-percentage is made of. Installed alongside
+  # discovery and records because without it that page stays honestly
+  # empty forever — there is no other producer of the roster store.
+  #
+  # Like the records unit, exit 2 ("budget exhausted, leagues
+  # remaining") is the normal steady state and is treated as success.
+  local sharpros_service_template="${APP_DIR}/deploy/systemd/dynasty-sharp-rosters.service.template"
+  local sharpros_timer_template="${APP_DIR}/deploy/systemd/dynasty-sharp-rosters.timer.template"
+  local sharpros_service_name="${SERVICE_NAME}-sharp-rosters"
+  local sharpros_service_path="/etc/systemd/system/${sharpros_service_name}.service"
+  local sharpros_timer_path="/etc/systemd/system/${sharpros_service_name}.timer"
+  local sharpros_needs_install=false
+
+  if [[ -f "${sharpros_service_template}" && -f "${sharpros_timer_template}" ]]; then
+    if sudo -n "${SYSTEMCTL_BIN}" cat "${sharpros_service_name}.timer" >/dev/null 2>&1; then
+      if [[ "${force_install_on}" == "true" ]]; then
+        log "FORCE_SERVICE_INSTALL enabled; rewriting ${sharpros_service_path} + timer."
+        sharpros_needs_install=true
+      else
+        log "Sharp-rosters timer already installed; skipping."
+      fi
+    else
+      log "Installing Sharp roster collection service + timer."
+      sharpros_needs_install=true
+    fi
+
+    if [[ "${sharpros_needs_install}" == "true" ]]; then
+      local tmp_sharpros_service tmp_sharpros_timer
+      tmp_sharpros_service="$(mktemp)"
+      tmp_sharpros_timer="$(mktemp)"
+      sed \
+        -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
+        -e "s/__APP_USER__/$(escape_sed_replacement "${APP_USER}")/g" \
+        -e "s/__APP_DIR__/$(escape_sed_replacement "${APP_DIR}")/g" \
+        -e "s/__VENV_DIR__/$(escape_sed_replacement "${VENV_DIR}")/g" \
+        "${sharpros_service_template}" > "${tmp_sharpros_service}"
+      sed \
+        -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
+        "${sharpros_timer_template}" > "${tmp_sharpros_timer}"
+      sudo -n "${INSTALL_BIN}" -m 0644 "${tmp_sharpros_service}" "${sharpros_service_path}"
+      sudo -n "${INSTALL_BIN}" -m 0644 "${tmp_sharpros_timer}" "${sharpros_timer_path}"
+      rm -f "${tmp_sharpros_service}" "${tmp_sharpros_timer}"
+      log "Installed ${sharpros_service_name}.service + .timer"
+    fi
+  fi
+
+
   # ── FFPC public Sharp ingestion timer ───────────────────────────────
   local ffpc_service_template="${APP_DIR}/deploy/systemd/dynasty-ffpc-sharp.service.template"
   local ffpc_timer_template="${APP_DIR}/deploy/systemd/dynasty-ffpc-sharp.timer.template"
@@ -875,6 +925,15 @@ main() {
     log "Enabled ${sharprec_service_name}.timer"
     sudo -n "${SYSTEMCTL_BIN}" start --no-block "${sharprec_service_name}.service" || \
       log "Note: initial sharp-records crawl could not be started; the timer will cover it."
+  fi
+  if [[ -f "${sharpros_service_template}" && -f "${sharpros_timer_template}" ]]; then
+    # --now arms the daily timer. No initial kick: this pass collects
+    # for the cohort that discovery and records produce, and on a fresh
+    # deploy those two have not finished yet — an immediate run would
+    # collect for an empty cohort and log a misleading zero. The 30-min
+    # OnActiveSec in the timer covers deploy day.
+    sudo -n "${SYSTEMCTL_BIN}" enable --now "${sharpros_service_name}.timer"
+    log "Enabled ${sharpros_service_name}.timer"
   fi
   if [[ "${ffpc_enabled}" == "true" && -f "${ffpc_service_template}" && -f "${ffpc_timer_template}" ]]; then
     sudo -n "${SYSTEMCTL_BIN}" enable --now "${ffpc_service_name}.timer"

--- a/deploy/systemd/dynasty-sharp-rosters.service.template
+++ b/deploy/systemd/dynasty-sharp-rosters.service.template
@@ -1,0 +1,55 @@
+[Unit]
+Description=Dynasty Trade Calculator Sharp roster collection (__SERVICE_NAME__)
+After=network-online.target
+Wants=network-online.target
+
+# The THIRD Sharp Tracker pass.  Discovery finds MANAGERS, the records
+# crawl finds their RESULTS — this finds what they currently OWN, which
+# is what /market/sharp-roster-percentage is made of.  Without it that
+# page reports "cohort_building" and an empty board, exactly as the
+# Buy/Sell Tracker does before a records crawl.
+#
+# THE COHORT IS NOT RE-DERIVED HERE.  The manager pool comes from
+# src/sharp/cohort.py::cohort_members — the same call the Buy/Sell
+# Tracker makes — so this crawl can never collect for a different set
+# of managers than the boards display.
+#
+# Cost: 2 Sleeper calls per LEAGUE (/league/{id} for format + status,
+# /league/{id}/rosters for the holdings), regardless of how many cohort
+# members play in it.  A league shared by five sharps costs two calls,
+# not ten.  FFPC costs ZERO calls: its roster contents already arrive
+# with the public-page crawl and are only lifted into the queryable
+# store here.
+#
+# IDEMPOTENT.  Rosters upsert on roster_key and holdings upsert on
+# (roster_key, canonical_asset_id), so a re-run overwrites rather than
+# inflating any count.  Re-running after a partial pass is safe and is
+# the intended way to work through a large graph.
+#
+# WHY A PROD-SIDE TIMER AND NOT CI: writes the SQLite ledger under
+# data/intel/, which is gitignored, so a crawl on a CI runner never
+# reaches the VPS.  Same reasoning as discovery, records, BDVM and
+# playerctx.
+#
+# Exit codes (scripts/crawl_sharp_rosters.py):
+#   0 - completed within budget
+#   1 - hard failure; the store is unchanged
+#   2 - budget exhausted with leagues remaining (NORMAL on a large graph)
+# SuccessExitStatus keeps 2 out of the failure counters.
+
+[Service]
+Type=oneshot
+User=__APP_USER__
+Group=__APP_USER__
+WorkingDirectory=__APP_DIR__
+EnvironmentFile=-__APP_DIR__/.env
+ExecStart=__VENV_DIR__/bin/python __APP_DIR__/scripts/crawl_sharp_rosters.py --budget 3000
+SuccessExitStatus=0 2
+StandardOutput=journal
+StandardError=journal
+Nice=10
+IOSchedulingClass=idle
+TimeoutStartSec=3600
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/dynasty-sharp-rosters.timer.template
+++ b/deploy/systemd/dynasty-sharp-rosters.timer.template
@@ -1,0 +1,37 @@
+[Unit]
+Description=Daily Sharp roster collection for __SERVICE_NAME__
+# No Requires= on the service: [Timer] Unit= already binds it, and a
+# [Unit] Requires= would start the service on every boot regardless of
+# OnCalendar and let a service failure stop the timer itself.
+# Persistent=true is the intended catch-up for missed runs.
+
+[Timer]
+# Daily at 05:50 UTC — AFTER discovery (04:20) and records (04:50),
+# because the cohort this pass collects for is produced by those two.
+# Running it first would collect rosters for yesterday's cohort.
+#
+# It also runs 30 minutes BEFORE the FFPC crawl at 06:20 rather than
+# after, and that ordering is deliberate: the FFPC half of this pass
+# reads roster contents the FFPC crawl has already stored, so it wants
+# the PREVIOUS day's FFPC data either way, and running before keeps
+# the Sleeper half — the half that actually spends API budget — off the
+# same minute as another crawl.
+#
+# DAILY IS THE MINIMUM USEFUL CADENCE, not a conservative choice.  The
+# board publishes 7-day and 30-day roster-percentage trends computed
+# from stored observations, and a trend can only resolve to the
+# granularity at which rosters were observed.  A weekly timer would
+# make the 7-day column a single-interval comparison.
+#
+# Also run once 30 minutes after the timer is first activated, so
+# enabling it just after 05:50 UTC does not leave the board empty until
+# the following day.
+OnActiveSec=30min
+OnCalendar=*-*-* 05:50:00 UTC
+RandomizedDelaySec=900
+Persistent=true
+AccuracySec=2min
+Unit=__SERVICE_NAME__-sharp-rosters.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/sharp-roster-percentage/METHODOLOGY.md
+++ b/docs/sharp-roster-percentage/METHODOLOGY.md
@@ -179,6 +179,44 @@ These are real and are not worked around.
    discovery ever captures `roster_positions`, this pass halves its
    cost.
 
+## Coverage is bounded by what discovery has recorded
+
+The collector asks `platform_memberships` which leagues each cohort
+member plays in. Discovery used to write a membership row **only when it
+expanded a league** (`/league/{id}/users`); the user→leagues branch
+queued the league but recorded no membership. Leagues left on the
+frontier by the call budget, `maxGenerations` or `maxLeaguesPerRun`
+therefore had none, and were invisible here — a sharp with four dynasty
+teams could contribute one roster to the denominator and still read as
+fully represented, because `cohortCoveragePct` counts *managers* seen,
+not their leagues.
+
+Discovery now records the membership at user-expansion time too. Sleeper's
+own `/user/{id}/leagues` proves it, so the row is a fact rather than an
+inference, and the PK makes it idempotent.
+
+**The remaining bound is real and worth watching:** a manager whose
+leagues discovery has not yet reached at all still contributes fewer
+rosters than they own. `transparency.rostersPerManager` is the honest
+readout — if it sits near 1.0 while sharps typically run several dynasty
+teams, discovery has not caught up, not that sharps own one team each.
+
+## Budget behaviour
+
+The collection order is `record_queue.prioritize_league_ids` — the same
+fair, persistent ordering the records crawl uses: never-collected
+leagues first, then previously collected ones oldest-first. Before this,
+the pass sorted by league id, so a run that hit its call budget
+re-collected the same alphabetical prefix on every subsequent run and
+the leagues after the cutoff were **never** collected. That is not a
+slow rollout, it is a permanently invisible tail, and it was silent —
+the board looked healthy while systematically omitting part of the
+cohort.
+
+Every run reports `leaguesRemaining`, so `--budget` can be sized from
+the journal rather than guessed. A run ending at 0 is keeping up; a
+stable non-zero number wants a bigger budget rather than patience.
+
 ## Auditing
 
 `scripts/validate_sharp_roster_percentage.py` re-derives every published

--- a/docs/sharp-roster-percentage/METHODOLOGY.md
+++ b/docs/sharp-roster-percentage/METHODOLOGY.md
@@ -1,0 +1,203 @@
+# Sharp Roster Percentage — methodology
+
+**Status:** shipped. No feature flag — it adds a route and a page and
+touches no existing output. It is empty until
+`scripts/crawl_sharp_rosters.py` has run, and says so rather than
+erroring.
+
+```
+Sharp Roster Percentage
+  = unique ELIGIBLE sharp rosters containing the player
+  ÷ eligible sharp rosters whose league can field his position
+```
+
+## The pool is the Buy/Sell Tracker's pool
+
+`src/sharp/cohort.py::cohort_members` is the single definition of "who
+is a sharp". The Sharp Buy/Sell Tracker (`src/sharp/market.py`), this
+board (`src/sharp/roster_percentage.py`), the roster collector
+(`src/sharp/roster_collect.py`) and the activity crawl
+(`scripts/crawl_sharp_activity.py`) all call it. There is no second
+list, and a change to qualification moves every one of them in the same
+deploy.
+
+Those definitions used to live inside `market.py`. Extracting them was
+the first commit of this feature, specifically so the obvious way to
+build a second sharp surface would not be to import a transactions board
+to get a manager pool — or, worse, to re-derive one.
+`market.py` re-exports every name, so `sharp_market.cohort_members`
+still resolves for existing callers and tests.
+
+`tests/sharp/test_roster_percentage.py::test_both_boards_resolve_the_pool_through_the_same_function`
+pins the identity, and a companion test greps this module for
+qualification vocabulary (`score_managers`, `minScorePercentile`,
+`ManagerRecord`) so a fork announces itself.
+
+Qualification itself is unchanged and is documented where it lives:
+league gates in `src/intel/league_filter.py` (dynasty only, ≥ 2
+seasons), manager gates and scoring in `src/sharp/score.py` +
+`config/sharp/scoring_v2.json`.
+
+## Rosters are the denominator, people are not
+
+A sharp with five legitimate dynasty teams contributes **five roster
+observations**; a sharp with one contributes one. That is the product
+definition — the question is what share of sharp *rosters* hold a
+player — and it is also the only version that can be checked against
+anything.
+
+Both numbers ship. `transparency.eligibleRosters` counts rosters;
+`transparency.uniqueSharpManagers` collapses linked accounts to humans
+through `cohort.canonical_manager_ids`, which reads the verified
+`manager_identity_links` table. An unlinked account maps to itself
+rather than being dropped — an unproven link is not a merge.
+
+## The denominator is per player
+
+A linebacker cannot be rostered in a league with no IDP slots; a kicker
+cannot be rostered in a league with no K slot. Dividing every player by
+every sharp roster would report ~20% for an IDP who is owned in *every*
+league that can roster him, and the number would be an artifact of the
+cohort's format mix rather than a fact about the player.
+
+Each player is therefore measured against the rosters whose league is
+known to field his position family (`_denominators`,
+`_roster_supports_family`). Three consequences worth knowing:
+
+* **A holding roster is always inside its own denominator.** A roster
+  that demonstrably holds an IDP proves its league fields IDP, whatever
+  the format capture says. Without this rule an unknown-format roster
+  could contribute a numerator it was excluded from counting against,
+  and a percentage could exceed 100%.
+* **Unknown formats are excluded, not assumed.** They are reported in
+  `dataQuality.formatUnknownRosters`.
+* **`eligibleRosters` is published per row**, because it differs
+  between rows on the same board.
+
+## Deduplication is structural
+
+Every counting rule is a primary key in `src/sharp/roster_store.py`, not
+a filter a caller could forget:
+
+| Hazard | Mechanism |
+|---|---|
+| Same roster collected twice, duplicate import, re-snapshot | `sharp_rosters` PK `roster_key` = `"<league_key>#<source_roster_id>"`, upsert in place |
+| A player counted twice on one roster | `sharp_roster_assets` PK `(roster_key, canonical_asset_id)` |
+| Two sharps in one league | Both resolve to the same `league_key`; each roster is its own `roster_key`, and the league is fetched once |
+| Taxi/IR double count | Sleeper's `players` array already contains taxi and reserve ids; those arrays are read only to *label*, never as extra populations |
+| **Season chain** — one dynasty league under a new `league_id` each year | `_collapse_season_chains` marks predecessors `superseded_by_later_season` using `previous_league_id`, which rides free in the payload already fetched |
+| One manager qualifying by two methods | `_QUALIFICATION_PRIORITY` dedup inside `cohort_members` |
+| Unresolvable player names | `AssetResolver` has no fuzzy fallback; unmapped assets are counted, never guessed onto a similar name |
+
+Nothing is silently discarded. An excluded roster stays a row with its
+reasons attached (`exclusion_reasons_json`), surfaced at
+`exclusions.byReason` and in the page's collapsed panel, so "why is the
+denominator smaller than the cohort" always has an answer.
+
+## Trends compare like populations
+
+History is stored as **open intervals** (`sharp_roster_asset_spans`),
+not daily copies — dynasty turnover is low, so this is a few rows per
+holding instead of one row per holding per day.
+
+A holding covers an instant when it had started by then and had not yet
+been *contradicted* (`closed_at_ms > as_of`), **not** when the last
+confirming observation was after it. The distinction is load-bearing:
+rosters are observed periodically, so a roster seen on day 0 and day 40
+has no confirmation at day 10 — yet the player was rostered then,
+because nothing had said otherwise. Reading the confirming timestamp
+instead silently zeroes every drop that happened between two crawls,
+which surfaces as a 30-day trend of exactly 0.0 regardless of what
+moved. Pinned by
+`test_roster_store.py::test_a_holding_persists_until_the_observation_that_contradicts_it`.
+
+Deltas are measured over the **intersection** of the two roster
+populations, and withheld entirely below 80% overlap
+(`MIN_TREND_POPULATION_OVERLAP`) with `reason:
+"roster_population_changed"`. A cohort that grew between the endpoints
+must never read as players gaining ownership. "No change" and "not
+comparable" render differently.
+
+Rosters not yet observed at the baseline are **absent** from it, not
+present-and-empty — present-and-empty would turn every later discovery
+into a fake ownership gain.
+
+## Sample-size policy
+
+| Eligible rosters | Behaviour |
+|---|---|
+| < 8 | Published with an explicit "below the minimum, not ranked as meaningful" banner |
+| 8–39 | Published with "Treat this result as directional because of the limited sample size" |
+| ≥ 40 | No banner |
+
+Per-row, a player measured against fewer than 5 rosters is flagged
+individually (the IDP-in-a-mostly-offense-cohort case) and marked `*`
+in the table. Every row publishes its own `sharpRosters` /
+`eligibleRosters`, so no percentage appears without its sample.
+
+## Known limitations
+
+These are real and are not worked around.
+
+1. **There is no general-dynasty roster-percentage feed.** Every ranking
+   source this platform ingests publishes values or ranks; Sleeper's
+   trending endpoint publishes 24-hour *add counts*, a flow rather than
+   a stock. So `marketRosterPct` and `sharpRosterAdvantage` are `null`,
+   `marketComparison.available` is `false`, and the page says why.
+   `set_market_ownership_provider` is the registration seam for a real
+   feed; it is deliberately unregistered rather than fed an estimate.
+   **The "sharp vs market" sorts exist and work, but rank nothing until
+   a provider is registered.**
+2. **FFPC contributes zero rosters today.** The parser
+   (`FFPCParser._parse_rosters`) is correct and test-pinned, but all ten
+   configured seeds in `config/sharp/ffpc_sources.json` are
+   `LeagueHome.aspx` pages, which yield transactions and standings — no
+   roster table. `collect_ffpc_rosters` lifts
+   `platform_memberships.metadata_json["rosterAssets"]` and that column
+   is empty for every FFPC row. The FFPC half activates the moment a
+   roster-bearing URL is configured; no code change is needed.
+3. **FFPC publishes no taxi/IR marking**, so FFPC assets are stored
+   `active`. That is the absence of a distinction, not a claim that none
+   are on taxi.
+4. **Trends need two collection passes.** The span table starts
+   accumulating at first crawl, so every trend reports
+   `available: false` until a second run exists. This is why the timer
+   is daily rather than weekly — a 7-day column cannot resolve finer
+   than the observation cadence.
+5. **Contending/rebuilding is derived from the current season's W/L**,
+   which rides free in the `/rosters` payload. Before four games are
+   played it answers `unknown` rather than defaulting a whole preseason
+   board into one bucket. It is deliberately *not* the BDVM
+   contend/retool/rebuild classifier (`src/bdvm/roster.py`), which needs
+   projections and a league config we do not have for arbitrary
+   discovered leagues.
+6. **League age is a floor, not an exact value** — inherited from
+   `league_filter.league_age_seasons`, which reports 2 for any chained
+   league because establishing more costs one request per link.
+7. **Sleeper league format is fetched per collection run**, not stored
+   by discovery. That is the second of the two calls per league. If
+   discovery ever captures `roster_positions`, this pass halves its
+   cost.
+
+## Auditing
+
+`scripts/validate_sharp_roster_percentage.py` re-derives every published
+number from the raw stored rows using code that shares nothing with the
+engine, then diffs. Ten checks, one per audit-list item: numerator,
+one-observation-per-roster, denominator, arithmetic bounds, duplicate
+rosters, duplicate identity attribution, asset mapping, excluded rosters
+never reaching a numerator, filters moving both sides, and agreement
+with the Buy/Sell Tracker's own payload.
+
+`GET /api/sharp/roster-percentage/audit?assetId=…` lists every roster
+behind one player's count, so a published number is checkable without
+database access.
+
+## Not a buy signal
+
+A high roster percentage is mostly a restatement of consensus value —
+elite players are rostered almost everywhere. Ownership is also shaped
+by league depth, format, acquisition cost, age and positional scarcity.
+The informative columns are the comparison ones: advantage over the
+market (when a feed exists) and the trend. The page carries this caveat
+in the UI, not only here.

--- a/frontend/__tests__/components/sharp-roster-percentage-page.test.jsx
+++ b/frontend/__tests__/components/sharp-roster-percentage-page.test.jsx
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SharpRosterPercentagePage from "@/app/market/sharp-roster-percentage/page";
+
+function jsonResponse(status, body) {
+  return { ok: status >= 200 && status < 300, status, json: async () => body };
+}
+
+const PLAYER = {
+  assetId: "4046",
+  rank: 1,
+  displayName: "Justin Jefferson",
+  position: "WR",
+  nflTeam: "MIN",
+  sharpRosters: 44,
+  eligibleRosters: 48,
+  sharpRosterPct: 0.9167,
+  marketRosterPct: null,
+  sharpRosterAdvantage: null,
+  value: 9500,
+  overallRank: 2,
+  slots: { active: 44 },
+  buySell: { signal: "distributing", buys: 1, sells: 6, net: -5, window: "30d" },
+  sampleWarning: null,
+  trend: {
+    sevenDay: { available: true, rosterPctChange: 0.02, rostersAdded: 1, rostersDropped: 0 },
+    thirtyDay: { available: true, rosterPctChange: -0.05, rostersAdded: 0, rostersDropped: 2 },
+    seasonToDate: { available: false, reason: "roster_population_changed", comparableRosters: 3 },
+  },
+};
+
+const BOARD = {
+  status: "ok",
+  generatedAt: 1_800_000_000_000,
+  lastUpdated: 1_800_000_000_000,
+  players: [PLAYER],
+  totalQualifyingPlayers: 1,
+  transparency: {
+    uniqueSharpManagers: 40,
+    eligibleRosters: 48,
+    sleeperRosters: 48,
+    ffpcRosters: 0,
+    otherPlatformRosters: 0,
+    cohortManagers: 50,
+    cohortManagersRepresented: 40,
+    cohortCoveragePct: 0.8,
+    lastRefreshedMs: 1_800_000_000_000,
+  },
+  cohort: { selectedManagers: 50 },
+  sample: { eligibleRosters: 48, rankable: true, warning: null },
+  marketComparison: { available: false, source: null, note: "No general-dynasty feed is ingested." },
+  exclusions: { byReason: { stale_roster_data: 3 }, excludedRosters: 3 },
+  dataQuality: { playersWithoutBoardValue: 0 },
+};
+
+function mockFetch(board = BOARD) {
+  return vi.fn(async () => jsonResponse(200, board));
+}
+
+beforeEach(() => {
+  global.fetch = mockFetch();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Sharp Roster Percentage page", () => {
+  it("renders the canonical title", async () => {
+    render(<SharpRosterPercentagePage />);
+    const heading = await screen.findByRole("heading", { name: "Sharp Roster Percentage", level: 1 });
+    expect(heading).toBeInTheDocument();
+  });
+
+  it("shows the percentage alongside the sample that produced it", async () => {
+    render(<SharpRosterPercentagePage />);
+    expect(await screen.findByText("91.7%")).toBeInTheDocument();
+    expect(screen.getByText("44 of 48")).toBeInTheDocument();
+  });
+
+  it("surfaces the transparency disclosures", async () => {
+    render(<SharpRosterPercentagePage />);
+    expect(await screen.findByText("Sharp managers")).toBeInTheDocument();
+    expect(screen.getByText("Eligible rosters")).toBeInTheDocument();
+    expect(screen.getByText("Sleeper rosters")).toBeInTheDocument();
+    expect(screen.getByText("FFPC rosters")).toBeInTheDocument();
+    expect(screen.getByText("Cohort represented")).toBeInTheDocument();
+    expect(screen.getByText("80%")).toBeInTheDocument();
+  });
+
+  it("explains that no market comparison exists rather than showing a zero", async () => {
+    render(<SharpRosterPercentagePage />);
+    expect(await screen.findByText(/No general-dynasty feed is ingested/)).toBeInTheDocument();
+  });
+
+  it("shows a widely-rostered player that sharps are selling", async () => {
+    // The whole point of joining the two boards: high ownership and
+    // active distribution tell different stories.
+    render(<SharpRosterPercentagePage />);
+    expect(await screen.findByText("Selling")).toBeInTheDocument();
+  });
+
+  it("warns explicitly when the sample is small", async () => {
+    global.fetch = mockFetch({
+      ...BOARD,
+      sample: {
+        eligibleRosters: 14,
+        rankable: true,
+        warning: {
+          level: "directional",
+          message:
+            "Based on 14 eligible sharp rosters. Treat this result as directional because of the limited sample size.",
+        },
+      },
+    });
+    render(<SharpRosterPercentagePage />);
+    expect(
+      await screen.findByText(/Based on 14 eligible sharp rosters\. Treat this result as directional/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the not-collected-yet state as an explanation, not an error", async () => {
+    global.fetch = mockFetch({
+      ...BOARD,
+      status: "cohort_building",
+      players: [],
+      totalQualifyingPlayers: 0,
+    });
+    render(<SharpRosterPercentagePage />);
+    expect(await screen.findByText("Collecting sharp rosters")).toBeInTheDocument();
+  });
+
+  it("lists excluded rosters with their reasons", async () => {
+    render(<SharpRosterPercentagePage />);
+    expect(await screen.findByText("Excluded rosters")).toBeInTheDocument();
+  });
+
+  it("refetches with the chosen filter when one changes", async () => {
+    const user = userEvent.setup();
+    render(<SharpRosterPercentagePage />);
+    await screen.findByText("91.7%");
+
+    const positionSelect = screen.getByLabelText(/Position/i);
+    await user.selectOptions(positionSelect, "LB");
+
+    await waitFor(() => {
+      const urls = global.fetch.mock.calls.map(([url]) => String(url));
+      expect(urls.some((u) => u.includes("position=LB"))).toBe(true);
+    });
+  });
+
+  it("requests the top 50 by default", async () => {
+    render(<SharpRosterPercentagePage />);
+    await waitFor(() => {
+      const urls = global.fetch.mock.calls.map(([url]) => String(url));
+      expect(urls.some((u) => u.includes("limit=50"))).toBe(true);
+    });
+  });
+
+  it("offers every documented list size and alternate view", async () => {
+    render(<SharpRosterPercentagePage />);
+    const show = await screen.findByLabelText(/Show/i);
+    expect([...show.options].map((o) => o.value)).toEqual(["25", "50", "100", "0"]);
+
+    const sort = screen.getByLabelText(/Sort by/i);
+    expect([...sort.options].map((o) => o.value)).toEqual([
+      "rostered",
+      "advantage",
+      "negativeAdvantage",
+      "valueWithoutRosters",
+      "rosteredWithoutValue",
+      "trend",
+    ]);
+  });
+
+  it("carries the caveat that ownership is not a buy signal", async () => {
+    render(<SharpRosterPercentagePage />);
+    expect(
+      await screen.findByText(/A high roster percentage is not a buy signal on its own/),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/helpers/naming-canon.js
+++ b/frontend/__tests__/helpers/naming-canon.js
@@ -59,6 +59,10 @@ export const CANON = {
   // NAME on Insider Trading's COHORT; the split gives each its own
   // route, and Sharp Tracker is deliberately not league-scoped.
   "/market/sharp-tracker": "Sharp Tracker",
+  // Same cohort as Sharp Tracker; the name says what it measures
+  // (ownership) rather than repeating "Sharp Tracker" with a suffix,
+  // which would make the two read as one feature split in half.
+  "/market/sharp-roster-percentage": "Sharp Roster Percentage",
   "/league/insider-trading": "Insider Trading",
   "/league": "Hub",
   "/league/activity": "Activity",

--- a/frontend/__tests__/nav-model.test.js
+++ b/frontend/__tests__/nav-model.test.js
@@ -41,6 +41,7 @@ const ROUTES_THAT_MUST_BE_REACHABLE = [
   "/edge",
   "/bdvm",
   "/market/sharp-tracker",
+  "/market/sharp-roster-percentage",
   "/idptc-rookies",
   "/league",
   "/league/activity",

--- a/frontend/__tests__/sharp-roster-percentage-lib.test.js
+++ b/frontend/__tests__/sharp-roster-percentage-lib.test.js
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  buildExclusionRows,
+  buildTransparencyTiles,
+  classifyEmptyState,
+  describeBuySell,
+  describeTrend,
+  formatCount,
+  formatDelta,
+  formatPct,
+  formatSample,
+  formatTimestamp,
+} from "@/lib/sharp-roster-percentage";
+
+describe("formatting", () => {
+  it("renders a percentage and an em dash for nothing", () => {
+    expect(formatPct(0.5)).toBe("50.0%");
+    expect(formatPct(1)).toBe("100.0%");
+    expect(formatPct(null)).toBe("—");
+    expect(formatPct(undefined)).toBe("—");
+    expect(formatPct(Number.NaN)).toBe("—");
+  });
+
+  it("signs a percentage-point delta", () => {
+    expect(formatDelta(0.333)).toBe("+33.3 pp");
+    expect(formatDelta(-0.1)).toBe("-10.0 pp");
+    expect(formatDelta(0)).toBe("0.0 pp");
+    expect(formatDelta(null)).toBe("—");
+  });
+
+  it("always shows the sample behind a cell", () => {
+    expect(formatSample({ sharpRosters: 3, eligibleRosters: 12 })).toBe("3 of 12");
+    expect(formatSample(null)).toBe("—");
+  });
+
+  it("does not render a missing count as zero", () => {
+    expect(formatCount(0)).toBe("0");
+    expect(formatCount(null)).toBe("—");
+    expect(formatTimestamp(null)).toBe("—");
+    expect(formatTimestamp(0)).toBe("—");
+  });
+});
+
+describe("describeTrend", () => {
+  it("reports a change when the populations are comparable", () => {
+    const trend = describeTrend(
+      { thirtyDay: { available: true, rosterPctChange: 0.25, rostersAdded: 3, rostersDropped: 0 } },
+      "thirtyDay",
+    );
+    expect(trend.available).toBe(true);
+    expect(trend.label).toBe("+25.0 pp");
+    expect(trend.tone).toBe("positive");
+  });
+
+  it("distinguishes 'not comparable' from 'no change'", () => {
+    const withheld = describeTrend(
+      {
+        thirtyDay: {
+          available: false,
+          reason: "roster_population_changed",
+          comparableRosters: 4,
+        },
+      },
+      "thirtyDay",
+    );
+    expect(withheld.available).toBe(false);
+    expect(withheld.label).toBe("n/a");
+    expect(withheld.reason).toMatch(/Sample changed too much/);
+
+    const flat = describeTrend({ thirtyDay: { available: true, rosterPctChange: 0 } }, "thirtyDay");
+    expect(flat.available).toBe(true);
+    expect(flat.label).toBe("0.0 pp");
+    expect(flat.label).not.toBe(withheld.label);
+  });
+
+  it("returns an em dash when the period is absent entirely", () => {
+    expect(describeTrend(undefined, "sevenDay").label).toBe("—");
+  });
+});
+
+describe("describeBuySell", () => {
+  it("reads accumulation and distribution as observations", () => {
+    const buying = describeBuySell({ signal: "accumulating", buys: 4, sells: 1, net: 3, window: "30d" });
+    expect(buying.label).toBe("Buying");
+    expect(buying.tone).toBe("positive");
+    expect(buying.detail).toBe("4 buys / 1 sell (net +3, 30d)");
+
+    const selling = describeBuySell({ signal: "distributing", buys: 0, sells: 5, net: -5, window: "30d" });
+    expect(selling.label).toBe("Selling");
+    expect(selling.tone).toBe("negative");
+  });
+
+  it("shows nothing for a player with no recent sharp activity", () => {
+    expect(describeBuySell({ signal: "none" }).label).toBe("—");
+    expect(describeBuySell(null).label).toBe("—");
+  });
+});
+
+describe("transparency", () => {
+  it("surfaces every required disclosure", () => {
+    const tiles = buildTransparencyTiles({
+      transparency: {
+        uniqueSharpManagers: 40,
+        eligibleRosters: 96,
+        sleeperRosters: 80,
+        ffpcRosters: 16,
+        otherPlatformRosters: 0,
+        cohortManagers: 50,
+        cohortManagersRepresented: 40,
+        cohortCoveragePct: 0.8,
+        lastRefreshedMs: 1_700_000_000_000,
+      },
+    });
+    const byKey = Object.fromEntries(tiles.map((t) => [t.key, t]));
+    expect(byKey.managers.value).toBe("40");
+    expect(byKey.rosters.value).toBe("96");
+    expect(byKey.sleeper.value).toBe("80");
+    expect(byKey.ffpc.value).toBe("16");
+    expect(byKey.other.value).toBe("0");
+    expect(byKey.coverage.value).toBe("80%");
+    expect(byKey.coverage.note).toBe("40 of 50");
+    expect(byKey.refreshed.value).not.toBe("—");
+  });
+
+  it("degrades to em dashes rather than zeros on an empty payload", () => {
+    const tiles = buildTransparencyTiles(null);
+    expect(tiles.every((t) => t.value === "—")).toBe(true);
+  });
+});
+
+describe("empty states", () => {
+  it("says 'not collected yet' rather than 'error'", () => {
+    const building = classifyEmptyState({ status: "cohort_building" });
+    expect(building.title).toBe("Collecting sharp rosters");
+    expect(building.detail).toMatch(/have not been collected yet/);
+  });
+
+  it("distinguishes no-eligible-rosters from no-filter-matches", () => {
+    expect(classifyEmptyState({ status: "no_eligible_rosters" }).title).toBe("No eligible rosters");
+    expect(classifyEmptyState({ status: "ok" }).title).toBe("No players match these filters");
+  });
+});
+
+describe("exclusions", () => {
+  it("humanises reasons and orders by weight", () => {
+    const rows = buildExclusionRows({
+      exclusions: { byReason: { stale_roster_data: 2, incompatible_league_format: 7 } },
+    });
+    expect(rows[0]).toMatchObject({ reason: "incompatible_league_format", count: 7 });
+    expect(rows[0].label).toBe("Incompatible league format");
+    expect(rows[1].label).toBe("Stale roster data");
+  });
+});
+
+describe("the library derives no numbers of its own", () => {
+  // The denominator rule is per-player and lives in the backend. A
+  // client-side percentage would agree today and be wrong the moment
+  // that rule changes, so the materializer must not contain one.
+  // Comments are stripped first: the module's own docstring explains
+  // the rule it must not implement, and a naive text search would
+  // match the explanation rather than any code.
+  const source = fs
+    .readFileSync(path.join(process.cwd(), "lib/sharp-roster-percentage.js"), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+
+  it("never divides sharpRosters by eligibleRosters", () => {
+    expect(source).not.toMatch(/sharpRosters\s*\/\s*/);
+    expect(source).not.toMatch(/\/\s*eligibleRosters/);
+    expect(source).not.toMatch(/sharpRosterPct\s*=/);
+  });
+
+  it("never sorts or re-ranks the board", () => {
+    expect(source).not.toMatch(/\.sort\(\s*\(a,\s*b\)\s*=>\s*b\.sharpRosterPct/);
+  });
+});

--- a/frontend/app/api/sharp/roster-percentage/audit/route.js
+++ b/frontend/app/api/sharp/roster-percentage/audit/route.js
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { proxyGet } from "@/lib/backend-proxy";
+
+// Dev-flow bridge only. Mirrors /api/sharp/market/audit: one asset's
+// full evidence, for checking a published number against the rosters
+// it came from.
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const NO_STORE_HEADERS = {
+  "Cache-Control": "private, no-store, no-cache, max-age=0, must-revalidate",
+  Pragma: "no-cache",
+};
+
+export async function GET(request) {
+  const incoming = new URL(request.url).searchParams;
+  const searchParams = Object.fromEntries(incoming.entries());
+  try {
+    const { data, status } = await proxyGet("/api/sharp/roster-percentage/audit", {
+      timeoutMs: 20000,
+      searchParams,
+    });
+    return NextResponse.json(data, { status, headers: NO_STORE_HEADERS });
+  } catch (err) {
+    return NextResponse.json(
+      { error: "sharp_roster_percentage_unavailable", detail: err?.message },
+      { status: 503, headers: NO_STORE_HEADERS },
+    );
+  }
+}

--- a/frontend/app/api/sharp/roster-percentage/route.js
+++ b/frontend/app/api/sharp/roster-percentage/route.js
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { proxyGet } from "@/lib/backend-proxy";
+
+// Dev-flow bridge only — in production nginx routes /api/* straight to
+// FastAPI.  Deliberately forwards NO leagueKey, for the same reason
+// /api/sharp/cohort does not: the sharp cohort is a global signal, and
+// scoping it to the caller's league would answer a different question
+// than the one this board asks.
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const NO_STORE_HEADERS = {
+  "Cache-Control": "private, no-store, no-cache, max-age=0, must-revalidate",
+  Pragma: "no-cache",
+};
+
+export async function GET(request) {
+  const incoming = new URL(request.url).searchParams;
+  const searchParams = Object.fromEntries(incoming.entries());
+  try {
+    const { data, status } = await proxyGet("/api/sharp/roster-percentage", {
+      timeoutMs: 20000,
+      searchParams,
+    });
+    return NextResponse.json(data, { status, headers: NO_STORE_HEADERS });
+  } catch (err) {
+    return NextResponse.json(
+      { error: "sharp_roster_percentage_unavailable", detail: err?.message },
+      { status: 503, headers: NO_STORE_HEADERS },
+    );
+  }
+}

--- a/frontend/app/market/sharp-roster-percentage/page.jsx
+++ b/frontend/app/market/sharp-roster-percentage/page.jsx
@@ -1,0 +1,444 @@
+"use client";
+
+/**
+ * Sharp Roster Percentage — which players the sharp cohort actually owns.
+ *
+ * Sibling of /market/sharp-tracker, and deliberately so: both boards
+ * read the SAME cohort (`src/sharp/cohort.py::cohort_members`), so the
+ * two answer different questions about one population rather than
+ * describing two populations that happen to share a name. That is why
+ * this page carries a Buy/Sell column — a player who is widely rostered
+ * AND being sold tells a different story from one whose ownership is
+ * climbing, and the join is the point.
+ *
+ * Everything numeric here is backend-computed. `lib/sharp-roster-percentage.js`
+ * formats and reshapes; it never divides. The denominator rule is
+ * per-player (a linebacker is measured against IDP leagues only), so a
+ * client-side percentage would be wrong the moment that rule moves.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Banner, DataTable, Panel, PageHeader, Select, StatTile } from "@/components/ds";
+import { LoadingState } from "@/components/ui";
+import { apiErrorMessage } from "@/lib/api-error";
+import {
+  buildExclusionRows,
+  buildTransparencyTiles,
+  classifyEmptyState,
+  describeBuySell,
+  describeTrend,
+  formatCount,
+  formatDelta,
+  formatPct,
+  formatSample,
+  formatTimestamp,
+} from "@/lib/sharp-roster-percentage";
+
+const PAGE_TITLE = "Sharp Roster Percentage";
+
+const POSITIONS = [
+  ["all", "All players"],
+  ["QB", "Quarterbacks"],
+  ["RB", "Running backs"],
+  ["WR", "Wide receivers"],
+  ["TE", "Tight ends"],
+  ["DL", "Defensive line / EDGE"],
+  ["LB", "Linebackers"],
+  ["DB", "Defensive backs"],
+  ["offense", "Offense only"],
+  ["idp", "IDP only"],
+];
+
+const PLATFORMS = [
+  ["all", "All supported platforms"],
+  ["sleeper", "Sleeper only"],
+  ["ffpc", "FFPC only"],
+];
+
+const FORMATS = [
+  ["all", "All formats"],
+  ["superflex", "Superflex leagues"],
+  ["oneQb", "One-quarterback leagues"],
+  ["tePremium", "Tight-end premium"],
+  ["nonTePremium", "Non tight-end premium"],
+];
+
+const CONTENTION = [
+  ["all", "All sharp rosters"],
+  ["contending", "Contending rosters"],
+  ["rebuilding", "Rebuilding rosters"],
+];
+
+const EXPERIENCE = [
+  ["all", "Rookies and veterans"],
+  ["rookies", "Rookies"],
+  ["veterans", "Veterans"],
+];
+
+const SORTS = [
+  ["rostered", "Most rostered by sharps"],
+  ["advantage", "Largest positive sharp advantage"],
+  ["negativeAdvantage", "Largest negative sharp advantage"],
+  ["valueWithoutRosters", "High value, low sharp ownership"],
+  ["rosteredWithoutValue", "Low rank, high sharp ownership"],
+  ["trend", "Rising fastest (30 days)"],
+];
+
+const LIMITS = [
+  ["25", "Top 25"],
+  ["50", "Top 50"],
+  ["100", "Top 100"],
+  ["0", "All qualifying players"],
+];
+
+const AUTO_REFRESH_MS = 300_000;
+const RETRYABLE_STATUSES = new Set([404, 502, 503, 504]);
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Same fetch posture as /market/sharp-tracker: never a cached body, and
+// a bounded retry for the transient 404 a cold backend route can return.
+async function fetchFreshJson(path, params, { attempts = 3 } = {}) {
+  let lastError = null;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const url = new URL(path, window.location.origin);
+    Object.entries(params || {}).forEach(([key, value]) => {
+      if (value != null && value !== "") url.searchParams.set(key, String(value));
+    });
+    url.searchParams.set("_sharpRefresh", String(Date.now()));
+    try {
+      const response = await fetch(url.toString(), {
+        cache: "no-store",
+        credentials: "same-origin",
+        headers: { "Cache-Control": "no-cache, no-store, max-age=0", Pragma: "no-cache" },
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (response.ok) return payload;
+      lastError = new Error(apiErrorMessage(payload, response.status));
+      if (!RETRYABLE_STATUSES.has(response.status) || attempt === attempts) throw lastError;
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(apiErrorMessage(error));
+      if (attempt === attempts) throw lastError;
+    }
+    await sleep(attempt * 750);
+  }
+  throw lastError || new Error("Request failed");
+}
+
+function Dropdown({ label, value, onChange, options }) {
+  return (
+    <label style={{ display: "flex", flexDirection: "column", gap: 4, minWidth: 190 }}>
+      <span className="muted" style={{ fontSize: "0.68rem", textTransform: "uppercase" }}>
+        {label}
+      </span>
+      <Select value={value} onChange={(event) => onChange(event.target.value)}>
+        {options.map(([optionValue, optionLabel]) => (
+          <option key={optionValue} value={optionValue}>
+            {optionLabel}
+          </option>
+        ))}
+      </Select>
+    </label>
+  );
+}
+
+function TrendCell({ row, period }) {
+  const trend = describeTrend(row.trend, period);
+  if (!trend.available) {
+    return (
+      <span className="muted" title={trend.reason || undefined}>
+        {trend.label}
+      </span>
+    );
+  }
+  return (
+    <span
+      title={`${trend.added} roster(s) added, ${trend.dropped} dropped`}
+      style={{
+        color:
+          trend.tone === "positive"
+            ? "var(--positive)"
+            : trend.tone === "negative"
+              ? "var(--negative)"
+              : undefined,
+      }}
+    >
+      {trend.label}
+    </span>
+  );
+}
+
+export default function SharpRosterPercentagePage() {
+  const [payload, setPayload] = useState(null);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [position, setPosition] = useState("all");
+  const [platform, setPlatform] = useState("all");
+  const [format, setFormat] = useState("all");
+  const [contention, setContention] = useState("all");
+  const [experience, setExperience] = useState("all");
+  const [sort, setSort] = useState("rostered");
+  const [limit, setLimit] = useState("50");
+
+  const load = useCallback(async () => {
+    try {
+      const data = await fetchFreshJson("/api/sharp/roster-percentage", {
+        position,
+        platform,
+        format,
+        contention,
+        experience,
+        sort,
+        limit,
+      });
+      setPayload(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [position, platform, format, contention, experience, sort, limit]);
+
+  useEffect(() => {
+    setLoading(true);
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    const timer = setInterval(load, AUTO_REFRESH_MS);
+    return () => clearInterval(timer);
+  }, [load]);
+
+  const rows = payload?.players || [];
+  const tiles = useMemo(() => buildTransparencyTiles(payload), [payload]);
+  const exclusions = useMemo(() => buildExclusionRows(payload), [payload]);
+  const marketAvailable = payload?.marketComparison?.available;
+  const sampleWarning = payload?.sample?.warning;
+
+  const columns = useMemo(() => {
+    const base = [
+      { key: "rank", header: "#", numeric: true, accessor: (row) => row.rank },
+      {
+        key: "displayName",
+        header: "Player",
+        accessor: (row) => row.displayName,
+      },
+      { key: "position", header: "Pos", accessor: (row) => row.position || "—" },
+      { key: "nflTeam", header: "Team", accessor: (row) => row.nflTeam || "—" },
+      {
+        key: "sharpRosterPct",
+        header: "Sharp roster %",
+        numeric: true,
+        headerInfo:
+          "Unique eligible sharp rosters holding the player, divided by the eligible " +
+          "sharp rosters whose league can field his position.",
+        render: (row) => (
+          <span title={row.sampleWarning?.message || undefined}>
+            {formatPct(row.sharpRosterPct)}
+            {row.sampleWarning ? " *" : ""}
+          </span>
+        ),
+        sortAccessor: (row) => row.sharpRosterPct,
+      },
+      {
+        key: "sample",
+        header: "Sample",
+        headerInfo: "Rosters holding the player / eligible rosters in his calculation.",
+        render: (row) => <span className="muted">{formatSample(row)}</span>,
+        sortAccessor: (row) => row.eligibleRosters,
+      },
+      {
+        key: "marketRosterPct",
+        header: "Dynasty roster %",
+        numeric: true,
+        headerInfo: marketAvailable
+          ? "General dynasty roster percentage, for comparison."
+          : "No general-dynasty ownership feed is ingested, so this is unavailable.",
+        render: (row) => formatPct(row.marketRosterPct),
+        sortAccessor: (row) => row.marketRosterPct ?? -1,
+      },
+      {
+        key: "sharpRosterAdvantage",
+        header: "Sharp advantage",
+        numeric: true,
+        headerInfo: "Sharp roster % minus general dynasty roster %.",
+        render: (row) => formatDelta(row.sharpRosterAdvantage),
+        sortAccessor: (row) => row.sharpRosterAdvantage ?? -Infinity,
+      },
+      {
+        key: "value",
+        header: "Value",
+        numeric: true,
+        render: (row) => formatCount(row.value),
+        sortAccessor: (row) => row.value ?? -1,
+      },
+      {
+        key: "overallRank",
+        header: "Board rank",
+        numeric: true,
+        render: (row) => formatCount(row.overallRank),
+        sortAccessor: (row) => row.overallRank ?? Number.MAX_SAFE_INTEGER,
+      },
+      {
+        key: "sevenDay",
+        header: "7d",
+        numeric: true,
+        hideBelow: "lg",
+        render: (row) => <TrendCell row={row} period="sevenDay" />,
+      },
+      {
+        key: "thirtyDay",
+        header: "30d",
+        numeric: true,
+        render: (row) => <TrendCell row={row} period="thirtyDay" />,
+      },
+      {
+        key: "seasonToDate",
+        header: "Season",
+        numeric: true,
+        hideBelow: "lg",
+        render: (row) => <TrendCell row={row} period="seasonToDate" />,
+      },
+      {
+        key: "buySell",
+        header: "Sharp buy/sell",
+        headerInfo: "Recent Sharp Buy/Sell Tracker activity from the same cohort.",
+        render: (row) => {
+          const item = describeBuySell(row.buySell);
+          return (
+            <span
+              title={item.detail || undefined}
+              style={{
+                color:
+                  item.tone === "positive"
+                    ? "var(--positive)"
+                    : item.tone === "negative"
+                      ? "var(--negative)"
+                      : undefined,
+              }}
+            >
+              {item.label}
+            </span>
+          );
+        },
+      },
+    ];
+    return base;
+  }, [marketAvailable]);
+
+  const empty = classifyEmptyState(payload);
+
+  return (
+    <main className="page">
+      <PageHeader
+        title={PAGE_TITLE}
+        description="Which players our verified sharp managers actually roster, across every league we can observe."
+      />
+
+      <Panel title="Filters" dense>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 14 }}>
+          <Dropdown label="Position" value={position} onChange={setPosition} options={POSITIONS} />
+          <Dropdown label="Platform" value={platform} onChange={setPlatform} options={PLATFORMS} />
+          <Dropdown label="League format" value={format} onChange={setFormat} options={FORMATS} />
+          <Dropdown
+            label="Roster stance"
+            value={contention}
+            onChange={setContention}
+            options={CONTENTION}
+          />
+          <Dropdown
+            label="Experience"
+            value={experience}
+            onChange={setExperience}
+            options={EXPERIENCE}
+          />
+          <Dropdown label="Sort by" value={sort} onChange={setSort} options={SORTS} />
+          <Dropdown label="Show" value={limit} onChange={setLimit} options={LIMITS} />
+        </div>
+      </Panel>
+
+      <Panel title="Sample behind these numbers" dense>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 20 }}>
+          {tiles.map((tile) => (
+            <StatTile key={tile.key} label={tile.label} value={tile.value} meta={tile.note} />
+          ))}
+        </div>
+      </Panel>
+
+      {sampleWarning ? (
+        <Banner
+          tone={sampleWarning.level === "insufficient" ? "warning" : "info"}
+          title={sampleWarning.level === "insufficient" ? "Sample too small" : "Limited sample"}
+        >
+          {sampleWarning.message}
+        </Banner>
+      ) : null}
+
+      {!marketAvailable && payload?.marketComparison?.note ? (
+        <Banner tone="info" title="No market comparison available">
+          {payload.marketComparison.note}
+        </Banner>
+      ) : null}
+
+      {error ? (
+        <Banner tone="negative" title="Could not load the board">
+          {error}
+        </Banner>
+      ) : null}
+
+      {loading && !payload ? (
+        <LoadingState />
+      ) : (
+        <Panel
+          title="Most rostered by sharps"
+          subtitle={
+            payload
+              ? `${formatCount(payload.totalQualifyingPlayers)} qualifying players · updated ${formatTimestamp(payload.lastUpdated)}`
+              : null
+          }
+        >
+          <DataTable
+            columns={columns}
+            rows={rows}
+            rowKey={(row) => row.assetId}
+            caption="Players ranked by the share of eligible sharp rosters that hold them."
+            density="compact"
+            presorted
+            emptyState={
+              <div>
+                <strong>{empty.title}</strong>
+                <p className="muted">{empty.detail}</p>
+              </div>
+            }
+          />
+          <p className="muted" style={{ fontSize: "0.72rem", marginTop: 10 }}>
+            A high roster percentage is not a buy signal on its own. Elite players are rostered
+            almost everywhere, and ownership is also shaped by league depth, format, acquisition
+            cost, age and positional scarcity. Rows marked * rest on a small denominator.
+          </p>
+        </Panel>
+      )}
+
+      {exclusions.length ? (
+        <Panel
+          title="Excluded rosters"
+          subtitle="Nothing is silently discarded — every excluded roster keeps its reason."
+          dense
+          collapsible
+          collapsed
+        >
+          <ul style={{ margin: 0, paddingLeft: 18 }}>
+            {exclusions.map((item) => (
+              <li key={item.reason}>
+                {item.label}: <strong>{formatCount(item.count)}</strong>
+              </li>
+            ))}
+          </ul>
+        </Panel>
+      ) : null}
+    </main>
+  );
+}

--- a/frontend/lib/nav-model.js
+++ b/frontend/lib/nav-model.js
@@ -205,6 +205,16 @@ export const NAV_MODEL = [
         hint: "What qualified dynasty managers are buying and selling",
         keywords: ["sharp", "market intelligence", "smart money", "cohort"],
       },
+      // Same cohort as Sharp Tracker, different question: what the
+      // sharps HOLD rather than what they are trading. It sits in
+      // Market for the same reason its sibling does — the cohort is
+      // global and `/api/sharp/roster-percentage` takes no `leagueKey`.
+      {
+        href: "/market/sharp-roster-percentage",
+        label: "Sharp Roster Percentage",
+        hint: "Which players the sharp cohort actually rosters",
+        keywords: ["sharp", "roster percentage", "ownership", "rostered", "exposure"],
+      },
     ],
   },
   {

--- a/frontend/lib/sharp-roster-percentage.js
+++ b/frontend/lib/sharp-roster-percentage.js
@@ -1,0 +1,180 @@
+/**
+ * Display helpers for the Sharp Roster Percentage board.
+ *
+ * PURE MATERIALIZER — same rule as `buildRows` and `lib/bdvm.js`: this
+ * file reshapes and formats numbers the backend already computed and
+ * never derives one of its own. No percentage is calculated here, no
+ * row is re-ranked here, and no missing value is filled in with a
+ * default that would read as data.
+ *
+ * The reason is specific to this feature rather than stylistic. Every
+ * number on this board is a claim about a sample, and the backend is
+ * the only layer that knows the sample: which rosters were eligible,
+ * which were excluded and why, and which rosters could even field the
+ * player in question. A frontend that recomputed a percentage from
+ * `sharpRosters / eligibleRosters` would produce the same number today
+ * and a wrong one the moment the denominator rule changes.
+ */
+
+/** Percentage, or an em dash when the backend published nothing. */
+export function formatPct(value, { digits = 1 } = {}) {
+  if (typeof value !== "number" || Number.isNaN(value)) return "—";
+  return `${(value * 100).toFixed(digits)}%`;
+}
+
+/** Signed percentage-point delta, for advantage and trend columns. */
+export function formatDelta(value, { digits = 1 } = {}) {
+  if (typeof value !== "number" || Number.isNaN(value)) return "—";
+  const points = value * 100;
+  const sign = points > 0 ? "+" : "";
+  return `${sign}${points.toFixed(digits)} pp`;
+}
+
+export function formatCount(value) {
+  return typeof value === "number" && !Number.isNaN(value) ? value.toLocaleString() : "—";
+}
+
+export function formatTimestamp(ms) {
+  if (typeof ms !== "number" || !Number.isFinite(ms) || ms <= 0) return "—";
+  try {
+    return new Date(ms).toLocaleString();
+  } catch {
+    return "—";
+  }
+}
+
+/** `3 of 12 rosters` — the sample behind one cell, always shown. */
+export function formatSample(row) {
+  if (!row) return "—";
+  const held = formatCount(row.sharpRosters);
+  const total = formatCount(row.eligibleRosters);
+  return `${held} of ${total}`;
+}
+
+const BUY_SELL_LABELS = {
+  accumulating: "Buying",
+  distributing: "Selling",
+  mixed: "Mixed",
+  thin: "Thin",
+  none: "—",
+};
+
+/**
+ * The Buy/Sell Tracker column, as words.
+ *
+ * A player can be widely rostered AND actively sold, which is the
+ * whole reason the two boards are joined — so this deliberately reads
+ * as an observation about recent transactions, never as advice.
+ */
+export function describeBuySell(buySell) {
+  if (!buySell || buySell.signal === "none") return { label: "—", detail: null, tone: "neutral" };
+  const { buys = 0, sells = 0, net = 0, signal, window } = buySell;
+  const tone =
+    signal === "accumulating" ? "positive" : signal === "distributing" ? "negative" : "neutral";
+  return {
+    label: BUY_SELL_LABELS[signal] || "—",
+    detail: `${buys} buy${buys === 1 ? "" : "s"} / ${sells} sell${sells === 1 ? "" : "s"}` +
+      ` (net ${net > 0 ? "+" : ""}${net}, ${window})`,
+    tone,
+  };
+}
+
+/**
+ * The trend cell for one period.
+ *
+ * Returns an explicit `unavailable` shape rather than a zero when the
+ * roster population moved too much between the endpoints. "No change"
+ * and "not comparable" must never render the same.
+ */
+export function describeTrend(trend, period = "thirtyDay") {
+  const item = trend?.[period];
+  if (!item) return { available: false, label: "—", reason: null };
+  if (!item.available) {
+    return {
+      available: false,
+      label: "n/a",
+      reason:
+        item.reason === "roster_population_changed"
+          ? `Sample changed too much to compare (${formatCount(item.comparableRosters)} rosters in both periods)`
+          : "Not comparable",
+    };
+  }
+  return {
+    available: true,
+    label: formatDelta(item.rosterPctChange),
+    added: item.rostersAdded,
+    dropped: item.rostersDropped,
+    reason: null,
+    tone:
+      item.rosterPctChange > 0 ? "positive" : item.rosterPctChange < 0 ? "negative" : "neutral",
+  };
+}
+
+/** The transparency strip, as label/value pairs in display order. */
+export function buildTransparencyTiles(payload) {
+  const t = payload?.transparency || {};
+  return [
+    { key: "managers", label: "Sharp managers", value: formatCount(t.uniqueSharpManagers) },
+    { key: "rosters", label: "Eligible rosters", value: formatCount(t.eligibleRosters) },
+    { key: "sleeper", label: "Sleeper rosters", value: formatCount(t.sleeperRosters) },
+    { key: "ffpc", label: "FFPC rosters", value: formatCount(t.ffpcRosters) },
+    {
+      key: "other",
+      label: "Other platforms",
+      value: formatCount(t.otherPlatformRosters),
+    },
+    {
+      key: "coverage",
+      label: "Cohort represented",
+      value: formatPct(t.cohortCoveragePct, { digits: 0 }),
+      note:
+        typeof t.cohortManagersRepresented === "number" && typeof t.cohortManagers === "number"
+          ? `${t.cohortManagersRepresented} of ${t.cohortManagers}`
+          : null,
+    },
+    { key: "refreshed", label: "Last refresh", value: formatTimestamp(t.lastRefreshedMs) },
+  ];
+}
+
+/**
+ * Why the board is empty, in the user's terms.
+ *
+ * Distinguishes the three real states so "we have not collected this
+ * yet" never renders as a failure — the same posture the Sharp Tracker
+ * takes with `cohort_building`.
+ */
+export function classifyEmptyState(payload) {
+  if (!payload) return { title: "No data", detail: "The board could not be loaded." };
+  if (payload.status === "cohort_building") {
+    return {
+      title: "Collecting sharp rosters",
+      detail:
+        "The sharp cohort is known, but its rosters have not been collected yet. " +
+        "Run the sharp roster crawl to populate this board.",
+    };
+  }
+  if (payload.status === "no_eligible_rosters") {
+    return {
+      title: "No eligible rosters",
+      detail:
+        "Sharp rosters have been collected, but none currently pass the eligibility " +
+        "gates. The exclusion breakdown below shows why.",
+    };
+  }
+  return {
+    title: "No players match these filters",
+    detail: "Widen the filters to see more of the board.",
+  };
+}
+
+/** Exclusion reasons as sorted, human-readable rows. */
+export function buildExclusionRows(payload) {
+  const byReason = payload?.exclusions?.byReason || {};
+  return Object.entries(byReason)
+    .map(([reason, count]) => ({
+      reason,
+      label: reason.replace(/_/g, " ").replace(/^\w/, (c) => c.toUpperCase()),
+      count,
+    }))
+    .sort((a, b) => b.count - a.count || a.reason.localeCompare(b.reason));
+}

--- a/scripts/crawl_sharp_activity.py
+++ b/scripts/crawl_sharp_activity.py
@@ -22,7 +22,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from src.intel import platform_ledger  # noqa: E402
 from src.intel import service as intel_service  # noqa: E402
-from src.sharp import platform_records  # noqa: E402
+from src.sharp import cohort as sharp_cohort  # noqa: E402
 from src.sharp import score as sharp_score  # noqa: E402
 
 DEFAULT_LEAGUE_KEY = "sharp-tracker"
@@ -32,22 +32,31 @@ DEFAULT_SLEEP_SECONDS = 0.12
 
 
 def qualified_sleeper_ids() -> tuple[list[str], dict[str, Any]]:
-    """Return source Sleeper IDs that passed every Sharp Score v2 gate."""
-    records, evidence = platform_records.build_manager_records()
-    scored = sharp_score.score_managers(records) if records else []
+    """Source Sleeper IDs of the automated-qualified sharp cohort.
+
+    Resolved through ``src/sharp/cohort.py::cohort_members`` — the same
+    call the Buy/Sell Tracker and the Roster Percentage board make.  It
+    used to re-derive the pool here (``build_manager_records`` →
+    ``score_managers`` → filter on ``qualified``), which was a second
+    copy of the selection rules living in a script: a change to
+    qualification moved the two boards and left the crawl that FEEDS
+    them selecting a different set of managers.
+
+    ``qualification="automated"`` is the deliberate slice.  Curated and
+    provisional members are FFPC-only, and this pass crawls Sleeper.
+    """
+    members, coverage = sharp_cohort.cohort_members(qualification="automated")
     qualified = sorted(
         {
-            manager.user_id.split(":", 1)[1]
-            for manager in scored
-            if manager.qualified and manager.user_id.startswith("sleeper:")
+            member.manager_key.split(":", 1)[1]
+            for member in members
+            if member.manager_key.startswith("sleeper:")
         }
     )
     summary = {
         "methodologyVersion": sharp_score.methodology_version(),
-        "managerRecords": len(records),
-        "evidenceManagers": len(evidence),
-        "evaluableManagers": sum(1 for manager in scored if manager.evaluable),
-        "qualifiedManagers": sum(1 for manager in scored if manager.qualified),
+        "evidenceManagers": coverage.get("evidenceManagers", 0),
+        "qualifiedManagers": len(members),
         "qualifiedSleeperManagers": len(qualified),
     }
     return qualified, summary

--- a/scripts/crawl_sharp_rosters.py
+++ b/scripts/crawl_sharp_rosters.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Collect the CURRENT rosters of the sharp cohort, on both platforms.
+
+Discovery finds MANAGERS, ``crawl_sharp_records.py`` finds their
+RECORDS — this finds what they currently OWN, which is what
+``/market/sharp-roster-percentage`` is made of.  Without it that page
+reports ``cohort_building`` and an empty board, exactly as the Buy/Sell
+Tracker does before a records crawl.
+
+    python scripts/crawl_sharp_rosters.py                 # budgeted pass
+    python scripts/crawl_sharp_rosters.py --budget 2000
+    python scripts/crawl_sharp_rosters.py --ffpc-only     # zero API calls
+    python scripts/crawl_sharp_rosters.py --stats         # coverage only
+    python scripts/crawl_sharp_rosters.py --audit 4046    # one player
+
+Costs 2 Sleeper calls per league (``/league/{id}`` for format + status,
+``/league/{id}/rosters`` for the holdings), regardless of how many
+cohort members play in it.  FFPC costs ZERO calls — its roster contents
+already arrive with the public-page crawl and are only lifted into the
+queryable store here.
+
+Idempotent: rosters upsert on ``roster_key`` and holdings upsert on
+``(roster_key, canonical_asset_id)``, so a re-run overwrites rather than
+inflating any count.
+
+Exit codes: 0 success, 1 failure, 2 budget exhausted with work left.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.sharp import roster_collect, roster_percentage, roster_store  # noqa: E402
+
+log = logging.getLogger("crawl_sharp_rosters")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--budget", type=int, default=roster_collect.DEFAULT_BUDGET)
+    parser.add_argument("--sleep", type=float, default=roster_collect.DEFAULT_SLEEP_S)
+    parser.add_argument(
+        "--qualification",
+        default="all",
+        choices=list(roster_percentage.sharp_cohort.ALLOWED_QUALIFICATION),
+        help="Which slice of the sharp cohort to collect for.",
+    )
+    parser.add_argument("--sleeper-only", action="store_true")
+    parser.add_argument("--ffpc-only", action="store_true")
+    parser.add_argument("--stats", action="store_true", help="Print coverage and exit.")
+    parser.add_argument("--audit", metavar="ASSET_ID", help="Audit one player and exit.")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+    if args.stats:
+        print(
+            json.dumps(
+                {
+                    "store": roster_store.coverage(),
+                    "exclusionReasons": roster_store.exclusion_reason_counts(),
+                },
+                indent=2,
+            )
+        )
+        return 0
+
+    if args.audit:
+        print(json.dumps(roster_percentage.audit_player(args.audit), indent=2))
+        return 0
+
+    run_id = f"sharp-rosters-{uuid.uuid4().hex[:12]}"
+    started = int(time.time() * 1000)
+    try:
+        summary = roster_collect.collect_all(
+            qualification=args.qualification,
+            budget=args.budget,
+            sleep_s=args.sleep,
+            run_id=run_id,
+            skip_sleeper=args.ffpc_only,
+            skip_ffpc=args.sleeper_only,
+        )
+    except Exception:  # noqa: BLE001 — the script's job is an exit code
+        log.exception("sharp roster crawl failed")
+        return 1
+    finished = int(time.time() * 1000)
+
+    try:
+        roster_collect.record_collection_run(
+            summary, started_ms=started, finished_ms=finished, run_id=run_id
+        )
+    except Exception:  # noqa: BLE001 — bookkeeping must not fail the crawl
+        log.exception("sharp roster crawl: run bookkeeping failed")
+
+    print(json.dumps(summary, indent=2))
+    if summary.get("sleeper", {}).get("budgetExhausted"):
+        log.warning("budget exhausted with leagues still uncollected — re-run to continue")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_sharp_roster_percentage.py
+++ b/scripts/validate_sharp_roster_percentage.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Audit the Sharp Roster Percentage board against the rosters underneath it.
+
+Re-derives every published number from the raw stored rows using code
+that shares nothing with the engine, then diffs. The point is to catch a
+plausible-looking board, so the checks deliberately do NOT call
+``build_board``'s helpers — they walk ``sharp_rosters`` /
+``sharp_roster_assets`` directly and count in plain Python.
+
+    python scripts/validate_sharp_roster_percentage.py            # top 10
+    python scripts/validate_sharp_roster_percentage.py --players 25
+    python scripts/validate_sharp_roster_percentage.py --json
+
+Checks, one per audit-list item:
+
+  1  numerator      published sharpRosters == distinct rosters holding him
+  2  one-per-roster no roster contributes two observations of one player
+  3  denominator    published eligibleRosters == rosters that could hold him
+  4  bounds         0 <= pct <= 1 and pct == numerator / denominator
+  5  dedup-rosters  no two roster rows share a (league, roster id)
+  6  dedup-identity a roster is attributed to exactly one manager
+  7  mapping        every counted asset id resolves in the player index
+  8  eligibility    excluded rosters never appear in any numerator
+  9  filters        numerator and denominator both move under a filter
+ 10  buy/sell       the tracker join agrees with the tracker's own payload
+
+Exit codes: 0 all checks passed, 1 a check failed, 2 nothing to audit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.sharp import cohort as sharp_cohort  # noqa: E402
+from src.sharp import roster_percentage as rp  # noqa: E402
+from src.sharp import roster_store  # noqa: E402
+
+
+class Report:
+    def __init__(self) -> None:
+        self.checks: list[dict[str, Any]] = []
+
+    def add(self, name: str, ok: bool, detail: str, **extra: Any) -> None:
+        self.checks.append({"check": name, "ok": bool(ok), "detail": detail, **extra})
+
+    @property
+    def failed(self) -> list[dict[str, Any]]:
+        return [c for c in self.checks if not c["ok"]]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "checks": self.checks,
+            "passed": len(self.checks) - len(self.failed),
+            "failed": len(self.failed),
+        }
+
+
+def _contract() -> dict[str, Any] | None:
+    """The live board, if this process can see one.
+
+    Read the same way every other out-of-server module reads it. When
+    the validator runs standalone there is no server, and the value join
+    is simply reported as unavailable rather than faked.
+    """
+    server = sys.modules.get("server") or sys.modules.get("__main__")
+    contract = getattr(server, "latest_contract_data", None)
+    if isinstance(contract, dict):
+        return contract
+    snapshot = Path(__file__).resolve().parents[1] / "data" / "latest_contract.json"
+    try:
+        return json.loads(snapshot.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def validate(
+    *,
+    ledger_path: Path | None = None,
+    player_count: int = 10,
+    now_ms: int | None = None,
+) -> tuple[Report, dict[str, Any]]:
+    report = Report()
+    contract = _contract()
+
+    members, _coverage = sharp_cohort.cohort_members(ledger_path=ledger_path)
+    cohort_keys = {m.manager_key for m in members}
+    stored = roster_store.load_rosters(path=ledger_path)
+    board = rp.build_board(contract=contract, ledger_path=ledger_path, limit=100, now_ms=now_ms)
+    now = board["generatedAt"]
+
+    # ── independent re-derivation, sharing nothing with the engine ────
+    eligible: list[dict[str, Any]] = []
+    for row in stored:
+        if not row["isEligible"]:
+            continue
+        if row["managerKey"] not in cohort_keys:
+            continue
+        age_days = (now - row["observedMs"]) / 86_400_000
+        if age_days > roster_store.DEFAULT_MAX_ROSTER_AGE_DAYS:
+            continue
+        if not row["assets"]:
+            continue
+        eligible.append(row)
+
+    if not eligible:
+        report.add(
+            "audit_possible",
+            False,
+            f"No eligible sharp rosters stored ({len(stored)} rows total). "
+            "Run scripts/crawl_sharp_rosters.py first.",
+        )
+        return report, board
+
+    holders: dict[str, list[str]] = defaultdict(list)
+    for row in eligible:
+        for asset in row["assets"]:
+            holders[asset["canonicalAssetId"]].append(row["rosterKey"])
+
+    supports: dict[str, set[str]] = defaultdict(set)
+    for row in eligible:
+        fmt = row.get("format") or {}
+        for family in (rp.FAMILY_OFFENSE, rp.FAMILY_IDP, rp.FAMILY_KICKER, rp.FAMILY_TEAM_DEFENSE):
+            if rp._roster_supports_family(fmt, family):
+                supports[family].add(row["rosterKey"])
+
+    player_index = rp.build_player_index(contract)
+    sample = board["players"][: max(1, int(player_count))]
+
+    # 1 + 4 — numerator and the arithmetic itself
+    numerator_bad, bounds_bad = [], []
+    for row in sample:
+        expected = set(holders.get(row["assetId"], []))
+        if len(expected) != row["sharpRosters"]:
+            numerator_bad.append(
+                {
+                    "assetId": row["assetId"],
+                    "published": row["sharpRosters"],
+                    "recount": len(expected),
+                }
+            )
+        pct = row["sharpRosterPct"]
+        recomputed = (
+            row["sharpRosters"] / row["eligibleRosters"] if row["eligibleRosters"] else None
+        )
+        if pct is None or not (0.0 <= pct <= 1.0) or abs(pct - (recomputed or -1)) > 1e-6:
+            bounds_bad.append({"assetId": row["assetId"], "pct": pct, "recomputed": recomputed})
+    report.add(
+        "numerator_matches_underlying_rosters",
+        not numerator_bad,
+        f"{len(sample) - len(numerator_bad)}/{len(sample)} players recount exactly",
+        mismatches=numerator_bad,
+    )
+    report.add(
+        "percentage_is_numerator_over_denominator_and_in_range",
+        not bounds_bad,
+        f"{len(sample) - len(bounds_bad)}/{len(sample)} players in range and consistent",
+        mismatches=bounds_bad,
+    )
+
+    # 2 — one ownership observation per roster per player
+    per_roster_dupes = []
+    for row in eligible:
+        counts = Counter(a["canonicalAssetId"] for a in row["assets"])
+        dupes = [asset for asset, n in counts.items() if n > 1]
+        if dupes:
+            per_roster_dupes.append({"rosterKey": row["rosterKey"], "assets": dupes})
+    report.add(
+        "one_observation_per_roster_per_player",
+        not per_roster_dupes,
+        f"{len(eligible)} rosters carry no duplicate player rows",
+        offenders=per_roster_dupes,
+    )
+
+    # 3 — the denominator is the eligible roster count for that player
+    denominator_bad = []
+    for row in sample:
+        family = row["positionFamily"]
+        expected = (supports.get(family, set()) | set(holders.get(row["assetId"], []))) & {
+            r["rosterKey"] for r in eligible
+        }
+        if len(expected) != row["eligibleRosters"]:
+            denominator_bad.append(
+                {
+                    "assetId": row["assetId"],
+                    "published": row["eligibleRosters"],
+                    "recount": len(expected),
+                }
+            )
+    report.add(
+        "denominator_matches_eligible_rosters",
+        not denominator_bad,
+        f"total eligible rosters={len(eligible)}; "
+        f"{len(sample) - len(denominator_bad)}/{len(sample)} per-player denominators match",
+        mismatches=denominator_bad,
+    )
+
+    # 5 — no duplicate rosters
+    key_counts = Counter((r["leagueKey"], r["sourceRosterId"]) for r in stored)
+    dupe_rosters = [
+        {"leagueKey": k[0], "rosterId": k[1], "rows": n} for k, n in key_counts.items() if n > 1
+    ]
+    report.add(
+        "no_duplicate_roster_rows",
+        not dupe_rosters,
+        f"{len(stored)} stored rosters, {len(key_counts)} distinct (league, roster id) pairs",
+        duplicates=dupe_rosters,
+    )
+
+    # 6 — one manager per roster
+    managers_per_roster = defaultdict(set)
+    for row in stored:
+        managers_per_roster[row["rosterKey"]].add(row["managerKey"])
+    split = [k for k, v in managers_per_roster.items() if len(v) > 1]
+    report.add(
+        "each_roster_has_exactly_one_manager",
+        not split,
+        f"{len(managers_per_roster)} rosters each attributed to one manager identity",
+        offenders=split,
+    )
+
+    # 7 — asset mapping
+    unmapped = []
+    if player_index:
+        for row in sample:
+            if row["assetType"] == "player" and row["assetId"] not in player_index:
+                unmapped.append(row["assetId"])
+        report.add(
+            "counted_assets_resolve_to_internal_player_ids",
+            not unmapped,
+            f"{len(sample) - len(unmapped)}/{len(sample)} sampled assets resolve in the board index",
+            unresolved=unmapped,
+        )
+    else:
+        report.add(
+            "counted_assets_resolve_to_internal_player_ids",
+            True,
+            "SKIPPED — no live contract available to this process; "
+            "player identity could not be cross-checked",
+            skipped=True,
+        )
+
+    # 8 — excluded rosters never reach a numerator
+    excluded_keys = {r["rosterKey"] for r in stored if not r["isEligible"]}
+    leaked = sorted(excluded_keys & {k for keys in holders.values() for k in keys})
+    report.add(
+        "excluded_rosters_never_enter_a_numerator",
+        not leaked,
+        f"{len(excluded_keys)} excluded rosters, none counted",
+        leaked=leaked,
+    )
+
+    # 9 — filters move both sides
+    filtered = rp.build_board(
+        contract=contract, ledger_path=ledger_path, limit=100, now_ms=now, platform="sleeper"
+    )
+    sleeper_rosters = sum(1 for r in eligible if r["platform"] == "sleeper")
+    ok = filtered["sample"]["eligibleRosters"] == sleeper_rosters
+    report.add(
+        "filters_move_numerator_and_denominator_together",
+        ok,
+        f"platform=sleeper denominator {filtered['sample']['eligibleRosters']} "
+        f"vs {sleeper_rosters} sleeper rosters counted independently",
+    )
+
+    # 10 — the buy/sell join agrees with the tracker's own board
+    try:
+        from src.sharp import market as sharp_market
+
+        tracker = sharp_market.market_payload(
+            window="30d", limit=500, ledger_path=ledger_path, now_ms=now
+        )
+        tracker_by_asset = {row["assetId"]: row for row in tracker["assets"]}
+        disagreements = []
+        for row in sample:
+            joined = row.get("buySell")
+            reference = tracker_by_asset.get(row["assetId"])
+            if joined and reference and joined["buys"] != reference["buys"]:
+                disagreements.append(
+                    {
+                        "assetId": row["assetId"],
+                        "rosterBoard": joined["buys"],
+                        "tracker": reference["buys"],
+                    }
+                )
+        report.add(
+            "buy_sell_join_agrees_with_the_tracker",
+            not disagreements,
+            f"{len(tracker_by_asset)} tracker rows compared against the joined column",
+            disagreements=disagreements,
+        )
+    except Exception as exc:  # noqa: BLE001
+        report.add("buy_sell_join_agrees_with_the_tracker", True, f"SKIPPED — {exc}", skipped=True)
+
+    return report, board
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--players", type=int, default=10, help="How many top players to verify.")
+    parser.add_argument("--json", action="store_true", help="Machine-readable output.")
+    args = parser.parse_args()
+
+    report, board = validate(player_count=args.players)
+
+    if args.json:
+        print(json.dumps({"report": report.to_dict(), "sample": board["players"][:5]}, indent=2))
+    else:
+        print(f"Sharp Roster Percentage audit — {len(report.checks)} checks\n")
+        for check in report.checks:
+            mark = "PASS" if check["ok"] else "FAIL"
+            print(f"  [{mark}] {check['check']}")
+            print(f"         {check['detail']}")
+        print()
+        if report.failed:
+            print("FAILED CHECKS:")
+            for check in report.failed:
+                print(json.dumps(check, indent=2))
+
+    if any(c["check"] == "audit_possible" and not c["ok"] for c in report.checks):
+        return 2
+    return 1 if report.failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server.py
+++ b/server.py
@@ -12578,6 +12578,21 @@ async def get_intel_refresh_status(request: Request):
 
 from src.sharp import service as _sharp_service  # noqa: E402
 
+# Register the sharp market routes EXPLICITLY rather than relying on the
+# import-time side effect inside ``_sharp_service``.
+#
+# That side effect only finds this app when ``server`` is the first thing
+# to import the module. Anything that imports ``src.sharp.service``
+# earlier — a test module, a script, another package — runs the
+# registrar against a not-yet-existing app, and Python's module cache
+# then means importing it here re-runs nothing. The routes silently
+# never attach and every ``/api/sharp/market`` request 404s.
+#
+# ``_register_http_routes`` is idempotent (it returns early when the
+# path is already present), so calling it here is safe alongside the
+# module-level call and the self-heal in ``cohort_status``.
+_sharp_service.register_http_routes()
+
 
 @app.get("/api/sharp/cohort")
 async def get_sharp_cohort(request: Request):

--- a/server.py
+++ b/server.py
@@ -12596,6 +12596,102 @@ async def get_sharp_cohort(request: Request):
     )
 
 
+@app.get("/api/sharp/roster-percentage")
+async def get_sharp_roster_percentage(request: Request):
+    """Which players the sharp cohort rosters most, and how reliably.
+
+    Shares the Buy/Sell Tracker's cohort exactly — both boards resolve
+    their pool through ``src/sharp/cohort.py::cohort_members`` — so it is
+    global for the same reason the cohort endpoint is, and takes no
+    ``leagueKey``.
+
+    Declared HERE rather than registered from ``src/sharp/service.py``.
+    That module's self-registration only finds the app when it is
+    imported by ``server.py`` first; when a test imports it earlier the
+    routes never attach, which is the failure
+    ``tests/sharp/test_public_api_allowlist.py`` hits under a full-suite
+    run.  A plain decorator has no such ordering dependency.
+
+    Always 200 with an explicit ``status``: an empty roster store is a
+    real state on a cohort whose rosters have not been collected yet,
+    and the page explains it rather than showing an error.
+    """
+    query = request.query_params
+
+    def _bool(name: str) -> bool:
+        return str(query.get(name) or "").strip().lower() in ("1", "true", "yes")
+
+    try:
+        payload = await run_in_threadpool(
+            _sharp_service.roster_percentage_payload,
+            contract=latest_contract_data,
+            qualification=str(query.get("qualification") or "all"),
+            position=str(query.get("position") or "all"),
+            platform=str(query.get("platform") or "all"),
+            league_format=str(query.get("format") or "all"),
+            contention=str(query.get("contention") or "all"),
+            experience=str(query.get("experience") or "all"),
+            sort=str(query.get("sort") or "rostered"),
+            limit=int(query.get("limit") or 50),
+            include_picks=_bool("includePicks"),
+        )
+    except (ValueError, TypeError) as exc:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "bad_request", "message": str(exc)},
+            headers={"Cache-Control": "no-store"},
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.exception("sharp roster percentage failed")
+        return JSONResponse(
+            status_code=503,
+            content={"error": "sharp_roster_percentage_unavailable", "message": str(exc)},
+            headers={"Cache-Control": "no-store"},
+        )
+    return JSONResponse(
+        content=payload,
+        headers={"Cache-Control": "private, max-age=300, stale-while-revalidate=900"},
+    )
+
+
+@app.get("/api/sharp/roster-percentage/audit")
+async def get_sharp_roster_percentage_audit(request: Request):
+    """Every roster behind one player's percentage, listed individually.
+
+    The manual-verification surface required before this feature could
+    be called done: a count is checkable against the underlying rosters
+    without database access, and the excluded rosters are reported with
+    their reasons alongside.
+    """
+    asset_id = str(request.query_params.get("assetId") or "").strip()
+    if not asset_id:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "missing_param", "message": "assetId required"},
+            headers={"Cache-Control": "no-store"},
+        )
+    try:
+        payload = await run_in_threadpool(
+            _sharp_service.roster_percentage_audit_payload,
+            asset_id,
+            qualification=str(request.query_params.get("qualification") or "all"),
+        )
+    except (ValueError, TypeError) as exc:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "bad_request", "message": str(exc)},
+            headers={"Cache-Control": "no-store"},
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.exception("sharp roster percentage audit failed")
+        return JSONResponse(
+            status_code=503,
+            content={"error": "sharp_roster_percentage_unavailable", "message": str(exc)},
+            headers={"Cache-Control": "no-store"},
+        )
+    return JSONResponse(content=payload, headers={"Cache-Control": "private, max-age=60"})
+
+
 # ── PLAYER CONTEXT (contracts / snap share / depth chart) ───────────────
 # R2 player-profile surface.  Serves per-player blocks from the
 # ``src/playerctx`` snapshot (``data/playerctx/snapshot.json``,

--- a/src/sharp/cohort.py
+++ b/src/sharp/cohort.py
@@ -1,0 +1,326 @@
+"""THE sharp cohort — one definition of "who is a sharp", for every feature.
+
+Every sharp-powered surface resolves its manager pool through this
+module.  The Sharp Buy/Sell Tracker (``src/sharp/market.py``) and the
+Sharp Roster Percentage board (``src/sharp/roster_percentage.py``) both
+call :func:`cohort_members`, so a change to qualification, an added
+curated manager, or a flipped FFPC flag moves BOTH boards in the same
+deploy — there is no second list to keep in sync.
+
+Why this file exists at all
+───────────────────────────
+The definitions below used to live inside ``market.py``.  That was fine
+while the tracker was the only consumer, but it made the cohort look
+like a property of the buy/sell board rather than a shared asset, and
+the obvious way to add a second feature would have been to import from
+``market`` (coupling a roster board to a transactions board) or — far
+worse — to re-derive the pool.  Moving them here makes the shared layer
+explicit.
+
+``market.py`` re-exports every name, so ``sharp_market.cohort_members``
+and ``sharp_market.CohortMember`` continue to resolve exactly as before.
+That is deliberate: existing tests monkeypatch ``market.cohort_members``
+and ``market.market_payload`` reads it as a module global, so the seam
+they patch is preserved.
+
+What the cohort IS
+──────────────────
+A ``CohortMember`` is one QUALIFIED MANAGER IDENTITY, not one human and
+not one roster:
+
+* ``manager_key``  ``"<platform>:<source_manager_id>"`` — the ledger's
+  identity key.  Two accounts belonging to one human are collapsed
+  downstream via ``canonical_manager_id``; see
+  :func:`canonical_manager_ids` for the resolution used by any feature
+  that must not count a person twice.
+* ``qualification_method``  how they got in — automated Sharp Score v2,
+  a curated high-stakes entry, or a provisional public observation.
+  These are NOT interchangeable and features may filter on them.
+* ``quality``  0..1.  Sharp Score/100 for automated members, the
+  configured weight for curated/provisional ones.
+
+Qualification itself is not decided here — it is decided by
+``src/sharp/score.py`` (gates + score) over evidence assembled by
+``src/sharp/platform_records.py``.  This module only SELECTS and
+DEDUPLICATES.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from src.intel import platform_ledger
+from src.sharp import platform_records
+from src.sharp import score as sharp_score
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FFPC_CONFIG_PATH = REPO_ROOT / "config" / "sharp" / "ffpc_sources.json"
+
+ALLOWED_QUALIFICATION = ("all", "automated", "curated", "provisional")
+
+# Automated qualification outranks a curated entry, which outranks a
+# provisional observation.  Used when ONE manager_key arrives through
+# more than one method — the strongest claim wins rather than the
+# manager appearing twice.
+_QUALIFICATION_PRIORITY = {
+    "provisional_public": 1,
+    "curated_high_stakes": 2,
+    "automated_qualified": 3,
+}
+
+
+@lru_cache(maxsize=4)
+def load_ffpc_config(path: str | None = None) -> dict[str, Any]:
+    target = Path(path) if path else FFPC_CONFIG_PATH
+    try:
+        raw = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+@dataclass(frozen=True)
+class CohortMember:
+    manager_key: str
+    platform: str
+    qualification_method: str
+    quality: float
+    display_name: str | None = None
+    methodology_version: str | None = None
+    source_rationale: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "managerKey": self.manager_key,
+            "platform": self.platform,
+            "qualificationMethod": self.qualification_method,
+            "quality": round(self.quality, 4),
+            "displayName": self.display_name,
+            "methodologyVersion": self.methodology_version,
+            "sourceRationale": self.source_rationale,
+        }
+
+
+def curated_members(config: dict[str, Any]) -> list[CohortMember]:
+    out = []
+    for raw in config.get("curatedManagers") or []:
+        if not isinstance(raw, dict):
+            continue
+        manager_key = str(raw.get("managerKey") or "").strip()
+        if not manager_key.startswith("ffpc:"):
+            continue
+        if not bool(raw.get("verified")) or not bool(raw.get("allowedToContribute")):
+            continue
+        weight = max(0.0, min(1.0, float(raw.get("weight") or 0.75)))
+        out.append(
+            CohortMember(
+                manager_key=manager_key,
+                platform="ffpc",
+                qualification_method="curated_high_stakes",
+                quality=weight,
+                display_name=str(raw.get("publicDisplayName") or "") or None,
+                source_rationale=str(raw.get("sourceRationale") or "") or None,
+            )
+        )
+    return out
+
+
+def provisional_members(
+    config: dict[str, Any],
+    *,
+    ledger_path: Path | None = None,
+) -> list[CohortMember]:
+    """Select public FFPC observations without claiming sharp-v2 qualification."""
+    if not bool(config.get("enabled")) or not bool(
+        config.get("allowProvisionalPublicInCombinedSignals")
+    ):
+        return []
+    league_keys = [
+        f"ffpc:{str(source.get('sourceLeagueId') or '').strip()}"
+        for source in config.get("seedLeagues") or []
+        if isinstance(source, dict)
+        and bool(source.get("enabled", True))
+        and bool(source.get("allowProvisionalContribution"))
+        and str(source.get("sourceLeagueId") or "").strip()
+    ]
+    if not league_keys:
+        return []
+    weight = max(
+        0.0,
+        min(1.0, float(config.get("provisionalPublicWeight") or 0.5)),
+    )
+    placeholders = ",".join("?" for _ in league_keys)
+    conn = platform_ledger.ensure_platform_schema(ledger_path)
+    try:
+        rows = conn.execute(
+            f"""
+            SELECT DISTINCT am.manager_key, pm.display_name
+              FROM asset_movements am
+              JOIN transactions tx
+                ON tx.transaction_key=am.transaction_key
+              LEFT JOIN platform_managers pm
+                ON pm.manager_key=am.manager_key
+             WHERE am.platform='ffpc'
+               AND am.league_key IN ({placeholders})
+               AND tx.tx_type='trade'
+               AND am.manager_key IS NOT NULL
+            """,
+            league_keys,
+        ).fetchall()
+    finally:
+        conn.close()
+    return [
+        CohortMember(
+            manager_key=str(row["manager_key"]),
+            platform="ffpc",
+            qualification_method="provisional_public",
+            quality=weight,
+            display_name=str(row["display_name"] or "") or None,
+            source_rationale=(
+                "Observed on an explicitly configured public FFPC dynasty page; "
+                "has not passed Sharp Score v2 history gates."
+            ),
+        )
+        for row in rows
+    ]
+
+
+def cohort_members(
+    *,
+    qualification: str = "all",
+    ledger_path: Path | None = None,
+    ffpc_config: dict[str, Any] | None = None,
+) -> tuple[list[CohortMember], dict[str, Any]]:
+    """``(members, coverage)`` — THE sharp pool.
+
+    This is the function every sharp feature must call.  Do not
+    reimplement the selection, and do not filter its output by anything
+    that amounts to a second qualification rule.
+    """
+    if qualification not in ALLOWED_QUALIFICATION:
+        raise ValueError(f"unsupported qualification: {qualification}")
+    records, evidence = platform_records.build_manager_records(ledger_path=ledger_path)
+    scored = sharp_score.score_managers(records)
+    config = ffpc_config if ffpc_config is not None else load_ffpc_config()
+    ffpc_enabled = bool(config.get("enabled"))
+    automatic = [
+        CohortMember(
+            manager_key=item.user_id,
+            platform=item.user_id.split(":", 1)[0],
+            qualification_method="automated_qualified",
+            quality=max(0.0, min(1.0, float(item.score or 0.0) / 100.0)),
+            methodology_version=item.methodology_version,
+        )
+        for item in scored
+        if item.qualified and (item.user_id.split(":", 1)[0] != "ffpc" or ffpc_enabled)
+    ]
+    curated_enabled = bool(ffpc_enabled and config.get("allowCuratedInCombinedSignals"))
+    curated = curated_members(config) if curated_enabled else []
+    provisional_enabled = bool(
+        ffpc_enabled and config.get("allowProvisionalPublicInCombinedSignals")
+    )
+    provisional = (
+        provisional_members(config, ledger_path=ledger_path) if provisional_enabled else []
+    )
+    if qualification == "automated":
+        selected = automatic
+    elif qualification == "curated":
+        selected = curated
+    elif qualification == "provisional":
+        selected = provisional
+    else:
+        selected = [*automatic, *curated, *provisional]
+
+    # A manager may be explicitly linked to one canonical identity and
+    # appear through two methods. Automated qualification wins; otherwise
+    # the higher configured quality wins.
+    by_key: dict[str, CohortMember] = {}
+    for item in selected:
+        prior = by_key.get(item.manager_key)
+        if prior is None or (
+            _QUALIFICATION_PRIORITY.get(item.qualification_method, 0),
+            item.quality,
+        ) > (
+            _QUALIFICATION_PRIORITY.get(prior.qualification_method, 0),
+            prior.quality,
+        ):
+            by_key[item.manager_key] = item
+    coverage = {
+        "automatedQualifiedManagers": len(automatic),
+        "curatedManagers": len(curated),
+        "curatedContributionEnabled": curated_enabled,
+        "provisionalManagers": len(provisional),
+        "provisionalContributionEnabled": provisional_enabled,
+        "evidenceManagers": len(evidence),
+        "methodologyVersion": sharp_score.methodology_version(),
+    }
+    return list(by_key.values()), coverage
+
+
+# ── person-level identity ────────────────────────────────────────────
+
+
+def canonical_manager_ids(
+    manager_keys: list[str] | tuple[str, ...],
+    *,
+    ledger_path: Path | None = None,
+) -> dict[str, str]:
+    """``{manager_key: canonical_manager_id}`` for the given keys.
+
+    One human with a Sleeper account AND an FFPC account is ONE person.
+    ``platform_managers.canonical_manager_id`` (set by the identity
+    linker) is what says so; ``manager_identity_links`` is the explicit
+    verified-link table that feeds it.
+
+    Keys with no recorded link map to THEMSELVES rather than being
+    dropped.  An unlinked manager is a distinct person as far as we can
+    prove, and silently collapsing unknowns would understate the pool.
+
+    Note what this is and is not for.  A roster count's DENOMINATOR is
+    rosters, not people (five real dynasty teams are five observations),
+    so this is not applied there.  It is what answers "how many unique
+    sharp managers are represented", and it is what stops the same
+    person's single roster from being counted once per linked account.
+    """
+    keys = [str(k) for k in manager_keys if str(k or "").strip()]
+    if not keys:
+        return {}
+    out = {key: key for key in keys}
+    conn = platform_ledger.ensure_platform_schema(ledger_path)
+    try:
+        for chunk_start in range(0, len(keys), 500):
+            chunk = keys[chunk_start : chunk_start + 500]
+            placeholders = ",".join("?" for _ in chunk)
+            for row in conn.execute(
+                f"""
+                SELECT pm.manager_key AS manager_key,
+                       COALESCE(mil.canonical_manager_id,
+                                pm.canonical_manager_id) AS canonical_id
+                  FROM platform_managers pm
+                  LEFT JOIN manager_identity_links mil
+                    ON mil.manager_key = pm.manager_key
+                 WHERE pm.manager_key IN ({placeholders})
+                """,
+                chunk,
+            ).fetchall():
+                canonical = str(row["canonical_id"] or "").strip()
+                if canonical:
+                    out[str(row["manager_key"])] = canonical
+    finally:
+        conn.close()
+    return out
+
+
+def unique_person_count(
+    manager_keys: list[str] | tuple[str, ...],
+    *,
+    ledger_path: Path | None = None,
+) -> int:
+    """How many distinct HUMANS the given manager keys represent."""
+    if not manager_keys:
+        return 0
+    return len(set(canonical_manager_ids(manager_keys, ledger_path=ledger_path).values()))

--- a/src/sharp/discovery.py
+++ b/src/sharp/discovery.py
@@ -334,6 +334,25 @@ def discover(
                     continue
                 known_leagues.add(lid)
 
+                # Record the membership we just PROVED: Sleeper's own
+                # ``/user/{uid}/leagues`` answered that this user is in
+                # this league, so the row is a fact, not an inference.
+                #
+                # It used to be written only by the league->users branch
+                # above, which meant a membership existed only for
+                # leagues the traversal actually EXPANDED. Leagues left
+                # on the frontier by the call budget, ``maxGenerations``
+                # or ``maxLeaguesPerRun`` had none — invisible to any
+                # consumer that asks "which leagues does this manager
+                # play in".
+                #
+                # That silently bounded the sharp ROSTER crawl
+                # (``src/sharp/roster_collect.py``) to the expanded
+                # subgraph, so a sharp with four dynasty teams could
+                # contribute one roster to the roster-percentage
+                # denominator and still read as fully represented.
+                memberships.append((lid, uid, None))
+
                 # SIGNAL eligibility is decided here and recorded; it
                 # never gates DISCOVERY.  A redraft league still gets
                 # traversed for the managers it introduces.

--- a/src/sharp/market.py
+++ b/src/sharp/market.py
@@ -1,34 +1,40 @@
-"""Unified Sleeper + FFPC Sharp market signals from normalized movements."""
+"""Unified Sleeper + FFPC Sharp market signals from normalized movements.
+
+The MANAGER POOL this board reads is not defined here — it comes from
+``src/sharp/cohort.py``, which is the one definition shared with every
+other sharp feature (today: the Sharp Roster Percentage board).  The
+cohort names are re-exported below so ``sharp_market.cohort_members``
+and ``sharp_market.CohortMember`` keep resolving for existing callers
+and tests, and so ``market_payload`` still reads ``cohort_members`` as
+a module global that tests can monkeypatch.
+"""
 
 from __future__ import annotations
 
 import json
 import time
-from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Sequence
 
 from src.intel import platform_ledger, signals
-from src.sharp import platform_records
 from src.sharp import score as sharp_score
+from src.sharp.cohort import (  # noqa: F401 — re-exported shared cohort surface
+    ALLOWED_QUALIFICATION as _ALLOWED_QUALIFICATION,
+)
+from src.sharp.cohort import (  # noqa: F401
+    FFPC_CONFIG_PATH,
+    CohortMember,
+    cohort_members,
+    curated_members,
+    load_ffpc_config,
+    provisional_members,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-FFPC_CONFIG_PATH = REPO_ROOT / "config" / "sharp" / "ffpc_sources.json"
 _ALLOWED_WINDOWS = ("48h", "7d", "14d", "30d", "90d", "all")
 _ALLOWED_SORTS = ("strength", "net", "volume", "velocity", "buys", "sells")
 _ALLOWED_PLATFORMS = ("all", "sleeper", "ffpc")
-_ALLOWED_QUALIFICATION = ("all", "automated", "curated", "provisional")
-
-
-@lru_cache(maxsize=4)
-def load_ffpc_config(path: str | None = None) -> dict[str, Any]:
-    target = Path(path) if path else FFPC_CONFIG_PATH
-    try:
-        raw = json.loads(target.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return {}
-    return raw if isinstance(raw, dict) else {}
 
 
 @lru_cache(maxsize=1)
@@ -98,180 +104,6 @@ def _fallback_asset_metadata(asset_id: str) -> dict[str, Any]:
             display += f" ({':'.join(parts[3:])})"
         return {"displayName": display, "position": "PICK", "nflTeam": None}
     return _local_asset_catalog().get(asset_id, {})
-
-
-@dataclass(frozen=True)
-class CohortMember:
-    manager_key: str
-    platform: str
-    qualification_method: str
-    quality: float
-    display_name: str | None = None
-    methodology_version: str | None = None
-    source_rationale: str | None = None
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "managerKey": self.manager_key,
-            "platform": self.platform,
-            "qualificationMethod": self.qualification_method,
-            "quality": round(self.quality, 4),
-            "displayName": self.display_name,
-            "methodologyVersion": self.methodology_version,
-            "sourceRationale": self.source_rationale,
-        }
-
-
-def curated_members(config: dict[str, Any]) -> list[CohortMember]:
-    out = []
-    for raw in config.get("curatedManagers") or []:
-        if not isinstance(raw, dict):
-            continue
-        manager_key = str(raw.get("managerKey") or "").strip()
-        if not manager_key.startswith("ffpc:"):
-            continue
-        if not bool(raw.get("verified")) or not bool(raw.get("allowedToContribute")):
-            continue
-        weight = max(0.0, min(1.0, float(raw.get("weight") or 0.75)))
-        out.append(
-            CohortMember(
-                manager_key=manager_key,
-                platform="ffpc",
-                qualification_method="curated_high_stakes",
-                quality=weight,
-                display_name=str(raw.get("publicDisplayName") or "") or None,
-                source_rationale=str(raw.get("sourceRationale") or "") or None,
-            )
-        )
-    return out
-
-
-def provisional_members(
-    config: dict[str, Any],
-    *,
-    ledger_path: Path | None = None,
-) -> list[CohortMember]:
-    """Select public FFPC observations without claiming sharp-v2 qualification."""
-    if not bool(config.get("enabled")) or not bool(
-        config.get("allowProvisionalPublicInCombinedSignals")
-    ):
-        return []
-    league_keys = [
-        f"ffpc:{str(source.get('sourceLeagueId') or '').strip()}"
-        for source in config.get("seedLeagues") or []
-        if isinstance(source, dict)
-        and bool(source.get("enabled", True))
-        and bool(source.get("allowProvisionalContribution"))
-        and str(source.get("sourceLeagueId") or "").strip()
-    ]
-    if not league_keys:
-        return []
-    weight = max(
-        0.0,
-        min(1.0, float(config.get("provisionalPublicWeight") or 0.5)),
-    )
-    placeholders = ",".join("?" for _ in league_keys)
-    conn = platform_ledger.ensure_platform_schema(ledger_path)
-    try:
-        rows = conn.execute(
-            f"""
-            SELECT DISTINCT am.manager_key, pm.display_name
-              FROM asset_movements am
-              JOIN transactions tx
-                ON tx.transaction_key=am.transaction_key
-              LEFT JOIN platform_managers pm
-                ON pm.manager_key=am.manager_key
-             WHERE am.platform='ffpc'
-               AND am.league_key IN ({placeholders})
-               AND tx.tx_type='trade'
-               AND am.manager_key IS NOT NULL
-            """,
-            league_keys,
-        ).fetchall()
-    finally:
-        conn.close()
-    return [
-        CohortMember(
-            manager_key=str(row["manager_key"]),
-            platform="ffpc",
-            qualification_method="provisional_public",
-            quality=weight,
-            display_name=str(row["display_name"] or "") or None,
-            source_rationale=(
-                "Observed on an explicitly configured public FFPC dynasty page; "
-                "has not passed Sharp Score v2 history gates."
-            ),
-        )
-        for row in rows
-    ]
-
-
-def cohort_members(
-    *,
-    qualification: str = "all",
-    ledger_path: Path | None = None,
-    ffpc_config: dict[str, Any] | None = None,
-) -> tuple[list[CohortMember], dict[str, Any]]:
-    if qualification not in _ALLOWED_QUALIFICATION:
-        raise ValueError(f"unsupported qualification: {qualification}")
-    records, evidence = platform_records.build_manager_records(ledger_path=ledger_path)
-    scored = sharp_score.score_managers(records)
-    config = ffpc_config if ffpc_config is not None else load_ffpc_config()
-    ffpc_enabled = bool(config.get("enabled"))
-    automatic = [
-        CohortMember(
-            manager_key=item.user_id,
-            platform=item.user_id.split(":", 1)[0],
-            qualification_method="automated_qualified",
-            quality=max(0.0, min(1.0, float(item.score or 0.0) / 100.0)),
-            methodology_version=item.methodology_version,
-        )
-        for item in scored
-        if item.qualified and (item.user_id.split(":", 1)[0] != "ffpc" or ffpc_enabled)
-    ]
-    curated_enabled = bool(ffpc_enabled and config.get("allowCuratedInCombinedSignals"))
-    curated = curated_members(config) if curated_enabled else []
-    provisional_enabled = bool(
-        ffpc_enabled and config.get("allowProvisionalPublicInCombinedSignals")
-    )
-    provisional = (
-        provisional_members(config, ledger_path=ledger_path) if provisional_enabled else []
-    )
-    if qualification == "automated":
-        selected = automatic
-    elif qualification == "curated":
-        selected = curated
-    elif qualification == "provisional":
-        selected = provisional
-    else:
-        selected = [*automatic, *curated, *provisional]
-
-    # A manager may be explicitly linked to one canonical identity and
-    # appear through two methods. Automated qualification wins; otherwise
-    # the higher configured quality wins.
-    by_key: dict[str, CohortMember] = {}
-    priority = {
-        "provisional_public": 1,
-        "curated_high_stakes": 2,
-        "automated_qualified": 3,
-    }
-    for item in selected:
-        prior = by_key.get(item.manager_key)
-        if prior is None or (priority.get(item.qualification_method, 0), item.quality) > (
-            priority.get(prior.qualification_method, 0),
-            prior.quality,
-        ):
-            by_key[item.manager_key] = item
-    coverage = {
-        "automatedQualifiedManagers": len(automatic),
-        "curatedManagers": len(curated),
-        "curatedContributionEnabled": curated_enabled,
-        "provisionalManagers": len(provisional),
-        "provisionalContributionEnabled": provisional_enabled,
-        "evidenceManagers": len(evidence),
-        "methodologyVersion": sharp_score.methodology_version(),
-    }
-    return list(by_key.values()), coverage
 
 
 def _aggregate_window(

--- a/src/sharp/roster_collect.py
+++ b/src/sharp/roster_collect.py
@@ -1,0 +1,707 @@
+"""Collect the CURRENT rosters of the sharp cohort, on both platforms.
+
+The third crawl pass.  ``discovery.py`` finds MANAGERS, ``records.py``
+finds their RESULTS, and this finds what they currently OWN — the fact a
+roster percentage is made of, which nothing in the tree persisted.
+
+The cohort is not re-derived here
+─────────────────────────────────
+The manager pool comes from ``src/sharp/cohort.py::cohort_members`` —
+the same call the Sharp Buy/Sell Tracker makes.  This module decides
+only which of that pool's ROSTERS are observable and eligible.  It has
+no notion of who qualifies as a sharp and must never grow one.
+
+Budget
+──────
+Two Sleeper calls per league (``/league/{id}`` for format + status,
+``/league/{id}/rosters`` for the holdings), paced by the same ``_Budget``
+shape ``records.py`` uses.  Leagues are visited once regardless of how
+many cohort members play in them, so a league shared by five sharps
+costs two calls, not ten.
+
+FFPC costs ZERO calls: its roster contents already arrive through the
+public-page crawl and sit in ``platform_memberships.metadata_json``
+under ``rosterAssets``.  This pass only lifts them into the queryable
+store.
+
+Nothing is silently dropped
+───────────────────────────
+Every roster reached is written, eligible or not, with its exclusion
+reasons attached.  A roster that fails a gate becomes an auditable row
+rather than an absence, which is what makes "why is the denominator
+smaller than the cohort" answerable.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+from src.intel import league_filter, platform_ledger
+from src.sharp import cohort as sharp_cohort
+from src.sharp import roster_store
+
+log = logging.getLogger(__name__)
+
+SLEEPER_BASE = "https://api.sleeper.app/v1"
+
+CALLS_PER_LEAGUE = 2
+DEFAULT_BUDGET = 600
+DEFAULT_SLEEP_S = 0.15
+
+# Sleeper league statuses that mean the league is not a live dynasty
+# team any more.  ``complete`` is normal at season end and is NOT an
+# exclusion — a completed 2026 league still describes real ownership
+# until the rollover.
+_ABANDONED_STATUSES = {"abandoned", "deleted", "archived"}
+
+# Identity confidence below which we will not attribute a roster.  FFPC
+# league-scoped team identities sit at 0.70 and are accepted; name-only
+# identities sit at 0.25 and are not — attributing a roster to a manager
+# matched on a display-name hash is exactly the "uncertain identity
+# matching" case the audit requires us to exclude.
+MIN_IDENTITY_CONFIDENCE = 0.5
+
+HttpGet = Callable[[str], Any]
+
+# ── exclusion reasons (the audit vocabulary) ─────────────────────────
+REASON_LEAGUE_NOT_SHARP_ELIGIBLE = "league_not_sharp_eligible"
+REASON_INCOMPATIBLE_FORMAT = "incompatible_league_format"
+REASON_ABANDONED_LEAGUE = "abandoned_or_inactive_league"
+REASON_ORPHANED_ROSTER = "orphaned_roster_no_owner"
+REASON_INCOMPLETE_ROSTER = "incomplete_roster_data"
+REASON_UNCERTAIN_IDENTITY = "uncertain_identity_match"
+REASON_NO_CANONICAL_ASSETS = "no_mappable_players"
+# A prior season of a league whose current season we also collected.
+# See ``_collapse_season_chains`` — one dynasty league is one roster,
+# however many seasons of it we have observed.
+REASON_SUPERSEDED_SEASON = "superseded_by_later_season"
+
+
+def _default_http_get(url: str) -> Any:
+    # Same reasoning as ``records.py``: a paced batch job must not ride
+    # the user-request circuit breaker, whose open state would burn
+    # budget on instant ``None``s without touching Sleeper.
+    from src.public_league import sleeper_client
+
+    return sleeper_client._request_json(url)
+
+
+@dataclass
+class CollectResult:
+    leagues_examined: int = 0
+    rosters_recorded: int = 0
+    eligible_rosters: int = 0
+    excluded_rosters: int = 0
+    assets_recorded: int = 0
+    unmapped_assets: int = 0
+    calls_used: int = 0
+    budget_exhausted: bool = False
+    exclusion_reasons: dict[str, int] = field(default_factory=dict)
+    errors: list[str] = field(default_factory=list)
+
+    def note_exclusions(self, reasons: Sequence[str]) -> None:
+        for reason in reasons:
+            self.exclusion_reasons[reason] = self.exclusion_reasons.get(reason, 0) + 1
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "leaguesExamined": self.leagues_examined,
+            "rostersRecorded": self.rosters_recorded,
+            "eligibleRosters": self.eligible_rosters,
+            "excludedRosters": self.excluded_rosters,
+            "assetsRecorded": self.assets_recorded,
+            "unmappedAssets": self.unmapped_assets,
+            "callsUsed": self.calls_used,
+            "budgetExhausted": self.budget_exhausted,
+            "exclusionReasons": dict(sorted(self.exclusion_reasons.items())),
+            "errors": self.errors[:20],
+        }
+
+
+class _Budget:
+    def __init__(self, budget: int, sleep_s: float, http_get: HttpGet, sleep_fn=time.sleep):
+        self.remaining = max(0, int(budget))
+        self.used = 0
+        self._sleep_s = max(0.0, float(sleep_s))
+        self._get = http_get
+        self._sleep = sleep_fn
+
+    def can_call(self, n: int = 1) -> bool:
+        return self.remaining >= n
+
+    def get(self, url: str) -> Any:
+        if self.remaining <= 0:
+            return None
+        if self.used > 0 and self._sleep_s > 0:
+            self._sleep(self._sleep_s)
+        self.remaining -= 1
+        self.used += 1
+        return self._get(url)
+
+
+# ── league format ────────────────────────────────────────────────────
+
+
+def league_format(league: dict[str, Any] | None) -> dict[str, Any]:
+    """The format facts the roster-percentage filters need.
+
+    Derived from the ``/league/{id}`` payload the collector already
+    fetches, so no extra call.  Every field is nullable and the readers
+    treat ``None`` as "unknown", never as "false" — a filter must not
+    quietly include a league whose format we could not determine.
+    """
+    if not isinstance(league, dict):
+        return {}
+    settings = league.get("settings") if isinstance(league.get("settings"), dict) else {}
+    scoring = (
+        league.get("scoring_settings") if isinstance(league.get("scoring_settings"), dict) else {}
+    )
+    positions = [str(p).upper() for p in (league.get("roster_positions") or []) if p]
+
+    starting_qb = positions.count("QB")
+    superflex = "SUPER_FLEX" in positions or "SFLEX" in positions or starting_qb >= 2
+    idp_slots = [p for p in positions if p in ("DL", "LB", "DB", "IDP_FLEX", "DE", "DT", "CB", "S")]
+    try:
+        te_bonus = float(scoring.get("bonus_rec_te") or 0.0)
+    except (TypeError, ValueError):
+        te_bonus = 0.0
+
+    return {
+        "teams": league.get("total_rosters"),
+        "season": league.get("season"),
+        "status": str(league.get("status") or "") or None,
+        "leagueType": league_filter.type_label(league),
+        "superflex": bool(superflex) if positions else None,
+        "startingQb": starting_qb if positions else None,
+        "tePremium": (te_bonus > 0) if scoring else None,
+        "teBonus": te_bonus if scoring else None,
+        "idp": bool(idp_slots) if positions else None,
+        # Whether the league even HAS a slot for these matters to the
+        # denominator, not just to display: a kicker cannot be rostered
+        # in a league with no K slot, so counting that league against
+        # him would understate every kicker on the board.
+        "kicker": ("K" in positions) if positions else None,
+        "teamDefense": ("DEF" in positions or "DST" in positions) if positions else None,
+        "taxiSlots": settings.get("taxi_slots"),
+        "bestBall": bool(settings.get("best_ball")),
+    }
+
+
+def _contention(roster: dict[str, Any]) -> str:
+    """``"contending" | "rebuilding" | "unknown"`` from the roster's own record.
+
+    Deliberately the cheapest defensible signal: the current season's
+    W/L already rides inside the ``/rosters`` payload, so this costs
+    nothing.  Before any game is played there is no evidence either way,
+    and that answers ``"unknown"`` rather than defaulting a whole
+    preseason board into one bucket.
+
+    This is NOT the BDVM contend/retool/rebuild classifier
+    (``src/bdvm/roster.py``).  That one needs projections and a league
+    config we do not have for arbitrary discovered leagues.
+    """
+    settings = roster.get("settings") if isinstance(roster.get("settings"), dict) else {}
+    try:
+        wins = int(settings.get("wins") or 0)
+        losses = int(settings.get("losses") or 0)
+        ties = int(settings.get("ties") or 0)
+    except (TypeError, ValueError):
+        return "unknown"
+    played = wins + losses + ties
+    if played < 4:
+        return "unknown"
+    win_pct = (wins + 0.5 * ties) / played
+    if win_pct >= 0.55:
+        return "contending"
+    if win_pct <= 0.45:
+        return "rebuilding"
+    return "unknown"
+
+
+# ── Sleeper ──────────────────────────────────────────────────────────
+
+
+def _sleeper_assets(roster: dict[str, Any]) -> list[roster_store.RosterAsset]:
+    """Every player the roster holds, slot-labelled.
+
+    Sleeper's ``players`` array is the WHOLE roster — taxi and reserve
+    players are members of it as well as of their own arrays.  So
+    ``players`` is the membership truth and ``taxi``/``reserve`` are
+    read only to LABEL those same ids.  Reading the three arrays as
+    separate populations would double-count every taxi player; the
+    store's primary key would collapse it anyway, but the label would
+    then depend on insertion order.
+
+    A taxi or IR player still counts as rostered, which is what the
+    slot label exists to make visible rather than to filter on.
+    """
+    players = [str(p).strip() for p in (roster.get("players") or []) if str(p or "").strip()]
+    taxi = {str(p).strip() for p in (roster.get("taxi") or []) if str(p or "").strip()}
+    reserve = {str(p).strip() for p in (roster.get("reserve") or []) if str(p or "").strip()}
+    out = []
+    for player_id in players:
+        if player_id in taxi:
+            slot = roster_store.SLOT_TAXI
+        elif player_id in reserve:
+            slot = roster_store.SLOT_RESERVE
+        else:
+            slot = roster_store.SLOT_ACTIVE
+        # Sleeper player ids ARE the canonical asset ids — see
+        # ``src/platforms/assets.py``, which anchors the catalog on them.
+        out.append(
+            roster_store.RosterAsset(
+                canonical_asset_id=player_id,
+                asset_type="player",
+                slot=slot,
+                source_asset_id=player_id,
+            )
+        )
+    return out
+
+
+def _cohort_sleeper_leagues(
+    manager_keys: Sequence[str],
+    *,
+    conn,
+) -> dict[str, set[str]]:
+    """``{source_league_id: {manager_key}}`` for the cohort's Sleeper leagues."""
+    sleeper_keys = [k for k in manager_keys if str(k).startswith("sleeper:")]
+    if not sleeper_keys:
+        return {}
+    out: dict[str, set[str]] = {}
+    for start in range(0, len(sleeper_keys), 400):
+        chunk = sleeper_keys[start : start + 400]
+        placeholders = ",".join("?" for _ in chunk)
+        for row in conn.execute(
+            f"""
+            SELECT league_key, manager_key
+              FROM platform_memberships
+             WHERE platform='sleeper' AND manager_key IN ({placeholders})
+            """,
+            chunk,
+        ).fetchall():
+            league_key = str(row["league_key"] or "")
+            if not league_key.startswith("sleeper:"):
+                continue
+            out.setdefault(league_key.split(":", 1)[1], set()).add(str(row["manager_key"]))
+    return out
+
+
+def _collapse_season_chains(
+    observations: list[roster_store.RosterObservation],
+    leagues: dict[str, dict[str, Any]],
+    result: CollectResult,
+) -> list[roster_store.RosterObservation]:
+    """Keep only the CURRENT season of each dynasty league chain.
+
+    Sleeper mints a NEW ``league_id`` every season and links the old one
+    through ``previous_league_id``.  A dynasty league we have observed
+    for three years is therefore three ids for ONE league, and the sharp
+    playing in it holds ONE team, not three.  Counting each id would
+    inflate both the numerator and the denominator — and unevenly, since
+    long-running leagues (the ones most likely to be sharp-eligible)
+    would be weighted by their age.
+
+    The chain data costs nothing: ``previous_league_id`` rides inside
+    the ``/league/{id}`` payload already fetched for the format.  A
+    league that is another collected league's predecessor is superseded;
+    its rosters are still STORED, marked ineligible with
+    ``superseded_by_later_season``, so the collapse is auditable rather
+    than a silent disappearance.
+
+    Chains reaching outside this run are unaffected — a predecessor we
+    did not collect cannot be superseded by something we never saw, and
+    guessing would drop a live league.
+    """
+    superseded = {
+        str(league.get("previous_league_id") or "").strip()
+        for league in leagues.values()
+        if str(league.get("previous_league_id") or "").strip()
+    } & set(leagues)
+    if not superseded:
+        return observations
+    for observation in observations:
+        league_id = observation.league_key.split(":", 1)[-1]
+        if league_id in superseded:
+            observation.exclusion_reasons = list(
+                dict.fromkeys([*observation.exclusion_reasons, REASON_SUPERSEDED_SEASON])
+            )
+            result.note_exclusions([REASON_SUPERSEDED_SEASON])
+    return observations
+
+
+def collect_sleeper_rosters(
+    *,
+    manager_keys: Sequence[str],
+    http_get: HttpGet | None = None,
+    budget: int = DEFAULT_BUDGET,
+    sleep_s: float = DEFAULT_SLEEP_S,
+    ledger_path: Path | None = None,
+    sleep_fn=time.sleep,
+    now_ms: int | None = None,
+    run_id: str | None = None,
+) -> CollectResult:
+    """Fetch and store the cohort's Sleeper rosters."""
+    result = CollectResult()
+    if not manager_keys:
+        return result
+    b = _Budget(budget, sleep_s, http_get or _default_http_get, sleep_fn=sleep_fn)
+    now = int(now_ms if now_ms is not None else time.time() * 1000)
+
+    conn = roster_store.ensure_roster_schema(ledger_path)
+    try:
+        by_league = _cohort_sleeper_leagues(manager_keys, conn=conn)
+        pool = set(manager_keys)
+        observations: list[roster_store.RosterObservation] = []
+        fetched: dict[str, dict[str, Any]] = {}
+
+        for league_id, member_keys in sorted(by_league.items()):
+            if not b.can_call(CALLS_PER_LEAGUE):
+                result.budget_exhausted = True
+                break
+            league = b.get(f"{SLEEPER_BASE}/league/{league_id}")
+            if not isinstance(league, dict):
+                result.errors.append(f"league_fetch_failed:{league_id}")
+                continue
+            result.leagues_examined += 1
+
+            rosters = b.get(f"{SLEEPER_BASE}/league/{league_id}/rosters")
+            if not isinstance(rosters, list):
+                result.errors.append(f"rosters_fetch_failed:{league_id}")
+                continue
+            fetched[str(league_id)] = league
+
+            league_key = f"sleeper:{league_id}"
+            fmt = league_format(league)
+            league_reasons: list[str] = []
+            sharp_reason = league_filter.sharp_exclusion_reason(league)
+            if sharp_reason:
+                league_reasons.append(
+                    REASON_INCOMPATIBLE_FORMAT
+                    if sharp_reason in ("best_ball", "redraft", "keeper")
+                    else REASON_LEAGUE_NOT_SHARP_ELIGIBLE
+                )
+            if str(league.get("status") or "").lower() in _ABANDONED_STATUSES:
+                league_reasons.append(REASON_ABANDONED_LEAGUE)
+
+            for roster in rosters:
+                if not isinstance(roster, dict):
+                    continue
+                source_roster_id = roster.get("roster_id")
+                if source_roster_id is None:
+                    continue
+                owner = str(roster.get("owner_id") or "").strip()
+                co_owners = [
+                    str(c).strip() for c in (roster.get("co_owners") or []) if str(c or "").strip()
+                ]
+
+                # Attribute to the cohort member who actually holds this
+                # roster.  A cohort co-owner is credited when the primary
+                # owner is not in the pool, matching how the Insider
+                # Trading crawl attributes co-owned teams.
+                attributed = None
+                if f"sleeper:{owner}" in pool:
+                    attributed = f"sleeper:{owner}"
+                else:
+                    for candidate in co_owners:
+                        if f"sleeper:{candidate}" in pool:
+                            attributed = f"sleeper:{candidate}"
+                            break
+                if attributed is None:
+                    continue  # not a sharp's roster — not our business
+
+                reasons = list(league_reasons)
+                if not owner and not co_owners:
+                    reasons.append(REASON_ORPHANED_ROSTER)
+                assets = _sleeper_assets(roster)
+                if not assets:
+                    reasons.append(REASON_INCOMPLETE_ROSTER)
+
+                observations.append(
+                    roster_store.RosterObservation(
+                        platform="sleeper",
+                        league_key=league_key,
+                        manager_key=attributed,
+                        source_roster_id=str(source_roster_id),
+                        assets=assets,
+                        season=str(league.get("season") or "") or None,
+                        team_name=None,
+                        exclusion_reasons=reasons,
+                        league_format=fmt,
+                        contention=_contention(roster),
+                        observed_ms=now,
+                        source_run_id=run_id,
+                    )
+                )
+                result.note_exclusions(reasons)
+
+            # ``member_keys`` is unused beyond league selection, but is
+            # kept in the map so a future per-member gate has it.
+            del member_keys
+
+        observations = _collapse_season_chains(observations, fetched, result)
+        totals = roster_store.record_rosters(observations, conn=conn)
+        result.rosters_recorded = totals["rosters"]
+        result.eligible_rosters = totals["eligibleRosters"]
+        result.excluded_rosters = totals["rosters"] - totals["eligibleRosters"]
+        result.assets_recorded = totals["assetsRecorded"]
+    finally:
+        conn.close()
+
+    result.calls_used = b.used
+    if not b.can_call(CALLS_PER_LEAGUE):
+        result.budget_exhausted = True
+    log.info("sharp.roster_collect.sleeper: %s", result.to_dict())
+    return result
+
+
+# ── FFPC ─────────────────────────────────────────────────────────────
+
+
+def collect_ffpc_rosters(
+    *,
+    manager_keys: Sequence[str],
+    ledger_path: Path | None = None,
+    now_ms: int | None = None,
+    run_id: str | None = None,
+) -> CollectResult:
+    """Lift already-crawled FFPC roster contents into the roster store.
+
+    Zero network calls: ``src/platforms/ffpc/parser.py::_parse_rosters``
+    already resolved these players against the Sleeper-keyed catalog
+    during the public-page crawl and stashed them on the membership row.
+
+    Two honest limitations are recorded rather than papered over:
+
+    * FFPC publishes no taxi/IR marking on its roster pages, so every
+      asset is stored as ``active``.  It is not a claim that none are on
+      taxi — it is the absence of the distinction.
+    * An FFPC player the resolver could not map has no canonical asset
+      id.  Those are counted into ``unmappedAssets`` and left out of the
+      roster rather than guessed onto a similar name, which is the same
+      no-fuzzy-fallback policy ``AssetResolver`` enforces.
+    """
+    result = CollectResult()
+    ffpc_keys = [k for k in manager_keys if str(k).startswith("ffpc:")]
+    if not ffpc_keys:
+        return result
+    now = int(now_ms if now_ms is not None else time.time() * 1000)
+
+    conn = roster_store.ensure_roster_schema(ledger_path)
+    try:
+        rows = []
+        for start in range(0, len(ffpc_keys), 400):
+            chunk = ffpc_keys[start : start + 400]
+            placeholders = ",".join("?" for _ in chunk)
+            rows.extend(
+                conn.execute(
+                    f"""
+                    SELECT pmem.league_key, pmem.manager_key, pmem.roster_id,
+                           pmem.source_team_id, pmem.team_name, pmem.metadata_json,
+                           pl.season AS season, pl.sharp_eligible AS sharp_eligible,
+                           pl.metadata_json AS league_metadata_json,
+                           pm.identity_confidence AS identity_confidence
+                      FROM platform_memberships pmem
+                      LEFT JOIN platform_leagues pl ON pl.league_key=pmem.league_key
+                      LEFT JOIN platform_managers pm ON pm.manager_key=pmem.manager_key
+                     WHERE pmem.platform='ffpc' AND pmem.manager_key IN ({placeholders})
+                    """,
+                    chunk,
+                ).fetchall()
+            )
+
+        observations: list[roster_store.RosterObservation] = []
+        leagues_seen: set[str] = set()
+        for row in rows:
+            try:
+                metadata = json.loads(row["metadata_json"] or "{}")
+            except (TypeError, ValueError):
+                metadata = {}
+            roster_assets = metadata.get("rosterAssets")
+            if not isinstance(roster_assets, list):
+                continue  # this membership came from a page with no roster table
+            leagues_seen.add(str(row["league_key"]))
+
+            assets = []
+            unmapped = 0
+            for item in roster_assets:
+                if not isinstance(item, dict):
+                    continue
+                canonical = str(item.get("canonicalAssetId") or "").strip()
+                if not canonical:
+                    unmapped += 1
+                    continue
+                assets.append(
+                    roster_store.RosterAsset(
+                        canonical_asset_id=canonical,
+                        asset_type="player",
+                        # FFPC pages carry no taxi/IR column.
+                        slot=roster_store.SLOT_ACTIVE,
+                        source_asset_id=str(item.get("sourceAssetId") or "") or None,
+                    )
+                )
+            result.unmapped_assets += unmapped
+
+            reasons: list[str] = []
+            try:
+                confidence = float(row["identity_confidence"] or 0.0)
+            except (TypeError, ValueError):
+                confidence = 0.0
+            if confidence < MIN_IDENTITY_CONFIDENCE:
+                reasons.append(REASON_UNCERTAIN_IDENTITY)
+            if not assets:
+                reasons.append(REASON_NO_CANONICAL_ASSETS if unmapped else REASON_INCOMPLETE_ROSTER)
+
+            try:
+                league_metadata = json.loads(row["league_metadata_json"] or "{}")
+            except (TypeError, ValueError):
+                league_metadata = {}
+            fmt = {
+                "leagueType": "dynasty",
+                "season": row["season"],
+                "status": None,
+                # FFPC public pages expose no roster-position list, so
+                # every format axis stays unknown rather than assumed.
+                "superflex": league_metadata.get("superflex"),
+                "tePremium": league_metadata.get("tePremium"),
+                "idp": league_metadata.get("idp"),
+                "teams": league_metadata.get("teams"),
+            }
+
+            source_roster_id = str(row["roster_id"] or row["source_team_id"] or "").strip()
+            if not source_roster_id:
+                # Without a team id there is no stable roster identity;
+                # counting it would risk merging two teams into one slot.
+                result.note_exclusions([REASON_UNCERTAIN_IDENTITY])
+                result.excluded_rosters += 1
+                continue
+
+            observations.append(
+                roster_store.RosterObservation(
+                    platform="ffpc",
+                    league_key=str(row["league_key"]),
+                    manager_key=str(row["manager_key"]),
+                    source_roster_id=source_roster_id,
+                    assets=assets,
+                    season=row["season"],
+                    team_name=row["team_name"],
+                    exclusion_reasons=reasons,
+                    league_format=fmt,
+                    contention="unknown",
+                    observed_ms=now,
+                    source_run_id=run_id,
+                )
+            )
+            result.note_exclusions(reasons)
+
+        totals = roster_store.record_rosters(observations, conn=conn)
+        result.leagues_examined = len(leagues_seen)
+        result.rosters_recorded = totals["rosters"]
+        result.eligible_rosters = totals["eligibleRosters"]
+        result.excluded_rosters += totals["rosters"] - totals["eligibleRosters"]
+        result.assets_recorded = totals["assetsRecorded"]
+    finally:
+        conn.close()
+
+    log.info("sharp.roster_collect.ffpc: %s", result.to_dict())
+    return result
+
+
+def collect_all(
+    *,
+    qualification: str = "all",
+    ledger_path: Path | None = None,
+    http_get: HttpGet | None = None,
+    budget: int = DEFAULT_BUDGET,
+    sleep_s: float = DEFAULT_SLEEP_S,
+    sleep_fn=time.sleep,
+    now_ms: int | None = None,
+    run_id: str | None = None,
+    skip_sleeper: bool = False,
+    skip_ffpc: bool = False,
+) -> dict[str, Any]:
+    """Refresh every reachable sharp roster on both platforms."""
+    members, coverage = sharp_cohort.cohort_members(
+        qualification=qualification, ledger_path=ledger_path
+    )
+    manager_keys = [m.manager_key for m in members]
+
+    sleeper = (
+        CollectResult()
+        if skip_sleeper
+        else collect_sleeper_rosters(
+            manager_keys=manager_keys,
+            http_get=http_get,
+            budget=budget,
+            sleep_s=sleep_s,
+            ledger_path=ledger_path,
+            sleep_fn=sleep_fn,
+            now_ms=now_ms,
+            run_id=run_id,
+        )
+    )
+    ffpc = (
+        CollectResult()
+        if skip_ffpc
+        else collect_ffpc_rosters(
+            manager_keys=manager_keys,
+            ledger_path=ledger_path,
+            now_ms=now_ms,
+            run_id=run_id,
+        )
+    )
+    return {
+        "cohortManagers": len(manager_keys),
+        "cohortCoverage": coverage,
+        "sleeper": sleeper.to_dict(),
+        "ffpc": ffpc.to_dict(),
+        "store": roster_store.coverage(path=ledger_path),
+    }
+
+
+def record_collection_run(
+    summary: dict[str, Any],
+    *,
+    started_ms: int,
+    finished_ms: int,
+    ledger_path: Path | None = None,
+    run_id: str,
+    status: str = "ok",
+) -> None:
+    """Log the pass into ``ingestion_runs`` so freshness is inspectable.
+
+    Filed under the pseudo-platform ``sharp_rosters`` rather than under
+    ``sleeper``/``ffpc``.  ``platform_ledger.platform_coverage`` reports
+    the LATEST run per platform, so filing this pass under ``sleeper``
+    would make the Buy/Sell Tracker's Sleeper freshness read as a roster
+    refresh.  That function iterates a fixed ``("sleeper", "ffpc")``
+    tuple, so this row is invisible to it by construction.
+    """
+    sleeper = summary.get("sleeper") or {}
+    ffpc = summary.get("ffpc") or {}
+    platform_ledger.record_ingestion_run(
+        run_id=run_id,
+        platform="sharp_rosters",
+        source_ref="cohort",
+        started_ms=started_ms,
+        finished_ms=finished_ms,
+        status=status,
+        # ``record_ingestion_run`` reads camelCase counter keys
+        # (``platform_ledger.py`` — ``values.get("pagesFetched")``), not
+        # the snake_case column names. Passing snake_case silently
+        # records zeros, which is how a run that did real work reads as
+        # one that did nothing.
+        counters={
+            "pagesFetched": int(sleeper.get("callsUsed") or 0),
+            "pagesParsed": int(sleeper.get("leaguesExamined") or 0)
+            + int(ffpc.get("leaguesExamined") or 0),
+            "unmappedPlayers": int(ffpc.get("unmappedAssets") or 0),
+        },
+        metadata=summary,
+        path=ledger_path,
+    )

--- a/src/sharp/roster_collect.py
+++ b/src/sharp/roster_collect.py
@@ -101,6 +101,11 @@ class CollectResult:
     unmapped_assets: int = 0
     calls_used: int = 0
     budget_exhausted: bool = False
+    # Leagues the budget did not reach this run. Published so an operator
+    # can size ``--budget`` from the journal instead of guessing: a run
+    # that ends with this at 0 is keeping up, and a run that ends with a
+    # stable non-zero number needs a bigger budget rather than patience.
+    leagues_remaining: int = 0
     exclusion_reasons: dict[str, int] = field(default_factory=dict)
     errors: list[str] = field(default_factory=list)
 
@@ -118,6 +123,7 @@ class CollectResult:
             "unmappedAssets": self.unmapped_assets,
             "callsUsed": self.calls_used,
             "budgetExhausted": self.budget_exhausted,
+            "leaguesRemaining": self.leagues_remaining,
             "exclusionReasons": dict(sorted(self.exclusion_reasons.items())),
             "errors": self.errors[:20],
         }
@@ -292,6 +298,43 @@ def _cohort_sleeper_leagues(
     return out
 
 
+def _last_observed_by_league(conn) -> dict[str, int]:
+    """``{source_league_id: newest observed_ms}`` from the roster store."""
+    out: dict[str, int] = {}
+    for row in conn.execute(
+        """
+        SELECT league_key, MAX(observed_ms) AS last_ms
+          FROM sharp_rosters
+         WHERE platform='sleeper'
+         GROUP BY league_key
+        """
+    ).fetchall():
+        league_key = str(row["league_key"] or "")
+        if league_key.startswith("sleeper:") and row["last_ms"] is not None:
+            out[league_key.split(":", 1)[1]] = int(row["last_ms"])
+    return out
+
+
+def _collection_order(league_ids: Sequence[str], *, conn) -> list[str]:
+    """Fair, persistent crawl order for a BUDGETED pass.
+
+    Reuses ``record_queue.prioritize_league_ids`` — the same ordering the
+    records crawl uses — rather than adding a second notion of fairness:
+    never-collected leagues first, then previously collected ones oldest
+    first, ties stable by id.
+
+    Without this the pass sorted by league id, so a run that hit its call
+    budget re-collected the same alphabetical prefix on every subsequent
+    run and the leagues after the cutoff were NEVER collected. That is
+    not a slow rollout — it is a permanently invisible tail, and it would
+    have been silent: the board would look healthy while systematically
+    omitting part of the cohort.
+    """
+    from src.sharp import record_queue
+
+    return record_queue.prioritize_league_ids(league_ids, _last_observed_by_league(conn))
+
+
 def _collapse_season_chains(
     observations: list[roster_store.RosterObservation],
     leagues: dict[str, dict[str, Any]],
@@ -360,9 +403,11 @@ def collect_sleeper_rosters(
         observations: list[roster_store.RosterObservation] = []
         fetched: dict[str, dict[str, Any]] = {}
 
-        for league_id, member_keys in sorted(by_league.items()):
+        for league_id in _collection_order(list(by_league), conn=conn):
+            member_keys = by_league[league_id]
             if not b.can_call(CALLS_PER_LEAGUE):
                 result.budget_exhausted = True
+                result.leagues_remaining = len(by_league) - result.leagues_examined
                 break
             league = b.get(f"{SLEEPER_BASE}/league/{league_id}")
             if not isinstance(league, dict):

--- a/src/sharp/roster_percentage.py
+++ b/src/sharp/roster_percentage.py
@@ -1,0 +1,921 @@
+"""Sharp Roster Percentage — how much of the sharp cohort owns each player.
+
+    Sharp Roster Percentage
+      = unique ELIGIBLE sharp rosters containing the player
+      ÷ total eligible sharp rosters that COULD contain him
+
+The pool is not defined here
+───────────────────────────
+Membership comes from ``src/sharp/cohort.py::cohort_members`` — the same
+call ``src/sharp/market.py`` makes for the Buy/Sell Tracker.  This module
+never decides who is a sharp, never adds a qualification rule, and never
+keeps its own list.  If the cohort changes, both boards change together.
+
+Rosters, not people, are the denominator
+────────────────────────────────────────
+A manager with five legitimate dynasty teams contributes FIVE roster
+observations; a manager with one contributes one.  That is deliberate
+per the product definition — the question is "what share of sharp
+rosters hold him", not "what share of sharp humans".  Both numbers are
+published: ``uniqueSharpManagers`` collapses linked accounts to people
+via ``cohort.canonical_manager_ids``, ``eligibleRosters`` does not.
+
+The denominator is PER PLAYER, and that is not a detail
+───────────────────────────────────────────────────────
+A linebacker cannot be rostered in a league with no IDP slots, and a
+kicker cannot be rostered in a league with no K slot.  Dividing by every
+sharp roster would make every IDP player look barely owned — an artifact
+of format mix, reported as a finding.  Each player is therefore measured
+against the rosters whose league is KNOWN to field his position family.
+Rosters whose format we could not determine are excluded from that
+player's denominator and counted in ``formatUnknownRosters`` rather than
+silently assumed either way.
+
+What this board is NOT
+──────────────────────
+A high roster percentage is not a buy signal.  Elite players are
+rostered almost everywhere, so the top of this board is mostly a
+restatement of consensus value.  The interesting columns are the
+comparison ones — advantage over the market, and the trend — which is
+why the payload ships those beside the raw percentage rather than
+leaving a caller to infer intent from rank alone.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable, Sequence
+
+from src.sharp import cohort as sharp_cohort
+from src.sharp import roster_store
+
+log = logging.getLogger(__name__)
+
+# ── sample-size policy ───────────────────────────────────────────────
+#
+# Below MIN_ELIGIBLE_ROSTERS a percentage is not published as a ranked
+# result at all: with eight rosters every player jumps in 12.5-point
+# steps and the ordering is mostly noise.  Between that and
+# DIRECTIONAL_ROSTER_CEILING the numbers ARE published but carry an
+# explicit directional warning, because the alternative — hiding them —
+# would leave a growing cohort looking permanently broken.
+MIN_ELIGIBLE_ROSTERS = 8
+DIRECTIONAL_ROSTER_CEILING = 40
+
+# A player measured against fewer rosters than this is flagged
+# individually even when the board as a whole is well sampled — the
+# IDP-in-a-mostly-offense-cohort case.
+MIN_PLAYER_DENOMINATOR = 5
+
+# A trend is only reported when both endpoints are measured over
+# substantially the same rosters.  Below this overlap the sample moved
+# too much for the delta to mean anything, and we say so instead.
+MIN_TREND_POPULATION_OVERLAP = 0.80
+
+DAY_MS = 86_400_000
+
+DEFAULT_LIMIT = 50
+ALLOWED_LIMITS = (25, 50, 100, 0)  # 0 = all qualifying players
+
+# ── position families ────────────────────────────────────────────────
+_OFFENSE = {"QB", "RB", "WR", "TE", "FB"}
+_DEFENSIVE_LINE = {"DL", "DE", "DT", "EDGE"}
+_LINEBACKER = {"LB", "ILB", "OLB", "MLB"}
+_DEFENSIVE_BACK = {"DB", "CB", "S", "SS", "FS"}
+_IDP = _DEFENSIVE_LINE | _LINEBACKER | _DEFENSIVE_BACK
+_KICKER = {"K", "PK"}
+_TEAM_DEFENSE = {"DEF", "DST", "D/ST"}
+
+FAMILY_OFFENSE = "offense"
+FAMILY_IDP = "idp"
+FAMILY_KICKER = "kicker"
+FAMILY_TEAM_DEFENSE = "teamDefense"
+FAMILY_UNKNOWN = "unknown"
+
+POSITION_FILTERS = (
+    "all",
+    "QB",
+    "RB",
+    "WR",
+    "TE",
+    "DL",
+    "LB",
+    "DB",
+    "offense",
+    "idp",
+)
+PLATFORM_FILTERS = ("all", "sleeper", "ffpc")
+FORMAT_FILTERS = ("all", "superflex", "oneQb", "tePremium", "nonTePremium")
+CONTENTION_FILTERS = ("all", "contending", "rebuilding")
+EXPERIENCE_FILTERS = ("all", "rookies", "veterans")
+
+SORTS = (
+    "rostered",
+    "advantage",
+    "negativeAdvantage",
+    "valueWithoutRosters",
+    "rosteredWithoutValue",
+    "trend",
+)
+
+
+def position_family(position: str | None) -> str:
+    pos = str(position or "").strip().upper()
+    if not pos:
+        return FAMILY_UNKNOWN
+    if pos in _OFFENSE:
+        return FAMILY_OFFENSE
+    if pos in _IDP:
+        return FAMILY_IDP
+    if pos in _KICKER:
+        return FAMILY_KICKER
+    if pos in _TEAM_DEFENSE:
+        return FAMILY_TEAM_DEFENSE
+    return FAMILY_UNKNOWN
+
+
+def _matches_position_filter(position: str | None, position_filter: str) -> bool:
+    pos = str(position or "").strip().upper()
+    if position_filter == "all":
+        return True
+    if position_filter == "offense":
+        return pos in _OFFENSE
+    if position_filter == "idp":
+        return pos in _IDP
+    if position_filter == "DL":
+        return pos in _DEFENSIVE_LINE
+    if position_filter == "LB":
+        return pos in _LINEBACKER
+    if position_filter == "DB":
+        return pos in _DEFENSIVE_BACK
+    return pos == position_filter
+
+
+def _roster_supports_family(league_format: dict[str, Any], family: str) -> bool | None:
+    """Can this roster's league field that position family?
+
+    ``None`` means UNKNOWN — the format was never captured — and an
+    unknown roster is excluded from that family's denominator rather
+    than counted either way.
+    """
+    if family in (FAMILY_OFFENSE, FAMILY_UNKNOWN):
+        return True
+    key = {
+        FAMILY_IDP: "idp",
+        FAMILY_KICKER: "kicker",
+        FAMILY_TEAM_DEFENSE: "teamDefense",
+    }[family]
+    value = (league_format or {}).get(key)
+    return None if value is None else bool(value)
+
+
+# ── roster filtering ─────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class RosterFilters:
+    platform: str = "all"
+    league_format: str = "all"
+    contention: str = "all"
+
+    def validate(self) -> None:
+        if self.platform not in PLATFORM_FILTERS:
+            raise ValueError(f"platform must be one of {PLATFORM_FILTERS}")
+        if self.league_format not in FORMAT_FILTERS:
+            raise ValueError(f"format must be one of {FORMAT_FILTERS}")
+        if self.contention not in CONTENTION_FILTERS:
+            raise ValueError(f"contention must be one of {CONTENTION_FILTERS}")
+
+
+def _roster_passes(roster: dict[str, Any], filters: RosterFilters) -> bool:
+    if filters.platform != "all" and roster.get("platform") != filters.platform:
+        return False
+    fmt = roster.get("format") or {}
+    if filters.league_format == "superflex" and fmt.get("superflex") is not True:
+        return False
+    if filters.league_format == "oneQb" and fmt.get("superflex") is not False:
+        return False
+    if filters.league_format == "tePremium" and fmt.get("tePremium") is not True:
+        return False
+    if filters.league_format == "nonTePremium" and fmt.get("tePremium") is not False:
+        return False
+    if filters.contention != "all" and roster.get("contention") != filters.contention:
+        return False
+    return True
+
+
+def eligible_rosters(
+    rosters: Iterable[dict[str, Any]],
+    *,
+    cohort_manager_keys: set[str],
+    now_ms: int,
+    max_age_days: int = roster_store.DEFAULT_MAX_ROSTER_AGE_DAYS,
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    """``(eligible, {reason: dropped})``.
+
+    Three gates on top of the ones the collector already recorded:
+
+    * the roster's manager must STILL be in the sharp cohort — a manager
+      who has since fallen below the bar must stop contributing, and
+      this is the join that enforces it;
+    * the observation must be fresh enough to describe the present;
+    * the roster must carry at least one mappable player.
+    """
+    kept: list[dict[str, Any]] = []
+    dropped: dict[str, int] = {}
+
+    def drop(reason: str) -> None:
+        dropped[reason] = dropped.get(reason, 0) + 1
+
+    cutoff = int(now_ms) - int(max_age_days) * DAY_MS
+    for roster in rosters:
+        if not roster.get("isEligible"):
+            for reason in roster.get("exclusionReasons") or ["unspecified"]:
+                drop(str(reason))
+            continue
+        if roster.get("managerKey") not in cohort_manager_keys:
+            drop("manager_no_longer_in_cohort")
+            continue
+        if int(roster.get("observedMs") or 0) < cutoff:
+            drop("stale_roster_data")
+            continue
+        if not roster.get("assets"):
+            drop("incomplete_roster_data")
+            continue
+        kept.append(roster)
+    return kept, dropped
+
+
+# ── player metadata + value join ─────────────────────────────────────
+
+
+def _contract_rows(contract: dict[str, Any] | None) -> list[dict[str, Any]]:
+    rows = (contract or {}).get("playersArray")
+    return [r for r in rows if isinstance(r, dict)] if isinstance(rows, list) else []
+
+
+def build_player_index(contract: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
+    """``{sleeperPlayerId: {name, position, nflTeam, value, overallRank}}``.
+
+    Canonical asset ids ARE Sleeper player ids (``src/platforms/assets.py``
+    anchors the catalog on them), and contract rows stamp that same id as
+    ``playerId``, so this join is by identifier rather than by name.
+    Rows without a Sleeper id cannot be joined to a roster and are
+    skipped rather than name-matched — a fuzzy fallback here would
+    attach one player's value to another's ownership.
+
+    Three contract field names are easy to get wrong and are worth
+    stating: the NFL team is ``team`` (there is no ``nflTeam`` on a
+    ``playersArray`` row), the rookie flag is ``rookie``, and the tier
+    is ``canonicalTierId``.  ``rankDerivedValue`` and
+    ``canonicalConsensusRank`` are stamped only for rows inside the
+    backend's ``OVERALL_RANK_LIMIT``, so a deep-roster player legitimately
+    has neither — that is reported as ``playersWithoutBoardValue``, not
+    filled with a zero.
+    """
+    index: dict[str, dict[str, Any]] = {}
+    for row in _contract_rows(contract):
+        player_id = str(row.get("playerId") or "").strip()
+        if not player_id:
+            continue
+        value = row.get("rankDerivedValue")
+        rank = row.get("canonicalConsensusRank")
+        index.setdefault(
+            player_id,
+            {
+                "displayName": row.get("displayName") or row.get("canonicalName"),
+                "position": (str(row.get("position") or "").strip().upper() or None),
+                "nflTeam": (
+                    str(row.get("team") or row.get("nflTeam") or "").strip().upper() or None
+                ),
+                "value": int(value) if isinstance(value, (int, float)) else None,
+                "overallRank": int(rank) if isinstance(rank, (int, float)) else None,
+                "age": row.get("age"),
+                "isRookie": bool(row.get("rookie") or row.get("isRookie")),
+            },
+        )
+    return index
+
+
+def _fallback_metadata(asset_id: str) -> dict[str, Any]:
+    """Name/position for an asset the live contract does not price.
+
+    Reuses the Buy/Sell Tracker's own local catalog so both boards
+    display the same name for the same id.
+    """
+    from src.sharp import market as sharp_market
+
+    meta = sharp_market._fallback_asset_metadata(asset_id) or {}
+    return {
+        "displayName": meta.get("displayName"),
+        "position": meta.get("position"),
+        "nflTeam": meta.get("nflTeam"),
+        "value": None,
+        "overallRank": None,
+        "age": None,
+        "isRookie": False,
+    }
+
+
+# ── market comparison (deliberately pluggable, empty today) ──────────
+
+MarketOwnershipProvider = Callable[[Sequence[str]], dict[str, float]]
+
+_market_provider: MarketOwnershipProvider | None = None
+
+
+def set_market_ownership_provider(provider: MarketOwnershipProvider | None) -> None:
+    """Register a general-dynasty roster-percentage source.
+
+    THERE IS NO SUCH SOURCE IN THIS CODEBASE TODAY.  Every ingested
+    ranking source publishes values or ranks, not ownership; Sleeper's
+    trending endpoint publishes 24-hour ADD COUNTS, which is a flow, not
+    a stock, and turning it into an ownership rate would be inventing a
+    number.  So the comparison columns are null and the payload says
+    ``marketComparisonAvailable: false`` rather than shipping a
+    plausible-looking fabrication.
+
+    The seam exists so that adding a real feed later is a registration,
+    not a rewrite of the board.
+    """
+    global _market_provider
+    _market_provider = provider
+
+
+def _market_ownership(asset_ids: Sequence[str]) -> dict[str, float]:
+    if _market_provider is None or not asset_ids:
+        return {}
+    try:
+        raw = _market_provider(asset_ids) or {}
+    except Exception:  # noqa: BLE001 — an optional comparison must never break the board
+        log.exception("sharp roster %%: market ownership provider failed")
+        return {}
+    out: dict[str, float] = {}
+    for key, value in raw.items():
+        try:
+            pct = float(value)
+        except (TypeError, ValueError):
+            continue
+        if 0.0 <= pct <= 1.0:
+            out[str(key)] = pct
+    return out
+
+
+# ── the board ────────────────────────────────────────────────────────
+
+
+def _tally(
+    rosters: Sequence[dict[str, Any]],
+) -> tuple[dict[str, set[str]], dict[str, dict[str, int]]]:
+    """``({assetId: {rosterKey}}, {assetId: {slot: n}})``.
+
+    The set is what makes a player count at most once per roster at the
+    aggregation layer too — the store's primary key already guarantees
+    it, and this keeps the guarantee true even if a caller hands in
+    hand-built rows.
+    """
+    holders: dict[str, set[str]] = {}
+    slots: dict[str, dict[str, int]] = {}
+    for roster in rosters:
+        key = str(roster.get("rosterKey"))
+        for asset in roster.get("assets") or []:
+            asset_id = str(asset.get("canonicalAssetId") or "")
+            if not asset_id:
+                continue
+            holders.setdefault(asset_id, set()).add(key)
+            slot = str(asset.get("slot") or roster_store.SLOT_ACTIVE)
+            bucket = slots.setdefault(asset_id, {})
+            bucket[slot] = bucket.get(slot, 0) + 1
+    return holders, slots
+
+
+def _denominators(
+    rosters: Sequence[dict[str, Any]],
+) -> tuple[dict[str, set[str]], dict[str, int]]:
+    """``({family: {rosterKey}}, {family: unknownFormatRosters})``."""
+    by_family: dict[str, set[str]] = {}
+    unknown: dict[str, int] = {}
+    families = (FAMILY_OFFENSE, FAMILY_IDP, FAMILY_KICKER, FAMILY_TEAM_DEFENSE, FAMILY_UNKNOWN)
+    for family in families:
+        by_family[family] = set()
+        unknown[family] = 0
+    for roster in rosters:
+        key = str(roster.get("rosterKey"))
+        fmt = roster.get("format") or {}
+        for family in families:
+            supported = _roster_supports_family(fmt, family)
+            if supported is None:
+                unknown[family] += 1
+            elif supported:
+                by_family[family].add(key)
+    return by_family, unknown
+
+
+def _trend(
+    asset_id: str,
+    *,
+    current_holders: set[str],
+    baseline_holders: dict[str, set[str]],
+    current_roster_keys: set[str],
+    baseline_roster_keys: set[str],
+) -> dict[str, Any]:
+    """Change in roster percentage between two instants.
+
+    Measured over the INTERSECTION of the two roster populations, so a
+    cohort that grew between the endpoints cannot masquerade as players
+    gaining ownership.  When the overlap is too small the delta is
+    withheld and the reason is returned in its place.
+    """
+    shared = current_roster_keys & baseline_roster_keys
+    union = current_roster_keys | baseline_roster_keys
+    overlap = (len(shared) / len(union)) if union else 0.0
+    if not shared or overlap < MIN_TREND_POPULATION_OVERLAP:
+        return {
+            "available": False,
+            "reason": "roster_population_changed",
+            "populationOverlap": round(overlap, 4),
+            "comparableRosters": len(shared),
+        }
+    now_held = {k for k in current_holders if k in shared}
+    then_held = {k for k in baseline_holders if k in shared}
+    return {
+        "available": True,
+        "populationOverlap": round(overlap, 4),
+        "comparableRosters": len(shared),
+        "rosterPctThen": round(len(then_held) / len(shared), 6),
+        "rosterPctNow": round(len(now_held) / len(shared), 6),
+        "rosterPctChange": round((len(now_held) - len(then_held)) / len(shared), 6),
+        "rostersAdded": len(now_held - then_held),
+        "rostersDropped": len(then_held - now_held),
+    }
+
+
+def _sample_warning(eligible_count: int) -> dict[str, Any] | None:
+    if eligible_count < MIN_ELIGIBLE_ROSTERS:
+        return {
+            "level": "insufficient",
+            "message": (
+                f"Based on {eligible_count} eligible sharp roster"
+                f"{'' if eligible_count == 1 else 's'}. That is below the "
+                f"{MIN_ELIGIBLE_ROSTERS}-roster minimum, so these percentages are "
+                "not ranked as meaningful results."
+            ),
+        }
+    if eligible_count < DIRECTIONAL_ROSTER_CEILING:
+        return {
+            "level": "directional",
+            "message": (
+                f"Based on {eligible_count} eligible sharp rosters. Treat this "
+                "result as directional because of the limited sample size."
+            ),
+        }
+    return None
+
+
+def build_board(
+    *,
+    contract: dict[str, Any] | None = None,
+    ledger_path: Path | None = None,
+    qualification: str = "all",
+    position: str = "all",
+    platform: str = "all",
+    league_format: str = "all",
+    contention: str = "all",
+    experience: str = "all",
+    sort: str = "rostered",
+    limit: int = DEFAULT_LIMIT,
+    include_picks: bool = False,
+    now_ms: int | None = None,
+    max_age_days: int = roster_store.DEFAULT_MAX_ROSTER_AGE_DAYS,
+    buy_sell_window: str = "30d",
+) -> dict[str, Any]:
+    """The Sharp Roster Percentage payload."""
+    if position not in POSITION_FILTERS:
+        raise ValueError(f"position must be one of {POSITION_FILTERS}")
+    if experience not in EXPERIENCE_FILTERS:
+        raise ValueError(f"experience must be one of {EXPERIENCE_FILTERS}")
+    if sort not in SORTS:
+        raise ValueError(f"sort must be one of {SORTS}")
+    filters = RosterFilters(platform=platform, league_format=league_format, contention=contention)
+    filters.validate()
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        raise ValueError("limit must be an integer") from None
+    if limit not in ALLOWED_LIMITS:
+        raise ValueError(f"limit must be one of {ALLOWED_LIMITS}")
+
+    now = int(now_ms if now_ms is not None else time.time() * 1000)
+
+    members, cohort_coverage = sharp_cohort.cohort_members(
+        qualification=qualification, ledger_path=ledger_path
+    )
+    cohort_keys = {m.manager_key for m in members}
+
+    stored = roster_store.load_rosters(path=ledger_path)
+    usable, exclusions = eligible_rosters(
+        stored,
+        cohort_manager_keys=cohort_keys,
+        now_ms=now,
+        max_age_days=max_age_days,
+    )
+    filtered = [r for r in usable if _roster_passes(r, filters)]
+    filtered_out = len(usable) - len(filtered)
+
+    roster_keys = {str(r["rosterKey"]) for r in filtered}
+    holders, slot_counts = _tally(filtered)
+    denominators, unknown_format = _denominators(filtered)
+
+    player_index = build_player_index(contract)
+    buy_sell = _buy_sell_index(
+        members=members,
+        ledger_path=ledger_path,
+        window=buy_sell_window,
+        now_ms=now,
+    )
+
+    baselines = {
+        "sevenDay": now - 7 * DAY_MS,
+        "thirtyDay": now - 30 * DAY_MS,
+        "seasonToDate": _season_start_ms(now),
+    }
+    baseline_holdings = {
+        name: roster_store.holdings_as_of(as_of, roster_keys=sorted(roster_keys), path=ledger_path)
+        for name, as_of in baselines.items()
+    }
+
+    market_pct = _market_ownership(sorted(holders))
+    rows: list[dict[str, Any]] = []
+    unpriced = 0
+    for asset_id, held_by in holders.items():
+        is_pick = asset_id.startswith("pick:")
+        if is_pick and not include_picks:
+            continue
+        meta = player_index.get(asset_id) or _fallback_metadata(asset_id)
+        pos = meta.get("position")
+        if not _matches_position_filter(pos, position):
+            continue
+        if experience == "rookies" and not meta.get("isRookie"):
+            continue
+        if experience == "veterans" and meta.get("isRookie"):
+            continue
+
+        family = FAMILY_UNKNOWN if is_pick else position_family(pos)
+        denominator_keys = denominators.get(family) or set()
+        # A roster that HOLDS the player proves its league fields his
+        # position, so it belongs in his denominator even when the
+        # format capture was incomplete. Without this an unknown-format
+        # roster could contribute a numerator it was excluded from
+        # counting against, and a percentage could exceed 100%.
+        applicable = (denominator_keys | held_by) & roster_keys
+        if not applicable:
+            continue
+        counted = held_by & applicable
+        pct = len(counted) / len(applicable)
+        if meta.get("value") is None:
+            unpriced += 1
+
+        market = market_pct.get(asset_id)
+        row = {
+            "assetId": asset_id,
+            "displayName": meta.get("displayName") or asset_id,
+            "position": pos,
+            "nflTeam": meta.get("nflTeam"),
+            "assetType": "pick" if is_pick else "player",
+            "positionFamily": family,
+            "sharpRosters": len(counted),
+            "eligibleRosters": len(applicable),
+            "sharpRosterPct": round(pct, 6),
+            "marketRosterPct": market,
+            "sharpRosterAdvantage": (round(pct - market, 6) if market is not None else None),
+            "value": meta.get("value"),
+            "overallRank": meta.get("overallRank"),
+            "slots": slot_counts.get(asset_id, {}),
+            "buySell": buy_sell.get(asset_id),
+            "sampleWarning": (
+                {
+                    "level": "insufficient",
+                    "message": (
+                        f"Only {len(applicable)} eligible sharp roster"
+                        f"{'' if len(applicable) == 1 else 's'} could roster this "
+                        "player, so the percentage is directional at best."
+                    ),
+                }
+                if len(applicable) < MIN_PLAYER_DENOMINATOR
+                else None
+            ),
+            "trend": {
+                name: _trend(
+                    asset_id,
+                    current_holders=counted,
+                    baseline_holders={
+                        key: assets
+                        for key, assets in (baseline_holdings[name] or {}).items()
+                        if asset_id in assets
+                    },
+                    current_roster_keys=applicable,
+                    baseline_roster_keys=set(baseline_holdings[name] or {}) & applicable,
+                )
+                for name in baselines
+            },
+        }
+        rows.append(row)
+
+    rows = _sort_rows(rows, sort)
+    total_qualifying = len(rows)
+    if limit:
+        rows = rows[:limit]
+    for index, row in enumerate(rows):
+        row["rank"] = index + 1
+
+    transparency = _transparency(
+        filtered,
+        members=members,
+        ledger_path=ledger_path,
+        unknown_format=unknown_format,
+    )
+    warning = _sample_warning(len(filtered))
+
+    return {
+        "status": "ok"
+        if filtered
+        else ("cohort_building" if not stored else "no_eligible_rosters"),
+        "generatedAt": now,
+        "lastUpdated": transparency.get("lastRefreshedMs"),
+        "methodologyVersion": cohort_coverage.get("methodologyVersion"),
+        "query": {
+            "position": position,
+            "platform": platform,
+            "format": league_format,
+            "contention": contention,
+            "experience": experience,
+            "qualification": qualification,
+            "sort": sort,
+            "limit": limit,
+            "includePicks": include_picks,
+        },
+        "players": rows,
+        "totalQualifyingPlayers": total_qualifying,
+        "transparency": transparency,
+        "cohort": {
+            **cohort_coverage,
+            "selectedManagers": len(members),
+        },
+        "sample": {
+            "eligibleRosters": len(filtered),
+            "minimumForRanking": MIN_ELIGIBLE_ROSTERS,
+            "directionalBelow": DIRECTIONAL_ROSTER_CEILING,
+            "warning": warning,
+            "rankable": len(filtered) >= MIN_ELIGIBLE_ROSTERS,
+        },
+        "marketComparison": {
+            "available": bool(market_pct),
+            "source": None if not market_pct else "registered_provider",
+            "note": (
+                "No general-dynasty roster-percentage feed is ingested by this "
+                "platform, so sharp-vs-market advantage is unavailable. Every "
+                "ranking source we ingest publishes values or ranks, and Sleeper's "
+                "trending endpoint publishes 24-hour add counts — a flow, not an "
+                "ownership rate. Those columns stay null rather than estimated."
+            )
+            if not market_pct
+            else None,
+        },
+        "exclusions": {
+            "byReason": dict(sorted(exclusions.items())),
+            "excludedRosters": sum(exclusions.values()),
+            "removedByFilters": filtered_out,
+            "storedRosters": len(stored),
+        },
+        "dataQuality": {
+            "playersWithoutBoardValue": unpriced,
+            "formatUnknownRosters": unknown_format,
+        },
+        "formula": {
+            "sharpRosterPct": (
+                "unique eligible sharp rosters containing the player ÷ eligible "
+                "sharp rosters whose league can field his position family"
+            ),
+            "denominator": (
+                "rosters, not people — one manager's five dynasty teams are five "
+                "roster observations"
+            ),
+            "dedup": (
+                "enforced by primary key: one row per (roster, player) and one row "
+                "per roster, so re-collection and duplicate imports cannot inflate"
+            ),
+        },
+    }
+
+
+def _season_start_ms(now_ms: int) -> int:
+    """Start of the current NFL season, in ms.
+
+    Approximated as 1 September of the season year, where the season
+    year rolls in September — the same convention
+    ``src/bdvm/actuals.py::current_nfl_season`` uses, so "season to
+    date" means the same thing on both surfaces.
+    """
+    from datetime import datetime, timezone
+
+    moment = datetime.fromtimestamp(now_ms / 1000, tz=timezone.utc)
+    year = moment.year if moment.month >= 9 else moment.year - 1
+    return int(datetime(year, 9, 1, tzinfo=timezone.utc).timestamp() * 1000)
+
+
+def _buy_sell_index(
+    *,
+    members: Sequence[Any],
+    ledger_path: Path | None,
+    window: str,
+    now_ms: int,
+) -> dict[str, dict[str, Any]]:
+    """Recent Sharp Buy/Sell Tracker activity, keyed by canonical asset.
+
+    Read through the tracker's OWN aggregation rather than re-querying
+    the ledger, so "3 sharp buys" means exactly what it means on
+    ``/market/sharp-tracker``.  A failure here degrades to no activity
+    column; it never takes the roster board down.
+    """
+    try:
+        from src.intel import platform_ledger, signals
+        from src.sharp import market as sharp_market
+
+        since, until = signals.window_bounds(window, now_ms)
+        movements = platform_ledger.query_movements(
+            manager_keys=[m.manager_key for m in members],
+            since_ms=since,
+            until_ms=until,
+            canonical_only=True,
+            path=ledger_path,
+        )
+        quality = {m.manager_key: m.quality for m in members}
+        aggregated = sharp_market._aggregate_window(movements, quality)
+    except Exception:  # noqa: BLE001 — optional enrichment
+        log.exception("sharp roster %%: buy/sell join failed")
+        return {}
+    out: dict[str, dict[str, Any]] = {}
+    for asset_id, item in aggregated.items():
+        buys, sells = int(item.get("buys") or 0), int(item.get("sells") or 0)
+        out[asset_id] = {
+            "window": window,
+            "buys": buys,
+            "sells": sells,
+            "net": buys - sells,
+            "uniqueManagers": item.get("uniqueManagers"),
+            "signal": _buy_sell_signal(buys, sells),
+            "lastTs": item.get("lastTs"),
+        }
+    return out
+
+
+def _buy_sell_signal(buys: int, sells: int) -> str:
+    """A label for the direction, never a recommendation.
+
+    Deliberately coarse: with the volumes a sharp cohort produces, a
+    finer scale would imply precision the counts do not carry.
+    """
+    volume = buys + sells
+    if volume == 0:
+        return "none"
+    net = buys - sells
+    if volume < 3:
+        return "thin"
+    if net > 0 and buys >= 2 * max(1, sells):
+        return "accumulating"
+    if net < 0 and sells >= 2 * max(1, buys):
+        return "distributing"
+    return "mixed"
+
+
+def _sort_rows(rows: list[dict[str, Any]], sort: str) -> list[dict[str, Any]]:
+    """Order the board, with unavailable values sinking rather than
+    sorting as zero."""
+
+    def advantage(row: dict[str, Any]) -> float | None:
+        return row.get("sharpRosterAdvantage")
+
+    def trend_change(row: dict[str, Any]) -> float | None:
+        item = (row.get("trend") or {}).get("thirtyDay") or {}
+        return item.get("rosterPctChange") if item.get("available") else None
+
+    def key(row: dict[str, Any]):
+        pct = row.get("sharpRosterPct") or 0.0
+        rank = row.get("overallRank")
+        if sort == "advantage":
+            value = advantage(row)
+            return (0 if value is not None else 1, -(value or 0.0), -pct)
+        if sort == "negativeAdvantage":
+            value = advantage(row)
+            return (0 if value is not None else 1, (value or 0.0), -pct)
+        if sort == "trend":
+            value = trend_change(row)
+            return (0 if value is not None else 1, -(value or 0.0), -pct)
+        if sort == "valueWithoutRosters":
+            # Highly valued, lightly owned: sort by board rank ascending
+            # among players whose ownership lags their rank.
+            return (0 if rank is not None else 1, rank or 0, pct)
+        if sort == "rosteredWithoutValue":
+            # Widely owned, poorly ranked: heavy ownership first, then
+            # the WORST board rank, so an unranked-but-owned player
+            # surfaces rather than sinking.
+            return (-pct, -(rank if rank is not None else 10**6))
+        return (-pct, -(row.get("value") or 0), row.get("displayName") or "")
+
+    return sorted(rows, key=key)
+
+
+def _transparency(
+    rosters: Sequence[dict[str, Any]],
+    *,
+    members: Sequence[Any],
+    ledger_path: Path | None,
+    unknown_format: dict[str, int],
+) -> dict[str, Any]:
+    manager_keys = sorted({str(r.get("managerKey")) for r in rosters if r.get("managerKey")})
+    try:
+        people = sharp_cohort.unique_person_count(manager_keys, ledger_path=ledger_path)
+    except Exception:  # noqa: BLE001
+        log.exception("sharp roster %%: person collapse failed")
+        people = len(manager_keys)
+
+    by_platform: dict[str, int] = {}
+    for roster in rosters:
+        name = str(roster.get("platform") or "unknown")
+        by_platform[name] = by_platform.get(name, 0) + 1
+
+    cohort_size = len(members)
+    represented = len({str(r.get("managerKey")) for r in rosters})
+    last_refreshed = max((int(r.get("observedMs") or 0) for r in rosters), default=None)
+
+    return {
+        "uniqueSharpManagers": people,
+        "sharpManagerAccounts": len(manager_keys),
+        "eligibleRosters": len(rosters),
+        "sleeperRosters": by_platform.get("sleeper", 0),
+        "ffpcRosters": by_platform.get("ffpc", 0),
+        "otherPlatformRosters": sum(
+            count for name, count in by_platform.items() if name not in ("sleeper", "ffpc")
+        ),
+        "cohortManagers": cohort_size,
+        "cohortManagersRepresented": represented,
+        "cohortCoveragePct": (round(represented / cohort_size, 4) if cohort_size else None),
+        "lastRefreshedMs": last_refreshed,
+        "rostersPerManager": (round(len(rosters) / represented, 2) if represented else None),
+        "formatUnknownRosters": unknown_format,
+    }
+
+
+def audit_player(
+    asset_id: str,
+    *,
+    ledger_path: Path | None = None,
+    qualification: str = "all",
+    now_ms: int | None = None,
+    max_age_days: int = roster_store.DEFAULT_MAX_ROSTER_AGE_DAYS,
+) -> dict[str, Any]:
+    """Every roster behind one player's percentage, and every one excluded.
+
+    This is the manual-verification surface: the numerator is listed
+    roster by roster, so a count can be checked against the underlying
+    rosters without a database client.
+    """
+    now = int(now_ms if now_ms is not None else time.time() * 1000)
+    members, _coverage = sharp_cohort.cohort_members(
+        qualification=qualification, ledger_path=ledger_path
+    )
+    cohort_keys = {m.manager_key for m in members}
+    stored = roster_store.load_rosters(path=ledger_path)
+    usable, exclusions = eligible_rosters(
+        stored, cohort_manager_keys=cohort_keys, now_ms=now, max_age_days=max_age_days
+    )
+    holding = []
+    for roster in usable:
+        for asset in roster.get("assets") or []:
+            if str(asset.get("canonicalAssetId")) == str(asset_id):
+                holding.append(
+                    {
+                        "rosterKey": roster["rosterKey"],
+                        "platform": roster["platform"],
+                        "leagueKey": roster["leagueKey"],
+                        "managerKey": roster["managerKey"],
+                        "sourceRosterId": roster["sourceRosterId"],
+                        "slot": asset.get("slot"),
+                        "observedMs": roster["observedMs"],
+                        "contention": roster.get("contention"),
+                        "format": roster.get("format"),
+                    }
+                )
+                break  # at most one observation per roster, by construction
+    return {
+        "assetId": str(asset_id),
+        "holdingRosters": sorted(holding, key=lambda r: r["rosterKey"]),
+        "holdingRosterCount": len(holding),
+        "eligibleRosterCount": len(usable),
+        "distinctRosterKeys": len({r["rosterKey"] for r in holding}),
+        "exclusions": dict(sorted(exclusions.items())),
+        "generatedAt": now,
+    }

--- a/src/sharp/roster_store.py
+++ b/src/sharp/roster_store.py
@@ -1,0 +1,660 @@
+"""Persisted sharp ROSTER observations — the store behind Sharp Roster %.
+
+Why a new store at all
+──────────────────────
+The sharp ledger records MOVEMENTS (who traded what, when).  A roster
+percentage needs the orthogonal fact — who HOLDS what right now — and
+that did not exist anywhere durable:
+
+* ``src/intel/crawler.py`` builds ``league_entry["holdings"]`` but writes
+  it to the per-league Insider Trading snapshot JSON, scoped to ONE
+  league's member pool.  ``src/intel/service.py::holdings_from_state``
+  is its only reader.  That pool is not the sharp cohort.
+* ``src/sharp/records.py`` fetches ``/league/{id}/rosters`` for
+  sharp-eligible leagues but reads only ``owner_id``/``settings`` — it
+  throws the player list away.
+* FFPC roster contents DO reach the ledger, but only as opaque
+  ``platform_memberships.metadata_json["rosterAssets"]`` — unqueryable
+  and with no eligibility, freshness, or exclusion record.
+
+Deduplication is STRUCTURAL, not a cleanup pass
+───────────────────────────────────────────────
+Every requirement about not double-counting is enforced by a primary
+key, so no caller can forget to apply it and no later refactor can drop
+it silently:
+
+    sharp_roster_assets  PK (roster_key, canonical_asset_id)
+        A player counts AT MOST ONCE per roster.  Re-observing the same
+        roster, importing the same page twice, or seeing the same player
+        arrive through two source rows all collapse to one row.
+
+    sharp_rosters        PK roster_key = "<league_key>#<source_roster_id>"
+        One row per real roster.  The same roster collected twice, or
+        reached through two different sharp members in the same league,
+        is ONE denominator slot.  Re-snapshotting overwrites in place.
+
+    sharp_roster_asset_spans  PK (roster_key, canonical_asset_id, span_start_ms)
+        History as OPEN INTERVALS rather than daily copies.  Dynasty
+        turnover is low, so this is a few rows per holding instead of one
+        row per holding per day, and it answers "did this roster hold
+        this player on date D" exactly.
+
+    sharp_roster_observations  PK (roster_key, observed_ms)
+        When a roster was actually LOOKED AT.  Needed so "not observed"
+        can never be read as "dropped the player" — a delta is only
+        computed over rosters observed in both periods.
+
+One sharp manager with five legitimate dynasty teams therefore
+contributes FIVE rows to ``sharp_rosters`` (five roster observations,
+which is what the denominator wants) while still being ONE person in
+``uniqueSharpManagers`` (see ``cohort.canonical_manager_ids``).
+
+Schema installation
+───────────────────
+``ensure_roster_schema`` is plain ``CREATE TABLE IF NOT EXISTS`` and is
+deliberately NOT wired into ``platform_ledger.PLATFORM_SCHEMA_VERSION``.
+Bumping that version would re-run the whole platform migration —
+``_backfill_sleeper``, ``_sync_legacy_entities``, invariant checks — on
+every deployed ledger just to add three tables.  These tables are
+additive, reference nothing in the platform migration, and are created
+on first use.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from src.intel import platform_ledger
+
+log = logging.getLogger(__name__)
+
+# Roster slots.  Sleeper's ``players`` array already CONTAINS the taxi
+# and reserve players, so these are a label on an existing membership,
+# never an extra one — see ``collect.py`` for how they are derived.
+SLOT_ACTIVE = "active"
+SLOT_TAXI = "taxi"
+SLOT_RESERVE = "reserve"
+
+# How long a roster observation stays usable as CURRENT.  Past this it
+# is excluded with ``stale_roster_data`` rather than quietly aging into
+# the denominator.
+DEFAULT_MAX_ROSTER_AGE_DAYS = 21
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS sharp_rosters (
+  roster_key             TEXT PRIMARY KEY,
+  platform               TEXT NOT NULL,
+  league_key             TEXT NOT NULL,
+  manager_key            TEXT NOT NULL,
+  source_roster_id       TEXT NOT NULL,
+  season                 TEXT,
+  team_name              TEXT,
+  is_eligible            INTEGER NOT NULL DEFAULT 0,
+  exclusion_reasons_json TEXT,
+  format_json            TEXT,
+  contention             TEXT,
+  asset_count            INTEGER NOT NULL DEFAULT 0,
+  player_count           INTEGER NOT NULL DEFAULT 0,
+  observed_ms            INTEGER NOT NULL,
+  first_seen_ms          INTEGER NOT NULL,
+  source_run_id          TEXT
+);
+
+CREATE TABLE IF NOT EXISTS sharp_roster_assets (
+  roster_key         TEXT NOT NULL,
+  canonical_asset_id TEXT NOT NULL,
+  asset_type         TEXT NOT NULL DEFAULT 'player',
+  slot               TEXT,
+  source_asset_id    TEXT,
+  observed_ms        INTEGER NOT NULL,
+  PRIMARY KEY (roster_key, canonical_asset_id)
+);
+
+-- ``span_end_ms`` is the LAST OBSERVATION THAT CONFIRMED the holding.
+-- ``closed_at_ms`` is the observation that CONTRADICTED it — the first
+-- time we looked and the player was gone.  Both are needed, and
+-- conflating them is a real bug rather than a redundancy: a roster seen
+-- on day 0 and again on day 40 has span_end_ms = day 0, but the player
+-- was still presumed rostered on day 10 because nothing had said
+-- otherwise yet.  Asking "was he held on day 10" against span_end_ms
+-- answers no; asking against closed_at_ms answers yes, which is what a
+-- 30-day trend needs to be right.
+CREATE TABLE IF NOT EXISTS sharp_roster_asset_spans (
+  roster_key         TEXT NOT NULL,
+  canonical_asset_id TEXT NOT NULL,
+  span_start_ms      INTEGER NOT NULL,
+  span_end_ms        INTEGER NOT NULL,
+  closed             INTEGER NOT NULL DEFAULT 0,
+  closed_at_ms       INTEGER,
+  PRIMARY KEY (roster_key, canonical_asset_id, span_start_ms)
+);
+
+CREATE TABLE IF NOT EXISTS sharp_roster_observations (
+  roster_key  TEXT NOT NULL,
+  observed_ms INTEGER NOT NULL,
+  eligible    INTEGER NOT NULL DEFAULT 0,
+  asset_count INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (roster_key, observed_ms)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sr_manager ON sharp_rosters(manager_key);
+CREATE INDEX IF NOT EXISTS idx_sr_league ON sharp_rosters(league_key);
+CREATE INDEX IF NOT EXISTS idx_sr_eligible ON sharp_rosters(is_eligible, observed_ms);
+CREATE INDEX IF NOT EXISTS idx_sra_asset ON sharp_roster_assets(canonical_asset_id);
+CREATE INDEX IF NOT EXISTS idx_sras_asset ON sharp_roster_asset_spans(canonical_asset_id);
+CREATE INDEX IF NOT EXISTS idx_sras_window
+  ON sharp_roster_asset_spans(span_start_ms, span_end_ms);
+CREATE INDEX IF NOT EXISTS idx_sro_ts ON sharp_roster_observations(observed_ms);
+"""
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def roster_key(league_key: str, source_roster_id: str) -> str:
+    """The stable identity of one roster.
+
+    ``league_key`` is already ``"<platform>:<source_league_id>"``, so
+    this is unique across platforms without a third component.  The
+    separator is ``#`` because Sleeper league ids and FFPC ltuids both
+    contain neither ``#`` nor a colon-delimited roster suffix.
+    """
+    return f"{str(league_key).strip()}#{str(source_roster_id).strip()}"
+
+
+def ensure_roster_schema(
+    path: Path | None = None,
+    *,
+    conn: sqlite3.Connection | None = None,
+) -> sqlite3.Connection:
+    """Create the roster tables if absent and return an open connection.
+
+    When ``conn`` is supplied ownership stays with the caller; otherwise
+    the caller must close the returned connection.
+    """
+    connection = conn if conn is not None else platform_ledger.ensure_platform_schema(path)
+    connection.executescript(_SCHEMA)
+    connection.commit()
+    return connection
+
+
+@dataclass
+class RosterAsset:
+    canonical_asset_id: str
+    asset_type: str = "player"
+    slot: str = SLOT_ACTIVE
+    source_asset_id: str | None = None
+
+
+@dataclass
+class RosterObservation:
+    """One roster, as seen at one moment.
+
+    ``exclusion_reasons`` being non-empty is what makes a roster
+    ineligible — eligibility is never asserted independently of the
+    reasons, so an excluded roster is always explainable.
+    """
+
+    platform: str
+    league_key: str
+    manager_key: str
+    source_roster_id: str
+    assets: list[RosterAsset] = field(default_factory=list)
+    season: str | None = None
+    team_name: str | None = None
+    exclusion_reasons: list[str] = field(default_factory=list)
+    league_format: dict[str, Any] = field(default_factory=dict)
+    contention: str | None = None
+    observed_ms: int | None = None
+    source_run_id: str | None = None
+
+    @property
+    def roster_key(self) -> str:
+        return roster_key(self.league_key, self.source_roster_id)
+
+    @property
+    def is_eligible(self) -> bool:
+        return not self.exclusion_reasons
+
+
+def _unique_assets(assets: Iterable[RosterAsset]) -> list[RosterAsset]:
+    """Collapse duplicate canonical assets within ONE roster.
+
+    The table's primary key would collapse them anyway; doing it here
+    too means ``asset_count`` reports the real number rather than the
+    number of source rows, and it makes the slot precedence explicit:
+    a player listed both actively and on taxi keeps the more specific
+    label rather than whichever row happened to be inserted last.
+    """
+    precedence = {SLOT_ACTIVE: 0, SLOT_RESERVE: 1, SLOT_TAXI: 2}
+    by_id: dict[str, RosterAsset] = {}
+    for asset in assets:
+        asset_id = str(asset.canonical_asset_id or "").strip()
+        if not asset_id:
+            continue
+        prior = by_id.get(asset_id)
+        if prior is None or precedence.get(asset.slot, 0) > precedence.get(prior.slot, 0):
+            by_id[asset_id] = RosterAsset(
+                canonical_asset_id=asset_id,
+                asset_type=asset.asset_type or "player",
+                slot=asset.slot or SLOT_ACTIVE,
+                source_asset_id=asset.source_asset_id,
+            )
+    return list(by_id.values())
+
+
+def record_roster(observation: RosterObservation, *, conn: sqlite3.Connection) -> dict[str, int]:
+    """Write one roster observation, replacing any prior state for it.
+
+    Idempotent by construction: re-recording the identical roster
+    produces the identical stored state, and re-recording a CHANGED
+    roster closes the spans of departed assets and opens spans for
+    arrivals.  The caller commits.
+    """
+    now = int(observation.observed_ms or _now_ms())
+    key = observation.roster_key
+    assets = _unique_assets(observation.assets)
+    player_count = sum(1 for a in assets if a.asset_type == "player")
+
+    prior = conn.execute(
+        "SELECT first_seen_ms FROM sharp_rosters WHERE roster_key=?", (key,)
+    ).fetchone()
+    first_seen = int(prior["first_seen_ms"]) if prior else now
+
+    conn.execute(
+        """
+        INSERT INTO sharp_rosters
+          (roster_key, platform, league_key, manager_key, source_roster_id,
+           season, team_name, is_eligible, exclusion_reasons_json,
+           format_json, contention, asset_count, player_count,
+           observed_ms, first_seen_ms, source_run_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(roster_key) DO UPDATE SET
+          platform=excluded.platform,
+          league_key=excluded.league_key,
+          manager_key=excluded.manager_key,
+          source_roster_id=excluded.source_roster_id,
+          season=excluded.season,
+          team_name=COALESCE(excluded.team_name, sharp_rosters.team_name),
+          is_eligible=excluded.is_eligible,
+          exclusion_reasons_json=excluded.exclusion_reasons_json,
+          format_json=excluded.format_json,
+          contention=excluded.contention,
+          asset_count=excluded.asset_count,
+          player_count=excluded.player_count,
+          observed_ms=excluded.observed_ms,
+          source_run_id=excluded.source_run_id
+        """,
+        (
+            key,
+            observation.platform,
+            observation.league_key,
+            observation.manager_key,
+            observation.source_roster_id,
+            observation.season,
+            observation.team_name,
+            1 if observation.is_eligible else 0,
+            json.dumps(sorted(set(observation.exclusion_reasons))),
+            json.dumps(observation.league_format or {}),
+            observation.contention,
+            len(assets),
+            player_count,
+            now,
+            first_seen,
+            observation.source_run_id,
+        ),
+    )
+
+    previous_ids = {
+        str(row["canonical_asset_id"])
+        for row in conn.execute(
+            "SELECT canonical_asset_id FROM sharp_roster_assets WHERE roster_key=?",
+            (key,),
+        ).fetchall()
+    }
+    current_ids = {a.canonical_asset_id for a in assets}
+
+    # Current holdings: replace wholesale so a dropped player disappears.
+    conn.execute("DELETE FROM sharp_roster_assets WHERE roster_key=?", (key,))
+    conn.executemany(
+        """
+        INSERT INTO sharp_roster_assets
+          (roster_key, canonical_asset_id, asset_type, slot,
+           source_asset_id, observed_ms)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        [(key, a.canonical_asset_id, a.asset_type, a.slot, a.source_asset_id, now) for a in assets],
+    )
+
+    # History: extend open spans that persist, close spans that ended,
+    # open spans for arrivals.
+    open_spans = {
+        str(row["canonical_asset_id"]): int(row["span_start_ms"])
+        for row in conn.execute(
+            """
+            SELECT canonical_asset_id, span_start_ms
+              FROM sharp_roster_asset_spans
+             WHERE roster_key=? AND closed=0
+            """,
+            (key,),
+        ).fetchall()
+    }
+    for asset_id in current_ids:
+        if asset_id in open_spans:
+            conn.execute(
+                """
+                UPDATE sharp_roster_asset_spans
+                   SET span_end_ms=?
+                 WHERE roster_key=? AND canonical_asset_id=? AND span_start_ms=?
+                """,
+                (now, key, asset_id, open_spans[asset_id]),
+            )
+        else:
+            conn.execute(
+                """
+                INSERT INTO sharp_roster_asset_spans
+                  (roster_key, canonical_asset_id, span_start_ms, span_end_ms, closed)
+                VALUES (?, ?, ?, ?, 0)
+                ON CONFLICT(roster_key, canonical_asset_id, span_start_ms)
+                DO UPDATE SET span_end_ms=excluded.span_end_ms, closed=0
+                """,
+                (key, asset_id, now, now),
+            )
+    for asset_id in open_spans:
+        if asset_id not in current_ids:
+            conn.execute(
+                """
+                UPDATE sharp_roster_asset_spans
+                   SET closed=1, closed_at_ms=?
+                 WHERE roster_key=? AND canonical_asset_id=? AND span_start_ms=?
+                """,
+                (now, key, asset_id, open_spans[asset_id]),
+            )
+
+    conn.execute(
+        """
+        INSERT INTO sharp_roster_observations
+          (roster_key, observed_ms, eligible, asset_count)
+        VALUES (?, ?, ?, ?)
+        ON CONFLICT(roster_key, observed_ms) DO UPDATE SET
+          eligible=excluded.eligible, asset_count=excluded.asset_count
+        """,
+        (key, now, 1 if observation.is_eligible else 0, len(assets)),
+    )
+
+    return {
+        "assetsRecorded": len(assets),
+        "assetsAdded": len(current_ids - previous_ids),
+        "assetsRemoved": len(previous_ids - current_ids),
+    }
+
+
+def record_rosters(
+    observations: Sequence[RosterObservation],
+    *,
+    path: Path | None = None,
+    conn: sqlite3.Connection | None = None,
+) -> dict[str, int]:
+    own = conn is None
+    connection = conn if conn is not None else ensure_roster_schema(path)
+    if conn is not None:
+        ensure_roster_schema(conn=connection)
+    totals = {"rosters": 0, "eligibleRosters": 0, "assetsRecorded": 0}
+    try:
+        for observation in observations:
+            result = record_roster(observation, conn=connection)
+            totals["rosters"] += 1
+            totals["eligibleRosters"] += 1 if observation.is_eligible else 0
+            totals["assetsRecorded"] += result["assetsRecorded"]
+        connection.commit()
+    finally:
+        if own:
+            connection.close()
+    return totals
+
+
+# ── reads ────────────────────────────────────────────────────────────
+
+
+def load_rosters(
+    *,
+    manager_keys: Sequence[str] | None = None,
+    path: Path | None = None,
+    conn: sqlite3.Connection | None = None,
+    include_ineligible: bool = True,
+) -> list[dict[str, Any]]:
+    """Every stored roster, with its assets attached.
+
+    Restricting to ``manager_keys`` is how a caller ties the store back
+    to the live sharp cohort: a roster whose manager has since fallen
+    out of the cohort must not keep contributing, and this is the only
+    place that filter belongs.
+    """
+    own = conn is None
+    connection = conn if conn is not None else ensure_roster_schema(path)
+    try:
+        clauses = []
+        params: list[Any] = []
+        if manager_keys is not None:
+            if not manager_keys:
+                return []
+            clauses.append(f"manager_key IN ({','.join('?' for _ in manager_keys)})")
+            params.extend(str(k) for k in manager_keys)
+        if not include_ineligible:
+            clauses.append("is_eligible=1")
+        where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+        rows = connection.execute(
+            f"SELECT * FROM sharp_rosters{where} ORDER BY roster_key", params
+        ).fetchall()
+        if not rows:
+            return []
+        keys = [str(r["roster_key"]) for r in rows]
+        assets_by_roster: dict[str, list[dict[str, Any]]] = {key: [] for key in keys}
+        for start in range(0, len(keys), 500):
+            chunk = keys[start : start + 500]
+            placeholders = ",".join("?" for _ in chunk)
+            for row in connection.execute(
+                f"""
+                SELECT roster_key, canonical_asset_id, asset_type, slot
+                  FROM sharp_roster_assets
+                 WHERE roster_key IN ({placeholders})
+                """,
+                chunk,
+            ).fetchall():
+                assets_by_roster[str(row["roster_key"])].append(
+                    {
+                        "canonicalAssetId": str(row["canonical_asset_id"]),
+                        "assetType": str(row["asset_type"] or "player"),
+                        "slot": str(row["slot"] or SLOT_ACTIVE),
+                    }
+                )
+        out = []
+        for row in rows:
+            key = str(row["roster_key"])
+            try:
+                reasons = json.loads(row["exclusion_reasons_json"] or "[]")
+            except (TypeError, ValueError):
+                reasons = []
+            try:
+                league_format = json.loads(row["format_json"] or "{}")
+            except (TypeError, ValueError):
+                league_format = {}
+            out.append(
+                {
+                    "rosterKey": key,
+                    "platform": str(row["platform"]),
+                    "leagueKey": str(row["league_key"]),
+                    "managerKey": str(row["manager_key"]),
+                    "sourceRosterId": str(row["source_roster_id"]),
+                    "season": row["season"],
+                    "teamName": row["team_name"],
+                    "isEligible": bool(row["is_eligible"]),
+                    "exclusionReasons": [str(r) for r in reasons],
+                    "format": league_format if isinstance(league_format, dict) else {},
+                    "contention": row["contention"],
+                    "assetCount": int(row["asset_count"] or 0),
+                    "playerCount": int(row["player_count"] or 0),
+                    "observedMs": int(row["observed_ms"] or 0),
+                    "firstSeenMs": int(row["first_seen_ms"] or 0),
+                    "assets": assets_by_roster.get(key, []),
+                }
+            )
+        return out
+    finally:
+        if own:
+            connection.close()
+
+
+def holdings_as_of(
+    as_of_ms: int,
+    *,
+    roster_keys: Sequence[str],
+    path: Path | None = None,
+    conn: sqlite3.Connection | None = None,
+) -> dict[str, set[str]]:
+    """``{roster_key: {canonical_asset_id}}`` as the rosters stood at ``as_of_ms``.
+
+    A holding covers ``as_of_ms`` when it had started by then and had not
+    yet been CONTRADICTED — that is, when the observation which found the
+    player gone came later (``closed_at_ms > as_of_ms``) or has not
+    happened at all (``closed = 0``).
+
+    Note what this is deliberately NOT: a test against ``span_end_ms``,
+    the last observation that confirmed the holding.  Rosters are
+    observed periodically, so a roster seen on day 0 and again on day 40
+    has no confirmation at day 10 — yet the player was rostered then,
+    because nothing had said otherwise.  Reading ``span_end_ms`` here
+    silently zeroes every drop that happened between two observations,
+    which shows up as a 30-day trend of exactly zero no matter what
+    moved.
+
+    Rosters never observed on or before ``as_of_ms`` are ABSENT from the
+    result rather than present-and-empty.  That distinction is what lets
+    a trend compare a like-for-like population instead of reading a
+    roster we had not yet discovered as one that owned nobody.
+    """
+    if not roster_keys:
+        return {}
+    own = conn is None
+    connection = conn if conn is not None else ensure_roster_schema(path)
+    try:
+        as_of = int(as_of_ms)
+        out: dict[str, set[str]] = {}
+        keys = [str(k) for k in roster_keys]
+        for start in range(0, len(keys), 400):
+            chunk = keys[start : start + 400]
+            placeholders = ",".join("?" for _ in chunk)
+            observed = {
+                str(row["roster_key"])
+                for row in connection.execute(
+                    f"""
+                    SELECT DISTINCT roster_key
+                      FROM sharp_roster_observations
+                     WHERE roster_key IN ({placeholders}) AND observed_ms <= ?
+                    """,
+                    [*chunk, as_of],
+                ).fetchall()
+            }
+            for key in observed:
+                out.setdefault(key, set())
+            if not observed:
+                continue
+            observed_list = sorted(observed)
+            obs_placeholders = ",".join("?" for _ in observed_list)
+            for row in connection.execute(
+                f"""
+                SELECT roster_key, canonical_asset_id
+                  FROM sharp_roster_asset_spans
+                 WHERE roster_key IN ({obs_placeholders})
+                   AND span_start_ms <= ?
+                   AND (closed = 0 OR COALESCE(closed_at_ms, span_end_ms) > ?)
+                """,
+                [*observed_list, as_of, as_of],
+            ).fetchall():
+                out[str(row["roster_key"])].add(str(row["canonical_asset_id"]))
+        return out
+    finally:
+        if own:
+            connection.close()
+
+
+def coverage(
+    *,
+    path: Path | None = None,
+    conn: sqlite3.Connection | None = None,
+) -> dict[str, Any]:
+    own = conn is None
+    connection = conn if conn is not None else ensure_roster_schema(path)
+    try:
+        row = connection.execute(
+            """
+            SELECT COUNT(*) AS rosters,
+                   SUM(CASE WHEN is_eligible=1 THEN 1 ELSE 0 END) AS eligible,
+                   COUNT(DISTINCT manager_key) AS managers,
+                   COUNT(DISTINCT league_key) AS leagues,
+                   MAX(observed_ms) AS latest_ms,
+                   MIN(observed_ms) AS earliest_ms
+              FROM sharp_rosters
+            """
+        ).fetchone()
+        by_platform = {
+            str(r["platform"]): {
+                "rosters": int(r["n"] or 0),
+                "eligibleRosters": int(r["eligible"] or 0),
+            }
+            for r in connection.execute(
+                """
+                SELECT platform, COUNT(*) AS n,
+                       SUM(CASE WHEN is_eligible=1 THEN 1 ELSE 0 END) AS eligible
+                  FROM sharp_rosters GROUP BY platform
+                """
+            ).fetchall()
+        }
+        return {
+            "rosters": int(row["rosters"] or 0),
+            "eligibleRosters": int(row["eligible"] or 0),
+            "managersWithRosters": int(row["managers"] or 0),
+            "leaguesWithRosters": int(row["leagues"] or 0),
+            "latestObservedMs": int(row["latest_ms"]) if row["latest_ms"] else None,
+            "earliestObservedMs": int(row["earliest_ms"]) if row["earliest_ms"] else None,
+            "platforms": by_platform,
+        }
+    finally:
+        if own:
+            connection.close()
+
+
+def exclusion_reason_counts(
+    *,
+    path: Path | None = None,
+    conn: sqlite3.Connection | None = None,
+) -> dict[str, int]:
+    """``{reason: rosters}`` — the audit trail for everything dropped.
+
+    Excluded rosters are kept as rows, never deleted, so "why is the
+    denominator smaller than the cohort" always has an answer.
+    """
+    own = conn is None
+    connection = conn if conn is not None else ensure_roster_schema(path)
+    try:
+        counts: dict[str, int] = {}
+        for row in connection.execute(
+            "SELECT exclusion_reasons_json FROM sharp_rosters WHERE is_eligible=0"
+        ).fetchall():
+            try:
+                reasons = json.loads(row["exclusion_reasons_json"] or "[]")
+            except (TypeError, ValueError):
+                reasons = ["unparseable_exclusion_record"]
+            for reason in reasons or ["unspecified"]:
+                counts[str(reason)] = counts.get(str(reason), 0) + 1
+        return dict(sorted(counts.items()))
+    finally:
+        if own:
+            connection.close()

--- a/src/sharp/service.py
+++ b/src/sharp/service.py
@@ -182,11 +182,18 @@ def _server_app():
 
 
 def _register_http_routes() -> None:
-    """Register routes when this module is imported by ``server.py``.
+    """Register the sharp market routes onto the running FastAPI app.
 
-    The existing server imports this service directly near its Sharp
-    section. Keeping registration here avoids a second API application or
-    a parallel FFPC router while preserving ``/api/sharp/cohort`` exactly.
+    Keeping registration here avoids a second API application or a
+    parallel FFPC router while preserving ``/api/sharp/cohort`` exactly.
+
+    IDEMPOTENT, and called from three places on purpose: the module-level
+    call below (the original path), ``server.py`` right after it imports
+    this module (the RELIABLE path — the module-level call is a no-op
+    whenever something imported this module before the app existed), and
+    ``cohort_status`` as a production self-heal.
+
+    Prefer the public :func:`register_http_routes` from outside.
 
     ``Request`` is imported at module scope because postponed annotations
     resolve handler types through module globals. A function-local import made
@@ -263,6 +270,15 @@ def _register_http_routes() -> None:
         methods=["GET"],
         name="get_sharp_market_audit",
     )
+
+
+def register_http_routes() -> None:
+    """Public entry point for :func:`_register_http_routes`.
+
+    ``server.py`` calls this immediately after importing the module, so
+    registration never depends on which importer happened to be first.
+    """
+    _register_http_routes()
 
 
 _register_http_routes()

--- a/src/sharp/service.py
+++ b/src/sharp/service.py
@@ -148,6 +148,23 @@ def market_audit_payload(asset_id: str, **kwargs: Any) -> dict[str, Any]:
     return sharp_market.audit_payload(asset_id, **kwargs)
 
 
+def roster_percentage_payload(**kwargs: Any) -> dict[str, Any]:
+    """Sharp Roster Percentage board.
+
+    Same cohort as :func:`market_payload` — both resolve their manager
+    pool through ``src/sharp/cohort.py``.
+    """
+    from src.sharp import roster_percentage
+
+    return roster_percentage.build_board(**kwargs)
+
+
+def roster_percentage_audit_payload(asset_id: str, **kwargs: Any) -> dict[str, Any]:
+    from src.sharp import roster_percentage
+
+    return roster_percentage.audit_player(asset_id, **kwargs)
+
+
 def _server_app():
     """Return the FastAPI app whether ``server.py`` was imported or executed.
 

--- a/tests/e2e/helpers/journey.js
+++ b/tests/e2e/helpers/journey.js
@@ -58,6 +58,7 @@ const TITLE = {
   "/phases": "Win-now vs Rebuild",
   "/edge": "Source Disagreement",
   "/market/sharp-tracker": "Sharp Tracker",
+  "/market/sharp-roster-percentage": "Sharp Roster Percentage",
   "/league/insider-trading": "Insider Trading",
   "/league": "Hub",
   "/league/activity": "Activity",

--- a/tests/scripts/test_crawl_sharp_activity.py
+++ b/tests/scripts/test_crawl_sharp_activity.py
@@ -12,27 +12,37 @@ activity = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(activity)
 
 
-def test_qualified_sleeper_ids_excludes_other_platforms_and_unqualified(monkeypatch):
-    records = [SimpleNamespace(user_id="sleeper:one"), SimpleNamespace(user_id="ffpc:two")]
-    scores = [
-        SimpleNamespace(user_id="sleeper:one", evaluable=True, qualified=True),
-        SimpleNamespace(user_id="sleeper:no", evaluable=True, qualified=False),
-        SimpleNamespace(user_id="ffpc:two", evaluable=True, qualified=True),
+def test_qualified_sleeper_ids_selects_from_the_shared_cohort(monkeypatch):
+    """The activity crawl selects from the ONE cohort, not its own copy.
+
+    It used to re-derive the pool here — ``build_manager_records`` then
+    ``score_managers`` then filter on ``qualified`` — which meant a
+    change to qualification moved the Sharp boards while the crawl that
+    feeds them kept selecting the old set. The selection now comes from
+    ``src/sharp/cohort.py``, so this test patches that seam and asserts
+    only what the function still does itself: keep the Sleeper accounts.
+    """
+    members = [
+        SimpleNamespace(manager_key="sleeper:one"),
+        SimpleNamespace(manager_key="ffpc:two"),
     ]
-    monkeypatch.setattr(
-        activity.platform_records, "build_manager_records", lambda: (records, {"a": 1})
-    )
-    monkeypatch.setattr(activity.sharp_score, "score_managers", lambda _records: scores)
+    captured = {}
+
+    def fake_cohort_members(**kwargs):
+        captured.update(kwargs)
+        return members, {"evidenceManagers": 1}
+
+    monkeypatch.setattr(activity.sharp_cohort, "cohort_members", fake_cohort_members)
     monkeypatch.setattr(activity.sharp_score, "methodology_version", lambda: "sharp-v2")
 
     manager_ids, summary = activity.qualified_sleeper_ids()
 
     assert manager_ids == ["one"]
+    # Curated and provisional members are FFPC-only; this pass crawls Sleeper.
+    assert captured == {"qualification": "automated"}
     assert summary == {
         "methodologyVersion": "sharp-v2",
-        "managerRecords": 2,
         "evidenceManagers": 1,
-        "evaluableManagers": 3,
         "qualifiedManagers": 2,
         "qualifiedSleeperManagers": 1,
     }

--- a/tests/sharp/test_discovery.py
+++ b/tests/sharp/test_discovery.py
@@ -200,6 +200,46 @@ class TestSpiderwebExpansion:
             conn.close()
         assert {"u1", "u2"} <= ids
 
+    def test_a_league_we_never_expanded_still_records_its_membership(self, db_path):
+        """ "Which leagues does this manager play in" must not be limited
+        to the leagues the traversal happened to expand.
+
+        Sleeper's own ``/user/{id}/leagues`` proves the membership, so the
+        row is a fact even when the league sits unexpanded on the
+        frontier. Recording it only in the league->users branch silently
+        bounded the sharp ROSTER crawl to the expanded subgraph: a sharp
+        with several dynasty teams could contribute one roster to the
+        roster-percentage denominator and still read as represented.
+        """
+        http = FakeSleeper(
+            {
+                f"{BASE}/league/L0/users": [user("u1")],
+                # u1 plays in three leagues; the cap stops us expanding them.
+                f"{BASE}/user/u1/leagues/nfl/2026": [
+                    league("L1"),
+                    league("L2"),
+                    league("L3"),
+                ],
+            }
+        )
+        discovery.discover(
+            http_get=http,
+            seeds=seeds(seed_leagues=["L0"], maxGenerations=1),
+            ledger_path=db_path,
+        )
+        conn = ledger.connect(db_path)
+        try:
+            rows = {
+                (r["league_id"], r["user_id"])
+                for r in conn.execute(
+                    "SELECT league_id, user_id FROM league_memberships"
+                ).fetchall()
+            }
+        finally:
+            conn.close()
+        assert ("L0", "u1") in rows  # from the league->users branch
+        assert {("L1", "u1"), ("L2", "u1"), ("L3", "u1")} <= rows
+
     def test_generation_cap_stops_expansion(self, db_path):
         http = FakeSleeper(
             {

--- a/tests/sharp/test_roster_collect.py
+++ b/tests/sharp/test_roster_collect.py
@@ -298,6 +298,49 @@ class TestSleeper:
         assert result.eligible_rosters == 1
         assert rc.REASON_SUPERSEDED_SEASON not in result.exclusion_reasons
 
+    def test_a_budgeted_run_rotates_instead_of_re_collecting_one_prefix(self, ledger):
+        """A capped run must ADVANCE, not restart at the same leagues.
+
+        Ordering by league id meant a budget-limited pass re-collected
+        the same alphabetical prefix every run, so leagues after the
+        cutoff were never collected at all — a permanently invisible
+        tail that the board would not have shown as missing.
+        """
+        for i in range(1, 7):
+            seed_sleeper_membership(ledger, "sleeper:u1", f"sleeper:L{i}")
+
+        collected_per_run = []
+        for run in range(3):
+            rc.collect_sleeper_rosters(
+                manager_keys=["sleeper:u1"],
+                http_get=fake_http(),
+                budget=4,  # two leagues per run
+                ledger_path=ledger,
+                sleep_fn=lambda _s: None,
+                now_ms=NOW + run * 86_400_000,
+            )
+            collected_per_run.append({r["leagueKey"] for r in rs.load_rosters(path=ledger)})
+
+        # Each run reaches leagues the previous ones had not.
+        assert len(collected_per_run[0]) == 2
+        assert len(collected_per_run[1]) == 4
+        assert len(collected_per_run[2]) == 6
+
+    def test_budget_exhaustion_reports_how_much_is_left(self, ledger):
+        for i in range(1, 7):
+            seed_sleeper_membership(ledger, "sleeper:u1", f"sleeper:L{i}")
+        result = rc.collect_sleeper_rosters(
+            manager_keys=["sleeper:u1"],
+            http_get=fake_http(),
+            budget=4,
+            ledger_path=ledger,
+            sleep_fn=lambda _s: None,
+            now_ms=NOW,
+        )
+        assert result.budget_exhausted is True
+        assert result.leagues_remaining == 4
+        assert result.to_dict()["leaguesRemaining"] == 4
+
     def test_recollection_is_idempotent(self, ledger):
         seed_sleeper_membership(ledger)
         http = fake_http()

--- a/tests/sharp/test_roster_collect.py
+++ b/tests/sharp/test_roster_collect.py
@@ -1,0 +1,497 @@
+"""The sharp roster collection pass — attribution, slots, exclusions.
+
+Every Sleeper call is faked. These tests are about what the collector
+DOES with a payload, not about Sleeper being reachable.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.intel import platform_ledger
+from src.platforms.base import NormalizedLeague, NormalizedManager, NormalizedMembership
+from src.sharp import roster_collect as rc
+from src.sharp import roster_store as rs
+
+NOW = 1_800_000_000_000
+
+
+def league_payload(**overrides):
+    base = {
+        "league_id": "L1",
+        "season": "2026",
+        "status": "in_season",
+        "total_rosters": 12,
+        "previous_league_id": "L0",  # makes it >= 2 seasons old
+        "settings": {"type": 2},  # dynasty
+        "roster_positions": ["QB", "RB", "WR", "TE", "FLEX", "SUPER_FLEX", "K", "BN"],
+        "scoring_settings": {"rec": 1.0},
+    }
+    base.update(overrides)
+    return base
+
+
+def roster_payload(roster_id="1", owner="u1", players=("4046", "6794"), **overrides):
+    base = {
+        "roster_id": roster_id,
+        "owner_id": owner,
+        "players": list(players),
+        "settings": {"wins": 8, "losses": 2, "ties": 0},
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture
+def ledger(tmp_path):
+    return tmp_path / "ledger.sqlite3"
+
+
+def seed_sleeper_membership(ledger, manager_key="sleeper:u1", league_key="sleeper:L1"):
+    conn = platform_ledger.ensure_platform_schema(ledger)
+    try:
+        platform_ledger.upsert_manager(
+            NormalizedManager.build("sleeper", manager_key.split(":", 1)[1]), conn=conn
+        )
+        platform_ledger.upsert_league(
+            NormalizedLeague.build("sleeper", league_key.split(":", 1)[1]), conn=conn
+        )
+        platform_ledger.upsert_membership(
+            NormalizedMembership(
+                platform="sleeper",
+                league_key=league_key,
+                manager_key=manager_key,
+                roster_id="1",
+            ),
+            conn=conn,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def fake_http(league=None, rosters=None):
+    league = league if league is not None else league_payload()
+    rosters = rosters if rosters is not None else [roster_payload()]
+
+    def _get(url):
+        if url.endswith("/rosters"):
+            return rosters
+        return league
+
+    return _get
+
+
+class TestSleeper:
+    def test_a_cohort_members_roster_is_collected(self, ledger):
+        seed_sleeper_membership(ledger)
+        result = rc.collect_sleeper_rosters(
+            manager_keys=["sleeper:u1"],
+            http_get=fake_http(),
+            ledger_path=ledger,
+            sleep_fn=lambda _s: None,
+            now_ms=NOW,
+        )
+        assert result.leagues_examined == 1
+        assert result.rosters_recorded == 1
+        assert result.eligible_rosters == 1
+        stored = rs.load_rosters(path=ledger)
+        assert stored[0]["managerKey"] == "sleeper:u1"
+        assert {a["canonicalAssetId"] for a in stored[0]["assets"]} == {"4046", "6794"}
+
+    def test_non_cohort_rosters_in_the_same_league_are_ignored(self, ledger):
+        seed_sleeper_membership(ledger)
+        rc.collect_sleeper_rosters(
+            manager_keys=["sleeper:u1"],
+            http_get=fake_http(
+                rosters=[
+                    roster_payload(roster_id="1", owner="u1"),
+                    roster_payload(roster_id="2", owner="stranger"),
+                    roster_payload(roster_id="3", owner="also-not-sharp"),
+                ]
+            ),
+            ledger_path=ledger,
+            sleep_fn=lambda _s: None,
+            now_ms=NOW,
+        )
+        stored = rs.load_rosters(path=ledger)
+        assert len(stored) == 1
+        assert stored[0]["sourceRosterId"] == "1"
+
+    def test_two_sharps_in_one_league_yield_two_rosters_from_one_fetch(self, ledger):
+        seed_sleeper_membership(ledger, "sleeper:u1")
+        seed_sleeper_membership(ledger, "sleeper:u2")
+        result = rc.collect_sleeper_rosters(
+            manager_keys=["sleeper:u1", "sleeper:u2"],
+            http_get=fake_http(
+                rosters=[
+                    roster_payload(roster_id="1", owner="u1"),
+                    roster_payload(roster_id="2", owner="u2"),
+                ]
+            ),
+            ledger_path=ledger,
+            sleep_fn=lambda _s: None,
+            now_ms=NOW,
+        )
+        assert result.calls_used == 2  # one league, not one per member
+        assert result.rosters_recorded == 2
+
+    def test_a_cohort_co_owner_is_credited_when_the_primary_is_not_sharp(self, ledger):
+        seed_sleeper_membership(ledger, "sleeper:u1")
+        rc.collect_sleeper_rosters(
+            manager_keys=["sleeper:u1"],
+            http_get=fake_http(
+                rosters=[roster_payload(owner="stranger", co_owners=["u1"])],
+            ),
+            ledger_path=ledger,
+            sleep_fn=lambda _s: None,
+            now_ms=NOW,
+        )
+        stored = rs.load_rosters(path=ledger)
+        assert len(stored) == 1
+        assert stored[0]["managerKey"] == "sleeper:u1"
+
+    def test_taxi_and_reserve_are_labelled_not_added_twice(self, ledger):
+        """Sleeper's ``players`` is the whole roster.
+
+        Taxi and reserve ids appear in ``players`` too, so reading the
+        three arrays as separate populations would count a taxi player
+        twice. They are read only to label.
+        """
+        seed_sleeper_membership(ledger)
+        rc.collect_sleeper_rosters(
+            manager_keys=["sleeper:u1"],
+            http_get=fake_http(
+                rosters=[
+                    roster_payload(
+                        players=("4046", "6794", "5849"),
+                        taxi=["6794"],
+                        reserve=["5849"],
+                    )
+                ]
+            ),
+            ledger_path=ledger,
+            sleep_fn=lambda _s: None,
+            now_ms=NOW,
+        )
+        stored = rs.load_rosters(path=ledger)[0]
+        assert stored["assetCount"] == 3
+        assert {a["canonicalAssetId"]: a["slot"] for a in stored["assets"]} == {
+            "4046": "active",
+            "6794": "taxi",
+            "5849": "reserve",
+        }
+
+    @pytest.mark.parametrize(
+        "league_overrides,expected",
+        [
+            ({"settings": {"type": 0}}, rc.REASON_INCOMPATIBLE_FORMAT),  # redraft
+            ({"settings": {"type": 1}}, rc.REASON_INCOMPATIBLE_FORMAT),  # keeper
+            (
+                {"settings": {"type": 2, "best_ball": 1}},
+                rc.REASON_INCOMPATIBLE_FORMAT,
+            ),
+            ({"previous_league_id": ""}, rc.REASON_LEAGUE_NOT_SHARP_ELIGIBLE),  # too new
+            ({"settings": {}}, rc.REASON_LEAGUE_NOT_SHARP_ELIGIBLE),  # unknown type
+            ({"status": "abandoned"}, rc.REASON_ABANDONED_LEAGUE),
+        ],
+    )
+    def test_ineligible_leagues_are_recorded_with_a_reason(
+        self, ledger, league_overrides, expected
+    ):
+        seed_sleeper_membership(ledger)
+        result = rc.collect_sleeper_rosters(
+            manager_keys=["sleeper:u1"],
+            http_get=fake_http(league=league_payload(**league_overrides)),
+            ledger_path=ledger,
+            sleep_fn=lambda _s: None,
+            now_ms=NOW,
+        )
+        assert result.eligible_rosters == 0
+        assert expected in result.exclusion_reasons
+        # Recorded, never discarded — the audit trail is the point.
+        stored = rs.load_rosters(path=ledger)
+        assert len(stored) == 1
+        assert expected in stored[0]["exclusionReasons"]
+
+    def test_an_empty_roster_is_flagged_incomplete(self, ledger):
+        seed_sleeper_membership(ledger)
+        result = rc.collect_sleeper_rosters(
+            manager_keys=["sleeper:u1"],
+            http_get=fake_http(rosters=[roster_payload(players=())]),
+            ledger_path=ledger,
+            sleep_fn=lambda _s: None,
+            now_ms=NOW,
+        )
+        assert rc.REASON_INCOMPLETE_ROSTER in result.exclusion_reasons
+
+    def test_the_budget_bounds_the_crawl(self, ledger):
+        for i in range(1, 6):
+            seed_sleeper_membership(ledger, "sleeper:u1", f"sleeper:L{i}")
+        result = rc.collect_sleeper_rosters(
+            manager_keys=["sleeper:u1"],
+            http_get=fake_http(),
+            budget=4,
+            ledger_path=ledger,
+            sleep_fn=lambda _s: None,
+            now_ms=NOW,
+        )
+        assert result.calls_used <= 4
+        assert result.budget_exhausted is True
+
+    def test_prior_seasons_of_one_league_chain_are_superseded(self, ledger):
+        """One dynasty league is ONE roster, however many seasons of it
+        we have observed.
+
+        Sleeper mints a new league_id each season and links back through
+        ``previous_league_id``. Counting each id would inflate numerator
+        and denominator together, and unevenly — the longest-running
+        leagues are exactly the ones most likely to be sharp-eligible.
+        """
+        seed_sleeper_membership(ledger, "sleeper:u1", "sleeper:L2026")
+        seed_sleeper_membership(ledger, "sleeper:u1", "sleeper:L2025")
+        seed_sleeper_membership(ledger, "sleeper:u1", "sleeper:L2024")
+
+        chain = {
+            "L2026": league_payload(league_id="L2026", season="2026", previous_league_id="L2025"),
+            "L2025": league_payload(league_id="L2025", season="2025", previous_league_id="L2024"),
+            "L2024": league_payload(league_id="L2024", season="2024", previous_league_id="L2023"),
+        }
+
+        def http(url):
+            league_id = url.split("/league/")[1].split("/")[0]
+            if url.endswith("/rosters"):
+                return [roster_payload()]
+            return chain[league_id]
+
+        result = rc.collect_sleeper_rosters(
+            manager_keys=["sleeper:u1"],
+            http_get=http,
+            ledger_path=ledger,
+            sleep_fn=lambda _s: None,
+            now_ms=NOW,
+        )
+        assert result.rosters_recorded == 3
+        assert result.eligible_rosters == 1
+        assert result.exclusion_reasons[rc.REASON_SUPERSEDED_SEASON] == 2
+
+        eligible = [r for r in rs.load_rosters(path=ledger) if r["isEligible"]]
+        assert len(eligible) == 1
+        assert eligible[0]["leagueKey"] == "sleeper:L2026"
+
+    def test_a_predecessor_outside_this_run_is_not_superseded(self, ledger):
+        """We cannot supersede a league we never collected.
+
+        L1's chain points at a 2025 instance we did not fetch. Dropping
+        L1 on that basis would remove a live league from the board.
+        """
+        seed_sleeper_membership(ledger, "sleeper:u1", "sleeper:L1")
+        result = rc.collect_sleeper_rosters(
+            manager_keys=["sleeper:u1"],
+            http_get=fake_http(league=league_payload(previous_league_id="never-fetched")),
+            ledger_path=ledger,
+            sleep_fn=lambda _s: None,
+            now_ms=NOW,
+        )
+        assert result.eligible_rosters == 1
+        assert rc.REASON_SUPERSEDED_SEASON not in result.exclusion_reasons
+
+    def test_recollection_is_idempotent(self, ledger):
+        seed_sleeper_membership(ledger)
+        http = fake_http()
+        for _ in range(3):
+            rc.collect_sleeper_rosters(
+                manager_keys=["sleeper:u1"],
+                http_get=http,
+                ledger_path=ledger,
+                sleep_fn=lambda _s: None,
+                now_ms=NOW,
+            )
+        assert rs.coverage(path=ledger)["rosters"] == 1
+
+
+class TestLeagueFormat:
+    def test_format_axes_come_from_the_league_payload(self):
+        fmt = rc.league_format(
+            league_payload(
+                roster_positions=["QB", "RB", "WR", "TE", "SUPER_FLEX", "LB", "DB", "K", "BN"],
+                scoring_settings={"rec": 1.0, "bonus_rec_te": 0.5},
+            )
+        )
+        assert fmt["superflex"] is True
+        assert fmt["tePremium"] is True
+        assert fmt["idp"] is True
+        assert fmt["kicker"] is True
+        assert fmt["teamDefense"] is False
+
+    def test_one_qb_non_tep_offense_only_is_detected(self):
+        fmt = rc.league_format(
+            league_payload(
+                roster_positions=["QB", "RB", "WR", "TE", "FLEX", "BN"],
+                scoring_settings={"rec": 1.0},
+            )
+        )
+        assert fmt["superflex"] is False
+        assert fmt["tePremium"] is False
+        assert fmt["idp"] is False
+
+    def test_an_unreadable_payload_yields_unknown_not_false(self):
+        """Unknown must never be silently rendered as "no"."""
+        fmt = rc.league_format({"league_id": "L1"})
+        assert fmt["superflex"] is None
+        assert fmt["idp"] is None
+        assert fmt["tePremium"] is None
+
+
+class TestContention:
+    def test_a_winning_record_reads_as_contending(self):
+        assert rc._contention({"settings": {"wins": 8, "losses": 2}}) == "contending"
+
+    def test_a_losing_record_reads_as_rebuilding(self):
+        assert rc._contention({"settings": {"wins": 2, "losses": 8}}) == "rebuilding"
+
+    def test_preseason_is_unknown_rather_than_a_default_bucket(self):
+        assert rc._contention({"settings": {"wins": 0, "losses": 0}}) == "unknown"
+        assert rc._contention({}) == "unknown"
+
+
+class TestFFPC:
+    def seed(self, ledger, roster_assets, *, confidence=0.7, manager="ffpc:league:F1:team:7"):
+        conn = platform_ledger.ensure_platform_schema(ledger)
+        try:
+            conn.execute(
+                """
+                INSERT INTO platform_managers
+                  (manager_key, platform, source_manager_id, source_identity_type,
+                   identity_scope, identity_confidence, first_seen_ms, last_seen_ms,
+                   metadata_json)
+                VALUES (?, 'ffpc', ?, 'league_scoped_team', 'league', ?, ?, ?, '{}')
+                """,
+                (manager, manager.split(":", 1)[1], confidence, NOW, NOW),
+            )
+            platform_ledger.upsert_league(
+                NormalizedLeague.build("ffpc", "F1", season="2026", sharp_eligible=True), conn=conn
+            )
+            platform_ledger.upsert_membership(
+                NormalizedMembership(
+                    platform="ffpc",
+                    league_key="ffpc:F1",
+                    manager_key=manager,
+                    source_team_id="7",
+                    roster_id="7",
+                    team_name="North Stars",
+                    metadata={"rosterAssets": roster_assets},
+                ),
+                conn=conn,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def test_already_crawled_roster_assets_are_lifted_without_network_calls(self, ledger):
+        self.seed(
+            ledger,
+            [
+                {"canonicalAssetId": "4046", "displayName": "Justin Jefferson"},
+                {"canonicalAssetId": "6794", "displayName": "Bijan Robinson"},
+            ],
+        )
+        result = rc.collect_ffpc_rosters(
+            manager_keys=["ffpc:league:F1:team:7"], ledger_path=ledger, now_ms=NOW
+        )
+        assert result.calls_used == 0
+        assert result.rosters_recorded == 1
+        assert result.eligible_rosters == 1
+        stored = rs.load_rosters(path=ledger)[0]
+        assert stored["platform"] == "ffpc"
+        assert {a["canonicalAssetId"] for a in stored["assets"]} == {"4046", "6794"}
+
+    def test_unmapped_players_are_counted_never_guessed(self, ledger):
+        self.seed(
+            ledger,
+            [
+                {"canonicalAssetId": "4046", "displayName": "Justin Jefferson"},
+                {"canonicalAssetId": None, "displayName": "Someone Unmatched"},
+            ],
+        )
+        result = rc.collect_ffpc_rosters(
+            manager_keys=["ffpc:league:F1:team:7"], ledger_path=ledger, now_ms=NOW
+        )
+        assert result.unmapped_assets == 1
+        stored = rs.load_rosters(path=ledger)[0]
+        assert [a["canonicalAssetId"] for a in stored["assets"]] == ["4046"]
+
+    def test_a_name_only_identity_is_excluded_as_uncertain(self, ledger):
+        """FFPC name-only identities sit at 0.25 confidence.
+
+        Attributing a roster to a manager matched on a display-name hash
+        is exactly the "uncertain identity matching" case the audit
+        requires be excluded rather than counted.
+        """
+        self.seed(
+            ledger,
+            [{"canonicalAssetId": "4046"}],
+            confidence=0.25,
+            manager="ffpc:league:F1:name:abc123",
+        )
+        result = rc.collect_ffpc_rosters(
+            manager_keys=["ffpc:league:F1:name:abc123"], ledger_path=ledger, now_ms=NOW
+        )
+        assert result.eligible_rosters == 0
+        assert rc.REASON_UNCERTAIN_IDENTITY in result.exclusion_reasons
+
+    def test_memberships_without_roster_contents_are_skipped(self, ledger):
+        conn = platform_ledger.ensure_platform_schema(ledger)
+        try:
+            conn.execute(
+                """
+                INSERT INTO platform_managers
+                  (manager_key, platform, source_manager_id, source_identity_type,
+                   identity_scope, identity_confidence, first_seen_ms, last_seen_ms,
+                   metadata_json)
+                VALUES ('ffpc:x', 'ffpc', 'x', 'global_verified', 'platform', 1.0, ?, ?, '{}')
+                """,
+                (NOW, NOW),
+            )
+            platform_ledger.upsert_membership(
+                NormalizedMembership(
+                    platform="ffpc",
+                    league_key="ffpc:F1",
+                    manager_key="ffpc:x",
+                    roster_id="1",
+                    metadata={"sourceUrl": "https://example.invalid"},
+                ),
+                conn=conn,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        result = rc.collect_ffpc_rosters(manager_keys=["ffpc:x"], ledger_path=ledger, now_ms=NOW)
+        assert result.rosters_recorded == 0
+
+
+def test_collection_run_is_filed_under_its_own_pseudo_platform(ledger):
+    """Must not overwrite the Buy/Sell Tracker's freshness reading."""
+    rc.record_collection_run(
+        {"sleeper": {"callsUsed": 4, "leaguesExamined": 2}, "ffpc": {"unmappedAssets": 1}},
+        started_ms=NOW,
+        finished_ms=NOW + 1000,
+        ledger_path=ledger,
+        run_id="test-run",
+    )
+    coverage = platform_ledger.platform_coverage(ledger)
+    assert coverage["sleeper"]["latestIngestion"] is None
+    assert coverage["ffpc"]["latestIngestion"] is None
+    conn = platform_ledger.ensure_platform_schema(ledger)
+    try:
+        row = conn.execute(
+            "SELECT platform, pages_fetched, metadata_json FROM ingestion_runs WHERE run_id=?",
+            ("test-run",),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row["platform"] == "sharp_rosters"
+    assert row["pages_fetched"] == 4
+    assert json.loads(row["metadata_json"])["sleeper"]["leaguesExamined"] == 2

--- a/tests/sharp/test_roster_percentage.py
+++ b/tests/sharp/test_roster_percentage.py
@@ -1,0 +1,694 @@
+"""Sharp Roster Percentage — the counting rules, in executable form.
+
+The audit checklist this feature shipped against is encoded here:
+one observation per roster per player, a denominator that is eligible
+ROSTERS, filters that move numerator and denominator together, trends
+that refuse to compare unlike populations, and a cohort that is shared
+with the Buy/Sell Tracker rather than redefined.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.sharp import cohort
+from src.sharp import market as sharp_market
+from src.sharp import roster_percentage as rp
+from src.sharp import roster_store as rs
+
+NOW = 1_800_000_000_000
+DAY = 86_400_000
+
+OFFENSE_ONLY = {"idp": False, "kicker": True, "superflex": True, "tePremium": False}
+IDP_LEAGUE = {"idp": True, "kicker": True, "superflex": True, "tePremium": True}
+ONE_QB = {"idp": False, "kicker": True, "superflex": False, "tePremium": False}
+
+CONTRACT = {
+    "playersArray": [
+        {
+            "playerId": "wr1",
+            "displayName": "Star Receiver",
+            "position": "WR",
+            "team": "MIN",
+            "rankDerivedValue": 9500,
+            "canonicalConsensusRank": 2,
+        },
+        {
+            "playerId": "rb1",
+            "displayName": "Good Back",
+            "position": "RB",
+            "team": "ATL",
+            "rankDerivedValue": 8000,
+            "canonicalConsensusRank": 12,
+        },
+        {
+            "playerId": "lb1",
+            "displayName": "Star Linebacker",
+            "position": "LB",
+            "team": "SF",
+            "rankDerivedValue": 5000,
+            "canonicalConsensusRank": 90,
+        },
+        {
+            "playerId": "rook1",
+            "displayName": "Fresh Rookie",
+            "position": "WR",
+            "team": "LAR",
+            "rankDerivedValue": 6000,
+            "canonicalConsensusRank": 45,
+            "rookie": True,
+        },
+    ]
+}
+
+
+def member(key: str) -> cohort.CohortMember:
+    return cohort.CohortMember(key, key.split(":", 1)[0], "automated_qualified", 0.9)
+
+
+@pytest.fixture
+def cohort_of(monkeypatch):
+    """Pin the sharp pool so these tests measure COUNTING, not qualification.
+
+    Qualification has its own tests (``test_score.py``); mixing the two
+    would make a scoring-threshold change break arithmetic assertions.
+    """
+
+    def _install(keys):
+        members = [member(k) for k in keys]
+        monkeypatch.setattr(
+            rp.sharp_cohort,
+            "cohort_members",
+            lambda **kwargs: (members, {"methodologyVersion": "sharp-v2"}),
+        )
+        monkeypatch.setattr(
+            rp.sharp_cohort,
+            "unique_person_count",
+            lambda manager_keys, **kwargs: len(set(manager_keys)),
+        )
+        return members
+
+    return _install
+
+
+def roster(manager, league, roster_id="1", assets=(), fmt=None, observed=NOW, **kwargs):
+    return rs.RosterObservation(
+        platform=kwargs.pop("platform", "sleeper"),
+        league_key=league,
+        manager_key=manager,
+        source_roster_id=roster_id,
+        assets=[a if isinstance(a, rs.RosterAsset) else rs.RosterAsset(a) for a in assets],
+        league_format=fmt if fmt is not None else OFFENSE_ONLY,
+        observed_ms=observed,
+        **kwargs,
+    )
+
+
+def board(ledger, **kwargs):
+    kwargs.setdefault("contract", CONTRACT)
+    kwargs.setdefault("now_ms", NOW)
+    kwargs.setdefault("limit", 100)
+    return rp.build_board(ledger_path=ledger, **kwargs)
+
+
+def row_for(payload, name):
+    return next((r for r in payload["players"] if r["displayName"] == name), None)
+
+
+@pytest.fixture
+def ledger(tmp_path):
+    return tmp_path / "ledger.sqlite3"
+
+
+# ── the formula ──────────────────────────────────────────────────────
+
+
+def test_percentage_is_holding_rosters_over_eligible_rosters(ledger, cohort_of):
+    cohort_of([f"sleeper:u{i}" for i in range(1, 5)])
+    rs.record_rosters(
+        [
+            roster("sleeper:u1", "sleeper:L1", assets=["wr1", "rb1"]),
+            roster("sleeper:u2", "sleeper:L2", assets=["wr1", "rb1"]),
+            roster("sleeper:u3", "sleeper:L3", assets=["wr1"]),
+            roster("sleeper:u4", "sleeper:L4", assets=["wr1"]),
+        ],
+        path=ledger,
+    )
+    payload = board(ledger)
+    wr = row_for(payload, "Star Receiver")
+    rb = row_for(payload, "Good Back")
+    assert (wr["sharpRosters"], wr["eligibleRosters"], wr["sharpRosterPct"]) == (4, 4, 1.0)
+    assert (rb["sharpRosters"], rb["eligibleRosters"], rb["sharpRosterPct"]) == (2, 4, 0.5)
+
+
+def test_denominator_equals_the_eligible_roster_count(ledger, cohort_of):
+    cohort_of([f"sleeper:u{i}" for i in range(1, 4)])
+    rs.record_rosters(
+        [
+            roster("sleeper:u1", "sleeper:L1", assets=["wr1"]),
+            roster("sleeper:u2", "sleeper:L2", assets=["wr1"]),
+            roster("sleeper:u3", "sleeper:L3", assets=["wr1"], exclusion_reasons=["best_ball"]),
+        ],
+        path=ledger,
+    )
+    payload = board(ledger)
+    assert payload["sample"]["eligibleRosters"] == 2
+    assert row_for(payload, "Star Receiver")["eligibleRosters"] == 2
+    assert payload["exclusions"]["byReason"] == {"best_ball": 1}
+
+
+def test_one_manager_many_leagues_contributes_one_roster_each(ledger, cohort_of):
+    """Five real dynasty teams are five roster observations, one person."""
+    cohort_of(["sleeper:u1"])
+    rs.record_rosters(
+        [roster("sleeper:u1", f"sleeper:L{i}", assets=["wr1"]) for i in range(1, 6)],
+        path=ledger,
+    )
+    payload = board(ledger)
+    assert payload["sample"]["eligibleRosters"] == 5
+    assert row_for(payload, "Star Receiver")["sharpRosters"] == 5
+    assert payload["transparency"]["uniqueSharpManagers"] == 1
+    assert payload["transparency"]["rostersPerManager"] == 5.0
+
+
+def test_a_player_counts_once_per_roster_even_across_slots(ledger, cohort_of):
+    cohort_of(["sleeper:u1"])
+    rs.record_rosters(
+        [
+            roster(
+                "sleeper:u1",
+                "sleeper:L1",
+                assets=[
+                    rs.RosterAsset("wr1", slot=rs.SLOT_ACTIVE),
+                    rs.RosterAsset("wr1", slot=rs.SLOT_TAXI),
+                ],
+            )
+        ],
+        path=ledger,
+    )
+    wr = row_for(board(ledger), "Star Receiver")
+    assert wr["sharpRosters"] == 1
+    assert wr["sharpRosterPct"] == 1.0
+
+
+def test_taxi_and_reserve_players_still_count_as_rostered(ledger, cohort_of):
+    cohort_of(["sleeper:u1", "sleeper:u2"])
+    rs.record_rosters(
+        [
+            roster("sleeper:u1", "sleeper:L1", assets=[rs.RosterAsset("wr1", slot=rs.SLOT_TAXI)]),
+            roster(
+                "sleeper:u2", "sleeper:L2", assets=[rs.RosterAsset("wr1", slot=rs.SLOT_RESERVE)]
+            ),
+        ],
+        path=ledger,
+    )
+    wr = row_for(board(ledger), "Star Receiver")
+    assert wr["sharpRosterPct"] == 1.0
+    assert wr["slots"] == {"taxi": 1, "reserve": 1}
+
+
+# ── per-player denominator ───────────────────────────────────────────
+
+
+def test_idp_players_are_measured_against_idp_leagues_only(ledger, cohort_of):
+    """The finding that makes this board honest.
+
+    Dividing a linebacker by every sharp roster would report 20% for a
+    player owned in every league that can roster him.
+    """
+    cohort_of([f"sleeper:u{i}" for i in range(1, 6)])
+    rs.record_rosters(
+        [roster(f"sleeper:u{i}", f"sleeper:L{i}", assets=["wr1"]) for i in range(1, 4)]
+        + [
+            roster("sleeper:u4", "sleeper:L4", assets=["wr1", "lb1"], fmt=IDP_LEAGUE),
+            roster("sleeper:u5", "sleeper:L5", assets=["wr1", "lb1"], fmt=IDP_LEAGUE),
+        ],
+        path=ledger,
+    )
+    payload = board(ledger)
+    lb = row_for(payload, "Star Linebacker")
+    assert (lb["sharpRosters"], lb["eligibleRosters"], lb["sharpRosterPct"]) == (2, 2, 1.0)
+    assert row_for(payload, "Star Receiver")["eligibleRosters"] == 5
+
+
+def test_a_holding_roster_is_always_inside_its_own_denominator(ledger, cohort_of):
+    """A percentage can never exceed 100% through unknown formats."""
+    cohort_of(["sleeper:u1", "sleeper:u2"])
+    rs.record_rosters(
+        [
+            # Format never captured, yet the roster demonstrably holds an IDP.
+            roster("sleeper:u1", "sleeper:L1", assets=["lb1"], fmt={}),
+            roster("sleeper:u2", "sleeper:L2", assets=["wr1"], fmt=IDP_LEAGUE),
+        ],
+        path=ledger,
+    )
+    lb = row_for(board(ledger), "Star Linebacker")
+    assert lb["sharpRosters"] <= lb["eligibleRosters"]
+    assert lb["sharpRosterPct"] <= 1.0
+
+
+def test_small_player_denominator_is_flagged_individually(ledger, cohort_of):
+    cohort_of([f"sleeper:u{i}" for i in range(1, 11)])
+    rs.record_rosters(
+        [roster(f"sleeper:u{i}", f"sleeper:L{i}", assets=["wr1"]) for i in range(1, 10)]
+        + [roster("sleeper:u10", "sleeper:L10", assets=["wr1", "lb1"], fmt=IDP_LEAGUE)],
+        path=ledger,
+    )
+    payload = board(ledger)
+    assert row_for(payload, "Star Linebacker")["sampleWarning"]["level"] == "insufficient"
+    assert row_for(payload, "Star Receiver")["sampleWarning"] is None
+
+
+# ── filters ──────────────────────────────────────────────────────────
+
+
+def _twelve_rosters():
+    """Six superflex/TEP rosters and six one-QB rosters; all hold wr1."""
+    out = []
+    for i in range(1, 13):
+        fmt = IDP_LEAGUE if i <= 6 else ONE_QB
+        assets = ["wr1"] + (["rb1"] if i <= 6 else [])
+        out.append(
+            roster(
+                f"sleeper:u{i}",
+                f"sleeper:L{i}",
+                assets=assets,
+                fmt=fmt,
+                contention="contending" if i % 2 else "rebuilding",
+            )
+        )
+    return out
+
+
+def test_format_filter_moves_numerator_and_denominator_together(ledger, cohort_of):
+    cohort_of([f"sleeper:u{i}" for i in range(1, 13)])
+    rs.record_rosters(_twelve_rosters(), path=ledger)
+
+    every = board(ledger)
+    assert row_for(every, "Good Back")["sharpRosters"] == 6
+    assert row_for(every, "Good Back")["eligibleRosters"] == 12
+
+    superflex = board(ledger, league_format="superflex")
+    assert superflex["sample"]["eligibleRosters"] == 6
+    assert row_for(superflex, "Good Back")["sharpRosterPct"] == 1.0
+
+    one_qb = board(ledger, league_format="oneQb")
+    assert one_qb["sample"]["eligibleRosters"] == 6
+    assert row_for(one_qb, "Good Back") is None  # nobody in a 1QB league holds him
+
+
+def test_contention_filter_reduces_both_sides(ledger, cohort_of):
+    cohort_of([f"sleeper:u{i}" for i in range(1, 13)])
+    rs.record_rosters(_twelve_rosters(), path=ledger)
+    contending = board(ledger, contention="contending")
+    assert contending["sample"]["eligibleRosters"] == 6
+    assert row_for(contending, "Star Receiver")["eligibleRosters"] == 6
+
+
+def test_platform_filter_selects_one_source(ledger, cohort_of):
+    cohort_of(["sleeper:u1", "ffpc:f1"])
+    rs.record_rosters(
+        [
+            roster("sleeper:u1", "sleeper:L1", assets=["wr1"]),
+            roster("ffpc:f1", "ffpc:F1", assets=["wr1"], platform="ffpc"),
+        ],
+        path=ledger,
+    )
+    assert board(ledger, platform="ffpc")["sample"]["eligibleRosters"] == 1
+    assert board(ledger, platform="sleeper")["sample"]["eligibleRosters"] == 1
+    assert board(ledger)["transparency"]["ffpcRosters"] == 1
+
+
+def test_position_filter_selects_players_without_shrinking_the_pool(ledger, cohort_of):
+    cohort_of([f"sleeper:u{i}" for i in range(1, 13)])
+    rs.record_rosters(_twelve_rosters(), path=ledger)
+    only_rb = board(ledger, position="RB")
+    assert [r["displayName"] for r in only_rb["players"]] == ["Good Back"]
+    assert only_rb["sample"]["eligibleRosters"] == 12
+
+
+def test_experience_filter_splits_rookies_from_veterans(ledger, cohort_of):
+    cohort_of(["sleeper:u1"])
+    rs.record_rosters([roster("sleeper:u1", "sleeper:L1", assets=["wr1", "rook1"])], path=ledger)
+    assert [r["displayName"] for r in board(ledger, experience="rookies")["players"]] == [
+        "Fresh Rookie"
+    ]
+    assert "Fresh Rookie" not in [
+        r["displayName"] for r in board(ledger, experience="veterans")["players"]
+    ]
+
+
+def test_picks_are_excluded_from_the_default_player_pool(ledger, cohort_of):
+    cohort_of(["sleeper:u1"])
+    rs.record_rosters(
+        [roster("sleeper:u1", "sleeper:L1", assets=["wr1", "pick:2027:1"])], path=ledger
+    )
+    assert [r["assetId"] for r in board(ledger)["players"]] == ["wr1"]
+    assert "pick:2027:1" in [r["assetId"] for r in board(ledger, include_picks=True)["players"]]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"position": "nonsense"},
+        {"platform": "yahoo"},
+        {"league_format": "dynasty"},
+        {"contention": "tanking"},
+        {"experience": "sophomores"},
+        {"sort": "vibes"},
+        {"limit": 37},
+    ],
+)
+def test_unsupported_filter_values_are_rejected(ledger, cohort_of, kwargs):
+    cohort_of(["sleeper:u1"])
+    with pytest.raises(ValueError):
+        board(ledger, **kwargs)
+
+
+def test_limit_selects_the_documented_list_sizes(ledger, cohort_of):
+    cohort_of([f"sleeper:u{i}" for i in range(1, 13)])
+    rs.record_rosters(_twelve_rosters(), path=ledger)
+    assert len(board(ledger, limit=1 if False else 25)["players"]) <= 25
+    everything = board(ledger, limit=0)
+    assert len(everything["players"]) == everything["totalQualifyingPlayers"]
+
+
+# ── eligibility ──────────────────────────────────────────────────────
+
+
+def test_a_manager_who_left_the_cohort_stops_contributing(ledger, cohort_of):
+    rs.record_rosters(
+        [
+            roster("sleeper:u1", "sleeper:L1", assets=["wr1"]),
+            roster("sleeper:gone", "sleeper:L2", assets=["wr1", "rb1"]),
+        ],
+        path=ledger,
+    )
+    cohort_of(["sleeper:u1"])
+    payload = board(ledger)
+    assert payload["sample"]["eligibleRosters"] == 1
+    assert payload["exclusions"]["byReason"]["manager_no_longer_in_cohort"] == 1
+    assert row_for(payload, "Good Back") is None
+
+
+def test_stale_rosters_are_excluded_with_a_reason(ledger, cohort_of):
+    cohort_of(["sleeper:u1", "sleeper:u2"])
+    rs.record_rosters(
+        [
+            roster("sleeper:u1", "sleeper:L1", assets=["wr1"]),
+            roster("sleeper:u2", "sleeper:L2", assets=["wr1"], observed=NOW - 60 * DAY),
+        ],
+        path=ledger,
+    )
+    payload = board(ledger)
+    assert payload["sample"]["eligibleRosters"] == 1
+    assert payload["exclusions"]["byReason"]["stale_roster_data"] == 1
+
+
+def test_collector_exclusion_reasons_survive_to_the_payload(ledger, cohort_of):
+    cohort_of(["sleeper:u1"])
+    rs.record_rosters(
+        [
+            roster(
+                "sleeper:u1",
+                "sleeper:L1",
+                assets=["wr1"],
+                exclusion_reasons=["abandoned_or_inactive_league"],
+            )
+        ],
+        path=ledger,
+    )
+    payload = board(ledger)
+    assert payload["exclusions"]["byReason"] == {"abandoned_or_inactive_league": 1}
+    assert payload["status"] == "no_eligible_rosters"
+
+
+# ── sample-size safeguards ───────────────────────────────────────────
+
+
+def test_a_tiny_cohort_is_labelled_not_ranked(ledger, cohort_of):
+    cohort_of(["sleeper:u1", "sleeper:u2"])
+    rs.record_rosters(
+        [
+            roster("sleeper:u1", "sleeper:L1", assets=["wr1"]),
+            roster("sleeper:u2", "sleeper:L2", assets=["wr1"]),
+        ],
+        path=ledger,
+    )
+    payload = board(ledger)
+    assert payload["sample"]["rankable"] is False
+    assert payload["sample"]["warning"]["level"] == "insufficient"
+
+
+def test_a_mid_sized_cohort_gets_the_directional_wording(ledger, cohort_of):
+    keys = [f"sleeper:u{i}" for i in range(1, 15)]
+    cohort_of(keys)
+    rs.record_rosters(
+        [roster(k, f"sleeper:L{i}", assets=["wr1"]) for i, k in enumerate(keys)], path=ledger
+    )
+    warning = board(ledger)["sample"]["warning"]
+    assert warning["level"] == "directional"
+    assert "Based on 14 eligible sharp rosters" in warning["message"]
+    assert "directional" in warning["message"]
+
+
+def test_a_large_cohort_carries_no_warning(ledger, cohort_of):
+    keys = [f"sleeper:u{i}" for i in range(1, 46)]
+    cohort_of(keys)
+    rs.record_rosters(
+        [roster(k, f"sleeper:L{i}", assets=["wr1"]) for i, k in enumerate(keys)], path=ledger
+    )
+    payload = board(ledger)
+    assert payload["sample"]["warning"] is None
+    assert payload["sample"]["rankable"] is True
+
+
+# ── trends ───────────────────────────────────────────────────────────
+
+
+def test_thirty_day_trend_measures_the_shared_roster_population(ledger, cohort_of):
+    keys = [f"sleeper:u{i}" for i in range(1, 11)]
+    cohort_of(keys)
+    then = NOW - 40 * DAY
+    rs.record_rosters(
+        [roster(k, f"sleeper:L{i}", assets=["wr1"], observed=then) for i, k in enumerate(keys)],
+        path=ledger,
+    )
+    rs.record_rosters(
+        [
+            roster(k, f"sleeper:L{i}", assets=["wr1"] + (["rb1"] if i < 4 else []))
+            for i, k in enumerate(keys)
+        ],
+        path=ledger,
+    )
+    trend = row_for(board(ledger), "Good Back")["trend"]["thirtyDay"]
+    assert trend["available"] is True
+    assert trend["comparableRosters"] == 10
+    assert trend["rostersAdded"] == 4
+    assert trend["rostersDropped"] == 0
+    assert trend["rosterPctChange"] == pytest.approx(0.4)
+
+
+def test_trend_is_withheld_when_the_population_moved_materially(ledger, cohort_of):
+    """A grown cohort must not read as players gaining ownership."""
+    keys = [f"sleeper:u{i}" for i in range(1, 11)]
+    cohort_of(keys)
+    rs.record_rosters(
+        [roster("sleeper:u1", "sleeper:L1", assets=["wr1"], observed=NOW - 40 * DAY)], path=ledger
+    )
+    rs.record_rosters(
+        [roster(k, f"sleeper:L{i}", assets=["wr1"]) for i, k in enumerate(keys)], path=ledger
+    )
+    trend = row_for(board(ledger), "Star Receiver")["trend"]["thirtyDay"]
+    assert trend["available"] is False
+    assert trend["reason"] == "roster_population_changed"
+
+
+def test_a_dropped_player_shows_a_negative_trend(ledger, cohort_of):
+    keys = [f"sleeper:u{i}" for i in range(1, 11)]
+    cohort_of(keys)
+    rs.record_rosters(
+        [
+            roster(k, f"sleeper:L{i}", assets=["wr1", "rb1"], observed=NOW - 40 * DAY)
+            for i, k in enumerate(keys)
+        ],
+        path=ledger,
+    )
+    rs.record_rosters(
+        [
+            roster(k, f"sleeper:L{i}", assets=["wr1"] + (["rb1"] if i < 5 else []))
+            for i, k in enumerate(keys)
+        ],
+        path=ledger,
+    )
+    trend = row_for(board(ledger), "Good Back")["trend"]["thirtyDay"]
+    assert trend["rostersDropped"] == 5
+    assert trend["rosterPctChange"] == pytest.approx(-0.5)
+
+
+# ── market comparison ────────────────────────────────────────────────
+
+
+def test_market_comparison_is_absent_and_says_so(ledger, cohort_of):
+    cohort_of(["sleeper:u1"])
+    rs.record_rosters([roster("sleeper:u1", "sleeper:L1", assets=["wr1"])], path=ledger)
+    payload = board(ledger)
+    assert payload["marketComparison"]["available"] is False
+    assert (
+        "no general-dynasty roster-percentage feed" in payload["marketComparison"]["note"].lower()
+    )
+    wr = row_for(payload, "Star Receiver")
+    assert wr["marketRosterPct"] is None
+    assert wr["sharpRosterAdvantage"] is None
+
+
+def test_a_registered_market_provider_produces_the_advantage_column(ledger, cohort_of):
+    cohort_of(["sleeper:u1", "sleeper:u2"])
+    rs.record_rosters(
+        [
+            roster("sleeper:u1", "sleeper:L1", assets=["wr1"]),
+            roster("sleeper:u2", "sleeper:L2", assets=["wr1"]),
+        ],
+        path=ledger,
+    )
+    rp.set_market_ownership_provider(lambda ids: {"wr1": 0.6})
+    try:
+        wr = row_for(board(ledger), "Star Receiver")
+        assert wr["marketRosterPct"] == 0.6
+        assert wr["sharpRosterAdvantage"] == pytest.approx(0.4)
+    finally:
+        rp.set_market_ownership_provider(None)
+
+
+def test_a_failing_market_provider_never_breaks_the_board(ledger, cohort_of):
+    cohort_of(["sleeper:u1"])
+    rs.record_rosters([roster("sleeper:u1", "sleeper:L1", assets=["wr1"])], path=ledger)
+
+    def boom(_ids):
+        raise RuntimeError("upstream down")
+
+    rp.set_market_ownership_provider(boom)
+    try:
+        payload = board(ledger)
+        assert payload["status"] == "ok"
+        assert payload["marketComparison"]["available"] is False
+    finally:
+        rp.set_market_ownership_provider(None)
+
+
+# ── sorting ──────────────────────────────────────────────────────────
+
+
+def test_alternate_sorts_change_the_ordering(ledger, cohort_of):
+    cohort_of([f"sleeper:u{i}" for i in range(1, 11)])
+    rs.record_rosters(
+        [
+            roster(f"sleeper:u{i}", f"sleeper:L{i}", assets=["wr1"] + (["rb1"] if i <= 2 else []))
+            for i in range(1, 11)
+        ],
+        path=ledger,
+    )
+    by_ownership = [r["displayName"] for r in board(ledger, sort="rostered")["players"]]
+    assert by_ownership[0] == "Star Receiver"
+
+    lagging = board(ledger, sort="valueWithoutRosters")["players"]
+    # Good Back ranks 12th on the board but sits on 2 of 10 rosters.
+    assert lagging[0]["displayName"] == "Star Receiver"
+    assert {r["displayName"] for r in lagging} == {"Star Receiver", "Good Back"}
+
+
+def test_sort_by_advantage_sinks_rows_without_a_market_number(ledger, cohort_of):
+    cohort_of(["sleeper:u1", "sleeper:u2"])
+    rs.record_rosters(
+        [
+            roster("sleeper:u1", "sleeper:L1", assets=["wr1", "rb1"]),
+            roster("sleeper:u2", "sleeper:L2", assets=["wr1", "rb1"]),
+        ],
+        path=ledger,
+    )
+    rp.set_market_ownership_provider(lambda ids: {"rb1": 0.1})
+    try:
+        rows = board(ledger, sort="advantage")["players"]
+        assert rows[0]["displayName"] == "Good Back"
+        assert rows[-1]["sharpRosterAdvantage"] is None
+    finally:
+        rp.set_market_ownership_provider(None)
+
+
+# ── transparency + audit ─────────────────────────────────────────────
+
+
+def test_transparency_reports_the_pool_behind_the_numbers(ledger, cohort_of):
+    cohort_of(["sleeper:u1", "sleeper:u2", "ffpc:f1", "sleeper:absent"])
+    rs.record_rosters(
+        [
+            roster("sleeper:u1", "sleeper:L1", assets=["wr1"]),
+            roster("sleeper:u1", "sleeper:L2", assets=["wr1"]),
+            roster("sleeper:u2", "sleeper:L3", assets=["wr1"]),
+            roster("ffpc:f1", "ffpc:F1", assets=["wr1"], platform="ffpc"),
+        ],
+        path=ledger,
+    )
+    t = board(ledger)["transparency"]
+    assert t["eligibleRosters"] == 4
+    assert t["sleeperRosters"] == 3
+    assert t["ffpcRosters"] == 1
+    assert t["otherPlatformRosters"] == 0
+    assert t["uniqueSharpManagers"] == 3
+    assert t["cohortManagers"] == 4
+    assert t["cohortManagersRepresented"] == 3
+    assert t["cohortCoveragePct"] == 0.75
+    assert t["lastRefreshedMs"] == NOW
+
+
+def test_audit_lists_every_roster_behind_a_count(ledger, cohort_of):
+    cohort_of(["sleeper:u1", "sleeper:u2", "sleeper:u3"])
+    rs.record_rosters(
+        [
+            roster("sleeper:u1", "sleeper:L1", assets=["wr1"]),
+            roster("sleeper:u2", "sleeper:L2", assets=["wr1"]),
+            roster("sleeper:u3", "sleeper:L3", assets=["rb1"]),
+        ],
+        path=ledger,
+    )
+    audit = rp.audit_player("wr1", ledger_path=ledger, now_ms=NOW)
+    assert audit["holdingRosterCount"] == 2
+    assert audit["distinctRosterKeys"] == 2
+    assert audit["eligibleRosterCount"] == 3
+    assert {r["rosterKey"] for r in audit["holdingRosters"]} == {"sleeper:L1#1", "sleeper:L2#1"}
+
+    payload = board(ledger)
+    assert row_for(payload, "Star Receiver")["sharpRosters"] == audit["holdingRosterCount"]
+
+
+# ── the shared cohort ────────────────────────────────────────────────
+
+
+def test_both_boards_resolve_the_pool_through_the_same_function():
+    """The core requirement: one source of truth for who is a sharp.
+
+    ``market`` is imported at MODULE level (top of this file) on purpose.
+    Its re-export is a ``from ... import`` binding taken at import time,
+    so importing it lazily inside a test that had already monkeypatched
+    the cohort module would capture the stub and make this assertion
+    describe the test harness rather than the code.
+    """
+    assert sharp_market.cohort_members is cohort.cohort_members
+    assert sharp_market.CohortMember is cohort.CohortMember
+    assert sharp_market.load_ffpc_config is cohort.load_ffpc_config
+    assert rp.sharp_cohort is cohort
+
+
+def test_the_roster_board_defines_no_qualification_of_its_own():
+    """A guard against the pool quietly forking.
+
+    If this feature ever grows its own notion of who qualifies, the
+    words will show up here first.
+    """
+    import inspect
+
+    source = inspect.getsource(rp)
+    for forbidden in ("score_managers", "qualified =", "minScorePercentile", "ManagerRecord"):
+        assert (
+            forbidden not in source
+        ), f"roster_percentage must not re-derive qualification: {forbidden}"

--- a/tests/sharp/test_roster_store.py
+++ b/tests/sharp/test_roster_store.py
@@ -1,0 +1,225 @@
+"""The roster store's deduplication guarantees are STRUCTURAL.
+
+Every assertion here is really about a primary key. If one of these
+fails, the fix is the schema, not a filter in the caller — the whole
+point of the design is that no caller can forget to deduplicate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.sharp import roster_store as rs
+
+NOW = 1_800_000_000_000
+
+
+def observation(**overrides):
+    base = dict(
+        platform="sleeper",
+        league_key="sleeper:L1",
+        manager_key="sleeper:u1",
+        source_roster_id="1",
+        assets=[rs.RosterAsset("4046"), rs.RosterAsset("6794")],
+        observed_ms=NOW,
+    )
+    base.update(overrides)
+    return rs.RosterObservation(**base)
+
+
+@pytest.fixture
+def ledger(tmp_path):
+    return tmp_path / "ledger.sqlite3"
+
+
+def test_same_roster_collected_twice_is_one_denominator_slot(ledger):
+    rs.record_rosters([observation(), observation()], path=ledger)
+    rows = rs.load_rosters(path=ledger)
+    assert len(rows) == 1
+    assert rs.coverage(path=ledger)["rosters"] == 1
+
+
+def test_duplicate_player_rows_within_one_roster_count_once(ledger):
+    rs.record_rosters(
+        [
+            observation(
+                assets=[
+                    rs.RosterAsset("4046"),
+                    rs.RosterAsset("4046"),
+                    rs.RosterAsset("4046"),
+                ]
+            )
+        ],
+        path=ledger,
+    )
+    row = rs.load_rosters(path=ledger)[0]
+    assert row["assetCount"] == 1
+    assert [a["canonicalAssetId"] for a in row["assets"]] == ["4046"]
+
+
+def test_one_manager_with_several_leagues_contributes_several_rosters(ledger):
+    rs.record_rosters(
+        [
+            observation(league_key="sleeper:L1"),
+            observation(league_key="sleeper:L2"),
+            observation(league_key="sleeper:L3"),
+        ],
+        path=ledger,
+    )
+    rows = rs.load_rosters(path=ledger)
+    assert len(rows) == 3
+    assert {r["managerKey"] for r in rows} == {"sleeper:u1"}
+
+
+def test_two_sharps_on_different_rosters_in_one_league_are_two_rosters(ledger):
+    rs.record_rosters(
+        [
+            observation(manager_key="sleeper:u1", source_roster_id="1"),
+            observation(manager_key="sleeper:u2", source_roster_id="2"),
+        ],
+        path=ledger,
+    )
+    assert len(rs.load_rosters(path=ledger)) == 2
+
+
+def test_taxi_and_reserve_slots_are_labelled_not_dropped(ledger):
+    rs.record_rosters(
+        [
+            observation(
+                assets=[
+                    rs.RosterAsset("4046", slot=rs.SLOT_ACTIVE),
+                    rs.RosterAsset("6794", slot=rs.SLOT_TAXI),
+                    rs.RosterAsset("5849", slot=rs.SLOT_RESERVE),
+                ]
+            )
+        ],
+        path=ledger,
+    )
+    row = rs.load_rosters(path=ledger)[0]
+    assert row["assetCount"] == 3
+    assert {a["canonicalAssetId"]: a["slot"] for a in row["assets"]} == {
+        "4046": rs.SLOT_ACTIVE,
+        "6794": rs.SLOT_TAXI,
+        "5849": rs.SLOT_RESERVE,
+    }
+
+
+def test_more_specific_slot_wins_when_a_player_appears_twice(ledger):
+    rs.record_rosters(
+        [
+            observation(
+                assets=[
+                    rs.RosterAsset("4046", slot=rs.SLOT_ACTIVE),
+                    rs.RosterAsset("4046", slot=rs.SLOT_TAXI),
+                ]
+            )
+        ],
+        path=ledger,
+    )
+    row = rs.load_rosters(path=ledger)[0]
+    assert row["assets"] == [{"canonicalAssetId": "4046", "assetType": "player", "slot": "taxi"}]
+
+
+def test_recollection_replaces_holdings_rather_than_accumulating(ledger):
+    rs.record_rosters([observation(assets=[rs.RosterAsset("4046")])], path=ledger)
+    rs.record_rosters(
+        [observation(assets=[rs.RosterAsset("6794")], observed_ms=NOW + 1000)], path=ledger
+    )
+    row = rs.load_rosters(path=ledger)[0]
+    assert [a["canonicalAssetId"] for a in row["assets"]] == ["6794"]
+
+
+def test_excluded_rosters_are_kept_with_their_reasons(ledger):
+    rs.record_rosters(
+        [observation(exclusion_reasons=["stale_roster_data", "orphaned_roster_no_owner"])],
+        path=ledger,
+    )
+    row = rs.load_rosters(path=ledger)[0]
+    assert row["isEligible"] is False
+    assert row["exclusionReasons"] == ["orphaned_roster_no_owner", "stale_roster_data"]
+    assert rs.exclusion_reason_counts(path=ledger) == {
+        "orphaned_roster_no_owner": 1,
+        "stale_roster_data": 1,
+    }
+
+
+class TestHistory:
+    def test_spans_answer_holdings_at_a_past_instant(self, ledger):
+        rs.record_rosters(
+            [observation(assets=[rs.RosterAsset("4046"), rs.RosterAsset("6794")])], path=ledger
+        )
+        rs.record_rosters(
+            [
+                observation(
+                    assets=[rs.RosterAsset("4046"), rs.RosterAsset("5849")],
+                    observed_ms=NOW + 86_400_000,
+                )
+            ],
+            path=ledger,
+        )
+        keys = ["sleeper:L1#1"]
+        assert rs.holdings_as_of(NOW, roster_keys=keys, path=ledger) == {
+            "sleeper:L1#1": {"4046", "6794"}
+        }
+        assert rs.holdings_as_of(NOW + 86_400_000, roster_keys=keys, path=ledger) == {
+            "sleeper:L1#1": {"4046", "5849"}
+        }
+
+    def test_a_roster_not_yet_observed_is_absent_not_empty(self, ledger):
+        """The distinction a trend depends on.
+
+        Present-and-empty would read as "this roster owned nobody",
+        turning every later discovery into a fake ownership gain.
+        """
+        rs.record_rosters([observation()], path=ledger)
+        assert rs.holdings_as_of(NOW - 1, roster_keys=["sleeper:L1#1"], path=ledger) == {}
+
+    def test_an_open_span_covers_instants_after_the_last_observation(self, ledger):
+        rs.record_rosters([observation()], path=ledger)
+        later = rs.holdings_as_of(NOW + 999_999, roster_keys=["sleeper:L1#1"], path=ledger)
+        assert later == {"sleeper:L1#1": {"4046", "6794"}}
+
+    def test_a_holding_persists_until_the_observation_that_contradicts_it(self, ledger):
+        """The gap between two observations is HELD, not unheld.
+
+        Rosters are observed periodically. A roster seen on day 0 and
+        again on day 40 was never confirmed on day 10 — but the player
+        was rostered then, because nothing had said otherwise yet.
+        Answering this against the last CONFIRMING observation instead
+        of the CONTRADICTING one zeroes every drop that happened between
+        two crawls, which surfaces as a 30-day trend of exactly 0.0 no
+        matter how much moved.
+        """
+        day = 86_400_000
+        rs.record_rosters(
+            [observation(assets=[rs.RosterAsset("4046")], observed_ms=NOW)], path=ledger
+        )
+        rs.record_rosters([observation(assets=[], observed_ms=NOW + 40 * day)], path=ledger)
+
+        keys = ["sleeper:L1#1"]
+        # Ten days in, the drop has not been observed yet.
+        assert rs.holdings_as_of(NOW + 10 * day, roster_keys=keys, path=ledger) == {
+            "sleeper:L1#1": {"4046"}
+        }
+        # At the observation that found him gone, he is gone.
+        assert rs.holdings_as_of(NOW + 40 * day, roster_keys=keys, path=ledger) == {
+            "sleeper:L1#1": set()
+        }
+
+
+def test_schema_creation_is_idempotent_and_does_not_touch_platform_version(ledger):
+    from src.intel import platform_ledger
+
+    conn = rs.ensure_roster_schema(ledger)
+    try:
+        before = conn.execute(
+            "SELECT value FROM meta WHERE key=?", (platform_ledger.MIGRATION_META_KEY,)
+        ).fetchone()
+        rs.ensure_roster_schema(conn=conn)
+        rs.ensure_roster_schema(conn=conn)
+        after = conn.execute(
+            "SELECT value FROM meta WHERE key=?", (platform_ledger.MIGRATION_META_KEY,)
+        ).fetchone()
+        assert before[0] == after[0] == str(platform_ledger.PLATFORM_SCHEMA_VERSION)
+    finally:
+        conn.close()

--- a/tests/sharp/test_service_route_registration.py
+++ b/tests/sharp/test_service_route_registration.py
@@ -16,3 +16,50 @@ def test_market_routes_register_when_server_executes_as_main(monkeypatch):
     paths = [getattr(route, "path", None) for route in app.routes]
     assert paths.count("/api/sharp/market") == 1
     assert paths.count("/api/sharp/market/audit") == 1
+
+
+def test_registration_survives_being_imported_before_the_app_exists(monkeypatch):
+    """The import-order trap, pinned.
+
+    ``src/sharp/service.py`` registers its routes as an import-time side
+    effect. When anything imports it BEFORE the app exists — a test
+    module, a script, another package — that call finds no app and
+    returns, and Python's module cache means importing it again later
+    re-runs nothing. The routes then never attach and every
+    ``/api/sharp/market`` request 404s.
+
+    ``server.py`` therefore calls the public entry point explicitly
+    after importing the module. This reproduces the bad ordering and
+    asserts that the explicit call still fixes it.
+    """
+    # 1. Module imported while no app exists anywhere — the side effect
+    #    is a no-op, exactly as on a cold import from a test module.
+    monkeypatch.delitem(service.sys.modules, "server", raising=False)
+    monkeypatch.delitem(service.sys.modules, "__main__", raising=False)
+    service._register_http_routes()
+
+    # 2. The app comes into existence afterwards.
+    app = FastAPI()
+    monkeypatch.setitem(service.sys.modules, "server", SimpleNamespace(app=app))
+    assert "/api/sharp/market" not in [getattr(r, "path", None) for r in app.routes]
+
+    # 3. The explicit call server.py makes attaches them.
+    service.register_http_routes()
+
+    paths = [getattr(route, "path", None) for route in app.routes]
+    assert paths.count("/api/sharp/market") == 1
+    assert paths.count("/api/sharp/market/audit") == 1
+
+
+def test_server_calls_the_public_registrar_after_importing_the_service():
+    """A source guard, because the failure is silent at runtime.
+
+    Nothing in a normal request path reveals that the routes were never
+    attached — the endpoint simply 404s, which reads as "not deployed
+    yet". If this line is ever removed, the ordering bug returns.
+    """
+    from pathlib import Path
+
+    source = Path(__file__).resolve().parents[2] / "server.py"
+    text = source.read_text(encoding="utf-8")
+    assert "_sharp_service.register_http_routes()" in text

--- a/tests/sharp/test_unified_market.py
+++ b/tests/sharp/test_unified_market.py
@@ -6,7 +6,7 @@ from src.platforms.base import (
     NormalizedMovement,
     NormalizedTransaction,
 )
-from src.sharp import market
+from src.sharp import cohort, market
 
 NOW = 1_800_000_000_000
 
@@ -213,12 +213,12 @@ def test_complete_automated_ffpc_score_can_enter_same_cohort(monkeypatch):
         losses=10,
     )
     monkeypatch.setattr(
-        market.platform_records,
+        cohort.platform_records,
         "build_manager_records",
         lambda **kwargs: ([record], {}),
     )
     monkeypatch.setattr(
-        market.sharp_score,
+        cohort.sharp_score,
         "score_managers",
         lambda records: [
             sharp_score.ManagerScore(
@@ -243,12 +243,12 @@ def test_disabling_ffpc_excludes_automated_and_curated_ffpc_members(monkeypatch)
 
     record = sharp_score.ManagerRecord(user_id="ffpc:site-user-42")
     monkeypatch.setattr(
-        market.platform_records,
+        cohort.platform_records,
         "build_manager_records",
         lambda **kwargs: ([record], {}),
     )
     monkeypatch.setattr(
-        market.sharp_score,
+        cohort.sharp_score,
         "score_managers",
         lambda records: [
             sharp_score.ManagerScore(


### PR DESCRIPTION
Which players our verified sharp managers actually roster — built on the **same pool** that powers the Sharp Buy/Sell Tracker, not a second list of sharps.

## One cohort, many surfaces

`CohortMember` / `cohort_members` / `curated_members` / `provisional_members` / `load_ffpc_config` move out of `market.py` into **`src/sharp/cohort.py`**, the single definition of "who is a sharp". `market.py` re-exports every name, so `sharp_market.cohort_members` and the monkeypatch seam existing tests use still resolve.

| surface | resolves its pool via |
|---|---|
| Sharp Buy/Sell Tracker | `cohort.cohort_members` |
| Sharp Roster Percentage | `cohort.cohort_members` |
| roster collection pass | `cohort.cohort_members` |
| activity crawl | `cohort.cohort_members` |

That last one is a fix: `scripts/crawl_sharp_activity.py` was re-deriving the pool itself (`build_manager_records` → `score_managers` → filter), so a change to qualification moved the boards while the crawl that *feeds* them kept selecting the old set. It was the only remaining second list.

Two tests keep it that way: one asserts the function identity across modules, another greps `roster_percentage.py` for qualification vocabulary so a future fork announces itself.

## The missing data layer

Nothing persisted what the cohort currently **owns**. The intel crawler's holdings are scoped to one league's member pool, `records.py` fetches `/rosters` and discards the player list, and FFPC roster contents sat unqueryable inside a metadata blob.

- **`src/sharp/roster_store.py`** — four additive tables. Deduplication is **structural**, not a cleanup pass: one row per roster, one row per `(roster, player)`, so re-collection, duplicate imports and repeat snapshots cannot inflate a count. History is stored as open intervals rather than daily copies. Created with `CREATE TABLE IF NOT EXISTS` and deliberately *not* wired to `PLATFORM_SCHEMA_VERSION` — bumping that re-runs the whole platform migration on every deployed ledger to add four additive tables.
- **`src/sharp/roster_collect.py`** — the third crawl pass (discovery → records → rosters). Two Sleeper calls per *league* regardless of how many sharps play in it; FFPC costs zero. Collapses season chains, so one dynasty league is one roster however many `league_id`s it has had. Every roster reached is stored, eligible or not, with its exclusion reasons attached.
- **`src/sharp/roster_percentage.py`** — the board.

## Two counting decisions worth reviewing

**The denominator is rosters, not people.** A sharp with five legitimate dynasty teams contributes five roster observations. Both numbers ship: `eligibleRosters` counts rosters, `uniqueSharpManagers` collapses linked accounts to humans.

**The denominator is per player.** A linebacker cannot be rostered in a league with no IDP slots. Dividing every player by every sharp roster reports ~20% for an IDP owned in *every* league that can roster him — an artifact of the cohort's format mix. Each player is measured against the rosters whose league is known to field his position family, and a roster that holds him is always inside his own denominator, so a percentage cannot exceed 100%.

Trends compare the **intersection** of the two roster populations and are withheld below 80% overlap, so cohort growth never reads as players gaining ownership. "No change" and "not comparable" render differently.

## Surfaces

`GET /api/sharp/roster-percentage` and `/audit`, declared directly in `server.py`.

`/market/sharp-roster-percentage` carries the full filter set, list sizes (25/50/100/all), the alternate sorts, a transparency strip, sample warnings and a collapsed exclusion breakdown. `frontend/lib/sharp-roster-percentage.js` is a pure materializer — a client-side percentage would agree today and be wrong the moment the per-player denominator rule moves, and a test greps the file to keep it that way.

## Three silent-coverage bugs fixed along the way (`e35114b`)

Each produced a board that looked healthy while omitting part of the cohort, which is why none surfaced in testing.

1. **Discovery recorded memberships only for expanded leagues.** The user→leagues branch queued a league and stored its metadata but wrote no `league_memberships` row, so leagues left on the frontier by the call budget, `maxGenerations` or `maxLeaguesPerRun` had none. The collector reads `platform_memberships` to find a sharp's leagues, so it was bounded to the expanded subgraph — and `cohortCoveragePct` counts *managers* seen, so a sharp represented by 1 of their 4 leagues still read as fully represented. Sleeper's own `/user/{id}/leagues` proves the membership, so the row is a fact rather than an inference.
2. **A budgeted roster pass re-collected the same prefix forever.** Ordering by league id meant a run that hit its call budget collected the same alphabetical prefix on every subsequent run, and leagues past the cutoff were *never* collected — a permanently invisible tail, not a slow rollout. Now uses `record_queue.prioritize_league_ids`, the fair ordering the records crawl already had. Each run reports `leaguesRemaining` so `--budget` can be sized from the journal.
3. **Route registration depended on import order.** `src/sharp/service.py` registers its market routes as an import-time side effect; anything importing it before the app exists makes that a no-op, and the module cache means the later import re-runs nothing — `/api/sharp/market` then 404s with no other symptom. `server.py` now calls the public `register_http_routes()` explicitly. This is what `tests/sharp/test_public_api_allowlist.py` was catching, so that test **now passes**.

## A bug the tests caught

A holding must persist until the observation that **contradicts** it, not until the last one that **confirms** it. Rosters are observed periodically, so a roster seen on day 0 and day 40 has no confirmation at day 10 — yet the player was rostered then. Reading the confirming timestamp silently zeroes every drop that happened between two crawls, surfacing as a 30-day trend of exactly 0.0 no matter what moved. Fixed and pinned.

## Honest gaps, documented rather than papered over

1. **No general-dynasty ownership feed exists in this platform.** Every ranking source publishes values or ranks; Sleeper's trending endpoint publishes 24-hour add counts — a flow, not a stock. So `marketRosterPct` and `sharpRosterAdvantage` are `null`, the page says why, and `set_market_ownership_provider` is the registration seam for a real feed. The sharp-vs-market sorts work but rank nothing until one is registered.
2. **FFPC contributes zero rosters today.** The parser is correct and test-pinned, but all ten configured seeds are `LeagueHome.aspx` pages that yield transactions and standings, no roster table. The FFPC half activates when a roster-bearing URL is configured — no code change needed.
3. **Trends need two collection passes** before they resolve, which is why the timer is daily rather than weekly.
4. **Coverage is still bounded by how far discovery has reached.** `transparency.rostersPerManager` is the honest readout — near 1.0 while sharps typically run several dynasty teams means discovery has not caught up, not that sharps own one team each.

Full list in `docs/sharp-roster-percentage/METHODOLOGY.md`.

## Verification

- **6076 Python tests** and **1675 frontend tests** pass.
- `pytest tests/sharp/ tests/intel/` — the partial run that previously failed on the import-order bug — is green at 447.
- `scripts/validate_sharp_roster_percentage.py` re-derives every published number from the raw rows using code that shares nothing with the engine. Run against a 69-roster / 41-manager population, all ten audit checks clear: numerator recount, one-observation-per-roster, denominator, arithmetic bounds, duplicate rosters, duplicate identity attribution, asset mapping, excluded rosters never reaching a numerator, filters moving both sides, and agreement with the Buy/Sell Tracker's own payload.
- Production build compiles the page at 4.88 kB (134 kB first load); all bundles under budget.

**The audit ran against a constructed fixture, not production data** — this container has no sharp data (`data/intel/` is gitignored and empty). The fixture reproduces the shapes that matter: multi-team managers, shared leagues, IDP vs offense-only formats, taxi/IR players, a season chain and excluded rosters. Re-running the validator on prod after the first crawl is the step that actually closes the audit requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)