### PR TITLE
Make the two owed observations checkable instead of scheduled

### DIFF
--- a/deploy/install-systemd-service.sh
+++ b/deploy/install-systemd-service.sh
@@ -1088,6 +1088,7 @@ main() {
   install_simple_timer "crowd-faab" "cross-league FAAB crowd accumulation"
   install_simple_timer "sharp-activity" "qualified-manager Sleeper activity crawl"
   install_simple_timer "board-snapshot" "canonical board as-of snapshot"
+  install_simple_timer "sharp-cohort-snapshot" "daily sharp-cohort baseline"
 
   # ── daemon-reload and enable ────────────────────────────────────────────
   # ce_needs_install was missing from this list. Every other timer's

--- a/deploy/systemd/dynasty-sharp-cohort-snapshot.service.template
+++ b/deploy/systemd/dynasty-sharp-cohort-snapshot.service.template
@@ -1,0 +1,50 @@
+[Unit]
+Description=Risk It sharp-cohort daily baseline snapshot (__SERVICE_NAME__)
+After=network-online.target
+Wants=network-online.target
+
+# Writes data/sharp/cohort/snapshot_<date>.json — who qualified as sharp
+# today, with each manager's score, percentile and weightsApplied.
+#
+# WHY THIS EXISTS: sharp-v2.1 changed WHO QUALIFIES and shipped with the
+# claim that ordering and membership were unaffected.  That claim could
+# not be checked, because nobody had captured the cohort BEFORE the
+# change and the moment is unrecoverable.  A daily baseline means the
+# next scoring change is measurable instead of argued about.
+#
+# WHY A PROD TIMER AND NOT CI: the cohort is derived from
+# data/intel/ledger.sqlite3, which is gitignored and lives on the box.
+# A CI runner sees an empty population — measured, and the script exits
+# 2 there rather than reporting a vacuous pass.  Same reasoning as the
+# playerctx and BDVM producers.
+#
+# Reads only; writes one small JSON per day into gitignored data/.
+# Nothing is pushed anywhere, so this needs no credentials.
+#
+# Exit codes (scripts/sharp_cohort_snapshot.py):
+#   0 - snapshot written
+#   2 - no evaluable managers; deliberately NOT 0, so "no data" cannot
+#       read as "measured and fine". Expected on a box whose crawls have
+#       not populated the ledger yet, which is why it is a success code
+#       below rather than a permanent red unit.
+SuccessExitStatus=0 2
+
+[Service]
+Type=oneshot
+User=__APP_USER__
+Group=__APP_USER__
+WorkingDirectory=__APP_DIR__
+EnvironmentFile=-__APP_DIR__/.env
+# `--daily` rather than a date-stamped --out path: the script owns its
+# own filename, so this needs no `/bin/sh -c` wrapper and no systemd `%`
+# escaping, and every path here resolves to a file that exists — the rule
+# tests/deploy/test_all_timers_are_wired.py enforces across all units.
+ExecStart=__VENV_DIR__/bin/python __APP_DIR__/scripts/sharp_cohort_snapshot.py --daily
+StandardOutput=journal
+StandardError=journal
+Nice=10
+IOSchedulingClass=idle
+TimeoutStartSec=600
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/dynasty-sharp-cohort-snapshot.timer.template
+++ b/deploy/systemd/dynasty-sharp-cohort-snapshot.timer.template
@@ -1,0 +1,24 @@
+[Unit]
+Description=Daily sharp-cohort baseline snapshot for __SERVICE_NAME__
+# No `Requires=` — it pulls the service in whenever the TIMER starts,
+# firing a snapshot on deploy day and again on every reboot.  `Unit=`
+# below is the only binding this needs.  Same choice as
+# dynasty-playerctx-history and dynasty-reception-depth.
+
+[Timer]
+# Daily 05:10 UTC.  Slot rationale: the three sharp crawls run in a
+# dependency order and the cohort is only meaningful after the second —
+# discovery 04:20 finds MANAGERS, records 04:50 finds their RESULTS
+# (which is what makes them scoreable), rosters 05:50 finds what they
+# OWN.  05:10 sits after records and before rosters, clear of the FFPC
+# crawl at 05:20.
+#
+# Snapshotting before records would capture a cohort built from
+# yesterday's evidence and quietly date every baseline by a day.
+OnCalendar=*-*-* 05:10:00 UTC
+Persistent=true
+AccuracySec=2min
+Unit=__SERVICE_NAME__-sharp-cohort-snapshot.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/consensus-edge/DECISIONS.md
+++ b/docs/consensus-edge/DECISIONS.md
@@ -1169,3 +1169,78 @@ Three things done instead of "fixing" a bug that cannot occur:
   than raising when the identity table is absent.
 
 **Status:** accepted 2026-08-05.
+
+---
+
+## ADR-029: the v2.1 cohort before/after is unrecoverable, so verify the invariant instead
+
+**Context.** ADR-028 shipped `sharp-v2.1` with a safety claim: the
+renormalization raises every score, but the ORDER and therefore the
+percentile-selected cohort are unchanged. It was asserted on synthetic
+records in `tests/sharp/test_score.py` and explicitly **not** measured
+against the live population, because the dev ledger yields zero cohort
+members. It was recorded as "owed, not done", and
+`scripts/sharp_cohort_snapshot.py` was added to make paying it a single
+command on prod.
+
+That debt cannot be paid in the form it was written. **v2.1 is already
+live**, and nobody captured the pre-v2.1 cohort — the "before" does not
+exist anywhere, on any box, in any commit. A before/after is not
+pending; it is impossible. Carrying it on the owed list indefinitely
+would be carrying a measurement that will never be taken, which is the
+same dishonesty as claiming it was.
+
+**Decision.** Verify the invariant the claim rests on, which needs no
+baseline at all.
+
+The argument is:
+
+> the absent component set is identical for every manager
+> → every score scales by the same factor
+> → the order cannot move
+> → and qualification is a percentile of the population, so the cohort
+>   cannot change.
+
+Every clause after the first *follows from* the first, and the first is
+a property of ONE population at ONE instant. If every evaluable
+manager's `components.weightsApplied` map is identical, the
+renormalization multiplied every score by the same constant. That is
+checkable on prod today.
+
+`scripts/sharp_cohort_snapshot.py --verify-invariant` does exactly that:
+it groups the population by `weightsApplied` and reports the distinct
+maps found. One map and no unstamped managers → the claim holds, and it
+holds as a proof rather than an argument. More than one → renormalization
+scaled managers by DIFFERENT factors, could have reordered them, and the
+shipped claim is false on that population.
+
+Three details that decide whether the check is worth trusting:
+
+- **An empty population exits 2, not 0.** "Every manager in an empty set
+  shares one weight map" is vacuously true and proves nothing, so a dev
+  box must not be able to report a pass. Same posture as
+  `scripts/backtest_perfect_draft.py`.
+- **An unstamped manager fails the check** rather than being skipped.
+  Treating "no `weightsApplied`" as "same as everyone else" would let the
+  check pass by ignoring precisely the rows it cannot see.
+- **Weights are compared at the precision they are stamped at** (6dp,
+  rounded at the source). Comparing raw floats would report a spurious
+  violation from representation noise instead of a real difference in
+  the absent set.
+
+**And a baseline now accumulates**, so the next scoring change does not
+repeat this. `dynasty-sharp-cohort-snapshot` writes
+`data/sharp/cohort/snapshot_<date>.json` daily at 05:10 UTC — after the
+04:50 records crawl that makes managers scoreable and before the 05:50
+roster pass. Snapshotting before records would capture a cohort built
+from yesterday's evidence and quietly date every baseline by a day.
+
+The script owns its own filename via `--daily` rather than taking a
+date-stamped path in the unit's `ExecStart`: that avoids a `/bin/sh -c`
+wrapper and systemd `%` escaping, and keeps every path in an ExecStart
+resolving to a file that exists — the rule
+`tests/deploy/test_all_timers_are_wired.py` enforces across all units,
+which caught the first attempt.
+
+**Status:** accepted 2026-08-05. Supersedes the "live cohort before/after"
+item owed by ADR-028; that item is closed as unrecoverable, not done.

--- a/scripts/sharp_cohort_snapshot.py
+++ b/scripts/sharp_cohort_snapshot.py
@@ -46,7 +46,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+_REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO))
 
 from src.sharp import cohort as sharp_cohort  # noqa: E402
 from src.sharp import platform_records  # noqa: E402
