### PR TITLE
Perfect Draft: make --record-snapshot work, and correct two stale claims

### DIFF
--- a/docs/perfect-draft.md
+++ b/docs/perfect-draft.md
@@ -427,9 +427,19 @@ structurally prevents one team's results reaching another.
   `dynasty_new` has 5. Nothing in this codebase ingests Sleeper's per-player
   taxi assignment; the payload carries `taxiSlotsAvailable` (default 0) and
   says so in `notes` rather than guessing.
-- **Second league unsupported.** The Sleeper-derived draft-capital fallback
-  emits no rookie fields, so `/draft` there falls back to a hardcoded rookie
-  list. The panel vanishes rather than optimizing against placeholders.
+- **Second league gets the board but not the panel**, and the reason changed.
+  This entry used to say the Sleeper-derived draft-capital fallback "emits no
+  rookie fields, so `/draft` there falls back to a hardcoded rookie list". That
+  is no longer true: `_serialize_pick` staples the real rookie board onto the
+  current season's slots (`src/api/draft_capital_fallback.py`), so `dynasty_new`
+  sees genuine rookie names and values on `/draft`.
+
+  The panel still vanishes there, for a different and unchanged reason: the
+  optimizer needs that league's **rosters**, not its rookie fields.
+  `GET /api/draft/roster-context` gates on whether the loaded contract's
+  `leagueKey` matches the request, and the server holds one league's rosters at
+  a time. So this unblocks when the second league's rosters are loaded — not
+  when the fallback improves.
 - **RESOLVED (2026-08-04), and the fix did not do what this entry predicted.**
   The flat per-addition waiver charge is gone, replaced by the `R(k)` ladder in
   §5, and the auction's own rookies no longer count as free agents. But this

--- a/scripts/backtest_perfect_draft.py
+++ b/scripts/backtest_perfect_draft.py
@@ -41,6 +41,13 @@ Usage::
         --snapshot data/draft_backtest/2026-pre.json \\
         --results  data/draft_backtest/2026-results.json
 
+``--record-snapshot`` reads the contract the running server would serve, but it
+does not need one running: it primes from the same on-disk cache the FastAPI
+lifespan primes from.  It does need whatever ``import server`` needs, which on
+prod is the systemd unit's ``.env`` (``JASON_LOGIN_PASSWORD``); on a dev box
+export ``ALLOW_DEFAULT_LOGIN_DEV=1`` instead.  Run it on **prod**, where the
+scraped ``data/dynasty_data_*.json`` and the league's rosters actually live.
+
 Exit codes follow the repo's script convention: 0 success, 1 error, 2 skipped
 (nothing to do). A missing corpus is **2**, not 0 — "no data" must not read as
 "passed".
@@ -91,8 +98,32 @@ def record_snapshot(out_dir: Path, league_key: str | None) -> int:
 
     contract = getattr(server, "latest_contract_data", None)
     if not contract:
+        # ``latest_contract_data`` is populated inside the FastAPI *lifespan*
+        # (``load_from_disk`` then ``_prime_latest_payload`` in ``server.py``),
+        # and importing the module does not run it.  So from a cold shell this
+        # global is always ``None`` and the capture below could never happen —
+        # which made the one step that is unrecoverable once the auction starts
+        # the one step that did not work.  Do what lifespan does; both are
+        # plain module-level functions that read the on-disk cache and need no
+        # running app.
+        #
+        # ``is_fresh_scrape`` is left at its default False, exactly as the
+        # lifespan call does: priming from cached disk data must not append a
+        # "today" entry to the rank history.  Capturing a snapshot is an
+        # observation and must not itself alter the record.
+        try:
+            server._prime_latest_payload(server.load_from_disk())  # noqa: SLF001
+        except Exception as exc:  # noqa: BLE001
+            print(f"ERROR: could not load the cached contract ({exc})", file=sys.stderr)
+            return EXIT_ERROR
+        contract = getattr(server, "latest_contract_data", None)
+    if not contract:
+        # Genuinely nothing on disk either. Still SKIPPED rather than OK — "no
+        # data" must not read as "captured".  Note this no longer means "start
+        # the server": the disk cache has now been consulted directly, so if it
+        # were there this would have found it.  Only a scrape fixes this.
         print(
-            "SKIPPED: no contract loaded — start the server or run a scrape first.",
+            "SKIPPED: no contract cached on disk — run a scrape first.",
             file=sys.stderr,
         )
         return EXIT_SKIPPED

--- a/server.py
+++ b/server.py
@@ -8748,10 +8748,17 @@ async def get_draft_roster_context(
             },
         )
     # The league-match gate is what scopes this feature to the league whose
