### PR TITLE
Close out the four remaining audit items — two of which reversed my own advice

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,6 +66,47 @@ waiver and draft analysis, and BDVM output are all login-gated, enforced by
 the backend's default-deny `/api/` gate and by `frontend/middleware.js`. A
 way around either of those is exactly what this policy is for.
 
+### The Sleeper league ID is not a credential
+
+The main league's Sleeper ID appears in **18 tracked files besides this
+one** — including `README.md` and `config/leagues/registry.json` — and is
+recoverable from the root commit onward. **This is accepted, and it is
+not a secret.** Do not report it as one.
+
+(Counted with `git grep -l <id>`, which returns **18**. This file
+deliberately does not repeat the literal — writing it here made the
+count 19 and the sentence describing it wrong in the same edit.)
+
+* **It is a public resource identifier.** Sleeper's read API takes it as a
+  URL path segment and requires no authentication; every Sleeper call in
+  this repo is an unauthenticated `GET` with no token or key.
+  `src/api/league_registry.py:94-101` says so in its own words — "the
+  Sleeper league ID is technically public (anyone can fetch
+  `/v1/league/<id>`)". `/api/leagues` withholds it for **API decoupling**,
+  so a league-identifier choice is not baked into URL formats — *not* for
+  confidentiality. Do not cite that endpoint as evidence the ID is
+  sensitive.
+* **Rotation is not available.** Sleeper league IDs are immutable
+  server-assigned identifiers. There is no rename or migrate; a new ID
+  means a new league and the loss of all history. The prior IDs in the
+  chain are committed too (`previous_league_id` in the snapshot).
+* **Removing it would protect nothing.** The only thing it unlocks is
+  reading rosters, transactions and manager *display names* — Sleeper
+  exposes no real names — and that same data is already committed here:
+  `audit/baseline/public_league_overview.json` carries every manager's
+  `ownerId`, `displayName` and `avatar`, and `exports/latest/` carries
+  234 `ownerId` fields. Scrubbing the ID from all 18 files would remove
+  zero personal information.
+* **A history rewrite is off the table.** It is in the **root commit**, so
+  removing it changes every SHA in the repository — breaking every open
+  PR, ~55 branches including the 17 `archive/*` kept as historical record,
+  every existing clone, and the deploy checkout.
+
+The genuine decision this touches is upstream and already recorded above:
+whether the repository should be public at all. `OA-01` in
+`docs/OWNER_ACTION_AUDIT_2026-07-29.md` covers it, and notes that a
+visibility change is not retroactive.
+
 ## Credentials
 
 No credential should ever be committed. `.gitignore` excludes `*.env`,

--- a/docs/audits/unfalsifiable-number-audit-2026-08-05.md
+++ b/docs/audits/unfalsifiable-number-audit-2026-08-05.md
@@ -15,8 +15,22 @@ their positions; a curated entry is required for each and `rebuild()` raises if 
 missing. There is no mechanism to record a finding the frozen registry does not contain,
 and `remediation-protocol.md` is explicit that the registry is "never regenerated".
 
