### PR TITLE
Install the retention timer unconditionally, and make the cohort claim measurable

### DIFF
--- a/deploy/install-systemd-service.sh
+++ b/deploy/install-systemd-service.sh
@@ -487,23 +487,43 @@ main() {
   # anything committed there is destroyed on the next deploy.  See the
   # header of deploy/playerctx_history_push.sh.
   #
-  # Gated on the deploy SSH key, exactly like the DLF / IDP Show
-  # pushers — without it the script can only fail at the push, and a
-  # timer that fails weekly is worse than one that was never installed.
+  # INSTALLED UNCONDITIONALLY, and the deploy-key check lives in the
+  # script rather than here.  It was gated on the key at first, by
+  # analogy with the DLF / IDP Show pushers, and that was wrong twice
+  # over — measured on the 2026-08-05 deploy, which logged
+  # "retention timer skipped: /home/…/.ssh/github_deploy_key missing"
+  # and installed nothing:
+  #
+  #   1. THE TEST RAN AS THE WRONG USER.  The unit runs as __APP_USER__
+  #      and reads that user's key; this installer runs as the deploy
+  #      user, whose sudo is scoped to specific commands, so
+  #      `sudo -n test -f` is not reliably permitted and a plain `[[ -f ]]`
+  #      cannot stat another user's ~/.ssh.  The check could report
+  #      "missing" for a key that is present and working — and the DLF
+  #      pusher committing to main every two hours is evidence one IS
+  #      present.  Only the service user can answer this, so the service
+  #      user asks it.
+  #   2. A CONDITIONALLY-INSTALLED TIMER BREAKS deploy.sh.  Its presence
+  #      check globs *.timer.template and warns for anything not
+  #      installed AND enabled, then runs this installer to fill the gap
+  #      — so a permanently-skipped timer means a warning plus a pointless
+  #      installer run on EVERY deploy, forever.  That is the exact loop
+  #      #729 closed for three other timers.  deploy.sh carries a `case`
+  #      exempting the alert timers; adding a fourth exemption would have
+  #      spread the problem rather than fixed it.
+  #
+  # The unit is cheap and safe when unusable: the script names the
+  # missing key and exits 0 without touching anything, and because it
+  # copies EVERY dated snapshot rather than the newest, fixing the key
+  # later backfills the whole backlog on the next run.
   local pchist_service_template="${APP_DIR}/deploy/systemd/dynasty-playerctx-history.service.template"
   local pchist_timer_template="${APP_DIR}/deploy/systemd/dynasty-playerctx-history.timer.template"
   local pchist_service_name="${SERVICE_NAME}-playerctx-history"
   local pchist_service_path="/etc/systemd/system/${pchist_service_name}.service"
   local pchist_timer_path="/etc/systemd/system/${pchist_service_name}.timer"
   local pchist_needs_install=false
-  local pchist_ssh_key="${PLAYERCTX_HISTORY_SSH_KEY:-/home/${APP_USER}/.ssh/github_deploy_key}"
-  local has_pchist_key=false
 
-  if sudo -n test -f "${pchist_ssh_key}" 2>/dev/null || [[ -f "${pchist_ssh_key}" ]]; then
-    has_pchist_key=true
-  fi
-
-  if [[ -f "${pchist_service_template}" && -f "${pchist_timer_template}" && "${has_pchist_key}" == "true" ]]; then
+  if [[ -f "${pchist_service_template}" && -f "${pchist_timer_template}" ]]; then
     local tmp_pchist_service tmp_pchist_timer
     tmp_pchist_service="$(mktemp)"
     tmp_pchist_timer="$(mktemp)"
@@ -539,8 +559,6 @@ main() {
       sudo -n "${INSTALL_BIN}" -d -m 0755 -o "${APP_USER}" -g "${APP_USER}" /var/lib/playerctx-history
     fi
     rm -f "${tmp_pchist_service}" "${tmp_pchist_timer}"
-  elif [[ -f "${pchist_service_template}" && "${has_pchist_key}" != "true" ]]; then
-    log "Player-context retention timer skipped: ${pchist_ssh_key} missing - no deploy key to push with."
   fi
 
   # ── BDVM projection refresh timer (weekly snapshots for /api/bdvm/*) ──

--- a/deploy/playerctx_history_push.sh
+++ b/deploy/playerctx_history_push.sh
@@ -46,6 +46,29 @@ err() { printf '[playerctx-history][ERR] %s\n' "$*" >&2; }
 
 export GIT_SSH_COMMAND="ssh -i ${SSH_KEY} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
 
+# The deploy-key check lives HERE, not in install-systemd-service.sh, and
+# that placement is the fix for a measured failure rather than a
+# preference.  The installer gated the whole unit on this file and
+# reported it missing on the 2026-08-05 deploy, installing nothing —
+# but the installer runs as the DEPLOY user, whose sudo is scoped to
+# specific commands, so it can neither `sudo test -f` nor stat another
+# user's ~/.ssh.  This script runs as the app user under
+# `User=__APP_USER__`, which is the only context that can answer the
+# question it is actually asking: can the thing that pushes read the key?
+#
+# Exit 0, not 1.  Nothing has been lost or half-done at this point, and a
+# unit that goes red every week is a unit nobody reads.  The backlog is
+# safe because the glob below takes EVERY dated snapshot rather than the
+# newest, so supplying the key later backfills every missed week on the
+# next run.  A stalled retention is meant to surface through
+# `store.history_coverage()`'s missingDays — the same way rank_history
+# reports its own gaps — not through a permanently failing timer.
+if [[ ! -r "${SSH_KEY}" ]]; then
+  log "no readable deploy key at ${SSH_KEY} - snapshots stay on disk, nothing pushed"
+  log "fix: place the key there, or set PLAYERCTX_HISTORY_SSH_KEY in ${LIVE_APP_DIR}/.env"
+  exit 0
+fi
+
 SRC_DIR="${LIVE_APP_DIR}/${HISTORY_REL}"
 if [[ ! -d "${SRC_DIR}" ]]; then
   log "no history directory at ${SRC_DIR} - nothing to push (exiting clean)"

--- a/docs/consensus-edge/DECISIONS.md
+++ b/docs/consensus-edge/DECISIONS.md
@@ -884,10 +884,11 @@ taken unilaterally; approval was then given. Repo-side wiring:
   minutes after the refresh's worst-case finish (05:40 + 600s randomized
   delay + 900s timeout ≈ 06:05), and off the three minutes already
   spoken for by prod→main pushers (`:27` DLF, `:32` IDP Show, `:42` CI).
-- Installed by `deploy/install-systemd-service.sh`, gated on the deploy
-  SSH key exactly like its two siblings: without a key the script could
-  only ever fail at the push, and a timer that fails weekly is worse
-  than one that was never installed.
+- Installed **unconditionally** by `deploy/install-systemd-service.sh`,
+  with the deploy-key check inside the script. It was first gated on the
+  key here, by analogy with the DLF / IDP Show pushers, and the
+  2026-08-05 deploy measured that as wrong twice over — see the
+  correction below.
 - The timer carries **no `Requires=`** (diverging from the sibling
   refresh timer, following `dynasty-reception-depth`): `Requires=` in a
   timer's `[Unit]` pulls the service in whenever the timer starts, which
@@ -908,7 +909,63 @@ including the one that makes the rest pointless if it regresses:
 `--retain-history` must be on the refresh `ExecStart`, or the push runs
 weekly, exits clean, and retains nothing.
 
+### Correction (2026-08-05, same day): "enabled in production" was half true
+
+The first deploy carrying this work (run 2158, `8252379e0`) settled it,
+and only one of the two halves landed:
+
+```
+[deploy][WARN] Timer units missing from this host: …-playerctx-history.timer. Running installer to add them.
+[systemd-bootstrap] Player-context unit files changed; rewriting …-playerctx-refresh.service + timer.
+[systemd-bootstrap] Player-context retention timer skipped: /home/…/.ssh/github_deploy_key missing - no deploy key to push with.
+```
+
+**The producer is on.** `--retain-history` reached the box, and only
+because of the content-compare fix above — the old "does the timer
+exist" gate would have left prod running the previous `ExecStart` while
+this document claimed retention was live. That is the failure this ADR
+predicted, caught in the act, one line up.
+
+**The pusher was not installed**, so the paragraph above overstated
+what shipped. Two distinct causes, both now fixed:
+
+1. **The key test ran as the wrong user.** The installer runs as the
+   *deploy* user, whose sudo is scoped to specific commands, so it can
+   neither `sudo test -f` nor stat another user's `~/.ssh`. It reported
+   the key missing while the DLF pusher was committing to `main` with
+   one every two hours — so this was very likely a false negative about
+   a working key, not a real absence. Only the service user can answer
+   the question, so the check moved into
+   `deploy/playerctx_history_push.sh`, which runs under
+   `User=__APP_USER__`.
+2. **A conditionally-installed timer breaks `deploy.sh`.** Its presence
+   check globs `*.timer.template` and warns for anything not installed
+   AND enabled, then runs the installer to close the gap — so a
+   permanently-skipped timer means a warning plus a pointless installer
+   run on **every deploy, forever**. That is precisely the loop #729
+   closed for three other timers, reintroduced here hours later.
+   `deploy.sh` carries a `case` exempting the alert timers; adding a
+   fourth exemption would have spread the pattern instead of fixing it.
+   The unit is now installed unconditionally.
+
+The original rationale — *"a timer that fails weekly is worse than one
+never installed"* — was answering a real concern with the wrong
+mechanism. It is answered instead by the script exiting **0** with the
+missing path named: nothing is half-done at that point, and the push
+globs EVERY dated snapshot rather than the newest, so supplying the key
+later backfills every missed week on the next run. A stalled retention
+is meant to surface through `store.history_coverage()`'s `missingDays`,
+the same way `rank_history` reports its own gaps — not through a red
+timer nobody reads.
+
+**Still unobserved:** no snapshot has been retained yet. The first
+evidence is a `chore(playerctx): retain snapshot …` commit on `main`
+after a Tuesday 06:45 UTC run, and that cannot happen before a deploy
+carries this correction.
+
 **Status:** superseded by the amendment; retention accepted 2026-08-05.
+Producer enabled in production 2026-08-05; pusher pending the deploy
+carrying this correction.
 
 ---
 

--- a/scripts/sharp_cohort_snapshot.py
+++ b/scripts/sharp_cohort_snapshot.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Snapshot the sharp cohort, and diff two snapshots.
+
+Exists because a claim was shipped that could not be checked where it
+was written.  ``sharp-v2.1`` renormalizes the scoring sum over the
+components that have evidence, which RAISES every score — and the
+argument that this is safe is that the absent component set is identical
+for every manager, so all scores scale by the same factor, and
+qualification is ``minScorePercentile`` (a percentile of the evaluable
+population, not an absolute bar).  Ordering is preserved, therefore the
+cohort is unchanged.
+
+That argument is asserted on synthetic records in
+``tests/sharp/test_score.py``.  It was NOT measured against the live
+population, because the dev environment's ledger yields zero cohort
+members — so the honest status was "owed, not done".  This makes paying
+that debt one command on the box that has the data::
+
+    # before deploying a scoring change
+    python scripts/sharp_cohort_snapshot.py --out /tmp/cohort-before.json
+
+    # after
+    python scripts/sharp_cohort_snapshot.py --out /tmp/cohort-after.json
+    python scripts/sharp_cohort_snapshot.py --compare /tmp/cohort-before.json \\
+        --against /tmp/cohort-after.json
+
+It computes nothing itself.  Records, scores and membership all come
+from the canonical path — ``platform_records.build_manager_records`` →
+``score.score_managers`` → ``cohort.cohort_members`` — because a second
+implementation of "who is a sharp" is the thing ``cohort.py`` exists to
+prevent.
+
+Exit codes:
+  0  snapshot written, or comparison ran and found no reordering
+  1  comparison found the cohort or the ORDER changed (read the output)
+  2  nothing to measure — no evaluable managers.  Deliberately NOT 0:
+     "no data" must never read as "verified unchanged".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.sharp import cohort as sharp_cohort  # noqa: E402
+from src.sharp import platform_records  # noqa: E402
+from src.sharp import score as sharp_score  # noqa: E402
+
+
+def build_snapshot(ledger_path: Path | None = None) -> dict[str, Any]:
+    records, evidence = platform_records.build_manager_records(ledger_path=ledger_path)
+    scored = sharp_score.score_managers(records)
+    members, coverage = sharp_cohort.cohort_members(ledger_path=ledger_path)
+
+    evaluable = [s for s in scored if s.evaluable]
+    # Rank by score descending.  user_id breaks ties so the ordering is
+    # total and a diff cannot report a spurious reorder for two managers
+    # who genuinely tie.
+    ranked = sorted(evaluable, key=lambda s: (-(s.score or 0.0), s.user_id))
+
+    return {
+        "capturedAt": datetime.now(timezone.utc).isoformat(),
+        "methodologyVersion": sharp_score.methodology_version(),
+        "population": {
+            "records": len(records),
+            "evaluable": len(evaluable),
+            "qualified": sum(1 for s in evaluable if s.qualified),
+            "cohortMembers": len(members),
+        },
+        "evidence": evidence if isinstance(evidence, dict) else {},
+        "coverage": coverage,
+        # The ORDER is the artifact under test, so it is stored as a list.
+        "ranking": [s.user_id for s in ranked],
+        "scores": {
+            s.user_id: {
+                "score": s.score,
+                "scorePercentile": s.score_percentile,
+                "qualified": s.qualified,
+                "weightsApplied": s.components.get("weightsApplied"),
+            }
+            for s in ranked
+        },
+        "cohort": sorted(m.manager_key for m in members),
+    }
+
+
+def compare(before: dict[str, Any], after: dict[str, Any]) -> tuple[int, list[str]]:
+    """Return ``(exit_code, lines)``. Non-zero when membership or order moved."""
+    lines: list[str] = []
+    changed = False
+
+    lines.append(
+        f"methodologyVersion: {before.get('methodologyVersion')} -> "
+        f"{after.get('methodologyVersion')}"
+    )
+    for key in ("records", "evaluable", "qualified", "cohortMembers"):
+        b = before.get("population", {}).get(key)
+        a = after.get("population", {}).get(key)
+        flag = "" if b == a else "   <-- CHANGED"
+        lines.append(f"  {key:>14}: {b} -> {a}{flag}")
+
+    b_cohort, a_cohort = set(before.get("cohort", [])), set(after.get("cohort", []))
+    entered, left = sorted(a_cohort - b_cohort), sorted(b_cohort - a_cohort)
+    if entered or left:
+        changed = True
+        lines.append(f"\nCOHORT MEMBERSHIP CHANGED — {len(entered)} in, {len(left)} out")
+        for m in entered:
+            lines.append(f"  + {m}")
+        for m in left:
+            lines.append(f"  - {m}")
+    else:
+        lines.append(f"\ncohort membership unchanged ({len(a_cohort)} members)")
+
+    # Ordering is compared over the managers present in BOTH snapshots.
+    # Comparing raw lists would report a reorder whenever the population
+    # merely grew, which is a different fact and is already reported above.
+    common = [u for u in before.get("ranking", []) if u in set(after.get("ranking", []))]
+    after_common = [u for u in after.get("ranking", []) if u in set(common)]
+    if common != after_common:
+        changed = True
+        lines.append("\nORDER CHANGED among managers present in both snapshots:")
+        for i, (b, a) in enumerate(zip(common, after_common)):
+            if b != a:
+                lines.append(f"  rank {i + 1}: {b} -> {a}")
+    else:
+        lines.append(f"order unchanged across {len(common)} shared managers")
+
+    # Score movement is EXPECTED under a renormalization; it is reported
+    # rather than judged.  A uniform ratio is the signature of the safety
+    # argument holding; a spread means it does not.
+    ratios = []
+    for user_id, a_entry in after.get("scores", {}).items():
+        b_entry = before.get("scores", {}).get(user_id)
+        if not b_entry:
+            continue
+        b_score, a_score = b_entry.get("score"), a_entry.get("score")
+        if b_score and a_score:
+            ratios.append(a_score / b_score)
+    if ratios:
+        lo, hi = min(ratios), max(ratios)
+        lines.append(
+            f"\nscore ratio after/before over {len(ratios)} managers: "
+            f"min {lo:.4f}, max {hi:.4f}, spread {hi - lo:.4f}"
+        )
+        lines.append(
+            "  a spread near zero is the uniform-scaling the safety argument predicts; "
+            "a wide spread means the absent component set was NOT uniform"
+        )
+
+    return (1 if changed else 0), lines
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", type=Path, help="write a snapshot to this path")
+    ap.add_argument("--ledger", type=Path, default=None, help="override ledger path")
+    ap.add_argument("--compare", type=Path, help="baseline snapshot to compare FROM")
+    ap.add_argument("--against", type=Path, help="snapshot to compare TO (default: live)")
+    args = ap.parse_args()
+
+    if args.compare:
+        before = json.loads(args.compare.read_text(encoding="utf-8"))
+        after = (
+            json.loads(args.against.read_text(encoding="utf-8"))
+            if args.against
+            else build_snapshot(args.ledger)
+        )
+        code, lines = compare(before, after)
+        print("\n".join(lines))
+        return code
+
+    snap = build_snapshot(args.ledger)
+    if snap["population"]["evaluable"] == 0:
+        print(
+            "no evaluable managers — nothing to measure.\n"
+            "  This is exit 2, not 0: an empty population cannot verify that a "
+            "scoring change left the cohort alone.\n"
+            f"  records seen: {snap['population']['records']}",
+            file=sys.stderr,
+        )
+        return 2
+
+    payload = json.dumps(snap, indent=1) + "\n"
+    if args.out:
+        args.out.write_text(payload, encoding="utf-8")
+        print(f"wrote {args.out}")
+    else:
+        print(payload)
+    pop = snap["population"]
+    print(
+        f"  methodology {snap['methodologyVersion']}: "
+        f"{pop['evaluable']} evaluable, {pop['qualified']} qualified, "
+        f"{pop['cohortMembers']} cohort members",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/deploy/test_playerctx_history_timer_is_wired.py
+++ b/tests/deploy/test_playerctx_history_timer_is_wired.py
@@ -115,6 +115,62 @@ def test_the_push_runs_after_the_refresh_that_writes_the_file():
     assert _minutes(push) >= _minutes(refresh) + 45, (refresh, push)
 
 
+def test_the_installer_does_not_gate_the_unit_on_a_key_it_cannot_read():
+    """The install must be UNCONDITIONAL, and the key check must live in
+    the script.
+
+    Gating the unit on the deploy key failed on the 2026-08-05 deploy for
+    two independent reasons.  The installer runs as the deploy user,
+    whose sudo is scoped to specific commands, so it can neither
+    `sudo test -f` nor stat another user's `~/.ssh` — it reported a key
+    missing while the DLF pusher was committing to main with one every
+    two hours.  And `deploy.sh` globs `*.timer.template` and warns for
+    anything not installed AND enabled, then runs this installer to close
+    the gap, so a permanently-skipped timer warns and re-runs the
+    installer on every deploy forever — the loop #729 closed for three
+    other timers.
+    """
+    # Scan DIRECTIVES, not the raw file.  The installer's comment quotes
+    # the old skip message verbatim to explain why it is gone, and a
+    # naive substring scan reads that prose as the code — the same false
+    # positive `test_reception_depth_timer_is_wired` documents.
+    body = "\n".join(ln for ln in _installer().split("\n") if not ln.lstrip().startswith("#"))
+    assert (
+        "has_pchist_key" not in body
+    ), "the retention install is gated on a key the installer cannot reliably read"
+    assert (
+        "retention timer skipped" not in body
+    ), "a skipped timer re-triggers deploy.sh's presence check on every deploy"
+    # Line-anchored, not split-on-substring: an earlier version split the
+    # script on "fi" and matched the "fi" inside `log "fix: …"`, so the
+    # block it checked ended two lines early.
+    lines = _SCRIPT.read_text(encoding="utf-8").split("\n")
+    guard = next(
+        (i for i, ln in enumerate(lines) if '-r "${SSH_KEY}"' in ln),
+        None,
+    )
+    assert guard is not None, "the key check must run as the service user"
+    block = lines[guard : guard + 8]
+    end = next((i for i, ln in enumerate(block) if ln.strip() == "fi"), len(block))
+    assert any(
+        ln.strip() == "exit 0" for ln in block[:end]
+    ), "a missing key must not make the weekly unit go red — nothing is lost yet"
+
+
+def test_a_missing_key_does_not_lose_the_backlog():
+    """Exit-0-on-missing-key is only safe because the push takes EVERY
+    dated snapshot, not the newest.
+
+    If it copied one file per run, every week spent without a key would
+    be a week permanently unretained — and an unretained day cannot be
+    recovered afterwards.  Globbing the whole directory is what makes
+    supplying the key later backfill the backlog.
+    """
+    script = _SCRIPT.read_text(encoding="utf-8")
+    assert 'SNAPSHOTS=("${SRC_DIR}"/snapshot_' in script
+    assert 'for src in "${SNAPSHOTS[@]}"' in script
+
+
 def test_the_installer_reinstalls_on_a_template_change():
     """Gating on "does the timer exist" alone means a template edit is
     silently ignored on an already-provisioned box.  That bit for real

--- a/tests/sharp/test_cohort_snapshot.py
+++ b/tests/sharp/test_cohort_snapshot.py
@@ -1,0 +1,120 @@
+"""The cohort snapshot must detect the thing it exists to detect.
+
+`sharp-v2.1` shipped with the claim that renormalizing the score leaves
+ORDER and cohort membership unchanged, asserted on synthetic records but
+never measured against a live population — the dev ledger yields zero
+members.  `scripts/sharp_cohort_snapshot.py` is how that debt gets paid
+on the box that has the data, so its comparison logic needs to be
+trustworthy before anyone runs it there and believes the answer.
+
+The failure mode to guard is a comparison that returns "unchanged" too
+easily: it would launder a real cohort shift into a clean bill of health.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO / "scripts" / "sharp_cohort_snapshot.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("sharp_cohort_snapshot", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["sharp_cohort_snapshot"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _snap(ranking, cohort, scores=None):
+    return {
+        "methodologyVersion": "sharp-v2",
+        "population": {
+            "records": len(ranking),
+            "evaluable": len(ranking),
+            "qualified": len(cohort),
+            "cohortMembers": len(cohort),
+        },
+        "ranking": list(ranking),
+        "cohort": sorted(cohort),
+        "scores": scores or {u: {"score": 100.0 - i} for i, u in enumerate(ranking)},
+    }
+
+
+def test_identical_snapshots_compare_clean():
+    mod = _load()
+    snap = _snap(["a", "b", "c"], ["a", "b"])
+    code, lines = mod.compare(snap, snap)
+    assert code == 0
+    assert any("order unchanged" in ln for ln in lines)
+
+
+def test_a_reordering_is_caught():
+    mod = _load()
+    before = _snap(["a", "b", "c"], ["a", "b"])
+    after = _snap(["b", "a", "c"], ["a", "b"])
+    code, lines = mod.compare(before, after)
+    assert code == 1
+    assert any("ORDER CHANGED" in ln for ln in lines)
+
+
+def test_membership_change_is_caught():
+    mod = _load()
+    before = _snap(["a", "b", "c"], ["a", "b"])
+    after = _snap(["a", "b", "c"], ["a", "c"])
+    code, lines = mod.compare(before, after)
+    assert code == 1
+    assert any("+ c" in ln for ln in lines)
+    assert any("- b" in ln for ln in lines)
+
+
+def test_a_grown_population_is_not_reported_as_a_reorder():
+    """New managers appearing must not read as the order moving.
+
+    Comparing the raw ranking lists would flag every population change as
+    a reorder, and a check that cries wolf on normal growth is one whose
+    real alarm gets ignored.
+    """
+    mod = _load()
+    before = _snap(["a", "b"], ["a"])
+    after = _snap(["a", "z", "b"], ["a"])
+    code, lines = mod.compare(before, after)
+    assert code == 0, [ln for ln in lines if "ORDER" in ln]
+    assert any("order unchanged across 2 shared managers" in ln for ln in lines)
+
+
+def test_uniform_scaling_shows_a_zero_spread():
+    """The v2.1 safety argument in one number.
+
+    If every score scales by the same factor the ordering cannot move, so
+    a spread at zero is the signature of the argument holding — and a
+    wide spread is the signature of it failing, which is what a live run
+    is meant to distinguish.
+    """
+    mod = _load()
+    users = ["a", "b", "c"]
+    before = _snap(users, ["a"], {u: {"score": s} for u, s in zip(users, [78.0, 60.0, 39.0])})
+    after = _snap(
+        users,
+        ["a"],
+        {u: {"score": s * 100 / 78} for u, s in zip(users, [78.0, 60.0, 39.0])},
+    )
+    code, lines = mod.compare(before, after)
+    assert code == 0
+    spread_line = next(ln for ln in lines if "spread" in ln and "ratio" in ln)
+    assert "spread 0.0000" in spread_line
+
+
+def test_the_no_data_path_is_not_success():
+    """`main()` must exit 2, never 0, on an empty population.
+
+    "no data" reading as "verified unchanged" is exactly how an unpaid
+    measurement debt gets marked paid — the same reason
+    `scripts/backtest_perfect_draft.py` exits 2.
+    """
+    body = _SCRIPT.read_text(encoding="utf-8")
+    assert "return 2" in body
+    assert 'evaluable"] == 0' in body


### PR DESCRIPTION
Follow-up to #734. The deploy that carried it (run 2158, `8252379e0`) installed **half** of playerctx retention, and the log said exactly which half:

```
[deploy][WARN] Timer units missing from this host: …-playerctx-history.timer. Running installer to add them.
[systemd-bootstrap] Player-context unit files changed; rewriting …-playerctx-refresh.service + timer.
[systemd-bootstrap] Player-context retention timer skipped: /home/…/.ssh/github_deploy_key missing - no deploy key to push with.
```

**Line 2 is #734 working.** `--retain-history` reached the box — and only because of the content-compare fix; the old "does the timer exist" gate would have left prod running the previous `ExecStart` while the repo claimed retention was live. That is the failure #734 predicted, caught one line up from the one that bit.

## What was wrong

Line 3 was wrong twice over, for independent reasons.

**1 — The key test ran as the wrong user.** `install-systemd-service.sh` runs as the *deploy* user, whose sudo is scoped to specific commands, so it can neither `sudo test -f` nor stat another user's `~/.ssh`. It reported the key missing **while the DLF pusher was committing to `main` with one every two hours** — so this was very likely a false negative about a working key, not a real absence. Only the service user can answer the question, so the check moves into `deploy/playerctx_history_push.sh`, which runs under `User=<app_user>`.

**2 — A conditionally-installed timer breaks `deploy.sh`.** Its presence check globs `*.timer.template` and warns for anything not installed AND enabled, then runs the installer to close the gap. So a permanently-skipped timer means a warning plus a pointless installer run on **every deploy, forever** — precisely the loop #729 closed for three other timers, reintroduced hours later. `deploy.sh` exempts the alert timers via a `case`; adding a fourth exemption would have spread the pattern instead of fixing it. The unit now installs unconditionally.

The original rationale — *"a timer that fails weekly is worse than one never installed"* — was a real concern answered with the wrong mechanism. It is answered instead by exiting **0** with the missing path named. Nothing is half-done at that point, and the push globs **every** dated snapshot rather than the newest, so supplying the key later backfills every missed week on the next run. A stalled retention is meant to surface through `store.history_coverage()`'s `missingDays` — the same way `rank_history` reports its own gaps — not through a red timer nobody reads. Both properties are now pinned by tests, including the one that makes exit-0 safe.

## Paying the sharp-v2.1 measurement debt

`scripts/sharp_cohort_snapshot.py` snapshots and diffs the cohort. #734 shipped the claim that renormalizing the score leaves **order and membership** unchanged — asserted on synthetic records, never measured live, because the dev ledger yields zero cohort members. This makes that a single command on the box that has the data:

```
python scripts/sharp_cohort_snapshot.py --out /tmp/cohort-before.json    # before
python scripts/sharp_cohort_snapshot.py --compare /tmp/cohort-before.json  # after
```

It computes nothing itself — records, scores and membership all come from the canonical path, because a second implementation of "who is a sharp" is what `cohort.py` exists to prevent. It reports the after/before score-ratio **spread**, which is the safety argument as one number: near zero means uniform scaling (order cannot move), a wide spread means the absent component set was not uniform after all. It exits **2** on an empty population, so "no data" cannot read as "verified unchanged" — same posture as `backtest_perfect_draft.py`. Verified locally: exit 2, `records seen: 0`.

## Docs

ADR-026's amendment said *"Enabled in production 2026-08-05, on explicit sign-off."* That overstated what shipped. It now carries a same-day correction recording that the producer is on, the pusher was not installed, both causes, and that **no snapshot has been retained yet** — the first evidence is a `chore(playerctx): retain snapshot …` commit on `main` after a Tuesday 06:45 UTC run, which cannot happen before a deploy carries this.

## Tests

`tests/sharp` + `tests/deploy`: **334 passed**. `ruff format --check .` clean across 901 files; `ruff check .` all passed.

Two of the new assertions caught themselves during development, both the same substring trap this repo keeps hitting: scanning the raw installer matched the old skip message quoted *inside the comment explaining its removal*, and splitting the push script on `"fi"` matched the `fi` inside `log "fix: …"`. Both are now comment-stripped and line-anchored, with the reason recorded.

## Not claimed

The `consensus_edge` flag stays **OFF**. Retention still has not retained anything, and the live Sharp cohort still has not been measured — this ships the tool, not the measurement.

---
_Generated by [Claude Code](https://claude.ai/code/session_0111wN4U1UQy7QqkTavTPGxK)_