### PR TITLE
Add a work-claim protocol, because six repairs were done twice

### DIFF
--- a/ASSISTANT_COORDINATION.md
+++ b/ASSISTANT_COORDINATION.md
@@ -25,6 +25,24 @@ git status --short --branch
 
 If the branch is not clean, inspect the existing changes before doing new work.
 
+**Then check whether someone else is already on it:**
+
+```bash
+python scripts/check_work_claims.py --files <paths you expect to change> --defect <ids>
+```
+
+This is not ceremony. On 2026-08-05 two sessions independently fixed the
+SAME six defects in one window — the TEP default, the rank-space market gap,
+the open redirect, FAAB budget mixing, ROS absence odds and the compact-view
+weights — and nobody noticed until one branch had already merged. Roughly a
+third of a session's output was discarded, and which version survived came
+down to which branch was mergeable first rather than which was better.
+
+The two rules above did not prevent it and could not have: they govern WHERE
+your work goes, not what someone else is already doing. See
+`docs/WORK_CLAIMS.md` for the full record and the claim format. Add your row
+in your first commit; set it `done` in your last.
+
 ## Branch Rules
 
 - Codex work goes on `codex/<task-name>`.

--- a/docs/WORK_CLAIMS.md
+++ b/docs/WORK_CLAIMS.md
@@ -18,24 +18,33 @@ branches are evidence.
 
 | Claim | Paths | Defect ids | Branch | Status |
 |---|---|---|---|---|
-| Work-claim protocol | docs/WORK_CLAIMS.md, scripts/check_work_claims.py, ASSISTANT_COORDINATION.md | — | claude/work-claim-protocol | open |
+| Work-claim protocol | docs/WORK_CLAIMS.md, scripts/check_work_claims.py, ASSISTANT_COORDINATION.md | — | claude/work-claim-protocol | done |
 
 ---
 
 ## Why this file exists
 
-On 2026-08-05, two sessions independently fixed the **same six defects**
-inside one working window, and neither noticed until one branch had already
-merged:
+On 2026-08-05, five sessions independently solved the **same eight defects**
+inside one working window, and in no case did anyone notice until a branch had
+already merged:
 
-| Defect | Fixed in | Also fixed in |
+| Defect | Solved in | And independently in |
 |---|---|---|
+| Market gap computed in rank space | #740 | #722 **and** #742 — three times |
 | `tepMultiplier` default forces the override path | #740 | #722 |
-| Market gap computed in rank space | #740 | #722 |
 | `_sanitize_next_path` accepts a backslash | #740 | #722 |
 | FAAB budget-regime mixing | #740 | #707 |
 | ROS absence coerced to 0.0 odds | #740 | #736 |
 | Compact view drops `appliedWeight` | #740 | main |
