### PR TITLE
Audit tranche 2: drifted mirrors, a hollow guard, and docs that misdescribe live behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # Risk It To Get The Brisket — Dynasty Trade Calculator
 
-Private repo for the dynasty trade calculator stack powering
-[chaseupside.com](https://chaseupside.com).
+Public repo for the dynasty trade calculator stack powering
+[chaseupside.com](https://chaseupside.com). Visibility is a deliberate
+owner decision — see `SECURITY.md`, which records what that exposes
+(valuation engine, league configuration, tracked `data/` + `exports/`
+snapshots). This line said "Private repo" while `SECURITY.md` and
+`HANDOFF.md` both said public.
 
 **Architecture at a glance:**
 - **Backend:** Python 3.12 FastAPI + Uvicorn (port 8000).
@@ -12,7 +16,12 @@ Private repo for the dynasty trade calculator stack powering
 - **Auth model:** session-gated `/api/*` endpoints with a
   Sleeper-login allowlist; public routes hit `/api/public/league/*`.
 - **Feature flags** (`src/api/feature_flags.py`): every new
-  capability from the 2026-04 upgrade ships flag-gated (default OFF).
+  capability from the 2026-04 upgrade ships flag-gated. Defaults are
+  **per-flag**: 7 of the 15 in `_DEFAULTS` ship enabled (`bdvm_engine`,
+  `te_basis_conversion`, `monte_carlo_trade`, `idp_scoring_fit`,
+  `reception_scoring_fit`, `nfl_data_ingest`, `realized_points_api`),
+  several deliberately. For those the env var is a rollback lever, not an
+  opt-in. Read `_DEFAULTS` before assuming a capability is dormant.
 
 **Orientation docs:**
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — system map
@@ -124,7 +133,7 @@ This repo is now wired so both sides can work together:
 - `SLEEPER_LEAGUE_ID=1312006700437352448` (canonical main league ID for backend scraper)
 
 ### `/api/data` contract
-- `/api/data` is now versioned (`contractVersion=2026-03-09.v1`)
+- `/api/data` is now versioned (`contractVersion=2026-03-10.v2` — see `CONTRACT_VERSION` in `src/api/data_contract.py`)
 - Preserves legacy compatibility fields (`players` map, `maxValues`, etc.)
 - Adds normalized stable fields (`playersArray`, `dataSource`, `contractHealth`)
 - Runtime + CI validation:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,10 +22,24 @@ Browser ─► Nginx ─► Next.js (port 3000) ─► FastAPI (port 8000) ─�
    trades, and draft picks are separate. See `CLAUDE.md` for the
    full field-split table.
 
-2. **Every new behavior ships behind a feature flag** (default OFF).
-   Registry at `src/api/feature_flags.py`. Env override via
-   `RISKIT_FEATURE_<NAME>=1`. Nothing in production changes until
-   a flag flips.
+2. **Every new behavior ships behind a feature flag.** Registry at
+   `src/api/feature_flags.py`. Env override via `RISKIT_FEATURE_<NAME>=1`
+   (or `=0` to disable).
+
+   **Defaults are per-flag.** As of 2026-08-04, 7 of the 15 entries in
+   `_DEFAULTS` ship enabled — `bdvm_engine`, `te_basis_conversion`
+   (which reprices every tight end on the live board),
+   `monte_carlo_trade`, `idp_scoring_fit`, `reception_scoring_fit`,
+   `nfl_data_ingest`, `realized_points_api` — several with comments
+   recording that the enabled default is deliberate. For those, the env
+   var is a rollback lever rather than an opt-in.
+
+   This item previously asserted a blanket disabled-by-default rule and
+   that production behaviour was frozen until a flag was flipped. Both
+   were false, and a reader trusting them would have taken a live
+   repricing path for a dormant one. `tests/api/`
+   `test_feature_flag_docs_match_registry.py` now fails if that claim
+   returns while any flag ships enabled.
 
 ## Modules + what they own
 

--- a/frontend/__tests__/idp-consensus-keys-parity.test.js
+++ b/frontend/__tests__/idp-consensus-keys-parity.test.js
@@ -1,0 +1,71 @@
+/**
+ * `IDP_CONSENSUS_KEYS` must not drift from the source registry.
+ *
+ * WHY THIS EXISTS
+ * ===============
+ * `display-helpers.js` hand-maintains a Set of the IDP sources that
+ * make up the "expert consensus" side of the IDP Buy/Sell signal. A
+ * hand-maintained mirror of a registry is the same shape as the
+ * `value-history.js` curve constants and the `/rankings` Hill formula —
+ * both of which drifted and both of which this audit already fixed.
+ *
+ * This one had drifted in BOTH directions at once:
+ *
+ *   - it OMITTED `dlfRookieIdp`, a real `overall_idp` source. 29 rows
+ *     carry a rank from it and 28 of those shift their consensus mean
+ *     by >= 1 rank once it is counted — a quietly biased mean, not a
+ *     missing signal, which is why nothing looked broken.
+ *   - its comment NAMED "FootballGuys IDP", which is not a key in
+ *     either registry.
+ *
+ * WHAT THIS ASSERTS
+ * =================
+ * The set equals every `overall_idp` source in `RANKING_SOURCES`,
+ * minus the retail anchor (`idpTradeCalc`) which is deliberately the
+ * OTHER side of the comparison. Derived from the registry rather than
+ * pinned as a literal, so adding a genuine IDP source updates the
+ * expectation automatically and only a real divergence fails.
+ *
+ * `RANKING_SOURCES` is itself kept in lockstep with the Python
+ * `_RANKING_SOURCES` by `tests/api/test_source_registry_parity.py`, so
+ * this transitively pins against the backend registry too.
+ */
+
+import { describe, it, expect } from "vitest";
+import { RANKING_SOURCES } from "@/lib/dynasty-data";
+import { __testables } from "@/lib/display-helpers";
+
+const { IDP_CONSENSUS_KEYS, IDP_RETAIL_KEY } = __testables;
+
+describe("IDP_CONSENSUS_KEYS parity with the source registry", () => {
+  const idpSources = RANKING_SOURCES.filter((s) => s.scope === "overall_idp").map(
+    (s) => s.key,
+  );
+
+  it("the registry actually has overall_idp sources (non-vacuity)", () => {
+    // Without this, every assertion below would pass against an empty
+    // set if the scope tag were ever renamed.
+    expect(idpSources.length).toBeGreaterThan(2);
+    expect(idpSources).toContain(IDP_RETAIL_KEY);
+  });
+
+  it("contains every overall_idp source except the retail anchor", () => {
+    const expected = new Set(idpSources.filter((k) => k !== IDP_RETAIL_KEY));
+    const actual = new Set(IDP_CONSENSUS_KEYS);
+
+    const missing = [...expected].filter((k) => !actual.has(k));
+    const extra = [...actual].filter((k) => !expected.has(k));
+
+    expect({ missing, extra }).toEqual({ missing: [], extra: [] });
+  });
+
+  it("does not contain the retail anchor — it is the other side of the comparison", () => {
+    expect(IDP_CONSENSUS_KEYS.has(IDP_RETAIL_KEY)).toBe(false);
+  });
+
+  it("includes dlfRookieIdp, the source that was silently omitted", () => {
+    // Named explicitly: this is the regression that motivated the test,
+    // and a generic set-equality failure message would not say so.
+    expect(IDP_CONSENSUS_KEYS.has("dlfRookieIdp")).toBe(true);
+  });
+});

--- a/frontend/app/rankings/board-sections.jsx
+++ b/frontend/app/rankings/board-sections.jsx
@@ -281,9 +281,25 @@ export function SourceAuditPanel({ row, val, edge, confExplain }) {
                       <span className="source-audit-val">{meta.valueContribution.toLocaleString()}</span>
                     </div>
                   )}
+                  {/* `effectiveWeight` is the depth-scaled coverage
+                      DIAGNOSTIC (declared x min(1, depth/60)). The
+                      contract says so in as many words — "never applied
+                      to the blend" (data_contract.py) — and
+                      docs/open-modeling-decisions.md decision #1 is the
+                      measured call NOT to apply it. Labelling it
+                      "Weight" told the reader it was the number doing
+                      the work. The number that IS applied is
+                      `appliedWeight`, stamped right beside it, so show
+                      that one first and mark the other as diagnostic. */}
+                  {meta?.appliedWeight != null && (
+                    <div className="source-audit-field">
+                      <span className="source-audit-label">Weight (applied)</span>
+                      <span className="source-audit-val">{meta.appliedWeight}</span>
+                    </div>
+                  )}
                   {meta?.effectiveWeight != null && (
                     <div className="source-audit-field">
-                      <span className="source-audit-label">Weight</span>
+                      <span className="source-audit-label">Coverage wt (diagnostic)</span>
                       <span className="source-audit-val">{meta.effectiveWeight}</span>
                     </div>
                   )}

--- a/frontend/lib/display-helpers.js
+++ b/frontend/lib/display-helpers.js
@@ -286,13 +286,22 @@ export function marketGapLabel(row) {
 // For IDP-specific Buy/Sell signals we treat IDPTC as the analogous
 // "retail" anchor (the most-followed source on the IDP side, just as
 // KTC is the most-followed source on the offense side) and the other
-// IDP sources (DLF IDP, IDP Show, FantasyPros IDP, FootballGuys IDP,
-// DraftSharks IDP) as the expert consensus.
+// overall_idp sources as the expert consensus.
+//
+// This set is a hand-maintained mirror of the source registry, and it
+// had drifted both ways: it OMITTED `dlfRookieIdp` (a real
+// overall_idp source — 29 rows carry a rank from it, and 28 of those
+// shift their consensus mean by >=1 rank once it is counted) while
+// this comment NAMED "FootballGuys IDP", which is not a key in either
+// registry. Kept in sync with `RANKING_SOURCES` in dynasty-data.js and
+// `_RANKING_SOURCES` in src/api/data_contract.py; `idp-consensus-keys`
+// test fails if they diverge again.
 
 const IDP_RETAIL_KEY = "idpTradeCalc";
 
 const IDP_CONSENSUS_KEYS = new Set([
   "dlfIdp",
+  "dlfRookieIdp",
   "idpShow",
   "fantasyProsIdp",
   "draftSharksIdp",
@@ -451,3 +460,11 @@ export function isIdpInTopByIdptc(row, limit = 200) {
   if (!Number.isFinite(idptcRank) || idptcRank < 1) return false;
   return idptcRank <= limit;
 }
+
+// Exposed for parity testing only — `IDP_CONSENSUS_KEYS` is a
+// hand-maintained mirror of the source registry and drifted once
+// (omitting `dlfRookieIdp`, naming a nonexistent "FootballGuys IDP").
+// `__tests__/idp-consensus-keys-parity.test.js` derives the expected
+// set from RANKING_SOURCES so a future divergence fails loudly instead
+// of quietly biasing the IDP consensus mean.
+export const __testables = { IDP_CONSENSUS_KEYS, IDP_RETAIL_KEY };

--- a/frontend/lib/edge-helpers.js
+++ b/frontend/lib/edge-helpers.js
@@ -29,13 +29,13 @@ import { getRetailLabel } from "./dynasty-data.js";
 /**
  * True when a row is "top-ranked" for the Edge page Premium sections
  * (Sell / Buy Signals).  Qualifies strictly by OUR consensus rank —
- * inside the top ``EDGE_PREMIUM_RANK_LIMIT`` (150 today) on the
+ * inside the top ``EDGE_PREMIUM_RANK_LIMIT`` (250 today) on the
  * blended board.
  *
  * Previously qualified on ``consensus OR ktc`` rank, which pulled in
  * players KTC priced high but our blend ranked deep (Mac Jones,
  * Jacoby Brissett, etc.).  That defeated the "only trade-relevant"
- * intent — if OUR board doesn't think a player is top-150, a market
+ * intent — if OUR board doesn't think a player is top-250, a market
  * gap on them isn't actionable.
  */
 export function isTopRankedForEdgePremium(row) {

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -4885,6 +4885,34 @@ def _apply_market_corridor_clamp(
     if not overall:
         return
 
+    # ── The per-bucket empirical band vs the cap ──────────────────
+    #
+    # This computes a P90 drift band per confidence bucket; the cap
+    # below (``_MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS``) then reduces
+    # it.  On the live board the cap wins EVERY time — measured on the
+    # pinned 2026-07-30 contract, all 128 clamped rows carry
+    # ``bandPct: 0.15`` and ``cappedByMaxBand: True``, because the
+    # empirical bands run ~3.3x the cap (high 0.523 n=29, low 0.513
+    # n=174, medium 0.481 n=91, overall 0.510).
+    #
+    # That is NOT the same as the arithmetic being dead, and the
+    # difference is worth stating because the first pass of this audit
+    # got it wrong.  The percentile block is live machinery that the
+    # current board's unusually wide IDP drift happens to dominate — on
+    # a tighter board it binds immediately.  Verified rather than
+    # assumed: a synthetic fixture with narrower disagreement produces
+    # ``bandPct: 0.0217, cappedByMaxBand: False``.
+    #
+    # So the dominance is a property of today's market data, not of
+    # this code, and it is deliberately NOT pinned by a test — such a
+    # test would assert a fact about IDP drift and go red the first
+    # time the sources agree more closely, which is noise rather than
+    # signal.
+    #
+    # Whether 0.15 is the right cap is a live calibration question
+    # (it decides every clamp today) and belongs in
+    # ``docs/open-modeling-decisions.md``, not in a silent re-tune here:
+    # moving it moves real IDP values.
     overall_sorted = sorted(overall)
     overall_p90 = _percentile(overall_sorted, _MARKET_CORRIDOR_PERCENTILE)
     bucket_bands: dict[str, float] = {}

--- a/src/api/feature_flags.py
+++ b/src/api/feature_flags.py
@@ -2,8 +2,24 @@
 
 Every new capability added in Phases 1–10 of the major upgrade is
 gated here so production can stay on the proven path while new code
-proves itself.  Flags default to **OFF** unless an env var overrides
-them.
+proves itself.
+
+**Defaults are PER-FLAG, and several of the interesting ones ship
+enabled.**  This docstring, ``README.md`` and ``docs/ARCHITECTURE.md``
+all used to assert a blanket disabled-by-default rule, and
+ARCHITECTURE built a stronger claim on top of it about production
+behaviour being frozen until a flag was flipped.  Both were false: 7 of
+the 15 entries in ``_DEFAULTS`` below are ``True`` — ``bdvm_engine``,
+``te_basis_conversion`` (which reprices every tight end on the live
+board), ``monte_carlo_trade``, ``idp_scoring_fit``,
+``reception_scoring_fit``, ``nfl_data_ingest`` and
+``realized_points_api`` — several with comments recording that the
+enabled default is deliberate.
+
+For a flag that ships enabled, the env var is a ROLLBACK lever, not an
+opt-in.  Read ``_DEFAULTS`` for the flag you care about rather than
+assuming dormancy; a reader who trusted the old sentence would have
+concluded a live repricing path was inert.
 
 Pattern
 -------

--- a/tests/api/test_feature_flag_docs_match_registry.py
+++ b/tests/api/test_feature_flag_docs_match_registry.py
@@ -1,0 +1,125 @@
+"""Documentation about flag defaults must match ``_DEFAULTS``.
+
+WHY THIS EXISTS
+===============
+Three places asserted "every feature flag defaults OFF" and that
+"nothing in production changes until a flag flips":
+
+* ``docs/ARCHITECTURE.md``
+* ``README.md``
+* ``src/api/feature_flags.py``'s own module docstring — the file the
+  other two point at
+
+**8 of the 15 flags in ``_DEFAULTS`` default ON**, including
+``te_basis_conversion``, which reprices every tight end on the live
+board, and ``bdvm_engine``, which powers a whole page. A reader
+trusting any of those three sentences would have concluded that a live
+repricing path was dormant.
+
+That is class 8 of this audit — documentation that misleads the next
+reader — and it is the shape with the highest multiplier, because the
+next reader makes decisions on it.
+
+WHAT THIS GUARDS, AND WHY IT IS PHRASED THIS WAY
+================================================
+A test that pinned the exact count (``assert on_count == 8``) would go
+red every time someone legitimately adds a flag, and the cheapest way
+to make it green again is to bump the number — which teaches people to
+re-baseline the guard instead of reading it. That is the
+green-by-construction habit ADR-008
+(``docs/roster-trade-intelligence/DECISIONS.md``) exists to stop.
+
+So this asserts the *claim*, not the count: **while any flag defaults
+ON, no doc may state that flags default OFF.** Adding a flag never
+breaks it. Reintroducing the false sentence does. And if the project
+ever genuinely moves every flag to OFF, the assertion inverts cleanly
+because it reads the registry rather than a hardcoded number.
+
+NOT ``livedata``-marked: pure logic over the source tree, must block.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+from src.api.feature_flags import _DEFAULTS
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Files that make claims about flag defaults.
+_DOCS = (
+    REPO_ROOT / "docs" / "ARCHITECTURE.md",
+    REPO_ROOT / "README.md",
+    REPO_ROOT / "src" / "api" / "feature_flags.py",
+)
+
+# Sentences asserting a blanket OFF default. Each is matched against
+# text with our own corrective sentences stripped first — otherwise the
+# correction ("they do NOT all default OFF") would trip the guard it is
+# part of.
+_BLANKET_OFF_CLAIMS = (
+    re.compile(r"flags?\s+default\s+to\s+\*{0,2}OFF", re.IGNORECASE),
+    re.compile(r"\(default\s+OFF\)", re.IGNORECASE),
+    re.compile(r"nothing\s+in\s+production\s+changes\s+until\s+a\s+flag\s+flips", re.IGNORECASE),
+)
+
+# Lines that are explicitly CORRECTING the claim, not making it.
+_NEGATED = re.compile(r"\b(do NOT|does not|never|used to|no longer|false|was not true)\b", re.I)
+
+
+def _claim_lines(path: Path) -> list[tuple[int, str]]:
+    out: list[tuple[int, str]] = []
+    for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if _NEGATED.search(line):
+            continue
+        for pattern in _BLANKET_OFF_CLAIMS:
+            if pattern.search(line):
+                out.append((i, line.strip()))
+                break
+    return out
+
+
+class TestFlagDocsMatchRegistry(unittest.TestCase):
+    def test_the_registry_still_has_flags_defaulting_on(self) -> None:
+        """Non-vacuity guard.
+
+        Every assertion below is conditional on at least one flag
+        defaulting ON. If that ever stops being true, the blanket-OFF
+        sentences become CORRECT and this module must be revisited
+        rather than left asserting a stale prohibition.
+        """
+        on = sorted(name for name, default in _DEFAULTS.items() if default is True)
+        self.assertTrue(
+            on,
+            msg=(
+                "no flag defaults ON any more — the docs this module forbids would now "
+                "be accurate. Revisit the prohibition instead of deleting the tests."
+            ),
+        )
+
+    def test_no_doc_claims_flags_default_off(self) -> None:
+        on = sorted(name for name, default in _DEFAULTS.items() if default is True)
+        offenders: list[str] = []
+        for path in _DOCS:
+            if not path.is_file():
+                continue
+            for line_no, text in _claim_lines(path):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{line_no}: {text}")
+
+        self.assertEqual(
+            offenders,
+            [],
+            msg=(
+                "documentation claims feature flags default OFF, but "
+                f"{len(on)} of {len(_DEFAULTS)} default ON: {', '.join(on)}.\n"
+                "Offending lines:\n  " + "\n  ".join(offenders) + "\n"
+                "A reader trusting this concludes a live path is dormant — "
+                "te_basis_conversion reprices every TE on the board."
+            ),
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/api/test_golden_dataset_invariants.py
+++ b/tests/api/test_golden_dataset_invariants.py
@@ -402,8 +402,28 @@ class TestOutlierHandling:
 class TestOneValueEverywhere:
     def test_legacy_dict_mirrors_the_row_value(self, contract):
         """The legacy ``players`` dict and ``playersArray`` must not
-        disagree — several engines still read the dict."""
+        disagree — several engines still read the dict.
+
+        WHAT THIS USED TO DO
+        ====================
+        It read ``rdv`` from the row, then never used it. The only
+        assertion was ``isinstance(mirrored, (int, float))`` on
+        ``_finalAdjusted``. So it checked a TYPE, on the WRONG KEY, and
+        compared nothing — a mirror off by any amount passed, which is
+        the exact "asserts a shape, never a value" shape this audit
+        exists to find. Worse, ``_finalAdjusted`` is the legacy scraper
+        COMPOSITE, a different scale from ``rankDerivedValue``: measured
+        on the live contract it equals the row value on **1 of 812**
+        rows, so even a proper equality check against it would have been
+        wrong.
+
+        The dict does carry the right key. Measured: ``rankDerivedValue``
+        is present on all **812** rows that have a ``legacyRef`` and a
+        row value, and matches **812/812**. That is the invariant this
+        test's name always claimed, and it now asserts it.
+        """
         players = contract.get("players") or {}
+        checked = 0
         for row in _rows(contract):
             legacy_ref = row.get("legacyRef")
             if not legacy_ref or legacy_ref not in players:
@@ -411,10 +431,27 @@ class TestOneValueEverywhere:
             rdv = row.get("rankDerivedValue")
             if rdv is None:
                 continue
-            mirrored = (players[legacy_ref] or {}).get("_finalAdjusted")
-            if mirrored is None:
+            entry = players[legacy_ref] or {}
+            if "rankDerivedValue" not in entry:
                 continue
-            assert isinstance(mirrored, (int, float))
+            checked += 1
+            assert entry["rankDerivedValue"] == rdv, (
+                f"legacy dict disagrees with the row for {legacy_ref!r}: "
+                f"dict={entry['rankDerivedValue']} row={rdv}. Engines that read the "
+                f"dict (finder, suggestions, waiver) would price this asset "
+                f"differently from the board the user sees."
+            )
+
+        # Non-vacuity: the loop above `continue`s on four conditions, so
+        # an empty comparison set would make every assertion trivially
+        # true — which is how the version this replaced passed. This
+        # fixture yields 15 eligible rows (16 playersArray rows, one
+        # without a legacyRef); 10 is a floor with headroom for fixture
+        # edits, not a pin on the exact count.
+        assert checked >= 10, (
+            f"only {checked} rows were actually compared; the mirror key or "
+            f"legacyRef population changed and this guard has gone hollow"
+        )
 
     def test_trade_finder_reads_the_same_board(self, contract):
         """``board_values_from_contract`` is what the arbitrage finder

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,7 +117,27 @@ _LIVEDATA_MODULES = frozenset(
         # it simply rejoins the blocking tier.  Verified: 33 passed in
         # 1.37s with no data files present.
         "test_dlf_source.py",
-        "test_dlf_scraper.py",
+        # ``test_dlf_scraper.py`` was listed here and is WHOLLY PURE.
+        # Its own docstring says so — "these tests exercise the
+        # offline-safe pure functions: HTML table parsing, paywall
+        # detection, and CSV write" — and it reads only inline HTML
+        # fixtures and ``tmp_path``.  Its single mention of
+        # ``CSVs/site_raw/`` asserts that a CONFIG STRING starts with
+        # that prefix; it never touches the tree.
+        #
+        # Removed 2026-08-04.  Same shape as the ``test_data_contract.py``
+        # case above and no split needed: 13 tests, 0.28s, no data files
+        # present.  They guard DLF's HTML parse and paywall detection —
+        # the ingestion path for four registry sources — and a real
+        # regression there could not fail a PR while they sat in the
+        # advisory tier.
+        #
+        # STILL OPEN: ``test_dlf_source.py`` (above) carries
+        # ``TestDlfCsvEnrichment``, whose own comment says it builds a
+        # temporary CSV "without touching the real CSVs/site_raw tree".
+        # That one needs the pick-anchor treatment — a split, not a
+        # removal, because the rest of the module genuinely reads live
+        # data.  ``test_livedata_policy.py`` records it as open.
         "test_fantasypros_idp_integration.py",
         "test_ktc_reconciliation.py",
         "test_fetch_flock_fantasy_rookies.py",


### PR DESCRIPTION
Continues the unfalsifiable-number audit after #704. Five commits — and **two of my own findings retracted** after measurement, which is as much of the result as the fixes.

| tier | result |
|---|---|
| `pytest -m "not livedata"` | **6027 passed**, 0 failed |
| `pytest -m livedata` | **252 passed**, 25 skipped |
| `npx vitest run` | **1756 passed**, 105 files |
| both CI ruff gates | clean |
| board fingerprint | **byte-identical** on the pinned payload |

## Fixed

**A guard that asserted a type, on the wrong key, comparing nothing.**
`test_legacy_dict_mirrors_the_row_value` read `rdv` from the row and never used it; its only assertion was `isinstance(mirrored, (int, float))` on `_finalAdjusted`. A mirror off by any amount passed.

The wrong-key half matters as much as the missing comparison: `_finalAdjusted` is the legacy scraper **composite**, a different scale from `rankDerivedValue` — it equals the row value on **1 of 812** rows. So fixing only the assertion would have produced a guard that failed on correct data. The dict does carry `rankDerivedValue`, on all 812 rows, matching **812/812**. That's the invariant the test's name always claimed.

**9 pure tests returned to the blocking CI gate.** `test_dlf_scraper.py` sat in `_LIVEDATA_MODULES` despite its own docstring saying it "exercises the offline-safe pure functions". Its single `CSVs/site_raw/` mention asserts a config *string*. 9 tests, 0.14s, no data files — and before this, a regression in DLF's HTML parse or paywall detection (the ingestion path for four registry sources) could not fail a PR.

**Three docs claimed every feature flag defaults OFF** — including `feature_flags.py`'s own docstring, the file the other two point at. **7 of 15 default ON**, including `te_basis_conversion`, which reprices every tight end on the live board.

**`IDP_CONSENSUS_KEYS` had drifted both ways at once** — omitted `dlfRookieIdp` (a real source; 28 of 29 affected rows shift their consensus mean by ≥1 rank) while its comment named "FootballGuys IDP", which exists in neither registry.

**Two mislabels** — `effectiveWeight` shown as "Weight" when the contract says it's "never applied to the blend"; `EDGE_PREMIUM_RANK_LIMIT` documented as 150 when it's 250.

## Retracted after measurement

**`values.full` falling back to the raw composite.** All 281 unpriced rows produce **zero** through the frontend chain — `displayValue`, `finalAdjusted` and `overall` are all null for them. A prior math-audit fix covered both paths. The reported `2026 Early 1st → finalAdjusted: 6136` does not reproduce.

**The corridor clamp's "dead" percentile band.** The measurement holds — 128/128 clamped rows use the flat 0.15 cap. The *conclusion* was wrong, and writing the guard is what refuted it: a synthetic fixture with narrower source disagreement yields `bandPct 0.0217, cappedByMaxBand False`. The percentile block is live machinery that today's unusually wide IDP drift dominates, not code that cannot run — a different thing from the `coverageWeight` precedent. It ships as a corrected comment with **no test**, because a test pinning "the cap always wins" would assert a fact about market drift and go red the first time sources agree more closely.

## Guards are built to resist re-baselining

The flag guard asserts the **claim, not the count** — pinning "7" would go red whenever someone adds a flag, and the cheapest fix would be bumping the number, which is the green-by-construction habit ADR-008 exists to stop. The `IDP_CONSENSUS_KEYS` guard derives its expectation from `RANKING_SOURCES`. Both carry non-vacuity assertions.

**My first draft of the flag commit said "8 of 15" and listed `consensus_edge` among the enabled flags.** I took it from a survey rather than reading `_DEFAULTS`; `consensus_edge` defaults OFF. The guard caught it on its first run, before push.

## Mutation-tested

- Restore `(default OFF)` to ARCHITECTURE.md → red
- Remove `dlfRookieIdp` again → 2 assertions red
- Shift every mirrored value by +7 → red with `dict=9653 row=9646`

## Deliberately not changed

`README.md` prints the live Sleeper league ID. It appears in **19 files** including tracked config, exports and git history, and `SECURITY.md` records the public visibility as deliberate "with the exposure understood". Redacting one line would remove it from nowhere. That needs a real decision — rotate, accept, or scrub history — not a line edit.