-So these are written down here instead. Everything below was checked against the 08-04
-registry first: **four of nine sweep findings were already recorded there** (the
+So they have their own registry, probed the same way:
+
+| artifact | role |
+|---|---|
+| `unfalsifiable-number-audit-2026-08-05.registry.json` | the findings as data — **the status authority** |
+| `unfalsifiable-number-audit-2026-08-05.status.json` | GENERATED; do not edit |
+| `scripts/unfalsifiable_status.py` | `--rebuild` / check, reusing `audit_status`'s `_probe` rather than forking it |
+| `tests/audit/test_unfalsifiable_status.py` | CI enforcement |
+
+Each finding carries a **defect signature** — a fragment of source present exactly while
+its mechanism is present — and each was verified to *vanish* under a simulated fix. That
+last step matters: U02's first signature was written from memory, did not match the
+source, and the checker reported "no drift" on a finding it was tracking not at all. The
+guard now asserts that an open finding's signature is locatable.
+
+Everything below was checked against the 08-04 registry first: **four of nine sweep findings were already recorded there** (the
 `model_registry.py validate` cross-snapshot comparison, the BDVM one-way sigma lane, the
 Perfect Draft scarcity multiplier, and the finder's confidence baseline — all High, none
 yet in a batch). Those are **not** repeated here. What follows is only what the registry

--- a/docs/audits/unfalsifiable-number-audit-2026-08-05.registry.json
+++ b/docs/audits/unfalsifiable-number-audit-2026-08-05.registry.json
@@ -1,0 +1,81 @@
+{
+  "audit": "unfalsifiable-number-audit-2026-08-05",
+  "source": "docs/audits/unfalsifiable-number-audit-2026-08-05.md",
+  "method": "Find numbers that reach users where nothing in the repository is capable of disagreeing with them, then give each one an adversary.",
+  "why_not_the_08_04_registry": "scripts/audit_status.py::_FINDINGS is a status overlay on a FROZEN artifact. _registry_criticals() walks decision-intelligence-audit-2026-08-04.registry.json in order and mints C01..C43 from positions; rebuild() raises if a curated entry is missing for one. There is no mechanism to record a finding that registry does not contain, and remediation-protocol.md states it is never regenerated. These are the findings it structurally cannot hold.",
+  "not_repeated_here": "Four of nine sweep findings were ALREADY recorded in the 08-04 registry as High severity and are deliberately excluded: model_registry.py validate (now FIXED, see 705cdc03), the BDVM one-way sigma lane, the Perfect Draft scarcity multiplier (gameplan.py:487), and the finder confidence baseline (Phase 5.1 names it verbatim). Re-filing them would duplicate a register rather than add to one.",
+  "findings": [
+    {
+      "id": "U01",
+      "title": "terminal._row_value returns 0.0, and both documented fallbacks are unreachable",
+      "path": "src/api/terminal.py",
+      "signature": "vf = values.get(\"full\")",
+      "status": "open",
+      "consequence": "engine_advice",
+      "measured": "values['full'] is present on 0 of 1069 rows of the built snapshot; rows with a rank but no value: 0 of 1069. 'full' is minted CLIENT-SIDE at frontend/lib/dynasty-data.js:983, so this backend function reads a frontend-only key. 97 of 665 rostered players evaluate to exactly 0.0, almost all IDP.",
+      "userSurface": "/trade Impact panel \u2014 an unpriced player resolves as an ordinary asset with value 0 and empty unresolvedIn/unresolvedOut, so nothing distinguishes 'worth nothing' from 'we have no price'. Also /terminal watchlist, movers and signals.",
+      "verifiedBy": "Read the three branches and measured the key population on audit/baseline/players_array.json. The comment's own justification ('0 of 740 ranked rows lack both value fields') counts only rows where branch 1 already returned.",
+      "notes": "The 2026-07-29 scope-aware fix recorded as cutting IDP reconstruction RMSE 826 -> 79 was applied to branch 3, which cannot execute."
+    },
+    {
+      "id": "U02",
+      "title": "/api/trade/simulate resolves zero of a team's 288 draft picks",
+      "path": "src/api/trade_simulator.py",
+      "signature": "row = row_index.get(key)",
+      "status": "open",
+      "consequence": "engine_advice",
+      "measured": "0 of 288 owned pick labels resolve. sleeper_overlay.py::_format_pick_label emits '2027 1st' (_build_pick_ownership always passes slot=None); board rows are '2026 Pick 1.01' / '2026 Early 1st'. team_impact.py:247 therefore computes pick_value over an asset list with no picks, so pick_share is structurally 0.",
+      "userSurface": "/trade 'Impact on <team>' \u2014 recomputing _classify_window with picks restored flips 10 of 12 posture labels. The same roster prices at 90,092 in simulate and 135,917 on /rosters.",
+      "verifiedBy": "Read _resolve_asset: a bare lowercased dict get with no alias resolution, against terminal.py:263's one-name-per-row index.",
+      "notes": "The frontend already solves this via frontend/lib/trade-logic.js:1184 resolvePickRow(..., pickAliases). trade_simulator.py:162-165 claims 'picks resolve the same way through row_index', which is what made it invisible. Signature anchors on the bare lookup in _resolve_asset; it vanishes when that call routes through an alias resolver."
+    },
+    {
+      "id": "U03",
+      "title": "FAAB recommends $0 for every player when every rival is unpriceable",
+      "path": "src/trade/faab_engine.py",
+      "signature": "continue  # unverifiable",
+      "status": "open",
+      "consequence": "engine_advice",
+      "measured": "With all rivals skipped, rival_bid_cdf(0) = 1.0, so EV(b) = rawCeiling - b is maximised at b = 0 and the optimiser returns the lowest grid point by construction \u2014 beside an objective ceiling the same engine may price at $100 of $100.",
+      "userSurface": "/waivers FaabRecommendation 'What you should bid' tiles.",
+      "verifiedBy": "Read the rival loop and the argmax. Reachable in production: data/sleeper_last_good.json carries faabRemaining: null for all 12 teams whenever the live overlay fetch fails.",
+      "notes": "INVERTS a recorded Low in the 08-04 registry, which describes the pre-#707 failure mode (reverting to full budget, i.e. bid too HIGH). faab_engine.py appears nowhere in that registry."
+    },
+    {
+      "id": "U04",
+      "title": "Board-health floors key on ktc, retired from the blend; the live anchor ktcSfTep has no floor",
+      "path": "config/weights/source_row_floors.json",
+      "signature": "\"ktc\"",
+      "status": "open",
+      "consequence": "board_value",
+      "measured": "Four separate floor sets (_DEFAULT_SOURCE_ROW_FLOORS, _DEFAULT_TOP50_COVERAGE_FLOORS, and the two config JSONs). 'ktc' is keyed in all four and is in none of the 21 registered sources; 'ktcSfTep' is registered and in none of the four. Sources with no row floor: 9 of 21 inline, 16 of 21 in config. Stripping ktcSfTep to 3 rows and re-running validate_api_data_contract returns ok=True, status=healthy, 0 new errors. The same treatment of ktc or idpTradeCalc returns degraded (~190-200 warnings).",
+      "userSurface": "contractHealth is stamped on every /api/data payload (server.py) and shown on /status. It would report healthy through a collapse of the market anchor. A detection gap, not a live wrong number.",
+      "verifiedBy": "Compared both floor dicts and both config files against get_ranking_source_registry(); config/sources/dlf_sources.template.json:33 records ktc's retirement from the blend on 2026-04-28.",
+      "notes": "src/api/source_health_alerts.py::resolve_threshold handles the vendor-prefix case correctly, so the floor configs are the outlier. tests/api/test_source_floor_invariant.py iterates _DEFAULT_SOURCE_ROW_FLOORS.items() rather than the registry, so its headline claim is true only of a set that has drifted off the live source list."
+    },
+    {
+      "id": "U05",
+      "title": "The coercion gate never scans src/draft or scripts",
+      "path": "scripts/check_decision_coercions.py",
+      "signature": "\"src/scoring\", \"frontend/lib\", )",
+      "status": "open",
+      "consequence": "engine_advice",
+      "measured": "_DECISION_ROOTS omits src/draft/, scripts/, src/model_registry/, frontend/app/ and frontend/components/. The model_registry validate defect (08-04 registry, High) sat in a tree the gate does not look at.",
+      "userSurface": "None directly \u2014 this is a guard that cannot fire for whole subtrees, so it is the reason other findings survive.",
+      "verifiedBy": "Read the tuple.",
+      "notes": "Deliberately NOT fixed by this audit. Widening the roots surfaces new violations across two trees, and config/coercion_baseline.json says 'Do not add to this file to make a build pass.' Absorbing a widened scope is the batch owner's call mid-pass."
+    },
+    {
+      "id": "U06",
+      "title": "The coercion gate's regexes cannot see a return-shaped fallback",
+      "path": "scripts/check_decision_coercions.py",
+      "signature": "_PY_PATTERN = re.compile(r\"\\bor\\s+(?:0\\.0|0|1\\.0|1|100|100\\.0)\\b(?!\\s*[.\\w])\")",
+      "status": "open",
+      "consequence": "engine_advice",
+      "measured": "Both regexes require an infix `or 0` / `?? 0` / `|| 0` between two expressions. Verified directly: 'return 0.0' -> no match, 'return None' -> no match, 'x = a or 0' -> match.",
+      "userSurface": "None directly \u2014 same shape as U05.",
+      "verifiedBy": "Ran both compiled patterns against the three literals.",
+      "notes": "This is why U01 escapes: src/api/terminal.py is a scanned file carrying 18 baselined entries, and its terminating `return 0.0` is invisible to the gate."
+    }
+  ]
+}

--- a/docs/audits/unfalsifiable-number-audit-2026-08-05.status.json
+++ b/docs/audits/unfalsifiable-number-audit-2026-08-05.status.json
@@ -1,0 +1,112 @@
+{
+  "source": "unfalsifiable-number-audit-2026-08-05.registry.json",
+  "note": "GENERATED. Status authority is the registry, not this file.",
+  "total": 6,
+  "tally": {
+    "open": 6
+  },
+  "findings": [
+    {
+      "id": "U01",
+      "title": "terminal._row_value returns 0.0, and both documented fallbacks are unreachable",
+      "path": "src/api/terminal.py",
+      "signature": "vf = values.get(\"full\")",
+      "status": "open",
+      "consequence": "engine_advice",
+      "measured": "values['full'] is present on 0 of 1069 rows of the built snapshot; rows with a rank but no value: 0 of 1069. 'full' is minted CLIENT-SIDE at frontend/lib/dynasty-data.js:983, so this backend function reads a frontend-only key. 97 of 665 rostered players evaluate to exactly 0.0, almost all IDP.",
+      "userSurface": "/trade Impact panel \u2014 an unpriced player resolves as an ordinary asset with value 0 and empty unresolvedIn/unresolvedOut, so nothing distinguishes 'worth nothing' from 'we have no price'. Also /terminal watchlist, movers and signals.",
+      "verifiedBy": "Read the three branches and measured the key population on audit/baseline/players_array.json. The comment's own justification ('0 of 740 ranked rows lack both value fields') counts only rows where branch 1 already returned.",
+      "notes": "The 2026-07-29 scope-aware fix recorded as cutting IDP reconstruction RMSE 826 -> 79 was applied to branch 3, which cannot execute.",
+      "probe": {
+        "result": "signature_present",
+        "path": "src/api/terminal.py",
+        "needle": "vf = values.get(\"full\")"
+      }
+    },
+    {
+      "id": "U02",
+      "title": "/api/trade/simulate resolves zero of a team's 288 draft picks",
+      "path": "src/api/trade_simulator.py",
+      "signature": "row = row_index.get(key)",
+      "status": "open",
+      "consequence": "engine_advice",
+      "measured": "0 of 288 owned pick labels resolve. sleeper_overlay.py::_format_pick_label emits '2027 1st' (_build_pick_ownership always passes slot=None); board rows are '2026 Pick 1.01' / '2026 Early 1st'. team_impact.py:247 therefore computes pick_value over an asset list with no picks, so pick_share is structurally 0.",
+      "userSurface": "/trade 'Impact on <team>' \u2014 recomputing _classify_window with picks restored flips 10 of 12 posture labels. The same roster prices at 90,092 in simulate and 135,917 on /rosters.",
+      "verifiedBy": "Read _resolve_asset: a bare lowercased dict get with no alias resolution, against terminal.py:263's one-name-per-row index.",
+      "notes": "The frontend already solves this via frontend/lib/trade-logic.js:1184 resolvePickRow(..., pickAliases). trade_simulator.py:162-165 claims 'picks resolve the same way through row_index', which is what made it invisible. Signature anchors on the bare lookup in _resolve_asset; it vanishes when that call routes through an alias resolver.",
+      "probe": {
+        "result": "signature_present",
+        "path": "src/api/trade_simulator.py",
+        "needle": "row = row_index.get(key)"
+      }
+    },
+    {
+      "id": "U03",
+      "title": "FAAB recommends $0 for every player when every rival is unpriceable",
+      "path": "src/trade/faab_engine.py",
+      "signature": "continue  # unverifiable",
+      "status": "open",
+      "consequence": "engine_advice",
+      "measured": "With all rivals skipped, rival_bid_cdf(0) = 1.0, so EV(b) = rawCeiling - b is maximised at b = 0 and the optimiser returns the lowest grid point by construction \u2014 beside an objective ceiling the same engine may price at $100 of $100.",
+      "userSurface": "/waivers FaabRecommendation 'What you should bid' tiles.",
+      "verifiedBy": "Read the rival loop and the argmax. Reachable in production: data/sleeper_last_good.json carries faabRemaining: null for all 12 teams whenever the live overlay fetch fails.",
+      "notes": "INVERTS a recorded Low in the 08-04 registry, which describes the pre-#707 failure mode (reverting to full budget, i.e. bid too HIGH). faab_engine.py appears nowhere in that registry.",
+      "probe": {
+        "result": "signature_present",
+        "path": "src/trade/faab_engine.py",
+        "needle": "continue  # unverifiable"
+      }
+    },
+    {
+      "id": "U04",
+      "title": "Board-health floors key on ktc, retired from the blend; the live anchor ktcSfTep has no floor",
+      "path": "config/weights/source_row_floors.json",
+      "signature": "\"ktc\"",
+      "status": "open",
+      "consequence": "board_value",
+      "measured": "Four separate floor sets (_DEFAULT_SOURCE_ROW_FLOORS, _DEFAULT_TOP50_COVERAGE_FLOORS, and the two config JSONs). 'ktc' is keyed in all four and is in none of the 21 registered sources; 'ktcSfTep' is registered and in none of the four. Sources with no row floor: 9 of 21 inline, 16 of 21 in config. Stripping ktcSfTep to 3 rows and re-running validate_api_data_contract returns ok=True, status=healthy, 0 new errors. The same treatment of ktc or idpTradeCalc returns degraded (~190-200 warnings).",
+      "userSurface": "contractHealth is stamped on every /api/data payload (server.py) and shown on /status. It would report healthy through a collapse of the market anchor. A detection gap, not a live wrong number.",
+      "verifiedBy": "Compared both floor dicts and both config files against get_ranking_source_registry(); config/sources/dlf_sources.template.json:33 records ktc's retirement from the blend on 2026-04-28.",
+      "notes": "src/api/source_health_alerts.py::resolve_threshold handles the vendor-prefix case correctly, so the floor configs are the outlier. tests/api/test_source_floor_invariant.py iterates _DEFAULT_SOURCE_ROW_FLOORS.items() rather than the registry, so its headline claim is true only of a set that has drifted off the live source list.",
+      "probe": {
+        "result": "signature_present",
+        "path": "config/weights/source_row_floors.json",
+        "needle": "\"ktc\""
+      }
+    },
+    {
+      "id": "U05",
+      "title": "The coercion gate never scans src/draft or scripts",
+      "path": "scripts/check_decision_coercions.py",
+      "signature": "\"src/scoring\", \"frontend/lib\", )",
+      "status": "open",
+      "consequence": "engine_advice",
+      "measured": "_DECISION_ROOTS omits src/draft/, scripts/, src/model_registry/, frontend/app/ and frontend/components/. The model_registry validate defect (08-04 registry, High) sat in a tree the gate does not look at.",
+      "userSurface": "None directly \u2014 this is a guard that cannot fire for whole subtrees, so it is the reason other findings survive.",
+      "verifiedBy": "Read the tuple.",
+      "notes": "Deliberately NOT fixed by this audit. Widening the roots surfaces new violations across two trees, and config/coercion_baseline.json says 'Do not add to this file to make a build pass.' Absorbing a widened scope is the batch owner's call mid-pass.",
+      "probe": {
+        "result": "signature_present",
+        "path": "scripts/check_decision_coercions.py",
+        "needle": "\"src/scoring\", \"frontend/lib\", )"
+      }
+    },
+    {
+      "id": "U06",
+      "title": "The coercion gate's regexes cannot see a return-shaped fallback",
+      "path": "scripts/check_decision_coercions.py",
+      "signature": "_PY_PATTERN = re.compile(r\"\\bor\\s+(?:0\\.0|0|1\\.0|1|100|100\\.0)\\b(?!\\s*[.\\w])\")",
+      "status": "open",
+      "consequence": "engine_advice",
+      "measured": "Both regexes require an infix `or 0` / `?? 0` / `|| 0` between two expressions. Verified directly: 'return 0.0' -> no match, 'return None' -> no match, 'x = a or 0' -> match.",
+      "userSurface": "None directly \u2014 same shape as U05.",
+      "verifiedBy": "Ran both compiled patterns against the three literals.",
+      "notes": "This is why U01 escapes: src/api/terminal.py is a scanned file carrying 18 baselined entries, and its terminating `return 0.0` is invisible to the gate.",
+      "probe": {
+        "result": "signature_present",
+        "path": "scripts/check_decision_coercions.py",
+        "needle": "_PY_PATTERN = re.compile(r\"\\bor\\s+(?:0\\.0|0|1\\.0|1|100|100\\.0)\\b(?!\\s*[.\\w])\")"
+      }
+    }
+  ]
+}

--- a/docs/measurements/mc-band-width-2026-08-05-h14.json
+++ b/docs/measurements/mc-band-width-2026-08-05-h14.json
@@ -1,0 +1,111 @@
+{
+  "measurement": "monte-carlo-band-width",
+  "question": "The simulator draws every asset from a flat +-15% band. How far does the board actually move over the same kind of interval?",
+  "flatBandUnderTest": 0.15,
+  "horizonDays": 14,
+  "panelDays": 112,
+  "panelStart": "2026-04-16",
+  "panelEnd": "2026-08-05",
+  "foldsAttempted": 7,
+  "foldsUsable": 7,
+  "byFold": [
+    {
+      "n": 365,
+      "p10": -0.23194,
+      "p50": -0.00621,
+      "p90": 0.32345,
+      "impliedHalfWidth": 0.27769,
+      "medianAbsReturn": 0.12911,
+      "flatBandCoverage": 0.5425,
+      "origin": "2026-04-16",
+      "horizon": "2026-04-30"
+    },
+    {
+      "n": 791,
+      "p10": -0.04414,
+      "p50": -0.00073,
+      "p90": 0.03747,
+      "impliedHalfWidth": 0.0408,
+      "medianAbsReturn": 0.01222,
+      "flatBandCoverage": 0.9848,
+      "origin": "2026-04-30",
+      "horizon": "2026-05-14"
+    },
+    {
+      "n": 788,
+      "p10": -0.02769,
+      "p50": 0.0,
+      "p90": 0.01423,
+      "impliedHalfWidth": 0.02096,
+      "medianAbsReturn": 0.00498,
+      "flatBandCoverage": 0.9924,
+      "origin": "2026-05-14",
+      "horizon": "2026-05-28"
+    },
+    {
+      "n": 794,
+      "p10": -0.02048,
+      "p50": 0.0,
+      "p90": 0.02483,
+      "impliedHalfWidth": 0.02266,
+      "medianAbsReturn": 0.00616,
+      "flatBandCoverage": 0.9924,
+      "origin": "2026-05-28",
+      "horizon": "2026-06-11"
+    },
+    {
+      "n": 796,
+      "p10": -0.01069,
+      "p50": 0.0,
+      "p90": 0.01471,
+      "impliedHalfWidth": 0.0127,
+      "medianAbsReturn": 0.00316,
+      "flatBandCoverage": 0.9987,
+      "origin": "2026-06-11",
+      "horizon": "2026-06-25"
+    },
+    {
+      "n": 787,
+      "p10": -0.03613,
+      "p50": 0.0014,
+      "p90": 0.06362,
+      "impliedHalfWidth": 0.04987,
+      "medianAbsReturn": 0.0118,
+      "flatBandCoverage": 0.8983,
+      "origin": "2026-06-25",
+      "horizon": "2026-07-09"
+    },
+    {
+      "n": 802,
+      "p10": -0.02626,
+      "p50": -0.00046,
+      "p90": 0.01985,
+      "impliedHalfWidth": 0.02305,
+      "medianAbsReturn": 0.00641,
+      "flatBandCoverage": 0.98,
+      "origin": "2026-07-09",
+      "horizon": "2026-07-23"
+    }
+  ],
+  "attrition": {
+    "noOrigin": 561,
+    "noHorizon": 244
+  },
+  "caveats": {
+    "modelIsCurrent": "The replay runs TODAY's Hill curves over past inputs, so measured movement is input-driven only; real board movement also came from constant promotions. This UNDERSTATES true movement, and the direction of that bias is easy to invert: understated movement makes the flat band look MORE excessive than it is, so a 'too wide' verdict is an UPPER BOUND on the excess, not a conservative floor. A 'too narrow' verdict would be the emphatic one.",
+    "panelHeterogeneity": "CSVs/site_raw held 9 sources on 2026-04-16 and 24 from 2026-06-01. Source count drives both band width and movement; read byFold, not just the pooled figure.",
+    "offseasonOnly": "The whole reconstructable window is the offseason. April-August volatility is not September volatility.",
+    "measuresSelfConsistency": "This is how much OUR board moves, not how wrong it is. It cannot capture common-mode error, so decision #4's 'too narrow, and for the right reason' argument survives this measurement intact.",
+    "simulatorHasNoHorizon": "monte_carlo.py's band is horizonless, so this yields a family of numbers (h7/h14/h30) rather than one. Choosing among them remains a judgement \u2014 an anchored one."
+  },
+  "pooled": {
+    "n": 5123,
+    "p10": -0.03471,
+    "p50": 0.0,
+    "p90": 0.03237,
+    "impliedHalfWidth": 0.03354,
+    "medianAbsReturn": 0.0079,
+    "flatBandCoverage": 0.9438
+  },
+  "verdict": "Over 7 disjoint 14-day folds (5123 player-pairs), the board's own p10-p90 half-width is 0.0335 (3.35%), against the simulator's flat 15%. The flat band is 4.47x that, and covers 94.4% of observed moves. Read the caveats before quoting: the replay understates movement (so this ratio is an UPPER bound on the excess), this is offseason data, and the per-fold spread in byFold is wide."
+}

--- a/docs/measurements/mc-band-width-2026-08-05-h30.json
+++ b/docs/measurements/mc-band-width-2026-08-05-h30.json
@@ -1,0 +1,67 @@
+{
+  "measurement": "monte-carlo-band-width",
+  "question": "The simulator draws every asset from a flat +-15% band. How far does the board actually move over the same kind of interval?",
+  "flatBandUnderTest": 0.15,
+  "horizonDays": 30,
+  "panelDays": 112,
+  "panelStart": "2026-04-16",
+  "panelEnd": "2026-08-05",
+  "foldsAttempted": 3,
+  "foldsUsable": 3,
+  "byFold": [
+    {
+      "n": 353,
+      "p10": -0.23966,
+      "p50": -0.00177,
+      "p90": 0.31735,
+      "impliedHalfWidth": 0.27851,
+      "medianAbsReturn": 0.14198,
+      "flatBandCoverage": 0.5184,
+      "origin": "2026-04-16",
+      "horizon": "2026-05-16"
+    },
+    {
+      "n": 787,
+      "p10": -0.04667,
+      "p50": -0.00103,
+      "p90": 0.02068,
+      "impliedHalfWidth": 0.03367,
+      "medianAbsReturn": 0.01122,
+      "flatBandCoverage": 0.9911,
+      "origin": "2026-05-16",
+      "horizon": "2026-06-15"
+    },
+    {
+      "n": 779,
+      "p10": -0.04411,
+      "p50": 0.00222,
+      "p90": 0.06632,
+      "impliedHalfWidth": 0.05522,
+      "medianAbsReturn": 0.0169,
+      "flatBandCoverage": 0.8947,
+      "origin": "2026-06-15",
+      "horizon": "2026-07-15"
+    }
+  ],
+  "attrition": {
+    "noOrigin": 517,
+    "noHorizon": 200
+  },
+  "caveats": {
+    "modelIsCurrent": "The replay runs TODAY's Hill curves over past inputs, so measured movement is input-driven only; real board movement also came from constant promotions. This UNDERSTATES true movement, and the direction of that bias is easy to invert: understated movement makes the flat band look MORE excessive than it is, so a 'too wide' verdict is an UPPER BOUND on the excess, not a conservative floor. A 'too narrow' verdict would be the emphatic one.",
+    "panelHeterogeneity": "CSVs/site_raw held 9 sources on 2026-04-16 and 24 from 2026-06-01. Source count drives both band width and movement; read byFold, not just the pooled figure.",
+    "offseasonOnly": "The whole reconstructable window is the offseason. April-August volatility is not September volatility.",
+    "measuresSelfConsistency": "This is how much OUR board moves, not how wrong it is. It cannot capture common-mode error, so decision #4's 'too narrow, and for the right reason' argument survives this measurement intact.",
+    "simulatorHasNoHorizon": "monte_carlo.py's band is horizonless, so this yields a family of numbers (h7/h14/h30) rather than one. Choosing among them remains a judgement \u2014 an anchored one."
+  },
+  "pooled": {
+    "n": 1919,
+    "p10": -0.07083,
+    "p50": -0.00039,
+    "p90": 0.09533,
+    "impliedHalfWidth": 0.08308,
+    "medianAbsReturn": 0.01935,
+    "flatBandCoverage": 0.865
+  },
+  "verdict": "Over 3 disjoint 30-day folds (1919 player-pairs), the board's own p10-p90 half-width is 0.0831 (8.31%), against the simulator's flat 15%. The flat band is 1.81x that, and covers 86.5% of observed moves. Read the caveats before quoting: the replay understates movement (so this ratio is an UPPER bound on the excess), this is offseason data, and the per-fold spread in byFold is wide."
+}

--- a/docs/measurements/mc-band-width-2026-08-05-h7.json
+++ b/docs/measurements/mc-band-width-2026-08-05-h7.json
@@ -1,0 +1,199 @@
+{
+  "measurement": "monte-carlo-band-width",
+  "question": "The simulator draws every asset from a flat +-15% band. How far does the board actually move over the same kind of interval?",
+  "flatBandUnderTest": 0.15,
+  "horizonDays": 7,
+  "panelDays": 112,
+  "panelStart": "2026-04-16",
+  "panelEnd": "2026-08-05",
+  "foldsAttempted": 15,
+  "foldsUsable": 15,
+  "byFold": [
+    {
+      "n": 494,
+      "p10": -0.01771,
+      "p50": 0.15524,
+      "p90": 1.9981,
+      "impliedHalfWidth": 1.0079,
+      "medianAbsReturn": 0.15654,
+      "flatBandCoverage": 0.4818,
+      "origin": "2026-04-16",
+      "horizon": "2026-04-23"
+    },
+    {
+      "n": 393,
+      "p10": -0.66388,
+      "p50": -0.07742,
+      "p90": 0.09232,
+      "impliedHalfWidth": 0.3781,
+      "medianAbsReturn": 0.12652,
+      "flatBandCoverage": 0.5445,
+      "origin": "2026-04-23",
+      "horizon": "2026-04-30"
+    },
+    {
+      "n": 795,
+      "p10": -0.03145,
+      "p50": 0.0,
+      "p90": 0.02623,
+      "impliedHalfWidth": 0.02884,
+      "medianAbsReturn": 0.0076,
+      "flatBandCoverage": 0.9874,
+      "origin": "2026-04-30",
+      "horizon": "2026-05-07"
+    },
+    {
+      "n": 797,
+      "p10": -0.02346,
+      "p50": 0.0,
+      "p90": 0.01965,
+      "impliedHalfWidth": 0.02156,
+      "medianAbsReturn": 0.00521,
+      "flatBandCoverage": 0.9925,
+      "origin": "2026-05-07",
+      "horizon": "2026-05-14"
+    },
+    {
+      "n": 792,
+      "p10": -0.02995,
+      "p50": 0.0,
+      "p90": 0.01119,
+      "impliedHalfWidth": 0.02057,
+      "medianAbsReturn": 0.00456,
+      "flatBandCoverage": 0.9912,
+      "origin": "2026-05-14",
+      "horizon": "2026-05-21"
+    },
+    {
+      "n": 799,
+      "p10": -0.00851,
+      "p50": 0.0,
+      "p90": 0.01068,
+      "impliedHalfWidth": 0.00959,
+      "medianAbsReturn": 0.00143,
+      "flatBandCoverage": 0.9987,
+      "origin": "2026-05-21",
+      "horizon": "2026-05-28"
+    },
+    {
+      "n": 426,
+      "p10": -0.03994,
+      "p50": 0.0584,
+      "p90": 1.76616,
+      "impliedHalfWidth": 0.90305,
+      "medianAbsReturn": 0.10089,
+      "flatBandCoverage": 0.5704,
+      "origin": "2026-05-28",
+      "horizon": "2026-06-04"
+    },
+    {
+      "n": 426,
+      "p10": -0.642,
+      "p50": -0.05851,
+      "p90": 0.03897,
+      "impliedHalfWidth": 0.34048,
+      "medianAbsReturn": 0.10652,
+      "flatBandCoverage": 0.5845,
+      "origin": "2026-06-04",
+      "horizon": "2026-06-11"
+    },
+    {
+      "n": 796,
+      "p10": -0.0116,
+      "p50": 0.0,
+      "p90": 0.0118,
+      "impliedHalfWidth": 0.0117,
+      "medianAbsReturn": 0.00246,
+      "flatBandCoverage": 0.9987,
+      "origin": "2026-06-11",
+      "horizon": "2026-06-18"
+    },
+    {
+      "n": 807,
+      "p10": -0.00931,
+      "p50": 0.0,
+      "p90": 0.01003,
+      "impliedHalfWidth": 0.00967,
+      "medianAbsReturn": 0.00134,
+      "flatBandCoverage": 1.0,
+      "origin": "2026-06-18",
+      "horizon": "2026-06-25"
+    },
+    {
+      "n": 806,
+      "p10": -0.01212,
+      "p50": 0.0,
+      "p90": 0.01173,
+      "impliedHalfWidth": 0.01193,
+      "medianAbsReturn": 0.00201,
+      "flatBandCoverage": 1.0,
+      "origin": "2026-06-25",
+      "horizon": "2026-07-02"
+    },
+    {
+      "n": 786,
+      "p10": -0.03098,
+      "p50": 0.00099,
+      "p90": 0.05601,
+      "impliedHalfWidth": 0.0435,
+      "medianAbsReturn": 0.00958,
+      "flatBandCoverage": 0.8969,
+      "origin": "2026-07-02",
+      "horizon": "2026-07-09"
+    },
+    {
+      "n": 804,
+      "p10": -0.01415,
+      "p50": 0.0,
+      "p90": 0.01388,
+      "impliedHalfWidth": 0.01402,
+      "medianAbsReturn": 0.00417,
+      "flatBandCoverage": 0.99,
+      "origin": "2026-07-09",
+      "horizon": "2026-07-16"
+    },
+    {
+      "n": 803,
+      "p10": -0.01814,
+      "p50": 0.0,
+      "p90": 0.01147,
+      "impliedHalfWidth": 0.0148,
+      "medianAbsReturn": 0.00465,
+      "flatBandCoverage": 0.9813,
+      "origin": "2026-07-16",
+      "horizon": "2026-07-23"
+    },
+    {
+      "n": 776,
+      "p10": -0.0747,
+      "p50": -0.00329,
+      "p90": 0.02499,
+      "impliedHalfWidth": 0.04985,
+      "medianAbsReturn": 0.01435,
+      "flatBandCoverage": 0.9704,
+      "origin": "2026-07-23",
+      "horizon": "2026-07-30"
+    }
+  ],
+  "attrition": {
+    "noOrigin": 1154,
+    "noHorizon": 837
+  },
+  "caveats": {
+    "modelIsCurrent": "The replay runs TODAY's Hill curves over past inputs, so measured movement is input-driven only; real board movement also came from constant promotions. This UNDERSTATES true movement, and the direction of that bias is easy to invert: understated movement makes the flat band look MORE excessive than it is, so a 'too wide' verdict is an UPPER BOUND on the excess, not a conservative floor. A 'too narrow' verdict would be the emphatic one.",
+    "panelHeterogeneity": "CSVs/site_raw held 9 sources on 2026-04-16 and 24 from 2026-06-01. Source count drives both band width and movement; read byFold, not just the pooled figure.",
+    "offseasonOnly": "The whole reconstructable window is the offseason. April-August volatility is not September volatility.",
+    "measuresSelfConsistency": "This is how much OUR board moves, not how wrong it is. It cannot capture common-mode error, so decision #4's 'too narrow, and for the right reason' argument survives this measurement intact.",
+    "simulatorHasNoHorizon": "monte_carlo.py's band is horizonless, so this yields a family of numbers (h7/h14/h30) rather than one. Choosing among them remains a judgement \u2014 an anchored one."
+  },
+  "pooled": {
+    "n": 10500,
+    "p10": -0.03613,
+    "p50": 0.0,
+    "p90": 0.03525,
+    "impliedHalfWidth": 0.03569,
+    "medianAbsReturn": 0.00619,
+    "flatBandCoverage": 0.9098
+  },
+  "verdict": "Over 15 disjoint 7-day folds (10500 player-pairs), the board's own p10-p90 half-width is 0.0357 (3.57%), against the simulator's flat 15%. The flat band is 4.20x that, and covers 91.0% of observed moves. Read the caveats before quoting: the replay understates movement (so this ratio is an UPPER bound on the excess), this is offseason data, and the per-fold spread in byFold is wide."
+}

--- a/docs/open-modeling-decisions.md
+++ b/docs/open-modeling-decisions.md
@@ -15,7 +15,7 @@ them. This document closes that gap. Decision #4 was added by the
 | 1 | apply `coverageWeight`? | **No.** Measured: 297 rows / 221 ranks move for a 3-source input change, with no accuracy evidence either way. Stays DIAGNOSTIC ONLY. |
 | 2 | retire the legacy rank-form curves? | **No — re-tuned and kept**, with a tested drift alarm. Migration turned out not to be a live option; the old constants were fit to the wrong target. |
 | 3 | re-threshold `low_conf_unstable`? | **No — rule retired.** The metric is structurally capped; no threshold makes it sound. |
-| 4 | what width should the Monte Carlo band be? | **Open — deliberately.** The flat ±15% is 4.8× the median measured source disagreement but 0.4× the maximum. Made *visible* (`bandSources` + disclaimer) rather than silently re-tuned. |
+| 4 | what width should the Monte Carlo band be? | **Measured 2026-08-05; constant unchanged.** The board's own weekly movement is a 3.57% half-width over 15 disjoint folds, so ±15% is ≤4.2× wider — but the band is horizonless, the data is offseason, and the replay understates movement. Made *visible* (`bandSources` + disclaimer) rather than re-tuned. |
 
 #1 and #4 remain reversible-on-new-evidence; #2 and #3 are closed.
 
@@ -404,14 +404,78 @@ Pinned by `tests/trade/test_monte_carlo_band_integrity.py`, including
 the asymmetry (a fully-measured run gets a clean disclaimer), so the
 qualification cannot be hardcoded into the string.
 
-### What would settle the width
+### MEASURED 2026-08-05 — and the answer is still "do not retune"
 
-Stamping the real Phase 4 interval — `src/canonical/confidence_intervals.py`
-exists and nothing calls it on the live contract — and then scoring
-band-implied win probabilities against realized trade outcomes, the
-same shape as `scripts/backtest_adjusted_board.py`. Until one of those
-exists, the honest state is a documented assumption that says so on
-every response.
+**Reproduce:** `python3 scripts/backtest_mc_band_width.py --horizon {7,14,30}`
+(requires `git fetch --unshallow`).
+**Results:** `docs/measurements/mc-band-width-2026-08-05-h{7,14,30}.json`
+
+The measurement decision #4 asked for now exists. It replays the real
+contract at two dates via `src/consensus_edge/panel.py` and measures how
+far the board's own `rankDerivedValue` actually moved — a strictly better
+quantity than `marketDispersionCV`, because it captures the board
+changing its mind rather than only the sources differing on one day.
+
+| horizon | folds | pairs | board p10-p90 half-width | flat ±15% is | coverage |
+|---|---|---|---|---|---|
+| 7d | 15 | 10,500 | **3.57%** | 4.20× wider | 91.0% |
+| 14d | 7 | 5,123 | **3.35%** | 4.47× wider | 94.4% |
+| 30d | 3 | 1,919 | **8.31%** | 1.81× wider | 86.5% |
+
+**The pooled number is not the finding. The distribution is.** Per-fold
+half-widths at h7 are bimodal — eleven folds between **0.96% and 4.98%**,
+then four at **34%, 38%, 90% and 101%**:
+
+| fold | half-width | sources | pairs |
+|---|---|---|---|
+| 2026-04-16 → 04-23 | 1.0079 | 13 → 19 | 494 |
+| 2026-05-28 → 06-04 | 0.9031 | 24 → 24 | 426 |
+| 2026-04-23 → 04-30 | 0.3781 | 19 → 22 | 393 |
+| 2026-06-04 → 06-11 | 0.3405 | 24 → 24 | 426 |
+| *(eleven others)* | 0.0096–0.0498 | 22–24 stable | 776–807 |
+
+Two of the four are explained by the panel growing its source count. The
+other two are **not** — their source count is stable at 24, but their
+join population halves (426 vs ~800). A week where only half the board
+can be matched is a coverage artifact, not a repricing. So all four
+outliers are properties of the replay, and none is evidence about how
+much value genuinely moves.
+
+**Decision: leave `FLAT_BAND = 0.15` alone.** Stated in advance of the
+run, and the result did not change it:
+
+* The simulator's band is **horizonless**, so the measurement yields a
+  family (3.57% / 3.35% / 8.31%), not a number. Picking one is still a
+  judgement.
+* The replay **understates** movement — it runs today's Hill curves over
+  past inputs, so it misses movement that came from constant promotions.
+  Note the direction carefully, because it inverts easily: understated
+  movement makes the flat band look *more* excessive than it is, so
+  "4.2× too wide" is an **upper bound on the excess**, not a floor.
+* It is entirely **offseason** data.
+* It measures board **self-consistency**, not correctness. The "too
+  narrow, and for the right reason" argument in the section above —
+  common-mode error, where every source is wrong together — survives
+  this measurement untouched.
+
+Replacing an unjustified constant with a differently-unjustified one is
+the failure mode this audit exists to prevent. What has changed is that
+the assumption is now bounded by evidence instead of resting on nothing.
+
+**What would settle it properly**, and what will not:
+
+* **Not** stamping the Phase 4 interval. `src/canonical/confidence_intervals.py`
+  looks like the answer and is not: two of its three branches return
+  hardcoded flat bands — one of them the identical ±15%, justified by an
+  unsourced docstring claim — and the module explicitly disclaims being
+  predictive ("a transparency metric, not a probability of realized
+  outcome"). Wiring it would flip `bandSources` to `stamped_value_band`
+  on most rows while changing nothing that is known.
+* **In-season data.** Re-run this after the season starts; the h30 result
+  (8.31%, 1.81×) already hints that the gap narrows as the horizon and
+  the volatility grow.
+* **A horizon for the simulator.** Until a trade band means "over N
+  days", no single width can be correct.
 
 ### Also fixed alongside (not a modeling question)
 

--- a/scripts/auto_refit_hill_curves.py
+++ b/scripts/auto_refit_hill_curves.py
@@ -311,6 +311,7 @@ def main() -> int:
         target = recorded if recorded is not None else "<version>"
         print(
             "\nA human must promote it — this script cannot. To land it:\n"
+            "  python3 scripts/model_registry.py evaluate --champion --record\n"
             f"  python3 scripts/model_registry.py validate {target}\n"
             f'  python3 scripts/model_registry.py promote {target} --reason "held-out win"\n'
             "  python3 scripts/model_registry.py apply\n"

--- a/scripts/backtest_mc_band_width.py
+++ b/scripts/backtest_mc_band_width.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""How far does the board actually move? — evidence for open decision #4.
+
+THE QUESTION
+============
+``src/trade/monte_carlo.py`` draws each asset's value from a band and
+reports the fraction of draws where side A wins.  On the live path that
+band is a flat **±15%** on every asset: ``valueBand`` is stamped on 0 of
+~1093 rows, so ``MonteCarloButton.jsx`` synthesizes one.
+
+``docs/open-modeling-decisions.md`` decision #4 recorded the width as an
+open question rather than picking a number, because the only quantity
+available was ``marketDispersionCV`` — how much the sources disagree on
+one day — which is 4.8x narrower than the flat band at the median and
+0.4x at the maximum.  Source disagreement is a **lower bound** on value
+uncertainty: it measures how much the boards differ today, not how wrong
+they might all be together.
+
+This measures something strictly better: **how much our own board
+actually moves**.  If the board reprices a player by 30% over a week,
+a ±15% band was too narrow for that player whatever the sources agreed
+on at the time.
+
+WHY NOT JUST WIRE THE PHASE-4 INTERVAL
+======================================
+``src/canonical/confidence_intervals.py`` looks like the answer and is
+not.  Two of its three branches return hardcoded flat bands — one of them
+the identical ±15%, justified by an unsourced docstring claim — and the
+module explicitly disclaims being predictive: "not a predictive
+confidence interval… a transparency metric, not a probability of realized
+outcome."  Stamping it would flip ``bandSources`` to
+``stamped_value_band`` on most rows while changing nothing that is
+actually known.
+
+METHOD
+======
+For each disjoint (origin, horizon) window over the reconstructable
+panel: rebuild the real contract at both dates via
+``panel.panel_day`` + ``build_api_data_contract``, take
+``rankDerivedValue`` per player, and record ``(v_h - v_o) / v_o``.
+Report the empirical p10/p90 half-width of that distribution against
+0.15, and the coverage the flat band would have achieved.
+
+Folds are the same disjoint windows ``src/consensus_edge/backtest.py``
+uses, so results are independent observations rather than an overlapping
+smear.
+
+WHAT THIS CANNOT TELL YOU — read before quoting it
+==================================================
+Four limits, emitted as JSON fields rather than prose so they travel
+with the numbers:
+
+* ``modelIsCurrent`` — the replay runs TODAY's Hill curves over past
+  inputs, so measured movement is input-driven only.  Real board movement
+  also came from constant promotions, so this **understates** true
+  movement — and the direction of that bias is easy to get backwards.
+  Understated movement makes the band look MORE excessive than it is: a
+  "±15% is too wide" verdict is therefore an **upper bound on the
+  excess**, not a conservative one.  A "too narrow" verdict would be the
+  emphatic one, because true movement is larger still.
+* ``panelHeterogeneity`` — ``CSVs/site_raw`` held 9 sources on
+  2026-04-16 and 24 from 2026-06-01.  Source count drives both band width
+  and movement, so per-fold figures are reported and the early era is
+  visible rather than blended away.
+* ``offseasonOnly`` — the whole reconstructable window is the offseason.
+  April-August volatility is not September volatility.
+* ``measuresSelfConsistency`` — this is how much OUR board moves, not how
+  wrong it is.  It cannot capture common-mode error, so decision #4's
+  "too narrow, and for the right reason" argument survives it.
+
+And the simulator has **no horizon at all**, so this yields a family of
+numbers (h7/h14/h30), not a single answer.  Choosing among them is still
+a judgement — but one anchored to measured quantities instead of to
+nothing.
+
+Exit codes: 0 verdict produced, 1 no usable folds, 2 refusing to measure
+(shallow clone, panel too short).  A missing corpus is 2, never 0 — "no
+data" must not read as "passed".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from src.api.data_contract import build_api_data_contract  # noqa: E402
+from src.consensus_edge import backtest as bt  # noqa: E402
+from src.consensus_edge import panel  # noqa: E402
+
+OUT_DIR = REPO / "docs" / "measurements"
+
+EXIT_OK, EXIT_NO_FOLDS, EXIT_REFUSED = 0, 1, 2
+
+# The constant under examination: MonteCarloButton.jsx synthesizes
+# p10 = v*0.85 / p90 = v*1.15 for every asset.
+FLAT_BAND = 0.15
+
+# Below this a fold's quantiles are noise, not a distribution.  Same
+# floor the consensus-edge backtest uses.
+MIN_PAIRS_PER_FOLD = bt.MIN_PAIRS_PER_FOLD
+
+
+def _log(msg: str) -> None:
+    print(f"[mc-band] {msg}", file=sys.stderr)
+
+
+def _board_values(when: date) -> dict[str, float]:
+    """``rankDerivedValue`` per player as of ``when``."""
+    with panel.panel_day(when) as day:
+        contract = build_api_data_contract(day.payload, csv_root=day.csv_root)
+    out: dict[str, float] = {}
+    for row in contract.get("playersArray") or []:
+        name = row.get("displayName") or row.get("name")
+        raw = row.get("rankDerivedValue")
+        if name and isinstance(raw, (int, float)) and raw > 0:
+            out[f"{name}::{row.get('assetClass') or ''}"] = float(raw)
+    return out
+
+
+def _halfwidth(returns: list[float]) -> dict[str, float]:
+    """Empirical p10/p90 half-width, and what ±15% would have covered."""
+    ordered = sorted(returns)
+    n = len(ordered)
+
+    def q(p: float) -> float:
+        return ordered[min(n - 1, max(0, int(round(p * (n - 1)))))]
+
+    p10, p90 = q(0.10), q(0.90)
+    covered = sum(1 for r in ordered if abs(r) <= FLAT_BAND) / n
+    return {
+        "n": n,
+        "p10": round(p10, 5),
+        "p50": round(q(0.50), 5),
+        "p90": round(p90, 5),
+        # Half the p10..p90 span — directly comparable to FLAT_BAND.
+        "impliedHalfWidth": round((p90 - p10) / 2.0, 5),
+        "medianAbsReturn": round(statistics.median(abs(r) for r in ordered), 5),
+        "flatBandCoverage": round(covered, 4),
+    }
+
+
+def run(horizon_days: int, *, limit_folds: int | None = None) -> dict[str, Any]:
+    try:
+        available = panel.available_dates()
+    except Exception as exc:  # noqa: BLE001 — refusing is the point
+        raise SystemExit(f"panel unavailable: {exc}")
+
+    windows = bt.folds(available, horizon_days)
+    if limit_folds:
+        windows = windows[:limit_folds]
+    _log(f"h{horizon_days}: {len(available)} panel days -> {len(windows)} disjoint folds")
+
+    cache: dict[date, dict[str, float]] = {}
+
+    def values(d: date) -> dict[str, float]:
+        if d not in cache:
+            cache[d] = _board_values(d)
+        return cache[d]
+
+    per_fold: list[dict[str, Any]] = []
+    pooled: list[float] = []
+    attrition = {"noOrigin": 0, "noHorizon": 0}
+
+    for w in windows:
+        try:
+            origin, horizon = values(w.origin), values(w.horizon)
+        except Exception as exc:  # noqa: BLE001 — one bad day must not kill the run
+            _log(f"  fold {w.origin}->{w.horizon} skipped: {exc}")
+            continue
+        rets: list[float] = []
+        for key, v0 in origin.items():
+            v1 = horizon.get(key)
+            if v1 is None:
+                attrition["noHorizon"] += 1
+                continue
+            rets.append((v1 - v0) / v0)
+        attrition["noOrigin"] += len(set(horizon) - set(origin))
+        if len(rets) < MIN_PAIRS_PER_FOLD:
+            _log(f"  fold {w.origin}->{w.horizon}: only {len(rets)} pairs, dropped")
+            continue
+        stats = _halfwidth(rets)
+        stats.update({"origin": w.origin.isoformat(), "horizon": w.horizon.isoformat()})
+        per_fold.append(stats)
+        pooled.extend(rets)
+        _log(
+            f"  {w.origin} -> {w.horizon}: n={stats['n']} "
+            f"halfWidth={stats['impliedHalfWidth']:.4f} "
+            f"coverage={stats['flatBandCoverage']:.3f}"
+        )
+
+    result: dict[str, Any] = {
+        "measurement": "monte-carlo-band-width",
+        "question": (
+            "The simulator draws every asset from a flat +-15% band. How far does the "
+            "board actually move over the same kind of interval?"
+        ),
+        "flatBandUnderTest": FLAT_BAND,
+        "horizonDays": horizon_days,
+        "panelDays": len(available),
+        "panelStart": available[0].isoformat() if available else None,
+        "panelEnd": available[-1].isoformat() if available else None,
+        "foldsAttempted": len(windows),
+        "foldsUsable": len(per_fold),
+        "byFold": per_fold,
+        "attrition": attrition,
+        "caveats": {
+            "modelIsCurrent": (
+                "The replay runs TODAY's Hill curves over past inputs, so measured "
+                "movement is input-driven only; real board movement also came from "
+                "constant promotions. This UNDERSTATES true movement, and the direction "
+                "of that bias is easy to invert: understated movement makes the flat "
+                "band look MORE excessive than it is, so a 'too wide' verdict is an "
+                "UPPER BOUND on the excess, not a conservative floor. A 'too narrow' "
+                "verdict would be the emphatic one."
+            ),
+            "panelHeterogeneity": (
+                "CSVs/site_raw held 9 sources on 2026-04-16 and 24 from 2026-06-01. "
+                "Source count drives both band width and movement; read byFold, not "
+                "just the pooled figure."
+            ),
+            "offseasonOnly": (
+                "The whole reconstructable window is the offseason. April-August "
+                "volatility is not September volatility."
+            ),
+            "measuresSelfConsistency": (
+                "This is how much OUR board moves, not how wrong it is. It cannot "
+                "capture common-mode error, so decision #4's 'too narrow, and for the "
+                "right reason' argument survives this measurement intact."
+            ),
+            "simulatorHasNoHorizon": (
+                "monte_carlo.py's band is horizonless, so this yields a family of "
+                "numbers (h7/h14/h30) rather than one. Choosing among them remains a "
+                "judgement — an anchored one."
+            ),
+        },
+    }
+
+    if not per_fold:
+        result["verdict"] = f"No usable folds at h{horizon_days}: refusing to report a band width."
+        return result
+
+    result["pooled"] = _halfwidth(pooled)
+    hw = result["pooled"]["impliedHalfWidth"]
+    cov = result["pooled"]["flatBandCoverage"]
+    ratio = FLAT_BAND / hw if hw else float("inf")
+    result["verdict"] = (
+        f"Over {len(per_fold)} disjoint {horizon_days}-day folds "
+        f"({result['pooled']['n']} player-pairs), the board's own p10-p90 half-width is "
+        f"{hw:.4f} ({hw * 100:.2f}%), against the simulator's flat {FLAT_BAND:.0%}. The "
+        f"flat band is {ratio:.2f}x that, and covers {cov:.1%} of observed moves. "
+        "Read the caveats before quoting: the replay understates movement (so this "
+        "ratio is an UPPER bound on the excess), this is offseason data, and the "
+        "per-fold spread in byFold is wide."
+    )
+    return result
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--horizon", type=int, default=7)
+    ap.add_argument("--max-folds", type=int, default=None, help="cap folds (dev only)")
+    ap.add_argument("--out", type=Path, default=None)
+    args = ap.parse_args()
+
+    try:
+        panel._assert_deep()  # noqa: SLF001
+    except Exception as exc:  # noqa: BLE001
+        _log(f"refusing to measure: {exc}")
+        _log("run `git fetch --unshallow` — a shallow clone covers only the days it has")
+        return EXIT_REFUSED
+
+    result = run(args.horizon, limit_folds=args.max_folds)
+
+    out = args.out or (OUT_DIR / f"mc-band-width-{date.today().isoformat()}-h{args.horizon}.json")
+    if result["foldsUsable"]:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+        _log(f"wrote {out.relative_to(REPO)}")
+    else:
+        _log("no usable folds — refusing to write a measurement")
+
+    print(result["verdict"])
+    return EXIT_OK if result["foldsUsable"] else EXIT_NO_FOLDS
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/model_registry.py
+++ b/scripts/model_registry.py
@@ -38,6 +38,7 @@ from src.model_registry.hill_masters import (  # noqa: E402
     CONSTANT_NAMES,
     MODEL_ID,
     PLAYER_VALUATION,
+    VALIDATED_PARAMS,
     git_sha as _git_sha,
     load_or_seed_registry as _load_or_seed,
     read_committed_constants,
@@ -187,15 +188,65 @@ def cmd_validate(args: argparse.Namespace) -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
 
-    champ_crit = (champ.holdout or {}).get("criterion")
-    chal_crit = (challenger.holdout or {}).get("criterion")
-    if chal_crit is None:
-        print(f"ERROR: challenger v{challenger.version} has no held-out score", file=sys.stderr)
+    # SCORE BOTH CURVES FRESH, ON ONE SNAPSHOT.
+    #
+    # This used to read the two STORED criteria and hand them straight to
+    # ``decide_promotion``.  ``promotion.py``'s module docstring says the
+    # comparison must be made on ONE snapshot with both curves scored
+    # against it, because the criterion's absolute level drifts with the
+    # market while the paired delta does not.  Stored scores are stamped
+    # whenever someone last ran ``evaluate --record``; a challenger's is
+    # stamped at ``register`` time.  Those dates coincide only by luck.
+    #
+    # Measured 2026-08-05 on the live registry, margin 25.0:
+    #
+    #   stored vs stored (what this did)   +12.79  REJECT (right, by luck)
+    #   both scored fresh (correct)        +22.44  REJECT
+    #   champion re-recorded only          +31.91  PROMOTE  <- WRONG
+    #
+    # That third row is the trap: "just re-record the champion" looks
+    # like a data fix and is the one action that produces a false
+    # PROMOTE, because refreshing only the staler side inflates the gap
+    # by exactly the drift removed.  The champion's stored score was 7
+    # days old, the challenger's 1.
+    #
+    # This matters more than an advisory CLI normally would:
+    # ``cmd_promote`` has NO holdout gate, so this verdict is the only
+    # thing between a human and ``promote`` + ``apply``.
+    #
+    # ``auto_refit_hill_curves.py`` already did it correctly
+    # (both fresh, then decide) — two code paths, one contract, one of
+    # them wrong.  This is now the same path.
+    try:
+        champ_eval = evaluate_offense_master(*(champ.params[k] for k in VALIDATED_PARAMS))
+        chal_eval = evaluate_offense_master(*(challenger.params[k] for k in VALIDATED_PARAMS))
+    except (HoldoutError, KeyError) as exc:
+        print(f"ERROR: the gate could not be evaluated: {exc}", file=sys.stderr)
+        print("Refusing to treat an unevaluable gate as a pass.", file=sys.stderr)
         return 2
 
+    champ_crit = champ_eval.criterion
+    chal_crit = chal_eval.criterion
+
     decision = decide_promotion(champ_crit, chal_crit)
-    print(f"champion   v{champ.version}: {champ_crit if champ_crit is not None else 'unmeasured'}")
-    print(f"challenger v{challenger.version}: {chal_crit:.1f}")
+    print(f"champion   v{champ.version}: {champ_crit:.4f}  (scored now)")
+    print(f"challenger v{challenger.version}: {chal_crit:.4f}  (scored now)")
+
+    # Show the stored figures alongside rather than silently correcting
+    # them, so a stale registry is visible instead of merely bypassed.
+    for label, ver, fresh in (
+        ("champion", champ, champ_crit),
+        ("challenger", challenger, chal_crit),
+    ):
+        stored = (ver.holdout or {}).get("criterion")
+        if isinstance(stored, (int, float)) and abs(stored - fresh) > 0.05:
+            when = (ver.holdout or {}).get("measuredAt") or "date not recorded"
+            print(
+                f"  note: {label} v{ver.version} has a STORED criterion of {stored:.4f} "
+                f"({when}), {fresh - stored:+.4f} from today's. The verdict above uses "
+                f"today's; run `evaluate --champion --record` to refresh the file."
+            )
+
     print(f"verdict: {'PROMOTE' if decision.promote else 'REJECT'} — {decision.reason}")
     if decision.alarm:
         print("ALARM: regression large enough to suspect the fit or its inputs.")

--- a/scripts/unfalsifiable_status.py
+++ b/scripts/unfalsifiable_status.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Defect-signature tripwires for the 2026-08-05 unfalsifiable-number audit.
+
+WHY THIS IS A SECOND SCRIPT AND NOT A CHANGE TO ``audit_status.py``
+==================================================================
+``scripts/audit_status.py`` is a status overlay on a **frozen** artifact.
+``_registry_criticals()`` walks the 08-04 registry in order and mints
+``C01…C43`` from positions; ``rebuild()`` raises if a curated entry is
+missing for one.  There is no seam for a finding that registry does not
+contain, and ``docs/audits/remediation-protocol.md`` states it is "never
+regenerated".
+
+It is also another session's live tooling, mid-batch.  So this reuses its
+**probe mechanism** — ``_probe`` and ``_squash`` are imported, not
+reimplemented, so there is one definition of "is the signature still
+there" — while keeping its own registry, its own status file and its own
+CLI.  If those helpers are ever renamed, this fails loudly at import,
+which is the correct outcome rather than a silent divergence.
+
+WHAT A SIGNATURE IS
+===================
+A fragment of source present exactly while the defect's mechanism is
+present.  A probe is a **tripwire, not a proof**: signature absent does
+not mean fixed (it may have moved), signature present does not mean live
+(surrounding semantics may have changed).  ``status`` is set by someone
+who read the code and ``verifiedBy`` records what they read.
+
+Status has one authority: ``docs/audits/unfalsifiable-number-audit-2026-08-05.registry.json``,
+which moves through review with the change that closes a finding.  The
+generated ``.status.json`` is output — do not edit it.
+
+Usage::
+
+    python3 scripts/unfalsifiable_status.py             # check for drift
+    python3 scripts/unfalsifiable_status.py --rebuild   # refresh probes
+
+Exit codes: 0 no drift, 1 drift, 2 could not run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+# One definition of the probe, borrowed rather than copied.  See the
+# module docstring for why this is an import and not a fork.
+from audit_status import _probe  # noqa: E402
+
+REGISTRY = REPO_ROOT / "docs" / "audits" / "unfalsifiable-number-audit-2026-08-05.registry.json"
+STATUS = REPO_ROOT / "docs" / "audits" / "unfalsifiable-number-audit-2026-08-05.status.json"
+
+OPEN, CLOSED = "open", "closed"
+
+
+def _findings() -> list[dict[str, Any]]:
+    doc = json.loads(REGISTRY.read_text(encoding="utf-8"))
+    findings = doc.get("findings") or []
+    if not findings:
+        raise SystemExit(f"{REGISTRY.name} lists no findings")
+    return findings
+
+
+def rebuild() -> int:
+    entries = []
+    for f in _findings():
+        e = dict(f)
+        e["probe"] = _probe(f.get("path"), f.get("signature"))
+        entries.append(e)
+
+    tally: dict[str, int] = {}
+    for e in entries:
+        tally[e.get("status", "?")] = tally.get(e.get("status", "?"), 0) + 1
+
+    STATUS.write_text(
+        json.dumps(
+            {
+                "source": REGISTRY.name,
+                "note": "GENERATED. Status authority is the registry, not this file.",
+                "total": len(entries),
+                "tally": tally,
+                "findings": entries,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    print(f"wrote {STATUS.relative_to(REPO_ROOT)} — {len(entries)} findings")
+    for k in sorted(tally):
+        print(f"  {k:>8}: {tally[k]}")
+    return 0
+
+
+def check() -> int:
+    if not STATUS.exists():
+        print(f"error: {STATUS.name} missing — run --rebuild first", file=sys.stderr)
+        return 2
+    recorded = {e["id"]: e for e in json.loads(STATUS.read_text(encoding="utf-8"))["findings"]}
+    current = {f["id"]: f for f in _findings()}
+
+    drift: list[str] = []
+
+    gone = sorted(set(recorded) - set(current))
+    added = sorted(set(current) - set(recorded))
+    if gone or added:
+        drift.append(f"registry and status disagree on membership: -{gone} +{added} — rebuild")
+
+    for fid, f in current.items():
+        was = (recorded.get(fid) or {}).get("probe") or {}
+        now = _probe(f.get("path"), f.get("signature"))
+        if was.get("result") in (None, "no_mechanical_probe"):
+            continue
+        if f["status"] == CLOSED and now["result"] == "signature_present":
+            drift.append(f"{fid} recorded CLOSED but its defect signature is back")
+        elif f["status"] == OPEN and now["result"] != was.get("result"):
+            drift.append(
+                f"{fid} probe changed: {was.get('result')} -> {now['result']}. "
+                "If it was fixed, mark it closed with the measured effect; if it "
+                "merely moved, re-anchor the signature by content."
+            )
+
+    print(f"unfalsifiable-number findings: {len(current)}")
+    if drift:
+        print(f"\nDRIFT ({len(drift)}):")
+        for d in drift:
+            print(f"  {d}")
+        return 1
+    print("no drift: every recorded status matches its probe.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--rebuild", action="store_true", help="refresh probes")
+    args = ap.parse_args()
+    try:
+        return rebuild() if args.rebuild else check()
+    except SystemExit:
+        raise
+    except Exception as exc:  # noqa: BLE001 — report, never traceback at the operator
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/model_registry/holdout.py
+++ b/src/model_registry/holdout.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 
 import csv
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
@@ -180,8 +181,23 @@ class HoldoutResult:
     training_labels: tuple[str, ...]
 
     def to_dict(self) -> dict[str, Any]:
+        # ``measuredAt`` exists because the criterion's absolute level
+        # drifts with the market — ~19 points on IDENTICAL parameters in
+        # 7 days, measured 2026-08-05, against a 25-point promotion
+        # margin.  Without a date, three scores taken on three different
+        # days sit in one file looking directly comparable, and the only
+        # way to tell them apart was hand-written prose in ``notes``.
+        # That is what let the registry record a verdict its own stored
+        # numbers disagree with (v3's note says +22.4; the stored pair
+        # gives +12.79).
+        #
+        # ``cmd_validate`` no longer trusts a stored criterion at all —
+        # it re-scores both curves — but it prints this date when the
+        # stored figure differs, so a stale registry is visible rather
+        # than silently bypassed.
         return {
             "criterion": round(self.criterion, 4),
+            "measuredAt": datetime.now(timezone.utc).isoformat(),
             "criterionName": "mean_per_source_rmse",
             "criterionUnits": "points on the 0-9999 value scale (lower is better)",
             "perSource": {k: round(v, 4) for k, v in sorted(self.per_source.items())},

--- a/tests/audit/test_unfalsifiable_status.py
+++ b/tests/audit/test_unfalsifiable_status.py
@@ -1,0 +1,180 @@
+"""The 2026-08-05 audit's findings must stay machine-checked.
+
+WHY THIS EXISTS
+===============
+Five findings from the unfalsifiable-number audit could not go into
+``scripts/audit_status.py``: that table is a status overlay on a
+**frozen** registry, keyed by position (``C01…C43``), with no seam for a
+finding the frozen artifact does not contain. Left as prose in a
+markdown file they were the least durable thing the audit produced — a
+list nobody re-probes is exactly what
+``docs/audits/remediation-protocol.md`` warns about ("a finding list
+maintained by memory would have had someone re-fixing W-2 in batch C9").
+
+So they now have a registry, a generated status file and a probe, reusing
+``audit_status``'s ``_probe`` rather than forking it.
+
+WHAT THIS GUARDS
+================
+The two ways a tripwire quietly stops being one:
+
+1. **A signature that is not present.** An OPEN finding whose signature
+   cannot be found is not being tracked — the probe records "absent",
+   the checker compares absent-to-absent, and it reports no drift
+   forever. This is not hypothetical: **U02 shipped with exactly that
+   defect during authoring** (its signature was written from memory as
+   ``row_index.get(str(name).strip().lower())`` when the source says
+   ``row = row_index.get(key)``), and ``unfalsifiable_status.py`` happily
+   reported "no drift" on all six. Only checking presence caught it.
+2. **A drifted registry.** Status is generated; if the generated file and
+   the registry disagree about membership, the check is running against
+   a stale set.
+
+Mirrors ``test_remediation_tooling.py``'s posture, including shelling out
+to the script so CI runs the real thing rather than a reimplementation.
+
+NOT ``livedata``-marked: reads the source tree, must block.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REGISTRY = REPO_ROOT / "docs" / "audits" / "unfalsifiable-number-audit-2026-08-05.registry.json"
+STATUS = REPO_ROOT / "docs" / "audits" / "unfalsifiable-number-audit-2026-08-05.status.json"
+SCRIPT = REPO_ROOT / "scripts" / "unfalsifiable_status.py"
+DOC = REPO_ROOT / "docs" / "audits" / "unfalsifiable-number-audit-2026-08-05.md"
+
+
+def _registry() -> dict:
+    return json.loads(REGISTRY.read_text(encoding="utf-8"))
+
+
+class TestTheArtifactsExist(unittest.TestCase):
+    """Non-vacuity: every assertion below reads these paths."""
+
+    def test_all_four_are_present(self) -> None:
+        for p in (REGISTRY, STATUS, SCRIPT, DOC):
+            self.assertTrue(p.is_file(), f"{p.relative_to(REPO_ROOT)} is missing")
+
+    def test_the_registry_has_findings(self) -> None:
+        self.assertGreaterEqual(len(_registry().get("findings") or []), 5)
+
+
+class TestEveryOpenFindingIsActuallyTracked(unittest.TestCase):
+    def test_open_findings_have_a_locatable_signature(self) -> None:
+        """The one that caught a real defect in this very registry.
+
+        An OPEN finding whose signature is absent is untracked: the
+        probe records absent, the checker sees absent, and it reports no
+        drift forever. U02 was written with a from-memory signature that
+        did not match the source and the tooling reported clean.
+        """
+        sys.path.insert(0, str(REPO_ROOT / "scripts"))
+        from audit_status import _probe  # noqa: PLC0415
+
+        unlocatable: list[str] = []
+        for f in _registry()["findings"]:
+            if f.get("status") != "open" or not f.get("signature"):
+                continue
+            result = _probe(f.get("path"), f["signature"])["result"]
+            if result != "signature_present":
+                unlocatable.append(f"{f['id']} ({f['path']}): {result}")
+        self.assertEqual(
+            unlocatable,
+            [],
+            msg=(
+                "these findings are recorded OPEN but their defect signature cannot be "
+                "found: " + "; ".join(unlocatable) + ". A signature that does not match "
+                "the source tracks nothing — the checker compares absent to absent and "
+                "reports no drift. Re-anchor it on text that is actually there, and "
+                "confirm it VANISHES when the defect is fixed."
+            ),
+        )
+
+    def test_every_finding_carries_its_evidence(self) -> None:
+        """A finding with no measurement is a claim, not a finding."""
+        thin: list[str] = []
+        for f in _registry()["findings"]:
+            for field in ("measured", "verifiedBy", "userSurface", "consequence"):
+                if not str(f.get(field) or "").strip():
+                    thin.append(f"{f['id']}.{field}")
+        self.assertEqual(thin, [], msg=f"missing evidence fields: {thin}")
+
+    def test_ids_are_unique(self) -> None:
+        ids = [f["id"] for f in _registry()["findings"]]
+        self.assertEqual(sorted(ids), sorted(set(ids)))
+
+
+class TestTheGeneratedStatusMatchesTheRegistry(unittest.TestCase):
+    def test_membership_agrees(self) -> None:
+        reg = {f["id"] for f in _registry()["findings"]}
+        st = {f["id"] for f in json.loads(STATUS.read_text(encoding="utf-8"))["findings"]}
+        self.assertEqual(
+            reg,
+            st,
+            msg=(
+                "the generated status file and the registry disagree about which "
+                "findings exist — run `python3 scripts/unfalsifiable_status.py --rebuild`. "
+                "Status is GENERATED; the registry is the authority."
+            ),
+        )
+
+    def test_the_status_file_says_it_is_generated(self) -> None:
+        """So nobody edits it by hand and has it silently overwritten."""
+        self.assertIn("GENERATED", json.loads(STATUS.read_text(encoding="utf-8"))["note"])
+
+
+class TestTheCheckerRuns(unittest.TestCase):
+    def test_the_script_reports_no_drift(self) -> None:
+        """Shell out, so CI exercises the real entry point."""
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            msg=(
+                "scripts/unfalsifiable_status.py reports drift:\n"
+                f"{proc.stdout}\n{proc.stderr}\n"
+                "A recorded status and the tree disagree. Either a defect was fixed "
+                "(mark it closed with the measured effect) or a signature moved "
+                "(re-anchor it by content)."
+            ),
+        )
+
+
+class TestItDidNotDisturbTheOtherAudit(unittest.TestCase):
+    """This audit deliberately does not touch the fix-plan session's
+    tooling. Proof, not assertion."""
+
+    def test_the_08_04_checker_still_passes(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(REPO_ROOT / "scripts" / "audit_status.py")],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        self.assertEqual(proc.returncode, 0, msg=f"{proc.stdout}\n{proc.stderr}")
+
+    def test_the_probe_is_imported_not_forked(self) -> None:
+        """One definition of 'is the signature still there'. If the name
+        is ever changed in audit_status.py this fails loudly, which is
+        the correct outcome — a silent fork is what this avoids."""
+        src = SCRIPT.read_text(encoding="utf-8")
+        self.assertIn("from audit_status import _probe", src)
+        self.assertNotIn("def _probe", src)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/model_registry/test_validate_cli.py
+++ b/tests/model_registry/test_validate_cli.py
@@ -1,0 +1,286 @@
+"""``model_registry.py validate`` must not compare two stored scores.
+
+WHY THIS EXISTS
+===============
+`cmd_validate` read the champion's and challenger's STORED holdout
+criteria and handed both to ``decide_promotion``. ``promotion.py``'s
+module docstring says the comparison must be made on ONE snapshot with
+both curves scored against it, because the criterion's absolute level
+drifts with the market while the paired delta does not.
+
+Stored scores carry whatever date someone last ran ``evaluate --record``;
+a challenger's is stamped at ``register`` time. Those coincide only by
+luck. Measured on the live registry 2026-08-05, margin 25.0:
+
+    stored vs stored (the old behaviour)   +12.79   REJECT (right, by luck)
+    both scored fresh (correct)            +22.44   REJECT
+    champion re-recorded only              +31.91   PROMOTE   <- WRONG
+
+The third row is why "just re-record the champion" is not a data fix:
+refreshing only the staler side inflates the gap by exactly the drift it
+removes. The champion's score was 7 days stale, the challenger's 1.
+
+The registry had already been bitten by this once and written it down —
+``hill_scope_masters.json`` records v1 being re-scored in 2026-07 for
+exactly this reason — and still shipped the defect in the CLI. Its own
+files disagree today: v3's note says the improvement was ``+22.4`` while
+the stored pair computes ``+12.79``.
+
+WHAT COULD DISAGREE WITH IT, BEFORE
+===================================
+Nothing. **No test imported, executed or subprocessed
+``scripts/model_registry.py`` at all** — the whole CLI (`status`,
+`evaluate`, `validate`, `promote`, `rollback`, `apply`) had zero direct
+coverage, and nothing would have failed if `cmd_validate` were deleted
+outright.
+
+`test_lifecycle.py` looks like coverage and is not: it calls
+``decide_promotion`` on criteria it computes itself, freshly and paired,
+inside the test. It exercises the correct semantics; the shipped CLI
+implemented different ones; nothing compared the two.
+
+WHY THIS MATTERS MORE THAN AN ADVISORY CLI USUALLY WOULD
+========================================================
+``cmd_promote`` has **no holdout gate** — it checks status and requires
+a reason, nothing else. So this verdict is the only thing standing
+between a human and ``promote`` + ``apply``, and ``apply`` writes the
+constants ``_compute_unified_rankings`` uses for every row.
+
+``evaluate_offense_master`` is stubbed here, so these are pure logic and
+must block; the live-CSV path is covered by ``test_holdout.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from src.model_registry.holdout import HoldoutError
+from src.model_registry.versioning import ModelRegistry, ModelVersion
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_cli():
+    """Import ``scripts/model_registry.py`` as a module.
+
+    It is a script, not a package member, so there is no import path for
+    it — which is a large part of why it went untested.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "_model_registry_cli", REPO_ROOT / "scripts" / "model_registry.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+CLI = _load_cli()
+
+CHAMP_PARAMS = {"HILL_PERCENTILE_C": 0.110, "HILL_PERCENTILE_S": 1.110}
+CHAL_PARAMS = {"HILL_PERCENTILE_C": 0.108, "HILL_PERCENTILE_S": 1.110}
+
+
+@dataclass
+class _FakeEval:
+    """Enough of ``HoldoutResult`` for ``cmd_validate``."""
+
+    criterion: float
+
+
+def _registry(champ_stored: float | None, chal_stored: float | None) -> ModelRegistry:
+    reg = ModelRegistry("hill")
+    reg.seed_champion(
+        ModelVersion(
+            model_id="hill",
+            version=2,
+            params=dict(CHAMP_PARAMS),
+            fitted_at="2026-07-28T00:00:00Z",
+            producer="test",
+            status="champion",
+            holdout={"criterion": champ_stored} if champ_stored is not None else None,
+        )
+    )
+    reg.add(
+        ModelVersion(
+            model_id="hill",
+            version=3,
+            params=dict(CHAL_PARAMS),
+            fitted_at="2026-08-04T00:00:00Z",
+            producer="test",
+            status="challenger",
+            holdout={"criterion": chal_stored} if chal_stored is not None else None,
+        )
+    )
+    return reg
+
+
+def _run(monkeypatch, *, champ_stored, chal_stored, champ_fresh, chal_fresh):
+    """Run ``cmd_validate`` with stored and fresh scores decoupled."""
+    monkeypatch.setattr(CLI, "_load_or_seed", lambda: _registry(champ_stored, chal_stored))
+
+    def fake_eval(c, s, **kw):
+        if (c, s) == (CHAMP_PARAMS["HILL_PERCENTILE_C"], CHAMP_PARAMS["HILL_PERCENTILE_S"]):
+            return _FakeEval(champ_fresh)
+        return _FakeEval(chal_fresh)
+
+    monkeypatch.setattr(CLI, "evaluate_offense_master", fake_eval)
+    return CLI.cmd_validate(argparse.Namespace(version=3))
+
+
+class TestThePremiseHolds:
+    """Non-vacuity: these numbers straddle the real margin, so a verdict
+    flip below is a genuine flip and not an artifact of the fixture."""
+
+    def test_the_margin_is_what_this_test_assumes(self):
+        from src.model_registry.promotion import PROMOTION_MARGIN
+
+        assert PROMOTION_MARGIN == 25.0
+
+    def test_the_fixture_numbers_straddle_it(self):
+        assert 806.9611 - 784.5184 < 25.0  # paired -> REJECT
+        assert 806.9611 - 775.0471 > 25.0  # champion-refreshed-only -> PROMOTE
+
+
+class TestTheVerdictComesFromFreshScores:
+    def test_stored_scores_do_not_decide(self, monkeypatch, capsys):
+        """The live numbers, with stored and fresh deliberately different.
+
+        Stored would give +12.79; fresh gives +22.44. Both REJECT, but
+        for different reasons — so this asserts the printed figures, not
+        just the exit code.
+        """
+        rc = _run(
+            monkeypatch,
+            champ_stored=787.8416,
+            chal_stored=775.0471,
+            champ_fresh=806.9611,
+            chal_fresh=784.5184,
+        )
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "806.9611" in out and "784.5184" in out
+        assert "REJECT" in out
+
+    def test_a_stale_champion_cannot_manufacture_a_promote(self, monkeypatch, capsys):
+        """THE headline case, and the one my own earlier advice got wrong.
+
+        Re-recording only the champion leaves a 7-day-stale challenger
+        beside a fresh champion: +31.91 against a 25-point margin, a
+        false PROMOTE. With both scored fresh the same registry yields
+        REJECT.
+        """
+        rc = _run(
+            monkeypatch,
+            champ_stored=806.9611,  # champion refreshed...
+            chal_stored=775.0471,  # ...challenger left stale
+            champ_fresh=806.9611,
+            chal_fresh=784.5184,
+        )
+        out = capsys.readouterr().out
+        assert rc == 1, "a stale-vs-fresh pairing produced a PROMOTE"
+        assert "REJECT" in out
+        assert "PROMOTE" not in out
+
+    @pytest.mark.parametrize("perturbation", [-150.0, -25.1, 25.1, 150.0])
+    def test_perturbing_a_stored_criterion_never_moves_the_verdict(
+        self, monkeypatch, capsys, perturbation
+    ):
+        """The mutation, as a property.
+
+        Each perturbation exceeds the promotion margin, so under the old
+        stored-vs-stored behaviour every one of these would flip or
+        distort the verdict.
+        """
+        rc = _run(
+            monkeypatch,
+            champ_stored=787.8416 + perturbation,
+            chal_stored=775.0471,
+            champ_fresh=806.9611,
+            chal_fresh=784.5184,
+        )
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "REJECT" in out
+
+    def test_a_genuine_win_still_promotes(self, monkeypatch, capsys):
+        """The asymmetry — this is not a blanket REJECT."""
+        rc = _run(
+            monkeypatch,
+            champ_stored=787.8416,
+            chal_stored=775.0471,
+            champ_fresh=806.9611,
+            chal_fresh=700.0,  # -106.96, comfortably past the margin
+        )
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "PROMOTE" in out
+
+
+class TestStalenessIsReportedNotHidden:
+    def test_a_drifted_stored_figure_is_named(self, monkeypatch, capsys):
+        """Re-scoring silently would tidy away the evidence that the
+        registry is stale. The fix must surface it, not just bypass it."""
+        _run(
+            monkeypatch,
+            champ_stored=787.8416,
+            chal_stored=775.0471,
+            champ_fresh=806.9611,
+            chal_fresh=784.5184,
+        )
+        out = capsys.readouterr().out
+        assert "STORED" in out
+        assert "787.8416" in out
+        assert "+19.1195" in out
+
+    def test_no_note_when_the_registry_is_current(self, monkeypatch, capsys):
+        """Without this the note could be unconditional and the test
+        above would still pass."""
+        _run(
+            monkeypatch,
+            champ_stored=806.9611,
+            chal_stored=784.5184,
+            champ_fresh=806.9611,
+            chal_fresh=784.5184,
+        )
+        assert "STORED" not in capsys.readouterr().out
+
+
+class TestAnUnevaluableGateIsNotAPass:
+    def test_holdout_error_exits_2(self, monkeypatch, capsys):
+        monkeypatch.setattr(CLI, "_load_or_seed", lambda: _registry(787.8416, 775.0471))
+
+        def boom(*a, **kw):
+            raise HoldoutError("holdout CSVs missing")
+
+        monkeypatch.setattr(CLI, "evaluate_offense_master", boom)
+        rc = CLI.cmd_validate(argparse.Namespace(version=3))
+        assert rc == 2, "an unevaluable gate must not read as a pass"
+        assert "Refusing" in capsys.readouterr().err
+
+    def test_missing_params_exit_2_rather_than_crash(self, monkeypatch, capsys):
+        """A version predating VALIDATED_PARAMS has no such keys. The
+        gate should refuse, not raise a KeyError at the operator."""
+        reg = _registry(787.8416, 775.0471)
+        reg.get(3).params.pop("HILL_PERCENTILE_C", None)
+        monkeypatch.setattr(CLI, "_load_or_seed", lambda: reg)
+        monkeypatch.setattr(CLI, "evaluate_offense_master", lambda c, s, **kw: _FakeEval(1.0))
+        assert CLI.cmd_validate(argparse.Namespace(version=3)) == 2
+
+
+class TestTheRecipeIncludesTheRefreshStep:
+    def test_the_driver_prints_evaluate_record_before_validate(self):
+        """ADR-008 step 2 was dropped when steps 1-4 were collapsed into
+        the driver, so the recipe handed to a human began at `validate`
+        against a registry nobody had refreshed."""
+        src = (REPO_ROOT / "scripts" / "auto_refit_hill_curves.py").read_text(encoding="utf-8")
+        i_eval = src.find("model_registry.py evaluate --champion --record")
+        i_val = src.find("model_registry.py validate {target}")
+        assert i_eval != -1, "the promotion recipe no longer refreshes the champion first"
+        assert i_eval < i_val, "the refresh step must come before validate"


### PR DESCRIPTION
Closes the four loose ends left by the unfalsifiable-number audit (#725). Investigating them **reversed my own recommendation on two**, so the corrections come first.

Board fingerprint **identical to `origin/main`** (1093 rows, `64f65e9a`). Nothing here touches a value path.

---

## ⚠ Correction 1 — the "one-command data fix" I recommended was unsafe

I said `python3 scripts/model_registry.py evaluate --champion --record` was a safe standalone data fix. It is the opposite. Measured on the live registry, `validate 3`, margin 25.0:

| comparison | improvement | verdict |
|---|---|---|
| stored vs stored (what it did) | +12.79 | REJECT — right verdict, wrong arithmetic |
| both scored fresh (correct) | **+22.44** | **REJECT — correct** |
| champion re-recorded only (what I proposed) | **+31.91** | **PROMOTE — wrong** |

Refreshing only the staler side inflates the gap by exactly the drift it removes: the champion's stored score was 7 days old, the challenger's 1. My proposal would have flipped a correct rejection into a recommendation to promote a curve that lost.

**The real fix is the mechanism.** `cmd_validate` now re-scores both curves via `evaluate_offense_master` — exactly as `auto_refit_hill_curves.py` already did. Two code paths, one contract, one of them wrong; now one path. `HoldoutError` → exit 2, because an unevaluable gate must not read as a pass.

This matters more than an advisory CLI normally would: **`cmd_promote` has no holdout gate at all**, so this verdict is the only thing between a human and `promote` + `apply`, and `apply` writes the constants every row is priced with.

Also: `HoldoutResult` gains `measuredAt` (it stored no date, which is how three scores from three different days sat in one file looking comparable), stored figures print *alongside* the fresh ones so a stale registry is visible rather than silently bypassed, and `evaluate --champion --record` is restored as step 1 of the printed recipe — ADR-008's step 2, dropped when the steps were collapsed into the driver.

**Report only, not promoted:** the corrected gate says v3 REJECT (+22.44); v2's win over v1 still holds today (−39.67).

**There were zero tests.** Nothing imported, executed or subprocessed `scripts/model_registry.py`; nothing would have failed if `cmd_validate` were deleted. `test_lifecycle.py` looks like coverage and isn't — it calls `decide_promotion` on criteria it computes itself, freshly and paired, so it exercises the correct semantics while the shipped CLI implemented different ones. 14 tests added.

## ⚠ Correction 2 — "rotate / accept / scrub" was a false choice

- **Rotate is impossible.** Sleeper league IDs are immutable server-assigned identifiers.
- **It is not a secret.** `src/api/league_registry.py:94-101` says so itself — "technically public (anyone can fetch `/v1/league/<id>`)" — and gives *API decoupling*, not confidentiality, as the reason `/api/leagues` withholds it.
- **Scrubbing removes nothing.** It is in the **root commit**, so a rewrite changes every SHA — breaking every open PR, ~55 branches including 17 `archive/*`, every clone and the deploy checkout — and deletes **zero** personal data, because `audit/baseline/public_league_overview.json` already commits all 12 managers' `ownerId`/`displayName`/`avatar`.

So documenting is the correct answer, not theatre. Added to `SECURITY.md`'s existing "Repository visibility" section, which already names the league configuration as accepted exposure.

Two things I got wrong in the writing: I'd said 19 tracked files (it's **18**), and quoting the literal ID made `SECURITY.md` the 19th match — falsifying the sentence in the same edit that made it. The section now names the ID without repeating it.

## ⚠ Correction 3 — wiring the Phase-4 interval would not have settled the band question

`src/canonical/confidence_intervals.py` looks like the answer and is not: **two of its three branches return hardcoded flat bands, one the identical ±15%**, justified by an unsourced docstring claim — and it explicitly disclaims being predictive ("a transparency metric, not a probability of realized outcome"). Wiring it would flip `bandSources` to `stamped_value_band` on most rows while changing nothing that is known.

---

## The measurement decision #4 actually asked for

`scripts/backtest_mc_band_width.py` replays the real contract at two dates via `src/consensus_edge/panel.py` and measures how far `rankDerivedValue` actually moved. Requires `git fetch --unshallow`; refuses with exit 2 on a shallow clone, because "no data" must not read as "passed".

| horizon | folds | pairs | board p10–p90 half-width | flat ±15% is | coverage |
|---|---|---|---|---|---|
| 7d | 15 | 10,500 | **3.57%** | 4.20× wider | 91.0% |
| 14d | 7 | 5,123 | **3.35%** | 4.47× wider | 94.4% |
| 30d | 3 | 1,919 | **8.31%** | 1.81× wider | 86.5% |

**The pooled number is not the finding — the distribution is.** Per-fold half-widths at h7 are bimodal: eleven folds between 0.96% and 4.98%, then four at 34%, 38%, 90% and 101%. Two of those four are the panel growing its source count (13→19, 19→22). The other two are **not** — source count is stable at 24, but the join population halves (426 vs ~800). A week where only half the board matches is a coverage artifact, not a repricing. So all four outliers are properties of the replay, and a retune driven by the pooled figure would have been driven by them.

**`FLAT_BAND` stays 0.15**, a rule stated before the run. The band is horizonless, the data is entirely offseason, and it measures self-consistency rather than correctness — the common-mode-error argument survives untouched.

I also caught a direction error in my own caveat before shipping: I'd written that understated movement makes a "too wide" verdict *conservative*. Backwards — it makes the band look **more** excessive than it is, so "4.2× too wide" is an **upper bound on the excess**. Corrected in the docstring, the JSON caveat and the verdict, and the JSONs regenerated.

## A machine-checked home for the findings the frozen registry can't hold

`scripts/audit_status.py` is a status overlay on a **frozen** artifact — `_registry_criticals()` mints `C01…C43` from positions and `rebuild()` raises if one lacks a curated entry. There is no seam for a finding it does not contain.

So: own registry, own generated status, own CLI — but **importing `_probe` from `audit_status` rather than forking it**, with a test asserting the import and asserting no local `def _probe`. A second test runs `audit_status.py` itself, proving this didn't disturb the fix-plan session's tooling.

**The guard caught a real defect in my own registry.** U02's signature was written from memory (`row_index.get(str(name).strip().lower())`); the source says `row = row_index.get(key)`. The checker reported "no drift" on all six — because an OPEN finding whose signature is *absent* is compared absent-to-absent and passes forever. It was tracking nothing. Each of the six signatures is now verified to **vanish** under a simulated fix.

---

## Verification

| gate | result |
|---|---|
| `pytest -m "not livedata"` | **6,671 passed** |
| `pytest -m livedata` | **252 passed**, 25 skipped |
| `ruff format --check .` | 911 files |
| `ruff check` (changed vs base) | clean |
| board fingerprint vs `origin/main` | **IDENTICAL** (`64f65e9a`) |
| `scripts/audit_status.py` | still passes, untouched |
| `git diff --stat origin/main...HEAD` | 15 files, all mine (three dots — two showed main's movement) |

### Mutations run

| mutation | result |
|---|---|
| restore stored-vs-stored in `cmd_validate` | 6 red (incl. the false PROMOTE) |
| unevaluable gate returns 0 | 2 red |
| four perturbations of the stored criterion, each > margin | pinned as a property |
| restore U02's from-memory signature | 2 red |
| add a finding without rebuilding status | 2 red |
| strip a finding's measured evidence | 1 red |

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDncHf1y167Yqt2CKYg97g)_