### PR TITLE
Add the production activation runbook for Sharp Roster Percentage

### DIFF
--- a/docs/runbooks/sharp-roster-percentage-activation.md
+++ b/docs/runbooks/sharp-roster-percentage-activation.md
@@ -1,0 +1,235 @@
+# Sharp Roster Percentage — production activation
+
+Everything for `/market/sharp-roster-percentage` is merged and tested.
+What is **not** done is the part that can only happen on the box that
+holds the data: the roster store starts empty, so the board reports
+`cohort_building` and shows nothing until the crawl has run there.
+
+Nothing here is a code change. Steps 1–5 are the activation; steps 6–7
+are optional features that are inert by design until you supply an
+input.
+
+| Tag | Where |
+|---|---|
+| **[VPS]** | shell on the production box, as the app user |
+| **[LOCAL]** | anywhere with a browser or a repo checkout |
+
+Feature reference: `docs/sharp-roster-percentage/METHODOLOGY.md`.
+
+---
+
+## Why the board can't be finished from CI or a dev container
+
+`GET /api/sharp/roster-percentage` reads `sharp_rosters` in
+`data/intel/ledger.sqlite3` — a **local, gitignored** SQLite file on the
+machine serving the API. The producer has to run where the reader lives.
+Same reasoning as the BDVM and playerctx refresh timers.
+
+---
+
+## Starting state this runbook assumes
+
+1. `main` is deployed (the feature merged via #710 and #723).
+2. The Sharp Buy/Sell Tracker already works — i.e. `/api/sharp/cohort`
+   reports `qualifiedManagers > 0`. **This board is downstream of the
+   same cohort.** If the tracker is still "cohort building", this board
+   will be honestly empty for exactly the same reason, and step 2 is
+   where you find that out.
+
+---
+
+## 1. [VPS] Confirm the timer installed
+
+`deploy.sh` runs `install-systemd-service.sh`, which installs
+`dynasty-sharp-rosters.{service,timer}` when it is missing. It should
+already be there after any deploy of `main`.
+
+```bash
+systemctl list-timers 'dynasty-sharp-rosters*'
+systemctl cat dynasty-sharp-rosters.timer | head -20
+```
+
+**Checkpoint:** the timer exists and is scheduled for `05:50 UTC` daily.
+If it is absent, re-run the installer:
+
+```bash
+cd /home/dynasty/trade-calculator
+FORCE_SERVICE_INSTALL=false bash deploy/install-systemd-service.sh
+```
+
+---
+
+## 2. [VPS] Confirm the cohort is non-empty
+
+```bash
+cd /home/dynasty/trade-calculator
+source ~/.venvs/trade-calculator/bin/activate
+python -c "from src.sharp import cohort; m,c = cohort.cohort_members(); print(len(m), c)"
+```
+
+**Checkpoint:** a non-zero count.
+
+**If it is 0, stop here** — the roster crawl has nobody to collect for,
+and an empty board is the correct output, not a bug. The fix is
+upstream, in that order: `scripts/discover_sharp_graph.py` (finds
+managers) → `scripts/crawl_sharp_records.py` (makes them scoreable).
+Both have their own timers at 04:20 and 04:50 UTC.
+
+---
+
+## 3. [VPS] First roster crawl
+
+```bash
+python scripts/crawl_sharp_rosters.py --budget 3000
+```
+
+Costs 2 Sleeper calls per **league** (not per member, and not per
+roster). Idempotent — re-running overwrites rather than inflating any
+count, so it is safe to run repeatedly.
+
+**Checkpoint:** `store.eligibleRosters > 0` in the JSON summary.
+
+### Sizing `--budget`
+
+Read `sleeper.leaguesRemaining` from the summary:
+
+* `0` — the budget is keeping up. Leave the unit as shipped.
+* stable non-zero across runs — raise `--budget` in
+  `deploy/systemd/dynasty-sharp-rosters.service.template`. This is **not**
+  something patience fixes on its own, though the crawl does rotate: it
+  orders leagues never-collected-first, then oldest-first, so each run
+  reaches leagues the last one did not.
+
+Exit code `2` means "budget exhausted, work remaining" and is a normal
+steady state on a large graph — the unit treats it as success.
+
+---
+
+## 4. [VPS] Run the audit against real data
+
+This is the step that actually closes the audit requirement. Everything
+verified pre-merge ran against a constructed fixture, plus one live
+crawl of a graph grown fresh from the seeds — **never production's
+accumulated cohort**.
+
+```bash
+python scripts/validate_sharp_roster_percentage.py --players 40
+```
+
+It re-derives every published number from the raw rows using code that
+shares nothing with the engine, then diffs.
+
+**Checkpoint:** all checks PASS, exit 0.
+
+One check will fail on a bare run, by design:
+
+```
+[FAIL] contract_available_for_position_aware_checks
+       NO CONTRACT — every position reads as unknown...
+```
+
+`latest_contract_data` is an in-process global of the running server, so
+a standalone script cannot see it. Without positions, the **per-player
+denominator** — the subtlest rule in the feature, the one that measures
+a linebacker against IDP leagues only — is not exercised at all. To
+audit it, pass a contract:
+
+```bash
+python scripts/validate_sharp_roster_percentage.py --players 40 --contract /path/to/contract.json
+```
+
+The file must contain `playersArray`. Note `exports/latest/dynasty_data_*.json`
+is the **legacy** shape and will be rejected; build a real one with:
+
+```python
+import json
+from src.api.data_contract import build_api_data_contract
+raw = json.load(open("exports/latest/dynasty_data_<date>.json"))
+json.dump(build_api_data_contract(raw), open("/tmp/contract.json", "w"))
+```
+
+**What "good" looks like** (from a real 12-roster / 6-manager run):
+
+```
+[PASS] denominator_matches_eligible_rosters   40/40 per-player denominators match
+[PASS] counted_assets_resolve_to_a_known_player_identity   40/40 resolve
+[PASS] board_coverage_of_rostered_players     36/40 priced; 4 unpriced
+```
+
+`board_coverage_of_rostered_players` is **informational**. Rostered
+players outside our ranked pool (deep veterans, practice-squad bodies)
+legitimately have no `rankDerivedValue`; they are reported as unpriced
+rather than valued at zero.
+
+---
+
+## 5. Wait 24h, then confirm trends resolve
+
+The 7d/30d/season columns read `n/a` until a **second** observation
+exists — history is stored as spans, and one snapshot is not a trend.
+This is why the timer is daily rather than weekly.
+
+**Checkpoint:** after the second crawl, at least one row shows a
+`thirtyDay` trend with `available: true`. Rows reading
+`roster_population_changed` are correct when the cohort is still
+growing — the delta is withheld rather than reporting cohort growth as
+players gaining ownership.
+
+### The number to watch afterwards
+
+`transparency.rostersPerManager`. Sharps typically run several dynasty
+teams, so a value near **1.0** means discovery has not reached their
+other leagues yet — not that sharps own one team each. Coverage is
+bounded by how far `discover_sharp_graph.py` has walked. It rises on its
+own as the graph compounds.
+
+---
+
+## 6. [LOCAL] Optional — activate the FFPC half
+
+FFPC contributes **zero rosters** today. The parser is correct and
+test-pinned, and the collector already lifts roster contents with no
+network calls; the gap is purely configuration. All ten seeds in
+`config/sharp/ffpc_sources.json` are `LeagueHome.aspx` pages, which
+yield transactions and standings but no roster table.
+
+Add a roster-bearing URL for a configured league and the FFPC half
+starts contributing on the next crawl. **No code change is needed.**
+
+Caveat worth knowing: FFPC publishes no taxi/IR marking, so FFPC assets
+are stored as `active`. That is the absence of a distinction, not a
+claim that none are on taxi.
+
+---
+
+## 7. Optional — the sharp-vs-market columns
+
+`marketRosterPct` and `sharpRosterAdvantage` are `null`, and two of the
+six sort options rank nothing, because **no general-dynasty ownership
+feed exists in this platform**. Every ranking source we ingest publishes
+values or ranks; Sleeper's trending endpoint publishes 24-hour *add
+counts* — a flow, not a stock. Converting one into the other would be
+inventing the number, so the page says why instead.
+
+To wire a real feed, register a provider:
+
+```python
+from src.sharp import roster_percentage
+roster_percentage.set_market_ownership_provider(fn)  # ids -> {id: 0.0..1.0}
+```
+
+That is the whole integration; the board, the advantage column and both
+sorts light up on their own.
+
+---
+
+## Known trap, unrelated to this feature
+
+`tests/frontend/test_fixed_elements_have_a_vertical_anchor.py` does
+`frontend.rglob("*.css")`, which sweeps in `frontend/.next/`. So **after
+running `npm run build` locally, that suite fails** on hashed build
+chunks with no defect behind it. `rm -rf frontend/.next` clears it.
+CI never sees this (`.next` is gitignored and CI checks out clean).
+
+Pre-existing, not caused by this feature, and worth fixing separately by
+excluding build output from that glob.

--- a/docs/sharp-roster-percentage/METHODOLOGY.md
+++ b/docs/sharp-roster-percentage/METHODOLOGY.md
@@ -5,6 +5,13 @@ touches no existing output. It is empty until
 `scripts/crawl_sharp_rosters.py` has run, and says so rather than
 erroring.
 
+> **Not yet activated in production.** The roster store is local and
+> gitignored, so the crawl has to run on the box serving the API before
+> the board shows anything. The remaining steps — and the two optional
+> features that stay inert until you supply an input (FFPC roster URLs,
+> a market-ownership feed) — are in
+> **`docs/runbooks/sharp-roster-percentage-activation.md`**.
+
 ```
 Sharp Roster Percentage
   = unique ELIGIBLE sharp rosters containing the player


### PR DESCRIPTION
Docs only — no code. Writes down the work that's left on Sharp Roster Percentage so it's findable instead of living in a chat log.

The feature is merged and tested, but it **cannot be finished from CI or a dev container**: the roster store is a local, gitignored SQLite file on the box serving the API, so the crawl has to run where the reader lives. Until it does, the board honestly reports `cohort_building` and shows nothing.

## New: `docs/runbooks/sharp-roster-percentage-activation.md`

Follows the existing runbook convention (`[VPS]`/`[LOCAL]` tags, preconditions, checkpoints). Steps 1–5 are the activation; 6–7 are optional features that are inert by design until someone supplies an input.

The two steps most likely to be misread:

- **Confirm the cohort is non-empty *before* crawling.** This board is downstream of the same pool as the Buy/Sell Tracker. If the tracker is still "cohort building", this board will be empty for exactly the same reason — that's a correct output, not a bug, and the runbook sends you upstream to discovery/records rather than debugging the roster pass.
- **One audit check fails on a bare run, by design.** `latest_contract_data` is an in-process global of the running server, so a standalone script can't see it — and without positions, the per-player denominator (the rule that measures a linebacker against IDP leagues only) isn't exercised at all. The runbook explains `--contract`, notes that `exports/latest/dynasty_data_*.json` is the legacy shape and will be rejected, and shows how to build a real one.

Also covers sizing `--budget` from `leaguesRemaining` rather than guessing, and why trends read `n/a` until a second observation exists.

## Honest framing of what's been verified

The runbook states plainly that everything checked pre-merge ran against a constructed fixture plus one live crawl of a graph grown fresh from the seeds — **never production's accumulated cohort**. Step 4 is what actually closes the audit requirement.

It also flags `transparency.rostersPerManager` as the number to watch: near 1.0 means discovery hasn't reached sharps' other leagues yet, not that sharps own one team each.

## Two optional features, neither needing code

- **FFPC contributes zero rosters today.** The parser is correct and test-pinned; all ten configured seeds are `LeagueHome.aspx` pages that yield no roster table. One roster-bearing URL activates that half.
- **The sharp-vs-market columns are null** because no general-dynasty ownership feed exists here. Sleeper's trending endpoint publishes 24-hour add counts — a flow, not a stock — so converting it would be inventing the number. `set_market_ownership_provider` is the whole integration.

## One unrelated trap, recorded because it cost real time

`tests/frontend/test_fixed_elements_have_a_vertical_anchor.py` globs `frontend/.next`, so after a local `npm run build` that suite fails on hashed build chunks with no defect behind it. `rm -rf frontend/.next` clears it; CI never sees it. Pre-existing and worth fixing separately by excluding build output from the glob — I've left it as a note rather than folding an unrelated fix into a docs PR.

`METHODOLOGY.md` links to the runbook so it's reachable from the feature docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Btu1kVCWeT6FkSE2HcMKUn)_