### PR TITLE
Perfect Draft: land the review fixes the consolidation left behind

### DIFF
--- a/docs/perfect-draft.md
+++ b/docs/perfect-draft.md
@@ -206,11 +206,13 @@ heuristic: the backend's greedy built its rungs as a nested sequence of legal
 cut-sets, so all of them are jointly droppable, and every subset of an
 independent set in a matroid is independent.
 
-The panel pairs each rookie with a cut from that same re-sorted order, not from
-the backend's. The two genuinely differ — the backend orders by ECC (value
-*over* waiver level) while the plan is charged the whole release value — and
-showing one order beside a cost taken from the other would name a roster player
-the plan never released.
+`consumptionOrder` is the single answer to "which cut is next", and **every**
+consumer must use it: the charge table, `applyDraftProgress` (mid-draft),
+`realizedResults` (what you bought) and the panel's cut column. The backend
+orders by ECC and the plan charges by release value; those orders are
+unrelated, so a consumer walking the wrong one charges a player twice and
+another never. Three separate places got this wrong before it was unified —
+worth remembering before adding a fourth.
 
 `k` is a **free variable** — the league caps nobody's rookie count. The
 optimizer may return zero rookies, one, or many, and is never required to spend

--- a/docs/roster-trade-intelligence/DECISIONS.md
+++ b/docs/roster-trade-intelligence/DECISIONS.md
@@ -509,6 +509,25 @@ already used here for *droppability*, but using it for *value* breaks the
 cardinality decomposition this ADR rests on. Left open and stated
 plainly in `docs/perfect-draft.md` §9 rather than half-fixed.
 
+**The consumption order is one decision, not four.** Introducing
+`releaseCost` created a second ordering of the cut ladder, and three
+separate consumers kept walking the backend's ECC order against it:
+`applyDraftProgress` (so a purchase deleted the wrong rung and the next
+plan re-offered a player it had already released), `realizedResults` (so
+"what you bought" was charged ~0 against a plan charged thousands — 23 of
+30 live rungs have an ECC of exactly 0), and the panel's cut column.
+`consumptionOrder` is now the single answer, and anything that walks the
+ladder must go through it.
+
+**Profile match is necessary but not sufficient for sharing a rookie
+board.** Both live leagues are `superflex_tep15_ppr1`, and the first cut
+of the cross-league rookie board gated on exactly that — which would have
+put DL/LB/DB rookies onto `dynasty_new`, a league with no IDP starting
+slots at all, at real dollar values ahead of the offensive rookies it can
+use. `idpEnabled` and `rosterSettings` are leagueKey properties; the
+scoring profile governs what a player is WORTH, not whether this league
+can field him.
+
 One performance note, because it is a trap rather than a tuning detail:
 the charge table must be built once per solve. `computeMaxBid` evaluates
 its indifference price over every dollar from the budget down, times

--- a/frontend/__tests__/components/PerfectDraftPanel.test.jsx
+++ b/frontend/__tests__/components/PerfectDraftPanel.test.jsx
@@ -564,3 +564,40 @@ describe("positional balance and opponent-aware pricing", () => {
     expect(screen.getByText("Beat the room")).toBeInTheDocument();
   });
 });
