### PR TITLE
Make a green E2E run mean the product is healthy

### DIFF
--- a/.github/workflows/prod-e2e-smoke.yml
+++ b/.github/workflows/prod-e2e-smoke.yml
@@ -87,6 +87,24 @@ jobs:
         shell: bash
         env:
           E2E_BASE_URL: ${{ steps.url.outputs.url }}
+          # This job runs ONE spec, not the full suite, so the reporter's
+          # default floor — sized for the nightly's 139 passed — would
+          # fail every prod smoke run.  Measured on run 30953000224
+          # (5349fea29, 2026-08-04 21:35Z): "32 passed (1.3m)", tests
+          # numbered [1/32]..[32/32], zero skipped = 16 tests x 2 chromium
+          # projects.
+          #
+          # 30 rather than 32: a floor equal to the exact count fires on
+          # any legitimate consolidation of two tests, and a floor that
+          # gets "adjusted" every quarter stops being believed.  30 still
+          # catches what this exists for — a spec-path typo or a project
+          # filter matching nothing takes the count to 0 or 16, not 31.
+          E2E_MIN_PASSED: "30"
+          # Zero, and it CAN be zero: public-league.spec.js has no
+          # conditional skips left — its three data-condition gates were
+          # converted to assertions.  Any skip here means a gate came
+          # back, which is exactly what we want to hear about.
+          E2E_MAX_SKIPPED: "0"
         run: |
           set -Eeuo pipefail
           # Chromium desktop + mobile viewport.  We intentionally skip
@@ -94,12 +112,27 @@ jobs:
           # require ``playwright install webkit`` and don't buy us
           # anything over the chromium mobile viewport for the public
           # /league layout coverage.
+          #
+          # NO `--reporter` FLAG.  It REPLACES playwright.config.js's
+          # whole reporter array, which unloaded stack-death-reporter.js
+          # and with it BOTH the stack-death abort AND the coverage floor
+          # — for every prod smoke run this workflow made before
+          # 2026-08-05.  The reporter's own header warns about this in
+          # capitals; this workflow did it anyway, which is the same
+          # never-fires class the guard was written to catch.
+          # tests/e2e/test_e2e_harness_guards.py now fails the PR if any
+          # workflow reintroduces the flag.
+          #
+          # Side effect worth knowing: the config's reporters are `list`
+          # + `html`.  `list` is what `--reporter=line` was approximating,
+          # and `html` now actually populates tests/e2e/playwright-report/,
+          # which the failure-artifact step below has been uploading empty
+          # since it was written.
           npx playwright test \
             -c tests/e2e/playwright.config.js \
             --project=desktop-1366 \
             --project=mobile-chromium \
-            tests/e2e/specs/public-league.spec.js \
-            --reporter=line
+            tests/e2e/specs/public-league.spec.js
 
       - name: Upload Playwright trace artifacts on failure
         if: failure()

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -172,6 +172,24 @@ pass; the journey specs above are their Next.js-era replacements.
    (`screenshot: only-on-failure`, `video: retain-on-failure`,
    `trace: on-first-retry`) — check `test-results/` or the CI
    artifact.
