### PR TITLE
Perfect Draft: measure the lineup-value gap before redesigning for it

### DIFF
--- a/docs/perfect-draft.md
+++ b/docs/perfect-draft.md
@@ -466,6 +466,38 @@ structurally prevents one team's results reaching another.
   breaks the `k`-decomposition, so it is genuinely harder than this entry
   previously implied.
 
+  **MEASURED (2026-08-05).** `scripts/measure_lineup_value_gap.py` walks
+  `k = 0..40` rookies onto a real roster and compares what the naive objective
+  credits against what the league's own 21 starting slots can actually field,
+  scored by the real solver. The distortion is not marginal — on the
+  2026-08-05 board, over `k = 1..40`:
+
+  | team | roster | naive credits | startable credits | share | first rookie adding 0 |
+  |---|---|---|---|---|---|
+  | Blaine | 53 | 132,172 | 33,411 | **25.3%** | k=3 (26 of 40 add nothing) |
+  | Eric | 58 | 132,172 | 15,995 | **12.1%** | k=6 (29 of 40) |
+  | MaKayla | 58 | 132,172 | 14,355 | **10.9%** | k=6 (30 of 40) |
+  | Jason | 57 | 132,172 | 11,478 | **8.7%** | k=3 (32 of 40) |
+
+  Past roughly `k = 20` every additional rookie adds **exactly zero** startable
+  value on every roster tested. So the objective is crediting four to eleven
+  times the value the lineup can realize, and the high-`k` preference follows
+  directly.
+
+  **But pure lineup value is not the answer either, and that is the real
+  finding.** This measurement scores *today's* lineup, and these are dynasty
+  rookies — a player who cannot crack the lineup now is exactly the asset
+  class this league is built to accumulate. Bench depth is also injury
+  insurance and trade currency. Zero is as wrong as full market value; the
+  truth is bounded between them.
+
+  That reframes Phase B. It is **not** "swap Σ market value for lineup value" —
+  that would trade one wrong number for another and would tell a dynasty
+  manager to stop buying at 20. It is "value a bench player below a starter at
+  a rate that is derived rather than invented", which is the same objection
+  §9's positional-balance entry raises. Until that rate has a defensible
+  source, shipping either extreme would be a regression dressed as a fix.
+
 - **Opponent modelling is a price cap, not a bidding model.** `bayesianTopCompetitor`
   (nomination-decayed tier interest) now reaches the optimizer through the
   **Prices** control: `"fair"` is the board's inflation-adjusted price and the

--- a/docs/roster-trade-intelligence/DECISIONS.md
+++ b/docs/roster-trade-intelligence/DECISIONS.md
@@ -509,6 +509,29 @@ already used here for *droppability*, but using it for *value* breaks the
 cardinality decomposition this ADR rests on. Left open and stated
 plainly in `docs/perfect-draft.md` §9 rather than half-fixed.
 
+**Amendment 3 (2026-08-05): the gap is measured, and it is large — but
+the fix is not the obvious one.** `scripts/measure_lineup_value_gap.py`
+walks rookies onto four real rosters and scores each step against the
+league's own 21 starting slots with the real solver. The naive objective
+credits **8.7%–25.3%** of what the lineup can field over `k = 1..40`, and
+past roughly `k = 20` every further rookie adds **exactly zero** startable
+value on every roster tested. So the diagnosis in the amendment above is
+confirmed with numbers rather than asserted.
+
+What the measurement also shows is that **swapping in lineup value would
+be its own error.** It scores *today's* lineup, and dynasty rookies are
+precisely the asset class that does not start today; bench depth is also
+injury insurance and trade currency. Zero is as wrong as full market
+value. A straight swap would tell a dynasty manager to stop buying at 20.
+
+So Phase B is re-scoped: the open problem is not "use the lineup solver
+for value", it is "discount a bench player against a starter at a rate
+with a defensible source". That is the same objection this file's
+positional-balance decision raises against folding a starting-slot
+minimum into the objective, and it gets the same answer — surface it,
+do not invent the rate. **Still open**; the measurement narrows it rather
+than closing it.
+
 **The consumption order is one decision, not four.** Introducing
 `releaseCost` created a second ordering of the cut ladder, and three
 separate consumers kept walking the backend's ECC order against it:

