### PR TITLE
Scope the auto-issue trackers to mainline runs

### DIFF
--- a/.github/workflows/audit-identity-matches.yml
+++ b/.github/workflows/audit-identity-matches.yml
@@ -111,7 +111,12 @@ jobs:
           retention-days: 30
 
       - name: Open / update rolling issue on collision
-        if: failure()
+        # Mainline only — see the long note on the same guard in e2e.yml,
+        # where this defect was actually observed (#716). `push` and
+        # `schedule` here are already main-only; `workflow_dispatch` is the
+        # path that can run this on a feature branch and file its result as
+        # a mainline verdict.
+        if: failure() && github.ref == 'refs/heads/main'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -189,7 +194,10 @@ jobs:
         # open `identity-collision` issue means "this failed at least once, ever"
         # rather than "this is broken now" — #663 sat open for hours after
         # its gate went green because of exactly this gap.
-        if: success()
+        #
+        # Mainline only, for the reason in e2e.yml: a green dispatch from a
+        # branch would close a real open mainline issue.
+        if: success() && github.ref == 'refs/heads/main'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit-rank-form-drift.yml
+++ b/.github/workflows/audit-rank-form-drift.yml
@@ -149,7 +149,11 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Open or update an issue on drift
-        if: ${{ steps.drift.outputs.exit_code == '2' }}
+        # Mainline only — see the long note on the same guard in e2e.yml
+        # (#716). This workflow's only non-main path is workflow_dispatch,
+        # and drift measured against a branch's constants is not a
+        # statement about the committed ones.
+        if: ${{ steps.drift.outputs.exit_code == '2' && github.ref == 'refs/heads/main' }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -192,7 +196,10 @@ jobs:
         # Both workflows also fall back to creating an UNLABELLED issue
         # when the label is missing (`|| gh issue create` without
         # --label), so the title search is the more reliable key anyway.
-        if: success()
+        #
+        # Mainline only, for the reason in e2e.yml: a green dispatch from a
+        # branch would close a real open mainline issue.
+        if: success() && github.ref == 'refs/heads/main'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,13 @@ name: E2E Safety Net
 # Failure handling mirrors scheduled-refresh.yml: an idempotent
 # tracking issue labelled ``e2e-failures`` is opened (or commented
 # on) so a broken journey can't sit unnoticed between manual runs.
+#
+# That tracker is about MAIN, and only main writes to it — both the
+# open and the close step require ``github.ref == 'refs/heads/main'``.
+# Dispatching this on a branch is a first-class use (it is how a branch
+# gets arbitrated against the green baseline), and its result is
+# reported in the run itself.  It just does not get to speak for main.
+# See the note on the alert step for the incident, #716.
 
 on:
   schedule:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -244,7 +244,32 @@ jobs:
         # scheduled-refresh.yml: ensure the label exists, then comment
         # on the open ``e2e-failures`` issue if there is one, else
         # open a single labelled issue and keep reusing it.
-        if: failure()
+        #
+        # MAINLINE RUNS ONLY, and the `github.ref` half is the load-bearing
+        # part of that condition.  The tracker answers one question — "is a
+        # critical journey broken on main right now?" — and a
+        # `workflow_dispatch` on a feature branch cannot contribute an
+        # answer to it either way.
+        #
+        # It contributed wrong ones in both directions.  #716 was opened
+        # 2026-08-04T18:59Z reading "Nightly E2E safety-net run failed"; it
+        # was a manual dispatch on `claude/sitewide-performance-audit-nubuz8`
+        # (PR #709), deliberately fired by the session working that branch to
+        # let CI arbitrate its own in-progress change.  Working as intended
+        # for them, filed as a mainline regression for everyone else.
+        #
+        # The close step below is the worse direction and the reason this is
+        # a guard rather than a wording fix: it is gated only on `success()`,
+        # so a green dispatch from ANY branch closes a genuine open mainline
+        # failure with "safety net is green again". A branch that never ran
+        # main's code would have issued main's all-clear.
+        #
+        # schedule and a dispatch on main both give `refs/heads/main`, so the
+        # legitimate paths are untouched. `branches: [main]` is already
+        # hardcoded across these workflows; matching that is deliberate over
+        # deriving the default branch from an event payload that varies by
+        # trigger.
+        if: failure() && github.ref == 'refs/heads/main'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -252,7 +277,7 @@ jobs:
           set -Eeuo pipefail
           RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           BODY=$(cat <<EOF
-          Nightly E2E safety-net run failed.
+          E2E safety-net run failed on \`main\` (trigger: ${GITHUB_EVENT_NAME}).
 
           - Workflow run: ${RUN_URL}
           - Commit: ${GITHUB_SHA}
@@ -303,8 +328,11 @@ jobs:
         #
         # A green run of THIS workflow is the all-clear by construction:
         # the suite is the gate, so there is no per-step outcome to
-        # re-derive.
-        if: success()
+        # re-derive.  On MAIN.  The ref guard is not symmetry with the
+        # alert step above — it is the stronger of the two requirements,
+        # because a false all-clear closes a real open failure and a false
+        # alarm merely files a wrong one.  See that step for the full note.
+        if: success() && github.ref == 'refs/heads/main'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -324,7 +352,7 @@ jobs:
           for N in $OPEN; do
             echo "closing #${N}"
             gh issue close "$N" --reason completed --comment \
-              "Nightly E2E safety net is green again — every critical journey passed.
+              "E2E safety net is green again on \`main\` — every critical journey passed.
 
           - Workflow run: ${RUN_URL}
           - Commit: ${GITHUB_SHA}

--- a/.github/workflows/intel-refresh.yml
+++ b/.github/workflows/intel-refresh.yml
@@ -222,7 +222,10 @@ jobs:
         # gh CLI tries to infer the repo from git and dies with
         # "fatal: not a git repository" — which is exactly how the
         # first live failure lost its tracking issue.
-        if: failure()
+        #
+        # Mainline only — see the long note on the same guard in e2e.yml
+        # (#716); workflow_dispatch is this workflow's only non-main path.
+        if: failure() && github.ref == 'refs/heads/main'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -271,7 +274,10 @@ jobs:
         # open `intel-stale` issue means "this failed at least once, ever"
         # rather than "this is broken now" — #663 sat open for hours after
         # its gate went green because of exactly this gap.
-        if: success()
+        #
+        # Mainline only, for the reason in e2e.yml: a green dispatch from a
+        # branch would close a real open mainline issue.
+        if: success() && github.ref == 'refs/heads/main'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/refit-hill-curves.yml
+++ b/.github/workflows/refit-hill-curves.yml
@@ -187,8 +187,20 @@ jobs:
       # Note also that this shares the `calibration` label with
       # audit-rank-form-drift.yml, whose auto-close therefore matches on
       # TITLE rather than label so it cannot reach over and close these.
+      # Mainline only, like the other issue-writing workflows — see the
+      # long note in e2e.yml (#716).  It matters MORE here than there,
+      # for two reasons that are specific to this file: there is no
+      # dedup (no `EXISTING` lookup, just `gh issue create`), so every
+      # branch dispatch mints a NEW issue rather than commenting on one;
+      # and there is no auto-close by design, so nothing ever retires
+      # them.  A promotion request is also a claim about the COMMITTED
+      # champion, which a branch's constants cannot make.
+      #
+      # This adds only an open-side guard.  The reasoning above against
+      # auto-closing promotion requests is untouched — not filing from a
+      # branch is not the same as closing something.
       - name: Open an issue when a human must act
-        if: steps.refit.outputs.exit_code == '1' || steps.refit.outputs.exit_code == '3'
+        if: (steps.refit.outputs.exit_code == '1' || steps.refit.outputs.exit_code == '3') && github.ref == 'refs/heads/main'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/scheduled-refresh.yml
+++ b/.github/workflows/scheduled-refresh.yml
@@ -671,7 +671,10 @@ jobs:
         # if an open ``stale-sources`` issue already exists, post a
         # comment with the new run details rather than spamming new
         # issues each cycle.
-        if: failure()
+        #
+        # Mainline only — see the long note on the same guard in e2e.yml
+        # (#716); workflow_dispatch is this workflow's only non-main path.
+        if: failure() && github.ref == 'refs/heads/main'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -742,7 +745,12 @@ jobs:
         # green run IS the all-clear.  Re-deriving "is it really fixed?"
         # from individual step outcomes would duplicate that logic and
         # let the two drift.
-        if: success()
+        #
+        # The one thing ``success()`` alone cannot establish is WHOSE run
+        # was green.  Mainline only, for the reason in e2e.yml (#716): a
+        # green dispatch from a branch would close a real open mainline
+        # issue with an all-clear it never measured.
+        if: success() && github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
Six workflows open and close tracking issues gated only on `failure()` / `success()`, with nothing about **which ref was measured**. A `workflow_dispatch` on a feature branch therefore files, and closes, verdicts about `main`.

## What was observed

**#716**, opened `2026-08-04T18:59Z`, reading *"Nightly E2E safety-net run failed."*

It was neither nightly nor `main`. It was a manual dispatch on `claude/sitewide-performance-audit-nubuz8` (PR #709), fired by the session working that branch to let CI arbitrate its own in-progress change. Correct behavior for them; filed as a mainline regression for everyone else.

## Why this is a guard and not a wording fix

The **close** half is the more dangerous direction. Gated only on `success()`, a green dispatch from *any* branch closes a genuine open mainline failure with *"safety net is green again"* — and the close step iterates `.[]` deliberately, so it drains **every** open one. A branch that never ran main's code would have issued main's all-clear.

A false alarm files a wrong issue. A false all-clear retires a real one.

## The change

Every issue-writing step now requires `github.ref == 'refs/heads/main'`:

| workflow | steps guarded |
|---|---|
| `e2e.yml` | alert + close |
| `audit-identity-matches.yml` | alert + close |
| `audit-rank-form-drift.yml` | drift-issue + close |
| `intel-refresh.yml` | alert + close |
| `scheduled-refresh.yml` | alert + close |
| `refit-hill-curves.yml` | promotion/alarm issue (open-side only — see below) |

`schedule`, `push`-to-main and a dispatch on `main` all give `refs/heads/main`, so **no legitimate path changes** — only the branch-dispatch path stops speaking for `main`.

`branches: [main]` is already hardcoded across these files, so matching it is deliberate over deriving the default branch from an event payload whose shape varies by trigger.

`refit-hill-curves.yml` was missed by the first sweep, which keyed on `gh issue close` — that file deliberately has no auto-close. The open direction has the same defect and it is **worse** there: no dedup (no `EXISTING` lookup, just `gh issue create`), so each branch dispatch mints a *new* issue rather than commenting on one, and nothing ever retires them. The documented reasoning against auto-closing promotion requests is untouched; not filing from a branch is not the same as closing something.

Also corrected the body strings and the `e2e.yml` header, which asserted "Nightly" for what can be a manual mainline run, and described the pre-guard contract.

## Verification

- All six files parse (`yaml.safe_load`).
- Guard sites confirmed present by an audit loop over every workflow containing `gh issue create|comment|close` — zero unguarded remain.
- `tests/api/test_config_parity.py` + `tests/canonical/test_rank_form_constants_tripwire.py` (the tests that read workflow files) pass: 10 passed.
- Against the incident: run `30940868651` had `head_branch: claude/sitewide-performance-audit-nubuz8`, so `github.ref` ≠ `refs/heads/main` and the alert step would not have run.

## Not fixed here

The E2E failure **#716 actually points at**. It belongs to PR #709's branch and that session is actively iterating on it — the commit under test says so explicitly. Once this merges, an E2E dispatch on `main` is what will legitimately resolve #716 in either direction.