### PR TITLE
Fix login sessions dropping after deploys (sliding TTL + per-user allowlist invalidation)

### DIFF
--- a/server.py
+++ b/server.py
@@ -547,8 +547,14 @@ def _get_auth_session(request: Request) -> dict | None:
     now = time.time()
     last_touch = session.get("_last_touch_epoch")
     if not isinstance(last_touch, (int, float)):
-        last_touch = session.get("last_seen_epoch") or 0
-    if now - float(last_touch) >= SESSION_TOUCH_INTERVAL_SECONDS:
+        last_touch = session.get("last_seen_epoch")
+    # A session with no recorded heartbeat is touched immediately;
+    # otherwise the write is throttled to once per interval.  Missing
+    # data drives an explicit branch rather than a fabricated epoch.
+    if (
+        not isinstance(last_touch, (int, float))
+        or now - float(last_touch) >= SESSION_TOUCH_INTERVAL_SECONDS
+    ):
         session["_last_touch_epoch"] = now
         try:
             from src.api import session_store as _ss

--- a/server.py
+++ b/server.py
@@ -198,6 +198,13 @@ def _session_ttl_days_seconds(default_days: float = 30.0) -> int:
 
 JASON_AUTH_COOKIE_MAX_AGE = _session_ttl_days_seconds()
 
+# How often an active session's ``last_seen_at`` is refreshed on disk.
+# The sliding TTL only needs a coarse heartbeat, so we throttle the
+# write to at most once per interval per session — keeping ``/api/data``
+# reads off the SQLite write path while still keeping active users
+# signed in indefinitely.
+SESSION_TOUCH_INTERVAL_SECONDS = 6 * 3600
+
 # Private-app allowlist.  Gates admin-only endpoints to operator
 # usernames.  Env var is comma-separated, lowercase-normalised at
 # load time.
@@ -533,6 +540,22 @@ def _get_auth_session(request: Request) -> dict | None:
                     exc,
                 )
             return None
+    # Sliding TTL heartbeat.  Bump ``last_seen_at`` at most once per
+    # SESSION_TOUCH_INTERVAL_SECONDS so an actively-used session never
+    # expires, without writing to SQLite on every request.  Best-effort:
+    # a failed touch just means the session ages toward its idle TTL.
+    now = time.time()
+    last_touch = session.get("_last_touch_epoch")
+    if not isinstance(last_touch, (int, float)):
+        last_touch = session.get("last_seen_epoch") or 0
+    if now - float(last_touch) >= SESSION_TOUCH_INTERVAL_SECONDS:
+        session["_last_touch_epoch"] = now
+        try:
+            from src.api import session_store as _ss
+
+            _ss.touch(session_id)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("session_store touch failed: %s", exc)
     return session
 
 

--- a/src/api/session_store.py
+++ b/src/api/session_store.py
@@ -14,12 +14,19 @@ Design
   layer — written on session create/clear, read once on startup
   to hydrate the in-memory dict.
 * TTL: sessions expire after ``SESSION_TTL_DAYS`` days (default
-  30) — matches the cookie ``max_age``.
-* Invalidation on allowlist change: every session row stores
-  ``allowlist_version`` (a hash of PRIVATE_APP_ALLOWED_USERNAMES).
-  On hydrate, sessions whose stored version doesn't match the
-  current are treated as invalid — prevents a session outliving
-  its allowlist entry.
+  30) of *inactivity* — the window slides off ``last_seen_at``,
+  which every authenticated request bumps (throttled) via
+  ``touch``.  An actively-used session never expires; only an
+  idle one does.  Matches the cookie ``max_age`` for a fresh
+  login.
+* Invalidation on allowlist removal: every session row stores the
+  session's ``username``.  On hydrate, a session is dropped only
+  when *its own* username is no longer in the current allowlist —
+  so removing one user signs out only that user, while adding a
+  user leaves every existing session intact.  An empty / unset
+  allowlist is treated as "no restriction" and never invalidates
+  (prevents a mis-deployed empty env var from logging everyone
+  out).  ``allowlist_version`` is still recorded for audit.
 * Corruption fallback: every call is wrapped in broad try/except;
   any SQLite error → in-memory dict continues working (existing
   behavior, no regression).
