### PR TITLE
Stop turning missing data into confident advice (Critical batch C3)

### DIFF
--- a/config/coercion_baseline.json
+++ b/config/coercion_baseline.json
@@ -1,6 +1,6 @@
 {
  "note": "Known missing-data coercions on decision paths, recorded so the gate can block NEW ones while the remediation batches burn these down. Each batch deletes its findings' entries. Do not add to this file to make a build pass.",
- "count": 697,
+ "count": 695,
  "violations": [
   "frontend/lib/auction-power.js::const raw = names.map((n) => Number(totalsObj[n]) || 0);",
   "frontend/lib/bdvm.js::assetCount: _num(r?.assetCount) ?? 0,",
@@ -514,8 +514,6 @@
   "src/ros/team_strength.py::confidence=float(agg.get(\"confidence\") or 0.0),",
   "src/ros/team_strength.py::out.sort(key=lambda t: -float(t.get(\"teamRosStrength\") or 0.0))",
   "src/ros/team_strength.py::ros_value=float(agg.get(\"rosValue\") or 0.0),",
-  "src/ros/trade_deadline.py::co = float((champs.get(owner) or {}).get(\"championshipOdds\") or 0.0)",
-  "src/ros/trade_deadline.py::po = float((playoffs.get(owner) or {}).get(\"playoffOdds\") or 0.0)",
   "src/ros/trade_deadline.py::rank = float(strength_row.get(\"rank\") or 0.0)",
   "src/ros/trade_deadline.py::total = max(1.0, float(len(strengths) or 1))",
   "src/roster_intel/engine.py::adjusted += float(row.get(\"leagueAdjustedDynastyValue\") or row.get(\"consensusValue\") or 0.0)",

--- a/docs/audits/decision-intelligence-audit-2026-08-04.status.json
+++ b/docs/audits/decision-intelligence-audit-2026-08-04.status.json
@@ -3,9 +3,9 @@
  "severity": "Critical",
  "total": 43,
  "tally": {
-  "open": 29,
-  "needs_review": 1,
-  "closed": 12,
+  "open": 25,
+  "needs_review": 2,
+  "closed": 15,
   "deferred": 1
  },
  "findings": [
@@ -76,8 +76,8 @@
    "auditId": "V-3",
    "path": "frontend/lib/dynasty-data.js",
    "signature": "full: Math.round(backendValue || rawValues.full)",
-   "status": "open",
-   "verifiedBy": "Live at two materializer sites, plus four coercions of the same shape in frontend/app/rankings/page.jsx (row.rankDerivedValue || row.values?.full || 0), including the sort comparators at :596-597.",
+   "status": "needs_review",
+   "verifiedBy": "PARTLY CLOSED, and the headline half is gone \u2014 re-measured in batch C3 by running buildRows over the real contract. The audit reported 260 rows promoting the raw scraper composite into the Value column, 158 of them above the deepest genuinely-priced player. Measured now: 261 rows the board declines to price, and ZERO render a non-zero number. The math audit's H1 fix made inferValueBundle return the board value only, so both sides of the `backendValue || rawValues.full` expression now derive from rankDerivedValue and the composite can no longer reach the column. The expression survives and looks like the defect, which is why this stays flagged rather than closed.\n\nWHAT REMAINS is the same defect class one step milder: those 261 rows render 0, which asserts 'worth nothing' rather than 'not priced', and 0 sorts and aggregates as a real value. That is the Unknown render rule (em-dash, sorts last, excluded from aggregates with the exclusion counted) and it is frontend-wide work \u2014 the type landed in C3 with the two ROS sites; this is scoped to its own batch rather than half-done here.",
    "closedBy": null,
    "measuredEffect": null,
    "batch": null,
@@ -675,16 +675,14 @@
    "auditEvidence": "`src/ros/playoff_sim.py:704` `schedule = _remaining_schedule(snapshot)` returns [] when the last loaded season is complete (offseason). The sim loop at `:721` then adds nothing to `sim_wins`, which was seeded from realized wins at `:719`, so every one of the 2,000 draws produces the identical ranking. Live output `data/ros/sims/latest_playoff.json`: `{'n_simulations': 2000, 'converged': True, 'wor",
    "auditId": "N-1",
    "path": "src/ros/playoff_sim.py",
-   "signature": "schedule = _remaining_schedule(snapshot)",
-   "status": "open",
-   "verifiedBy": "An empty remaining schedule still yields degenerate 100%/0% odds stamped converged: true.",
+   "signature": null,
+   "status": "closed",
+   "verifiedBy": "Fixed in batch C3. With no remaining schedule the simulation loop drew no games, so all 2000 'simulations' replayed the standings and every team landed on exactly 1.0 or 0.0 \u2014 stamped converged: true, in August, before a 2026 game was played. The fix does NOT refuse every empty schedule, because a FINISHED season is the same shape and there 1.0/0.0 is a fact: it separates the two on whether any games have been played, and returns an empty board with an explicit unsimulable reason only when nothing has been played AND nothing is scheduled. simulate_playoff_odds therefore emits no odds rather than certain ones, which is what lets C36's classifier report 'Insufficient evidence' instead of reading a 0.0.",
    "closedBy": null,
    "measuredEffect": null,
    "batch": null,
    "probe": {
-    "result": "signature_present",
-    "path": "src/ros/playoff_sim.py",
-    "needle": "schedule = _remaining_schedule(snapshot)"
+    "result": "no_mechanical_probe"
    }
   },
   {
@@ -695,16 +693,14 @@
    "auditEvidence": "`src/ros/trade_deadline.py:82` `po = float((playoffs.get(owner) or {}).get(\"playoffOdds\") or 0.0)` \u2014 an owner absent from `latest_playoff.json` gets a confident 0.0, not None. The sim covers 8 owners; `data/ros/team_strength/latest.json` has 12. Executing `build_team_directions()` against the committed data on disk returns: `Brent | po 0.0 | co 0.0 | pct 1.0 | Seller` \u2014 Brent is ranked #1 of 12 on",
    "auditId": "N-2",
    "path": "src/ros/trade_deadline.py",
-   "signature": "float((playoffs.get(owner) or {}).get(\"playoffOdds\") or 0.0)",
-   "status": "open",
-   "verifiedBy": "A missing owner is still coerced to 0.0 and labelled Seller.",
+   "signature": null,
+   "status": "closed",
+   "verifiedBy": "Fixed in batch C3, and MEASURED on the live cache rather than asserted: build_team_directions over data/ros/ moved FOUR managers (Brent, Kich, Blaine, jstuedle) from 'Seller' to 'Insufficient evidence' \u2014 Brent being rank #1 in the league on ROS strength, told to sell his roster for no reason but absence from an 8-row sim file in a 12-team league. The two genuinely measured 0% teams (Ed, Collin) still read Seller, which is the control: the fix withholds fabricated answers without silencing real ones. Absent owners are still LISTED (dropping them would trade one wrong answer for another) with null odds, a machine-readable reason, measurable: false, and a label that reuses none of the seven buy/sell verbs. They sort last rather than as the worst team. Pinned by tests/ros/test_trade_deadline_unknown.py, including a live-data case that fails if any unmeasurable row ever regains a sell verb.",
    "closedBy": null,
    "measuredEffect": null,
    "batch": null,
    "probe": {
-    "result": "signature_present",
-    "path": "src/ros/trade_deadline.py",
-    "needle": "float((playoffs.get(owner) or {}).get(\"playoffOdds\") or 0.0)"
+    "result": "no_mechanical_probe"
    }
   },
   {
@@ -735,16 +731,14 @@
    "auditEvidence": "src/ros/trade_deadline.py:71 `owner_ids = sorted(set(playoffs) | set(champs) | set(strengths))` unions 12 team-strength owners with 8 sim owners; :79-80 `po = float((playoffs.get(owner) or {}).get(\"playoffOdds\") or 0.0)` / `co = float((champs.get(owner) or {}).get(\"championshipOdds\") or 0.0)` silently substitute 0.0 for absent owners. Reproduced against the live on-disk caches (data/ros/sims/lates",
    "auditId": "N-2b",
    "path": "src/ros/trade_deadline.py",
-   "signature": "owner_ids = sorted(set(playoffs) | set(champs) | set(strengths))",
-   "status": "open",
-   "verifiedBy": "The union still admits owners present in only one input, which is how a missing team reaches the BUY/SELL ladder at all. Closed together with C36.",
+   "signature": null,
+   "status": "closed",
+   "verifiedBy": "Closed with C36, but note the union at this line was deliberately KEPT. Narrowing it to the intersection would have hidden four real managers to avoid mislabelling them \u2014 a league that appears to have 8 teams is its own wrong answer. What changed is what the union's extra rows are allowed to say: they reach the classifier no longer, and carry an explicit refusal instead of a coerced 0.0.",
    "closedBy": null,
    "measuredEffect": null,
    "batch": null,
    "probe": {
-    "result": "signature_present",
-    "path": "src/ros/trade_deadline.py",
-    "needle": "owner_ids = sorted(set(playoffs) | set(champs) | set(strengths))"
+    "result": "no_mechanical_probe"
    }
   },
   {

--- a/scripts/audit_status.py
+++ b/scripts/audit_status.py
@@ -111,11 +111,25 @@ _FINDINGS: dict[str, tuple[str, str | None, str | None, str, str]] = {
         "V-3",
         "frontend/lib/dynasty-data.js",
         "full: Math.round(backendValue || rawValues.full)",
-        OPEN,
-        "Live at two materializer sites, plus four coercions of the same "
-        "shape in frontend/app/rankings/page.jsx "
-        "(row.rankDerivedValue || row.values?.full || 0), including the "
-        "sort comparators at :596-597.",
+        REVIEW,
+        "PARTLY CLOSED, and the headline half is gone — re-measured in "
+        "batch C3 by running buildRows over the real contract. The audit "
+        "reported 260 rows promoting the raw scraper composite into the "
+        "Value column, 158 of them above the deepest genuinely-priced "
+        "player. Measured now: 261 rows the board declines to price, and "
+        "ZERO render a non-zero number. The math audit's H1 fix made "
+        "inferValueBundle return the board value only, so both sides of "
+        "the `backendValue || rawValues.full` expression now derive from "
+        "rankDerivedValue and the composite can no longer reach the "
+        "column. The expression survives and looks like the defect, "
+        "which is why this stays flagged rather than closed.\n\n"
+        "WHAT REMAINS is the same defect class one step milder: those "
+        "261 rows render 0, which asserts 'worth nothing' rather than "
+        "'not priced', and 0 sorts and aggregates as a real value. That "
+        "is the Unknown render rule (em-dash, sorts last, excluded from "
+        "aggregates with the exclusion counted) and it is frontend-wide "
+        "work — the type landed in C3 with the two ROS sites; this is "
+        "scoped to its own batch rather than half-done here.",
     ),
     "C05": (
         "T-1",
@@ -404,17 +418,42 @@ _FINDINGS: dict[str, tuple[str, str | None, str | None, str, str]] = {
     "C35": (
         "N-1",
         "src/ros/playoff_sim.py",
-        "schedule = _remaining_schedule(snapshot)",
-        OPEN,
-        "An empty remaining schedule still yields degenerate 100%/0% odds "
-        "stamped converged: true.",
+        None,
+        CLOSED,
+        "Fixed in batch C3. With no remaining schedule the simulation "
+        "loop drew no games, so all 2000 'simulations' replayed the "
+        "standings and every team landed on exactly 1.0 or 0.0 — stamped "
+        "converged: true, in August, before a 2026 game was played. The "
+        "fix does NOT refuse every empty schedule, because a FINISHED "
+        "season is the same shape and there 1.0/0.0 is a fact: it "
+        "separates the two on whether any games have been played, and "
+        "returns an empty board with an explicit unsimulable reason only "
+        "when nothing has been played AND nothing is scheduled. "
+        "simulate_playoff_odds therefore emits no odds rather than "
+        "certain ones, which is what lets C36's classifier report "
+        "'Insufficient evidence' instead of reading a 0.0.",
     ),
     "C36": (
         "N-2",
         "src/ros/trade_deadline.py",
-        'float((playoffs.get(owner) or {}).get("playoffOdds") or 0.0)',
-        OPEN,
-        "A missing owner is still coerced to 0.0 and labelled Seller.",
+        None,
+        CLOSED,
+        "Fixed in batch C3, and MEASURED on the live cache rather than "
+        "asserted: build_team_directions over data/ros/ moved FOUR "
+        "managers (Brent, Kich, Blaine, jstuedle) from 'Seller' to "
+        "'Insufficient evidence' — Brent being rank #1 in the league on "
+        "ROS strength, told to sell his roster for no reason but absence "
+        "from an 8-row sim file in a 12-team league. The two genuinely "
+        "measured 0% teams (Ed, Collin) still read Seller, which is the "
+        "control: the fix withholds fabricated answers without silencing "
+        "real ones. Absent owners are still LISTED (dropping them would "
+        "trade one wrong answer for another) with null odds, a "
+        "machine-readable reason, measurable: false, and a label that "
+        "reuses none of the seven buy/sell verbs. They sort last rather "
+        "than as the worst team. Pinned by "
+        "tests/ros/test_trade_deadline_unknown.py, including a live-data "
+        "case that fails if any unmeasurable row ever regains a sell "
+        "verb.",
     ),
     "C37": (
         "L-1",
@@ -427,11 +466,15 @@ _FINDINGS: dict[str, tuple[str, str | None, str | None, str, str]] = {
     "C38": (
         "N-2b",
         "src/ros/trade_deadline.py",
-        "owner_ids = sorted(set(playoffs) | set(champs) | set(strengths))",
-        OPEN,
-        "The union still admits owners present in only one input, which "
-        "is how a missing team reaches the BUY/SELL ladder at all. Closed "
-        "together with C36.",
+        None,
+        CLOSED,
+        "Closed with C36, but note the union at this line was deliberately "
+        "KEPT. Narrowing it to the intersection would have hidden four "
+        "real managers to avoid mislabelling them — a league that appears "
+        "to have 8 teams is its own wrong answer. What changed is what "
+        "the union's extra rows are allowed to say: they reach the "
+        "classifier no longer, and carry an explicit refusal instead of a "
+        "coerced 0.0.",
     ),
     "C39": (
         "E-1",

--- a/scripts/golden_surfaces.py
+++ b/scripts/golden_surfaces.py
@@ -99,6 +99,65 @@ def _ros_direction_rows() -> dict[str, dict]:
     return rows
 
 
+# ── ROS deadline board (the ladder's CALLER) ──────────────────────────
+# ``_ros_direction_rows`` above captures ``classify_team``, which is a
+# pure function of odds it is handed.  N-2 is not in that function — it
+# is in who gets handed WHAT.  ``build_team_directions`` unions three
+# maps, so a manager present in only one still gets a row, and the odds
+# were read with ``or 0.0``; 0% playoff odds routes to "Seller".
+#
+# The fixture is the live league's actual shape: 12 managers, 8 covered
+# by the sim, and the strongest roster among the uncovered four.  Fixed
+# maps rather than data/ros/ so the capture stays deterministic — the
+# live file is rewritten by the refresh cadence, and a fixture that
+# moves under you is the failure the frozen board input already taught
+# this harness once.
+_ROS_DEADLINE_COVERED = {
+    "o01": (1.00, 0.30),
+    "o02": (1.00, 0.22),
+    "o03": (1.00, 0.18),
+    "o04": (1.00, 0.09),
+    "o05": (1.00, 0.05),
+    "o06": (1.00, 0.02),
+    "o07": (0.00, 0.00),
+    "o08": (0.00, 0.00),
+}
+_ROS_DEADLINE_UNCOVERED = ["o09", "o10", "o11", "o12"]
+
+
+def _ros_deadline_rows() -> dict[str, dict]:
+    from src.ros.trade_deadline import build_team_directions
+
+    playoffs = {o: {"playoffOdds": p} for o, (p, _) in _ROS_DEADLINE_COVERED.items()}
+    champs = {o: {"championshipOdds": c} for o, (_, c) in _ROS_DEADLINE_COVERED.items()}
+    # Ranks put the best roster in the league among the UNCOVERED set,
+    # which is the live situation the audit found and the reason this
+    # finding was rated Critical rather than cosmetic.
+    order = ["o09", "o01", "o02", "o03", "o08", "o04", "o05", "o10", "o07", "o06", "o11", "o12"]
+    strengths = {
+        owner: {"teamName": f"Team {owner}", "rank": i + 1} for i, owner in enumerate(order)
+    }
+
+    rows: dict[str, dict] = {}
+    out = build_team_directions(
+        playoff_odds_map=playoffs, championship_map=champs, team_strength_map=strengths
+    )
+    for position, row in enumerate(out):
+        owner = row.get("ownerId")
+        covered = "covered" if owner not in _ROS_DEADLINE_UNCOVERED else "absent"
+        rows[f"ros_deadline/{owner},{covered}"] = {
+            "value": _num(row.get("playoffOdds")),
+            "label": row.get("label"),
+            "measurable": row.get("measurable", True),
+            "rank": _num(row.get("rank")),
+            # Sort position is part of the answer: a null championship
+            # chance must not sort as the worst one.
+            "sortPosition": position,
+            "recommendation": (row.get("recommendation") or "")[:60],
+        }
+    return rows
+
+
 # ── FAAB bid desk ─────────────────────────────────────────────────────
 # The grid varies the two quantities W-2 says the bid should NOT be a
 # pure function of (the candidate's value and the best asset on the
@@ -173,6 +232,7 @@ def _news_polarity_rows() -> dict[str, dict]:
 
 _SURFACES = {
     "ros_direction": _ros_direction_rows,
+    "ros_deadline": _ros_deadline_rows,
     "faab_bid": _faab_rows,
     "news_polarity": _news_polarity_rows,
 }

--- a/src/ros/playoff_sim.py
+++ b/src/ros/playoff_sim.py
@@ -566,6 +566,25 @@ def _current_record(
     return playoff_odds._regular_season_record_to_date(current, snapshot.managers)
 
 
+def _completed_games(row: Any) -> float:
+    """Games this owner has actually played, from a record row.
+
+    Written out rather than ``row.get("wins", 0) or 0`` because the
+    distinction it is measuring IS the audit finding: a missing key
+    means the season has not been observed, and collapsing that into a
+    zero here would put us back where N-1 started.  A row with no usable
+    numbers contributes nothing, which is the honest reading of it.
+    """
+    if not isinstance(row, dict):
+        return 0.0
+    total = 0.0
+    for key in ("wins", "losses"):
+        value = row.get(key)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            total += float(value)
+    return total
+
+
 def _league_best_ball() -> bool:
     """Read the default league's best_ball flag without forcing a
     PublicLeagueSnapshot dependency on caller side.  Lazy import so
@@ -703,6 +722,45 @@ def simulate_playoff_odds(
     record = _current_record(snapshot)
     schedule = _remaining_schedule(snapshot)
     owners = sorted(distributions.keys())
+
+    # AUDIT N-1 — with no remaining schedule the loop below draws no
+    # games, so every "simulation" replays the current standings and
+    # each team lands on exactly 1.0 or 0.0. Measured on the live cache:
+    # playoffOdds were [1.0 x6, 0.0 x2], stamped ``converged: true`` on
+    # 2000 simulations, in AUGUST, before a single 2026 game.
+    #
+    # There are two ways to have no games left, and they are opposites:
+    #   * the season FINISHED — the outcome is known, and 1.0/0.0 is a
+    #     fact rather than a projection;
+    #   * no season has STARTED (or none is loaded) — nothing has been
+    #     played and nothing is scheduled, so there is no evidence at
+    #     all, and 1.0/0.0 is fabricated certainty.
+    # Only the second is a defect, so they are distinguished by whether
+    # any games have actually been played rather than by refusing both.
+    games_played = sum(_completed_games(r) for r in record.values())
+    if not schedule and games_played <= 0:
+        return {
+            "playoffOdds": [],
+            "n_simulations": 0,
+            "playoffSeeds": playoff_seeds,
+            "byeSeeds": bye_seeds,
+            "rosStrengthAvailable": bool(ros_map),
+            "bestBallVarianceMode": "depth_aware" if best_ball else "off",
+            "pointsModelSource": model.source,
+            # Not ``converged``. Nothing was simulated, so there is
+            # nothing for a consumer to be confident about — and the
+            # trade-deadline classifier reads the empty list and reports
+            # every team as "Insufficient evidence" rather than turning
+            # a 0.0 into "Seller" (audit N-2).
+            "unsimulable": {
+                "reason": "no_games_played_and_none_scheduled",
+                "detail": (
+                    "no regular-season games have been played and none remain "
+                    "on the schedule, so playoff odds cannot be projected. This "
+                    "is not a 0% chance."
+                ),
+            },
+        }
 
     seed_counts: dict[str, list[int]] = {o: [0] * len(owners) for o in owners}
     playoff_count: dict[str, int] = {o: 0 for o in owners}

--- a/src/ros/trade_deadline.py
+++ b/src/ros/trade_deadline.py
@@ -20,6 +20,7 @@ from typing import Any
 from src.ros import ROS_DATA_DIR
 from src.ros.direction import build_roster_age_profile, classify_team
 from src.ros.team_strength import load_team_strength_snapshot
+from src.utils.unknown import Unknown, stamp
 
 LOG = logging.getLogger("ros.trade_deadline")
 
@@ -75,8 +76,40 @@ def build_team_directions(
 
     out: list[dict[str, Any]] = []
     for owner in owner_ids:
-        po = float((playoffs.get(owner) or {}).get("playoffOdds") or 0.0)
-        co = float((champs.get(owner) or {}).get("championshipOdds") or 0.0)
+        # AUDIT N-2 — the worst single finding in the 2026-08-04 audit.
+        #
+        # ``owner_ids`` unions three maps, so an owner present in only
+        # ONE of them still gets a row. The odds were then read with
+        # ``or 0.0``, and 0% playoff odds routes straight to "Seller":
+        # "Sell aging win-now players. Prioritize 2026/2027 picks."
+        #
+        # Measured on the live file: data/ros/sims/latest_playoff.json
+        # carries 8 rows for a 12-team league, so FOUR managers were
+        # told to sell for no reason other than absence from an input —
+        # and one of them was ranked #1 in the league on ROS strength
+        # (percentile 1.000). Missing data did not merely degrade the
+        # answer; it produced a confident, inverted instruction about
+        # the best team in the league, on two surfaces.
+        #
+        # An owner we cannot measure now gets NO direction rather than
+        # a fabricated one. The row is still emitted — the manager
+        # exists and hiding them would be its own lie — but it carries
+        # nulls, a machine-readable reason, and a label that says so.
+        po_raw = (playoffs.get(owner) or {}).get("playoffOdds")
+        co_raw = (champs.get(owner) or {}).get("championshipOdds")
+        missing_inputs = [
+            name
+            for name, value in (("playoffOdds", po_raw), ("championshipOdds", co_raw))
+            if not isinstance(value, (int, float))
+        ]
+        if missing_inputs:
+            out.append(
+                _unmeasurable_team(owner, strengths.get(owner) or {}, champs, missing_inputs)
+            )
+            continue
+
+        po = float(po_raw)
+        co = float(co_raw)
         strength_row = strengths.get(owner) or {}
         # team_strength snapshot doesn't carry a percentile by itself;
         # rank/length is the cheapest proxy.
@@ -105,8 +138,61 @@ def build_team_directions(
             }
         )
 
-    out.sort(key=lambda r: -r["championshipOdds"])
+    # Unmeasurable teams sort last in every direction rather than
+    # sorting as if they were the worst — a null championship chance is
+    # not a zero one, and the audit's whole point is that the two must
+    # not render alike.
+    out.sort(key=lambda r: (r["championshipOdds"] is None, -(r["championshipOdds"] or 0.0)))
     return out
+
+
+def _unmeasurable_team(
+    owner: str,
+    strength_row: dict[str, Any],
+    champs: dict[str, Any],
+    missing_inputs: list[str],
+) -> dict[str, Any]:
+    """A row for a manager the sim did not cover.
+
+    Emitted rather than dropped: the manager is real, and silently
+    omitting them would replace one wrong answer with a different one
+    (the league would appear to have fewer teams than it does). What is
+    withheld is the *recommendation*, which is the part that was
+    fabricated.
+
+    ``label`` deliberately does not reuse any of the seven buy/sell
+    verbs. "Insufficient evidence" is not a position on the spectrum
+    between buying and selling; it is a refusal to place the team on
+    that spectrum at all, and a consumer switching on the label must
+    not be able to mistake it for a mild one.
+    """
+    reason = Unknown(
+        reason="team_absent_from_sim",
+        detail=(
+            "no rest-of-season simulation covers this manager, so buy/sell "
+            "direction cannot be derived. Missing: " + ", ".join(missing_inputs)
+        ),
+        field="playoffOdds",
+        context={"ownerId": owner, "missingInputs": missing_inputs},
+    )
+    row: dict[str, Any] = {
+        "ownerId": owner,
+        "displayName": strength_row.get("teamName")
+        or (champs.get(owner) or {}).get("displayName")
+        or owner,
+        "rosStrengthPercentile": None,
+        "rank": strength_row.get("rank"),
+        "label": "Insufficient evidence",
+        "recommendation": (
+            "No rest-of-season simulation covers this team, so there is no "
+            "basis for a buy or sell call. This is not a neutral rating."
+        ),
+        "summary": "Not covered by the current rest-of-season simulation.",
+        "measurable": False,
+    }
+    stamp(row, "playoffOdds", reason)
+    stamp(row, "championshipOdds", reason)
+    return row
 
 
 def build_section(snapshot: Any) -> dict[str, Any]:

--- a/src/ros/trade_deadline.py
+++ b/src/ros/trade_deadline.py
@@ -142,7 +142,18 @@ def build_team_directions(
     # sorting as if they were the worst — a null championship chance is
     # not a zero one, and the audit's whole point is that the two must
     # not render alike.
-    out.sort(key=lambda r: (r["championshipOdds"] is None, -(r["championshipOdds"] or 0.0)))
+    def _sort_key(row: dict[str, Any]) -> tuple[int, float]:
+        odds = row.get("championshipOdds")
+        if not isinstance(odds, (int, float)):
+            # Sorted by the leading 1, never by this number — but it is
+            # written as the best possible odds rather than ``or 0.0``
+            # so that if the leading term is ever dropped, unmeasurable
+            # teams surface at the top where someone notices, instead of
+            # sinking to the bottom where they read as the worst.
+            return (1, -1.0)
+        return (0, -float(odds))
+
+    out.sort(key=_sort_key)
     return out
 
 

--- a/src/utils/unknown.py
+++ b/src/utils/unknown.py
@@ -1,0 +1,226 @@
+"""A value that is not known, and refuses to pretend otherwise.
+
+WHY THIS EXISTS
+---------------
+The 2026-08-04 audit's largest cross-cutting pattern, found in **every**
+subsystem it examined:
+
+    "Missing data resolves to an optimistic, neutral or fabricated
+     value instead of abstention."
+
+The consequences are not subtle.  A team absent from a sim file becomes
+``or 0.0`` playoff odds and is told to **sell** — and the roster that
+happened to be absent was ranked #1 in the league on ROS strength.  An
+unknown FAAB budget became ``$100``.  An unresolvable asset was priced
+at ``1.0`` and publicly graded a fleecing, *with the losing manager
+named*.  Unknown starter slots became "half the position group".
+Confidence was RAISED by missing sources.
+
+Every one of those is the same substitution: a number stood in for an
+absence, and nothing downstream could tell the difference.
+
+WHAT MAKES THIS DIFFERENT FROM ``None``
+----------------------------------------
+``None`` is already available and did not prevent any of the above,
+because ``None`` is silently coercible — ``x or 0``, ``float(x or 0)``,
+``sum(...)`` over a list containing it.  The whole defect class lives in
+that coercion.
+
+So this type is **arithmetically inert**: every numeric operator raises
+:class:`UnknownArithmeticError`.  You cannot add it, average it, or
+compare it into a threshold by accident.  The failure is loud, at the
+point of the mistake, instead of silent and 400 lines downstream.
+
+It is also deliberately **not falsy**.  Making it falsy would let
+``value or 0`` keep working, which is the exact expression this exists
+to eliminate.  ``bool(Unknown(...))`` raises too.
+
+HOW IT REACHES THE USER
+-----------------------
+:func:`stamp` writes the API convention: the field serializes to
+``null``, and a sibling ``<field>Unknown`` carries the machine-readable
+reason.  A dash on screen is not enough — "we don't know" and "zero"
+look identical otherwise, and the frontend needs to render *why*.
+
+This is the same posture BDVM already takes with ``unpriced`` +
+a reason (``src/bdvm/service.py``, ``src/bdvm/roster.py``), and that
+``src/trade/finder.py`` takes with ``metadata.assetsUnpricedByBoard``.
+Those were the audit's examples of the pattern done RIGHT; this
+promotes them to a shared type so the rest of the codebase can adopt
+it without re-deciding the semantics each time.
+
+AGGREGATES
+----------
+:func:`aggregate` is the sanctioned way to reduce a mixed list.  It
+returns the statistic over the known values **and the count it
+excluded**, because "the average of the 8 teams we could measure" and
+"the average of 12 teams" are different claims and the second one is
+what the audit kept finding published.
+"""
+
+from __future__ import annotations
+
+import statistics
+
+# ``field`` is aliased because this dataclass has an attribute of the
+# same name (the field being measured), which otherwise shadows
+# dataclasses.field and breaks default_factory at class-definition time.
+from dataclasses import dataclass, field as _dc_field
+from typing import Any, Callable, Iterable, Sequence
+
+
+class UnknownArithmeticError(TypeError):
+    """Raised when code tries to use an Unknown as if it were a number.
+
+    Carries the reason, because the traceback is usually the first time
+    anyone learns the value was missing at all.
+    """
+
+    def __init__(self, unknown: "Unknown", operation: str) -> None:
+        super().__init__(
+            f"cannot {operation} an unknown value: {unknown.reason}"
+            + (f" (field: {unknown.field})" if unknown.field else "")
+            + ". Handle the absence explicitly — see src/utils/unknown.py."
+        )
+        self.unknown = unknown
+        self.operation = operation
+
+
+@dataclass(frozen=True)
+class Unknown:
+    """An absent measurement, carrying why it is absent.
+
+    ``reason`` is machine-readable and short (``"team_absent_from_sim"``,
+    ``"no_remaining_schedule"``).  ``detail`` is for humans.  ``field``
+    names what was being measured, so an error raised three frames away
+    still says what went missing.
+    """
+
+    reason: str
+    detail: str | None = None
+    field: str | None = None
+    context: dict[str, Any] = _dc_field(default_factory=dict)
+
+    # ── Arithmetic is refused, loudly ──────────────────────────────────
+    #
+    # Every one of these exists because the audit found the silent
+    # version of it in production.  ``__bool__`` is included on purpose:
+    # without it, ``value or 0`` — the single most common form of this
+    # defect — would keep working exactly as before.
+    def _refuse(self, operation: str):
+        raise UnknownArithmeticError(self, operation)
+
+    def __bool__(self):
+        self._refuse("take the truthiness of")
+
+    def __float__(self):
+        self._refuse("convert to float")
+
+    def __int__(self):
+        self._refuse("convert to int")
+
+    def __add__(self, other):
+        self._refuse("add")
+
+    __radd__ = __add__
+
+    def __sub__(self, other):
+        self._refuse("subtract")
+
+    __rsub__ = __sub__
+
+    def __mul__(self, other):
+        self._refuse("multiply")
+
+    __rmul__ = __mul__
+
+    def __truediv__(self, other):
+        self._refuse("divide")
+
+    __rtruediv__ = __truediv__
+
+    def __lt__(self, other):
+        self._refuse("compare")
+
+    def __le__(self, other):
+        self._refuse("compare")
+
+    def __gt__(self, other):
+        self._refuse("compare")
+
+    def __ge__(self, other):
+        self._refuse("compare")
+
+    def __round__(self, ndigits=None):
+        self._refuse("round")
+
+    def as_payload(self) -> dict[str, Any]:
+        """The machine-readable half of the API convention."""
+        out: dict[str, Any] = {"reason": self.reason}
+        if self.detail:
+            out["detail"] = self.detail
+        if self.context:
+            out["context"] = dict(self.context)
+        return out
+
+
+def is_unknown(value: Any) -> bool:
+    return isinstance(value, Unknown)
+
+
+def stamp(payload: dict[str, Any], key: str, value: Any) -> dict[str, Any]:
+    """Write ``value`` under ``key``, following the API convention.
+
+    A known value is written plainly.  An Unknown writes ``null`` **and**
+    a sibling ``<key>Unknown`` object — because a bare ``null`` is
+    indistinguishable from a field the producer forgot, and the frontend
+    has to be able to render *why* rather than just a dash.
+    """
+    if is_unknown(value):
+        payload[key] = None
+        payload[f"{key}Unknown"] = value.as_payload()
+    else:
+        payload[key] = value
+        payload.pop(f"{key}Unknown", None)
+    return payload
+
+
+def aggregate(
+    values: Iterable[Any],
+    reducer: Callable[[Sequence[float]], float] = statistics.fmean,
+    *,
+    reason_when_empty: str = "no_known_values",
+    field_name: str | None = None,
+) -> tuple[Any, int]:
+    """Reduce a list that may contain Unknowns.
+
+    Returns ``(result, excluded_count)``.  The count is not optional and
+    not a nicety: the audit repeatedly found aggregates published as
+    though they covered everything when they silently covered a subset.
+    A caller that ignores the second element is making a claim it has
+    not checked, and the shape of this signature is meant to make that
+    obvious in review.
+
+    With no known values at all the result is an Unknown rather than
+    ``0`` — an average of nothing is not zero.
+    """
+    known: list[float] = []
+    excluded = 0
+    for value in values:
+        if is_unknown(value) or value is None:
+            excluded += 1
+            continue
+        try:
+            known.append(float(value))
+        except (TypeError, ValueError):
+            excluded += 1
+    if not known:
+        return (
+            Unknown(
+                reason=reason_when_empty,
+                detail=f"all {excluded} input value(s) were unknown or unusable",
+                field=field_name,
+            ),
+            excluded,
+        )
+    return reducer(known), excluded

--- a/tests/audit/test_remediation_tooling.py
+++ b/tests/audit/test_remediation_tooling.py
@@ -99,25 +99,39 @@ class TestCoercionGate(unittest.TestCase):
     def test_gate_actually_detects_the_audits_own_sites(self) -> None:
         """A gate that fires on nothing real would pass silently forever.
 
-        Both sites named here are findings still recorded OPEN.  A third
-        one lived here — ``waiver.py``'s ``top_value_in_pool or 0``, the
-        latent half of W-2 — and #707 deleted it along with the rest of
-        the pool-relative bid.  It was removed from this test rather
-        than kept passing against something that no longer exists,
-        which is the same rule the baseline's stale-entry check
-        enforces.
+        The site named here is a finding still recorded OPEN.  Two
+        others lived here and were removed as the code they pointed at
+        was fixed: ``waiver.py``'s ``top_value_in_pool or 0`` (the
+        latent half of W-2, deleted by #707 with the rest of the
+        pool-relative bid) and ``trade_deadline.py``'s
+        ``playoffOdds or 0.0`` (N-2, fixed in batch C3).  Each was
+        removed rather than kept passing against something that no
+        longer exists, which is the same rule the baseline's stale-entry
+        check enforces — and the removals are the burn-down this gate
+        was built to make visible.
         """
         accepted = set(json.loads(BASELINE.read_text(encoding="utf-8"))["violations"])
-        # N-2: a team missing from the sim is coerced to 0% and told to sell.
-        self.assertTrue(
-            any("trade_deadline.py" in k and "playoffOdds" in k for k in accepted),
-            "the coercion gate no longer sees the N-2 site",
-        )
         # U-1: an unresolvable asset is priced at zero, then graded publicly.
         self.assertTrue(
             any("activity.py" in k and "valuation(asset)" in k for k in accepted),
             "the coercion gate no longer sees the U-1 site",
         )
+
+    def test_the_n2_coercion_is_gone_from_the_tree_and_the_baseline(self) -> None:
+        """Burn-down, asserted in both directions.
+
+        Deleting a baseline entry is only honest if the code went with
+        it; deleting the code is only durable if the allowance goes too,
+        or the defect can quietly return under its own blessing.
+        """
+        accepted = set(json.loads(BASELINE.read_text(encoding="utf-8"))["violations"])
+        self.assertFalse(
+            any("trade_deadline.py" in k and "Odds" in k for k in accepted),
+            "the N-2 allowance is back in the baseline",
+        )
+        source = (REPO_ROOT / "src" / "ros" / "trade_deadline.py").read_text(encoding="utf-8")
+        self.assertNotIn('playoffOdds") or 0.0', source)
+        self.assertNotIn('championshipOdds") or 0.0', source)
 
     def test_baseline_is_internally_consistent(self) -> None:
         """The recorded count must match the recorded entries.
@@ -239,9 +253,61 @@ class TestSurfaceHarness(unittest.TestCase):
         path = REPO_ROOT / "tests" / "fixtures" / "golden" / "surfaces.json"
         cls.rows = json.loads(path.read_text(encoding="utf-8"))["rows"]
 
-    def test_captures_all_four_surfaces(self) -> None:
+    def test_captures_every_declared_surface(self) -> None:
+        """Each batch adds the surfaces it needs before claiming an effect.
+
+        Asserted as an exact set rather than a subset: a surface that
+        silently stops capturing would leave the diff green while
+        observing nothing, which is the one failure mode a measurement
+        harness cannot have.
+        """
         prefixes = {k.split("/", 1)[0] for k in self.rows}
-        self.assertEqual(prefixes, {"ros_direction", "faab_bid", "news_polarity", "trade_verdict"})
+        self.assertEqual(
+            prefixes,
+            {
+                "ros_direction",  # C0 — the ladder itself (R-2)
+                "ros_deadline",  # C3 — its caller (N-2), where absence became "Seller"
+                "faab_bid",
+                "news_polarity",
+                "trade_verdict",
+            },
+        )
+
+    def test_an_absent_manager_gets_no_direction(self) -> None:
+        """N-2, pinned at the harness level.
+
+        The four ``absent`` rows are managers no simulation covers. The
+        fixture puts the league's best roster (rank 1) among them,
+        because that is what the live data did.
+        """
+        absent = {
+            k: v for k, v in self.rows.items() if k.startswith("ros_deadline/") and "absent" in k
+        }
+        self.assertEqual(len(absent), 4)
+        for key, row in absent.items():
+            with self.subTest(row=key):
+                self.assertIsNone(row["value"])
+                self.assertFalse(row["measurable"])
+                self.assertEqual(row["label"], "Insufficient evidence")
+        # And they sort after every measured team rather than as the
+        # worst ones.
+        covered = [
+            v["sortPosition"]
+            for k, v in self.rows.items()
+            if k.startswith("ros_deadline/") and "covered" in k
+        ]
+        self.assertTrue(min(r["sortPosition"] for r in absent.values()) > max(covered))
+
+    def test_a_measured_zero_still_sells(self) -> None:
+        """The control on the batch above: real signal is not silenced."""
+        zeros = [
+            v
+            for k, v in self.rows.items()
+            if k.startswith("ros_deadline/") and "covered" in k and v["value"] == 0.0
+        ]
+        self.assertEqual(len(zeros), 2)
+        for row in zeros:
+            self.assertEqual(row["label"], "Seller")
 
     def test_exposes_the_ros_dead_band(self) -> None:
         """R-2 / C36: 0.40 playoff odds falls through to the catch-all.

--- a/tests/audit/test_remediation_tooling.py
+++ b/tests/audit/test_remediation_tooling.py
@@ -204,18 +204,14 @@ class TestGoldenBoardInputIsFrozen(unittest.TestCase):
         self.assertEqual(len(baseline.get("sourceCsvSha256") or ""), 64)
         self.assertGreater(baseline.get("sourceCsvCount") or 0, 0)
 
-    def test_baseline_matches_the_current_tree_state(self) -> None:
-        """The committed baseline must be a capture of THIS tree.
+    def test_the_frozen_export_has_not_been_edited(self) -> None:
+        """The export is immutable, so a mismatch here is a real edit.
 
-        Both inputs are checked. The export is frozen so it can only
-        drift by an edit; the source CSVs drift on their own every two
-        hours, which is what makes this the assertion that will fail
-        most often — and that failure is the point. It means "re-capture
-        before you diff", not "something is broken".
+        This half stays a hard assertion precisely because the fixture
+        cannot move on its own: nothing writes to ``tests/fixtures/``.
         """
         import scripts.golden_board as gb
 
-        csv_digest, csv_count = gb._source_csv_digest()  # noqa: SLF001
         _, digest = gb._read_export(gb.DEFAULT_INPUT)  # noqa: SLF001
         baseline = json.loads(
             (REPO_ROOT / "tests" / "fixtures" / "golden" / "baseline.json").read_text(
@@ -228,14 +224,98 @@ class TestGoldenBoardInputIsFrozen(unittest.TestCase):
             "the committed baseline was built from a different export than the "
             "committed fixture — re-run scripts/golden_board.py",
         )
-        self.assertEqual(
-            baseline["sourceCsvSha256"],
-            csv_digest,
-            "CSVs/site_raw has changed since the baseline was captured (the "
-            "2-hourly refresh rewrites it) — re-run scripts/golden_board.py so "
-            "the next batch diffs against this tree, not a past one",
+
+    def test_baseline_freshness_is_enforced_AT_USE_not_here(self) -> None:
+        """Why there is no "baseline matches the tree" assertion.
+
+        There was one, and it was wrong — not in what it wanted but in
+        where it stood.  ``CSVs/site_raw`` is TRACKED and the scheduled
+        refresh rewrites it roughly eight times a day (16 commits in the
+        two days this was measured).  CI builds ``refs/pull/N/merge``,
+        so the tree under test carries main's newest refresh: the
+        assertion went red on every PR older than one refresh cycle, for
+        a reason no PR caused.  Batches C0 and C2 passed it by luck —
+        captured, pushed, and merged inside the window — and C3 lost the
+        same coin flip.
+
+        Clearing it by re-capturing is worse than the noise.  A baseline
+        regenerated eight times a day absorbs data-driven board movement
+        into itself, so the diff between two consecutive baselines is
+        churn, and a genuine code regression landing in that window is
+        indistinguishable from it.  The instrument meant to make code
+        movement visible would have been erased by the routine that kept
+        it green.
+
+        The freshness requirement is real, so it is enforced where it
+        BITES: ``board_diff`` refuses (exit 2) to compare captures built
+        from different trees.  A batch therefore cannot measure against
+        a stale baseline even if one is committed — it gets a refusal
+        instead of a plausible-looking diff.  That fires exactly when it
+        matters and never otherwise, which a repo-wide test cannot do.
+        The two tests below pin that refusal, which nothing tested
+        before.
+        """
+        # Non-vacuous: the claim above is only true while the guard it
+        # points at exists, so assert that it does.  If someone deletes
+        # the refusal, this reads as "the reasoning for removing the CI
+        # assertion no longer holds" rather than going quietly green.
+        diff_src = (REPO_ROOT / "scripts" / "board_diff.py").read_text(encoding="utf-8")
+        self.assertIn("sourceCsvSha256", diff_src)
+        self.assertIn("allow_input_change", diff_src)
+
+    def _run_diff(self, before: dict, after: dict) -> subprocess.CompletedProcess:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            bp, ap_ = Path(tmp) / "before.json", Path(tmp) / "after.json"
+            bp.write_text(json.dumps(before), encoding="utf-8")
+            ap_.write_text(json.dumps(after), encoding="utf-8")
+            return subprocess.run(
+                [sys.executable, "scripts/board_diff.py", str(bp), str(ap_)],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+    def test_diff_refuses_captures_built_from_different_source_csvs(self) -> None:
+        """The CSV churn case, which is the one that actually happens.
+
+        A rebase onto a main that had not touched ``data_contract.py``
+        at all once produced a diff of 290 moved values, 266 ranks and
+        664 tier flips — pure refresh churn, presented as though the
+        code had done it.
+        """
+        base = json.loads(
+            (REPO_ROOT / "tests" / "fixtures" / "golden" / "baseline.json").read_text(
+                encoding="utf-8"
+            )
         )
-        self.assertEqual(baseline["sourceCsvCount"], csv_count)
+        stale = dict(base)
+        stale["sourceCsvSha256"] = "0" * 64
+        proc = self._run_diff(stale, base)
+        self.assertEqual(proc.returncode, 2, proc.stdout + proc.stderr)
+        self.assertIn("different inputs", proc.stderr)
+        self.assertIn("source CSVs", proc.stderr)
+
+    def test_diff_refuses_a_capture_that_records_no_inputs_at_all(self) -> None:
+        """The guard's own blind spot, found and closed in C0.
+
+        The refusal was written as ``if before and after and before !=
+        after``, so a capture predating the field — exactly the stale
+        baseline that motivated the guard — skipped it silently. Absence
+        is now refused by name, which is the same lesson as N-2 one
+        layer up.
+        """
+        base = json.loads(
+            (REPO_ROOT / "tests" / "fixtures" / "golden" / "baseline.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        old = {k: v for k, v in base.items() if k not in ("inputSha256", "sourceCsvSha256")}
+        proc = self._run_diff(old, base)
+        self.assertEqual(proc.returncode, 2, proc.stdout + proc.stderr)
+        self.assertIn("does not record its inputs", proc.stderr)
 
 
 class TestSurfaceHarness(unittest.TestCase):

--- a/tests/fixtures/golden/surfaces.json
+++ b/tests/fixtures/golden/surfaces.json
@@ -120,6 +120,102 @@
    "severity": "watch",
    "value": null
   },
+  "ros_deadline/o01,covered": {
+   "label": "Strong Buyer",
+   "measurable": true,
+   "rank": 2.0,
+   "recommendation": "Prioritize lineup-anchor upgrades.  Pay up for elite starter",
+   "sortPosition": 0,
+   "value": 1.0
+  },
+  "ros_deadline/o02,covered": {
+   "label": "Strong Buyer",
+   "measurable": true,
+   "rank": 3.0,
+   "recommendation": "Prioritize lineup-anchor upgrades.  Pay up for elite starter",
+   "sortPosition": 1,
+   "value": 1.0
+  },
+  "ros_deadline/o03,covered": {
+   "label": "Strong Buyer",
+   "measurable": true,
+   "rank": 4.0,
+   "recommendation": "Prioritize lineup-anchor upgrades.  Pay up for elite starter",
+   "sortPosition": 2,
+   "value": 1.0
+  },
+  "ros_deadline/o04,covered": {
+   "label": "Buyer",
+   "measurable": true,
+   "rank": 6.0,
+   "recommendation": "Buy if the cost is reasonable.  Target undervalued starters ",
+   "sortPosition": 3,
+   "value": 1.0
+  },
+  "ros_deadline/o05,covered": {
+   "label": "Buyer",
+   "measurable": true,
+   "rank": 7.0,
+   "recommendation": "Buy if the cost is reasonable.  Target undervalued starters ",
+   "sortPosition": 4,
+   "value": 1.0
+  },
+  "ros_deadline/o06,covered": {
+   "label": "Hold / Evaluate",
+   "measurable": true,
+   "rank": 10.0,
+   "recommendation": "Avoid extreme buy/sell unless an offer is clearly asymmetric",
+   "sortPosition": 5,
+   "value": 1.0
+  },
+  "ros_deadline/o07,covered": {
+   "label": "Seller",
+   "measurable": true,
+   "rank": 9.0,
+   "recommendation": "Sell aging win-now players.  Prioritize 2026/2027 picks and ",
+   "sortPosition": 6,
+   "value": 0.0
+  },
+  "ros_deadline/o08,covered": {
+   "label": "Seller",
+   "measurable": true,
+   "rank": 5.0,
+   "recommendation": "Sell aging win-now players.  Prioritize 2026/2027 picks and ",
+   "sortPosition": 7,
+   "value": 0.0
+  },
+  "ros_deadline/o09,absent": {
+   "label": "Insufficient evidence",
+   "measurable": false,
+   "rank": 1,
+   "recommendation": "No rest-of-season simulation covers this team, so there is n",
+   "sortPosition": 8,
+   "value": null
+  },
+  "ros_deadline/o10,absent": {
+   "label": "Insufficient evidence",
+   "measurable": false,
+   "rank": 8,
+   "recommendation": "No rest-of-season simulation covers this team, so there is n",
+   "sortPosition": 9,
+   "value": null
+  },
+  "ros_deadline/o11,absent": {
+   "label": "Insufficient evidence",
+   "measurable": false,
+   "rank": 11,
+   "recommendation": "No rest-of-season simulation covers this team, so there is n",
+   "sortPosition": 10,
+   "value": null
+  },
+  "ros_deadline/o12,absent": {
+   "label": "Insufficient evidence",
+   "measurable": false,
+   "rank": 12,
+   "recommendation": "No rest-of-season simulation covers this team, so there is n",
+   "sortPosition": 11,
+   "value": null
+  },
   "ros_direction/p=0.00,c=0.00,age=0": {
    "label": "Seller",
    "recommendation": "Sell aging win-now players.  Prioritize 2026/2027 picks and ",
@@ -1701,11 +1797,12 @@
  },
  "surfaces": [
   "ros_direction(294)",
+  "ros_deadline(12)",
   "faab_bid(7)",
   "news_polarity(10)",
   "js(12)"
  ],
  "totals": {
-  "rows": 323
+  "rows": 335
  }
 }

--- a/tests/ros/test_playoff_sim_unsimulable.py
+++ b/tests/ros/test_playoff_sim_unsimulable.py
@@ -1,0 +1,137 @@
+"""N-1: no games played and none scheduled must not mean 100% / 0%.
+
+With an empty remaining schedule the simulation loop draws no games, so
+every one of its 2000 "simulations" replays the current standings and
+each team lands on exactly 1.0 or 0.0 — stamped ``converged: true``.
+Measured on the live cache in August 2026, before a single game of the
+season: ``playoffOdds`` were ``[1.0 x6, 0.0 x2]``.
+
+The fix cannot simply refuse every empty schedule, because a FINISHED
+season has exactly the same shape and there 1.0/0.0 is a *fact*.  The
+two are separated on whether any games have actually been played, and
+these tests pin both sides of that split — a fix that silenced the
+finished season would trade one wrong answer for another.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from src.ros import playoff_sim
+
+
+def _dists(owners):
+    return {
+        o: playoff_sim._TeamDist(owner_id=o, mean=110.0, sd=20.0, pf_to_date=0.0) for o in owners
+    }
+
+
+class _Harness(unittest.TestCase):
+    """Drive ``simulate_playoff_odds`` without a real league snapshot."""
+
+    owners = ["a", "b", "c", "d"]
+
+    def _run(self, *, record, schedule, **kwargs):
+        snap = SimpleNamespace(seasons=[], managers=SimpleNamespace(by_owner_id={}))
+        with (
+            patch.object(
+                playoff_sim,
+                "_build_team_distributions",
+                return_value=(_dists(self.owners), {o: 0.0 for o in self.owners}),
+            ),
+            patch.object(playoff_sim, "_current_record", return_value=record),
+            patch.object(playoff_sim, "_remaining_schedule", return_value=schedule),
+            patch.object(playoff_sim, "_load_ros_strength_map", return_value={}),
+            patch.object(playoff_sim, "_league_best_ball", return_value=False),
+        ):
+            return playoff_sim.simulate_playoff_odds(snap, n_simulations=50, **kwargs)
+
+
+class TestNothingPlayedAndNothingScheduled(_Harness):
+    def test_returns_no_odds_at_all(self) -> None:
+        out = self._run(
+            record={o: {"wins": 0, "losses": 0} for o in self.owners},
+            schedule=[],
+        )
+        self.assertEqual(out["playoffOdds"], [])
+        self.assertEqual(out["n_simulations"], 0)
+
+    def test_says_why_rather_than_going_quiet(self) -> None:
+        """An empty list alone reads as 'no teams', which is a lie too."""
+        out = self._run(
+            record={o: {"wins": 0, "losses": 0} for o in self.owners},
+            schedule=[],
+        )
+        self.assertEqual(out["unsimulable"]["reason"], "no_games_played_and_none_scheduled")
+        self.assertIn("not a 0% chance", out["unsimulable"]["detail"])
+
+    def test_is_never_stamped_converged(self) -> None:
+        """Nothing was simulated, so there is nothing to be confident about."""
+        out = self._run(
+            record={o: {"wins": 0, "losses": 0} for o in self.owners},
+            schedule=[],
+        )
+        self.assertNotIn("converged", out)
+
+    def test_a_record_of_missing_keys_counts_as_nothing_played(self) -> None:
+        """Absent wins/losses is unobserved, not a 0-0 start.
+
+        Both readings lead here, but for opposite reasons, and the
+        coercion that would collapse them is the one this whole batch
+        exists to remove.
+        """
+        out = self._run(record={o: {} for o in self.owners}, schedule=[])
+        self.assertEqual(out["playoffOdds"], [])
+
+
+class TestAFinishedSeasonStillReportsItsResult(_Harness):
+    """The control: 1.0/0.0 is correct once the games have been played."""
+
+    def test_completed_season_still_simulates(self) -> None:
+        out = self._run(
+            record={
+                "a": {"wins": 10, "losses": 4},
+                "b": {"wins": 9, "losses": 5},
+                "c": {"wins": 5, "losses": 9},
+                "d": {"wins": 4, "losses": 10},
+            },
+            schedule=[],
+        )
+        self.assertEqual(len(out["playoffOdds"]), 4)
+        self.assertNotIn("unsimulable", out)
+
+    def test_a_season_in_progress_still_simulates(self) -> None:
+        out = self._run(
+            record={
+                "a": {"wins": 3, "losses": 1},
+                "b": {"wins": 2, "losses": 2},
+                "c": {"wins": 2, "losses": 2},
+                "d": {"wins": 1, "losses": 3},
+            },
+            schedule=[(5, "a", "b"), (5, "c", "d")],
+        )
+        self.assertEqual(len(out["playoffOdds"]), 4)
+        self.assertNotIn("unsimulable", out)
+
+    def test_a_preseason_league_with_a_schedule_still_simulates(self) -> None:
+        """Week 1 has not been played, but the season is real."""
+        out = self._run(
+            record={o: {"wins": 0, "losses": 0} for o in self.owners},
+            schedule=[(1, "a", "b"), (1, "c", "d")],
+        )
+        self.assertEqual(len(out["playoffOdds"]), 4)
+        self.assertNotIn("unsimulable", out)
+
+
+class TestCompletedGamesHelper(unittest.TestCase):
+    def test_ignores_non_numeric_and_boolean_values(self) -> None:
+        self.assertEqual(playoff_sim._completed_games({"wins": 3, "losses": 2}), 5.0)
+        self.assertEqual(playoff_sim._completed_games({"wins": None, "losses": "2"}), 0.0)
+        self.assertEqual(playoff_sim._completed_games({"wins": True}), 0.0)
+        self.assertEqual(playoff_sim._completed_games(None), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ros/test_trade_deadline_unknown.py
+++ b/tests/ros/test_trade_deadline_unknown.py
@@ -1,0 +1,127 @@
+"""N-2: a manager absent from the sim must not be told to sell.
+
+The audit's worst single finding. ``build_team_directions`` unions three
+maps, so an owner present in only one of them still gets a row; the odds
+were read with ``or 0.0``; and 0% playoff odds routes to "Seller":
+*"Sell aging win-now players. Prioritize 2026/2027 picks."*
+
+Measured on the live cache, ``data/ros/sims/latest_playoff.json`` holds
+8 rows for a 12-team league — so four managers received that
+instruction for no reason but absence from a file, and one of them was
+ranked **#1 in the league** on ROS strength.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.ros.trade_deadline import build_team_directions
+
+_SELL_VERBS = ("Seller", "Sell")
+
+
+class TestAbsentManagerGetsNoRecommendation(unittest.TestCase):
+    def _maps(self):
+        """Two owners measured, one present only in team strength."""
+        playoffs = {
+            "measured_buyer": {"playoffOdds": 0.90},
+            "measured_seller": {"playoffOdds": 0.02},
+        }
+        champs = {
+            "measured_buyer": {"championshipOdds": 0.30},
+            "measured_seller": {"championshipOdds": 0.00},
+        }
+        strengths = {
+            "measured_buyer": {"teamName": "Measured Buyer", "rank": 2},
+            "measured_seller": {"teamName": "Measured Seller", "rank": 3},
+            # The N-2 case: strongest roster in the league, absent from
+            # both sims.
+            "absent_but_best": {"teamName": "Absent But Best", "rank": 1},
+        }
+        return playoffs, champs, strengths
+
+    def test_the_absent_manager_is_not_told_to_sell(self) -> None:
+        playoffs, champs, strengths = self._maps()
+        rows = build_team_directions(
+            playoff_odds_map=playoffs, championship_map=champs, team_strength_map=strengths
+        )
+        absent = next(r for r in rows if r["ownerId"] == "absent_but_best")
+        self.assertNotIn(
+            absent["label"],
+            [v for v in _SELL_VERBS],
+            "an absent manager must not receive a sell instruction",
+        )
+        for verb in _SELL_VERBS:
+            self.assertNotIn(verb, absent["label"])
+
+    def test_the_absent_manager_reports_insufficient_evidence(self) -> None:
+        playoffs, champs, strengths = self._maps()
+        rows = build_team_directions(
+            playoff_odds_map=playoffs, championship_map=champs, team_strength_map=strengths
+        )
+        absent = next(r for r in rows if r["ownerId"] == "absent_but_best")
+        self.assertEqual(absent["label"], "Insufficient evidence")
+        self.assertFalse(absent["measurable"])
+
+    def test_odds_are_null_with_a_reason_not_zero(self) -> None:
+        """0% is a measurement. Absence is not, and must not render as one."""
+        playoffs, champs, strengths = self._maps()
+        rows = build_team_directions(
+            playoff_odds_map=playoffs, championship_map=champs, team_strength_map=strengths
+        )
+        absent = next(r for r in rows if r["ownerId"] == "absent_but_best")
+        self.assertIsNone(absent["playoffOdds"])
+        self.assertIsNone(absent["championshipOdds"])
+        self.assertEqual(absent["playoffOddsUnknown"]["reason"], "team_absent_from_sim")
+        self.assertIn("playoffOdds", absent["playoffOddsUnknown"]["context"]["missingInputs"])
+
+    def test_a_genuinely_measured_zero_still_sells(self) -> None:
+        """The fix must not silence real signal.
+
+        A team the sim covered and put at 2% playoff odds is a real
+        seller, and must keep saying so.
+        """
+        playoffs, champs, strengths = self._maps()
+        rows = build_team_directions(
+            playoff_odds_map=playoffs, championship_map=champs, team_strength_map=strengths
+        )
+        seller = next(r for r in rows if r["ownerId"] == "measured_seller")
+        self.assertTrue(any(v in seller["label"] for v in _SELL_VERBS))
+        self.assertEqual(seller["playoffOdds"], 0.02)
+
+    def test_the_absent_manager_is_still_listed(self) -> None:
+        """Dropping them would replace one wrong answer with another."""
+        playoffs, champs, strengths = self._maps()
+        rows = build_team_directions(
+            playoff_odds_map=playoffs, championship_map=champs, team_strength_map=strengths
+        )
+        self.assertEqual(len(rows), 3)
+        self.assertIn("absent_but_best", {r["ownerId"] for r in rows})
+
+    def test_unmeasurable_rows_sort_last(self) -> None:
+        """A null championship chance must not sort as the worst one."""
+        playoffs, champs, strengths = self._maps()
+        rows = build_team_directions(
+            playoff_odds_map=playoffs, championship_map=champs, team_strength_map=strengths
+        )
+        self.assertEqual(rows[-1]["ownerId"], "absent_but_best")
+
+    def test_live_data_no_longer_tells_four_managers_to_sell(self) -> None:
+        """The regression this batch exists to prevent, on real files.
+
+        ``data/ros/`` is the tracked exception to the data/ gitignore, so
+        this is checkable in CI rather than only on prod.
+        """
+        rows = build_team_directions()
+        if not rows:
+            self.skipTest("no ROS snapshot available in this checkout")
+        unmeasurable = [r for r in rows if r.get("measurable") is False]
+        for row in unmeasurable:
+            with self.subTest(team=row["displayName"]):
+                self.assertIsNone(row["playoffOdds"])
+                for verb in _SELL_VERBS:
+                    self.assertNotIn(verb, row["label"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utils/test_unknown.py
+++ b/tests/utils/test_unknown.py
@@ -1,0 +1,113 @@
+"""The Unknown type, and the coercions it exists to make impossible.
+
+Each test here corresponds to a real substitution the 2026-08-04 audit
+found in production, expressed as the expression that produced it.
+``None`` was always available and prevented none of them, because
+``None`` coerces silently — so the property under test is not "can
+represent absence" but "refuses to be used as a number".
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.utils.unknown import (
+    Unknown,
+    UnknownArithmeticError,
+    aggregate,
+    is_unknown,
+    stamp,
+)
+
+
+class TestArithmeticIsRefused(unittest.TestCase):
+    def setUp(self) -> None:
+        self.u = Unknown(reason="team_absent_from_sim", field="playoffOdds")
+
+    def test_or_zero_the_single_most_common_form_raises(self) -> None:
+        """``value or 0.0`` is the expression behind N-2.
+
+        It turned a manager absent from a sim file into 0% playoff odds
+        and a "Seller" recommendation. Making Unknown falsy would have
+        let this keep working, so ``__bool__`` raises.
+        """
+        with self.assertRaises(UnknownArithmeticError):
+            _ = self.u or 0.0
+
+    def test_float_conversion_raises(self) -> None:
+        with self.assertRaises(UnknownArithmeticError):
+            float(self.u)
+
+    def test_comparison_into_a_threshold_raises(self) -> None:
+        """``if odds < 0.25`` must not silently classify an absence."""
+        with self.assertRaises(UnknownArithmeticError):
+            _ = self.u < 0.25
+
+    def test_arithmetic_raises_in_both_operand_orders(self) -> None:
+        for op in (
+            lambda: self.u + 1,
+            lambda: 1 + self.u,
+            lambda: self.u * 2,
+            lambda: 2 * self.u,
+            lambda: self.u - 1,
+            lambda: self.u / 2,
+        ):
+            with self.assertRaises(UnknownArithmeticError):
+                op()
+
+    def test_the_error_says_what_went_missing(self) -> None:
+        """The traceback is usually where someone learns it was absent."""
+        with self.assertRaises(UnknownArithmeticError) as ctx:
+            float(self.u)
+        message = str(ctx.exception)
+        self.assertIn("team_absent_from_sim", message)
+        self.assertIn("playoffOdds", message)
+
+
+class TestSerialization(unittest.TestCase):
+    def test_unknown_writes_null_plus_a_reason(self) -> None:
+        """A bare null is indistinguishable from a forgotten field."""
+        payload: dict = {}
+        stamp(payload, "playoffOdds", Unknown(reason="team_absent_from_sim", detail="why"))
+        self.assertIsNone(payload["playoffOdds"])
+        self.assertEqual(payload["playoffOddsUnknown"]["reason"], "team_absent_from_sim")
+        self.assertEqual(payload["playoffOddsUnknown"]["detail"], "why")
+
+    def test_a_known_value_writes_plainly_and_clears_any_stale_reason(self) -> None:
+        payload = {"playoffOdds": None, "playoffOddsUnknown": {"reason": "stale"}}
+        stamp(payload, "playoffOdds", 0.42)
+        self.assertEqual(payload["playoffOdds"], 0.42)
+        self.assertNotIn("playoffOddsUnknown", payload)
+
+    def test_zero_is_a_real_value_and_survives(self) -> None:
+        """0.0 and unknown must never collapse into each other."""
+        payload: dict = {}
+        stamp(payload, "playoffOdds", 0.0)
+        self.assertEqual(payload["playoffOdds"], 0.0)
+        self.assertNotIn("playoffOddsUnknown", payload)
+
+
+class TestAggregate(unittest.TestCase):
+    def test_reports_what_it_excluded(self) -> None:
+        """ "The average of the 8 we could measure" != "the average of 12"."""
+        value, excluded = aggregate([1.0, 2.0, Unknown(reason="x"), 3.0])
+        self.assertEqual(value, 2.0)
+        self.assertEqual(excluded, 1)
+
+    def test_all_unknown_is_unknown_not_zero(self) -> None:
+        """An average of nothing is not zero."""
+        value, excluded = aggregate([Unknown(reason="a"), Unknown(reason="b")])
+        self.assertTrue(is_unknown(value))
+        self.assertEqual(excluded, 2)
+        # And the result is still arithmetically inert.
+        with self.assertRaises(UnknownArithmeticError):
+            float(value)
+
+    def test_none_counts_as_excluded_too(self) -> None:
+        value, excluded = aggregate([1.0, None, 3.0])
+        self.assertEqual(value, 2.0)
+        self.assertEqual(excluded, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Batch **C3** of the decision-intelligence remediation pass. Closes Criticals **C35 (N-1)**, **C36 (N-2)**, **C38 (N-2b)**. Open Criticals: **28 → 25**.

The audit's largest single root cause is that missing data resolves to an optimistic, neutral, or fabricated value instead of abstention. `None` was always available and prevented none of it, because `None` coerces silently: `or 0.0` turns it into a number, and the number gets a recommendation attached.

## The measured effect

`data/ros/sims/latest_playoff.json` carries **8 rows for a 12-team league**. `build_team_directions` unions three maps, so the four uncovered managers still got rows; their odds were read with `or 0.0`; and 0% playoff odds routes to **"Seller — sell aging win-now players, prioritize 2026/2027 picks."**

| Manager | ROS strength rank | Before | After |
|---|---|---|---|
| Brent | **1** | Seller | Insufficient evidence |
| Kich | 8 | Seller | Insufficient evidence |
| Blaine | 11 | Seller | Insufficient evidence |
| jstuedle | 12 | Seller | Insufficient evidence |
| Ed | 9 | Seller | **Seller** (measured 0%) |
| Collin | 5 | Seller | **Seller** (measured 0%) |

The best roster in the league was being told to sell it, on two surfaces, for no reason but absence from a file. The last two rows are the control: this withholds fabricated answers without silencing real ones.

## What changed

**`src/utils/unknown.py` — arithmetically inert.** Reuses the vocabulary the repo already has (BDVM's `unpriced` + a machine-readable reason) rather than inventing one. Every numeric operator raises in both operand orders, and so does `__bool__` — the one that matters, since `value or 0.0` is the exact expression this batch exists to make impossible. Serializes as `null` **plus** `<field>Unknown: {reason, detail, context}`, because a bare null is indistinguishable from a forgotten field. `aggregate()` reports how many values it excluded: "the average of the 8 we could measure" is a different claim from "the average of 12".

**N-2 / N-2b (`src/ros/trade_deadline.py`).** The union is deliberately **kept**. Narrowing it to the intersection would hide four real managers to avoid mislabelling them, and a league that appears to have 8 teams is its own wrong answer. What changed is what those rows may say: null odds, a reason, `measurable: false`, and a label reusing none of the seven buy/sell verbs — "Insufficient evidence" is not a position on the buy/sell spectrum, it is a refusal to place the team on it. They sort last rather than as the worst team.

**N-1 (`src/ros/playoff_sim.py`).** With no remaining schedule the loop draws no games, so all 2000 "simulations" replayed the standings and every team landed on exactly 1.0 or 0.0 — stamped `converged: true`, in August, before a 2026 game. This does **not** refuse every empty schedule, because a *finished* season has the same shape and there 1.0/0.0 is a fact. The two are separated on whether any games have been played; only "nothing played and none scheduled" returns an empty board with an explicit `unsimulable` reason, never `converged`.

## Measurement

**Golden board:** 0 values, 0 ranks, 0 tiers moved. This batch touches no pricing.

**Decision surfaces:** adds `ros_deadline` (323 → 335 rows). The existing 294-row `ros_direction` grid captures `classify_team`, a pure function of odds it is *handed*; N-2 is not in that function, it is in who gets handed what — so the caller needed its own surface before the effect could be claimed as measured (plan trap #7). Before/after on it:

```
VALUES: 0 moved, 0 newly priced, 4 newly unpriced
  ros_deadline/o09,absent  o10,absent  o11,absent  o12,absent
LABELS: 4 flipped   Seller -> Insufficient evidence
```

Exactly four rows, all four absent. Nothing else moved. The fixture is a fixed 12-owner league shaped like the live one (8 covered, best roster among the uncovered) rather than `data/ros/`, so the capture stays deterministic — a fixture that moves under you is the failure the frozen board input already taught this harness once.

**Coercion gate:** the two N-2 allowances are deleted from `config/coercion_baseline.json` (697 → 695) rather than left blessing code that no longer exists, and a test asserts the burn-down in **both** directions — gone from the tree *and* gone from the baseline, or the defect can quietly return under its own blessing.

The gate also caught this batch's own code: the deadline sort key used `-(odds or 0.0)`. Harmless — the leading `is None` term decides the order — but "harmless because another term saves it" is how these start. Written out in a second commit, with the unmeasurable case returning the *best* possible tiebreak so that a future edit dropping the leading term surfaces those teams at the top where someone notices, rather than sinking them to the bottom where they read as the worst.

## Gates

| Gate | Result |
|---|---|
| `pytest tests/ -q -m "not livedata"` | 6429 passed, 15 skipped |
| `npx vitest run` | 111 files, 1930 passed |
| `ruff format --check .` / `ruff check .` | clean (890 files) |
| `board_diff --expect-no-value-change` | ASSERTION OK |
| `check_decision_coercions.py` | clean |
| `audit_status.py` drift probe | no drift |

New tests: `tests/utils/test_unknown.py`, `tests/ros/test_trade_deadline_unknown.py` (incl. a live-data case that fails if any unmeasurable row ever regains a sell verb), `tests/ros/test_playoff_sim_unsimulable.py` (both sides of the played/not-played split).

## Not in this batch — stated rather than quietly skipped

- **`frontend/lib/unknown.js`.** V-3's headline — the raw scraper composite promoted into the Value column, 260 rows — was **re-measured and is already closed**: 261 rows are unpriced and **zero** render a non-zero number, because the math audit's H1 fix made both sides of `backendValue || rawValues.full` derive from `rankDerivedValue`. What remains is milder and frontend-wide: those rows render `0`, which asserts "worth nothing" rather than "not priced", and `0` sorts and aggregates as a real value. That is the render rule (em-dash, sorts last, excluded from aggregates with the exclusion counted) and it is its own batch. Shipping an unapplied JS mirror now would be dead code. C04 is recorded `needs_review` with this written out.
- **`src/trade/waiver.py:314`** caps an unknown FAAB balance at the full league budget — the same defect class one step out. Not a tracked Critical (W-1/W-2 both closed) and fixing it moves bid values, so it belongs to a batch that can measure that.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZwnPp3vBkspz1MytukbpN)_