+8. **A flaky pass is a failure.**  `retries: 1` in CI exists for the
+   trace, not for a second opinion: `failOnFlakyTests` in
+   `playwright.config.js` fails any run where a test passed only on
+   retry.  Before that key landed, Playwright reported such a run as
+   `passed` / exit 0 and nothing read the flaky count — so `e2e.yml`'s
+   close step would retire the open `e2e-failures` issue on a run that
+   had watched a critical journey fail.
+   The key lives in the config, not in `stack-death-reporter.js`,
+   because `--reporter=…` on the command line replaces the reporter
+   array and unloads every guard in that file; a CLI flag cannot unload
+   a config key.  The reporter prints the explanation and deliberately
+   returns no status.  `E2E_ALLOW_FLAKY=1` is for a local session
+   chasing something else — `test_e2e_harness_guards.py` fails the PR
+   if a workflow sets it.
+   Convention 5's rule has no exceptions left, either: the last
+   conditional skip that could hide a live defect — the settings
+   override journey's base-contract-fallback skip — is now an
+   assertion.
 
 ## CI
 

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -116,6 +116,51 @@ module.exports = defineConfig({
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
+  // Retries stay at 1 so `trace: "on-first-retry"` below still captures a
+  // failing attempt — that trace is what makes a flake debuggable at all.
+  // What changes here is what a retried pass MEANS.
+  //
+  // Playwright's run status for "failed attempt 0, passed attempt 1" is
+  // `passed`, exit 0: the test is filed as FLAKY and the run is green.
+  // Measured 2026-08-05 by grepping every workflow and all of tests/e2e/:
+  // NOTHING read that flaky count.  So `e2e.yml`'s close step — gated on
+  // `success() && github.ref == 'refs/heads/main'` — would CLOSE the
+  // `e2e-failures` tracker on a run that watched a critical journey fail
+  // and then pass, and it iterates `.[]`, so it drains every open one.
+  // Its stated premise is "a green run of THIS workflow is the all-clear
+  // by construction".  A silent retry in front of it broke that premise.
+  //
+  // #718 scoped that close step to mainline runs — it fixed WHO may speak
+  // for main.  This is the half it explicitly left open: HOW MUCH one
+  // green run proves.
+  //
+  // There IS a live intermittent defect for a retry to launder: React
+  // streaming leaves its `<div id="S:1">` staging copy in the DOM, so a
+  // page's markup exists twice and any non-`.first()` locator throws a
+  // strict-mode violation.  The suite's only two windows onto it are
+  // journey-trade.spec.js (/arbitrage) and waivers-smoke.spec.js
+  // (/waivers) — one retry hides both.
+  //
+  // THIS LIVES IN THE CONFIG, NOT IN stack-death-reporter.js, AND THAT
+  // PLACEMENT IS THE WHOLE POINT.  A `--reporter=…` on the command line
+  // REPLACES the reporter array below and unloads every guard in that
+  // file — see its header, and what prod-e2e-smoke.yml did for its entire
+  // history.  A CLI flag cannot unload a config key, and
+  // `--fail-on-flaky-tests` can only set it TRUE: program.js emits
+  // `true` or `undefined`, never `false`, and common/config.js resolves
+  // `takeFirst(cliOverride, userConfig, false)`.  Putting the predicate
+  // in the reporter would have rebuilt the exact defect this PR removes.
+  //
+  // The predicate is Playwright's own `TestCase.outcome() === "flaky"`
+  // (runner/failureTracker.js), evaluated BEFORE onEnd — the same word
+  // the HTML report prints.  stack-death-reporter.js adds a banner
+  // explaining the red; it deliberately returns no status.
+  //
+  // E2E_ALLOW_FLAKY=1 is the hatch for a human chasing something else
+  // locally.  tests/e2e/test_e2e_harness_guards.py fails the PR if a
+  // workflow sets it, or if `retries` keeps a non-zero CI branch while
+  // this key goes missing.
+  failOnFlakyTests: !!process.env.CI && !process.env.E2E_ALLOW_FLAKY,
   workers: process.env.CI ? 1 : undefined,
   outputDir: "test-results",
   reporter: [

--- a/tests/e2e/specs/journey-settings-overrides.spec.js
+++ b/tests/e2e/specs/journey-settings-overrides.spec.js
@@ -50,6 +50,21 @@ test.describe("journey: settings source toggles", () => {
     test.setTimeout(180_000);
     const guard = attachConsoleGuards(page);
 
+    // Collect the app's base-contract fallback warnings from the START of
+    // the journey.  This listener used to be attached further down, after
+    // the first round-trip had already been asserted — so it watched an
+    // arbitrary window that began once the thing it was diagnosing had
+    // already succeeded.  Its output is now folded into the badge failure
+    // message below, which is the only place it is read.
+    const fallbackWarnings = [];
+    page.on("console", (msg) => {
+      if (msg.type() !== "warning") return;
+      const text = msg.text() || "";
+      if (text.includes("/api/rankings/overrides") || text.includes("falling through to base contract")) {
+        fallbackWarnings.push(text);
+      }
+    });
+
     await page.goto(pageUrl("/settings"), { waitUntil: "domcontentloaded" });
     const toggles = page.locator('input.settings-src-toggle[aria-label^="Include "]');
     await expect(toggles.first()).toBeVisible({ timeout: 30_000 });
@@ -88,37 +103,69 @@ test.describe("journey: settings source toggles", () => {
     // render from the base contract while that second round-trip is
     // still in flight.
     //
-    // Degradation caveat: fetchDynastyData deliberately falls back to
-    // the base contract (with a console.warn) when the overrides POST
-    // fails — e.g. a starved runner timing out the CPU-heavy blend
-    // recompute.  That fallback is designed behavior, not the
-    // regression this spec exists to catch (the round-trip itself was
-    // hard-asserted above), so when the app logs that exact warning
-    // we skip the badge assertion instead of failing on it.
-    const fallbackWarnings = [];
-    page.on("console", (msg) => {
-      if (msg.type() !== "warning") return;
-      const text = msg.text() || "";
-      if (text.includes("/api/rankings/overrides") || text.includes("falling through to base contract")) {
-        fallbackWarnings.push(text);
-      }
-    });
+    // This block used to `test.skip` when the badge never appeared AND
+    // the app had logged its base-contract fallback warning.  That reads
+    // as honest — the first round-trip IS hard-asserted above — but
+    // docs/e2e-assertion-audit.md measured the skip firing ROUTINELY,
+    // reason "...Failed to fetch".  A product degradation that reports as
+    // a green skip is the one thing tests/e2e/README.md's convention 5
+    // forbids: "Skip cleanly on absent INFRA — never on absent DATA."  A
+    // degraded overrides endpoint is the product failing, not absent
+    // infrastructure.
+    //
+    // The audit's own remedy was "a floor on consecutive skips, or
+    // removal once the endpoint is reliable".  Playwright keeps no
+    // cross-run state, so a consecutive-skip floor means a new counter
+    // in e2e.yml — more machinery than the thing it guards, firing a day
+    // late, and a second place where "green" gets computed.
+    //
+    // So: removal, with a MORE specific assertion in its place rather
+    // than a weaker one.  /rankings fires its OWN overrides POST during
+    // hydration; that second round-trip is what the badge depends on and
+    // what the skip was silently forgiving.  Assert it directly, so a
+    // failure says "the second overrides POST returned 503" instead of
+    // "badge missing, cause unknown".  The underlying fragility is
+    // docs/e2e-assertion-audit.md §3.3 — the Next proxy routes' hard 3s
+    // abort — which is product-side and not this spec's to hide.
+    //
+    // Note this also restores guard.assertClean() below: test.skip()
+    // throws, so on the skip path every browser console error collected
+    // on this journey was discarded too.
+    const rehydrateOverrides = page
+      .waitForResponse(
+        (res) =>
+          res.url().includes("/api/rankings/overrides") &&
+          res.request().method() === "POST",
+        { timeout: 90_000 },
+      )
+      .catch(() => null);
 
     const rows = await gotoRankingsBoard(page);
     expect(await rows.count()).toBeGreaterThan(50);
+
+    const rehydrateResponse = await rehydrateOverrides;
+    expect(
+      rehydrateResponse,
+      "/rankings should re-fire the overrides POST on hydration — without it the custom mix is never applied",
+    ).not.toBeNull();
+    expect(
+      rehydrateResponse.status(),
+      "the /rankings-side overrides round-trip should also recompute successfully",
+    ).toBe(200);
 
     const badge = page.locator('[aria-label="Custom source mix active"]').first();
     const badgeVisible = await badge
       .waitFor({ state: "visible", timeout: 60_000 })
       .then(() => true)
       .catch(() => false);
-    if (!badgeVisible && fallbackWarnings.length > 0) {
-      test.skip(
-        true,
-        `override endpoint degraded to base-contract fallback on this run (${fallbackWarnings[0]}) — round-trip already asserted`,
-      );
-    }
-    expect(badgeVisible, "custom-mix badge should appear once a source is disabled").toBeTruthy();
+    expect(
+      badgeVisible,
+      `custom-mix badge should appear once a source is disabled${
+        fallbackWarnings.length > 0
+          ? ` — the app logged a base-contract fallback: ${fallbackWarnings[0]}`
+          : ""
+      }`,
+    ).toBeTruthy();
 
     guard.assertClean();
   });

--- a/tests/e2e/stack-death-reporter.js
+++ b/tests/e2e/stack-death-reporter.js
@@ -116,18 +116,60 @@ async function findDeadOrigin() {
 // never-fires class as a workflow that cannot start: absence of
 // failure read as evidence of success.
 //
-// Measured baseline on the chromium desktop + mobile projects:
-// ~149 passed / 29 skipped.  The 29 are deliberate project gating
-// (desktop journeys skipped on the mobile project and vice versa,
-// plus fixed-viewport visual suites).  The floor sits well under the
-// baseline so ordinary drift doesn't trip it, but a run where a whole
-// layer silently stopped executing — an env var lost, a fixture
-// skipping, a project filter typo — lands far below it.
+// Measured baseline, chromium desktop + mobile, read from the summary
+// line of run 30945387957 (aa6f415f2, 2026-08-04, dispatched on main):
+//
+//     49 skipped
+//     139 passed (1.9m)
+//
+// The comment this replaces claimed "~149 passed / 29 skipped" and said
+// the ceiling existed because "well above ~29 means a whole layer
+// stopped running".  Skips had drifted 29 -> 49 against a ceiling of 60
+// and nothing fired, so the guard's STATED tolerance and its REAL
+// tolerance had come apart — the ORCHESTRATION.md 6.15 shape, inside
+// the file written to prevent it.  Re-derive both numbers from a named
+// green run before changing them, and cite the run.
+//
+// The floor still sits under the baseline so ordinary drift doesn't
+// trip it, but a run where a whole layer silently stopped executing —
+// an env var lost, a fixture skipping, a project filter typo — lands
+// far below it.
 //
 // Deliberately a FAILURE, not a warning: a warning in a green run is
 // something nobody reads.
-const MIN_EXPECTED_PASSED = Number(process.env.E2E_MIN_PASSED || 100);
-const MAX_EXPECTED_SKIPPED = Number(process.env.E2E_MAX_SKIPPED || 60);
+//
+// Parsed, not coerced, and that matters as of the same change that
+// wrote this: `Number("3O")` is NaN, and BOTH `passed < NaN` and
+// `skipped > NaN` are false — one typo in a workflow's `env:` block
+// would disable this entire guard while the banner it prints claims the
+// opposite.  That hole was unreachable while nothing set these vars;
+// prod-e2e-smoke.yml now sets them by hand in YAML, so it is reachable.
+// Empty string is treated as unset rather than 0, because
+// `E2E_MAX_SKIPPED: ""` reads as "I set the ceiling to zero" and would
+// otherwise silently land on the default of 60.
+function coverageBound(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) {
+    throw new Error(
+      `${name}="${raw}" is not a number.  Refusing to run: an unparseable ` +
+        `coverage bound disables the floor silently and the run reports green.`,
+    );
+  }
+  return n;
+}
+
+// 120, raised from 100 against the measured 139.  At 100 a run could
+// lose 39 of the suite's tests and still clear the floor — more than a
+// quarter of it — which is a lot of silence for a guard whose banner
+// says "this green is not trustworthy".  120 keeps 19 tests of headroom
+// for ordinary drift.  The skip ceiling stays at 60 against a measured
+// 49: project gating moves in steps of 2-4 whenever a describe block
+// gains desktopOnly/mobileOnly, and a bound that needs adjusting every
+// quarter stops being believed.
+const MIN_EXPECTED_PASSED = coverageBound("E2E_MIN_PASSED", 120);
+const MAX_EXPECTED_SKIPPED = coverageBound("E2E_MAX_SKIPPED", 60);
 
 class StackDeathReporter {
   constructor() {
@@ -135,6 +177,20 @@ class StackDeathReporter {
     this.tripped = false;
     this.completed = 0;
     this.counts = { passed: 0, skipped: 0, failed: 0 };
+    this.rootSuite = null;
+  }
+
+  /**
+   * Held only so onEnd can ask Playwright which tests ended up flaky,
+   * using Playwright's own predicate (`TestCase.outcome()`) rather than
+   * a hand-rolled retry count.  `result.retry > 0 && status === "passed"`
+   * is close but not the same: outcome() also weighs `expectedStatus`,
+   * and a test whose first attempt fails and whose retry hits a dynamic
+   * `test.skip()` scores "unexpected", not "flaky".  One predicate, and
+   * it is the same word the HTML report's badge uses.
+   */
+  onBegin(_config, suite) {
+    this.rootSuite = suite || null;
   }
 
   onTestEnd(test, result) {
@@ -189,6 +245,66 @@ class StackDeathReporter {
   }
 
   /**
+   * Name the flaky tests.  DIAGNOSTIC ONLY — read this before moving it.
+   *
+   * The run is already red by the time this executes.  `failOnFlakyTests`
+   * in playwright.config.js is what fails it: failureTracker.result()
+   * consults it and is computed BEFORE onEnd is called.  This block
+   * deliberately returns no status, and must not start.
+   *
+   * DO NOT move the flaky predicate into this file.  A `--reporter=…` on
+   * the command line REPLACES the config's reporter array and unloads
+   * this module whole — see the header above; that is how the
+   * stack-death guard was once "verified" while never running, and it is
+   * how every prod-e2e-smoke run before 2026-08-05 executed with no
+   * guards at all.  A config key survives that flag; this printout does
+   * not.  Two mechanisms on purpose: one that cannot be unloaded, and
+   * one that explains.
+   *
+   * What this adds over Playwright's own "N flaky" line is WHY the run
+   * is red and what to check first.
+   */
+  _reportFlaky() {
+    if (process.env.E2E_ALLOW_FLAKY) return;
+    if (!this.rootSuite || typeof this.rootSuite.allTests !== "function") return;
+    const flaky = this.rootSuite
+      .allTests()
+      .filter((t) => typeof t.outcome === "function" && t.outcome() === "flaky");
+    if (flaky.length === 0) return;
+
+    const line = "═".repeat(72);
+    const names = flaky
+      .map((t) => `  • ${t.titlePath().slice(1).filter(Boolean).join(" › ")}`)
+      .join("\n");
+    process.stderr.write(
+      `\n${line}\n` +
+        `E2E FLAKY — THIS GREEN WAS EARNED ON A RETRY\n` +
+        `${line}\n` +
+        `${flaky.length} test(s) failed once and passed on retry:\n\n` +
+        `${names}\n\n` +
+        `Playwright's own status for that is "passed", exit 0.  Without\n` +
+        `failOnFlakyTests in playwright.config.js, e2e.yml's close step\n` +
+        `would retire the open e2e-failures issue on this run — and it\n` +
+        `iterates .[], so it drains every open one.\n\n` +
+        `FIRST THING TO CHECK: a strict-mode violation ("resolved to 2\n` +
+        `elements").  React streaming intermittently leaves its\n` +
+        `<div id="S:1"> staging copy in the DOM, so the page's markup\n` +
+        `exists twice.  It is invisible in a screenshot, in the a11y\n` +
+        `tree, and to a human clicking around.  That is a PRODUCT defect.\n\n` +
+        `DO NOT "fix" it by adding .first() to the locator.  The two\n` +
+        `sites that can see it — journey-trade.spec.js (/arbitrage) and\n` +
+        `waivers-smoke.spec.js (/waivers) — are the ONLY detectors this\n` +
+        `repo has for duplicated markup, and .first() restores the\n` +
+        `silence while looking like a fix.\n\n` +
+        `Traces for the failed attempt are in tests/e2e/test-results/\n` +
+        `(trace: "on-first-retry").  Read those before re-running.\n` +
+        `E2E_ALLOW_FLAKY=1 accepts a retried green locally; a workflow\n` +
+        `that sets it fails tests/e2e/test_e2e_harness_guards.py.\n` +
+        `${line}\n\n`,
+    );
+  }
+
+  /**
    * Enforce the coverage floor.  Returning a status from onEnd is
    * Playwright's supported way for a reporter to change the run's
    * outcome, so a suite that executed almost nothing exits non-zero
@@ -199,7 +315,16 @@ class StackDeathReporter {
    * tripped (that run was already declared invalid).
    */
   onEnd(result) {
-    if (!this.enabled || this.tripped) return undefined;
+    if (this.tripped) return undefined;
+    // Diagnostic first, and OUTSIDE the `enabled` gate.  It has to print
+    // on a run that failOnFlakyTests has already turned red — and the
+    // coverage-floor branch below returns early on exactly those runs.
+    // E2E_NO_STACK_GUARD does not silence it either: that switch is
+    // documented as "run through a dead stack anyway", and this block
+    // changes no status, so silencing it would open a fresh gap between
+    // a switch's stated purpose and its actual reach.
+    this._reportFlaky();
+    if (!this.enabled) return undefined;
     if (result && result.status === "failed") return undefined;
 
     const { passed, skipped } = this.counts;

--- a/tests/e2e/test_e2e_harness_guards.py
+++ b/tests/e2e/test_e2e_harness_guards.py
@@ -313,5 +313,206 @@ class TestNoRetiredNameInE2EAssertions(unittest.TestCase):
         )
 
 
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+PLAYWRIGHT_CONFIG = E2E_DIR / "playwright.config.js"
+
+
+def _yaml_code_only(text: str) -> str:
+    """Strip ``#`` comment lines from YAML before pattern-matching.
+
+    MANDATORY for every check below, not a nicety.  The workflows now
+    carry long comments explaining why ``--reporter`` must not be passed
+    and why ``E2E_ALLOW_FLAKY`` must not be set — so a naive substring
+    scan matches the warning against the defect and fails on a correct
+    file.  This file already recorded that trap hitting it once; it hit
+    again while these guards were written.
+
+    Deliberately line-oriented and conservative: a ``#`` inside a quoted
+    scalar would be over-stripped, which can only cause a guard to look
+    at less text, never to invent an offender.
+    """
+    out = []
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        out.append(line.split(" #", 1)[0])
+    return "\n".join(out)
+
+
+def _playwright_run_blocks() -> list[tuple[Path, str]]:
+    """(workflow, run-block text) for every step that invokes playwright."""
+    blocks = []
+    for path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        code = _yaml_code_only(path.read_text(encoding="utf-8"))
+        for chunk in re.split(r"\n\s*-\s+name:", code):
+            if "playwright test" in chunk:
+                blocks.append((path, chunk))
+    return blocks
+
+
+class TestNoWorkflowUnloadsThePlaywrightReporters(unittest.TestCase):
+    """``--reporter`` on the CLI unloads every guard in the reporter array.
+
+    Playwright's ``--reporter`` REPLACES ``playwright.config.js``'s
+    ``reporter`` list rather than adding to it, so one flag silently
+    unloads ``stack-death-reporter.js`` — the stack-death abort, the
+    coverage floor and the flaky banner, all three at once, with nothing
+    printed to say so.
+
+    This is not hypothetical twice over.  The reporter's own header
+    records that the stack-death guard was first "verified" under
+    ``--reporter=line`` and had therefore never executed.  And
+    ``prod-e2e-smoke.yml`` passed the same flag for its entire history:
+    every production smoke run this repo ever made ran with no guards.
+    Fixed 2026-08-05; this test is what stops it coming back.
+    """
+
+    # Keyed (workflow filename, flag).  EMPTY, and that is the desired
+    # state — every entry here is a hole in the guard, same convention as
+    # _GOTO_EXEMPT above.  An entry needs a reason that survives being
+    # read adversarially; "we only wanted prettier output" is not one,
+    # because that is exactly the trade that produced the incident.
+    _REPORTER_EXEMPT: dict[tuple[str, str], str] = {}
+
+    def test_no_workflow_passes_a_reporter_flag(self):
+        offenders = []
+        for path, chunk in _playwright_run_blocks():
+            if not re.search(r"--reporter\b", chunk):
+                continue
+            if (path.name, "--reporter") in self._REPORTER_EXEMPT:
+                continue
+            offenders.append(path.name)
+        self.assertEqual(
+            offenders,
+            [],
+            "A workflow passes --reporter to playwright, which replaces the "
+            "config's reporter array and unloads stack-death-reporter.js "
+            "(stack-death abort + coverage floor + flaky banner). Remove the "
+            "flag; the config already provides list + html.\n" + "\n".join(offenders),
+        )
+
+    def test_every_exemption_is_still_real(self):
+        for name, _flag in self._REPORTER_EXEMPT:
+            self.assertTrue(
+                (WORKFLOWS_DIR / name).exists(),
+                f"_REPORTER_EXEMPT names {name}, which no longer exists. "
+                "Drop the entry rather than leaving a hole propped open.",
+            )
+
+
+class TestFlakyRunsCannotReportGreen(unittest.TestCase):
+    """A retried pass must not read as a clean pass.
+
+    ``retries: 1`` in CI means a test can fail, be retried, pass, and
+    leave the run's status at ``passed`` with exit 0.  Nothing read that
+    flaky count until 2026-08-05, so ``e2e.yml``'s close step would
+    retire the ``e2e-failures`` tracker on a run that contained failures
+    — draining every open one, since it iterates ``.[]``.
+
+    The predicate lives in ``playwright.config.js`` as
+    ``failOnFlakyTests``, NOT in the reporter, precisely because a
+    ``--reporter`` flag can unload the reporter and cannot touch a config
+    key.
+    """
+
+    def test_config_fails_the_run_on_flaky(self):
+        src = PLAYWRIGHT_CONFIG.read_text(encoding="utf-8")
+        self.assertIn(
+            "failOnFlakyTests",
+            src,
+            "playwright.config.js no longer sets failOnFlakyTests. Without it "
+            "a retried failure reports as a green run and e2e.yml's close "
+            "step retires the tracking issue on it.",
+        )
+
+    def test_retries_and_fail_on_flaky_stay_paired(self):
+        """The invariant that actually matters.
+
+        ``retries: 0`` plus the key is merely stricter and is fine.  What
+        must never happen is a non-zero CI retry count with the key gone:
+        that silently restores the old false green, and the diff that
+        does it does not look wrong on its own.
+        """
+        src = PLAYWRIGHT_CONFIG.read_text(encoding="utf-8")
+        retries = re.search(r"^\s*retries:\s*(.+?),\s*$", src, re.MULTILINE)
+        self.assertIsNotNone(retries, "could not find a retries: line to check")
+        expr = retries.group(1)
+        has_nonzero_ci_branch = "CI" in expr and not re.fullmatch(r"0", expr.strip())
+        if has_nonzero_ci_branch:
+            self.assertIn(
+                "failOnFlakyTests",
+                src,
+                f"retries is {expr!r} (non-zero under CI) but failOnFlakyTests "
+                "is gone. Those two are a pair: retries without it means a "
+                "flaky test reports green.",
+            )
+
+    def test_no_workflow_disables_the_guards(self):
+        offenders = []
+        for path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+            code = _yaml_code_only(path.read_text(encoding="utf-8"))
+            for var in ("E2E_ALLOW_FLAKY", "E2E_NO_STACK_GUARD"):
+                if re.search(rf"^\s*{var}\s*:", code, re.MULTILINE):
+                    offenders.append(f"{path.name} sets {var}")
+        self.assertEqual(
+            offenders,
+            [],
+            "A workflow disables an E2E guard. Both switches exist for a "
+            "human debugging locally, not for CI — setting either in a "
+            "workflow restores the green this repo just stopped "
+            "manufacturing.\n" + "\n".join(offenders),
+        )
+
+
+class TestSubsetRunsCarryTheirOwnCoverageFloor(unittest.TestCase):
+    """A workflow running ONE spec needs its own floor, or none at all.
+
+    ``stack-death-reporter.js`` defaults to ``E2E_MIN_PASSED=100``, sized
+    for the nightly's full suite (139 passed on run 30945387957).  A
+    workflow that names a single spec path runs ~32 and would fail every
+    time — so a subset run MUST declare its own bounds.
+
+    The converse matters just as much: a workflow running the FULL suite
+    must NOT set them, or the nightly's floor becomes editable from YAML,
+    which is how a floor quietly becomes unenforceable.
+
+    Values must be numeric literals.  ``Number("3O")`` is NaN and both
+    ``passed < NaN`` and ``skipped > NaN`` are false, so one typo would
+    disable the coverage floor while its banner claims the opposite.
+    ``coverageBound()`` in the reporter now throws on that, and this
+    keeps the typo out of the tree in the first place.
+    """
+
+    _BOUNDS = ("E2E_MIN_PASSED", "E2E_MAX_SKIPPED")
+
+    def test_subset_runs_declare_numeric_bounds(self):
+        offenders = []
+        for path, chunk in _playwright_run_blocks():
+            names_a_spec = bool(re.search(r"tests/e2e/specs/\S+\.spec\.js", chunk))
+            found = {}
+            for var in self._BOUNDS:
+                m = re.search(rf"^\s*{var}\s*:\s*(.+?)\s*$", chunk, re.MULTILINE)
+                if m:
+                    found[var] = m.group(1).strip().strip("\"'")
+
+            if names_a_spec:
+                for var in self._BOUNDS:
+                    if var not in found:
+                        offenders.append(f"{path.name} runs a single spec but does not set {var}")
+                    elif not re.fullmatch(r"\d+", found[var]):
+                        offenders.append(
+                            f"{path.name} sets {var}={found[var]!r}, which is not a "
+                            "plain integer — an unparseable bound disables the floor"
+                        )
+            elif found:
+                offenders.append(
+                    f"{path.name} runs the full suite but sets "
+                    f"{sorted(found)} — that makes the nightly's floor "
+                    "editable from YAML"
+                )
+        self.assertEqual(offenders, [], "\n".join(offenders))
+
+
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
#718 scoped the auto-issue trackers to mainline runs — it fixed **who** may speak for `main`. It did not fix **how much one green run proves**, which I said on #716 rather than leave the tracker looking sound. This is that half.

Three independent ways a green run could mean *"the suite didn't look"*, all `docs/ORCHESTRATION.md` §6.15's class. Each verified against `origin/main` before being touched.

## 1. A retried failure read as green — and closed the tracker

`playwright.config.js` — `retries: process.env.CI ? 1 : 0`. A test can fail on attempt 0, pass on attempt 1, and leave the run's status at `passed`, exit 0. Grepping every workflow and all of `tests/e2e/`: **nothing read the flaky count.**

So `e2e.yml`'s close step retired the `e2e-failures` issue on a run that contained failures — draining *every* open one, since it iterates `.[]` — under its stated premise that *"a green run of THIS workflow is the all-clear by construction."*

Fixed with `failOnFlakyTests`. **The predicate is in the config, not in `stack-death-reporter.js`, and that placement is the entire point:** a `--reporter=` flag replaces the reporter array and unloads every guard in that file, so putting it there would have rebuilt the exact defect fixed in §2 below. A CLI flag cannot unload a config key, and `--fail-on-flaky-tests` can only set it *true*.

Proven rather than assumed — scratchpad run, no stack needed:

| case | result |
|---|---|
| `failOnFlakyTests` present, flaky test | exit **1** |
| key **removed**, same flaky test | exit **0**, banner still prints |

That second row is the proof that the config key — not my banner — is what fails the run.

`retries` stays at 1: the retry is what produces `trace: "on-first-retry"`, and the defect was never the retry, only its silence.

## 2. The prod smoke unloaded its own guards

`prod-e2e-smoke.yml` passed `--reporter=line`, replacing the config's reporter array and unloading `stack-death-reporter.js` — the stack-death abort **and** the coverage floor — for every production smoke run it has ever made. The reporter's own header warns about this in capitals.

The trap in the obvious fix: the floor defaults to 100, but that job runs one spec. Measured on run `30953000224` — `32 passed`, tests `[1/32]`–`[32/32]`, **zero skipped**. Bounds now set to match. Side effect: `playwright-report/` is populated, so the failure-artifact step stops uploading an empty directory.

## 3. A product degradation became a green skip

`journey-settings-overrides.spec.js` skipped when the custom-mix badge never appeared and the app had logged its base-contract fallback — measured firing *routinely*. That is what `tests/e2e/README.md` convention 5 forbids: *"Skip cleanly on absent INFRA — never on absent DATA."*

Replaced with a **more** specific assertion, not a weaker one: `/rankings` fires its own overrides POST on hydration, and that second round-trip is what the badge depends on and what the skip was forgiving. A failure now says *"the second overrides POST returned 503"* instead of *"badge missing, cause unknown."* It also recovers `guard.assertClean()` — `test.skip()` throws, so on the skip path every console error on that journey was discarded too.

## Two live defects found while verifying

- **`Number("3O")` is `NaN`, and both `passed < NaN` and `skipped > NaN` are `false`** — one typo in a workflow `env:` block would silently disable the coverage floor while its banner claimed otherwise. Unreachable while nothing set those vars; §2 sets them by hand in YAML. `coverageBound()` now refuses to run instead.
- **The reporter's documented baseline was wrong.** It claimed "~149 passed / 29 skipped". Run `30945387957` measured **139 passed / 49 skipped** — skips had drifted to 49 against a ceiling of 60 and nothing fired, and a floor of 100 let 39 tests vanish silently. Baseline corrected and cited; floor raised to 120.

## Guards, so this cannot quietly come back

In `test_e2e_harness_guards.py`, which runs in the **fast pytest gate** — so these fire on PRs even though the suite itself does not:

- no workflow may pass `--reporter`
- no workflow may set `E2E_ALLOW_FLAKY` / `E2E_NO_STACK_GUARD`
- `retries` and `failOnFlakyTests` must stay paired (non-zero CI retries without the key is the silent regression)
- a subset run must declare numeric bounds; a full-suite run must not set them at all

Per this file's own doctrine, **each was verified by reintroducing its defect and watching it fail** — 5 for 5, then green again.

## Expected consequence, stated up front

The nightly will now go red **roughly one night in ten**, because there is a real intermittent defect: React streaming leaving its `<div id="S:1">` staging copy in the DOM, so page markup exists twice. Filed as **#730** — it had no tracker at all, because it was diagnosed inside #716 which was then closed.

Two honesty notes: the per-load rates behind that estimate are another session's measurement reported on #716, **not reproduced by me**; and the estimate is derived from them, not itself a measurement.

That noise is the point. The alternative is the current state, where the same defect fires just as often and the workflow reports success.

## Verification

- `ruff check .` clean; `ruff format --check` clean (884 files)
- `node --check` on all three JS files; `yaml.safe_load` on the workflow
- `test_e2e_harness_guards.py`: 13 passed
- 5/5 defect-reintroduction checks fire, then revert to green
- 4/4 Playwright self-test cases (flaky→1, key-removed→0, coverage floor→1, NaN→named error)
- full `pytest -m "not livedata"` running; I'll report the result on this PR

## Out of scope

Fixing the `#S:1` race (#730) — likely a React 19.2 / Next 16.2 streaming bug and open-ended; this makes it *visible*, which is the prerequisite. And `E2E Safety Net` still cannot be a required check: it has no `pull_request` trigger by deliberate design. Worth noting the repo has **no branch protection at all**, so not even `Validate PR` is required — owner action OA-02.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKhaEruQrSLhWKZPEGmEEm)_