+
+describe("live-bid target is reconciled with the board", () => {
+  beforeEach(() => {
+    fetch.mockResolvedValue(jsonResponse(200, okPayload()));
+  });
+
+  it("gives the control an accessible name", async () => {
+    // ds Select has no `label` prop — it spreads rest onto the native element,
+    // so `label=` shipped an invalid attribute and no accessible name.
+    render(<PerfectDraftPanel stats={STATS} workspace={WORKSPACE} />);
+    await screen.findByRole("table");
+    const select = screen.getByRole("combobox", { name: /live bid/i });
+    expect(select).toBeInTheDocument();
+    expect(select).not.toHaveAttribute("label");
+  });
+
+  it("says the auction closed instead of advising on a sold player", async () => {
+    // A live bid ENDS by the player being sold, which removes him from the
+    // undrafted pool. Left alone the panel printed a blank name beside
+    // "max $0 / Let him go" — advice about an auction that had closed.
+    const { rerender } = render(<PerfectDraftPanel stats={STATS} workspace={WORKSPACE} />);
+    await screen.findByRole("table");
+    fireEvent.change(screen.getByRole("combobox", { name: /live bid/i }), {
+      target: { value: "jeremiyah-love" },
+    });
+    fireEvent.change(screen.getByLabelText("Current bid"), { target: { value: "20" } });
+
+    const sold = {
+      ...STATS,
+      enrichedPlayers: STATS.enrichedPlayers.map((p) =>
+        p.id === "jeremiyah-love" ? { ...p, drafted: true } : p,
+      ),
+    };
+    rerender(<PerfectDraftPanel stats={sold} workspace={WORKSPACE} />);
+    expect(await screen.findByText(/Sold — pick the next player/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/components/PerfectDraftPanel.test.jsx
+++ b/frontend/__tests__/components/PerfectDraftPanel.test.jsx
@@ -376,6 +376,49 @@ describe("live updating as the auction proceeds", () => {
     expect(within(table).getByText("Unpriced Body")).toBeInTheDocument();
   });
 
+  it("consumes the rung the plan charged, not the head of the backend's list", async () => {
+    // The two orders coincide in the default fixture — Deep Bench Guy is both
+    // the ECC head and the cheapest release — so nothing above discriminates
+    // whether the panel actually hands `waiverLadder` to `applyDraftProgress`.
+    // This ladder separates them: the ECC head releases for 3000 and the
+    // cheapest release is the ECC tail.
+    const ctx = {
+      ...CONTEXT,
+      openRosterSpots: 0,
+      cutLadder: {
+        ...CONTEXT.cutLadder,
+        rungs: [
+          {
+            playerId: "big",
+            name: "Big Release",
+            position: "WR",
+            effectiveCutCost: 0,
+            baseValue: 3000,
+            scarcityMultiplier: 1,
+            valueBasis: "board",
+          },
+          {
+            playerId: "small",
+            name: "Small Release",
+            position: "WR",
+            effectiveCutCost: 500,
+            baseValue: 1000,
+            scarcityMultiplier: 1,
+            valueBasis: "board",
+          },
+        ],
+      },
+    };
+    fetch.mockResolvedValue(jsonResponse(200, { ...okPayload(), context: ctx }));
+    render(<PerfectDraftPanel stats={withBought(1, 20)} workspace={WORKSPACE} />);
+    const table = await screen.findByRole("table");
+    // One purchase against zero open spots consumes Small Release (cheapest to
+    // let go), leaving Big Release. Slicing the backend's head instead would
+    // spend Big Release and re-offer Small Release — the double-charge.
+    expect(within(table).getByText("Big Release")).toBeInTheDocument();
+    expect(within(table).queryByText("Small Release")).not.toBeInTheDocument();
+  });
+
   it("reports what has already been bought alongside the remaining plan", async () => {
     render(<PerfectDraftPanel stats={withBought(1, 20)} workspace={WORKSPACE} />);
     await screen.findByRole("table");

--- a/frontend/__tests__/perfect-draft.test.js
+++ b/frontend/__tests__/perfect-draft.test.js
@@ -29,6 +29,7 @@ import {
   optimizeDraft,
   realizedResults,
   computeMaxBid,
+  consumptionOrder,
   displacementCost,
   evaluateBid,
   logPriceDispersion,
@@ -1357,5 +1358,94 @@ describe("live bidding", () => {
     expect(impossible.netIfWon).toBeNull();
     expect(impossible.gain).toBeNull();
     expect(impossible.verdict).toBe("stop");
+  });
+});
+
+describe("one consumption order, shared by every consumer", () => {
+  // The backend ships rungs ascending by ECC (value OVER waiver level); the
+  // ladder model charges the cheapest by releaseCost (the whole value). Those
+  // orders are unrelated — a rung with ECC 0 can be the most expensive release
+  // on the board. Anything that walks the ladder in the wrong one charges a
+  // player twice and another never.
+  const rungs = [
+    // Backend order: ECC ascending. Release order is the REVERSE.
+    { playerId: "A", name: "A", position: "WR", effectiveCutCost: 0, baseValue: 3000, scarcityMultiplier: 1 },
+    { playerId: "B", name: "B", position: "WR", effectiveCutCost: 500, baseValue: 1000, scarcityMultiplier: 1 },
+  ];
+  const waiverLadder = [500, 400, 300, 200];
+
+  it("orders cuts by release cost under the ladder, by ECC without it", () => {
+    expect(consumptionOrder(rungs, waiverLadder).map((r) => r.playerId)).toEqual(["B", "A"]);
+    expect(consumptionOrder(rungs, null).map((r) => r.playerId)).toEqual(["A", "B"]);
+  });
+
+  it("never re-offers a cut a purchase already consumed", () => {
+    // Buy one rookie with no open spots: the plan charges B (cheapest release).
+    const after = applyDraftProgress({
+      openRosterSpots: 0,
+      cutLadder: rungs,
+      waiverLadder,
+      rookiesBought: 1,
+    });
+    expect(after.rungsUsed).toBe(1);
+    // B is gone — not A. Slicing the ECC head would leave B available and
+    // charge him a second time on the next purchase.
+    expect(after.cutLadder.map((r) => r.playerId)).toEqual(["A"]);
+  });
+
+  it("charges realized purchases exactly what the plan would have charged", () => {
+    // The invariant that makes "bought so far" comparable to "the plan", which
+    // is the entire stated purpose of realizedResults.
+    const shared = {
+      openRosterSpots: 0,
+      cutLadder: rungs,
+      waiverLadder,
+      waiverValues: {},
+    };
+    const players = [
+      { id: "r1", name: "R1", pos: "WR", boardValue: 5000 },
+      { id: "r2", name: "R2", pos: "WR", boardValue: 4000 },
+    ];
+    const realized = realizedResults({
+      ...shared,
+      stats: {
+        enrichedPlayers: players.map((p) => ({
+          ...p,
+          drafted: true,
+          mine: true,
+          pick: { amount: 5 },
+        })),
+      },
+    });
+    const planned = solveFrontier({
+      ...shared,
+      budget: 10,
+      rookies: players.map((p) => ({ ...p, price: 5 })),
+    }).frontier.find((f) => f.k === 2);
+
+    expect(realized.grossSurplus).toBe(planned.grossSurplus);
+    expect(realized.replacement).toBe(planned.replacement);
+    // Taking ECC here (0 + 500) against the plan's releaseCost (1000 + 3000)
+    // made the two incomparable by 3500 on this fixture, and by ~everything on
+    // the live board where 23 of 30 rungs have an ECC of exactly 0.
+    expect(realized.displacement).toBe(planned.displacement);
+    expect(realized.netValue).toBe(planned.netValue);
+  });
+
+  it("leaves the flat model's ECC accounting untouched", () => {
+    const realized = realizedResults({
+      openRosterSpots: 0,
+      cutLadder: rungs,
+      waiverValues: { WR: 1000 },
+      stats: {
+        enrichedPlayers: [
+          { id: "r1", name: "R1", pos: "WR", boardValue: 5000, drafted: true, mine: true, pick: { amount: 5 } },
+        ],
+      },
+    });
+    // No ladder supplied: ECC order, ECC cost, replacement folded into gross.
+    expect(realized.replacement).toBe(0);
+    expect(realized.displacement).toBe(0);
+    expect(realized.grossSurplus).toBe(4000);
   });
 });

--- a/frontend/app/league/sections/draft-capital.jsx
+++ b/frontend/app/league/sections/draft-capital.jsx
@@ -76,6 +76,17 @@ export default function DraftCapitalSection() {
   }
   if (!data) return <EmptyCard label="Draft capital" />;
 
+  // Picks for the season the header claims to be describing. Rows carry
+  // `season`; when none do (the workbook path, one season only) this is the
+  // whole list, so the filter is inert there rather than emptying the page.
+  const currentSeasonPicks = (() => {
+    const all = data.picks || [];
+    const season = Number(data.season);
+    if (!Number.isFinite(season)) return all;
+    const scoped = all.filter((p) => Number(p?.season) === season);
+    return scoped.length > 0 ? scoped : all;
+  })();
+
   return (
     <>
       <div className="card" style={{ marginTop: "var(--space-md)" }}>
@@ -104,7 +115,7 @@ export default function DraftCapitalSection() {
         </div>
         <TeamTotalsChart
           teamTotals={data.teamTotals}
-          picks={data.picks}
+          picks={currentSeasonPicks}
           totalBudget={data.totalBudget}
           numTeams={data.numTeams}
           draftRounds={data.draftRounds}
@@ -112,8 +123,15 @@ export default function DraftCapitalSection() {
         />
       </div>
 
+      {/* The Sleeper-derived path builds BOTH the current season and the next
+          into one flat picks array (it stamps `coveredPickYears` to say so),
+          and every grid below groups by round with no season filter — so each
+          round rendered twice, with duplicate "1.01" labels and a doubled
+          round total. The workbook path carries one season and is unaffected,
+          which is why nothing caught it. Filter once, here, and pass the
+          current season's picks down. */}
       <PickValueGrid
-        picks={data.picks}
+        picks={currentSeasonPicks}
         draftRounds={data.draftRounds}
         numTeams={data.numTeams}
       />
@@ -123,9 +141,9 @@ export default function DraftCapitalSection() {
           projection for the ones after it. */}
       <PickProjectorPanel />
 
-      <TradeSimulator picks={data.picks} teamTotals={data.teamTotals} />
+      <TradeSimulator picks={currentSeasonPicks} teamTotals={data.teamTotals} />
 
-      <PicksByRound picks={data.picks} draftRounds={data.draftRounds} />
+      <PicksByRound picks={currentSeasonPicks} draftRounds={data.draftRounds} />
     </>
   );
 }

--- a/frontend/components/draft/PerfectDraftPanel.jsx
+++ b/frontend/components/draft/PerfectDraftPanel.jsx
@@ -198,12 +198,17 @@ export function PerfectDraftPanel({ stats, workspace }) {
   // solve. Recomputing it on every render would re-solve on every keystroke
   // in the bid box. Declared here, above the early returns, because a hook
   // after a conditional return is a hook-order violation.
+  // Deferred for the same reason the main solve is: evaluateBid runs a
+  // knapsack plus a scan over every dollar of the budget, and the bid box is
+  // a text input. Memoizing alone was not enough — `bidAmount` is a dependency,
+  // so each keystroke still invalidated it and re-solved synchronously.
+  const deferredBidAmount = useDeferredValue(bidAmount);
   const liveBid = useMemo(
     () =>
-      deferredInput && bidTarget && bidAmount !== ""
-        ? evaluateBid(deferredInput, bidTarget, bidAmount)
+      deferredInput && bidTarget && deferredBidAmount !== ""
+        ? evaluateBid(deferredInput, bidTarget, deferredBidAmount)
         : null,
-    [deferredInput, bidTarget, bidAmount],
+    [deferredInput, bidTarget, deferredBidAmount],
   );
 
   const phase = draftPhase(stats);
@@ -227,10 +232,16 @@ export function PerfectDraftPanel({ stats, workspace }) {
   if (!result) return null;
 
   const { plan, alternatives, confidence, nearTies, meta } = result;
-  const cutRungs = progress.cutLadder;
-  const openSpots = progress.openRosterSpots;
+  const cutRungs = deferredInput?.cutLadder ?? progress.cutLadder;
+  const openSpots = deferredInput?.openRosterSpots ?? progress.openRosterSpots;
 
-  const bidTargetName = rookies.find((r) => r.id === bidTarget)?.name || "";
+  // A live bid ends when the player is sold, and selling him removes him from
+  // `rookies` (filtered on !drafted). Left alone, `bidTarget` kept his id and
+  // the panel printed a blank name beside "max $0 / Let him go" — advice about
+  // an auction that had already closed.
+  const bidTargetRookie = rookies.find((r) => r.id === bidTarget) || null;
+  const bidTargetName = bidTargetRookie?.name || "";
+  const bidTargetSold = Boolean(bidTarget) && !bidTargetRookie;
 
   // The cuts the plan was CHARGED for, in the order it was charged for them.
   //
@@ -239,7 +250,11 @@ export function PerfectDraftPanel({ stats, workspace }) {
   // ladder's own order beside a cost taken from a different ordering would
   // name a player the plan never released. Legal because the backend's rungs
   // are jointly droppable, so any subset of them is a legal cut-set.
-  const usingLadder = Array.isArray(context?.waiverLadder) && context.waiverLadder.length > 0;
+  // Read from the DEFERRED input, not live context: `plan` comes from the
+  // deferred solve, so pairing its rookies against live open-spot counts would
+  // mislabel the cut column for the whole duration of every recalculation.
+  const usingLadder =
+    Array.isArray(deferredInput?.waiverLadder) && deferredInput.waiverLadder.length > 0;
   const chargedCuts = usingLadder
     ? [...cutRungs].sort((a, b) => releaseCost(a) - releaseCost(b))
     : cutRungs;
@@ -605,7 +620,7 @@ export function PerfectDraftPanel({ stats, workspace }) {
 
       <div className={styles.pageActions}>
         <Select
-          label="Live bid"
+          aria-label="Live bid — player on the block"
           value={bidTarget}
           onChange={(e) => setBidTarget(e.target.value)}
         >
@@ -631,7 +646,11 @@ export function PerfectDraftPanel({ stats, workspace }) {
             disabled={!bidTarget}
           />
         </label>
-        {liveBid ? (
+        {bidTargetSold ? (
+          <span className="muted" style={{ fontSize: "var(--font-size-2xs)" }}>
+            Sold — pick the next player on the block.
+          </span>
+        ) : liveBid ? (
           <span style={{ fontSize: "var(--font-size-2xs)" }}>
             <Badge
               tone={
@@ -658,7 +677,7 @@ export function PerfectDraftPanel({ stats, workspace }) {
         ) : null}
       </div>
 
-      {liveBid && liveBid.verdict === "stop" && liveBid.pivot?.players?.length ? (
+      {!bidTargetSold && liveBid && liveBid.verdict === "stop" && liveBid.pivot?.players?.length ? (
         <p className="muted" style={{ fontSize: "var(--font-size-2xs)" }}>
           If you lose {bidTargetName}, the best remaining plan is{" "}
           {liveBid.pivot.players.map((q) => q.name).join(", ")}.

--- a/frontend/components/draft/PerfectDraftPanel.jsx
+++ b/frontend/components/draft/PerfectDraftPanel.jsx
@@ -152,14 +152,20 @@ export function PerfectDraftPanel({ stats, workspace }) {
   // both past what has already been bought so the recommendation below is the
   // REMAINING plan — otherwise roster room is double-counted and the ladder
   // re-offers cuts those purchases already consumed.
+  //
+  // `waiverLadder` is what tells it WHICH rungs those were. Without it the
+  // function consumes the backend's ECC head while the solve below charges the
+  // release-cheapest, and this is the only production call site — so omitting
+  // it leaves the shared-consumption-order fix inert on the live page.
   const progress = useMemo(
     () =>
       applyDraftProgress({
         openRosterSpots: context?.openRosterSpots || 0,
         cutLadder: context?.cutLadder?.rungs || [],
+        waiverLadder: context?.waiverLadder || null,
         rookiesBought,
       }),
-    [context?.openRosterSpots, context?.cutLadder?.rungs, rookiesBought],
+    [context?.openRosterSpots, context?.cutLadder?.rungs, context?.waiverLadder, rookiesBought],
   );
 
   const solveInput = useMemo(

--- a/frontend/lib/perfect-draft.js
+++ b/frontend/lib/perfect-draft.js
@@ -260,6 +260,25 @@ export function releaseCost(rung) {
 }
 
 /**
+ * The order cuts are actually consumed in, under whichever model is live.
+ *
+ * The backend ships rungs ascending by ECC.  The ladder model charges the
+ * cheapest by `releaseCost`, which is a different quantity and therefore a
+ * different order.  Every consumer that walks the ladder — the charge table,
+ * mid-draft progress, realized results, the panel's cut column — must walk it
+ * the same way, or one player is charged twice and another never.
+ *
+ * Legal because the backend's greedy built its rungs as a nested sequence of
+ * legal cut-sets: all of them are jointly droppable, so any subset is too.
+ */
+export function consumptionOrder(cutLadder, waiverLadder) {
+  const rungs = Array.isArray(cutLadder) ? cutLadder : [];
+  const ladder = Array.isArray(waiverLadder) && waiverLadder.length ? waiverLadder : null;
+  if (!ladder) return rungs;
+  return [...rungs].sort((a, b) => releaseCost(a) - releaseCost(b));
+}
+
+/**
  * Cumulative release cost of the cuts a k-rookie plan forces.
  *
  * Takes the CHEAPEST cuts by release cost rather than in ladder order, which is
@@ -815,13 +834,13 @@ function buildItems(input) {
 }
 
 /** Best achievable net value over a set of items, plus the winning plan. */
-function bestNetOver(items, input, kCap) {
+function bestNetOver(items, input, kCap, precomputed = null) {
   const { budget = 0 } = input || {};
   const B = Math.max(0, Math.floor(Number(budget) || 0));
   const ladder = ladderOf(input);
   let best = { netValue: 0, players: [], k: 0, spend: 0 };
   if (!items.length || kCap <= 0) return best;
-  const { F, took, width } = solveKnapsack(items, B, kCap);
+  const { F, took, width } = precomputed || solveKnapsack(items, B, kCap);
   const table = buildChargeTable(input, ladder);
   for (let k = 1; k <= kCap; k++) {
     const charges = table.at(k);
@@ -879,13 +898,19 @@ export function computeMaxBid(input, rookieId, { bid = null } = {}) {
     ),
   );
 
-  const without = bestNetOver(others, input, kCapAll);
+  // ONE knapsack over `others`, shared by both users of it. `bestNetOver`
+  // used to build its own and this line rebuilt an argument-identical copy
+  // six lines later — `Math.max(0, kCapAll - 1) + 1 === kCapAll` because
+  // kCapAll is floored at 1 above. That doubled the cost of every max-bid,
+  // and there is one max-bid per recommended rookie.
+  const solved = solveKnapsack(others, B, kCapAll);
+  const without = bestNetOver(others, input, kCapAll, solved);
   if (!target) {
     return { planMaxBid: 0, netWith: null, netWithout: without.netValue, pivot: without };
   }
 
   // Phi(q): best net over plans containing the target priced at q.
-  const { F } = solveKnapsack(others, B, Math.max(0, kCapAll - 1) + 1);
+  const { F } = solved;
   const table = buildChargeTable(input, ladder);
   const phi = (q) => {
     const rem = B - q;
@@ -1265,6 +1290,16 @@ export function optimizeDraft(input) {
  * remaining rung — the same order the plan itself assumes, so the accounting
  * stays consistent with how the cost was quoted at the time.
  *
+ * "Cheapest" must mean the same thing here as it does in `buildChargeTable`,
+ * and under the ladder model it does NOT mean the backend's order.  The
+ * backend ships rungs ascending by ECC (value over waiver level); the ladder
+ * model charges the cheapest by `releaseCost` (the whole value).  Those
+ * orderings are unrelated — a rung with an ECC of 0 can have the largest
+ * release cost on the board.  Consuming the ECC head while charging the
+ * release-cheapest re-offers one player as a cut on purchase after purchase
+ * and never charges another at all, which is precisely the failure the
+ * paragraph above says this function exists to prevent.
+ *
  * `ladderExhausted` matters for display: a plan of zero because there is no
  * modelled room left reads identically to a plan of zero because nothing is
  * worth buying, and those call for opposite actions.
@@ -1273,9 +1308,10 @@ export function applyDraftProgress({
   openRosterSpots = 0,
   cutLadder = [],
   rookiesBought = 0,
+  waiverLadder = null,
 } = {}) {
   const open = Math.max(0, Number(openRosterSpots) || 0);
-  const ladder = Array.isArray(cutLadder) ? cutLadder : [];
+  const ladder = consumptionOrder(cutLadder, waiverLadder);
   const bought = Math.max(0, Number(rookiesBought) || 0);
 
   const spotsUsed = Math.min(bought, open);
@@ -1332,6 +1368,7 @@ export function realizedResults({
   const { rungsUsed } = applyDraftProgress({
     openRosterSpots,
     cutLadder,
+    waiverLadder,
     rookiesBought: bought.length,
   });
 
@@ -1348,9 +1385,14 @@ export function realizedResults({
     0,
   );
   const replacement = ladder ? replacementCost(bought.length, ladder, openRosterSpots) : 0;
-  const displacement = (Array.isArray(cutLadder) ? cutLadder : [])
+  // The SAME cost and the SAME order the plan was charged on. Taking ECC here
+  // while the plan takes releaseCost made "what you bought" and "what the plan
+  // would buy" incomparable — which is the one thing this function exists to
+  // be. On the live board 23 of 30 rungs have an ECC of 0, so realized
+  // displacement was ~0 against a plan charged thousands.
+  const displacement = consumptionOrder(cutLadder, waiverLadder)
     .slice(0, rungsUsed)
-    .reduce((s, r) => s + (Number(r?.effectiveCutCost) || 0), 0);
+    .reduce((s, r) => s + (ladder ? releaseCost(r) : Number(r?.effectiveCutCost) || 0), 0);
   const spend = bought.reduce((s, p) => s + (Number(p?.pick?.amount) || 0), 0);
 
   return {

--- a/server.py
+++ b/server.py
@@ -8602,6 +8602,15 @@ async def get_draft_capital(request: Request, refresh: str = ""):
         # what stops /draft there falling back to a hardcoded list. A league on
         # a different profile gets no rookie fields rather than another
         # profile's board.
+        #
+        # Profile match is necessary but NOT sufficient. Both live leagues are
+        # ``superflex_tep15_ppr1``, yet ``dynasty_main`` starts DL/LB/DB and
+        # ``dynasty_new`` starts none — ``idpEnabled`` and ``rosterSettings``
+        # are leagueKey properties, not profile properties. Serving the shared
+        # board verbatim would put defenders nobody can start onto a non-IDP
+        # league's draft board, at real dollar values, ahead of offensive
+        # rookies it can. So IDP rows are dropped for a league that does not
+        # use them and the dollar ladder is rebuilt over what remains.
         rookie_rows = None
         try:
             from src.api.league_registry import get_scoring_profile  # noqa: PLC0415
@@ -8610,7 +8619,16 @@ async def get_draft_capital(request: Request, refresh: str = ""):
             if loaded_key and get_scoring_profile(loaded_key) == get_scoring_profile(
                 league_cfg.key
             ):
+                from src.trade.angle import _IDP_POSITIONS as _ANGLE_IDP_POSITIONS  # noqa: PLC0415
+
                 pool = _our_rookie_pool(_KTC_TOTAL_PICKS)
+                if pool and not getattr(league_cfg, "idp_enabled", True):
+                    pool = [
+                        r
+                        for r in pool
+                        if str(r.get("assetClass") or "").lower() != "idp"
+                        and str(r.get("pos") or "").upper() not in _ANGLE_IDP_POSITIONS
+                    ]
                 if pool:
                     dollars = _rookie_dollars_from_values(
                         [r["value"] for r in pool], DRAFT_TOTAL_BUDGET

--- a/tests/api/test_draft_capital_fallback_rounds.py
+++ b/tests/api/test_draft_capital_fallback_rounds.py
@@ -217,3 +217,47 @@ def test_omitting_the_rookie_board_leaves_the_payload_exactly_as_before(_no_netw
     # overallPick is unconditional — the frontend sorts on it before it can
     # know whether any rookie fields are present.
     assert all("overallPick" in p for p in out["picks"])
+
+
+def test_idp_rookies_are_kept_off_a_non_idp_league_board(monkeypatch):  # noqa: PLR0915
+    """Sharing a scoring profile is necessary but NOT sufficient.
+
+    Both live leagues are ``superflex_tep15_ppr1``, yet ``dynasty_main``
+    starts DL/LB/DB and ``dynasty_new`` starts none — ``idpEnabled`` and
+    ``rosterSettings`` are leagueKey properties, not profile properties.
+    Serving the shared rookie board verbatim would put defenders nobody can
+    start onto the non-IDP league's draft board, at real dollar values, ahead
+    of the offensive rookies it can actually use.
+    """
+    from src.api import league_registry
+
+    # Other tests in the session monkeypatch LEAGUE_REGISTRY_PATH and leave the
+    # module cache pointing at a fixture, so read the REAL registry explicitly
+    # and put it back afterwards. The premise below is about this repo's actual
+    # league config; a fixture would assert nothing.
+    monkeypatch.delenv("LEAGUE_REGISTRY_PATH", raising=False)
+    league_registry.reload_registry()
+    main = league_registry.get_league_by_key("dynasty_main")
+    new = league_registry.get_league_by_key("dynasty_new")
+    assert main is not None and new is not None
+    # The premise: same profile, opposite IDP posture. If this ever stops
+    # being true the gate below needs revisiting rather than silently passing.
+    assert main.scoring_profile == new.scoring_profile
+    assert main.idp_enabled is True
+    assert new.idp_enabled is False
+
+    from src.trade.angle import _IDP_POSITIONS
+
+    pool = [
+        {"name": "Offense Rookie", "pos": "WR", "value": 5000, "assetClass": "offense"},
+        {"name": "Defender Rookie", "pos": "LB", "value": 4800, "assetClass": "idp"},
+        {"name": "Edge Rookie", "pos": "DL", "value": 4600, "assetClass": "idp"},
+    ]
+    # The filter server.py applies for a league with idp_enabled False.
+    kept = [
+        r
+        for r in pool
+        if str(r.get("assetClass") or "").lower() != "idp"
+        and str(r.get("pos") or "").upper() not in _IDP_POSITIONS
+    ]
+    assert [r["name"] for r in kept] == ["Offense Rookie"]

--- a/tests/frontend/test_fixed_elements_have_a_vertical_anchor.py
+++ b/tests/frontend/test_fixed_elements_have_a_vertical_anchor.py
@@ -38,8 +38,26 @@ from pathlib import Path
 
 import pytest
 
+#: Directories holding CSS this repo did not author.
+#:
+#: ``.next`` is compiled output and ``node_modules`` is third-party, and
+#: scanning either is worse than useless here. A ``position: fixed`` rule in a
+#: build chunk came from a source file this suite already scans, so the extra
+#: cases assert nothing new — while a rule from a dependency is one the repo
+#: cannot fix, so flagging it would be the cry-wolf failure the docstring above
+#: says the scope exists to avoid.
+#:
+#: They also made the suite RACE. The file list is captured at import time and
+#: frozen into the parametrisation, so a ``next build`` running concurrently
+#: replaces a hashed chunk and the test dies on ``FileNotFoundError`` — three
+#: false failures in one session, none of them reproducible on a re-run. CI
+#: never saw it because pytest and the frontend build are separate jobs there.
+_GENERATED_DIRS = frozenset({".next", "node_modules"})
+
 _CSS_FILES = sorted(
-    (Path(__file__).resolve().parents[2] / "frontend").rglob("*.css")
+    path
+    for path in (Path(__file__).resolve().parents[2] / "frontend").rglob("*.css")
+    if _GENERATED_DIRS.isdisjoint(path.parts)
 )
 
 #: Offsets that anchor a box on the vertical axis. ``inset`` (and its
@@ -163,3 +181,10 @@ def test_there_is_css_to_scan():
     """Guards against the parametrisation silently collapsing to zero
     cases if the frontend tree ever moves."""
     assert _CSS_FILES, "no CSS files found — this suite would pass vacuously"
+    # And that the exclusion above narrowed the scan without emptying it: a
+    # typo in _GENERATED_DIRS that matched everything would otherwise leave
+    # this suite passing vacuously in exactly the way the assert above exists
+    # to prevent.
+    assert not any(
+        not _GENERATED_DIRS.isdisjoint(p.parts) for p in _CSS_FILES
+    ), "generated CSS is still being scanned"


### PR DESCRIPTION
## Why this exists

PR #655 was closed without merging, and the work reached `main` anyway via
**#723 "Consolidate the six open PRs onto main"**. Every Perfect Draft file is
present on `main` — but the consolidation captured the branch at an **earlier
state**, and the gap is not cosmetic.

The evidence a reviewer can check in seconds:

```
$ git diff 2b55b916 origin/main -- frontend/lib/perfect-draft.js
(no output)
```

`main:frontend/lib/perfect-draft.js` is byte-identical to `2b55b916` — the
commit *before* `65cce54c`, which is the one that fixed the twelve defects an
adversarial review confirmed, including both HIGH-severity ones.

Two file:line citations, against `main` as it stands:

- `main:frontend/lib/perfect-draft.js:1272-1283` — `applyDraftProgress` takes no
  `waiverLadder` and still does `ladder.slice(rungsUsed)` on the backend's order.
- `main:frontend/lib/perfect-draft.js:1351-1353` — `realizedResults` still
  reduces on `effectiveCutCost`.

`main` *did* pick up ruff formatting, so #723 was a partial, hand-resolved
consolidation rather than a clean take of one commit — which is why the gap is
uneven and easy to miss. (One correction to my own earlier read: the server-side
IDP gate is **not** on main. The `_ANGLE_IDP_POSITIONS` occurrence at
`server.py:6722` is a pre-existing, unrelated angle-finder call site.)

## What is broken on main right now

**1. A cut is charged twice and another never.** The backend orders ladder rungs
ascending by ECC (value *over* waiver level); the ladder model charges the
cheapest by release cost (the whole value). Those orders are unrelated — a rung
with an ECC of 0 can be the most expensive release on the board. Reproduced on
the real captured ladder: Malachi Moore (release 497) is charged *and displayed
as the recommended release* on three consecutive purchases, while Mukuba (1422)
and Parrish (1872) are deleted from the model and never charged — three
purchases charging 1491 against a true 3181. This is the exact failure
`applyDraftProgress`'s own docstring says it exists to prevent.

**2. "Bought so far" is not comparable to "the plan".** `realizedResults`
charges ECC while the plan charges release value. On the live board 23 of 30
rungs have an ECC of exactly 0, so realized displacement is ~0 against a plan
charged thousands — and being comparable to the plan is the only reason that
function exists.

## What this PR does

`consumptionOrder` becomes the single answer to "which cut is next", and every
consumer routes through it. Alongside that, the smaller confirmed fixes from the
same review that also missed the consolidation:

| Fix | File |
|---|---|
| `consumptionOrder`; `applyDraftProgress` + `realizedResults` route through it | `frontend/lib/perfect-draft.js` |
| `computeMaxBid` builds **one** knapsack, not two argument-identical ones | `frontend/lib/perfect-draft.js` |
| IDP rookies kept off a league that starts none | `server.py` |
| live bid deferred (`deferredBidAmount`) — memoizing alone re-solved per keystroke | `PerfectDraftPanel.jsx` |
| sold bid target no longer advises on a closed auction (`bidTargetSold`) | `PerfectDraftPanel.jsx` |
| `aria-label` instead of an invalid `label` prop on the live-bid `Select` | `PerfectDraftPanel.jsx` |
| `/league` filters picks to the current season — the Sleeper-derived path rendered every round twice | `draft-capital.jsx` |
| fixed-position CSS scan excludes generated dirs (a real build-race flake) | `test_fixed_elements_have_a_vertical_anchor.py` |

### One fix that is new here, not a port

`applyDraftProgress` learned its `waiverLadder` parameter in `65cce54c`, but the
panel — **the only production call site** — never passed it. The library fix was
therefore inert on the live page: the panel kept slicing the ECC head and handing
the remainder to a solve that charges the release-cheapest, which is defect (1)
above still reachable through the only path a user has. `realizedResults` was
unaffected, because it reads only `rungsUsed` (a count) and does its own
`consumptionOrder` slice.

The existing component fixture could not catch it: "Deep Bench Guy" is both the
ECC head and the cheapest release, so the two orderings coincide there and every
assertion passes under either behaviour. The added case separates them — the ECC
head releases for 3000, the cheapest release sits at the ECC tail.

## Verification

The ported tests were confirmed to **fail against main's sources** before being
kept — a regression test that passes either way proves nothing. Checking out
`origin/main`'s `perfect-draft.js`, `PerfectDraftPanel.jsx` and
`draft-capital.jsx` under this branch's test files:

```
Tests  5 failed | 139 passed (144)
  × orders cuts by release cost under the ladder, by ECC without it
  × never re-offers a cut a purchase already consumed
  × charges realized purchases exactly what the plan would have charged
  × gives the control an accessible name
  × says the auction closed instead of advising on a sold player
```

The new panel-wiring test was separately verified to fail with only that
one-line argument removed, holding everything else fixed.

CI's own gates, run locally in CI's order, sequentially:

| Gate | Result |
|---|---|
| `ruff format --check .` | 876 files already formatted |
| `ruff check .` | All checks passed |
| `pytest tests/ -x -q -m "not livedata"` | 6344 passed, 15 skipped |
| `vitest run` | 111 files, 1930 passed |
| `npm run build` + bundle budgets | all pages under budget; `/draft` 135.3 KB / 150 KB |

Note this branch carries **only the delta** — reopening #655 would have been 12
commits, most already on main via #723.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6oCgi8MGEbZUUh9LsTGtu)_