-    # rosters are actually loaded.  A league served only by the Sleeper-derived
-    # draft-capital fallback has no genuine rookie pool on /draft, and would
-    # also fail this check — so the panel vanishes rather than optimizing
-    # against placeholder players.
+    # rosters are actually loaded.  Every figure the optimizer needs — open
+    # spots, the cut ladder, waiver levels — is derived from THIS league's
+    # rosters, and the server holds one league's at a time, so serving another
+    # league's would be wrong rather than merely incomplete.
+    #
+    # This comment used to justify the gate by saying a league served only by
+    # the Sleeper-derived draft-capital fallback "has no genuine rookie pool on
+    # /draft, and would also fail this check".  The first half stopped being
+    # true when ``_serialize_pick`` began stapling the real rookie board onto
+    # that path; the gate is unchanged and still correct, because it turns on
+    # rosters and never on rookie fields.
     loaded_meta = (contract.get("meta") or {}) if isinstance(contract, dict) else {}
     loaded_league = loaded_meta.get("leagueKey")
     if loaded_league and loaded_league != league_cfg.key:

--- a/tests/draft/test_backtest_snapshot_hydration.py
+++ b/tests/draft/test_backtest_snapshot_hydration.py
@@ -1,0 +1,120 @@
+"""``--record-snapshot`` must work from a cold shell, because nothing else can.
+
+The pre-draft board and every team's roster context stop being recoverable the
+moment the first rookie pick lands, and no code recovers an observation nobody
+made — so this capture is the one step in the whole backtest chain whose window
+closes permanently.  It is also the only one that unblocks fitting
+``PRICE_DISPERSION_PRIOR``.
+
+It did not work.  ``record_snapshot`` reads ``server.latest_contract_data``,
+which is populated inside the FastAPI *lifespan* (``load_from_disk`` then
+``_prime_latest_payload``).  Importing the module does not run lifespan, so from
+a plain ``python scripts/backtest_perfect_draft.py --record-snapshot`` the
+global was always ``None`` and the script exited 2 — "start the server or run a
+scrape first" — on a machine whose disk cache was sitting right there.
+
+What is pinned:
+
+* the hydration fallback runs, and a snapshot lands, when the global is unset
+  but the on-disk cache has a contract;
+* it is a FALLBACK — an already-primed process is not re-primed, so a live
+  server's in-memory generation is never swapped underneath it;
+* a genuinely empty disk still exits 2, never 0.  "No data" must not read as
+  "captured", which is the same reason the corpus check exits 2 rather than 0.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from scripts.backtest_perfect_draft import EXIT_OK, EXIT_SKIPPED, record_snapshot
+
+_CONTRACT = {"meta": {"leagueKey": "dynasty_main"}}
+
+
+def _fake_server(*, primed, on_disk):
+    """A stand-in for the real ``server`` module.
+
+    Deliberately not the real one: importing it pulls the whole app in, and the
+    behaviour under test is entirely about which of two globals is populated
+    and when.
+    """
+    mod = types.ModuleType("server")
+    mod.latest_contract_data = _CONTRACT if primed else None
+    mod.DRAFT_TOTAL_BUDGET = 1200
+    mod._KTC_TOTAL_PICKS = 72
+    mod.prime_calls = []
+
+    def load_from_disk():
+        return dict(on_disk) if on_disk else None
+
+    def _prime_latest_payload(data, *, is_fresh_scrape=False):
+        mod.prime_calls.append(data)
+        mod.latest_contract_data = data
+
+    def _our_rookie_pool(_n):
+        return [{"name": "Jeremiyah Love", "pos": "RB", "value": 7798.0}]
+
+    def _rookie_dollars_from_values(values, _budget):
+        return [135 for _ in values]
+
+    mod.load_from_disk = load_from_disk
+    mod._prime_latest_payload = _prime_latest_payload
+    mod._our_rookie_pool = _our_rookie_pool
+    mod._rookie_dollars_from_values = _rookie_dollars_from_values
+    return mod
+
+
+@pytest.fixture
+def fake_context(monkeypatch):
+    """Stub ``src.draft.context`` so the test isolates the hydration path."""
+    ctx = types.ModuleType("src.draft.context")
+    ctx.CONTEXT_VERSION = "test.v1"
+    ctx.list_draft_teams = lambda _c: [{"name": "Alpha"}]
+    ctx.build_roster_context = lambda _c, _k, team_name=None: {
+        "team": {"name": team_name},
+        "openRosterSpots": 5,
+    }
+    monkeypatch.setitem(sys.modules, "src.draft.context", ctx)
+    return ctx
+
+
+def test_a_cold_process_hydrates_from_disk_and_captures(tmp_path, monkeypatch, fake_context):
+    """The regression: unset global + populated disk must still capture."""
+    server = _fake_server(primed=False, on_disk=_CONTRACT)
+    monkeypatch.setitem(sys.modules, "server", server)
+
+    assert record_snapshot(tmp_path, None) == EXIT_OK
+
+    written = list(tmp_path.glob("*-pre.json"))
+    assert len(written) == 1, "the capture is the whole point; it must land on disk"
+    assert server.prime_calls == [_CONTRACT], "hydration should run exactly once"
+
+
+def test_an_already_primed_process_is_not_re_primed(tmp_path, monkeypatch, fake_context):
+    """It is a fallback, not an unconditional reload.
+
+    Re-priming a live server would swap its in-memory generation for whatever
+    happens to be on disk — a different contract from the one whose board is
+    being captured.
+    """
+    server = _fake_server(primed=True, on_disk={"meta": {"leagueKey": "stale_from_disk"}})
+    monkeypatch.setitem(sys.modules, "server", server)
+
+    assert record_snapshot(tmp_path, None) == EXIT_OK
+    assert server.prime_calls == [], "a primed process must not be re-primed"
+    assert server.latest_contract_data is _CONTRACT
+
+
+def test_an_empty_disk_still_skips_rather_than_claiming_success(
+    tmp_path, monkeypatch, fake_context
+):
+    """Exit 2, not 0 — "nothing to capture" must not read as "captured"."""
+    server = _fake_server(primed=False, on_disk=None)
+    monkeypatch.setitem(sys.modules, "server", server)
+
+    assert record_snapshot(tmp_path, None) == EXIT_SKIPPED
+    assert list(tmp_path.glob("*-pre.json")) == []


### PR DESCRIPTION
## The pre-draft capture could not run

`scripts/backtest_perfect_draft.py --record-snapshot` is the only step that
unblocks **both** backtesting and fitting `PRICE_DISPERSION_PRIOR`, and its
window closes permanently when the first 2026 rookie pick lands — the pre-draft
board and every team's roster context stop being recoverable, and no code
recovers an observation nobody made. The script's own docstring says "Run BEFORE
the auction; it is the step whose absence blocks every past season."

**It did not work.** `record_snapshot` reads `server.latest_contract_data`, but
that global is populated inside the FastAPI *lifespan* — `load_from_disk()` then
`_prime_latest_payload(...)` at `server.py:2594-2595` — and importing the module
does not run lifespan. So a plain `python scripts/backtest_perfect_draft.py
--record-snapshot` always saw `None` and exited **2** ("start the server or run a
scrape first") on a machine whose disk cache was sitting right there.
`data/draft_backtest/` does not exist anywhere in the tree, consistent with it
never having run.

It now primes from the same on-disk cache lifespan primes from. Both functions
are plain module-level (`server.py:2065`, `:1748`) and need no running app.

Two properties that are load-bearing:

- **`is_fresh_scrape` stays at its default `False`**, exactly as the lifespan
  call does. Capturing a snapshot is an observation and must not append a
  "today" entry to the rank history.
- **It is a fallback, not an unconditional reload.** An already-primed process
  is not re-primed — doing so would swap a live server's in-memory generation
  for whatever is on disk, i.e. a different board from the one being captured.

The genuinely-empty case still exits **2**, never 0 — "no data" must not read as
"captured", the same reason the corpus check exits 2. Its message no longer says
"start the server", because the disk cache has now been consulted directly; only
a scrape fixes that state.

### Verified end to end

From a cold shell, with a contract present, the capture exits 0 and carries real
data:

```
Wrote data/draft_backtest/2026-08-05-pre.json (72 rookies, 12 rosters).

leagueKey: dynasty_main   rookies: 72   contexts: 12
sample ctx: openRosterSpots 5, cutLadder.rungs 30, waiverLadder 90
sample rookie: Jeremiyah Love RB boardValue 7798.0 preDraft 135.5
```

Three tests pin the behaviour, and the first **fails against the unfixed
script** (exit 2 vs 0): hydration happens when the global is unset, does not
happen when the process is already primed, and an empty disk still skips.

The module docstring now also records what `import server` requires
(`JASON_LOGIN_PASSWORD` on prod, `ALLOW_DEFAULT_LOGIN_DEV=1` on a dev box), and
that this must be run on prod where the scraped contract and rosters live —
that was the other thing standing between an operator and a capture.

## Two stale claims about the second league

Phase 5 made `_serialize_pick` staple the real rookie board onto the
Sleeper-derived draft-capital path, so `dynasty_new` gets genuine rookie names
and values on `/draft`. Two places still said it emits none:

- `docs/perfect-draft.md` §9 claimed `/draft` there "falls back to a hardcoded
  rookie list".
- the `/api/draft/roster-context` league gate justified itself with "a league
  served only by the Sleeper-derived draft-capital fallback has no genuine
  rookie pool on /draft, and would also fail this check".

**The gate is unchanged and still correct.** It turns on whether that league's
*rosters* are loaded, never on rookie fields, and the server holds one league's
rosters at a time. Only the stated reason was stale. Both now say what is
actually true: the second league gets the board but not the panel, and that
unblocks when its rosters load, not when the fallback improves.

No behaviour changes in this half — documentation and one comment.

## Verification

Backend-only; no frontend file is touched, so the vitest and bundle-budget gates
carry over from main unchanged.

| Gate | Result |
|---|---|
| `ruff format --check .` | clean |
| `ruff check .` | All checks passed |
| `pytest tests/draft/test_backtest_snapshot_hydration.py` | 3 passed; 1 fails without the fix |
| `pytest tests/ -x -q -m "not livedata"` | running at time of opening — will report |

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6oCgi8MGEbZUUh9LsTGtu)_