### PR TITLE
Stop non-data routes from fetching the player contract (and fix the dead search button)

### DIFF
--- a/frontend/__tests__/app-shell-route-gates.test.js
+++ b/frontend/__tests__/app-shell-route-gates.test.js
@@ -1,0 +1,113 @@
+/**
+ * AppShell route gates — which routes hydrate the player pipeline.
+ *
+ * Two INDEPENDENT predicates, deliberately not merged:
+ *
+ *   isPublicOnlyRoute    — a PRIVACY boundary. The /league subtree is
+ *                          reachable logged-out, and /api/data carries
+ *                          private rankings, edge signals and trade
+ *                          targets. Adding a route here is a security
+ *                          statement.
+ *   isNoPlayerDataRoute  — a COST decision. These are private routes
+ *                          that simply have no player data to render.
+ *
+ * Folding the second list into the first would make the next person
+ * auditing "what is public" read /admin off the public list and get a
+ * wrong answer. These tests exist mostly to keep them apart.
+ *
+ * Pure functions, so tested directly — a wrong entry breaks a page
+ * rather than slowing it, which is worth a cheap unit test.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({ usePathname: () => "/" }));
+
+import { __routeGates } from "@/components/AppShell";
+
+const { isPublicOnlyRoute, isNoPlayerDataRoute, NO_PLAYER_DATA_ROUTE_PREFIXES } =
+  __routeGates;
+
+// Mirrors AppShell's own composition. If this drifts from the component,
+// the assertions below stop describing production.
+const privateDataEnabled = (pathname) =>
+  !isPublicOnlyRoute(pathname) && !isNoPlayerDataRoute(pathname);
+
+describe("isPublicOnlyRoute — the privacy boundary", () => {
+  it("matches /league and its descendants", () => {
+    expect(isPublicOnlyRoute("/league")).toBe(true);
+    expect(isPublicOnlyRoute("/league/franchise/abc")).toBe(true);
+  });
+
+  it("does not match a route that merely shares a prefix string", () => {
+    // "/leagues" starts with "/league" as a STRING but is a different
+    // route; the guard joins on a path separator for exactly this.
+    expect(isPublicOnlyRoute("/leagues")).toBe(false);
+  });
+
+  it("stays limited to /league — new entries here are security changes", () => {
+    expect(__routeGates.PUBLIC_ONLY_ROUTE_PREFIXES).toEqual(["/league"]);
+  });
+
+  it("handles a null pathname without throwing", () => {
+    expect(isPublicOnlyRoute(null)).toBe(false);
+    expect(isPublicOnlyRoute(undefined)).toBe(false);
+    expect(isPublicOnlyRoute("")).toBe(false);
+  });
+});
+
+describe("isNoPlayerDataRoute — the cost decision", () => {
+  it.each(NO_PLAYER_DATA_ROUTE_PREFIXES)("matches %s exactly", (route) => {
+    expect(isNoPlayerDataRoute(route)).toBe(true);
+  });
+
+  it("matches descendants, so /admin/sharp-identities is covered", () => {
+    expect(isNoPlayerDataRoute("/admin/sharp-identities")).toBe(true);
+  });
+
+  it("does not match on a shared prefix string", () => {
+    expect(isNoPlayerDataRoute("/logins")).toBe(false);
+    expect(isNoPlayerDataRoute("/administration")).toBe(false);
+  });
+
+  it("handles a null pathname without throwing", () => {
+    expect(isNoPlayerDataRoute(null)).toBe(false);
+  });
+});
+
+describe("the two routes deliberately NOT gated", () => {
+  // Both were audited and rejected. They are asserted here so a future
+  // "obvious" addition fails a test that explains itself rather than
+  // breaking the page at runtime.
+  it("keeps /settings on the player pipeline — it calls useDynastyData() itself", () => {
+    // Gating the shell would not even stop its fetch, because the PAGE
+    // mounts the hook. It would only strip its search.
+    expect(isNoPlayerDataRoute("/settings")).toBe(false);
+    expect(privateDataEnabled("/settings")).toBe(true);
+  });
+
+  it("keeps /tools/trade-coverage on the pipeline — it reads useApp().rawData", () => {
+    expect(isNoPlayerDataRoute("/tools/trade-coverage")).toBe(false);
+    expect(privateDataEnabled("/tools/trade-coverage")).toBe(true);
+  });
+
+  it("gates the other /tools health pages, which read /api/status instead", () => {
+    expect(privateDataEnabled("/tools/source-health")).toBe(false);
+    expect(privateDataEnabled("/tools/ros-data-health")).toBe(false);
+  });
+});
+
+describe("privateDataEnabled composition", () => {
+  it("is false for either reason, and true only when neither applies", () => {
+    expect(privateDataEnabled("/league")).toBe(false); // privacy
+    expect(privateDataEnabled("/login")).toBe(false); // cost
+    expect(privateDataEnabled("/rankings")).toBe(true);
+    expect(privateDataEnabled("/trade")).toBe(true);
+    expect(privateDataEnabled("/draft")).toBe(true);
+  });
+
+  it("leaves the data-bearing routes alone", () => {
+    for (const route of ["/", "/rankings", "/trade", "/draft", "/waivers", "/bdvm"]) {
+      expect(privateDataEnabled(route), `${route} must keep its data`).toBe(true);
+    }
+  });
+});

--- a/frontend/__tests__/components/shell/TopBar.test.jsx
+++ b/frontend/__tests__/components/shell/TopBar.test.jsx
@@ -20,7 +20,7 @@ vi.mock("@/components/LeagueSwitcher", () => ({
 }));
 
 import TopBar from "@/components/shell/TopBar";
-import { MobileTabBar } from "@/components/shell/MobileChrome";
+import { MobileTabBar, MobileTopBar } from "@/components/shell/MobileChrome";
 // The real predicate, not a local copy — a stale duplicate here is how
 // the shell and the middleware drifted apart in the first place.
 import { isPublicPath } from "@/lib/public-routes";
@@ -260,5 +260,56 @@ describe("MobileTabBar", () => {
     expect(screen.getByRole("link", { name: /Sign in/ })).toHaveAttribute("href", "/login");
     expect(screen.getByRole("link", { name: /League/ })).toHaveAttribute("href", "/league");
     expect(screen.queryByRole("link", { name: /Ranks/ })).toBeNull();
+  });
+});
+
+describe("search affordance is gated on searchEnabled, not authenticated", () => {
+  // Regression: global search reads the player contract, and there are
+  // signed-in routes that never load one — the public /league subtree
+  // and AppShell's no-player-data routes. Both nav bars used to render
+  // the button on `authenticated` alone while AppShell's openSearch()
+  // returned early, so a signed-in user on /league saw a search button
+  // that did nothing at all.
+  it("TopBar renders the button when search is available", () => {
+    render(
+      <TopBar
+        authenticated
+        isPublic={isPublic}
+        onSearch={() => {}}
+        searchEnabled
+        onLogout={() => {}}
+      />
+    );
+    expect(screen.getByRole("button", { name: /Search/ })).toBeInTheDocument();
+  });
+
+  it("TopBar hides it when search cannot work, even signed in", () => {
+    render(
+      <TopBar
+        authenticated
+        isPublic={isPublic}
+        onSearch={() => {}}
+        searchEnabled={false}
+        onLogout={() => {}}
+      />
+    );
+    expect(screen.queryByRole("button", { name: /Search/ })).toBeNull();
+  });
+
+  it("MobileTopBar hides it when search cannot work", () => {
+    render(<MobileTopBar authenticated onSearch={() => {}} searchEnabled={false} />);
+    expect(screen.queryByRole("button", { name: /Search/ })).toBeNull();
+  });
+
+  it("MobileTopBar shows it when search is available", () => {
+    render(<MobileTopBar authenticated onSearch={() => {}} searchEnabled />);
+    expect(screen.getByRole("button", { name: /Search/ })).toBeInTheDocument();
+  });
+
+  it("defaults to showing the button, so callers predating the prop are unaffected", () => {
+    render(
+      <TopBar authenticated isPublic={isPublic} onSearch={() => {}} onLogout={() => {}} />
+    );
+    expect(screen.getByRole("button", { name: /Search/ })).toBeInTheDocument();
   });
 });

--- a/frontend/__tests__/public-league.test.js
+++ b/frontend/__tests__/public-league.test.js
@@ -181,10 +181,29 @@ describe("AppShell public-route gating", () => {
     expect(appShellSource).toMatch(/PUBLIC_ONLY_ROUTE_PREFIXES[^\n]*\/league/);
   });
 
-  it("refuses to hydrate useDynastyData inside the public shell", () => {
-    // PublicAppShell must explicitly not call useDynastyData.
-    const publicShellMatch = appShellSource.match(/function PublicAppShell[\s\S]*?^}/m);
-    expect(publicShellMatch).toBeTruthy();
-    expect(publicShellMatch[0]).not.toMatch(/useDynastyData\(/);
+  it("refuses to hydrate useDynastyData inside the dataless shell", () => {
+    // Renamed from PublicAppShell to NoPlayerDataAppShell when private
+    // routes with no player data (/login, /more, /admin, …) started
+    // taking the same branch. The privacy invariant this test guards is
+    // unchanged: whichever shell serves /league must never call
+    // useDynastyData, because /api/data carries private rankings, edge
+    // signals and trade targets.
+    //
+    // toBeTruthy() on the match is load-bearing — if this component is
+    // renamed again the regex stops matching, and without that assertion
+    // `not.toMatch` on an empty string would PASS and the guard would
+    // silently stop guarding.
+    const shellMatch = appShellSource.match(/function NoPlayerDataAppShell[\s\S]*?^}/m);
+    expect(shellMatch).toBeTruthy();
+    expect(shellMatch[0]).not.toMatch(/useDynastyData\(/);
+  });
+
+  it("routes /league to the dataless shell, not the private one", () => {
+    // The rename above is only safe if the branch still sends /league
+    // there. Pin the composition, so a future edit that gates /league
+    // into PrivateAppShell fails here rather than in production.
+    expect(appShellSource).toMatch(
+      /!isPublicOnlyRoute\(pathname\)\s*&&\s*!isNoPlayerDataRoute\(pathname\)/,
+    );
   });
 });

--- a/frontend/app/AppShellWrapper.jsx
+++ b/frontend/app/AppShellWrapper.jsx
@@ -78,7 +78,7 @@ function ShellChrome({ children }) {
   // INSIDE AppShell so the search affordances can reach it.
   return (
     <AppShellSearchBridge>
-      {(openSearch) => (
+      {(openSearch, searchEnabled) => (
         <>
           <a href="#main" className="shell-skip-link">
             Skip to content
@@ -88,9 +88,14 @@ function ShellChrome({ children }) {
             isAdmin={isAdmin}
             isPublic={isPublicRoute}
             onSearch={openSearch}
+            searchEnabled={searchEnabled}
             onLogout={logout}
           />
-          <MobileTopBar authenticated={authenticated} onSearch={openSearch} />
+          <MobileTopBar
+            authenticated={authenticated}
+            onSearch={openSearch}
+            searchEnabled={searchEnabled}
+          />
           <StaleDataBanner />
           <RouteFocusManager mainRef={mainRef} />
           <main
@@ -116,10 +121,13 @@ function ShellChrome({ children }) {
 
 // Small bridge so the chrome (rendered inside AppShell) can hand the
 // context's openSearch down to both nav bars without re-importing
-// useApp in every shell component.
+// useApp in every shell component.  It also carries `searchEnabled`,
+// because whether search WORKS is AppShell's answer to give — the nav
+// bars cannot derive it from `authenticated` alone (a signed-in user on
+// /league is authenticated and still has no contract to search).
 function AppShellSearchBridge({ children }) {
-  const { openSearch } = useApp();
-  return children(openSearch);
+  const { openSearch, searchEnabled } = useApp();
+  return children(openSearch, searchEnabled);
 }
 
 // ── Main shell wrapper ───────────────────────────────────────────────────

--- a/frontend/components/AppShell.jsx
+++ b/frontend/components/AppShell.jsx
@@ -106,6 +106,7 @@ const AppContext = createContext({
   openSearch: () => {},
   registerAddToTrade: () => {},
   privateDataEnabled: true,
+  searchEnabled: false,
 });
 
 export function useApp() {
@@ -127,6 +128,49 @@ function isPublicOnlyRoute(pathname) {
   );
 }
 
+// Routes that are PRIVATE but have no use for player data.  Deliberately
+// a SECOND list rather than more entries in PUBLIC_ONLY_ROUTE_PREFIXES:
+// that constant is a privacy boundary ("public visitors must not see the
+// contract"), and every route below is one only a signed-in user reaches.
+// Folding them together would make the next person auditing "what is
+// public" read `/admin` off the public list and get a wrong answer.
+//
+// The win is real rather than bookkeeping: `prefetchBaseContract()` is
+// called INSIDE useDynastyData (useDynastyData.js:111), which only
+// PrivateAppShell mounts, so skipping that branch skips the multi-MB
+// GET itself — not merely the ~1,100-row buildRows pass.
+//
+// Every entry was checked for `useApp()` / `useDynastyData()` consumers
+// in its tree.  Two candidates were REJECTED and must stay off this list:
+//   /settings              — calls useDynastyData() directly (page.jsx),
+//                            so gating the shell would not even stop its
+//                            fetch; it would only strip its search.
+//   /tools/trade-coverage  — reads useApp().rawData to build the audit.
+const NO_PLAYER_DATA_ROUTE_PREFIXES = [
+  "/login",
+  "/more",
+  "/design",
+  "/admin",
+  "/tools/source-health",
+  "/tools/ros-data-health",
+];
+
+function isNoPlayerDataRoute(pathname) {
+  if (!pathname) return false;
+  return NO_PLAYER_DATA_ROUTE_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(prefix + "/"),
+  );
+}
+
+// Exported for direct unit testing — these are pure functions and cheap
+// to pin, and a wrong entry breaks a page rather than slowing it.
+export const __routeGates = {
+  PUBLIC_ONLY_ROUTE_PREFIXES,
+  NO_PLAYER_DATA_ROUTE_PREFIXES,
+  isPublicOnlyRoute,
+  isNoPlayerDataRoute,
+};
+
 /**
  * AppShell provides app-wide data, player popup, and global search.
  * Wrap children in layout.jsx.
@@ -136,12 +180,23 @@ function isPublicOnlyRoute(pathname) {
  */
 export default function AppShell({ children, authenticated = false }) {
   const pathname = usePathname();
-  const privateDataEnabled = !isPublicOnlyRoute(pathname);
+  // Two INDEPENDENT reasons to skip the player pipeline, composed rather
+  // than merged: one is a privacy boundary, one is "this page has no use
+  // for it".  Each stays readable on its own.
+  //
+  // Gating on `authenticated` instead of a route list was considered and
+  // rejected: useAuth is tri-state and AppShellWrapper passes
+  // `authenticated === true`, so it is `false` during the auth probe.
+  // That would serialize the contract fetch behind an auth round-trip on
+  // EVERY page — trading a wasted fetch on /login for a slower first
+  // paint everywhere.
+  const privateDataEnabled =
+    !isPublicOnlyRoute(pathname) && !isNoPlayerDataRoute(pathname);
 
   return privateDataEnabled ? (
     <PrivateAppShell authenticated={authenticated}>{children}</PrivateAppShell>
   ) : (
-    <PublicAppShell authenticated={authenticated}>{children}</PublicAppShell>
+    <NoPlayerDataAppShell authenticated={authenticated}>{children}</NoPlayerDataAppShell>
   );
 }
 
