### PR TITLE
Stop a dropped connection in the session mint from failing a whole E2E job

### DIFF
--- a/tests/e2e/helpers/auth-fixture.js
+++ b/tests/e2e/helpers/auth-fixture.js
@@ -21,6 +21,10 @@
 const base = require("@playwright/test");
 const { pageUrl } = require("./journey");
 
+// Session minting lives in its own module so it can be exercised without
+// Playwright's runner present.  See mint-session.js for why it retries.
+const { mintSession } = require("./mint-session");
+
 exports.test = base.test.extend({
   authedPage: async ({ page, baseURL }, use) => {
     const secret = process.env.E2E_TEST_SECRET;
@@ -28,9 +32,7 @@ exports.test = base.test.extend({
       base.test.skip(true, "E2E_TEST_SECRET not set — skipping signed-in tests");
       return;
     }
-    const resp = await page.request.post(`${baseURL}/api/test/create-session`, {
-      headers: { Authorization: `Bearer ${secret}` },
-    });
+    const resp = await mintSession(page, baseURL, secret);
     if (!resp.ok()) {
       base.test.skip(
         true,

--- a/tests/e2e/helpers/mint-session.js
+++ b/tests/e2e/helpers/mint-session.js
@@ -1,0 +1,67 @@
+/**
+ * Mint the E2E test session, retrying ONLY a dropped connection.
+ *
+ * Split out of `auth-fixture.js` so it carries no `@playwright/test` import and
+ * can be exercised by a plain `node` script — the fixture itself cannot be
+ * required without Playwright's runner present.
+ *
+ * WHY THIS RETRIES — and why that is not laundering a failure.
+ *
+ * Every authed spec runs this in its fixture, before a single assertion.  On
+ * 2026-08-05 two of them (`journey-rankings.spec.js:109` and `:152`) failed
+ * with `apiRequestContext.post: read ECONNRESET` and both passed on Playwright's
+ * retry, so the run reported **0 failed, 2 flaky, 140 passed** — and
+ * `failOnFlakyTests` correctly turned that into a red job, blocking a PR whose
+ * files were nowhere near either spec.
+ *
+ * The reset is a keep-alive race between Playwright's request context and
+ * uvicorn recycling an idle connection.  It carries no product signal: this
+ * POST is setup, not a behaviour under test, and a connection that dies before
+ * it is answered says nothing about the app.
+ *
+ * The distinction that keeps `failOnFlakyTests` honest:
+ *
+ *   - a transport error (no answer)      → retry, bounded
+ *   - ANY HTTP response, including 5xx   → returned as-is, never retried
+ *
+ * So a backend that answers wrongly still fails exactly as before, and a
+ * backend that is genuinely dead still fails: every attempt gets the same reset
+ * and the last error is rethrown, so `stack-death-reporter.js` still sees its
+ * `CONNECTION_ERROR` and prints the stack-death banner.  What this removes is a
+ * single dropped connection, which was previously indistinguishable from a real
+ * defect.
+ *
+ * Pinned by `tests/e2e/test_auth_fixture_retry.js`.
+ */
+
+// Transport-level failures, as distinct from an HTTP response.  These mean the
+// request never got an answer at all, so there is no status to reason about.
+const TRANSPORT_ERROR = /ECONNRESET|ECONNREFUSED|EPIPE|socket hang up/i;
+
+const MINT_ATTEMPTS = 3;
+const MINT_BACKOFF_MS = 250;
+
+const MINT_PATH = "/api/test/create-session";
+
+async function mintSession(page, baseURL, secret) {
+  let lastErr;
+  for (let attempt = 1; attempt <= MINT_ATTEMPTS; attempt += 1) {
+    try {
+      return await page.request.post(`${baseURL}${MINT_PATH}`, {
+        headers: { Authorization: `Bearer ${secret}` },
+      });
+    } catch (err) {
+      // Only a transport failure is retryable.  Anything else — a bad URL, a
+      // Playwright API misuse — is a real error and must surface immediately
+      // rather than being tried three times and reported as a connection blip.
+      if (!TRANSPORT_ERROR.test(String((err && err.message) || err))) throw err;
+      lastErr = err;
+      if (attempt < MINT_ATTEMPTS) {
+        await new Promise((resolve) => setTimeout(resolve, MINT_BACKOFF_MS * attempt));
+      }
+    }
+  }
+  throw lastErr;
+}
+
+module.exports = { mintSession, MINT_ATTEMPTS, MINT_PATH, TRANSPORT_ERROR };

--- a/tests/e2e/test_auth_fixture_retry.js
+++ b/tests/e2e/test_auth_fixture_retry.js
@@ -1,0 +1,100 @@
+/**
+ * `mintSession` retries a dropped connection, and nothing else.
+ *
+ * WHY THIS FILE EXISTS
+ *
+ * The E2E session mint runs in the `authedPage` fixture before every authed
+ * spec.  A single `ECONNRESET` there failed the spec outright; Playwright's
+ * retry then passed it, and `failOnFlakyTests` turned the retried green into a
+ * red job.  On 2026-08-05 that is exactly what happened to PR #741 — **0
+ * failed, 2 flaky, 140 passed** — on two specs the PR did not touch.
+ *
+ * Retrying setup is only safe if it cannot also hide a real failure, so the
+ * boundary is asserted here rather than left to the comment:
+ *
+ *   - transport error (no HTTP answer)  → retried, bounded at 3
+ *   - ANY HTTP response, 5xx included   → returned untouched, never retried
+ *   - a non-transport throw             → propagates on the FIRST attempt
+ *   - all attempts reset                → rethrows, so stack-death still fires
+ *
+ * Run: node tests/e2e/test_auth_fixture_retry.js  (exit 0 = pass)
+ * Also executed by tests/e2e/test_e2e_harness_guards.py.
+ */
+
+const assert = require("node:assert");
+const { mintSession } = require("./helpers/mint-session");
+
+/** A stand-in for Playwright's `page`, scripting one outcome per attempt. */
+function fakePage(outcomes) {
+  const calls = [];
+  return {
+    calls,
+    request: {
+      post: async (url, opts) => {
+        calls.push({ url, opts });
+        const next = outcomes.shift();
+        if (next instanceof Error) throw next;
+        return next;
+      },
+    },
+  };
+}
+
+const okResponse = { ok: () => true, status: () => 200 };
+
+async function main() {
+  // 1. A clean mint calls once and returns the response.
+  {
+    const page = fakePage([okResponse]);
+    const resp = await mintSession(page, "http://x", "s");
+    assert.strictEqual(resp, okResponse);
+    assert.strictEqual(page.calls.length, 1, "a clean mint must not retry");
+    assert.strictEqual(
+      page.calls[0].opts.headers.Authorization,
+      "Bearer s",
+      "the bearer secret must still be sent",
+    );
+  }
+
+  // 2. One reset, then success — the case that was failing whole jobs.
+  {
+    const page = fakePage([new Error("apiRequestContext.post: read ECONNRESET"), okResponse]);
+    const resp = await mintSession(page, "http://x", "s");
+    assert.strictEqual(resp, okResponse);
+    assert.strictEqual(page.calls.length, 2, "a reset must be retried exactly once here");
+  }
+
+  // 3. An HTTP response is NEVER retried — not even a 500.  This is the
+  //    property that keeps the retry from laundering a real backend failure.
+  {
+    const five00 = { ok: () => false, status: () => 500 };
+    const page = fakePage([five00, okResponse]);
+    const resp = await mintSession(page, "http://x", "s");
+    assert.strictEqual(resp, five00, "a 500 must be returned, not retried away");
+    assert.strictEqual(page.calls.length, 1, "an HTTP answer must not trigger a retry");
+  }
+
+  // 4. A non-transport throw surfaces immediately, undisguised.
+  {
+    const boom = new TypeError("page.request.post is not a function");
+    const page = fakePage([boom, okResponse]);
+    await assert.rejects(() => mintSession(page, "http://x", "s"), /not a function/);
+    assert.strictEqual(page.calls.length, 1, "a real error must not be retried");
+  }
+
+  // 5. A genuinely dead stack still fails, and still looks like a connection
+  //    error, so stack-death-reporter.js keeps matching it.
+  {
+    const reset = () => new Error("apiRequestContext.post: read ECONNRESET");
+    const page = fakePage([reset(), reset(), reset()]);
+    await assert.rejects(() => mintSession(page, "http://x", "s"), /ECONNRESET/);
+    assert.strictEqual(page.calls.length, 3, "must stop at the attempt bound");
+  }
+
+  console.log("auth-fixture mintSession: 5 assertions passed");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/e2e/test_e2e_harness_guards.py
+++ b/tests/e2e/test_e2e_harness_guards.py
@@ -514,5 +514,54 @@ class TestSubsetRunsCarryTheirOwnCoverageFloor(unittest.TestCase):
         self.assertEqual(offenders, [], "\n".join(offenders))
 
 
+class TestSessionMintRetrySemantics(unittest.TestCase):
+    """The session mint retries a dropped connection, and nothing else.
+
+    ``mintSession`` runs in the ``authedPage`` fixture before every authed
+    spec, so a single ``ECONNRESET`` there failed the spec outright.  On
+    2026-08-05 that produced **0 failed, 2 flaky, 140 passed** on PR #741 —
+    ``journey-rankings.spec.js:109`` and ``:152``, neither touched by that PR
+    — and ``failOnFlakyTests`` correctly turned the retried green into a red
+    job.
+
+    Retrying setup is only safe if it cannot also hide a real failure.  The
+    JS guard asserts that boundary directly (a 5xx is returned untouched, a
+    non-transport throw propagates on the first attempt, an exhausted retry
+    still rethrows so ``stack-death-reporter.js`` keeps matching it).
+
+    It runs here, in the fast pytest gate, for the same reason as the guards
+    above: this defect makes authed specs fail *everywhere at once* and so
+    reads as a broken product rather than a broken harness.  Running it from
+    pytest also means it needs no Playwright runner — which is exactly why
+    ``mintSession`` lives in its own module.
+    """
+
+    def test_mint_session_guard_passes(self) -> None:
+        import shutil
+        import subprocess
+
+        node = shutil.which("node")
+        if node is None:  # pragma: no cover - CI always has node
+            self.skipTest("node not on PATH")
+
+        guard = E2E_DIR / "test_auth_fixture_retry.js"
+        self.assertTrue(guard.is_file(), f"missing guard script: {guard}")
+
+        proc = subprocess.run(
+            [node, str(guard)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=str(REPO_ROOT),
+        )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            "tests/e2e/test_auth_fixture_retry.js failed — the session-mint "
+            "retry no longer has the semantics it claims:\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}",
+        )
+
+
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
Found while auditing the open PR backlog: **this is what is currently blocking #741**, and it can block any PR.

## The failure

`mintSession` runs in the `authedPage` fixture before every authed spec, and had no retry. A single transport error there fails the spec outright.

PR #741, [run 31025224262](https://github.com/jasonleetucker-code/riskittogetthebrisket/actions/runs/31025224262):

```
0 failed · 2 flaky · 140 passed (4.1m)

✘ journey-rankings.spec.js:109  search input filters the board by name fragment
✓ journey-rankings.spec.js:109  (retry #1)
✘ journey-rankings.spec.js:152  global search ('/' shortcut) …
✓ journey-rankings.spec.js:152  (retry #1)

Error: apiRequestContext.post: read ECONNRESET
Error: apiRequestContext.post: read ECONNRESET
```

Zero real failures. `failOnFlakyTests` then correctly turned the retried green into `exit code 1`, and #741 — whose diff is `src/public_league/matchup_recap.py`, a recap page and some comments — was blocked by two rankings specs it never touched.

The reset is a keep-alive race between Playwright's request context and uvicorn recycling an idle connection. It is undocumented anywhere in the repo; the only existing acknowledgement of `ECONNRESET` is `stack-death-reporter.js`'s `CONNECTION_ERROR` regex.

## Why this is not a relaxation of the flaky gate

The retry is scoped so it cannot launder a real failure, and the boundary is asserted rather than asserted-in-a-comment:

| situation | behaviour |
|---|---|
| transport error — the request got **no answer at all** | retried, bounded at 3 |
| **any** HTTP response, 5xx included | returned untouched, never retried |
| a non-transport throw (bad URL, API misuse) | propagates on attempt 1 |
| every attempt reset | rethrows, so `stack-death-reporter.js` still matches and still prints its banner |

A backend that answers wrongly fails exactly as before. A backend that is genuinely dead still fails, with the right banner. What is removed is a single dropped connection **during setup** — a POST that is not a behaviour under test — which was previously indistinguishable from a real defect.

`failOnFlakyTests` in `playwright.config.js` is **untouched**, and `TestFlakyGateIsArmed`, the guard that asserts it is still set, still passes. This fixes the flake instead of tolerating it, which is the posture that gate exists to enforce.

## Shape

`mintSession` moves to `tests/e2e/helpers/mint-session.js` so it carries no `@playwright/test` import — the fixture itself cannot be `require`d without Playwright's runner, which would have made the guard below impossible to run cheaply.

`tests/e2e/test_auth_fixture_retry.js` pins all four rows of that table and runs in the **fast pytest gate** via `test_e2e_harness_guards.py`, alongside the existing harness guards, for the reason that file states: this class of defect makes authed specs fail *everywhere at once* and so reads as a broken product rather than a broken harness.

## Testing

- `pytest tests/e2e/test_e2e_harness_guards.py` — **14 passed** (13 existing + the new one)
- `node tests/e2e/test_auth_fixture_retry.js` — 5 assertions passed
- `ruff format --check` / `ruff check` — clean
- **Mutation-tested**: changing `mint-session.js` to retry *every* error rather than only transport errors makes the guard fail on the "a real error must not be retried" assertion.

## Limitation, stated

I have not reproduced the `ECONNRESET` locally — it is a timing race on a loaded CI runner, and the diagnosis rests on the run log above plus the absence of any retry in the fixture. If the reset turns out to have a server-side cause in `/api/test/create-session`, this change makes the symptom rare rather than fixing that cause, and the exhausted-retry path still surfaces it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYcUBrcQvMWvK4MJ5pTstc)_