### PR TITLE
Run the E2E safety net on PRs that touch the app shell

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,7 +56,13 @@ name: E2E Safety Net
 # Failure handling mirrors scheduled-refresh.yml: an idempotent
 # tracking issue labelled ``e2e-failures`` is opened (or commented
 # on) so a broken journey can't sit unnoticed between manual runs.
-# Both issue steps are scoped to NON-PR runs — see the guards on them.
+#
+# That tracker is about MAIN, and only main writes to it.  Both issue
+# steps require `github.ref == 'refs/heads/main'` AND a non-PR event —
+# the ref clause keeps a branch DISPATCH from speaking for main (#716),
+# the event clause keeps a PR run from doing the same.  Neither clause
+# subsumes the other in intent, so both are stated; see the notes on the
+# steps themselves.
 
 on:
   schedule:
@@ -309,13 +315,27 @@ jobs:
         # on the open ``e2e-failures`` issue if there is one, else
         # open a single labelled issue and keep reusing it.
         #
-        # NON-PR RUNS ONLY.  This issue tracks "is main's safety net
-        # broken".  A PR run failing says something about the PR, not
-        # about main, and the failure is already visible on the PR's own
-        # checks — commenting here would bury the real signal under one
-        # comment per red PR run, which is exactly the "permanently red"
-        # noise the close-step below was added to end.
-        if: failure() && github.event_name != 'pull_request'
+        # MAIN ONLY, and the two clauses below guard DIFFERENT things —
+        # do not collapse them into one.
+        #
+        # The ref clause is about BRANCH DISPATCH, not about PRs.
+        # Dispatching this workflow on a branch is a first-class use (it
+        # is how a branch gets arbitrated against the green baseline),
+        # and its result is reported in the run itself.  It just does not
+        # get to speak for main.  See #716, and see the close step below
+        # for why that one is the dangerous direction.
+        #
+        # The event clause states the PR-run intent at the point of use.
+        # A PR run failing says something about the PR, not about main,
+        # and the failure is already visible on the PR's own checks —
+        # commenting here would bury the real signal under one comment
+        # per red PR run, which is exactly the "permanently red" noise
+        # the close step below was added to end.  It is redundant with
+        # the ref clause TODAY (a `pull_request` run's ref is
+        # `refs/pull/<n>/merge`, never `refs/heads/main`), and it is kept
+        # so that adding a `push:` trigger later cannot silently make PR
+        # runs eligible.
+        if: failure() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -323,7 +343,7 @@ jobs:
           set -Eeuo pipefail
           RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           BODY=$(cat <<EOF
-          Nightly E2E safety-net run failed.
+          E2E safety-net run failed on \`main\` (trigger: ${GITHUB_EVENT_NAME}).
 
           - Workflow run: ${RUN_URL}
           - Commit: ${GITHUB_SHA}
@@ -376,13 +396,17 @@ jobs:
         # the suite is the gate, so there is no per-step outcome to
         # re-derive.
         #
-        # NON-PR RUNS ONLY, and this guard is the more important of the
-        # two.  A PR run is green for the PR's HEAD — a merge commit of
-        # a branch that is not main.  Letting it close the issue would
-        # declare main healthy on evidence from code that was never on
-        # main, and any PR touching the shell could silently clear a
-        # genuine nightly failure.
-        if: success() && github.event_name != 'pull_request'
+        # MAIN ONLY — same two clauses as the alert step, and this is
+        # the stronger of the two requirements, because a false all-clear
+        # CLOSES a real open failure while a false alarm merely files a
+        # wrong one.  Both ways of not being main are live here:
+        #
+        # - a green DISPATCH on a branch would issue main's all-clear
+        #   from code that was never on main (#716);
+        # - a green PR run is green for a merge commit of a branch that
+        #   is not main, so any shell-touching PR could silently clear a
+        #   genuine nightly failure.
+        if: success() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -402,7 +426,7 @@ jobs:
           for N in $OPEN; do
             echo "closing #${N}"
             gh issue close "$N" --reason completed --comment \
-              "Nightly E2E safety net is green again — every critical journey passed.
+              "E2E safety net is green again on \`main\` — every critical journey passed.
 
           - Workflow run: ${RUN_URL}
           - Commit: ${GITHUB_SHA}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,23 +11,52 @@ name: E2E Safety Net
 # trade surfaces respond, settings overrides round-trip — so each
 # redesign phase can rewrite markup and prove nothing functional broke.
 #
-# Triggers: manual dispatch + nightly cron ONLY — deliberately NOT on
-# every PR.  The suite boots the whole stack, builds the frontend,
-# and drives a real browser through dozens of journeys; it runs for
-# many minutes, which is too slow for the PR feedback loop.
-# pr-validation.yml keeps the fast checks on PRs; this workflow
-# catches cross-page functional regressions within a day.
+# Triggers: nightly cron, manual dispatch, and PRs that touch the app
+# SHELL — still deliberately NOT every PR.  The suite boots the whole
+# stack, builds the frontend, and drives a real browser through dozens
+# of journeys; it runs for many minutes, which is too slow to put in
+# front of every change.  pr-validation.yml keeps the fast checks on
+# every PR; this one is the slow, targeted second gate.
+#
+# Why the path-filtered PR trigger exists (added after #709):
+#
+# A `dynamic()` import added to `components/AppShell.jsx` put a React
+# lazy boundary around `{children}` — the entire page.  Every route's
+# content became deferred streaming content, so React staged it in a
+# hidden `<div id="S:1">`, moved it into place, and left the staged
+# copy behind.  /waivers served THREE <main> elements: the shell's,
+# the page's, and a hidden second full copy of the page.
+#
+# Nothing else in the repo saw it.  The duplicate has no client rects
+# and never reaches the accessibility tree, so it is invisible in a
+# screenshot and to a human clicking around.  Six rounds of performance
+# instrumentation — CLS, LCP, INP, long-task/TBT, scroll FPS, per-route
+# bundle size — ALL reported unchanged numbers for a build that rendered
+# every page twice.  pr-validation.yml runs pytest, vitest and lint; it
+# never opens a browser.  The only detector was a Playwright strict-mode
+# violation ("resolved to 2 elements") in waivers-smoke.spec.js, in this
+# workflow, which at the time ran nightly and so caught it a day late
+# and on a branch nobody was watching.
+#
+# Hence: when a change touches the shell, the layout, the auth gate or
+# the bundler config, run the browser BEFORE merge.  The paths below are
+# deliberately narrow — see the note beside them.
+#
+# EXPECT INTERMITTENT REDS, and read them carefully before blaming the
+# PR.  The app has a pre-existing SSR-streaming race in which the same
+# `#S:1` staging copy is occasionally left behind, measured at 1/15
+# loads on /arbitrage and 1/45 on /waivers — IDENTICAL rates on a build
+# of main and on the #709 branch, so it is main's defect, not any one
+# PR's.  Tracked separately.  Before attributing a red run here to the
+# PR under review, reproduce the rate against a build of the base
+# branch.  Do NOT "fix" it by loosening those locators: they are the
+# only detector this repo has for a bug class every performance metric
+# is blind to.
 #
 # Failure handling mirrors scheduled-refresh.yml: an idempotent
 # tracking issue labelled ``e2e-failures`` is opened (or commented
 # on) so a broken journey can't sit unnoticed between manual runs.
-#
-# That tracker is about MAIN, and only main writes to it — both the
-# open and the close step require ``github.ref == 'refs/heads/main'``.
-# Dispatching this on a branch is a first-class use (it is how a branch
-# gets arbitrated against the green baseline), and its result is
-# reported in the run itself.  It just does not get to speak for main.
-# See the note on the alert step for the incident, #716.
+# Both issue steps are scoped to NON-PR runs — see the guards on them.
 
 on:
   schedule:
@@ -35,9 +64,37 @@ on:
     # from scheduled-refresh's :42 cadence.
     - cron: "23 6 * * *"
   workflow_dispatch: {}
+  pull_request:
+    # The SSR/module-graph surface: anything here can change how the
+    # app streams and hydrates, which is the bug class above.
+    #
+    # `frontend/components/ds/**` is deliberately ABSENT despite being
+    # the widest-blast-radius candidate.  The design system is touched
+    # by a large share of frontend PRs, so including it would quietly
+    # turn this into the every-PR gate the header rules out.  Dispatch
+    # the workflow by hand for a risky `ds` change instead.
+    paths:
+      - "frontend/app/layout.jsx"
+      - "frontend/app/AppShellWrapper.jsx"
+      - "frontend/components/AppShell.jsx"
+      - "frontend/components/shell/**"
+      - "frontend/middleware.js"
+      - "frontend/lib/public-routes.js"
+      # Bundler + framework config: `sideEffects`, dependency bumps and
+      # next.config changes all move chunk boundaries, and chunk
+      # boundaries are what decide when React defers a boundary.
+      - "frontend/package.json"
+      - "frontend/next.config.*"
+      # The suite and its harness — a change here should prove itself.
+      - "tests/e2e/**"
+      - ".github/workflows/e2e.yml"
 
 concurrency:
-  group: e2e-safety-net
+  # Per-ref, NOT one global group.  With a single `e2e-safety-net` group
+  # and `cancel-in-progress`, the first PR run would cancel the nightly
+  # (and every other PR's run) — and a cancelled run reports the same
+  # "not green" as a failed one while having tested nothing.
+  group: e2e-safety-net-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # ``issues: write`` for the idempotent failure-tracking issue below.
@@ -252,31 +309,13 @@ jobs:
         # on the open ``e2e-failures`` issue if there is one, else
         # open a single labelled issue and keep reusing it.
         #
-        # MAINLINE RUNS ONLY, and the `github.ref` half is the load-bearing
-        # part of that condition.  The tracker answers one question — "is a
-        # critical journey broken on main right now?" — and a
-        # `workflow_dispatch` on a feature branch cannot contribute an
-        # answer to it either way.
-        #
-        # It contributed wrong ones in both directions.  #716 was opened
-        # 2026-08-04T18:59Z reading "Nightly E2E safety-net run failed"; it
-        # was a manual dispatch on `claude/sitewide-performance-audit-nubuz8`
-        # (PR #709), deliberately fired by the session working that branch to
-        # let CI arbitrate its own in-progress change.  Working as intended
-        # for them, filed as a mainline regression for everyone else.
-        #
-        # The close step below is the worse direction and the reason this is
-        # a guard rather than a wording fix: it is gated only on `success()`,
-        # so a green dispatch from ANY branch closes a genuine open mainline
-        # failure with "safety net is green again". A branch that never ran
-        # main's code would have issued main's all-clear.
-        #
-        # schedule and a dispatch on main both give `refs/heads/main`, so the
-        # legitimate paths are untouched. `branches: [main]` is already
-        # hardcoded across these workflows; matching that is deliberate over
-        # deriving the default branch from an event payload that varies by
-        # trigger.
-        if: failure() && github.ref == 'refs/heads/main'
+        # NON-PR RUNS ONLY.  This issue tracks "is main's safety net
+        # broken".  A PR run failing says something about the PR, not
+        # about main, and the failure is already visible on the PR's own
+        # checks — commenting here would bury the real signal under one
+        # comment per red PR run, which is exactly the "permanently red"
+        # noise the close-step below was added to end.
+        if: failure() && github.event_name != 'pull_request'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -284,7 +323,7 @@ jobs:
           set -Eeuo pipefail
           RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           BODY=$(cat <<EOF
-          E2E safety-net run failed on \`main\` (trigger: ${GITHUB_EVENT_NAME}).
+          Nightly E2E safety-net run failed.
 
           - Workflow run: ${RUN_URL}
           - Commit: ${GITHUB_SHA}
@@ -335,11 +374,15 @@ jobs:
         #
         # A green run of THIS workflow is the all-clear by construction:
         # the suite is the gate, so there is no per-step outcome to
-        # re-derive.  On MAIN.  The ref guard is not symmetry with the
-        # alert step above — it is the stronger of the two requirements,
-        # because a false all-clear closes a real open failure and a false
-        # alarm merely files a wrong one.  See that step for the full note.
-        if: success() && github.ref == 'refs/heads/main'
+        # re-derive.
+        #
+        # NON-PR RUNS ONLY, and this guard is the more important of the
+        # two.  A PR run is green for the PR's HEAD — a merge commit of
+        # a branch that is not main.  Letting it close the issue would
+        # declare main healthy on evidence from code that was never on
+        # main, and any PR touching the shell could silently clear a
+        # genuine nightly failure.
+        if: success() && github.event_name != 'pull_request'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -359,7 +402,7 @@ jobs:
           for N in $OPEN; do
             echo "closing #${N}"
             gh issue close "$N" --reason completed --comment \
-              "E2E safety net is green again on \`main\` — every critical journey passed.
+              "Nightly E2E safety net is green again — every critical journey passed.
 
           - Workflow run: ${RUN_URL}
           - Commit: ${GITHUB_SHA}

--- a/tests/deploy/test_e2e_workflow_triggers.py
+++ b/tests/deploy/test_e2e_workflow_triggers.py
@@ -1,0 +1,148 @@
+"""The E2E safety net's triggering rules are load-bearing and unpinned.
+
+Three separate decisions live in ``.github/workflows/e2e.yml`` that are
+invisible from the job body, and every one of them has already been got
+wrong once:
+
+1. **Who may write to the ``e2e-failures`` tracker.**  That issue answers
+   "is MAIN's safety net broken".  Both steps therefore require
+   ``github.ref == 'refs/heads/main'`` *and* a non-``pull_request``
+   event.  A green run that is not main's must not close it: #716 was a
+   green DISPATCH on a branch issuing main's all-clear, and a green PR
+   run is green for a merge commit of a branch that is not main.  The
+   close direction is the dangerous one — a false all-clear closes a
+   real open failure, while a false alarm merely files a wrong one.
+
+   The two clauses are redundant today (a ``pull_request`` run's ref is
+   ``refs/pull/<n>/merge``, never ``refs/heads/main``), which is exactly
+   the trap: it makes replacing one with the other look like a no-op.
+   It is not.  Dropping the ref clause re-opens #716 while every test
+   and every PR check stays green.
+
+2. **The PR path list.**  It is the SSR/module-graph surface, added
+   after #709 put a ``dynamic()`` boundary around ``{children}`` and
+   shipped a build that rendered every page twice.  Six rounds of
+   performance instrumentation reported unchanged numbers for it; this
+   suite's Playwright strict-mode locators were the sole detector.  The
+   *exclusion* of ``frontend/components/ds/**`` is as deliberate as any
+   inclusion — the design system is touched by a large share of frontend
+   PRs, so listing it would quietly turn this into the every-PR gate the
+   header rules out.
+
+3. **Per-ref concurrency.**  With one global group and
+   ``cancel-in-progress``, the first PR run cancels the nightly and every
+   other PR's run — and a cancelled run reports the same "not green" as a
+   failure while having tested nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_REPO = Path(__file__).resolve().parents[2]
+_WORKFLOW = _REPO / ".github" / "workflows" / "e2e.yml"
+
+# The steps that write to the shared ``e2e-failures`` tracking issue.
+_ISSUE_STEP_NAMES = (
+    "Alert on workflow failure",
+    "Close the tracking issue when the suite is green",
+)
+
+_EXPECTED_PR_PATHS = [
+    "frontend/app/layout.jsx",
+    "frontend/app/AppShellWrapper.jsx",
+    "frontend/components/AppShell.jsx",
+    "frontend/components/shell/**",
+    "frontend/middleware.js",
+    "frontend/lib/public-routes.js",
+    "frontend/package.json",
+    "frontend/next.config.*",
+    "tests/e2e/**",
+    ".github/workflows/e2e.yml",
+]
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _triggers(wf: dict) -> dict:
+    # ``on:`` is a YAML 1.1 boolean, so safe_load keys it as True.  Accept
+    # either in case a future loader is configured differently.
+    return wf.get("on", wf.get(True))
+
+
+def _steps(wf: dict) -> list[dict]:
+    return [step for job in wf["jobs"].values() for step in job.get("steps", [])]
+
+
+def _step_named(wf: dict, name: str) -> dict:
+    for step in _steps(wf):
+        if step.get("name") == name:
+            return step
+    raise AssertionError(
+        f"step {name!r} is gone from e2e.yml — if it was renamed, update "
+        "_ISSUE_STEP_NAMES here rather than deleting the guard it carries"
+    )
+
+
+def test_workflow_parses() -> None:
+    assert isinstance(_workflow(), dict)
+
+
+def test_all_three_triggers_are_present() -> None:
+    triggers = _triggers(_workflow())
+    assert set(triggers) == {"schedule", "workflow_dispatch", "pull_request"}
+
+
+def test_pr_trigger_is_path_filtered_to_the_shell_surface() -> None:
+    pr = _triggers(_workflow())["pull_request"]
+    assert pr["paths"] == _EXPECTED_PR_PATHS
+
+
+def test_pr_trigger_still_exercises_itself() -> None:
+    # The workflow is on its own path list, so a change to the triggering
+    # rules proves them in the same PR that makes it.
+    pr = _triggers(_workflow())["pull_request"]
+    assert ".github/workflows/e2e.yml" in pr["paths"]
+
+
+def test_design_system_is_deliberately_not_a_pr_trigger() -> None:
+    pr = _triggers(_workflow())["pull_request"]
+    assert not [p for p in pr["paths"] if p.startswith("frontend/components/ds")], (
+        "adding components/ds/** turns this into the every-PR gate the "
+        "workflow header rules out; dispatch by hand for a risky ds change"
+    )
+
+
+def test_concurrency_is_keyed_per_pr_or_ref() -> None:
+    concurrency = _workflow()["concurrency"]
+    assert concurrency["cancel-in-progress"] is True
+    assert (
+        concurrency["group"]
+        == "e2e-safety-net-${{ github.event.pull_request.number || github.ref }}"
+    )
+
+
+def test_only_main_may_write_to_the_failures_tracker() -> None:
+    wf = _workflow()
+    for name in _ISSUE_STEP_NAMES:
+        condition = _step_named(wf, name)["if"]
+        assert "github.ref == 'refs/heads/main'" in condition, (
+            f"{name!r} lost its ref guard.  A non-'pull_request' check is "
+            "NOT a substitute: workflow_dispatch on a branch satisfies it, "
+            "which is incident #716."
+        )
+        assert "github.event_name != 'pull_request'" in condition, (
+            f"{name!r} lost its PR-run guard."
+        )
+
+
+def test_the_two_tracker_steps_guard_opposite_outcomes() -> None:
+    wf = _workflow()
+    assert _step_named(wf, "Alert on workflow failure")["if"].startswith("failure()")
+    assert _step_named(wf, "Close the tracking issue when the suite is green")["if"].startswith(
+        "success()"
+    )

--- a/tests/deploy/test_e2e_workflow_triggers.py
+++ b/tests/deploy/test_e2e_workflow_triggers.py
@@ -135,9 +135,8 @@ def test_only_main_may_write_to_the_failures_tracker() -> None:
             "NOT a substitute: workflow_dispatch on a branch satisfies it, "
             "which is incident #716."
         )
-        assert "github.event_name != 'pull_request'" in condition, (
-            f"{name!r} lost its PR-run guard."
-        )
+        has_event_guard = "github.event_name != 'pull_request'" in condition
+        assert has_event_guard, f"{name!r} lost its PR-run guard."
 
 
 def test_the_two_tracker_steps_guard_opposite_outcomes() -> None:


### PR DESCRIPTION
Closes the gap that let #709 ship a bug rendering every page twice.

## Why

`e2e.yml`'s header said the suite deliberately does not run on PRs, and gave a good reason: it boots the whole stack and drives a real browser, which is too slow for every change. **That reason still holds for most changes.** It did not hold for the one class of change that just got through.

#709 added a `dynamic()` import to `components/AppShell.jsx`. `dynamic()` is `React.lazy`, which needs a Suspense boundary; with no local one the nearest ancestor is the App Router's, and `{children}` — the entire page — renders inside it. Every route's content became deferred streaming content: staged in a hidden `<div id="S:1">`, moved into place, and the staged copy left behind. **`/waivers` served three `<main>` elements** — the shell's, the page's, and a hidden second full copy of the page.

Nothing else in the repo saw it. The duplicate has no client rects and never reaches the accessibility tree, so it is invisible in a screenshot and to a human clicking around. Six rounds of performance instrumentation — CLS, LCP, INP, long-task/TBT, scroll FPS, per-route bundle size — **all reported unchanged numbers** for a build that rendered every page twice. `pr-validation.yml` runs pytest, vitest and lint; it never opens a browser. The sole detector was a Playwright strict-mode violation in `waivers-smoke.spec.js`, in this workflow, which ran nightly and so caught it a day late on a branch nobody was watching.

## What changed

**1. A path-filtered `pull_request` trigger.** The paths are the SSR/module-graph surface — root layout, shell composition, the auth gate, bundler and framework config, plus the suite itself:

```
frontend/app/layout.jsx          frontend/middleware.js
frontend/app/AppShellWrapper.jsx frontend/lib/public-routes.js
frontend/components/AppShell.jsx frontend/package.json
frontend/components/shell/**     frontend/next.config.*
tests/e2e/**                     .github/workflows/e2e.yml
```

`AppShell.jsx` and `package.json` are both on that list, so **this trigger would have caught #709 at review time.**

`frontend/components/ds/**` is deliberately **excluded**, and the file says why: the design system is touched by a large share of frontend PRs, so including it would quietly turn this into the every-PR gate the header rules out. Dispatch the workflow by hand for a risky `ds` change.

**2. Per-ref concurrency.** The group was a single global `e2e-safety-net` with `cancel-in-progress: true`. The first PR run would have cancelled the nightly *and* every other PR's run — and a cancelled run reports the same "not green" as a failure while having tested nothing. Now keyed on `github.event.pull_request.number || github.ref`.

**3. Both tracking-issue steps require main AND a non-PR event.**

```yaml
if: failure() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
if: success() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
```

The two clauses guard different things and neither subsumes the other in intent:

- The **ref** clause is about branch *dispatch*, not PRs. Dispatching this workflow on a branch is a first-class use — it is how a branch gets arbitrated against the green baseline — but its result must not speak for `main`. That is #716.
- The **event** clause states the PR-run intent at the point of use. A PR failure is already visible on the PR's own checks; commenting on the tracker would bury the real signal under one comment per red PR run, the exact "permanently red" noise the close step was added to end. It is redundant with the ref clause today (a PR run's ref is `refs/pull/<n>/merge`), and it is kept so that adding a `push:` trigger later cannot silently make PR runs eligible.

The close step is the more dangerous of the two in both directions: a false all-clear closes a real open failure, while a false alarm merely files a wrong one.

*(First revision of this PR replaced the ref guard with the event guard instead of conjoining them. That was unnecessary — the ref check already excluded PR runs — and it re-opened #716, since `workflow_dispatch` on a branch satisfies `!= 'pull_request'`. Fixed in the second commit.)*

## Expect intermittent reds, and read them before blaming the PR

This is documented in the workflow header. The app has a **pre-existing** SSR-streaming race in which the same `#S:1` staging copy is occasionally left behind — measured at **1/15 loads on `/arbitrage` and 1/45 on `/waivers`, identical rates on a build of `main` and on the #709 branch**. It is `main`'s defect, not any one PR's, and is tracked separately in #716.

Before attributing a red run here to the PR under review, reproduce the rate against a build of the base branch. **Do not "fix" it by loosening those locators** — they are the only detector this repo has for a bug class every performance metric is blind to.

## Testing

- New `tests/deploy/test_e2e_workflow_triggers.py` (8 tests) `yaml.safe_load`s the workflow and pins the three triggers, the ten path globs, the deliberate *absence* of `components/ds/**`, the per-ref concurrency expression, and the ref guard on both issue steps. Each assertion was verified to fail against the form it guards against before being kept. It lives beside the existing workflow-wiring tests in `tests/deploy/` and runs in `pr-validation.yml` with the rest of pytest — nothing in the repo referenced `e2e.yml` before this.
- No change to the job body — same steps, same stack boot, same Playwright invocation. Only triggering, concurrency and the two issue-step guards moved.
- This PR touches `.github/workflows/e2e.yml`, which is on its own path list, so the new trigger exercises itself here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeQ4SkH9khPRx2b3WunSTA)_