### PR TITLE
fix(deps): next 16.2.12, built with --webpack so the bundle gate can measure

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "html2canvas": "^1.4.1",
-        "next": "15.5.22",
+        "next": "16.2.12",
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "react-markdown": "^10.1.0"
@@ -1450,15 +1450,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.22",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.22.tgz",
-      "integrity": "sha512-O5BlKb3KtsHkvO0gjjV66PuJnAgCtIEIzwkt50HRAHsQkU1t77eksIXSZV84/WMtZJjWrnDUPKHVRi0D62nSAA==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.12.tgz",
+      "integrity": "sha512-d0Z5Bc13Fa4nR8pFAKx2jay2yhJM16vlfHbTzYnUQAxlNb6B6lmn4hjt69lYNt4kRtyYP6gEM49lPRHNbIyneg==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.22",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.22.tgz",
-      "integrity": "sha512-/VISwtffSg8+fVvBbXdglsvruCsdbBC4dG25iU6xascKVqfQKsj/OtjGnOEkIS7pX5GB9e9/r5QprpicsGL3gw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.12.tgz",
+      "integrity": "sha512-0W1R0teHWJrqKX0FH20IzzIWAOuGtBxPGuObrxy1lE8hQvCFj49KE8a3WUg0D7sq6rn6zkM4c7YGUnhudBS6oA==",
       "cpu": [
         "arm64"
       ],
@@ -1472,9 +1472,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.22",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.22.tgz",
-      "integrity": "sha512-NiA9ve8hbiuhG/Q17a2mZDRVxMTtg3rTOgjLnDaLlE+AEPAQlkkuKrfePEbeOrgYmX0U2KGX4EVEn09hXU5GlQ==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.12.tgz",
+      "integrity": "sha512-Hy5Ls099+aFUmOLmIgPfLqNi6iCwhL3uQCssz5rWk+5Nkc6TUKCE83DY5BbNylfm3+mfwcSFnLRfrZDJhVxdtw==",
       "cpu": [
         "x64"
       ],
@@ -1488,14 +1488,11 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.22",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.22.tgz",
-      "integrity": "sha512-vAPa9vltW+UW/KWtjXeSUFgV3wb1x9d/BeyC6WFI6eBpL0D2f70oGwtOp6193mNW3qusrpgBzMQferPf+Zh8Dw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.12.tgz",
+      "integrity": "sha512-+YqU2h1cQkHsGfvjAsrSmst8UIFBibBGm5x3Xgel8NLMiDQtNOM4sM2GOEMvG5YiOBNeN/Ykk8cQC2S0Xrqljg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1507,14 +1504,11 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.22",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.22.tgz",
-      "integrity": "sha512-iknK80pWlNDnkdSr13bd8mMuG3Z2oTxODwsZHvuMY7caMk77+rBLdHVWsy8v2EVa3ZojJ/+wJX5fnq8va6Gv8A==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.12.tgz",
+      "integrity": "sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1526,14 +1520,11 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.22",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.22.tgz",
-      "integrity": "sha512-penuEdkwU2OOAiS+n4LE8T/VIoCfAI01QcLZTJ2xc3+l4Q22L/DzURocmI2LU1b+8BMQoLAP1Sze3uYAZT05Bg==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.12.tgz",
+      "integrity": "sha512-7A3q26W+h7gnA15uqBToNuDqBEFZZcqh0mW2mn4AJh/G5pdg2RVE3n4slzLEliASZFG3NmsbEzng/x2Sh09mBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1545,14 +1536,11 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.22",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.22.tgz",
-      "integrity": "sha512-ZM0BKJm3FZ+guG6WT6PcyOLtp6paZ5tngcJC/uUKvLW4Y0TQnnVi1+UGdo8Q6Yxp5gaS82pmC1rD/oFlhkWB3g==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.12.tgz",
+      "integrity": "sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1564,9 +1552,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.22",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.22.tgz",
-      "integrity": "sha512-rY/YaumrZaS0//94BnHLF5VSRp0GFUO4GvXNuoCBb0cGSci96yO+p1JaNL2aq9YZAYv9cuZRziV02x5IQH/wjg==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.12.tgz",
+      "integrity": "sha512-X6hzsOUJac/e7AWSbn9gQ9nzHld1xWP5iyjHpYWvud8pufB679O1xg4JDyKr8Xd69Jvd+kM2Der6uftiZCmjYA==",
       "cpu": [
         "arm64"
       ],
@@ -1580,9 +1568,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.22",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.22.tgz",
-      "integrity": "sha512-s5IA4cyrbR2XK/5NWcu5dp8CfPBiKME+UhvNperia7uQybEgg5+LIhGMiY37WQE4rcI4owsDcU4IVUjLoTuDkA==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.12.tgz",
+      "integrity": "sha512-F6fakeHuFTLOPt0bslQJdf+xtT+WIP9DVn/m4y1w1mRnVPyh3D/cNvzlRkxM444xfm+IvvYNSOrKiA2CDJ0Uxw==",
       "cpu": [
         "x64"
       ],
