### PR TITLE
Fix #716: the streaming &quot;duplicate&quot; was the specs asserting mid-stream

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,16 +42,35 @@ name: E2E Safety Net
 # the bundler config, run the browser BEFORE merge.  The paths below are
 # deliberately narrow — see the note beside them.
 #
-# EXPECT INTERMITTENT REDS, and read them carefully before blaming the
-# PR.  The app has a pre-existing SSR-streaming race in which the same
-# `#S:1` staging copy is occasionally left behind, measured at 1/15
-# loads on /arbitrage and 1/45 on /waivers — IDENTICAL rates on a build
-# of main and on the #709 branch, so it is main's defect, not any one
-# PR's.  Tracked separately.  Before attributing a red run here to the
-# PR under review, reproduce the rate against a build of the base
-# branch.  Do NOT "fix" it by loosening those locators: they are the
-# only detector this repo has for a bug class every performance metric
-# is blind to.
+# The "#S:1 streaming race" (#716) is FIXED — and it was never an app
+# defect.  This paragraph used to say the staging copy was "occasionally
+# left behind" at 1/15 on /arbitrage and 1/45 on /waivers.  Both the
+# diagnosis and the numbers were wrong.
+#
+# Routes with a `loading.jsx` (/waivers, /arbitrage, ~8 others) are
+# wrapped by the App Router in a Suspense boundary and STREAMED: the
+# body arrives inside `<div hidden id="S:n">` and an inline
+# `$RC("B:n","S:n")` moves it into place.  For a few milliseconds around
+# that swap the document can satisfy a selector twice, and Playwright's
+# strict mode throws ON THE SPOT rather than retrying.  Nothing is left
+# behind and nothing is broken — a spec was simply asserting mid-stream.
+# The server HTML was verified to contain exactly ONE copy on 20/20
+# samples, so the duplicate never existed server-side at all.
+#
+# The real rate was ~13-20% per detector, not 1/45 — an order of
+# magnitude worse than documented, across four detector points, which is
+# why a fully green run had become close to a coin flip.
+#
+# Fixed by `awaitStreamSettled()` in tests/e2e/helpers/journey.js: wait
+# for React's streaming machinery to finish, THEN assert.  Measured
+# 25/25 and 12/12 clean afterward, from 13-20% failing.
+#
+# The locators themselves were NOT loosened, and must not be.  They are
+# the only detector this repo has for the #709 class — a build that
+# renders every page twice, which every performance metric is blind to.
+# That bug is a PERSISTENT duplicate: it survives streaming completion
+# and still trips strict mode.  Verified by injecting one after
+# `awaitStreamSettled` and confirming the count still goes 1 -> 2.
 #
 # Failure handling mirrors scheduled-refresh.yml: an idempotent
 # tracking issue labelled ``e2e-failures`` is opened (or commented

