### PR TITLE
fix(terminal,bdvm): un-invert the movers verbs and disclose proxy fundamentals

### DIFF
--- a/frontend/__tests__/bdvm-lib.test.js
+++ b/frontend/__tests__/bdvm-lib.test.js
@@ -220,6 +220,33 @@ describe("buildBdvmIndex + bdvmEntryForRow (rankings gap join)", () => {
     ],
   };
 
+  // Audit finding B-8.  The /bdvm page badges a proxy-backed fundamental;
+  // this index dropped the flag, so the /rankings and /draft "Fund gap"
+  // columns rendered a signed gap and a signal-coloured pill with a
+  // tooltip asserting "the market underprices the player" on rows whose
+  // fundamental is last season's realized scoring, not a projection.
+  it("carries anyProxy so the joined columns can disclose it", () => {
+    const index = buildBdvmIndex({
+      players: [
+        player("Proxy Guy", {
+          playerId: "p1",
+          projection: { anyProxy: true, fpg: 1, sourceCount: 1 },
+        }),
+        player("Real Guy", {
+          playerId: "p2",
+          projection: { anyProxy: false, fpg: 1, sourceCount: 2 },
+        }),
+      ],
+    });
+    expect(bdvmEntryForRow(index, { playerId: "p1", name: "x" }).anyProxy).toBe(true);
+    expect(bdvmEntryForRow(index, { playerId: "p2", name: "x" }).anyProxy).toBe(false);
+  });
+
+  it("defaults anyProxy to false when the payload omits projection", () => {
+    const index = buildBdvmIndex({ players: [player("Bare", { playerId: "b1" })] });
+    expect(bdvmEntryForRow(index, { playerId: "b1", name: "x" }).anyProxy).toBe(false);
+  });
+
   it("joins playerId-first, then canonical name key", () => {
     const index = buildBdvmIndex(payload);
     // rankings rows carry playerId at top level or under raw

--- a/frontend/__tests__/components/sharp-roster-percentage-page.test.jsx
+++ b/frontend/__tests__/components/sharp-roster-percentage-page.test.jsx
@@ -82,12 +82,21 @@ describe("Sharp Roster Percentage page", () => {
 
   it("surfaces the transparency disclosures", async () => {
     render(<SharpRosterPercentagePage />);
-    expect(await screen.findByText("Sharp managers")).toBeInTheDocument();
+    // Await a DATA value, not a label.  The page paints the stat labels
+    // immediately with "—" placeholders and fills the values in only
+    // after the fetch resolves, so `findByText("Sharp managers")`
+    // resolves on the first paint — before any data — and the
+    // synchronous `getByText("80%")` below then raced the fetch.  It
+    // won that race on an unloaded machine and lost it on a busy CI
+    // runner, which is what made this test intermittently red with no
+    // product defect behind it.  Anchoring the await on the
+    // last-arriving value makes the rest of the assertions safe.
+    expect(await screen.findByText("80%")).toBeInTheDocument();
+    expect(screen.getByText("Sharp managers")).toBeInTheDocument();
     expect(screen.getByText("Eligible rosters")).toBeInTheDocument();
     expect(screen.getByText("Sleeper rosters")).toBeInTheDocument();
     expect(screen.getByText("FFPC rosters")).toBeInTheDocument();
     expect(screen.getByText("Cohort represented")).toBeInTheDocument();
-    expect(screen.getByText("80%")).toBeInTheDocument();
   });
 
   it("explains that no market comparison exists rather than showing a zero", async () => {

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -1187,6 +1187,10 @@ export default function RankingsPage() {
         headerInfo:
           "BDVM fundamental value (balanced) minus market anchor — " +
           "positive means the market underprices the player. " +
+          "A trailing * marks a proxy-backed fundamental: no real " +
+          "projection source covers that player, so the value is last " +
+          "season's realized scoring and the gap is not a clean " +
+          "fundamental-vs-market read. " +
           "Visible only while the BDVM engine is enabled.",
         render: (row) => {
           const entry = bdvmEntryForRow(bdvmIndex, row);
@@ -1202,16 +1206,28 @@ export default function RankingsPage() {
             );
           }
           const css = bdvmSignalEdgeCss(entry.signal);
+          // Disclose a proxy-backed fundamental (audit finding B-8).  The
+          // /bdvm page badges this; this column used to render the gap
+          // with no indication that the fundamental side may be last
+          // season's realized PPG rather than a projection.
+          const proxyNote = entry.anyProxy
+            ? " — PROXY: fundamental is the reconstructed baseline (last " +
+              "season's realized scoring), not a real projection, so this " +
+              "gap partly reflects information the market has and it does not"
+            : "";
           const title =
             `${entry.signal}: ${entry.signalReason} — fundamental ` +
             `${formatBdvmValue(entry.fundamental)} vs market ` +
-            `${formatBdvmValue(entry.marketValue)}`;
+            `${formatBdvmValue(entry.marketValue)}${proxyNote}`;
+          const shown = entry.anyProxy
+            ? `${formatBdvmGap(entry.gap)}*`
+            : formatBdvmGap(entry.gap);
           return css ? (
             <span className={`edge-label ${css}`} title={title}>
-              {formatBdvmGap(entry.gap)}
+              {shown}
             </span>
           ) : (
-            <span title={title}>{formatBdvmGap(entry.gap)}</span>
+            <span title={title}>{shown}</span>
           );
         },
       });

--- a/frontend/components/terminal/MoversPanel.jsx
+++ b/frontend/components/terminal/MoversPanel.jsx
@@ -188,8 +188,14 @@ export default function MoversPanel() {
       {!loading && !error && (
         <div className={styles.moverColumns}>
           <div className={styles.moverColumn}>
+            {/* A riser's price has already gone UP, so it is a candidate to
+                sell HIGH — not to buy low.  These two headings were the
+                wrong way round (audit finding S-8): the panel instructed
+                the user to buy what had just appreciated and sell what had
+                just depreciated, the inverse of both phrases, on the
+                terminal's most prominent movement widget. */}
             <h3 className={`${styles.moverColumnTitle} ${styles.moverColumnTitleUp}`}>
-              Risers — buy-low candidates
+              Risers — sell-high candidates
             </h3>
             {risers.length === 0 ? (
               <p className={styles.moverEmpty}>No qualifying movers in this window.</p>
@@ -205,7 +211,7 @@ export default function MoversPanel() {
           </div>
           <div className={styles.moverColumn}>
             <h3 className={`${styles.moverColumnTitle} ${styles.moverColumnTitleDown}`}>
-              Fallers — sell-high candidates
+              Fallers — buy-low candidates
             </h3>
             {fallers.length === 0 ? (
               <p className={styles.moverEmpty}>No qualifying movers in this window.</p>

--- a/frontend/lib/bdvm.js
+++ b/frontend/lib/bdvm.js
@@ -200,6 +200,18 @@ export function buildBdvmIndex(payload) {
       fundamental: _num(p?.tradeValue?.balanced),
       signal: p?.signal?.signal ?? "",
       signalReason: p?.signal?.reason ?? "",
+      // Carried so the /rankings and /draft "Fund gap" columns can
+      // disclose what the /bdvm page already does (audit finding B-8).
+      // Where no real projection source covers a player the fundamental
+      // is the §8.3 reconstructed baseline — last season's realized PPG —
+      // so the gap is structurally "the market knows things last year's
+      // box scores don't", i.e. a momentum-fade signal rather than
+      // fundamental analysis.  The /bdvm page badges that honestly; this
+      // index omitted the flag entirely, so the two joined columns
+      // rendered a signed gap and a signal-coloured pill with a tooltip
+      // asserting "positive means the market underprices the player" —
+      // an interpretation that is unwarranted on a proxy-backed row.
+      anyProxy: Boolean(p?.projection?.anyProxy),
     };
     const id = p?.playerId != null ? String(p.playerId).trim() : "";
     if (id) byId.set(id, entry);


### PR DESCRIPTION
Two more findings from the [2026-08-04 decision-intelligence audit](https://github.com/jasonleetucker-code/riskittogetthebrisket/blob/main/docs/audits/decision-intelligence-audit-2026-08-04.md). Frontend-only; no valuation logic touched.

Running total: **4 of 43 Critical + 130 High** addressed across #715 and this PR.

## S-8 — the movers panel labelled both columns backwards

```
Risers  — buy-low candidates     <- a riser's price already went UP
Fallers — sell-high candidates   <- a faller's price already went DOWN
```

The terminal's most prominent movement widget was instructing the user to **buy what had just appreciated and sell what had just depreciated** — the inverse of what both phrases mean. Swapped, with the reasoning recorded at the call site so it doesn't get "fixed" back.

## B-8 — proxy disclosure was stripped on the two joined surfaces

Where no real projection source covers a player, BDVM's "fundamental" is the §8.3 reconstructed baseline — **last season's realized PPG**, flagged `is_proxy`. For those rows the fundamental-vs-market gap is structurally *"the market has newer information than last year's box scores"*: a momentum-fade signal, not fundamental analysis. It will read SELL on anyone whose market rose on offseason news, and BUY on declining veterans with a good past season.

The `/bdvm` page handles this honestly with an explicit badge. But `buildBdvmIndex` — the index feeding the **`/rankings` and `/draft` "Fund gap" columns** — omitted `anyProxy` entirely, while the column tooltip asserted *"positive means the market underprices the player."*

Now: `anyProxy` is carried through the index, proxy-backed rows render with a trailing `*`, and both the cell tooltip and the column header explain what that means. Two regression tests pin the carry and its default.

## Verification

- Frontend suite: **103 files, 1750 tests, all passing**
- `ruff format --check .` clean (831 files)
- No backend or valuation change; the board is byte-identical

## What I deliberately did not do here

**T-2 (trade verdict fairness bands) and T-1 (undefined give/receive direction).** T-2's fix is specified in the audit, but it touches two functions with ~15 existing assertions encoding the old absolute thresholds, and it is largely cosmetic while **T-1 is unfixed** — the meter can currently name the *wrong side* as the winner, so correcting the band widths on a possibly-inverted verdict would be polish on top of a sign error. Those two want to land together, with the typed `TradeSide { gives, receives }` the audit recommends. I'd rather leave the flagship trade verdict alone than half-change it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pk5ViWdcv6zokYU9uvFMW

---
_Generated by [Claude Code](https://claude.ai/code/session_018pk5ViWdcv6zokYU9uvFMW)_