### PR TITLE
Make Perfect Draft reachable: five defects behind one blank panel

### DIFF
--- a/frontend/__tests__/components/PerfectDraftPanel.test.jsx
+++ b/frontend/__tests__/components/PerfectDraftPanel.test.jsx
@@ -644,3 +644,73 @@ describe("live-bid target is reconciled with the board", () => {
     expect(await screen.findByText(/Sold — pick the next player/i)).toBeInTheDocument();
   });
 });
+
+describe("the team it asks about", () => {
+  it("follows the workspace when a placeholder team is replaced by the real one", async () => {
+    // The cold-boot sequence on /draft, which is what took this panel off the
+    // page entirely on `main`.
+    //
+    // `useLeague()` reports no league until /api/leagues answers, so the page
+    // hydrates from the unsuffixed legacy storage key, misses, and falls back
+    // to `createDefaultWorkspace()` — whose first team is a placeholder that
+    // is not in the league. The panel used to LATCH that name in
+    // `useState(myTeamName)`, ask the backend for a team that does not exist,
+    // take the 400 as a failure and vanish — permanently, because the latched
+    // name never changed, so the roster-context hook never refetched even
+    // after the real workspace arrived. It took its own team <Select> with
+    // it, so the user could not correct it without a reload.
+    const placeholder = {
+      settings: { myTeamIdx: 0 },
+      teams: [{ name: "Russini Panini" }, { name: "Beta" }],
+    };
+
+    // URLSearchParams encodes the space as "+", so match on the bare token
+    // rather than encodeURIComponent — getting this wrong makes the mock
+    // answer 200 to everything and the test proves nothing.
+    fetch.mockImplementation((url) =>
+      Promise.resolve(
+        String(url).includes("Russini")
+          ? jsonResponse(400, { error: "unknown_team", leagueKey: "pd_main" })
+          : jsonResponse(200, okPayload()),
+      ),
+    );
+
+    const { container, rerender } = render(
+      <PerfectDraftPanel stats={STATS} workspace={placeholder} />,
+    );
+    // Wait for the 400 to be CLASSIFIED, not merely requested: asserting on
+    // the initial loading render would pass no matter what the server said.
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("teamName=Russini"),
+        expect.anything(),
+      ),
+    );
+    await waitFor(() =>
+      expect(container.querySelector(".perfect-draft-panel")).toBeNull(),
+    );
+
+    // The league resolves and the real league-scoped workspace hydrates.
+    rerender(<PerfectDraftPanel stats={STATS} workspace={WORKSPACE} />);
+    expect(await screen.findByRole("table")).toBeInTheDocument();
+  });
+
+  it("keeps an explicit pick instead of snapping back to the workspace team", async () => {
+    // The flip side: following the workspace must not undo a deliberate
+    // choice, or the team selector would be unusable.
+    fetch.mockResolvedValue(jsonResponse(200, okPayload()));
+    render(<PerfectDraftPanel stats={STATS} workspace={WORKSPACE} />);
+    await screen.findByRole("table");
+
+    const teamSelect = screen.getByRole("combobox", { name: /team to optimize/i });
+    fireEvent.change(teamSelect, { target: { value: "Beta" } });
+
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("teamName=Beta"),
+        expect.anything(),
+      ),
+    );
+    expect(teamSelect).toHaveValue("Beta");
+  });
+});