@@ -162,7 +217,11 @@ function PrivateAppShell({ children, authenticated }) {
   );
 }
 
-function PublicAppShell({ children, authenticated }) {
+// Serves BOTH reasons above: the public /league subtree, where hydrating
+// /api/data would leak private data, and private routes that simply have
+// no player data to show.  Named for what it does (no player data) rather
+// than for either reason, since it now answers to two.
+function NoPlayerDataAppShell({ children, authenticated }) {
   // No useDynastyData call — the public page pipeline must never
   // hydrate from /api/data.  The search + popup components render
   // against an empty rows list so they simply no-op rather than
@@ -295,6 +354,15 @@ function InnerAppShell({ loading, error, rows, siteKeys, rawData, privateDataEna
         openSearch,
         registerAddToTrade,
         privateDataEnabled,
+        // Exposed so the chrome can HIDE the search affordance rather
+        // than render one that no-ops.  openSearch() returns early when
+        // this is false, but TopBar/MobileTopBar gated the button on
+        // `authenticated` alone — so a signed-in user on /league has been
+        // seeing a dead search button, and gating more routes would have
+        // spread that.  Search genuinely cannot work without the
+        // contract (it searches players), so hiding it is the honest
+        // outcome, not a compromise.
+        searchEnabled,
       }}
     >
       {children}

--- a/frontend/components/shell/MobileChrome.jsx
+++ b/frontend/components/shell/MobileChrome.jsx
@@ -55,7 +55,10 @@ function DrawerGroup({ label, items, pathname, onNavigate }) {
   );
 }
 
-export function MobileTopBar({ authenticated, onSearch }) {
+// See the note on TopBar: `searchEnabled` is not derivable from
+// `authenticated`, because signed-in routes exist that load no player
+// contract.  Defaults true so existing callers are unaffected.
+export function MobileTopBar({ authenticated, onSearch, searchEnabled = true }) {
   const pathname = usePathname();
   return (
     <header className="shell-mobile-topbar" data-html2canvas-ignore>
@@ -63,7 +66,7 @@ export function MobileTopBar({ authenticated, onSearch }) {
       <div className="shell-mobile-actions">
         {authenticated && <LeagueSwitcher variant="mobile" />}
         {authenticated && <TeamSwitcher variant="mobile" />}
-        {authenticated && (
+        {authenticated && searchEnabled && (
           <button
             type="button"
             className="shell-icon-btn"

--- a/frontend/components/shell/TopBar.jsx
+++ b/frontend/components/shell/TopBar.jsx
@@ -52,7 +52,20 @@ function visibleGroups(authenticated, isPublic) {
   }).filter(Boolean);
 }
 
-export default function TopBar({ authenticated, isAdmin, isPublic, onSearch, onLogout }) {
+// `searchEnabled` is separate from `authenticated` on purpose: global
+// search reads the player contract, and there are signed-in routes that
+// never load one (the public /league subtree, and the no-player-data
+// routes in AppShell).  Gating the button on `authenticated` rendered a
+// control whose onClick returns early — a dead affordance.  Defaults true
+// so any caller that predates the prop keeps its current behaviour.
+export default function TopBar({
+  authenticated,
+  isAdmin,
+  isPublic,
+  onSearch,
+  searchEnabled = true,
+  onLogout,
+}) {
   const pathname = usePathname();
   const groups = visibleGroups(authenticated, isPublic);
   const systemItems = systemItemsFor({ isAdmin });
@@ -93,7 +106,7 @@ export default function TopBar({ authenticated, isAdmin, isPublic, onSearch, onL
         <div className="shell-nav-right">
           {authenticated && <LeagueSwitcher variant="desktop" />}
           {authenticated && <TeamSwitcher variant="desktop" />}
-          {authenticated && (
+          {authenticated && searchEnabled && (
             <button
               type="button"
               className="shell-search-btn"


### PR DESCRIPTION
Ledger item "Planned #3". `/login` fetched the multi-MB `/api/data` contract and materialized ~1,100 rows to render a password box. Six routes did.

**The win is the network request, not just the render.** `prefetchBaseContract()` is called *inside* `useDynastyData` (`useDynastyData.js:111`), and only `PrivateAppShell` mounts that hook — so taking the other branch skips the GET itself, not merely the `buildRows` pass.

## Measured, in a signed-in browser

| route | contract requests | `<main>` rendered |
|---|---|---|
| `/login` | **0** | 121 chars |
| `/more` | **0** | 1,616 chars |
| `/design` | **0** | 3,854 chars |
| `/admin` | **0** | 2,148 chars |
| `/tools/source-health` | **0** | 141 chars |
| `/rankings` *(control)* | 1 | — |
| `/settings` *(control)* | 1 | — |
| `/tools/trade-coverage` *(control)* | 1 | — |

Watched as real network traffic rather than asserted from the code. The control group is the probe's own self-check: without it, five zeros could equally mean the probe was blind. Render is checked alongside, because a gated page that *crashed* would also fetch nothing.

## A second list, not more entries in `PUBLIC_ONLY_ROUTE_PREFIXES`

That constant is a **privacy boundary** — its own comment says the contract "leaks private rankings, edge signals, trade targets, and source-override state that public visitors must not see." Every route added here is private; only a signed-in user reaches `/admin`. Folding them together would leave the next person auditing "what is public" reading `/admin` off the public list and getting a wrong answer.

So: two independently-named predicates, composed. `PublicAppShell` becomes `NoPlayerDataAppShell`, since it now answers to both reasons.

**Two candidates were audited and rejected**, and are pinned as such so a future "obvious" addition fails a test that explains itself:

- **`/settings`** calls `useDynastyData()` *directly*, so gating the shell wouldn't even stop its fetch — it would only strip its search.
- **`/tools/trade-coverage`** reads `useApp().rawData` to build the audit.

**Gating on `authenticated` instead of a route list was also rejected.** `useAuth` is tri-state and `AppShellWrapper` passes `authenticated === true`, so it's `false` during the auth probe. That would serialize the contract fetch behind an auth round-trip on *every* page — trading a wasted fetch on `/login` for a slower first paint everywhere.

## Fixes a live defect on the way

`searchEnabled` is `privateDataEnabled && authenticated`, and `openSearch()` returns early without it — but `TopBar` and `MobileTopBar` rendered the search button on `authenticated` **alone**. So a signed-in user on `/league` has been seeing a search button that does nothing, and gating six more routes would have spread it.

`searchEnabled` now reaches both nav bars through the existing `AppShellSearchBridge`. Search reads the player contract, so hiding the affordance where there is no contract is the honest outcome, not a compromise. Defaults `true`, so callers predating the prop are unaffected.

## Testing

- **2010 tests pass** (118 files).
- New `app-shell-route-gates.test.js` pins both predicates, prefix-vs-separator matching (`/leagues` must not match `/league`), and the two deliberate exclusions.
- `TopBar.test.jsx` gains search-affordance gating for both nav bars, including the default-on case.
- `public-league.test.js`'s static guard is updated for the rename and gains an assertion that `/league` still routes to the dataless shell. Its `toBeTruthy()` on the regex match is load-bearing — a failed match would make the following `not.toMatch()` pass vacuously and the guard would silently stop guarding.
- Bundle budgets unchanged: `/login` 7.6/15 KB, `/more` 8.1/10 KB (the tightest in the repo).

Branched off `main` rather than stacked on #758, so this is independently mergeable.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaMgGfyHGEs38eGJ3kBf6H)_