@@ -156,13 +157,128 @@ def compare(before: dict[str, Any], after: dict[str, Any]) -> tuple[int, list[st
     return (1 if changed else 0), lines
 
 
+def verify_invariant(snapshot: dict[str, Any]) -> tuple[int, list[str]]:
+    """Check the claim `sharp-v2.1` shipped on, from ONE snapshot.
+
+    The before/after this was meant to be measured with is
+    **unrecoverable**: v2.1 is already live, and nobody captured the
+    pre-v2.1 cohort.  Carrying it as an owed measurement is carrying a
+    debt that cannot be paid in the form stated.
+
+    But the safety argument does not actually need a baseline.  It is:
+
+        the absent component set is identical for every manager,
+        so every score scales by the same factor,
+        so the ORDER cannot move,
+        and qualification is a percentile of the population,
+        so the cohort cannot change.
+
+    Every clause after the first follows from it, and the first is a
+    property of a SINGLE population at a SINGLE instant: if every
+    evaluable manager's ``weightsApplied`` map is identical, the
+    renormalization multiplied every score by the same constant.  That
+    is checkable right now, on prod, with no baseline at all.
+
+    Returns ``(exit_code, lines)``.  Non-zero means the absent set is NOT
+    uniform — the case where v2.1 could have reordered managers and the
+    shipped claim would be false.
+    """
+    lines: list[str] = []
+    scores = snapshot.get("scores", {})
+
+    groups: dict[str, list[str]] = {}
+    missing: list[str] = []
+    for user_id, entry in scores.items():
+        applied = entry.get("weightsApplied")
+        if not isinstance(applied, dict) or not applied:
+            missing.append(user_id)
+            continue
+        key = json.dumps({k: round(float(v), 9) for k, v in sorted(applied.items())})
+        groups.setdefault(key, []).append(user_id)
+
+    if missing:
+        lines.append(
+            f"{len(missing)} manager(s) carry no weightsApplied stamp — "
+            "the renormalization is unauditable for them"
+        )
+        lines.append(f"  e.g. {', '.join(missing[:5])}")
+
+    if not groups:
+        lines.append("no manager carries a weightsApplied stamp; nothing to verify")
+        return 1, lines
+
+    lines.append(f"distinct weightsApplied maps across {len(scores)} managers: {len(groups)}")
+    for key, members in sorted(groups.items(), key=lambda kv: -len(kv[1])):
+        weights = json.loads(key)
+        total = sum(weights.values())
+        lines.append(f"  {len(members):>5} manager(s), sum {total:.6f}: {weights}")
+
+    if len(groups) == 1 and not missing:
+        lines.append(
+            "\nINVARIANT HOLDS: one absent-component set across the whole population, "
+            "so every score scaled by the same factor and the ordering — hence the "
+            "percentile-selected cohort — could not have moved."
+        )
+        return 0, lines
+
+    lines.append(
+        "\nINVARIANT VIOLATED: managers do NOT share one absent-component set, so "
+        "renormalization scaled them by DIFFERENT factors and could have reordered "
+        "them. The sharp-v2.1 safety claim does not hold on this population."
+    )
+    return 1, lines
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--out", type=Path, help="write a snapshot to this path")
     ap.add_argument("--ledger", type=Path, default=None, help="override ledger path")
     ap.add_argument("--compare", type=Path, help="baseline snapshot to compare FROM")
     ap.add_argument("--against", type=Path, help="snapshot to compare TO (default: live)")
+    ap.add_argument(
+        "--daily",
+        action="store_true",
+        help="write data/sharp/cohort/snapshot_<utc-date>.json (used by the prod timer)",
+    )
+    ap.add_argument(
+        "--verify-invariant",
+        action="store_true",
+        help="check the sharp-v2.1 uniform-scaling claim on ONE snapshot (no baseline needed)",
+    )
     args = ap.parse_args()
+
+    # The script owns its own filename, deliberately.  Putting
+    # `snapshot_$(date -u +%Y-%m-%d).json` in the unit's ExecStart needs a
+    # `/bin/sh -c` wrapper and systemd `%` escaping, and it breaks the
+    # repo's rule — pinned by tests/deploy/test_all_timers_are_wired.py —
+    # that every path in an ExecStart resolves to a file that exists.
+    # Same reasoning as store.history_path owning the playerctx naming.
+    if args.daily and not args.out:
+        args.out = (
+            _REPO
+            / "data"
+            / "sharp"
+            / "cohort"
+            / f"snapshot_{datetime.now(timezone.utc).date().isoformat()}.json"
+        )
+
+    if args.verify_invariant:
+        snap = (
+            json.loads(args.compare.read_text(encoding="utf-8"))
+            if args.compare
+            else build_snapshot(args.ledger)
+        )
+        if snap.get("population", {}).get("evaluable", 0) == 0:
+            print(
+                "no evaluable managers — the invariant is VACUOUS here, not verified.\n"
+                "  Exit 2, because 'every manager in an empty set shares one weight map' "
+                "is trivially true and proves nothing about production.",
+                file=sys.stderr,
+            )
+            return 2
+        code, lines = verify_invariant(snap)
+        print("\n".join(lines))
+        return code
 
     if args.compare:
         before = json.loads(args.compare.read_text(encoding="utf-8"))
@@ -188,6 +304,10 @@ def main() -> int:
 
     payload = json.dumps(snap, indent=1) + "\n"
     if args.out:
+        # The prod timer writes into data/sharp/cohort/, which does not
+        # exist on a fresh box — a dated baseline lost to a missing
+        # parent directory is a baseline that cannot be recovered later.
+        args.out.parent.mkdir(parents=True, exist_ok=True)
         args.out.write_text(payload, encoding="utf-8")
         print(f"wrote {args.out}")
     else:

--- a/server.py
+++ b/server.py
@@ -4590,6 +4590,15 @@ async def get_status():
             # silent; surfacing coverage here is what makes it visible
             # before a study needs the history and finds it absent.
             "rankHistoryCoverage": _rank_history_coverage_safe(),
+            # The same argument one directory over, and the same defect
+            # the line above exists to prevent.  `store.history_coverage`
+            # was written so a halted retention timer is "visible before
+            # a study needs the data rather than after it produces a
+            # wrong answer" — and was then wired to nothing.  That is
+            # what let the 2026-08-05 deploy install the producer, skip
+            # the pusher, and leave the only symptom in a deploy log
+            # nobody re-reads.
+            "playerctxHistoryCoverage": _playerctx_history_coverage_safe(),
             "idMappingCoverage": _id_mapping_coverage_safe(),
             "nflDataProvider": _nfl_data_provider_status_safe(),
             "normalizationHealth": _normalization_health_safe(),
@@ -4633,6 +4642,76 @@ def _rank_history_coverage_safe() -> dict:
         return _rank_history.coverage()
     except Exception as exc:  # noqa: BLE001
         log.warning("rank_history coverage failed: %s", exc)
+        return {}
+
+
+def _playerctx_pending_push(history_dir) -> dict:
+    """Dated snapshots written locally but never committed.
+
+    THE PRODUCER AND THE PUSHER FAIL INDEPENDENTLY, and only one of the
+    two is visible in ``history_coverage``:
+
+    * the producer stalls  → the directory goes stale → ``staleDays`` grows.
+    * the pusher stalls    → the directory looks perfect and ``main`` gets
+      nothing.
+
+    The second is the one that actually happened on 2026-08-05, and
+    coverage alone cannot see it — which is precisely why it went
+    unnoticed until someone read a deploy log.  ``data/`` is gitignored
+    repo-wide and retained snapshots reach the tree only by an explicit
+    ``git add -f``, so "on disk but not tracked" is exactly "written but
+    not pushed".
+
+    Degrades to ``{}`` rather than raising or guessing: outside a git
+    checkout there is no answer, and a fabricated zero would read as
+    "nothing pending".
+    """
+    import subprocess
+
+    try:
+        proc = subprocess.run(
+            ["git", "ls-files", "--", "data/playerctx/history"],
+            cwd=str(BASE_DIR),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if proc.returncode != 0:
+            return {}
+        tracked = {
+            line.rsplit("/", 1)[-1].strip() for line in proc.stdout.splitlines() if line.strip()
+        }
+        pending = sorted(
+            p.name for p in history_dir.glob("snapshot_*.json") if p.name not in tracked
+        )
+        out: dict = {"pendingPush": len(pending)}
+        if pending:
+            # Filename carries the date and sorts chronologically, which
+            # is why store.history_path writes snapshot_YYYY-MM-DD.json.
+            out["oldestPendingDate"] = pending[0].replace("snapshot_", "", 1).replace(".json", "")
+        return out
+    except Exception as exc:  # noqa: BLE001
+        log.warning("playerctx pending-push probe failed: %s", exc)
+        return {}
+
+
+def _playerctx_history_coverage_safe() -> dict:
+    """Retained playerctx snapshot coverage, tolerant of read errors.
+
+    Same contract as ``_rank_history_coverage_safe`` — never raises —
+    plus the pending-push augmentation, which lives here rather than in
+    ``store`` so the store stays a pure filesystem module with no git
+    dependency.
+    """
+    try:
+        from src.playerctx import store as _pcx_store
+
+        coverage = _pcx_store.history_coverage()
+        if coverage.get("exists"):
+            coverage.update(_playerctx_pending_push(_pcx_store.HISTORY_DIR))
+        return coverage
+    except Exception as exc:  # noqa: BLE001
+        log.warning("playerctx history coverage failed: %s", exc)
         return {}
 
 

--- a/tests/deploy/test_playerctx_history_push_runs.py
+++ b/tests/deploy/test_playerctx_history_push_runs.py
@@ -1,0 +1,219 @@
+"""Run `deploy/playerctx_history_push.sh` for real, against a bare repo.
+
+Until this file, the script had **never executed** — not in CI, not
+locally, not on the box.  `test_playerctx_history_timer_is_wired.py`
+greps its source text, which proves the wiring and nothing about the
+behaviour.  Its first real run was scheduled against production `main`,
+where a bug costs a week and is discovered by absence: no snapshot
+appears, and nobody can tell "the timer never fired" from "the timer
+fired and did nothing".
+
+Everything here drives the script through the env overrides it already
+exposes, with a local bare repo standing in for GitHub.  No network, no
+ssh: `GIT_SSH_COMMAND` is set by the script but git never consults it
+for a filesystem remote.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO / "deploy" / "playerctx_history_push.sh"
+
+pytestmark = pytest.mark.skipif(
+    subprocess.run(["which", "git"], capture_output=True).returncode != 0,
+    reason="git not available",
+)
+
+
+def _git(*args: str, cwd: Path) -> str:
+    proc = subprocess.run(["git", *args], cwd=str(cwd), capture_output=True, text=True, check=True)
+    return proc.stdout
+
+
+def _make_origin(tmp_path: Path) -> Path:
+    """A bare repo with one commit on `main`, standing in for GitHub."""
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    _git("init", "-q", "-b", "main", cwd=seed)
+    _git("config", "user.email", "t@t.local", cwd=seed)
+    _git("config", "user.name", "t", cwd=seed)
+    (seed / "README.md").write_text("seed\n", encoding="utf-8")
+    # data/ gitignored repo-wide, exactly as in the real repo — this is
+    # what makes the script's `git add -f` load-bearing rather than
+    # incidental.
+    (seed / ".gitignore").write_text("data/\n", encoding="utf-8")
+    _git("add", "-A", cwd=seed)
+    _git("commit", "-qm", "seed", cwd=seed)
+
+    origin = tmp_path / "origin.git"
+    _git("clone", "-q", "--bare", str(seed), str(origin), cwd=tmp_path)
+    return origin
+
+
+def _make_live_dir(tmp_path: Path, dates: list[str]) -> Path:
+    """A fake live deploy dir holding dated snapshots plus a decoy."""
+    live = tmp_path / "live"
+    hist = live / "data" / "playerctx" / "history"
+    hist.mkdir(parents=True)
+    for d in dates:
+        (hist / f"snapshot_{d}.json").write_text(
+            json.dumps({"asOf": d, "players": {}}), encoding="utf-8"
+        )
+    # The 38 MB depth-chart CSV and 14 MB Sleeper dump live one directory
+    # up in production.  A directory-level add would sweep them in; the
+    # script names each file instead, and this decoy is what proves it.
+    (live / "data" / "playerctx" / "depth_charts_2026.csv").write_text("x" * 4096, encoding="utf-8")
+    (hist / "notes.txt").write_text("not a snapshot", encoding="utf-8")
+    return live
+
+
+def _run(
+    tmp_path: Path, live: Path, origin: Path, *, key: Path | None
+) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.update(
+        {
+            "PLAYERCTX_HISTORY_WORK_DIR": str(tmp_path / "work"),
+            "PLAYERCTX_HISTORY_REPO_URL": str(origin),
+            "PLAYERCTX_HISTORY_APP_DIR": str(live),
+            "PLAYERCTX_HISTORY_SSH_KEY": str(key) if key else str(tmp_path / "absent-key"),
+            "GIT_CONFIG_GLOBAL": str(tmp_path / "gitconfig"),
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+        }
+    )
+    return subprocess.run(
+        ["bash", str(_SCRIPT)], env=env, capture_output=True, text=True, timeout=120
+    )
+
+
+def _committed_files(origin: Path) -> list[str]:
+    return [
+        ln.strip()
+        for ln in _git("ls-tree", "-r", "--name-only", "main", cwd=origin).splitlines()
+        if ln.strip()
+    ]
+
+
+def test_a_snapshot_actually_lands_as_a_commit(tmp_path):
+    """The whole point, executed rather than asserted about."""
+    origin = _make_origin(tmp_path)
+    live = _make_live_dir(tmp_path, ["2026-08-11"])
+    key = tmp_path / "key"
+    key.write_text("not-a-real-key", encoding="utf-8")
+
+    proc = _run(tmp_path, live, origin, key=key)
+    assert proc.returncode == 0, proc.stderr
+
+    files = _committed_files(origin)
+    assert "data/playerctx/history/snapshot_2026-08-11.json" in files, files
+    log = _git("log", "--format=%s", "main", cwd=origin)
+    assert "chore(playerctx): retain snapshot" in log
+
+
+def test_every_pending_snapshot_is_taken_not_just_the_newest(tmp_path):
+    """This is what makes exit-0-on-a-missing-key safe.
+
+    If the push took one file per run, every week spent without a deploy
+    key would be a week permanently unretained — and an unretained day
+    cannot be recovered afterwards.  The wiring test asserts the glob's
+    SHAPE; this asserts the consequence.
+    """
+    origin = _make_origin(tmp_path)
+    live = _make_live_dir(tmp_path, ["2026-08-11", "2026-08-18", "2026-08-25"])
+    key = tmp_path / "key"
+    key.write_text("k", encoding="utf-8")
+
+    proc = _run(tmp_path, live, origin, key=key)
+    assert proc.returncode == 0, proc.stderr
+
+    files = _committed_files(origin)
+    for d in ("2026-08-11", "2026-08-18", "2026-08-25"):
+        assert f"data/playerctx/history/snapshot_{d}.json" in files, (d, files)
+
+
+def test_nothing_outside_the_history_directory_is_ever_staged(tmp_path):
+    """`git add -f` with an explicit path list, never a directory.
+
+    A `git add -A` is what put an earlier PR into merge conflict by
+    committing two scrape-state timestamps nobody intended, and the
+    directory next door holds a 38 MB CSV.  Neither the decoy nor the
+    non-snapshot file may appear.
+    """
+    origin = _make_origin(tmp_path)
+    live = _make_live_dir(tmp_path, ["2026-08-11"])
+    key = tmp_path / "key"
+    key.write_text("k", encoding="utf-8")
+
+    assert _run(tmp_path, live, origin, key=key).returncode == 0
+
+    files = _committed_files(origin)
+    assert not any("depth_charts" in f for f in files), files
+    assert not any(f.endswith("notes.txt") for f in files), files
+    assert [f for f in files if "playerctx/history" in f] == [
+        "data/playerctx/history/snapshot_2026-08-11.json"
+    ]
+
+
+def test_a_missing_key_exits_clean_and_pushes_nothing(tmp_path):
+    """Exit 0, not 1 — a unit that goes red weekly is one nobody reads,
+    and nothing is half-done at that point."""
+    origin = _make_origin(tmp_path)
+    live = _make_live_dir(tmp_path, ["2026-08-11"])
+
+    proc = _run(tmp_path, live, origin, key=None)
+    assert proc.returncode == 0, proc.stderr
+    assert "no readable deploy key" in proc.stdout + proc.stderr
+    assert not any("playerctx/history" in f for f in _committed_files(origin))
+
+
+def test_the_backlog_survives_a_keyless_run(tmp_path):
+    """The claim exit-0 rests on, end to end: a keyless week loses
+    nothing, and the next run with a key backfills it."""
+    origin = _make_origin(tmp_path)
+    live = _make_live_dir(tmp_path, ["2026-08-11", "2026-08-18"])
+
+    assert _run(tmp_path, live, origin, key=None).returncode == 0
+    assert not any("playerctx/history" in f for f in _committed_files(origin))
+
+    key = tmp_path / "key"
+    key.write_text("k", encoding="utf-8")
+    assert _run(tmp_path, live, origin, key=key).returncode == 0
+
+    files = _committed_files(origin)
+    assert "data/playerctx/history/snapshot_2026-08-11.json" in files
+    assert "data/playerctx/history/snapshot_2026-08-18.json" in files
+
+
+def test_no_snapshots_exits_clean(tmp_path):
+    origin = _make_origin(tmp_path)
+    live = _make_live_dir(tmp_path, [])
+    key = tmp_path / "key"
+    key.write_text("k", encoding="utf-8")
+
+    proc = _run(tmp_path, live, origin, key=key)
+    assert proc.returncode == 0, proc.stderr
+    assert "no dated snapshots" in proc.stdout + proc.stderr
+
+
+def test_a_second_run_with_no_new_files_is_a_no_op(tmp_path):
+    """Re-pushing an unchanged tree must not create an empty commit —
+    the weekly timer runs whether or not the refresh produced anything."""
+    origin = _make_origin(tmp_path)
+    live = _make_live_dir(tmp_path, ["2026-08-11"])
+    key = tmp_path / "key"
+    key.write_text("k", encoding="utf-8")
+
+    assert _run(tmp_path, live, origin, key=key).returncode == 0
+    first = _git("rev-parse", "main", cwd=origin).strip()
+
+    proc = _run(tmp_path, live, origin, key=key)
+    assert proc.returncode == 0, proc.stderr
+    assert "no changes after copy" in proc.stdout + proc.stderr
+    assert _git("rev-parse", "main", cwd=origin).strip() == first

--- a/tests/playerctx/test_history_coverage_is_surfaced.py
+++ b/tests/playerctx/test_history_coverage_is_surfaced.py
@@ -1,0 +1,82 @@
+"""Retention coverage must reach a surface someone reads.
+
+`store.history_coverage` was written to make a halted retention timer
+visible "before a study needs the data rather than after it produces a
+wrong answer" — and was then wired to nothing at all, while its sibling
+`rank_history.coverage()` was surfaced on `/api/status` with a comment
+making the identical argument.
+
+That gap is why the 2026-08-05 deploy could install the producer, skip
+the pusher, and leave the only symptom in a deploy log nobody re-reads.
+A monitor that exists but is unreachable reads exactly like a working
+one, which is the failure this repo keeps rediscovering.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+_SERVER = _REPO / "server.py"
+
+
+def _server() -> str:
+    return _SERVER.read_text(encoding="utf-8", errors="replace")
+
+
+def test_the_status_payload_carries_retention_coverage():
+    body = _server()
+    assert '"playerctxHistoryCoverage": _playerctx_history_coverage_safe()' in body
+
+
+def test_the_helper_exists_and_never_raises():
+    """Same contract as `_rank_history_coverage_safe`: a diagnostic that
+    can take down the endpoint it reports on is worse than none."""
+    body = _server()
+    assert "def _playerctx_history_coverage_safe()" in body
+    block = body.split("def _playerctx_history_coverage_safe()", 1)[1].split("\ndef ", 1)[0]
+    assert "except Exception" in block
+    assert "return {}" in block
+
+
+def test_the_helper_uses_a_repo_root_that_server_actually_defines():
+    """The first draft passed `REPO_ROOT`, which `server.py` does not
+    define — a NameError inside the try, swallowed by the same guard that
+    makes the helper safe, so the field would have silently reported `{}`
+    forever. A monitor that always says "nothing to see" is worse than no
+    monitor, because it looks like a passing check.
+    """
+    body = _server()
+    block = body.split("def _playerctx_pending_push(", 1)[1].split("\ndef ", 1)[0]
+    names = set(re.findall(r"cwd=str\((\w+)\)", block))
+    assert names, "the git probe must run in an explicit working directory"
+    for name in names:
+        assert re.search(rf"^{name} = ", body, re.M), f"{name} is not defined in server.py"
+
+
+def test_pending_push_is_measured_not_assumed():
+    """The producer and the pusher fail independently.
+
+    `history_coverage` sees only the first: a stalled pusher leaves the
+    local directory looking perfect while `main` gets nothing, which is
+    the failure that actually happened. `data/` is gitignored repo-wide
+    and retained snapshots reach the tree only via an explicit
+    `git add -f`, so "on disk but untracked" is exactly "written but not
+    pushed".
+    """
+    body = _server()
+    assert "def _playerctx_pending_push(" in body
+    block = body.split("def _playerctx_pending_push(", 1)[1].split("\ndef ", 1)[0]
+    assert "ls-files" in block
+    assert "pendingPush" in block
+    # Absence of an answer must not be reported as zero pending.
+    assert "return {}" in block
+
+
+def test_the_probe_cannot_hang_the_status_endpoint():
+    """`/api/status` is polled by the settings page and the tools pages.
+    A subprocess without a timeout there is a way to wedge all of them."""
+    body = _server()
+    block = body.split("def _playerctx_pending_push(", 1)[1].split("\ndef ", 1)[0]
+    assert "timeout=" in block

--- a/tests/sharp/test_cohort_snapshot.py
+++ b/tests/sharp/test_cohort_snapshot.py
@@ -108,6 +108,67 @@ def test_uniform_scaling_shows_a_zero_spread():
     assert "spread 0.0000" in spread_line
 
 
+def _with_weights(users, weights_by_user):
+    snap = _snap(users, [users[0]])
+    for u in users:
+        snap["scores"][u]["weightsApplied"] = weights_by_user[u]
+    return snap
+
+
+_UNIFORM = {"performance": 0.4615, "multiLeagueConsistency": 0.2821, "longevity": 0.1538}
+
+
+def test_a_uniform_absent_set_proves_the_ordering_claim():
+    """One distinct weightsApplied map across the population is the whole
+    sharp-v2.1 safety argument: same factor for everyone, so the order —
+    and therefore the percentile-selected cohort — cannot have moved."""
+    mod = _load()
+    users = ["a", "b", "c"]
+    snap = _with_weights(users, {u: dict(_UNIFORM) for u in users})
+    code, lines = mod.verify_invariant(snap)
+    assert code == 0
+    assert any("INVARIANT HOLDS" in ln for ln in lines)
+
+
+def test_a_split_absent_set_fails_loudly():
+    """If managers do NOT share one absent set, renormalization scaled
+    them by different factors and could have reordered them — which is
+    exactly the case the shipped claim assumed away."""
+    mod = _load()
+    users = ["a", "b", "c"]
+    other = {"performance": 0.36, "rosterQuality": 0.22, "multiLeagueConsistency": 0.22}
+    snap = _with_weights(users, {"a": dict(_UNIFORM), "b": dict(_UNIFORM), "c": other})
+    code, lines = mod.verify_invariant(snap)
+    assert code == 1
+    assert any("INVARIANT VIOLATED" in ln for ln in lines)
+    assert any("distinct weightsApplied maps" in ln and ": 2" in ln for ln in lines)
+
+
+def test_an_unstamped_manager_is_not_silently_counted_as_agreeing():
+    """A missing stamp means the renormalization is unauditable for that
+    manager. Treating "no stamp" as "same as everyone else" would let the
+    check pass by ignoring the rows it cannot see."""
+    mod = _load()
+    users = ["a", "b"]
+    snap = _with_weights(users, {u: dict(_UNIFORM) for u in users})
+    snap["scores"]["b"]["weightsApplied"] = None
+    code, lines = mod.verify_invariant(snap)
+    assert code == 1
+    assert any("no weightsApplied stamp" in ln for ln in lines)
+
+
+def test_float_noise_does_not_split_an_otherwise_uniform_set():
+    """weightsApplied is rounded to 6dp at the source; comparing raw
+    floats would report a spurious violation from representation noise
+    rather than a real difference in the absent set."""
+    mod = _load()
+    users = ["a", "b"]
+    jittered = {k: v + 1e-12 for k, v in _UNIFORM.items()}
+    snap = _with_weights(users, {"a": dict(_UNIFORM), "b": jittered})
+    code, _ = mod.verify_invariant(snap)
+    assert code == 0
+
+
 def test_the_no_data_path_is_not_success():
     """`main()` must exit 2, never 0, on an empty population.
 


### PR DESCRIPTION
The two items left over from #744 were carried as "unobserved, waiting on time". Investigating both showed neither was a waiting problem — each had a real defect underneath, and one of them was **impossible** rather than pending.

## 1 — The retention monitor was built and never connected

`src/playerctx/store.py::history_coverage` exists, is unit-tested, and its own docstring says it is there so a halted timer is *"visible before a study needs the data rather than after it produces a wrong answer."*

It was wired to **nothing**, while its sibling `rank_history.coverage()` is surfaced on `/api/status` with a comment making the identical argument. That gap is exactly why the 2026-08-05 deploy could install the producer, silently skip the pusher, and leave the only symptom in a deploy log nobody re-reads.

Now surfaced as `playerctxHistoryCoverage` — plus `pendingPush`, which matters more than the coverage itself:

| failure | symptom | seen by |
|---|---|---|
| producer stalls | directory goes stale | `staleDays` |
| **pusher stalls** | directory looks perfect, `main` gets nothing | **nothing, until now** |

The second is the one that actually happened. `data/` is gitignored repo-wide and retained snapshots reach the tree only through an explicit `git add -f`, so "on disk but untracked" is precisely "written but not pushed". Verified against this repo: planting one untracked dated snapshot yields `pendingPush: 1, oldestPendingDate: "2026-08-11"`.

A test pins something the first draft got wrong: it passed `REPO_ROOT`, which `server.py` does not define. That `NameError` would have been swallowed by the same guard that makes the helper safe, so the field would have reported `{}` forever — a monitor that always says "nothing to see" is worse than no monitor, because it reads as a passing check.

## 2 — The push script had never executed. At all.

Not in CI, not locally, not on the box. `test_playerctx_history_timer_is_wired.py` greps its **source text**, which proves the wiring and nothing about the behaviour. Its first real run was scheduled against production `main`, where a bug costs a week and is discovered by absence — and nobody could distinguish "the timer never fired" from "the timer fired and did nothing".

Seven tests now drive it end to end against a local bare repo. Two carry their weight beyond smoke coverage:

- **every pending snapshot is taken, not just the newest** — this is the property that makes exit-0-on-a-missing-key safe, and it was previously asserted only by grepping for a glob;
- **nothing outside the history directory is ever staged**, against a planted decoy — the 38 MB depth-chart CSV lives one directory up, and a `git add -A` is what put an earlier PR into merge conflict.

## 3 — The v2.1 before/after is unrecoverable, so verify the invariant

`sharp-v2.1` is already live and nobody captured the prior cohort. The "before" does not exist on any box or in any commit. A before/after is not pending; it is impossible, and leaving it on the owed list forever is the same dishonesty as claiming it was done.

But the claim needs no baseline. The argument is *"the absent component set is identical for every manager → every score scales by the same factor → the order cannot move → and qualification is a percentile, so the cohort cannot change."* Every clause after the first follows from it, and the first is a property of **one population at one instant**.

`--verify-invariant` groups the live population by `weightsApplied` and reports the distinct maps. One map → the claim holds as a proof rather than an argument. More than one → renormalization scaled managers by different factors and the shipped claim is false on that population.

Three details decide whether it is worth trusting, all tested:
- an **empty population exits 2** — "every manager in an empty set shares one weight map" is vacuously true and proves nothing, so a dev box cannot report a pass (verified locally: exit 2);
- an **unstamped manager fails** rather than being skipped — treating "no stamp" as "agrees" would let the check pass by ignoring the rows it cannot see;
- weights compare at the **6dp they are stamped at**, so representation noise cannot fake a violation.

## 4 — A baseline now accumulates

`dynasty-sharp-cohort-snapshot`, daily 05:10 UTC — after the 04:50 records crawl that makes managers scoreable, before the 05:50 roster pass, clear of FFPC at 05:20. Snapshotting before records would capture a cohort built from yesterday's evidence and quietly date every baseline by a day.

The first attempt put `snapshot_$(date -u +%Y-%m-%d).json` in `ExecStart` and was caught by main's own `test_all_timers_are_wired`, which requires every ExecStart path to resolve to a real file. The script owns its filename via `--daily` instead — which also drops a `/bin/sh -c` wrapper and systemd `%` escaping.

## Tests

Full suite **6700 passed, 0 failed**. `ruff format --check .` clean across 911 files; `ruff check .` all passed.

## Not claimed

The `consensus_edge` flag stays **OFF**. Retention still has not retained anything — the first `chore(playerctx): retain snapshot …` commit is due Tuesday, and this PR makes its absence *visible* rather than making it happen sooner. The invariant check ships here; running it on prod is still a prod-side action.

---
_Generated by [Claude Code](https://claude.ai/code/session_0111wN4U1UQy7QqkTavTPGxK)_