@@ -93,11 +100,22 @@ def _setup(path: Path) -> None:
 
 
 def _allowlist_version(allowlist: Iterable[str] | None) -> str:
-    """Stable hash of the allowlist — used to invalidate sessions
-    on roster change without manually rotating them."""
+    """Stable hash of the allowlist — recorded per row for audit."""
     items = sorted({s.strip().lower() for s in (allowlist or []) if s})
     raw = ",".join(items).encode("utf-8")
     return hashlib.sha256(raw).hexdigest()[:16]
+
+
+def _allowlist_set(allowlist: Iterable[str] | None) -> set[str] | None:
+    """Normalised set of allowed usernames, or ``None`` when the
+    allowlist is empty / unset.
+
+    ``None`` means "no restriction" — hydrate keeps every session.
+    A non-empty set means "keep only sessions whose username is a
+    member", so removing a user invalidates only that user.
+    """
+    items = {s.strip().lower() for s in (allowlist or []) if s and s.strip()}
+    return items or None
 
 
 def persist(
@@ -148,6 +166,31 @@ def persist(
         _LOGGER.warning("session_store persist failed: %s", exc)
 
 
+def touch(session_id: str, *, db_path: Path | None = None) -> None:
+    """Bump ``last_seen_at`` to now so an active session's sliding
+    TTL keeps sliding.  A no-op for unknown session ids.  Best-effort:
+    any SQLite error is swallowed (auth still works in-memory)."""
+    path = db_path or _DEFAULT_DB_PATH
+    if not _setup_done.is_set():
+        try:
+            _setup(path)
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.warning("session_store touch setup failed: %s", exc)
+            return
+    try:
+        with _db_lock:
+            conn = _connect(path)
+            try:
+                conn.execute(
+                    f"UPDATE {_TABLE} SET last_seen_at = ? WHERE session_id = ?",
+                    (time.time(), str(session_id)),
+                )
+            finally:
+                conn.close()
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.warning("session_store touch failed: %s", exc)
+
+
 def evict(session_id: str, *, db_path: Path | None = None) -> None:
     """Remove a session (user logged out)."""
     path = db_path or _DEFAULT_DB_PATH
@@ -176,12 +219,16 @@ def hydrate(
     allowlist: Iterable[str] | None = None,
     db_path: Path | None = None,
 ) -> dict[str, dict[str, Any]]:
-    """Load every non-expired, allowlist-current session into an
+    """Load every non-expired, still-allowed session into an
     in-memory dict — call once at startup.
 
-    Sessions whose stored ``allowlist_version`` doesn't match the
-    CURRENT allowlist are dropped (and removed from disk) so a
-    rotation invalidates every session instantly.
+    A session is dropped (and removed from disk) when either:
+      * it has been idle longer than the TTL (``last_seen_at``
+        older than the cutoff — a sliding window), or
+      * its ``username`` is no longer in the current allowlist.
+
+    An empty / unset allowlist imposes no membership restriction,
+    so a mis-deployed blank env var can't sign everyone out.
     """
     path = db_path or _DEFAULT_DB_PATH
     if not _setup_done.is_set():
@@ -191,7 +238,7 @@ def hydrate(
             _LOGGER.warning("session_store setup on hydrate failed: %s", exc)
             return {}
 
-    current_ver = _allowlist_version(allowlist)
+    allowed = _allowlist_set(allowlist)
     cutoff = time.time() - _SESSION_TTL_SECONDS
     out: dict[str, dict[str, Any]] = {}
     expired_ids: list[str] = []
@@ -207,10 +254,13 @@ def hydrate(
             finally:
                 conn.close()
         for sid, user, sluid, dn, av, am, ver, created, last in rows:
-            if created < cutoff:
+            # Sliding TTL — expire on idle time, not age.  Fall back
+            # to created_at for legacy rows written before touch().
+            last_active = last if last and last > 0 else created
+            if last_active < cutoff:
                 expired_ids.append(sid)
                 continue
-            if ver != current_ver:
+            if allowed is not None and str(user or "").strip().lower() not in allowed:
                 expired_ids.append(sid)
                 continue
             out[sid] = {
@@ -224,6 +274,7 @@ def hydrate(
                     time.gmtime(created),
                 ),
                 "created_at_epoch": created,
+                "last_seen_epoch": last_active,
             }
         if expired_ids:
             with _db_lock:

--- a/tests/api/test_session_store.py
+++ b/tests/api/test_session_store.py
@@ -2,8 +2,11 @@
 
 Pins:
   * persist + hydrate round-trips a session.
-  * TTL expiry drops old rows on hydrate.
-  * Allowlist rotation invalidates all sessions.
+  * Sliding TTL: idle time (last_seen_at) drives expiry, and touch()
+    keeps an active session alive.
+  * Allowlist removal invalidates only the removed user's sessions;
+    adding a user leaves existing sessions intact; an empty allowlist
+    imposes no restriction.
   * Corrupted / missing DB returns empty, never raises.
   * evict removes a single session.
   * force_clear_all removes everything.
@@ -51,7 +54,7 @@ def test_hydrate_empty_db_returns_empty_dict(tmp_path):
     assert got == {}
 
 
-def test_allowlist_rotation_invalidates_sessions(tmp_path):
+def test_allowlist_removal_invalidates_removed_user(tmp_path):
     db = tmp_path / "s.sqlite"
     session_store.persist(
         "sid-1",
@@ -59,10 +62,40 @@ def test_allowlist_rotation_invalidates_sessions(tmp_path):
         allowlist=["old_user"],
         db_path=db,
     )
-    # Rotate — old_user removed, new_user added.
+    # old_user is dropped from the allowlist entirely.
     session_store._setup_done.clear()  # noqa: SLF001
     hydrated = session_store.hydrate(allowlist=["new_user"], db_path=db)
-    assert hydrated == {}, "session outlived its allowlist"
+    assert hydrated == {}, "removed user's session outlived its allowlist"
+
+
+def test_adding_a_user_keeps_existing_sessions(tmp_path):
+    """Regression: adding a NEW user to the allowlist must not sign
+    out everyone else (the old global-version-hash behavior did)."""
+    db = tmp_path / "s.sqlite"
+    session_store.persist(
+        "sid-existing",
+        {"username": "jasonleetucker"},
+        allowlist=["jasonleetucker"],
+        db_path=db,
+    )
+    # A second operator is added; the allowlist set changes.
+    session_store._setup_done.clear()  # noqa: SLF001
+    hydrated = session_store.hydrate(
+        allowlist=["jasonleetucker", "new_teammate"],
+        db_path=db,
+    )
+    assert "sid-existing" in hydrated
+    assert hydrated["sid-existing"]["username"] == "jasonleetucker"
+
+
+def test_empty_allowlist_imposes_no_restriction(tmp_path):
+    """A blank / unset allowlist must not invalidate every session."""
+    db = tmp_path / "s.sqlite"
+    session_store.persist("sid-1", {"username": "u"}, allowlist=["u"], db_path=db)
+    session_store._setup_done.clear()  # noqa: SLF001
+    assert "sid-1" in session_store.hydrate(allowlist=[], db_path=db)
+    session_store._setup_done.clear()  # noqa: SLF001
+    assert "sid-1" in session_store.hydrate(allowlist=None, db_path=db)
 
 
 def test_ttl_expiry_drops_old_sessions(tmp_path, monkeypatch):
@@ -79,6 +112,42 @@ def test_ttl_expiry_drops_old_sessions(tmp_path, monkeypatch):
     session_store._setup_done.clear()  # noqa: SLF001
     hydrated = session_store.hydrate(allowlist=["u"], db_path=db)
     assert hydrated == {}
+
+
+def test_sliding_ttl_uses_last_seen_not_created(tmp_path, monkeypatch):
+    """An old session that was recently active must survive: expiry
+    keys off last_seen_at, not created_at."""
+    db = tmp_path / "s.sqlite"
+    monkeypatch.setattr(session_store, "_SESSION_TTL_SECONDS", 100.0)
+    # created long ago, but persist stamps last_seen_at = now.
+    session_store.persist(
+        "sid-active",
+        {"username": "u", "created_at_epoch": time.time() - 10_000},
+        allowlist=["u"],
+        db_path=db,
+    )
+    session_store._setup_done.clear()  # noqa: SLF001
+    hydrated = session_store.hydrate(allowlist=["u"], db_path=db)
+    assert "sid-active" in hydrated
+    assert hydrated["sid-active"]["last_seen_epoch"] > time.time() - 100
+
+
+def test_touch_keeps_idle_session_alive(tmp_path, monkeypatch):
+    db = tmp_path / "s.sqlite"
+    monkeypatch.setattr(session_store, "_SESSION_TTL_SECONDS", 1.0)
+    session_store.persist("sid-1", {"username": "u"}, allowlist=["u"], db_path=db)
+    time.sleep(1.2)  # would expire on its own
+    session_store.touch("sid-1", db_path=db)  # heartbeat bumps last_seen
+    session_store._setup_done.clear()  # noqa: SLF001
+    hydrated = session_store.hydrate(allowlist=["u"], db_path=db)
+    assert "sid-1" in hydrated, "touch() should have refreshed the sliding TTL"
+
+
+def test_touch_unknown_session_is_noop(tmp_path):
+    db = tmp_path / "s.sqlite"
+    session_store.persist("sid-real", {"username": "u"}, allowlist=["u"], db_path=db)
+    session_store.touch("sid-does-not-exist", db_path=db)  # must not raise
+    assert session_store.count_active(db_path=db) == 1
 
 
 def test_evict_removes_single_session(tmp_path):


### PR DESCRIPTION
## Why

"Why isn't my last session on here?" — the persistent session store (`src/api/session_store.py`), which exists specifically so users don't have to re-login after each of the 5–8 deploys/day, was silently dropping sessions on restart in two avoidable ways.

## Root causes fixed

**1. An allowlist change signed *everyone* out.**
Each session row stored a hash of the *entire* `PRIVATE_APP_ALLOWED_USERNAMES` allowlist, and `hydrate()` dropped any session whose stored hash ≠ the current hash. So adding a single new operator — or a deploy where the env var came up blank and fell back to the default — changed the hash and invalidated **every** session at once.

Now `hydrate()` drops a session only when *its own* `username` is no longer in the allowlist. Adding a user leaves existing sessions intact, removing a user signs out only that user, and an **empty/unset allowlist imposes no restriction** (so a mis-deployed blank env var can't log everyone out). `allowlist_version` is still written per row for audit.

**2. The 30-day TTL was fixed from first login, not sliding.**
Expiry keyed off `created_at`, so even a daily-active user was evicted 30 days after their *first* login. `persist()` bumped `last_seen_at` but the TTL check never looked at it.

TTL now slides off `last_seen_at`, refreshed by a new `session_store.touch()` that `_get_auth_session` calls at most once per 6h per session (`SESSION_TOUCH_INTERVAL_SECONDS`) — keeping the `/api/data` read path off SQLite writes. Legacy rows with no `last_seen_at` fall back to `created_at`.

> Note: cause #3 from the diagnosis — the `data/session_store.sqlite` file not surviving a deploy because `data/` is gitignored — is a deployment/volume concern, not a code fix, and is out of scope for this PR. If hydrate logs `hydrated 0 sessions` after a deploy, that's the one to chase in infra.

## Changes

- `src/api/session_store.py` — `_allowlist_set()` helper; per-username invalidation in `hydrate()`; sliding TTL on `last_seen_at`; new `touch()`; `last_seen_epoch` added to hydrated payload.
- `server.py` — `SESSION_TOUCH_INTERVAL_SECONDS` constant; throttled `touch()` heartbeat in `_get_auth_session` (best-effort, mirrors existing evict-on-expiry pattern).
- `tests/api/test_session_store.py` — new/updated specs.

## Testing

`python -m pytest tests/api/test_session_store.py -q` → **15 passed**. Covers: adding a user keeps existing sessions, empty allowlist keeps all, removed user is dropped, sliding TTL uses `last_seen`, `touch()` revives an idle session, and `touch()` of an unknown id is a safe no-op. Broader FastAPI-dependent auth suites couldn't run in this sandbox (fastapi not installed); `server.py` byte-compiles clean and the edit is a self-contained best-effort call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXUt5NFCNf49q43nXWAbed

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXUt5NFCNf49q43nXWAbed)_