--- a/frontend/app/api/draft-capital/route.js
+++ b/frontend/app/api/draft-capital/route.js
@@ -8,10 +8,18 @@ export async function GET(request) {
     // not the server-resolved default.  Omitted → backend resolves as
     // before (unchanged for the unscoped DraftCapitalSection).
     const leagueKey = request?.nextUrl?.searchParams?.get("leagueKey");
-    const { data, status } = await proxyGet(
-      "/api/draft-capital",
-      leagueKey ? { searchParams: { leagueKey } } : undefined,
-    );
+    // Forward the session cookie. This endpoint answers 200 to anyone, but
+    // REDACTS the rookie fields for public callers — `rookieName` and
+    // `rookieBoardValue` come back null on all 72 picks. That is not a
+    // visible failure anywhere: /draft's auto-sync writes the empty pool
+    // onto the workspace, every rookie ends up without a positive
+    // `boardValue`, and the Perfect Draft solve drops the whole pool and
+    // renders a panel with zero rows. Only bites where Next serves /api/*
+    // itself (dev, E2E); nginx routes past this file in production.
+    const { data, status } = await proxyGet("/api/draft-capital", {
+      ...(leagueKey ? { searchParams: { leagueKey } } : {}),
+      cookie: request.headers.get("cookie") || "",
+    });
     return NextResponse.json(data, { status });
   } catch (err) {
     return NextResponse.json(

--- a/frontend/app/api/draft/roster-context/route.js
+++ b/frontend/app/api/draft/roster-context/route.js
@@ -13,9 +13,16 @@ export async function GET(request) {
     }
     // The cut ladder runs the lineup solver over a full roster; allow more
     // than the 5s default for a cold build.
+    //
+    // The session cookie has to be forwarded: this endpoint is behind auth,
+    // and without it the backend answers 401, which the panel classifies as
+    // a failure and silent-vanishes on. Production never noticed because
+    // nginx routes /api/* past this file entirely — it only bites where Next
+    // serves /api/* itself, which is dev and the E2E stack.
     const { data, status } = await proxyGet("/api/draft/roster-context", {
       searchParams,
       timeoutMs: 30000,
+      cookie: request.headers.get("cookie") || "",
     });
     // Upstream status passes through verbatim so the client's failure
     // classifier can tell "flag off" from "wrong league" from "broken".

--- a/frontend/app/api/leagues/route.js
+++ b/frontend/app/api/leagues/route.js
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+
+import { proxyGet } from "@/lib/backend-proxy";
+
+// Dev-only bridge to the FastAPI backend, and the missing member of the set.
+//
+// In production nginx routes every `/api/*` path straight to the backend, so
+// this file is never reached. Where Next serves `/api/*` itself — local dev
+// and the E2E stack, neither of which runs nginx — its absence was NOT a
+// harmless 404. `useLeague()` fetches `/api/leagues` (useLeague.js:53); with
+// no route, Next answered the HTML 404 page, the JSON parse failed, and
+// `leagues` stayed empty. `selectedLeagueKey` only returns a candidate that
+// is in that list (useLeague.js:165-183), so it was permanently "".
+//
+// That silently un-scopes every league-keyed surface. Concretely on /draft:
+// `draftStorageKey` falls back to the UNSUFFIXED legacy key
+// (draft/page.jsx:3426-3431), so the league-scoped workspace never hydrates
+// and the board sits on `createDefaultWorkspace()`'s placeholder teams for
+// the life of the page.
+//
+// Cookies must be forwarded: the endpoint is public but has an authenticated
+// view, adding `userDefaultKey` and per-league `userDefaultTeam` — which is
+// exactly the part that tells the UI which league and team to land on.
+export async function GET(request) {
+  try {
+    const { data, status } = await proxyGet("/api/leagues", {
+      cookie: request.headers.get("cookie") || "",
+    });
+    // Pass the upstream status through verbatim so the client can tell
+    // "no leagues configured" from "backend down".
+    return NextResponse.json(data, {
+      status,
+      // Per-user (userDefaultKey/userDefaultTeam). Never cache at the edge.
+      headers: { "Cache-Control": "no-store, private" },
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: "leagues_unavailable", detail: err?.message },
+      { status: 503, headers: { "Cache-Control": "no-store, private" } },
+    );
+  }
+}

--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -3584,10 +3584,27 @@ export default function DraftDashboardPage() {
   // are matched by name-derived id).  Runs once after hydration; the
   // manual "Sync from contract" button is still available for
   // mid-session refreshes.
-  const autoSyncRanRef = useRef(false);
+  // Keyed on the STORAGE KEY, not a bare "have I run" boolean.
+  //
+  // `hydrated` flips true after the FIRST hydration, and on a cold load that
+  // one runs against the unsuffixed legacy key — `useLeague()` reports no
+  // league until /api/leagues answers, so `draftStorageKey` has not become
+  // `..._<leagueKey>` yet. A once-ever guard therefore spent its single run
+  // populating the throwaway placeholder workspace: the 72-rookie pool landed
+  // on the DEFAULT board (and got persisted to the legacy key), then the
+  // league resolved, the real league-scoped workspace hydrated with no pool,
+  // and the sync refused to run again. Every rookie was left without a
+  // `boardValue`, so Perfect Draft priced nothing and reported that no rookie
+  // was worth buying — on a board showing 72 rookies.
+  //
+  // It is a race, so it presented as an intermittent empty plan rather than a
+  // reliable one. Re-running per storage key also covers league switching,
+  // and re-running is cheap: the merge below already no-ops when the incoming
+  // pool matches what the workspace holds.
+  const autoSyncKeyRef = useRef("");
   useEffect(() => {
-    if (!hydrated || autoSyncRanRef.current) return;
-    autoSyncRanRef.current = true;
+    if (!hydrated || autoSyncKeyRef.current === draftStorageKey) return;
+    autoSyncKeyRef.current = draftStorageKey;
     let cancelled = false;
     (async () => {
       try {
@@ -3681,7 +3698,7 @@ export default function DraftDashboardPage() {
     return () => {
       cancelled = true;
     };
-  }, [hydrated]);
+  }, [hydrated, draftStorageKey]);
 
   const stats = useMemo(() => computeDraftStats(workspace), [workspace]);
   // Retrospective inflation trajectory — O(N²) in pick count, but

--- a/frontend/components/draft/PerfectDraftPanel.jsx
+++ b/frontend/components/draft/PerfectDraftPanel.jsx
@@ -14,7 +14,7 @@
  * configuration states, not failures worth shouting about mid-draft.
  */
 
-import { useDeferredValue, useMemo, useState } from "react";
+import { useDeferredValue, useEffect, useMemo, useState } from "react";
 
 import {
   Badge,
@@ -87,15 +87,43 @@ export function PerfectDraftPanel({ stats, workspace }) {
   // passed, because the test fixture used the flat shape.
   const myTeamIdx = workspace?.settings?.myTeamIdx ?? workspace?.myTeamIdx ?? 0;
   const myTeamName = workspace?.teams?.[myTeamIdx]?.name || "";
-  const [teamName, setTeamName] = useState(myTeamName);
+  // FOLLOW the workspace; only an explicit pick overrides it.
+  //
+  // This used to be `useState(myTeamName)`, which latched the FIRST name it
+  // ever saw. `teamName || myTeamName` below looks like a fallback but only
+  // rescues the empty-string case — a wrong non-empty name stuck forever.
+  //
+  // And on a cold load it is reliably wrong. `useLeague()` reports no league
+  // until /api/leagues answers, so the page hydrates from the unsuffixed
+  // legacy storage key, misses, and falls back to `createDefaultWorkspace()`
+  // — whose first team is the placeholder "Russini Panini". The lazy panel
+  // resolves inside that window, latches the placeholder, and asks the
+  // backend for a team the league does not have. That is a 400
+  // (`unknown_team`), which classifies as a failure, which returns null at
+  // the guard below — taking this panel's own team <Select> down with it, so
+  // the user cannot correct it without a reload. The real workspace arriving
+  // moments later changed nothing, because the latched name never changed
+  // and so `useRosterContext` never refetched.
+  const [teamOverride, setTeamOverride] = useState("");
+  const teamName = teamOverride || myTeamName;
   const [strategy, setStrategy] = useState("balanced");
   const [priceBasis, setPriceBasis] = useState("fair");
   // Live bidding: which rookie is on the block, and where the bidding is now.
   const [bidTarget, setBidTarget] = useState("");
   const [bidAmount, setBidAmount] = useState("");
   const { teams, context, failure, loading, refetch } = useRosterContext({
-    teamName: teamName || myTeamName,
+    teamName,
   });
+
+  // An explicit pick belongs to the league it was made in. Carrying it across
+  // a league switch asks the new league for a team it does not have, which is
+  // the same `unknown_team` 400 that made this panel vanish in the first
+  // place — so drop it and fall back to the workspace's own team.
+  useEffect(() => {
+    const clear = () => setTeamOverride("");
+    window.addEventListener("league:changed", clear);
+    return () => window.removeEventListener("league:changed", clear);
+  }, []);
 
   // Available rookies with their live expected price. `inflatedFair` is the
   // board's own live price model (preDraft x tier-adjusted inflation) — the
@@ -507,8 +535,8 @@ export function PerfectDraftPanel({ stats, workspace }) {
         {teams.length > 1 ? (
           <Select
             aria-label="Team to optimize"
-            value={teamName || myTeamName}
-            onChange={(e) => setTeamName(e.target.value)}
+            value={teamName}
+            onChange={(e) => setTeamOverride(e.target.value)}
           >
             {teams.map((t) => (
               <option key={t.ownerId || t.name} value={t.name}>

--- a/frontend/lib/backend-proxy.js
+++ b/frontend/lib/backend-proxy.js
@@ -11,10 +11,19 @@ const BACKEND_BASE = (() => {
 
 /**
  * Proxy a GET request to the backend.
+ *
+ * `cookie` is REQUIRED for any backend endpoint behind auth. This helper
+ * sends no credentials of its own, so omitting it against an authenticated
+ * endpoint yields a 401 — and only where Next actually serves `/api/*`
+ * (dev, and the E2E stack, which runs no nginx). In production nginx routes
+ * `/api/*` straight to the backend and these routes are never reached, so
+ * the failure is invisible in prod and looks like a broken feature in dev.
+ * Pass `request.headers.get("cookie")` from the route handler.
+ *
  * @param {string} path — backend path (e.g. "/api/draft-capital")
- * @param {object} opts — { timeoutMs, searchParams }
+ * @param {object} opts — { timeoutMs, searchParams, cookie }
  */
-export async function proxyGet(path, { timeoutMs = 5000, searchParams } = {}) {
+export async function proxyGet(path, { timeoutMs = 5000, searchParams, cookie } = {}) {
   const url = new URL(path, BACKEND_BASE);
   if (searchParams) {
     for (const [k, v] of Object.entries(searchParams)) {
@@ -24,7 +33,11 @@ export async function proxyGet(path, { timeoutMs = 5000, searchParams } = {}) {
   const ctl = new AbortController();
   const timer = setTimeout(() => ctl.abort(), timeoutMs);
   try {
-    const res = await fetch(url.toString(), { cache: "no-store", signal: ctl.signal });
+    const res = await fetch(url.toString(), {
+      cache: "no-store",
+      signal: ctl.signal,
+      ...(cookie ? { headers: { Cookie: cookie } } : {}),
+    });
     const data = await res.json();
     return { data, status: res.status };
   } finally {

--- a/tests/e2e/specs/journey-perfect-draft.spec.js
+++ b/tests/e2e/specs/journey-perfect-draft.spec.js
@@ -42,9 +42,29 @@ const LIVE_SYNC_KEY = `next_draft_live_sync__${LEAGUE}`;
  * did and what let the bug ship.
  */
 async function seedWorkspace(page, teamNames, { myRemaining = 400 } = {}) {
+  // `feedBudget` is seeded DELIBERATELY different from `initialBudget`, and
+  // the spec does not work without it.
+  //
+  // /draft auto-syncs team budgets from /api/draft-capital on mount
+  // (page.jsx:3872 → mergeDraftCapitalTeams, mode "sync"). That feed keys
+  // teams by their SLEEPER TEAM NAME ("Russini Panini", "CollinFoz"), while
+  // `teamNames` here comes from the contract's `sleeper.teams[].name` — the
+  // MANAGER names ("Jason", "Ed") that /api/draft/roster-context matches on.
+  // The two namespaces barely overlap, so every seeded row misses the feed
+  // and takes the unmatched branch, which ZEROES it (draft-logic.js:1441).
+  // The panel then correctly reports that nothing is worth buying with $0,
+  // and the row assertion below fails for a reason that has nothing to do
+  // with the optimizer.
+  //
+  // Seeding `feedBudget !== initialBudget` marks the row as user-edited,
+  // which is a first-class state the sync preserves by design
+  // (draft-logic.js:1400-1414) — the same thing that happens when a manager
+  // types their own carry-over balance. The manager name is kept because
+  // that is the one roster-context can resolve.
   const teams = teamNames.slice(0, 12).map((name, i) => ({
     name,
     initialBudget: i === 0 ? myRemaining : 400,
+    feedBudget: 0,
   }));
   await page.addInitScript(
     ([wsKey, syncKey, leagueKey, wsTeams]) => {
@@ -90,6 +110,19 @@ test.describe("journey: perfect draft", () => {
       "the panel returns null on any non-ok response, so invisible means broken",
     ).toBeVisible({ timeout: 90_000 });
 
+    // Assert the BUDGET survived before asserting rows. A zeroed budget makes
+    // "no rookie is worth his price" the correct answer, so the row assertion
+    // below would fail on a 60s timeout that says nothing about why. This
+    // turns the fixture's own precondition into a named failure.
+    const budgetText = await panel.innerText();
+    const seededBudget = budgetText.match(/BUDGET\s*\$([\d,]+)/i);
+    expect(seededBudget, "the panel must render a Budget tile").not.toBeNull();
+    expect(
+      Number(seededBudget[1].replace(/,/g, "")),
+      "budget is $0 — the seeded team budget was zeroed (see seedWorkspace), " +
+        "so an empty plan is correct and proves nothing about the optimizer",
+    ).toBeGreaterThan(0);
+
     const rows = page.locator(SEL.perfectDraftRow);
     await expect(rows.first()).toBeVisible({ timeout: 60_000 });
     const rowCount = await rows.count();
@@ -101,7 +134,11 @@ test.describe("journey: perfect draft", () => {
     expect(firstName).not.toMatch(/^Rookie #/);
 
     // No NaN / undefined / $NaN leaking into the rendered numbers.
-    await expectNoBadValueTokens(panel);
+    // (page, selector) — NOT (locator). Passing the Locator made
+    // `querySelectorAll` receive an HTMLElement and throw a SyntaxError. It
+    // never surfaced because the assertions above this line had never once
+    // passed, so this call had never executed.
+    await expectNoBadValueTokens(page, SEL.perfectDraftPanel);
 
     guard.assertClean();
   });

--- a/tests/e2e/specs/signed-in-smoke.spec.js
+++ b/tests/e2e/specs/signed-in-smoke.spec.js
@@ -81,14 +81,34 @@ test.describe("signed-in: basic navigation + UI render", () => {
     // its listbox is populated from that same list.  Opening it and
     // matching against the contract proves the roster pipeline reached
     // the UI — not merely that some chrome rendered.
-    const switcher = authedPage.locator('button[aria-haspopup="listbox"]').first();
+    //
+    // Target the TEAM switcher by class, not `button[aria-haspopup="listbox"]`
+    // .first(). The shell renders two listbox buttons — LeagueSwitcher and
+    // TeamSwitcher — and the league one comes first in DOM order, so `.first()`
+    // opened the LEAGUE menu and counted 2 leagues against 12 teams.
+    //
+    // That was latent, not new: the E2E stack had no Next bridge for
+    // /api/leagues, so `useLeague()` never resolved and LeagueSwitcher rendered
+    // nothing. `.first()` therefore hit the team switcher by accident. Adding
+    // the missing bridge made the league switcher appear and the ambiguity
+    // real.
+    // `.first()` is kept from the original and is doing a DIFFERENT job than
+    // the class: it absorbs the pre-existing SSR-streaming duplicate (#716),
+    // under which the shell can render two of everything. Dropping it turns
+    // this test into a second #716 detector and makes it intermittently red
+    // for a reason unrelated to what it asserts — the dedicated detectors in
+    // waivers-smoke/arbitrage already cover that bug, deliberately.
+    const switcher = authedPage.locator("button.team-switcher-toggle").first();
     await expect(
       switcher,
       "team switcher only renders when rosters loaded — absent means the contract served none",
     ).toBeVisible({ timeout: 60_000 });
     await switcher.click();
 
-    const options = authedPage.locator('[role="option"]');
+    // Scoped to the team menu, and to ONE of them, for both reasons above:
+    // an unscoped [role="option"] counts the league menu's entries too, and a
+    // streaming duplicate would double the count.
+    const options = authedPage.locator(".team-switcher-menu").first().locator('[role="option"]');
     await expect
       .poll(() => options.count(), {
         message: `team switcher should offer all ${teamNames.length} contract teams`,


### PR DESCRIPTION
Fixes the `journey-perfect-draft` failures tracked in #732. `main`'s E2E has been red on its own nightly since this spec landed.

## Why this was invisible until now

`journey-perfect-draft.spec.js` reached `main` via #723 at 00:04Z; the last E2E run on `main` was 19:54Z the evening before. Across all 30 recorded runs of `e2e.yml` there is **no run on any `claude/perfect-draft-*` branch** — so the spec had never executed in CI, anywhere. #726's path-filtered PR trigger is what finally ran it, on its first outing, and it found real bugs.

Reproduced locally (2 failed / 1 passed, matching CI exactly) and fixed in order. Each defect was only visible once the one before it was out of the way, which is why this is five and not one.

## The app — a cold-load race, and it affects production

**1. The panel latched the team.** `useState(myTeamName)` captured the *first* name it ever saw. `teamName || myTeamName` looks like a fallback but only rescues the empty-string case, so a wrong non-empty name stuck forever. On a cold load it is reliably wrong:

`useLeague()` reports no league until `/api/leagues` answers, so `/draft` hydrates from the unsuffixed legacy storage key, misses, and falls back to `createDefaultWorkspace()` — whose first team is `"Russini Panini"`, not a team in the league. The lazy panel resolves inside that window, asks the backend for that team, gets **400 `unknown_team`**, classifies it as a failure and returns `null`. Permanently — the latched name never changed, so `useRosterContext` never refetched when the real workspace arrived. It takes its own team `<Select>` down with it, so a user cannot correct it without a reload.

Now derived from the workspace, with an explicit pick as an override, cleared on `league:changed` so a selection can't follow you into a league that has no such team.

**2. The rookie-pool auto-sync ran once, ever**, gated on `hydrated` — which flips true after that same pre-league hydration. So the 72-rookie pool was written onto the throwaway placeholder workspace (and persisted to the legacy key); the real league-scoped workspace then hydrated with no pool, and the sync refused to run again. Every rookie ended up without a `boardValue`, so the solve priced nothing and the panel reported that **no rookie was worth buying — on a board showing 72 rookies**. Being a race, it presented as an intermittent empty plan rather than a reliable one.

Now keyed on `draftStorageKey`, which also covers league switching. Re-running is cheap: the merge already no-ops when the incoming pool matches.

## The Next bridge — dev + E2E only

In production nginx routes `/api/*` straight to the backend, so none of these are reachable there. They bite exactly where Next serves `/api/*` itself.

**3. `/api/leagues` had no route at all.** Next answered its HTML 404 page, the JSON parse failed, `leagues` stayed empty, and `selectedLeagueKey` — which only returns a candidate present in that list — was permanently `""`. That is what un-scoped the draft workspace in (1) and (2).

**4. `roster-context` forwarded no cookie**, so the authenticated endpoint answered 401 and the panel vanished on it.

**5. `draft-capital` forwarded no cookie.** It answers 200 to anyone but **redacts** the rookie fields for public callers: `rookieName` and `rookieBoardValue` came back null on all 72 picks, which surfaces as no failure anywhere.

`proxyGet` grows an opt-in `cookie` param rather than always sending credentials. **21 other bridges still call it bare**, several against authenticated endpoints (`/api/bdvm/*`, `/api/sharp/*`) — deliberately out of scope here, but worth a follow-up.

## The spec — it could not have passed as written

- **`seedWorkspace` seeded budgets the app immediately zeroed.** The capital auto-sync keys teams by **Sleeper team name** while the fixture seeds the **manager names** `roster-context` matches on; the two namespaces barely overlap, so every seeded row took the unmatched branch and was zeroed. The panel then *correctly* reported that nothing is worth buying with $0. Seeding `feedBudget` distinct from `initialBudget` marks the row user-edited, which the sync preserves by design — the same state as a manager typing their carry-over balance.
- **`expectNoBadValueTokens(panel)`** passed a Locator to a `(page, selector)` helper, so `querySelectorAll` received an `HTMLElement` and threw. It had never run, because the assertions above it had never passed.
- **Added**: assert the Budget tile is non-zero *before* asserting rows, so a zeroed budget fails by name instead of as a 60s row timeout that says nothing about why.

**No locator was loosened.**

## Testing

- `journey-perfect-draft` **3/3, five consecutive runs** — it was a race, so one green run proves nothing.
- **Full E2E suite: 193 passed, 0 failed** (including `/arbitrage`, the #716 streaming race, on this run).
- **vitest: 1932 passed** across 111 files.
- The two new panel tests were **mutation-tested**: re-latching `teamName` turns the first one red. The first version of that test was thrown away for passing against *both* versions — `encodeURIComponent("Russini Panini")` does not match the `+` that `URLSearchParams` actually emits, so the mock had been answering 200 to everything.

## Not fixed here

The two team-name namespaces (capital feed vs. contract rosters) are a real seam — a workspace loaded from the capital feed carries names `roster-context` cannot resolve for 11 of 12 teams. The de-latch makes that recoverable rather than fatal, but threading `ownerId` through the workspace is the actual fix and is a bigger change. Noted on #732.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeQ4SkH9khPRx2b3WunSTA)_