@@ -2421,7 +2409,6 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.8.tgz",
       "integrity": "sha512-zAgkquC2WYF0PIc6XbNYkA2uuxxFavzgmX61R+dHDUa558V8Ejf8ozTZFR6QzM24RWu4kBcRkhJ5kpz77j9fnQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4056,13 +4043,14 @@
       }
     },
     "node_modules/next": {
-      "version": "15.5.22",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.22.tgz",
-      "integrity": "sha512-mrtal1sRxO4YrlDS98sDuIvGZivKbFix8w7oAL9ZynfOgc3cADQOQgvwtMooc18Qr8bKzvQAcHwHZ0mbJ7zcfQ==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.12.tgz",
+      "integrity": "sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.22",
+        "@next/env": "16.2.12",
         "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -4071,18 +4059,18 @@
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+        "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.22",
-        "@next/swc-darwin-x64": "15.5.22",
-        "@next/swc-linux-arm64-gnu": "15.5.22",
-        "@next/swc-linux-arm64-musl": "15.5.22",
-        "@next/swc-linux-x64-gnu": "15.5.22",
-        "@next/swc-linux-x64-musl": "15.5.22",
-        "@next/swc-win32-arm64-msvc": "15.5.22",
-        "@next/swc-win32-x64-msvc": "15.5.22",
-        "sharp": "^0.34.3"
+        "@next/swc-darwin-arm64": "16.2.12",
+        "@next/swc-darwin-x64": "16.2.12",
+        "@next/swc-linux-arm64-gnu": "16.2.12",
+        "@next/swc-linux-arm64-musl": "16.2.12",
+        "@next/swc-linux-x64-gnu": "16.2.12",
+        "@next/swc-linux-x64-musl": "16.2.12",
+        "@next/swc-win32-arm64-msvc": "16.2.12",
+        "@next/swc-win32-x64-msvc": "16.2.12",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,8 +7,8 @@
   },
   "scripts": {
     "dev": "next dev -p 3000",
-    "build": "next build && node scripts/check-bundle-sizes.mjs",
-    "build:nocheck": "next build",
+    "build": "next build --webpack && node scripts/check-bundle-sizes.mjs",
+    "build:nocheck": "next build --webpack",
     "start": "next start -p 3000",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "html2canvas": "^1.4.1",
-    "next": "15.5.22",
+    "next": "16.2.12",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-markdown": "^10.1.0"


### PR DESCRIPTION
Closes the **last open security exposure** in the dependency set. `GHSA-89xv-2m56-2m9x` has no fix in the 15.x line, which is why Dependabot raised a major despite `dependabot.yml` ignoring `next` majors.

Supersedes #658, which carries the same version bump without the flag and therefore cannot pass CI.

## Two changes, and the second is what makes the first landable

1. `next` 15.5.22 → 16.2.12 — identical to #658.
2. `next build` → `next build --webpack` in **both** build scripts.

Next 16 makes Turbopack the default builder, and Turbopack emits a flat, content-hashed chunk layout (`static/chunks/1de9myc15dqxx.js`) with nothing tying a file to a route. Per-page bundle attribution simply does not exist there, so `scripts/check-bundle-sizes.mjs` cannot measure a Turbopack build.

The flag could not be added ahead of this bump — Next 15.5.12 doesn't accept it. That ordering is why #658 sat blocked.

Both scripts, because every build path reaches one of them:

| caller | script |
|---|---|
| `pr-validation.yml:247` | `build:nocheck` |
| `deploy.yml:206`, `deploy/deploy.sh:295`, `deploy/rollback.sh:348` | `build` |

## The flag can't be silently dropped later

That's the property #703 was written for, and I verified it on this tree rather than assuming it: built with Turbopack and ran the gate against the output.

```
turbopack build exit=0
[check-bundle-sizes] no app-router chunk dir at .../.next.turbo/static/chunks/app.
...Build with `next build --webpack`, or replace this script with a Turbopack-native measurement.
gate exit=2
```

The build succeeds and the **gate** fails, naming the cause. Before #703 this same situation exited 0 having measured nothing.

## Verification on Next 16.2.12

| check | result |
|---|---|
| `next build --webpack` | exit 0, all 43 routes |
| `check:bundles` | **all 14** budgeted pages resolved, every one under budget |
| largest page | `/league` 163.4 KB vs 170 KB budget |
| tightest headroom | `/draft` 125.6 KB vs 128 KB (2.4 KB) |
| `vitest` | 99 files, 1647 tests, all passing |

Plus a live probe, because the page auth gate is `frontend/middleware.js` and it is the **only** one — a silent middleware break under a new major is the specific risk worth testing for:

```
/rankings  -> 307  /login?next=%2Frankings
/trade     -> 307  /login?next=%2Ftrade
/settings  -> 307  /login?next=%2Fsettings
/draft     -> 307  /login?next=%2Fdraft
/login     -> 200
/league    -> 200
```

(`/more` also 307s — correct, it isn't in `PUBLIC_EXACT`.)

## Not done here, deliberately

Next 16 deprecates the `middleware` file convention in favour of `proxy`:

```
⚠ The "middleware" file convention is deprecated. Please use "proxy" instead.
```

It still runs — the 307s above are from this build. Renaming the sole page auth gate inside a major framework bump is a separate change with its own blast radius, and it needs a `CLAUDE.md` update too, since that file documents `middleware.js` by name. Deprecated, not removed; it works for the 16.x line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrVJELpwtdym5DuC8NPYe5)_