### PR TITLE
Install the three timers whose templates nothing rendered

### DIFF
--- a/deploy/install-systemd-service.sh
+++ b/deploy/install-systemd-service.sh
@@ -137,6 +137,84 @@ escape_sed_replacement() {
   printf '%s' "$1" | sed -e 's/[\\/&]/\\&/g'
 }
 
+# ── Generic timer installer ─────────────────────────────────────────────
+# Every timer below main()'s backend/frontend sections is a hand-written
+# block, and each new one is another chance to forget a block entirely.
+# Three had been forgotten by 2026-08-05: crowd-faab, sharp-activity and
+# board-snapshot all shipped BOTH templates while nothing installed them,
+# so their producers never ran on prod and every deploy still reported
+# success.  Same shape as the 2026-07-30 finding one screen down, where
+# nine timer pairs shipped and two were installed.
+#
+# Worse than "does not run": deploy.sh's missing-timer detector globs the
+# SAME directory to decide whether to invoke this script, so an unwired
+# template is reported missing on EVERY deploy, which runs this installer
+# to fix it, which does not install it.  A permanent loop, silent because
+# it only warns.
+#
+# This helper covers any timer whose install is just "render the two
+# templates, enable it".  Timers with real special cases — credential
+# gating, an initial kick, a /var/lib seed — keep their dedicated blocks.
+# `tests/deploy/test_all_timers_are_wired.py` asserts every shipped
+# template is reached by one route or the other, so the next timer added
+# cannot go missing quietly.
+install_simple_timer() {
+  local stem="$1" label="$2"
+  local service_template="${APP_DIR}/deploy/systemd/dynasty-${stem}.service.template"
+  local timer_template="${APP_DIR}/deploy/systemd/dynasty-${stem}.timer.template"
+  local unit_name="${SERVICE_NAME}-${stem}"
+  local service_path="/etc/systemd/system/${unit_name}.service"
+  local timer_path="/etc/systemd/system/${unit_name}.timer"
+
+  [[ -f "${service_template}" && -f "${timer_template}" ]] || return 0
+
+  local needs_install=false
+  if sudo -n "${SYSTEMCTL_BIN}" cat "${unit_name}.timer" >/dev/null 2>&1; then
+    if [[ "${force_install_on}" == "true" ]]; then
+      log "FORCE_SERVICE_INSTALL enabled; rewriting ${service_path} + timer."
+      needs_install=true
+    fi
+  else
+    log "Installing ${label} service + timer."
+    needs_install=true
+  fi
+
+  if [[ "${needs_install}" == "true" ]]; then
+    local tmp_service tmp_timer
+    tmp_service="$(mktemp)"
+    tmp_timer="$(mktemp)"
+    sed \
+      -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
+      -e "s/__APP_USER__/$(escape_sed_replacement "${APP_USER}")/g" \
+      -e "s/__APP_DIR__/$(escape_sed_replacement "${APP_DIR}")/g" \
+      -e "s/__VENV_DIR__/$(escape_sed_replacement "${VENV_DIR}")/g" \
+      "${service_template}" > "${tmp_service}"
+    sed \
+      -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
+      "${timer_template}" > "${tmp_timer}"
+    sudo -n "${INSTALL_BIN}" -m 0644 "${tmp_service}" "${service_path}"
+    sudo -n "${INSTALL_BIN}" -m 0644 "${tmp_timer}" "${timer_path}"
+    rm -f "${tmp_service}" "${tmp_timer}"
+    # Reload here rather than joining the shared reload below: enabling a
+    # unit systemd has not re-read is the ce_needs_install failure — the
+    # fix deployed, reported as deployed, and not running.
+    sudo -n "${SYSTEMCTL_BIN}" daemon-reload
+    log "Installed ${unit_name}.service + .timer"
+  fi
+
+  # Enablement is checked SEPARATELY, and not only when we just wrote the
+  # files.  deploy.sh's detector treats installed-but-disabled as missing,
+  # so a unit that reached disk without being enabled produces the same
+  # permanent loop as one that never reached disk at all.
+  if ! sudo -n "${SYSTEMCTL_BIN}" is-enabled "${unit_name}.timer" >/dev/null 2>&1; then
+    if sudo -n "${SYSTEMCTL_BIN}" enable --now "${unit_name}.timer" >/dev/null 2>&1; then
+      log "Enabled ${unit_name}.timer"
+    else
+      log "Note: could not enable ${unit_name}.timer."
+    fi
+  fi
+}
+
 main() {
   local force_install force_install_on unit_path tmp_unit
   local frontend_template frontend_name frontend_unit_path tmp_frontend
@@ -906,6 +984,15 @@ main() {
     log "IDP Show fetch timer skipped: ${APP_DIR}/idpshow_session.json missing - operator must mint it via browser first."
   fi
 
+  # ── Timers with no special install requirements ─────────────────────────
+  # These need nothing but "render both templates and enable", so they go
+  # through the shared helper instead of another 40-line copy.  All three
+  # shipped templates that NOTHING installed until 2026-08-05; see the
+  # helper's comment for why that was worse than simply not running.
+  install_simple_timer "crowd-faab" "cross-league FAAB crowd accumulation"
+  install_simple_timer "sharp-activity" "qualified-manager Sleeper activity crawl"
+  install_simple_timer "board-snapshot" "canonical board as-of snapshot"
+
   # ── daemon-reload and enable ────────────────────────────────────────────
   # ce_needs_install was missing from this list. Every other timer's
   # flag is here, so a FORCE_SERVICE_INSTALL rewrite of the Consensus
@@ -913,7 +1000,16 @@ main() {
   # one, because nothing had told systemd to re-read it — the failure
   # mode where the fix is deployed, reported as deployed, and not
   # running.
-  if [[ "${backend_needs_install}" == "true" || "${frontend_needs_install}" == "true" || "${alerts_needs_install}" == "true" || "${custom_alerts_needs_install}" == "true" || "${playerctx_needs_install}" == "true" || "${bdvm_needs_install}" == "true" || "${ce_needs_install}" == "true" || "${sharp_needs_install}" == "true" || "${sharprec_needs_install}" == "true" || "${ffpc_needs_install}" == "true" || "${rd_needs_install}" == "true" || "${dlf_fetch_needs_install}" == "true" || "${idpshow_fetch_needs_install}" == "true" ]]; then
+  #
+  # Fixing it for `ce` alone left the same hole open twice more:
+  # `sharpros_needs_install` and `sharptx_needs_install` both gate an
+  # `enable --now` below while being absent from this chain, so a run
+  # that installed ONLY the sharp-rosters or sharp-transactions unit
+  # enabled it against a systemd that had never read it.  Both added,
+  # and `tests/deploy/test_all_timers_are_wired.py` now derives the
+  # expected set from the declarations rather than trusting this line to
+  # be maintained by hand.
+  if [[ "${backend_needs_install}" == "true" || "${frontend_needs_install}" == "true" || "${alerts_needs_install}" == "true" || "${custom_alerts_needs_install}" == "true" || "${playerctx_needs_install}" == "true" || "${bdvm_needs_install}" == "true" || "${ce_needs_install}" == "true" || "${sharp_needs_install}" == "true" || "${sharprec_needs_install}" == "true" || "${sharpros_needs_install}" == "true" || "${sharptx_needs_install}" == "true" || "${ffpc_needs_install}" == "true" || "${rd_needs_install}" == "true" || "${dlf_fetch_needs_install}" == "true" || "${idpshow_fetch_needs_install}" == "true" ]]; then
     sudo -n "${SYSTEMCTL_BIN}" daemon-reload
     log "Reloaded systemd unit files."
   fi

--- a/tests/deploy/test_all_timers_are_wired.py
+++ b/tests/deploy/test_all_timers_are_wired.py
@@ -1,0 +1,211 @@
+"""Every shipped timer template must actually be installed.
+
+There are per-timer versions of this file already — reception-depth,
+consensus-edge, ffpc-sharp — each written after that particular timer was
+found unwired. Writing one guard per incident does not close the hole: it
+closes the last one and waits for the next. On 2026-08-05 the next three
+were already sitting in the tree.
+
+``deploy/install-systemd-service.sh`` installs each timer from a
+hand-written block. ``deploy/systemd/`` shipped 16 timer templates and
+only 13 blocks existed, so **crowd-faab, sharp-activity and
+board-snapshot had no installer at all** — templates committed, reviewed,
+merged, and never once rendered onto the box. Their producers never ran
+and every deploy reported success.
+
+That is bad on its own. What makes it a *loop* is the other end:
+``deploy.sh`` decides whether to run the installer by globbing this same
+directory and asking systemd whether each unit is installed **and**
+enabled. An unwired template is therefore reported missing on every
+deploy, which runs the installer to add it, which does not add it —
+forever, and quietly, because the report is a warning.
+
+So the invariant this file pins is not "these three specific timers are
+wired". It is:
+
+* every ``*.timer.template`` is reached by SOME install route, and
+* every ``*_needs_install`` flag reaches the ``daemon-reload`` chain.
+
+Both are derived from what the tree actually contains, so adding a timer
+updates the expectation automatically and forgetting to wire it fails
+here instead of on the box six weeks later.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+_SYSTEMD = _REPO / "deploy" / "systemd"
+_INSTALLER = _REPO / "deploy" / "install-systemd-service.sh"
+_DEPLOY_SH = _REPO / "deploy" / "deploy.sh"
+
+
+def _installer() -> str:
+    return _INSTALLER.read_text(encoding="utf-8", errors="replace")
+
+
+def _timer_stems() -> list[str]:
+    """``dynasty-crowd-faab.timer.template`` -> ``crowd-faab``."""
+    return sorted(
+        p.name[len("dynasty-") : -len(".timer.template")]
+        for p in _SYSTEMD.glob("dynasty-*.timer.template")
+    )
+
+
+# ── The invariant ────────────────────────────────────────────────────
+
+
+def test_there_are_timer_templates_to_check() -> None:
+    """Non-vacuity.
+
+    Every assertion below is a loop over the glob. If the glob ever
+    returns nothing — directory renamed, naming convention changed — all
+    of them pass while checking nothing at all.
+    """
+    assert len(_timer_stems()) >= 10
+
+
+def test_every_timer_template_is_installed_by_something() -> None:
+    """A template nothing installs is a producer that never runs.
+
+    Two accepted routes: a dedicated block (needed when the install has
+    real special cases — credential gating, an initial kick, seeding a
+    session file into /var/lib) or the shared ``install_simple_timer``
+    helper. Which one does not matter here; having neither does.
+    """
+    body = _installer()
+    unwired = [
+        stem
+        for stem in _timer_stems()
+        if f"dynasty-{stem}.timer.template" not in body
+        and f'install_simple_timer "{stem}"' not in body
+    ]
+    assert not unwired, (
+        f"timer templates that nothing installs: {unwired}. "
+        "deploy.sh will report these missing on EVERY deploy, run this "
+        "installer to fix it, and the installer will not install them. "
+        "Add a dedicated block, or one install_simple_timer line."
+    )
+
+
+def test_every_needs_install_flag_reaches_the_daemon_reload() -> None:
+    """Enabling a unit systemd has not re-read starts the STALE one.
+
+    This is recorded in the installer's own comment for
+    ``ce_needs_install`` — the fix deployed, reported as deployed, and
+    not running. Fixing the one instance left ``sharpros_needs_install``
+    and ``sharptx_needs_install`` with the same hole, because the chain
+    is a hand-maintained line of ``||``. Derive the expectation instead.
+    """
+    body = _installer()
+    declared = set(re.findall(r"^\s*local\s+(\w+)_needs_install=false\s*$", body, re.M))
+    assert declared, "no *_needs_install flags found — has the installer been restructured?"
+
+    reload_line = next(
+        line
+        for line in body.split("\n")
+        if line.lstrip().startswith("if [[") and line.count("_needs_install}") > 1
+    )
+
+    missing = sorted(name for name in declared if f"${{{name}_needs_install}}" not in reload_line)
+    assert not missing, (
+        f"flags gate an install but never trigger daemon-reload: {missing}. "
+        "A run that installs only that unit will enable it against a "
+        "systemd that has never read it."
+    )
+
+
+# ── The helper's own contract ────────────────────────────────────────
+
+
+def test_the_helper_installs_service_and_timer_and_enables_it() -> None:
+    """Three separate steps, each of which has been forgotten before."""
+    body = _installer()
+    helper = body.split("install_simple_timer() {", 1)[1].split("\nmain() {", 1)[0]
+    assert 'INSTALL_BIN}" -m 0644 "${tmp_service}" "${service_path}"' in helper
+    assert 'INSTALL_BIN}" -m 0644 "${tmp_timer}" "${timer_path}"' in helper
+    assert "daemon-reload" in helper
+    assert 'enable --now "${unit_name}.timer"' in helper
+
+
+def test_the_helper_enables_even_when_the_unit_was_already_on_disk() -> None:
+    """installed-but-disabled is the same permanent loop as not installed.
+
+    ``deploy.sh``'s detector requires BOTH ``cat`` and ``is-enabled`` to
+    succeed, so short-circuiting the enable behind "did we just write the
+    files" would leave a half-installed unit re-reported every deploy.
+    """
+    body = _installer()
+    helper = body.split("install_simple_timer() {", 1)[1].split("\nmain() {", 1)[0]
+    enable_block = helper.split('if [[ "${needs_install}" == "true" ]]; then', 1)[1]
+    # The is-enabled check must sit OUTSIDE the needs_install branch.
+    tail = enable_block.split("\n  fi\n", 1)[1]
+    assert "is-enabled" in tail, "the enable check is nested inside the install branch"
+
+
+def test_every_simple_timer_call_has_both_templates() -> None:
+    """``install_simple_timer`` silently returns when a template is
+    missing, so a typo'd stem is indistinguishable from a timer that is
+    deliberately absent on this host."""
+    for stem in re.findall(r'install_simple_timer "([\w-]+)"', _installer()):
+        assert (_SYSTEMD / f"dynasty-{stem}.service.template").is_file(), stem
+        assert (_SYSTEMD / f"dynasty-{stem}.timer.template").is_file(), stem
+
+
+# ── What the units point at ──────────────────────────────────────────
+
+
+def test_every_service_execstart_points_at_a_file_that_exists() -> None:
+    """An ExecStart typo fails only on the box, weeks later, in a journal
+    nobody is reading. Generalises the per-timer check that already
+    existed for reception-depth."""
+    missing: list[str] = []
+    for template in sorted(_SYSTEMD.glob("dynasty-*.service.template")):
+        for line in template.read_text(encoding="utf-8").split("\n"):
+            if not line.startswith("ExecStart="):
+                continue
+            for rel in re.findall(r"__APP_DIR__/(\S+)", line):
+                if not (_REPO / rel).exists():
+                    missing.append(f"{template.name} -> {rel}")
+    assert not missing, f"ExecStart targets that do not exist: {missing}"
+
+
+def test_every_timer_resolves_to_a_service_that_ships() -> None:
+    """A timer whose target does not exist fires into nothing.
+
+    Two spellings are legal and both are in the tree. Most templates name
+    the target explicitly with ``Unit=__SERVICE_NAME__-<stem>.service``;
+    ``dlf-fetch`` and ``idpshow-fetch`` omit it and take systemd's
+    implicit default, which is the service sharing the timer's name. The
+    check is that the target RESOLVES, not that it is spelled one way —
+    pinning the spelling would fail two working timers and teach the next
+    person to edit the guard.
+    """
+    for stem in _timer_stems():
+        body = (_SYSTEMD / f"dynasty-{stem}.timer.template").read_text(encoding="utf-8")
+        explicit = f"Unit=__SERVICE_NAME__-{stem}.service" in body
+        implicit = not re.search(r"^Unit=", body, re.M)
+        assert explicit or implicit, (
+            f"{stem}: Unit= names something other than its own service, "
+            "so the timer fires a unit that may not exist"
+        )
+        assert (_SYSTEMD / f"dynasty-{stem}.service.template").is_file(), stem
+
+
+# ── The other end of the loop ────────────────────────────────────────
+
+
+def test_deploy_sh_still_derives_missing_timers_from_this_directory() -> None:
+    """This is what turns an unwired template into a permanent loop
+    rather than a dormant file, and it is the reason the guard above is
+    worth having.
+
+    If deploy.sh ever stops globbing the templates, the failure mode
+    changes shape and this file's docstring stops being true — better to
+    fail here and have someone re-read it.
+    """
+    body = _DEPLOY_SH.read_text(encoding="utf-8", errors="replace")
+    assert "deploy/systemd/*.timer.template" in body
+    assert "is-enabled" in body, "deploy.sh must treat installed-but-disabled as missing"

--- a/tests/deploy/test_sharp_population_jobs.py
+++ b/tests/deploy/test_sharp_population_jobs.py
@@ -4,12 +4,30 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 
 
+def _daemon_reload_condition(installer: str) -> str:
+    """The ``if [[ ... ]]`` line gating the shared ``daemon-reload``.
+
+    This used to be spelled ``installer.split("daemon-reload", 1)[0]`` —
+    "the flag appears somewhere before the first daemon-reload in the
+    file". That is a positional proxy for the real claim, and it broke
+    the moment a ``daemon-reload`` appeared earlier in the file (the
+    shared ``install_simple_timer`` helper, which reloads for itself).
+    Nothing about the sharp jobs had changed. Assert the claim directly.
+    """
+    return next(
+        line
+        for line in installer.split("\n")
+        if line.lstrip().startswith("if [[") and line.count("_needs_install}") > 1
+    )
+
+
 def test_normal_deploy_installs_and_kicks_all_sharp_population_jobs():
     installer = (ROOT / "deploy" / "install-systemd-service.sh").read_text()
     deploy = (ROOT / "deploy" / "deploy.sh").read_text()
-    assert "sharp_needs_install" in installer.split("daemon-reload", 1)[0]
-    assert "sharprec_needs_install" in installer.split("daemon-reload", 1)[0]
-    assert "ffpc_needs_install" in installer.split("daemon-reload", 1)[0]
+    reload_condition = _daemon_reload_condition(installer)
+    assert "sharp_needs_install" in reload_condition
+    assert "sharprec_needs_install" in reload_condition
+    assert "ffpc_needs_install" in reload_condition
     assert 'start --no-block "${sharprec_service_name}.service"' in installer
     assert 'start --no-block "${ffpc_service_name}.service"' in installer
     assert 'is-enabled "${timer_unit}"' in deploy


### PR DESCRIPTION
Found while verifying that #707's FAAB work had actually reached production. It had — but its timer had not, and neither had two others.

## The defect

`deploy/systemd/` ships **16** timer templates. `install-systemd-service.sh` had **13** hand-written blocks. Three templates had no installer at all:

| stem | producer | shipped in |
|---|---|---|
| `crowd-faab` | `scripts/fetch_crowd_faab.py` | #707 (mine) |
| `sharp-activity` | `scripts/crawl_sharp_activity.py` | pre-existing |
| `board-snapshot` | `scripts/snapshot_board.py` | pre-existing |

Committed, reviewed, merged — and never once rendered onto the box. Their producers never ran and every deploy still reported success.

## Why it is a loop, not a dormant file

`deploy.sh` decides whether to invoke the installer by globbing **that same directory** and asking systemd whether each unit is installed *and* enabled:

```bash
for timer_template in "${APP_DIR}"/deploy/systemd/*.timer.template; do
  ...
  if ! sudo -n "${SYSTEMCTL_BIN}" cat "${timer_unit}" >/dev/null 2>&1 || \
     ! sudo -n "${SYSTEMCTL_BIN}" is-enabled "${timer_unit}" >/dev/null 2>&1; then
    missing_timers="${missing_timers} ${timer_unit}"
  fi
done
```

So an unwired template is reported missing on **every** deploy, which runs the installer to add it, which does not add it. Forever, and quietly, because the report is only a `warn`.

That detector was itself written after the 2026-07-30 finding recorded in `deploy.sh`'s own comment — nine timer pairs shipped, two installed, `journalctl -u dynasty-bdvm-refresh` empty while `/api/bdvm/*` served nothing. The detector correctly spotted these three. Nothing on the other end could act on it.

## The fix

`install_simple_timer <stem> <label>` covers any timer whose install is just "render both templates, enable it". Timers with real special cases — credential gating, an initial kick, seeding a session file into `/var/lib` — keep their dedicated blocks; this is additive, and no existing block is touched.

One subtlety is load-bearing: the helper re-checks **enablement separately**, not only when it just wrote the files. `deploy.sh`'s detector requires both `cat` *and* `is-enabled`, so a unit that reached disk without being enabled produces the identical permanent loop as one that never reached disk.

## The `ce_needs_install` hole, where it was still open

The installer carries a comment explaining that `ce_needs_install` had been missing from the `daemon-reload` chain — "the failure mode where the fix is deployed, reported as deployed, and not running." That fix added one flag by hand and left two behind:

```
declared:  alerts backend bdvm ce custom_alerts dlf_fetch ffpc frontend
           idpshow_fetch playerctx rd sharp sharprec sharpros sharptx
in chain:  ... sharprec ffpc rd dlf_fetch idpshow_fetch
missing:   sharpros, sharptx        ← both gate an `enable --now`
```

A run installing only sharp-rosters or sharp-transactions enabled it against a systemd that had never re-read the unit. Both added.

## The guard

Three per-timer guards already existed — `test_reception_depth_timer_is_wired.py`, `test_consensus_edge_snapshot_timer_is_wired.py`, `test_ffpc_sharp_timer_is_wired.py` — each written after **that** timer was found unwired. One guard per incident closes the last hole and waits for the next; by 2026-08-05 the next three were already in the tree.

`tests/deploy/test_all_timers_are_wired.py` derives both invariants from the tree instead of restating them:

- every `*.timer.template` is reached by some install route (dedicated block **or** helper call)
- every `*_needs_install` flag reaches the `daemon-reload` chain

Adding a timer updates the expectation automatically; forgetting to wire it fails here rather than on the box six weeks later. Plus a generalisation of reception-depth's own check: every `ExecStart` that names an `__APP_DIR__/` path must point at a file that exists.

## Verification

**Mutation-tested** — each goes red, none of it is green-by-construction:

| mutation | fails |
|---|---|
| delete `install_simple_timer "crowd-faab"` | `test_every_timer_template_is_installed_by_something` |
| drop `sharpros` from the reload chain | `test_every_needs_install_flag_reaches_the_daemon_reload` |
| nest the enable inside the install branch | `test_the_helper_enables_even_when_the_unit_was_already_on_disk` |

**Executed, not just linted.** The helper was driven against stubbed `sudo`/`systemctl`/`install` across four states, since unexecuted bash is the exact class of bug being fixed here:

```
run 1 (fresh box)             install service + timer, daemon-reload, enable
run 2 (idempotent re-deploy)  silent no-op
run 3 (on disk, disabled)     re-enables without rewriting
run 4 (template absent)       silent return
```

Rendered units carry no unsubstituted `__PLACEHOLDER__`, and `ExecStart` resolves to `/opt/venv/bin/python <APP_DIR>/scripts/fetch_crowd_faab.py`.

**Gates**: 6375 passed, 26 skipped (`-m "not livedata"`). `ruff format --check .` and `ruff check .` clean repo-wide. `bash -n` clean on both deploy scripts.

## One thing I deliberately did NOT change

`test_every_timer_resolves_to_a_service_that_ships` accepts two spellings, because two are legal and both are in the tree: most templates name the target with `Unit=__SERVICE_NAME__-<stem>.service`, while `dlf-fetch` and `idpshow-fetch` omit it and take systemd's implicit same-name default.

While confirming that, I noticed five timers carry `Requires=` in `[Unit]` — which the repo's own templates and `test_reception_depth_timer_is_wired.py` warn against, since it force-starts the service on every boot and lets a service failure deactivate the timer. `dlf-fetch` and `idpshow-fetch` additionally hardcode `Requires=dynasty-…` rather than `__SERVICE_NAME__-…`, which is latent only because `SERVICE_NAME` is `dynasty` everywhere today.

That is a real pre-existing issue across five working production timers, and rewriting their boot semantics is a different change from wiring three that never ran. Reported rather than bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfyGg2NcQBQcZ1Lq8XxwpB

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfyGg2NcQBQcZ1Lq8XxwpB)_