--- a/scripts/measure_lineup_value_gap.py
+++ b/scripts/measure_lineup_value_gap.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Phase A: how much does the unweighted-sum objective overstate a big plan?
+
+``docs/perfect-draft.md`` §9 says roster value is an **unweighted sum of market
+values**, so a 58-man roster that starts 21 still books bench player #40 at full
+market value.  That is the stated reason the optimizer prefers very large plans
+— fixing the replacement term moved the recommendation only 35 → 34.
+
+The honest fix is lineup-aware roster value, and it is expensive: it is
+set-dependent, so it breaks the cardinality decomposition the whole solver rests
+on (ADR-010 amendment 2).  Before trading exactness away for it, measure whether
+the distortion is real.
+
+**The measurement.** Both objectives agree on what a roster contains; they
+disagree on what it is worth.  So walk ``k = 0..N`` rookies added to a real
+roster and compare, at each step:
+
+* ``naive`` — Σ board value over every player, which is what the solver credits.
+  The marginal value of rookie ``k`` is simply his own board value.
+* ``lineup`` — Σ board value over the players the league's own starting slots
+  can actually field, from the real solver
+  (``src/ros/lineup.py::solve_optimal_assignment``).  The marginal value of
+  rookie ``k`` is whatever he adds to the *startable* total, which is zero once
+  better players already hold every slot he is eligible for.
+
+The ratio of those two marginals is the distortion.  If it collapses to zero
+after a handful of rookies, the naive objective is crediting the rest with value
+they do not add, and Phase B is justified.  If it stays near 1, it is not.
+
+**Why board value and not ``ros_value``.**  ``solve_optimal_assignment``
+maximizes whatever weight it is handed, and ``RosterAsset.ros_value`` is
+explicitly documented as "lineup feasibility ONLY — never cost arithmetic".
+The question here is a *valuation* one — what is the startable market value —
+so the weight passed in is board value.  Slot eligibility is untouched, which
+is the part of the solver that matters.
+
+Usage::
+
+    ALLOW_DEFAULT_LOGIN_DEV=1 python scripts/measure_lineup_value_gap.py
+    ALLOW_DEFAULT_LOGIN_DEV=1 python scripts/measure_lineup_value_gap.py \\
+        --team "Team Name" --max-k 40 --json out.json
+
+Exit codes follow the repo convention: 0 success, 1 error, 2 skipped (no
+contract to measure against — never 0, so "no data" cannot read as "measured").
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_SKIPPED = 2
+
+
+def _startable_value(assets: list[Any], slots: list[str]) -> float:
+    """Board value of the best lineup this pool can field.
+
+    Weight is board value, so the matching answers "which players give the most
+    startable market value", which is the quantity the objective is arguing
+    about.  Unpriced players carry 0 — they cannot be credited with value the
+    board never gave them.
+    """
+    from src.ros.lineup import solve_optimal_assignment  # noqa: PLC0415
+
+    pool = []
+    for a in assets:
+        lp = a.to_lineup_player()
+        # ``ros_value`` is the solver's weight field; re-point it at board value
+        # for this question only.  Eligibility (position / fantasy_positions) is
+        # untouched, which is the part that encodes the league's lineup rules.
+        pool.append(
+            type(lp)(
+                player_id=lp.player_id,
+                canonical_name=lp.canonical_name,
+                position=lp.position,
+                ros_value=float(a.board_value or 0.0),
+                injured=lp.injured,
+                bye=lp.bye,
+                fantasy_positions=lp.fantasy_positions,
+            )
+        )
+    assignment = solve_optimal_assignment(pool, list(slots))
+    return sum(float(p.ros_value or 0.0) for p in assignment.values())
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--team", default=None, help="team name (default: first team)")
+    ap.add_argument("--max-k", type=int, default=40, help="how many rookies to walk")
+    ap.add_argument("--json", default=None, help="also write the series here")
+    args = ap.parse_args(argv)
+
+    try:
+        import server  # noqa: PLC0415
+
+        from src.draft.context import (  # noqa: PLC0415
+            _index_contract_rows,
+            _teams,
+            build_roster_assets,
+        )
+        from src.draft.displacement import RosterAsset  # noqa: PLC0415
+        from src.ros.lineup import load_league_starter_slots  # noqa: PLC0415
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: could not import the app ({exc})", file=sys.stderr)
+        return EXIT_ERROR
+
+    contract = getattr(server, "latest_contract_data", None)
+    if not contract:
+        # Same hydration the snapshot capture uses: the global is only populated
+        # inside the FastAPI lifespan, so a cold shell has to prime it.
+        server._prime_latest_payload(server.load_from_disk())  # noqa: SLF001
+        contract = getattr(server, "latest_contract_data", None)
+    if not contract:
+        print("SKIPPED: no contract cached on disk — run a scrape first.", file=sys.stderr)
+        return EXIT_SKIPPED
+
+    league_key = (contract.get("meta") or {}).get("leagueKey")
+    teams = _teams(contract)
+    if not teams:
+        print("SKIPPED: contract carries no rosters.", file=sys.stderr)
+        return EXIT_SKIPPED
+    team = next((t for t in teams if t.get("name") == args.team), None) if args.team else teams[0]
+    if team is None:
+        print(f"ERROR: no team named {args.team!r}.", file=sys.stderr)
+        return EXIT_ERROR
+
+    by_id, by_name = _index_contract_rows(contract)
+    assets, _unmatched = build_roster_assets(team, by_name, by_id)
+    slots = load_league_starter_slots(league_key)
+
+    pool = server._our_rookie_pool(server._KTC_TOTAL_PICKS)  # noqa: SLF001
+    if not pool:
+        print("SKIPPED: contract carries no rookie pool.", file=sys.stderr)
+        return EXIT_SKIPPED
+
+    rookies = [
+        RosterAsset(
+            player_id=f"rookie::{r.get('name')}",
+            name=str(r.get("name")),
+            position=str(r.get("pos") or "").strip().upper(),
+            board_value=float(r.get("value") or 0.0),
+            ros_value=float(r.get("value") or 0.0),
+            fantasy_positions=(str(r.get("pos") or "").strip().upper(),),
+        )
+        for r in pool
+    ]
+    rookies.sort(key=lambda a: -(a.board_value or 0.0))
+    max_k = max(0, min(args.max_k, len(rookies)))
+
+    base_naive = sum(float(a.board_value or 0.0) for a in assets)
+    base_lineup = _startable_value(assets, slots)
+
+    rows: list[dict[str, Any]] = []
+    prev_lineup = base_lineup
+    for k in range(1, max_k + 1):
+        added = rookies[:k]
+        naive = base_naive + sum(float(a.board_value or 0.0) for a in added)
+        lineup = _startable_value(list(assets) + added, slots)
+        rows.append(
+            {
+                "k": k,
+                "rookie": added[-1].name,
+                "pos": added[-1].position,
+                "boardValue": round(float(added[-1].board_value or 0.0), 1),
+                "naiveMarginal": round(float(added[-1].board_value or 0.0), 1),
+                "lineupMarginal": round(lineup - prev_lineup, 1),
+                "naiveTotal": round(naive, 1),
+                "lineupTotal": round(lineup, 1),
+            }
+        )
+        prev_lineup = lineup
+
+    print(f"league={league_key} team={team.get('name')!r} roster={len(assets)} slots={len(slots)}")
+    print(f"baseline: naive={base_naive:,.0f}  startable={base_lineup:,.0f}")
+    print()
+    print(f"{'k':>3} {'rookie':<24} {'pos':<4} {'naive Δ':>9} {'lineup Δ':>9} {'credited':>9}")
+    for r in rows:
+        share = (r["lineupMarginal"] / r["naiveMarginal"]) if r["naiveMarginal"] else 0.0
+        print(
+            f"{r['k']:>3} {r['rookie'][:24]:<24} {r['pos']:<4} "
+            f"{r['naiveMarginal']:>9,.0f} {r['lineupMarginal']:>9,.0f} {share:>8.0%}"
+        )
+
+    if rows:
+        total_naive = sum(r["naiveMarginal"] for r in rows)
+        total_lineup = sum(r["lineupMarginal"] for r in rows)
+        dead = [r["k"] for r in rows if r["lineupMarginal"] <= 0]
+        print()
+        print(
+            f"over k=1..{max_k}: naive credits {total_naive:,.0f}, "
+            f"lineup credits {total_lineup:,.0f} "
+            f"({(total_lineup / total_naive if total_naive else 0):.1%})"
+        )
+        if dead:
+            print(f"first rookie adding NO startable value: k={dead[0]} ({len(dead)} of {max_k})")
+        else:
+            print("every rookie in this range adds startable value")
+
+    if args.json:
+        Path(args.json).write_text(
+            json.dumps(
+                {
+                    "leagueKey": league_key,
+                    "team": team.get("name"),
+                    "slots": len(slots),
+                    "baselineNaive": base_naive,
+                    "baselineLineup": base_lineup,
+                    "series": rows,
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/draft/context.py
+++ b/src/draft/context.py
@@ -202,6 +202,57 @@ def _match_team(
     return None
 
 
+def build_roster_assets(
+    team: Mapping[str, Any],
+    by_name: Mapping[str, Mapping[str, Any]],
+    by_id: Mapping[str, Mapping[str, Any]],
+) -> tuple[list[RosterAsset], list[str]]:
+    """Join one team's roster to the board.
+
+    Returns ``(assets, unmatched_names)``.  Extracted from
+    :func:`build_roster_context` so analysis tooling can get at the roster
+    itself — the context payload carries only per-position *counts*, and
+    anything asking "what would this lineup actually be?" needs the players.
+    Duplicating the join in a script would be a second definition of who is on
+    a roster, which is exactly the kind of parallel system this repo avoids.
+    """
+    names = [str(n) for n in (team.get("players") or []) if str(n or "").strip()]
+    ids = [str(i) for i in (team.get("playerIds") or []) if str(i or "").strip()]
+    assets: list[RosterAsset] = []
+    unmatched: list[str] = []
+    for idx, name in enumerate(names):
+        row = by_name.get(_norm(name))
+        if row is None and idx < len(ids):
+            row = by_id.get(_norm(ids[idx]))
+        if row is None:
+            unmatched.append(name)
+            # Still occupies a roster spot, and is a legitimate cut candidate —
+            # dropping him from the model would understate roster pressure.
+            assets.append(
+                RosterAsset(
+                    player_id=ids[idx] if idx < len(ids) else name,
+                    name=name,
+                    position="",
+                    board_value=None,
+                )
+            )
+            continue
+        value = row.get("rankDerivedValue")
+        fantasy = row.get("fantasyPositions")
+        assets.append(
+            RosterAsset(
+                player_id=str(row.get("playerId") or name),
+                name=str(row.get("displayName") or row.get("canonicalName") or name),
+                position=str(row.get("position") or "").strip().upper(),
+                board_value=float(value) if isinstance(value, (int, float)) and value > 0 else None,
+                ros_value=float(row.get("rosValue") or 0.0),
+                fantasy_positions=tuple(fantasy) if isinstance(fantasy, (list, tuple)) else (),
+                injured=bool(row.get("injured")),
+            )
+        )
+    return assets, unmatched
+
+
 def build_roster_context(
     contract: Mapping[str, Any] | None,
     league_key: str | None,
@@ -265,41 +316,7 @@ def build_roster_context(
             "rookie surplus is therefore the raw board value"
         )
 
-    # Join this team's roster to the board.
-    names = [str(n) for n in (team.get("players") or []) if str(n or "").strip()]
-    ids = [str(i) for i in (team.get("playerIds") or []) if str(i or "").strip()]
-    assets: list[RosterAsset] = []
-    unmatched: list[str] = []
-    for idx, name in enumerate(names):
-        row = by_name.get(_norm(name))
-        if row is None and idx < len(ids):
-            row = by_id.get(_norm(ids[idx]))
-        if row is None:
-            unmatched.append(name)
-            # Still occupies a roster spot, and is a legitimate cut candidate —
-            # dropping him from the model would understate roster pressure.
-            assets.append(
-                RosterAsset(
-                    player_id=ids[idx] if idx < len(ids) else name,
-                    name=name,
-                    position="",
-                    board_value=None,
-                )
-            )
-            continue
-        value = row.get("rankDerivedValue")
-        fantasy = row.get("fantasyPositions")
-        assets.append(
-            RosterAsset(
-                player_id=str(row.get("playerId") or name),
-                name=str(row.get("displayName") or row.get("canonicalName") or name),
-                position=str(row.get("position") or "").strip().upper(),
-                board_value=float(value) if isinstance(value, (int, float)) and value > 0 else None,
-                ros_value=float(row.get("rosValue") or 0.0),
-                fantasy_positions=tuple(fantasy) if isinstance(fantasy, (list, tuple)) else (),
-                injured=bool(row.get("injured")),
-            )
-        )
+    assets, unmatched = build_roster_assets(team, by_name, by_id)
 
     if unmatched:
         notes.append(


### PR DESCRIPTION
## Why

ADR-010's second amendment says roster value is an **unweighted sum of market
values** and names lineup-aware value as the honest fix — while noting that
using the lineup solver for *value* breaks the cardinality decomposition the
whole solver rests on. That is a large trade to make on an asserted diagnosis,
so this measures the distortion first.

`scripts/measure_lineup_value_gap.py` walks `k = 0..40` rookies onto a real
roster and compares, at each step, what the naive objective credits against what
the league's own 21 starting slots can actually field — scored by the real
solver, `src/ros/lineup.py::solve_optimal_assignment`.

Board value is passed as the matching weight because the question here is a
*valuation* one; `RosterAsset.ros_value` is documented as "lineup feasibility
ONLY — never cost arithmetic". Slot eligibility, which is the part encoding the
league's lineup rules, is untouched.

## The gap is real, and large

Over `k = 1..40` on the 2026-08-05 board:

| team | roster | naive credits | startable credits | share | first rookie adding 0 |
|---|---|---|---|---|---|
| Blaine | 53 | 132,172 | 33,411 | **25.3%** | k=3 (26 of 40 add nothing) |
| Eric | 58 | 132,172 | 15,995 | **12.1%** | k=6 (29 of 40) |
| MaKayla | 58 | 132,172 | 14,355 | **10.9%** | k=6 (30 of 40) |
| Jason | 57 | 132,172 | 11,478 | **8.7%** | k=3 (32 of 40) |

Past roughly `k = 20`, every further rookie adds **exactly zero** startable value
on every roster tested. The objective credits four to eleven times what the
lineup can realize, and the high-`k` preference follows directly. The diagnosis
in the amendment is now confirmed with numbers rather than asserted.

## But the obvious fix would be its own error — this is the actual finding

The measurement scores **today's** lineup, and dynasty rookies are precisely the
asset class that does not start today. Bench depth is also injury insurance and
trade currency. **Zero is as wrong as full market value.** A straight swap to
lineup value would tell a dynasty manager to stop buying at 20.

So Phase B is *re-scoped*, not unblocked. The open problem is not "use the
lineup solver for value" — it is "discount a bench player against a starter at a
rate with a defensible source". That is the same objection this repo already
raises against folding a positional minimum into the objective, and it gets the
same answer: surface it, don't invent the rate.

**Nothing ships behind a flag here, because there is nothing yet worth
shipping.** Recorded as ADR-010 amendment 3 and in `docs/perfect-draft.md` §9.

## Changes

| Change | File |
|---|---|
| The measurement, exit 0/1/2 per repo convention (2 = no contract, never 0) | `scripts/measure_lineup_value_gap.py` (new) |
| `build_roster_assets` extracted so the script can reach the roster — the context payload carries only per-position *counts*. Behaviour-preserving; duplicating the join would be a second definition of who is on a roster | `src/draft/context.py` |
| Amendment 3 | `docs/roster-trade-intelligence/DECISIONS.md` |
| §9 measured table + the re-scoping | `docs/perfect-draft.md` |

No production code path changes: the extraction is a pure move, and nothing else
is touched. No frontend files, so the vitest and bundle-budget gates carry over
from main unchanged.

## Verification

| Gate | Result |
|---|---|
| `ruff format --check .` | 886 files already formatted |
| `ruff check .` | All checks passed |
| `pytest tests/ -x -q -m "not livedata"` | 6378 passed, 15 skipped |
| `pytest tests/draft/` (extraction is behaviour-preserving) | 61 passed |

The measurement was run against the live board on four separate rosters to
confirm the result is not an artifact of one team's shape.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6oCgi8MGEbZUUh9LsTGtu)_