--- a/tests/e2e/helpers/journey.js
+++ b/tests/e2e/helpers/journey.js
@@ -361,6 +361,50 @@ async function expectNoBadValueTokens(page, scopeSelector) {
  * ``assertClean()`` at the end of the test.  (Same contract as the
  * old utils/app.js guard, rebuilt for the Next.js frontend.)
  */
+/**
+ * Wait until React has finished swapping streamed content into place.
+ *
+ * WHY THIS EXISTS, and why it is NOT a loosened assertion (#716).
+ *
+ * Routes with a `loading.jsx` — /waivers and /arbitrage among them — are
+ * wrapped by the App Router in a Suspense boundary and streamed. The server
+ * sends the page body inside `<div hidden id="S:n">`, then an inline
+ * `$RC("B:n","S:n")` moves it into place. For a brief window around that swap
+ * the document can satisfy a selector TWICE, and Playwright's strict mode
+ * throws on the spot rather than retrying — so a spec that asserts during the
+ * window fails with "resolved to 2 elements" on a page that is completely
+ * healthy a few milliseconds later.
+ *
+ * Measured on /waivers, 25 loads per arm: asserting immediately caught the
+ * window 1/25; asserting after this helper, 0/25. Under load (CI) the first
+ * number is far worse — 13-20% per detector across four detector points, which
+ * is why the suite was effectively unable to go green.
+ *
+ * CRITICALLY, this does not weaken the #709 detector. The bug those strict
+ * locators exist to catch is a PERSISTENT duplicate — a build that renders
+ * every page twice, forever. That survives streaming completion and still
+ * trips strict mode here. What this removes is only the transient window,
+ * which is normal React streaming and not a defect in anything.
+ *
+ * Keyed on React's own machinery (`div[hidden][id^="S:"]` staging containers
+ * and `template[id^="B:"]` boundary markers) rather than on `div[hidden]`
+ * generally, so an app component that legitimately renders a hidden div cannot
+ * make this hang.
+ */
+async function awaitStreamSettled(page, { timeout = 30_000 } = {}) {
+  await page
+    .waitForFunction(
+      () =>
+        !document.querySelector('div[hidden][id^="S:"]') &&
+        !document.querySelector('template[id^="B:"]'),
+      null,
+      { timeout },
+    )
+    // A route that never streamed has nothing to settle; that is a pass, not a
+    // failure. Swallowing here keeps this usable as an unconditional prelude.
+    .catch(() => {});
+}
+
 function attachConsoleGuards(page, { allow = [] } = {}) {
   const defaultAllow = [
     // Chrome resource noise (404 favicons, aborted prefetches).
@@ -413,4 +457,5 @@ module.exports = {
   contractFixture,
   expectNoBadValueTokens,
   attachConsoleGuards,
+  awaitStreamSettled,
 };

--- a/tests/e2e/specs/journey-trade.spec.js
+++ b/tests/e2e/specs/journey-trade.spec.js
@@ -25,6 +25,7 @@ const {
   SEL,
   pageHeading,
   titleFor,
+  awaitStreamSettled,
 } = require("../helpers/journey");
 
 test.describe("journey: trade surfaces", () => {
@@ -147,6 +148,9 @@ test.describe("journey: trade surfaces", () => {
   }) => {
     const guard = attachConsoleGuards(page);
     await page.goto(pageUrl("/arbitrage"), { waitUntil: "domcontentloaded" });
+    // /arbitrage has a loading.jsx, so the App Router streams it. Let the swap
+    // finish before any strict locator runs — see awaitStreamSettled (#716).
+    await awaitStreamSettled(page);
 
     await expect(pageHeading(page, titleFor("/arbitrage"))).toBeVisible({
       timeout: 30_000,

--- a/tests/e2e/specs/waivers-smoke.spec.js
+++ b/tests/e2e/specs/waivers-smoke.spec.js
@@ -15,11 +15,14 @@ const { test, expect } = require("../helpers/auth-fixture");
 // page-route list, so the backend origin 404s it — production works
 // because nginx routes page traffic straight to Next.  pageUrl()
 // (E2E_PAGE_ORIGIN) reproduces that topology for local/CI runs.
-const { pageUrl, NAME } = require("../helpers/journey");
+const { pageUrl, NAME, awaitStreamSettled } = require("../helpers/journey");
 
 test.describe("signed-in: /waivers page", () => {
   test("renders header + sections", async ({ authedPage }) => {
     await authedPage.goto(pageUrl("/waivers"));
+    // /waivers has a loading.jsx, so the App Router streams it. Let the swap
+    // finish before any strict locator runs — see awaitStreamSettled (#716).
+    await awaitStreamSettled(authedPage);
     // Assert the page's OWN <h1>, not body text: the R1 shell puts a
     // "Waivers" nav link in the sidebar on every page, so a body-level
     // /Waivers/i match passed even when the page itself failed to
@@ -35,6 +38,9 @@ test.describe("signed-in: /waivers page", () => {
 
   test("rookie toggle is present and toggleable", async ({ authedPage }) => {
     await authedPage.goto(pageUrl("/waivers"));
+    // /waivers has a loading.jsx, so the App Router streams it. Let the swap
+    // finish before any strict locator runs — see awaitStreamSettled (#716).
+    await awaitStreamSettled(authedPage);
     const toggle = authedPage.getByLabel(NAME.waiverRookieToggle, {
       exact: false,
     });
@@ -46,6 +52,9 @@ test.describe("signed-in: /waivers page", () => {
 
   test("position filter dropdown is present", async ({ authedPage }) => {
     await authedPage.goto(pageUrl("/waivers"));
+    // /waivers has a loading.jsx, so the App Router streams it. Let the swap
+    // finish before any strict locator runs — see awaitStreamSettled (#716).
+    await awaitStreamSettled(authedPage);
     const select = authedPage.getByLabel(NAME.waiverPositionFilter);
     await expect(select).toBeVisible({ timeout: 30000 });
   });
@@ -54,6 +63,9 @@ test.describe("signed-in: /waivers page", () => {
 
   test("manual add/drop calculator section renders", async ({ authedPage }) => {
     await authedPage.goto(pageUrl("/waivers"));
+    // /waivers has a loading.jsx, so the App Router streams it. Let the swap
+    // finish before any strict locator runs — see awaitStreamSettled (#716).
+    await awaitStreamSettled(authedPage);
     // The calculator's heading is unique — distinguishes from the
     // existing Best Add/Drop Moves recommendation table.
     await expect(authedPage.locator("body")).toContainText(


### PR DESCRIPTION
Closes #716. The E2E suite had become close to unable to go green — this is what was actually happening.

## The recorded diagnosis was wrong, and so were the numbers

#716 was written up as an app defect: "the `#S:1` staging copy is occasionally left behind", at 1/15 on `/arbitrage` and 1/45 on `/waivers`.

Routes with a `loading.jsx` — `/waivers` and `/arbitrage` among about ten — are wrapped by the App Router in a Suspense boundary and **streamed**. The server sends the page body inside `<div hidden id="S:n">`, and an inline `$RC("B:n","S:n")` moves it into place. For a few milliseconds around that swap the document can satisfy a selector twice, and Playwright's strict mode **throws on the spot rather than retrying**. A spec asserting inside that window fails with "resolved to 2 elements" against a page that is perfectly healthy a moment later.

Nothing is left behind, and nothing in the app is broken:

- The served HTML contains exactly **one** `Include rookies` on **20/20** samples — the duplicate never existed server-side.
- **No** React hydration error accompanies it (`#418`/`#419`/`#42x` and `pageerror`, zero across 20 loads).
- Querying the second match a moment later **times out** — the element is already gone. Transient, not a leak.

Two readings that sent me down the wrong path, recorded so the next person skips them: `querySelectorAll("main").length === 2` is **normal** here (the shell renders `<main id="main">`, the page renders its own inside it), and the empty `<div hidden>` left after completion is React's own, not a symptom.

## The real rate is an order of magnitude worse than documented

Measured with `--retries=0`:

| Arm | Fail rate |
|---|---|
| `/waivers` toggle, feature branch | 2/15 — 13% |
| `/waivers` toggle, `main` | 3/15 — 20% |

~13–20% **per detector**, across four detector points (`waivers` and `arbitrage` × desktop and mobile). Not 1/45. That is why a fully green run had become roughly a coin flip, and why #743 could not land.

## The fix

`awaitStreamSettled()` in `tests/e2e/helpers/journey.js` waits for React's own streaming machinery — `div[hidden][id^="S:"]` staging containers and `template[id^="B:"]` boundary markers — to be gone, then the spec asserts. Keyed on those rather than `div[hidden]` generally, so an app component that legitimately renders a hidden div cannot hang it; a route that never streamed settles immediately. Applied at the two detector sites only.

## This does not loosen the locators, and does not mask #709

That is the entire point, so I verified it instead of asserting it. The bug those strict locators exist to catch is a **persistent** duplicate — a build that renders every page twice, forever — and that survives streaming completion. Injecting one after `awaitStreamSettled` takes the count from **1 → 2**, so strict mode still trips.

A test that cannot fail is worse than no test. This one still fails for the reason it was written; it just no longer fails for a reason that was never a bug.

## Measured

- `waivers` rookie toggle: **25/25 clean**, from ~13–20% failing.
- `/arbitrage`: **12/12 clean**.
- Full E2E suite: **green twice back to back** (192 and 203 passed, 0 failed).
- `tests/deploy/test_e2e_workflow_triggers.py` still passes; `e2e.yml` parses.

The workflow header's paragraph is rewritten — it was stating a wrong mechanism and wrong numbers to every reviewer who hit a red run, and explicitly telling them to reproduce a rate that was off by 10×.

## Follow-on

#743 (Perfect Draft, currently unreachable in production on a cold load) is held pending this. Once this merges I'll rebase it onto a genuinely green baseline so its green means something.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeQ4SkH9khPRx2b3WunSTA)_