+| SSR streaming "duplicate" (#716) | #741 | #747 |
+
+**Eight duplicated repairs across five sessions**, and the market-gap defect was
+solved three separate times.
+
+**#742 was pushed AFTER #740 merged.** Its branch does not contain `cef17703`, and
+it touches the same three files the merged fix landed in. So this is not a tidy
+retrospective about a bad afternoon — the collisions were still happening while
+this document was being written.
 
 Every individual collision was resolved sensibly — the better-documented
 version was kept each time. The aggregate was not sensible: roughly a third

--- a/docs/WORK_CLAIMS.md
+++ b/docs/WORK_CLAIMS.md
@@ -1,0 +1,90 @@
+# Work Claims
+
+**What you are about to work on, recorded before you start.**
+
+One row per piece of work in flight. Add yours in your first commit; set it
+`done` in your last. Check it before you begin:
+
+```bash
+python scripts/check_work_claims.py --files <paths you will change> --defect <ids>
+```
+
+That script also scans remote branches, because claims are voluntary and
+branches are evidence.
+
+---
+
+## Open claims
+
+| Claim | Paths | Defect ids | Branch | Status |
+|---|---|---|---|---|
+| Work-claim protocol | docs/WORK_CLAIMS.md, scripts/check_work_claims.py, ASSISTANT_COORDINATION.md | — | claude/work-claim-protocol | open |
+
+---
+
+## Why this file exists
+
+On 2026-08-05, two sessions independently fixed the **same six defects**
+inside one working window, and neither noticed until one branch had already
+merged:
+
+| Defect | Fixed in | Also fixed in |
+|---|---|---|
+| `tepMultiplier` default forces the override path | #740 | #722 |
+| Market gap computed in rank space | #740 | #722 |
+| `_sanitize_next_path` accepts a backslash | #740 | #722 |
+| FAAB budget-regime mixing | #740 | #707 |
+| ROS absence coerced to 0.0 odds | #740 | #736 |
+| Compact view drops `appliedWeight` | #740 | main |
+
+Every individual collision was resolved sensibly — the better-documented
+version was kept each time. The aggregate was not sensible: roughly a third
+of a session's output was discarded, and **which version survived came down
+to which branch happened to be mergeable first, not which was better.** In
+at least one case nobody compared the two implementations at all.
+
+`ASSISTANT_COORDINATION.md` already required branching, and already required
+`git pull --ff-only origin main` before starting. Neither prevented any of
+this, and it is worth being precise about why: **both rules are about where
+your work goes, and none of them tells you what someone else is already
+doing.** A branch you never listed is a branch you will duplicate.
+
+So the missing step is not another rule about branching. It is a place to
+look, and something worth looking at when you get there.
+
+## The format, and why it is a markdown table
+
+A markdown table is editable in the same commit as the work, readable in a
+PR diff, and mergeable by hand. A JSON registry would conflict on every
+concurrent claim — which is exactly the failure this is meant to reduce.
+
+Columns:
+
+- **Claim** — one line a human recognises. "FAAB budget regimes", not "fix bug".
+- **Paths** — comma-separated files you expect to change. Approximate is fine;
+  the point is overlap detection, not a manifest.
+- **Defect ids** — `C12`, `W22-F001`, audit finding ids, `—` if none.
+- **Branch** — where the work lives, so a collision has somewhere to go.
+- **Status** — `open` while in flight, `done` once merged or abandoned.
+
+## What to do when you hit an overlap
+
+Not "stop". Overlap is often legitimate — two people fixing different bugs
+in one large file collide on paths and not on meaning.
+
+1. **Read the other branch.** `git diff origin/main..origin/<branch> -- <path>`.
+2. **If it is the same defect:** do not write it again. Either take theirs and
+   move on, or say concretely why yours should replace it — on the PR, before
+   the work, not after.
+3. **If it is a different defect in the same file:** carry on, and say so in
+   your claim row so the next person does not have to re-derive it.
+
+## Honest limits
+
+- Nothing enforces this. `check_work_claims.py` exits 0 unless you pass
+  `--strict`. A gate that cries wolf gets ignored, which is roughly how the
+  previous coordination rules failed.
+- It only helps if run *before* the work. Run afterwards it is a conflict
+  report.
+- A session that never fetches sees stale branches. The branch scan is only
+  as current as your last `git fetch`.

--- a/scripts/check_work_claims.py
+++ b/scripts/check_work_claims.py
@@ -3,17 +3,19 @@
 
 WHY THIS EXISTS
 ---------------
-On 2026-08-05 two sessions independently fixed the SAME defects inside one
-window, and neither noticed until one branch was already merged:
+On 2026-08-05 five sessions independently solved the SAME defects inside one
+window, and nobody noticed until a branch had already merged:
 
+    market gap in value space              #740, #722 AND #742
     tepMultiplier default -> null          #740 and #722
-    market gap in value space              #740 and #722
     _sanitize_next_path backslash          #740 and #722
     FAAB budget normalisation              #740 and #707
     ROS absence as 0.0 odds                #740 and #736
     compact-view appliedWeight             #740 and main
+    SSR streaming duplicate (#716)         #741 and #747
 
-Six repairs, done twice. Every individual collision was resolved sensibly —
+Eight repairs, done twice or three times.  #742 was pushed AFTER #740 merged
+and does not contain it, so this is not a closed incident. Every individual collision was resolved sensibly —
 the better-documented version was kept each time — but roughly a third of a
 session's output was thrown away, and which version survived came down to
 which branch happened to be mergeable first rather than which was better.

--- a/scripts/check_work_claims.py
+++ b/scripts/check_work_claims.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Tell a session, before it starts, whether someone else is already on this.
+
+WHY THIS EXISTS
+---------------
+On 2026-08-05 two sessions independently fixed the SAME defects inside one
+window, and neither noticed until one branch was already merged:
+
+    tepMultiplier default -> null          #740 and #722
+    market gap in value space              #740 and #722
+    _sanitize_next_path backslash          #740 and #722
+    FAAB budget normalisation              #740 and #707
+    ROS absence as 0.0 odds                #740 and #736
+    compact-view appliedWeight             #740 and main
+
+Six repairs, done twice. Every individual collision was resolved sensibly —
+the better-documented version was kept each time — but roughly a third of a
+session's output was thrown away, and which version survived came down to
+which branch happened to be mergeable first rather than which was better.
+
+``ASSISTANT_COORDINATION.md`` already told everyone to branch and to pull
+before starting. That was not the gap. The gap is that nothing tells you
+**what someone else is currently touching**, and a branch you cannot see is
+a branch you will duplicate.
+
+WHAT THIS CHECKS
+----------------
+Two questions, both answerable in seconds:
+
+1. Does ``docs/WORK_CLAIMS.md`` have an open claim overlapping the files or
+   defect ids you are about to work on?
+2. Do any *remote branches* — merged or not — already touch those files?
+   Claims are voluntary and will be forgotten; branches are evidence.
+
+WHAT IT DOES NOT DO
+-------------------
+It does not block anything. A collision is sometimes correct (two people
+fixing different bugs in one file), and a gate that cries wolf gets ignored,
+which is how the last one failed. This prints what it found and exits 0
+unless you ask for ``--strict``.
+
+USAGE
+-----
+    python scripts/check_work_claims.py --files src/api/faab_analytics.py ...
+    python scripts/check_work_claims.py --defect C12 --defect W22-F001
+    python scripts/check_work_claims.py --claim "FAAB budget regimes" \\
+        --files src/api/faab_analytics.py --branch claude/my-session
+
+Run it BEFORE writing code, not after. After is a merge conflict.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLAIMS_PATH = REPO_ROOT / "docs" / "WORK_CLAIMS.md"
+
+# Branches whose overlap is never interesting.
+_IGNORED_BRANCH_RE = re.compile(r"^origin/(HEAD|main)$")
+
+
+def _git(*args: str) -> str:
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout
+    except OSError:
+        return ""
+
+
+def parse_claims() -> list[dict[str, str]]:
+    """Read the claim table.  A malformed row is skipped, never fatal.
+
+    The format is a markdown table on purpose: it has to be editable in the
+    same commit as the work, readable in a PR diff, and mergeable without a
+    tool.  A JSON registry would conflict on every concurrent claim, which
+    is precisely the failure mode this is meant to reduce.
+    """
+    if not CLAIMS_PATH.exists():
+        return []
+    claims: list[dict[str, str]] = []
+    for line in CLAIMS_PATH.read_text(encoding="utf-8").splitlines():
+        if not line.strip().startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) < 5:
+            continue
+        if cells[0].lower() in {"claim", "what"} or set(cells[0]) <= {"-", ":"}:
+            continue
+        claims.append(
+            {
+                "what": cells[0],
+                "paths": cells[1],
+                "defects": cells[2],
+                "branch": cells[3],
+                "status": cells[4].lower(),
+            }
+        )
+    return claims
+
+
+def branches_touching(paths: list[str], *, exclude: str | None) -> dict[str, list[str]]:
+    """Remote branches whose diff against main touches any of ``paths``.
+
+    Evidence beats self-report: this catches the session that never wrote a
+    claim down, which — on the record above — is every session so far.
+    """
+    out: dict[str, list[str]] = {}
+    raw = _git("for-each-ref", "--format=%(refname:short)", "refs/remotes/origin")
+    for branch in (b.strip() for b in raw.splitlines() if b.strip()):
+        if _IGNORED_BRANCH_RE.match(branch) or (exclude and branch.endswith(exclude)):
+            continue
+        base = _git("merge-base", "origin/main", branch).strip()
+        if not base:
+            continue
+        changed = set(_git("diff", "--name-only", f"{base}..{branch}").split())
+        hits = sorted(p for p in paths if p in changed)
+        if hits:
+            out[branch] = hits
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--files", nargs="*", default=[], help="paths you intend to change")
+    ap.add_argument("--defect", action="append", default=[], help="defect id (C12, W22-F001, ...)")
+    ap.add_argument("--claim", help="short description, for the suggested row")
+    ap.add_argument("--branch", help="your branch, excluded from the overlap scan")
+    ap.add_argument("--strict", action="store_true", help="exit 1 when something overlaps")
+    args = ap.parse_args()
+
+    if not args.files and not args.defect:
+        ap.error("give --files and/or --defect — there is nothing to check otherwise")
+
+    collided = False
+
+    claims = parse_claims()
+    open_claims = [c for c in claims if c["status"].startswith("open")]
+    for c in open_claims:
+        paths = [p.strip() for p in c["paths"].split(",") if p.strip()]
+        defects = {d.strip().upper() for d in c["defects"].split(",") if d.strip()}
+        path_hits = sorted(set(args.files) & set(paths))
+        defect_hits = sorted({d.upper() for d in args.defect} & defects)
+        if path_hits or defect_hits:
+            collided = True
+            print(f"OPEN CLAIM — {c['what']}  ({c['branch']})")
+            if path_hits:
+                print(f"    shared files:   {', '.join(path_hits)}")
+            if defect_hits:
+                print(f"    shared defects: {', '.join(defect_hits)}")
+
+    if args.files:
+        for branch, hits in branches_touching(args.files, exclude=args.branch).items():
+            collided = True
+            print(f"BRANCH ALREADY TOUCHES THESE — {branch}")
+            print(f"    {', '.join(hits)}")
+
+    if not collided:
+        print("No overlapping claim or branch found.")
+        if args.claim:
+            paths = ", ".join(args.files) or "—"
+            defects = ", ".join(args.defect) or "—"
+            branch = args.branch or "<your-branch>"
+            print("\nAdd this row to docs/WORK_CLAIMS.md in your first commit:\n")
+            print(f"| {args.claim} | {paths} | {defects} | {branch} | open |")
+        return 0
+
+    print(
+        "\nOverlap is not automatically wrong — two people can fix different "
+        "bugs in one file.\nBut find out which it is BEFORE writing the code. "
+        "After is a merge conflict, or worse,\ntwo correct implementations "
+        "where the one that survives is whichever merged first."
+    )
+    return 1 if args.strict else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
On 2026-08-05 two sessions independently fixed the **same six defects** inside one working window, and neither noticed until one branch had already merged:

| Defect | Fixed in | Also fixed in |
|---|---|---|
| `tepMultiplier` default forces the override path | #740 | #722 |
| Market gap computed in rank space | #740 | #722 |
| `_sanitize_next_path` accepts a backslash | #740 | #722 |
| FAAB budget-regime mixing | #740 | #707 |
| ROS absence coerced to 0.0 odds | #740 | #736 |
| Compact view drops `appliedWeight` | #740 | main |

Every individual collision resolved sensibly — the better-documented version was kept each time. **The aggregate did not.** Roughly a third of a session's output was discarded, and which version survived came down to which branch happened to be mergeable first rather than which was better. In at least one case the two implementations were never compared at all.

## Why the existing rules didn't help

`ASSISTANT_COORDINATION.md` already required branching, and already required `git pull --ff-only origin main` before starting. Worth being precise about why neither prevented any of this: **both govern where your work goes, and neither tells you what someone else is already doing.** A branch you never listed is a branch you will duplicate.

So this doesn't add another rule about branching. It adds a place to look, and a reason to look there.

## What lands

| File | Role |
|---|---|
| `docs/WORK_CLAIMS.md` | One row per piece of work in flight, plus the incident record |
| `scripts/check_work_claims.py` | Checks that table **and** scans remote branches |
| `ASSISTANT_COORDINATION.md` | The check becomes step three of every session |

The branch scan matters more than the table: claims are voluntary and will be forgotten, but branches are evidence. On the record above, *every* session so far would have been caught by the scan and missed by the table.

**Verified against the real collision.** Run with the files #740 and #722 both changed, it names the other branch:

```
BRANCH ALREADY TOUCHES THESE — origin/claude/fantasy-football-master-audit-umvex5
    frontend/lib/display-helpers.js, src/api/faab_analytics.py
```

Run clean, it prints the claim row to paste.

## Two deliberate limits

- **It does not block.** Exit 0 unless `--strict`. Overlap is often legitimate — two people fixing different bugs in one large file — and a gate that cries wolf gets ignored, which is roughly how the previous rules failed.
- **It only helps run *before* the work.** Run afterwards, it is a conflict report.

The table is markdown rather than JSON so a claim can land in the same commit as the work, be read in a PR diff, and merge by hand. A JSON registry would conflict on every concurrent claim — precisely the failure this exists to reduce.

---
_Generated by [Claude Code](https://claude.ai/code/session_0128wdrJPDMB5ke7WTnLaCKG)_