### PR TITLE
Fix the board FPS harness — it was measuring itself, and windowing DOES fix the board

### DIFF
--- a/docs/performance-optimization.md
+++ b/docs/performance-optimization.md
@@ -995,7 +995,122 @@ One known tail: `/draft` hits ~0.18 in roughly 1 run in 5, attributed
 to a `DIV.muted` block collapsing 361×166 → 0 at ~900ms.  Pre-existing,
 not round 6's doing, and not yet fixed.
 
-## 2026-08-05 — row windowing: BUILT, MEASURED, REVERTED
+## 2026-08-06 — RETRACTION: row windowing DOES fix it, and the harness lied
+
+**The section immediately below is wrong and is kept only as a record.**
+Its conclusion — "row count is not what makes the board scroll slowly" —
+was produced by a harness that measured its own scroll loop. Fixing the
+harness reverses the finding completely.
+
+### The defect in the instrument
+
+`measure-board-fps.mjs` drove the page with `window.scrollBy()` +
+`await new Promise(r => setTimeout(r, 16))`, 30 times. That is not a
+scroll; it is 30 jumps paced by a timer, and the frame counter therefore
+measured how fast that loop could turn over — bounded **above** by the
+timer at ~60/s regardless of how fast the page was. Every absolute number
+below is a property of the loop as much as of the board, which is exactly
+why the 65-row board (32.1) and the 964-row board (28.6) came out
+indistinguishable. They are not.
+
+Rewritten to drive the scroll with CDP `Input.synthesizeScrollGesture`
+and sample `requestAnimationFrame` timestamps with **no timer anywhere in
+the loop**, 9000 px at 2400 px/s, 3 runs each, median:
+
+| board | rows | DOM nodes | 1× | 4× | 6× |
+|---|---|---|---|---|---|
+| capped | 200 | 6,597 | 32.8 | 9.0 | — |
+| "Show all" | 964 | 30,501 | **22–27** | **5.7–6.5** | **4.1** |
+| *control: trivial 600-div page* | — | ~1,800 | **60.0** | **60.0** | **59.7** |
+
+The control is the part that makes the rest readable, and it is new: a
+trivial page holds **60 FPS at every throttle rate, including 6×**. So
+the harness can produce 60 here, CPU throttling alone does not degrade
+it, and the board's collapse is entirely the board's.
+
+### Windowing reaches the 1× target outright
+
+Simulated by removing all but ~60 rows from layout on the live board
+(`display:none` on `:nth-child(n+61)`) — the same thing a window achieves
+by unmounting, without needing the implementation:
+
+| arm | 1× | 4× | 6× |
+|---|---|---|---|
+| baseline, 964 rows | 22.2 | 6.0 | 4.1 |
+| **~60 rows laid out** | **59.5** | **23.3** | **15.0** |
+| ~200 rows laid out | 36.6 | 9.9 | — |
+
+**1×: 22 → 59.5, which MEETS the ≥50 target.** 4×: 6.0 → 23.3, still
+short of ≥30 but a ~4× improvement. 6×: 4.1 → 15.0.
+
+The old table's "windowing bought ~2 FPS" was the timer floor absorbing
+the entire effect.
+
+### It is LAYOUT, not paint — and that is why the CSS fixes all failed
+
+Every cheap intervention was ablated on the live board, `!important`
+overrides, same driver, with the baseline re-measured first and last so
+drift is visible (it is ~10%, and every arm below sits inside it):
+
+| suspect removed | 1× | 4× |
+|---|---|---|
+| baseline | 26.5 / 22.8 (drift) | 6.5 / 5.4 |
+| `tr:hover .sticky-name` (cursor parked off-table) | 23.4 | 6.3 |
+| `.sticky-name` `box-shadow` | 25.2 | 5.2 |
+| `.sticky-name` `position: sticky` | 22.4 | 6.2 |
+| `thead th` `position: sticky` | 21.4 | 4.4 |
+| all sticky, everywhere | 20.6 | 4.7 |
+| `table-layout: fixed` | 24.2 | 6.0 |
+| `content-visibility: auto` on rows | 22.7 | 6.5 |
+| `contain: layout paint style` on rows | 23.4 | 5.7 |
+| **`visibility: hidden` on rows 61+** (skips PAINT, keeps layout) | **29.5** | **9.4** |
+| **`display: none` on rows 61+** (skips LAYOUT too) | **59.5** | **23.3** |
+
+The last two rows are the finding. Skipping *paint* for 900 rows buys
+~3 FPS. Skipping *layout* as well buys 33. **The cost is table layout,
+and it is not reachable by any containment property** — which is why
+`content-visibility` and `contain` did nothing: neither is honoured on
+`<tr>` the way it is on a block element.
+
+That closes the "can we avoid virtualization with CSS" question with a
+measured no.
+
+### And it is not JavaScript
+
+The live board's rendered HTML was snapshotted with every stylesheet
+inlined and every `<script>` stripped, then reloaded as a static
+document and scrolled with the identical driver:
+
+| | rows | nodes | 1× | 4× |
+|---|---|---|---|---|
+| live board (React, hydrated) | 964 | 30,501 | 27.9 | 6.2 |
+| static snapshot, **no JS at all** | 964 | 30,475 | 27.5 | 6.9 |
+
+Identical. Nothing runs during the scroll — no listener, no observer, no
+React work. (The one rAF+ResizeObserver pair in the tree,
+`ds/DataTable.jsx:294-310`, does not fire on scroll; the old claim of
+"zero rAF/ResizeObserver in the frontend" was false, but the conclusion
+it supported survives.) So there is no JS to optimise here, and the old
+section's advice — "start by profiling what the page does per frame" —
+would have led straight to a dead end.
+
+### What this means for planned item #2
+
+It is **live again**, and the reverted implementation on this branch's
+history is the right starting point. The two things that were true about
+it remain true and must be re-solved, not skipped:
+
+* `journey-rankings.spec.js:81` counts rows before/after filtering and
+  asserts the count drops. Under windowing both counts pin to the window
+  size. This doc's standing rule against loosening board assertions still
+  applies — but the trade has changed, because the change now delivers
+  its goal. Re-point that assertion at `aria-rowcount`, which is the
+  honest observable once a window exists, rather than deleting it.
+* The 4× target is still missed (23.3 vs ≥30). Windowing is necessary and
+  not sufficient; per-row node reduction (~32 nodes/row today) is the
+  complement, and it now has a measured reason to exist.
+
+### The superseded section follows
 
 Planned item #2 ("the rankings board past the row cap") was implemented
 in full and then backed out, because the measurement says its premise is

--- a/docs/performance-optimization.md
+++ b/docs/performance-optimization.md
@@ -995,6 +995,92 @@ One known tail: `/draft` hits ~0.18 in roughly 1 run in 5, attributed
 to a `DIV.muted` block collapsing 361×166 → 0 at ~900ms.  Pre-existing,
 not round 6's doing, and not yet fixed.
 
+## 2026-08-05 — row windowing: BUILT, MEASURED, REVERTED
+
+Planned item #2 ("the rankings board past the row cap") was implemented
+in full and then backed out, because the measurement says its premise is
+wrong. **Row count is not what makes the board scroll slowly.**
+
+This section exists so nobody builds it a second time. The instrument
+that produced the numbers is committed —
+`frontend/scripts/measure-board-fps.mjs` — so every line below is
+re-runnable rather than remembered.
+
+### The premise, and the measurement that refutes it
+
+This doc said: "Getting 500+ rows to 30 FPS is the windowing work",
+i.e. only rendering fewer rows reaches the target. Measured on one
+machine, one session, same harness, 3 runs each (median):
+
+| board | rows | DOM nodes | FPS @1× |
+|---|---|---|---|
+| capped | 65 | 2,305 | **32.1** |
+| "Show all", no window | 964 | 30,553 | **28.6** |
+| "Show all", windowed | 964 | **3,763** | **30.9** |
+| *control: trivial page* | — | 204 | **59.5** |
+
+Read the first two rows together: a **15× increase in rows and a 13×
+increase in DOM nodes costs about 11% of the frame rate.** Then read the
+control: this machine renders a bare scrolling page at 59.5 FPS, so the
+~30 the board sits at is not a hardware ceiling.
+
+The board is ~30 FPS at *any* size. Whatever costs the other half of the
+frame budget is **page-level, not row-level** — so windowing, which is
+purely a row-count intervention, cannot fix it. It did exactly what it
+promised (30,553 → 3,763 nodes, an 8× cut) and bought ~2 FPS.
+
+### What was ruled out
+
+Injected `!important` overrides on the live board, same scroll loop:
+
+| suspect disabled | FPS |
+|---|---|
+| nothing (baseline) | 38.1 |
+| `backdrop-filter` | 39.5 |
+| `position: sticky` | 40.0 |
+| `box-shadow` | 38.7 |
+
+None of them. Note also the spread — this baseline read 38.1 where the
+same board read 32.1 minutes earlier. **These FPS numbers carry roughly
+20% run-to-run variance**, which is wide enough that the 28.6 / 30.9 /
+32.1 trio should be treated as one number, not three. The 59.5 control
+sits well outside that band, which is why the page-level conclusion
+holds while finer distinctions do not.
+
+### The second, independent reason it was reverted
+
+Windowing makes the mounted row count stop tracking the board size, and
+a journey spec legitimately depends on that. `journey-rankings.spec.js:81`
+("position filter narrows the board to one position") counts rows before
+and after filtering and asserts the count drops. Under windowing both
+counts pin to the window size and the assertion fails — not because
+filtering broke, but because a real user-visible behaviour stopped being
+observable through the DOM.
+
+That test could have been rewritten against `aria-rowcount`. It was not,
+because doing so trades away a working detector to accommodate a change
+that does not deliver its goal — and this doc has a standing rule against
+loosening board assertions to make a change fit.
+
+### If someone picks this up again
+
+* **Do not start from row count.** Start by profiling what the page does
+  per frame during a scroll — the answer is not in this table's size.
+* The windowing implementation worked and is recoverable from this
+  branch's history if the profile ever justifies it: opt-in `windowRows`
+  prop, document-scroll, spacer rows, data-driven zebra parity,
+  absolute-index callbacks, full-render fallback when geometry is
+  unmeasurable (jsdom reports 0 and all 28 DataTable tests depend on it).
+* One trap it hit, worth keeping: measure row height from a row the table
+  itself renders (`data-ds-row`), never `tbody tr`. The first `tr` can be
+  a caller-authored tier separator, and measuring one collapses the window
+  to its floor.
+
+### Also corrected here
+
+The row counts in this doc are stale: "Show all" is **964 rows** today,
+not the ~632 or ~1,095 quoted elsewhere, at ~32 DOM nodes per row.
+
 ## Rejected (attempted, reverted)
 
 ### Browser revalidation via `If-None-Match`/`304` — **not safe as-is**

--- a/docs/performance-optimization.md
+++ b/docs/performance-optimization.md
@@ -1179,13 +1179,27 @@ loosening board assertions to make a change fit.
 
 ### If someone picks this up again
 
-* **Do not start from row count.** Start by profiling what the page does
-  per frame during a scroll — the answer is not in this table's size.
-* The windowing implementation worked and is recoverable from this
-  branch's history if the profile ever justifies it: opt-in `windowRows`
-  prop, document-scroll, spacer rows, data-driven zebra parity,
-  absolute-index callbacks, full-render fallback when geometry is
-  unmeasurable (jsdom reports 0 and all 28 DataTable tests depend on it).
+* ~~**Do not start from row count.** Start by profiling what the page
+  does per frame during a scroll~~ — **REVERSED by the retraction above.**
+  Row count is exactly where to start, and the per-frame profile is a
+  dead end: a static snapshot of the board with every script stripped
+  scrolls at the same speed as the live page, so there is nothing running
+  per frame to find.
+* ~~The windowing implementation worked and is recoverable from this
+  branch's history~~ — **FALSE, corrected 2026-08-06.** It is not
+  recoverable and never was: `git log --all -S windowRows` returns
+  nothing, the branch has exactly one pre-retraction commit (the
+  measurement), and no dangling object holds it. It was built in a
+  working tree and reverted without ever being committed. Anyone acting
+  on the retraction above is **writing it from scratch**, and should
+  budget accordingly. What survives is the design, which was sound and is
+  worth re-using: opt-in `windowRows` prop (default off, rankings only —
+  `DataTable` has 12 consumers), document-scroll rather than a new scroll
+  container, spacer rows to preserve scroll height, data-driven zebra
+  parity, absolute-index callbacks through `renderBeforeRow` /
+  `renderAfterRow` / `col.render`, and a full-render fallback when
+  geometry is unmeasurable (jsdom reports 0 rects and all 28 DataTable
+  tests depend on that fallback).
 * One trap it hit, worth keeping: measure row height from a row the table
   itself renders (`data-ds-row`), never `tbody tr`. The first `tr` can be
   a caller-authored tier separator, and measuring one collapses the window

--- a/frontend/scripts/measure-board-fps.mjs
+++ b/frontend/scripts/measure-board-fps.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+/**
+ * Scroll-FPS harness for the rankings board.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * docs/performance-optimization.md sets a target of >=50 FPS at 1x CPU
+ * and >=30 at 4x for the board past its row cap ("Show more" / "Show
+ * all"), and records 39.5 / 8.8 against it. Those numbers came from a
+ * manual session. Windowing the table is a large, shared-component
+ * change, so the claim that it helped needs an instrument anyone can
+ * re-run rather than a number someone remembers taking.
+ *
+ * WHAT IT MEASURES
+ * ----------------
+ * Frames delivered during a programmatic scroll of the FULL board, via a
+ * requestAnimationFrame counter inside the page. Not paint timings, not
+ * a synthetic benchmark — the thing a user feels when they drag the
+ * scrollbar down a 632-row table.
+ *
+ * CPU throttling goes through CDP `Emulation.setCPUThrottlingRate`,
+ * which is what makes a fast sandbox stand in for a real laptop. 1x on
+ * this hardware is not a phone; the 4x and 6x rows are the honest ones.
+ *
+ * IT REFUSES TO REPORT A NUMBER IT DID NOT EARN
+ * ---------------------------------------------
+ * Same posture as assertGateIsMeasuring() in check-bundle-sizes.mjs and
+ * the needle detector in measure-duplication.mjs. If the board never
+ * rendered rows, if "Show all" never took effect, or if the page never
+ * actually scrolled, it exits non-zero and says which — because "60 FPS"
+ * measured on a page that rendered nothing is worse than no measurement.
+ *
+ * USAGE
+ *   node frontend/scripts/measure-board-fps.mjs [--throttle 1,4,6]
+ *                                               [--runs 3] [--json]
+ *
+ * Requires the stack up (backend :8000, Next :3000 on a PRODUCTION
+ * build — `next dev` numbers are meaningless here) and E2E_TEST_SECRET
+ * matching the backend's, since the board needs a signed-in session.
+ */
+import { chromium } from "playwright";
+
+const API = process.env.E2E_BASE_URL || "http://127.0.0.1:8000";
+const PAGE_ORIGIN = process.env.E2E_PAGE_ORIGIN || "http://127.0.0.1:3000";
+const SECRET = process.env.E2E_TEST_SECRET || "";
+
+function parseArgs(argv) {
+  const out = { throttle: [1, 4, 6], runs: 3, json: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--throttle") out.throttle = argv[++i].split(",").map(Number);
+    else if (argv[i] === "--runs") out.runs = Number(argv[++i]);
+    else if (argv[i] === "--json") out.json = true;
+  }
+  return out;
+}
+
+// Scrolls the document top-to-bottom in fixed steps while a rAF loop
+// counts delivered frames. Returns null rather than a number when the
+// page did not actually move, so "it scrolled smoothly" can never be
+// reported for a page that never scrolled.
+const SCROLL_AND_COUNT = async ({ steps, stepPx, settleMs }) => {
+  const startTop = window.scrollY;
+  const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
+  if (maxScroll < stepPx) return { error: `page is not scrollable (max ${maxScroll}px)` };
+
+  let frames = 0;
+  let running = true;
+  const tick = () => {
+    if (!running) return;
+    frames += 1;
+    requestAnimationFrame(tick);
+  };
+  requestAnimationFrame(tick);
+
+  const t0 = performance.now();
+  for (let i = 0; i < steps; i += 1) {
+    window.scrollBy(0, stepPx);
+    // One frame of settle per step, so the scroll is paced like a drag
+    // rather than a single jump the browser can collapse.
+    await new Promise((r) => setTimeout(r, settleMs));
+  }
+  const elapsed = performance.now() - t0;
+  running = false;
+
+  const moved = window.scrollY - startTop;
+  if (moved < stepPx) return { error: `scroll did not move (delta ${moved}px)` };
+  return { frames, elapsedMs: elapsed, fps: (frames / elapsed) * 1000, moved, maxScroll };
+};
+
+const args = parseArgs(process.argv.slice(2));
+
+if (!SECRET) {
+  console.error("E2E_TEST_SECRET is unset — the board needs a signed-in session.");
+  process.exit(2);
+}
+
+const browser = await chromium.launch({
+  executablePath: process.env.PW_CHROMIUM_PATH || undefined,
+  args: ["--no-sandbox"],
+});
+const ctx = await browser.newContext({ baseURL: API, viewport: { width: 1366, height: 900 } });
+
+// Secret goes in an Authorization: Bearer header — server.py reads it
+// from there and 404s otherwise, which looks exactly like a missing route.
+const session = await ctx.request.post(`${API}/api/test/create-session`, {
+  headers: { Authorization: `Bearer ${SECRET}` },
+  timeout: 60_000,
+});
+if (!session.ok()) {
+  console.error(`could not mint session: ${session.status()}`);
+  await browser.close();
+  process.exit(2);
+}
+
+const page = await ctx.newPage();
+const cdp = await ctx.newCDPSession(page);
+
+await page.goto(`${PAGE_ORIGIN}/rankings`, { waitUntil: "domcontentloaded" });
+
+const rowSel = ".ds-table-wrap table tbody tr.rankings-row-clickable";
+await page.locator(rowSel).first().waitFor({ timeout: 90_000 });
+
+// Defeat the row cap — that is the whole point of the measurement. The
+// board renders "Show all" only when there are more rows than the cap.
+const showAll = page.getByRole("button", { name: /Show all/i });
+const cappedCount = await page.locator(rowSel).count();
+if (await showAll.count()) {
+  await showAll.first().click();
+  // "Show all" is a non-urgent transition (page.jsx), so the row count
+  // grows a beat later; poll rather than assuming it is synchronous.
+  await page
+    .waitForFunction(
+      ([sel, before]) => document.querySelectorAll(sel).length > before,
+      [rowSel, cappedCount],
+      { timeout: 90_000 },
+    )
+    .catch(() => {});
+}
+const mountedAfter = await page.locator(rowSel).count();
+
+// The BOARD size, which is not the mounted count once the table is
+// windowed — that is the whole point of windowing. `aria-rowcount` on
+// <tbody> carries the full row count when a window is active; without a
+// window the two are the same number.
+//
+// Getting this wrong is a trap worth naming: the first version compared
+// mounted counts and refused a windowed run ("65 -> 60") as if "Show
+// all" had failed, when in fact it had worked and the window was doing
+// its job. A guard that fires on success is as bad as one that never
+// fires.
+const boardCount = await page.evaluate(() => {
+  const tb = document.querySelector(".ds-table-wrap table tbody");
+  const declared = Number(tb?.getAttribute("aria-rowcount") || 0);
+  return declared > 0
+    ? declared
+    : document.querySelectorAll(".ds-table-wrap table tbody tr.rankings-row-clickable").length;
+});
+
+if (mountedAfter <= 0) {
+  console.error("REFUSING TO REPORT: the board mounted zero rows.");
+  await browser.close();
+  process.exit(2);
+}
+if (boardCount <= cappedCount) {
+  console.error(
+    `REFUSING TO REPORT: "Show all" did not grow the board ` +
+      `(${cappedCount} -> ${boardCount}). This would measure the capped ` +
+      `board and call it the full one.`,
+  );
+  await browser.close();
+  process.exit(2);
+}
+// The >=50-row E2E assertions must stay true under windowing, so check
+// it here too rather than finding out from a red suite later.
+if (mountedAfter < 50) {
+  console.error(
+    `REFUSING TO REPORT: only ${mountedAfter} rows mounted. ` +
+      `journey.js (minRows 50) and mobile-smoke both require >= 50.`,
+  );
+  await browser.close();
+  process.exit(2);
+}
+const fullCount = boardCount;
+
+const results = [];
+for (const rate of args.throttle) {
+  const samples = [];
+  for (let run = 0; run < args.runs; run += 1) {
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await page.waitForTimeout(300);
+    await cdp.send("Emulation.setCPUThrottlingRate", { rate });
+    const r = await page.evaluate(SCROLL_AND_COUNT, {
+      steps: 30,
+      stepPx: 400,
+      settleMs: 16,
+    });
+    await cdp.send("Emulation.setCPUThrottlingRate", { rate: 1 });
+    if (r.error) {
+      console.error(`REFUSING TO REPORT at ${rate}x: ${r.error}`);
+      await browser.close();
+      process.exit(2);
+    }
+    samples.push(r.fps);
+  }
+  samples.sort((a, b) => a - b);
+  results.push({ rate, median: samples[Math.floor(samples.length / 2)], samples });
+}
+
+// Row NODE count — the other half of the story. Windowing should cut
+// mounted DOM sharply even where FPS is already acceptable.
+const domNodes = await page.evaluate(() => document.querySelectorAll("*").length);
+const mountedRows = await page.locator(rowSel).count();
+
+await browser.close();
+
+if (args.json) {
+  console.log(JSON.stringify({ fullCount, mountedRows, domNodes, results }, null, 2));
+} else {
+  console.log(`\nrankings board scroll FPS — ${fullCount} rows after "Show all"`);
+  console.log(`mounted rows: ${mountedRows}   total DOM nodes: ${domNodes}\n`);
+  console.log("CPU throttle   median FPS   samples");
+  console.log("-".repeat(52));
+  for (const r of results) {
+    console.log(
+      `${String(r.rate + "x").padEnd(14)} ${r.median.toFixed(1).padEnd(12)} ` +
+        r.samples.map((s) => s.toFixed(1)).join(", "),
+    );
+  }
+  const target = { 1: 50, 4: 30 };
+  console.log("");
+  for (const r of results) {
+    if (target[r.rate] == null) continue;
+    const ok = r.median >= target[r.rate];
+    console.log(
+      `${r.rate}x: ${r.median.toFixed(1)} vs target >=${target[r.rate]} — ${ok ? "MEETS" : "BELOW"}`,
+    );
+  }
+}

--- a/frontend/scripts/measure-board-fps.mjs
+++ b/frontend/scripts/measure-board-fps.mjs
@@ -13,26 +13,78 @@
  *
  * WHAT IT MEASURES
  * ----------------
- * Frames delivered during a programmatic scroll of the FULL board, via a
- * requestAnimationFrame counter inside the page. Not paint timings, not
- * a synthetic benchmark — the thing a user feels when they drag the
- * scrollbar down a 632-row table.
+ * Frame intervals delivered during a REAL scroll of the full board:
+ * `requestAnimationFrame` timestamps sampled inside the page while CDP
+ * `Input.synthesizeScrollGesture` drives the scroll from outside it.
  *
  * CPU throttling goes through CDP `Emulation.setCPUThrottlingRate`,
  * which is what makes a fast sandbox stand in for a real laptop. 1x on
  * this hardware is not a phone; the 4x and 6x rows are the honest ones.
  *
+ * ⚠ THE FIRST VERSION OF THIS SCRIPT MEASURED ITSELF. Read this before
+ * changing the driver back.
+ *
+ * It scrolled with an in-page loop:
+ *
+ *     for (let i = 0; i < steps; i++) {
+ *       window.scrollBy(0, stepPx);
+ *       await new Promise((r) => setTimeout(r, 16));   // <-- the bug
+ *     }
+ *
+ * That is 30 discrete jumps paced by a timer, not a scroll. The frame
+ * count it produced was `max(timer floor, layout+paint per step)` — i.e.
+ * bounded ABOVE by the timer at ~60/s no matter how fast the page was,
+ * and pushed below it by anything slow. Every absolute number it
+ * reported was a property of the loop as much as of the board, and the
+ * numbers it gave (trivial page 59.5, 65-row board 32.1, 964-row board
+ * 28.6) are exactly what that artifact looks like: the control pinned at
+ * the timer floor and both boards landing in one indistinguishable band.
+ *
+ * The relative comparison survived that — both boards were measured
+ * identically, so "15x the rows costs ~11%" still held — but the
+ * absolute framing ("the board is ~30 FPS against a >=50 target") did
+ * not, and it was published before this was noticed.
+ *
+ * So: NO TIMER IN THE MEASUREMENT LOOP, and the page is not asked to
+ * drive its own scroll. The gesture is synthesized by the browser at a
+ * declared px/s, the page only records `rAF` timestamps, and the two
+ * never gate each other.
+ *
+ * WHY INTERVALS AND NOT A MEAN
+ * ----------------------------
+ * Jank is long frames, not a low average. A scroll that delivers 55
+ * frames in a second feels broken if four of them were 120 ms. So the
+ * report leads with median FPS but also carries p95 frame time and the
+ * count of frames over 32 ms (two missed vsyncs at 60 Hz), which is the
+ * number that actually tracks what a user calls "chuggy".
+ *
  * IT REFUSES TO REPORT A NUMBER IT DID NOT EARN
  * ---------------------------------------------
  * Same posture as assertGateIsMeasuring() in check-bundle-sizes.mjs and
  * the needle detector in measure-duplication.mjs. If the board never
- * rendered rows, if "Show all" never took effect, or if the page never
- * actually scrolled, it exits non-zero and says which — because "60 FPS"
- * measured on a page that rendered nothing is worse than no measurement.
+ * rendered rows, if "Show all" never took effect, if the page never
+ * actually scrolled, or if too few frames were sampled to say anything,
+ * it exits non-zero and says which.
+ *
+ * THE CONTROL IS PRINTED, NOT ASSUMED
+ * -----------------------------------
+ * Every run first measures a trivial scrollable page at the same
+ * throttle rates. That is this hardware's ceiling under this driver, and
+ * it is what makes a board number readable: "28 FPS" means nothing until
+ * you know whether the harness can produce 60 here at all. The old
+ * script's real failure was that its control read 59.5 and nobody asked
+ * why it was suspiciously close to the timer it was using.
  *
  * USAGE
  *   node frontend/scripts/measure-board-fps.mjs [--throttle 1,4,6]
  *                                               [--runs 3] [--json]
+ *                                               [--no-hover] [--capped]
+ *
+ * `--no-hover` parks the cursor outside the table before scrolling. The
+ * board has `tr:hover .sticky-name { background: ... }` on a sticky,
+ * box-shadowed cell in every row (app/ds.css), so hover repaints are a
+ * live suspect for scroll cost; running with and without discriminates
+ * them from the sticky positioning itself.
  *
  * Requires the stack up (backend :8000, Next :3000 on a PRODUCTION
  * build — `next dev` numbers are meaningless here) and E2E_TEST_SECRET
@@ -45,47 +97,160 @@ const PAGE_ORIGIN = process.env.E2E_PAGE_ORIGIN || "http://127.0.0.1:3000";
 const SECRET = process.env.E2E_TEST_SECRET || "";
 
 function parseArgs(argv) {
-  const out = { throttle: [1, 4, 6], runs: 3, json: false };
+  const out = { throttle: [1, 4, 6], runs: 3, json: false, hover: true, capped: false };
   for (let i = 0; i < argv.length; i += 1) {
     if (argv[i] === "--throttle") out.throttle = argv[++i].split(",").map(Number);
     else if (argv[i] === "--runs") out.runs = Number(argv[++i]);
     else if (argv[i] === "--json") out.json = true;
+    else if (argv[i] === "--no-hover") out.hover = false;
+    else if (argv[i] === "--capped") out.capped = true;
   }
   return out;
 }
 
-// Scrolls the document top-to-bottom in fixed steps while a rAF loop
-// counts delivered frames. Returns null rather than a number when the
-// page did not actually move, so "it scrolled smoothly" can never be
-// reported for a page that never scrolled.
-const SCROLL_AND_COUNT = async ({ steps, stepPx, settleMs }) => {
-  const startTop = window.scrollY;
-  const maxScroll = document.documentElement.scrollHeight - window.innerHeight;
-  if (maxScroll < stepPx) return { error: `page is not scrollable (max ${maxScroll}px)` };
+// Gesture shape. `speed` is px/s handed to the browser's own gesture
+// synthesizer, so the scroll is paced by the compositor rather than by
+// anything this script does. 2400 px/s over 9000 px is ~3.75 s of
+// continuous scrolling — long enough to sample a few hundred frames,
+// fast enough to be a realistic flick rather than a crawl.
+const SCROLL_DISTANCE_PX = 9000;
+const SCROLL_SPEED_PX_S = 2400;
+// Below this many frames there is no distribution to take percentiles
+// of, so the script refuses. It is deliberately LOW.
+//
+// The first value here was 30, and it was wrong in an instructive way:
+// at 4x throttle the board delivered 29 frames across the whole gesture
+// — under 8 FPS — and the guard rejected the run. That is a guard firing
+// on the FINDING. Refusing to report "the board is very slow" because
+// the board was very slow is the same class of error as the earlier
+// version's guard that rejected a windowed run for having fewer mounted
+// rows, just pointing the other way.
+//
+// So: refuse only where the arithmetic genuinely breaks down, and flag
+// thin samples in the output instead of suppressing them.
+const MIN_FRAMES = 8;
+// Below this the percentiles are directionally useful but coarse; the
+// report says so rather than presenting them as equal to a dense run.
+const THIN_SAMPLE_FRAMES = 30;
 
-  let frames = 0;
-  let running = true;
-  const tick = () => {
-    if (!running) return;
-    frames += 1;
+// Installed in the page BEFORE the gesture. Records rAF timestamps and
+// nothing else — no scrolling, no timers, no work that could itself
+// become the thing being measured.
+const START_SAMPLER = () => {
+  window.__fpsProbe = {
+    ts: [],
+    running: true,
+    startY: window.scrollY,
+    maxScroll: document.documentElement.scrollHeight - window.innerHeight,
+  };
+  const tick = (now) => {
+    const p = window.__fpsProbe;
+    if (!p || !p.running) return;
+    p.ts.push(now);
     requestAnimationFrame(tick);
   };
   requestAnimationFrame(tick);
-
-  const t0 = performance.now();
-  for (let i = 0; i < steps; i += 1) {
-    window.scrollBy(0, stepPx);
-    // One frame of settle per step, so the scroll is paced like a drag
-    // rather than a single jump the browser can collapse.
-    await new Promise((r) => setTimeout(r, settleMs));
-  }
-  const elapsed = performance.now() - t0;
-  running = false;
-
-  const moved = window.scrollY - startTop;
-  if (moved < stepPx) return { error: `scroll did not move (delta ${moved}px)` };
-  return { frames, elapsedMs: elapsed, fps: (frames / elapsed) * 1000, moved, maxScroll };
 };
+
+// Stops the sampler and reduces the timestamps. Returns an `error` key
+// rather than a number whenever the run cannot support one.
+const STOP_SAMPLER = (minFrames) => {
+  const p = window.__fpsProbe;
+  if (!p) return { error: "sampler was never installed" };
+  p.running = false;
+  const moved = window.scrollY - p.startY;
+  if (p.maxScroll < 200) {
+    return { error: `page is not scrollable (max ${Math.round(p.maxScroll)}px)` };
+  }
+  if (Math.abs(moved) < 200) {
+    return { error: `scroll did not move (delta ${Math.round(moved)}px)` };
+  }
+  const ts = p.ts;
+  if (ts.length < minFrames) {
+    return { error: `only ${ts.length} frames sampled (need ${minFrames})` };
+  }
+  const deltas = [];
+  for (let i = 1; i < ts.length; i += 1) deltas.push(ts[i] - ts[i - 1]);
+  const sorted = [...deltas].sort((a, b) => a - b);
+  const pct = (q) => sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * q))];
+  const span = ts[ts.length - 1] - ts[0];
+  return {
+    frames: ts.length,
+    elapsedMs: span,
+    // Frames-per-second over the sampled window. With no timer pacing
+    // the loop this is bounded only by the display refresh rate.
+    fps: ((ts.length - 1) / span) * 1000,
+    medianFrameMs: pct(0.5),
+    p95FrameMs: pct(0.95),
+    // Two missed vsyncs at 60 Hz. This is the jank number.
+    longFrames: deltas.filter((d) => d > 32).length,
+    // NOTE: `thinSample` is stamped by the CALLER, in Node. This
+    // function is serialized into the page, so it can only see its own
+    // arguments — a module-scope constant referenced here is a
+    // ReferenceError at runtime, not a build error.
+    moved: Math.round(moved),
+    maxScroll: Math.round(p.maxScroll),
+  };
+};
+
+/**
+ * One measurement: install sampler, let the BROWSER scroll, collect.
+ *
+ * The gesture is issued over CDP and awaited there, so the page's main
+ * thread is never asked to pace it. That is the whole difference from
+ * the retracted version — see the header.
+ */
+async function measureScroll(page, cdp, { x, y }) {
+  await page.evaluate(START_SAMPLER);
+  await cdp.send("Input.synthesizeScrollGesture", {
+    x,
+    y,
+    // Negative yDistance scrolls the content DOWN (the gesture models
+    // finger/wheel movement, not content movement). The `moved` guard in
+    // STOP_SAMPLER catches it if that convention ever flips.
+    yDistance: -SCROLL_DISTANCE_PX,
+    speed: SCROLL_SPEED_PX_S,
+    gestureSourceType: "mouse",
+  });
+  const r = await page.evaluate(STOP_SAMPLER, MIN_FRAMES);
+  if (r.error) return r;
+  // Stamped here rather than in the page — see STOP_SAMPLER's note.
+  return { ...r, thinSample: r.frames < THIN_SAMPLE_FRAMES };
+}
+
+/**
+ * The instrument's ceiling on this hardware, under this driver.
+ *
+ * A trivial document of the same scroll height with none of the board's
+ * DOM. Without it a board number is unreadable: "28 FPS" could be the
+ * board or could be the harness, and the retracted version could not
+ * tell those apart — its control read 59.5 because that was its timer.
+ */
+async function measureControl(page, cdp, rates, runs) {
+  await page.goto("about:blank");
+  await page.setContent(
+    `<style>body{margin:0}div{height:40px;border-bottom:1px solid #ccc}</style>` +
+      `<body>${'<div>row</div>'.repeat(600)}</body>`,
+  );
+  const out = [];
+  for (const rate of rates) {
+    const samples = [];
+    for (let i = 0; i < runs; i += 1) {
+      await page.evaluate(() => window.scrollTo(0, 0));
+      await page.waitForTimeout(200);
+      await cdp.send("Emulation.setCPUThrottlingRate", { rate });
+      const r = await measureScroll(page, cdp, { x: 400, y: 400 });
+      await cdp.send("Emulation.setCPUThrottlingRate", { rate: 1 });
+      if (r.error) {
+        return { error: `control failed at ${rate}x: ${r.error}` };
+      }
+      samples.push(r);
+    }
+    samples.sort((a, b) => a.fps - b.fps);
+    out.push({ rate, ...samples[Math.floor(samples.length / 2)] });
+  }
+  return { rows: out };
+}
 
 const args = parseArgs(process.argv.slice(2));
 
@@ -115,6 +280,17 @@ if (!session.ok()) {
 const page = await ctx.newPage();
 const cdp = await ctx.newCDPSession(page);
 
+// Control FIRST, on a blank page, before the app is ever loaded — so the
+// ceiling is measured on a process the board has not yet touched.
+const control = await measureControl(page, cdp, args.throttle, args.runs);
+if (control.error) {
+  console.error(`REFUSING TO REPORT: ${control.error}`);
+  console.error("The harness could not measure a trivial page, so any board");
+  console.error("number it produced would be unattributable.");
+  await browser.close();
+  process.exit(2);
+}
+
 await page.goto(`${PAGE_ORIGIN}/rankings`, { waitUntil: "domcontentloaded" });
 
 const rowSel = ".ds-table-wrap table tbody tr.rankings-row-clickable";
@@ -122,9 +298,16 @@ await page.locator(rowSel).first().waitFor({ timeout: 90_000 });
 
 // Defeat the row cap — that is the whole point of the measurement. The
 // board renders "Show all" only when there are more rows than the cap.
+//
+// `--capped` skips it, which is how the row-count question is answered:
+// measure the SAME page at the default cap and at full size and compare.
+// Without a paired capped run, a low full-board number cannot be
+// attributed to row count rather than to the board's fixed per-frame
+// cost, and attributing it wrongly is what sends someone off to build a
+// virtualizer that does not help.
 const showAll = page.getByRole("button", { name: /Show all/i });
 const cappedCount = await page.locator(rowSel).count();
-if (await showAll.count()) {
+if (!args.capped && (await showAll.count())) {
   await showAll.first().click();
   // "Show all" is a non-urgent transition (page.jsx), so the row count
   // grows a beat later; poll rather than assuming it is synchronous.
@@ -161,7 +344,7 @@ if (mountedAfter <= 0) {
   await browser.close();
   process.exit(2);
 }
-if (boardCount <= cappedCount) {
+if (!args.capped && boardCount <= cappedCount) {
   console.error(
     `REFUSING TO REPORT: "Show all" did not grow the board ` +
       `(${cappedCount} -> ${boardCount}). This would measure the capped ` +
@@ -182,6 +365,16 @@ if (mountedAfter < 50) {
 }
 const fullCount = boardCount;
 
+// The gesture is aimed at the middle of the viewport, which is over the
+// table. With --no-hover the pointer is parked in the left margin first,
+// so `tr:hover .sticky-name` never fires. Discriminating hover repaints
+// from the sticky positioning itself is a one-flag experiment; do that
+// before editing any CSS.
+const gestureAt = args.hover ? { x: 683, y: 500 } : { x: 8, y: 500 };
+if (!args.hover) {
+  await page.mouse.move(8, 500);
+}
+
 const results = [];
 for (const rate of args.throttle) {
   const samples = [];
@@ -189,21 +382,17 @@ for (const rate of args.throttle) {
     await page.evaluate(() => window.scrollTo(0, 0));
     await page.waitForTimeout(300);
     await cdp.send("Emulation.setCPUThrottlingRate", { rate });
-    const r = await page.evaluate(SCROLL_AND_COUNT, {
-      steps: 30,
-      stepPx: 400,
-      settleMs: 16,
-    });
+    const r = await measureScroll(page, cdp, gestureAt);
     await cdp.send("Emulation.setCPUThrottlingRate", { rate: 1 });
     if (r.error) {
       console.error(`REFUSING TO REPORT at ${rate}x: ${r.error}`);
       await browser.close();
       process.exit(2);
     }
-    samples.push(r.fps);
+    samples.push(r);
   }
-  samples.sort((a, b) => a - b);
-  results.push({ rate, median: samples[Math.floor(samples.length / 2)], samples });
+  samples.sort((a, b) => a.fps - b.fps);
+  results.push({ rate, ...samples[Math.floor(samples.length / 2)], samples });
 }
 
 // Row NODE count — the other half of the story. Windowing should cut
@@ -213,26 +402,57 @@ const mountedRows = await page.locator(rowSel).count();
 
 await browser.close();
 
+const controlByRate = new Map(control.rows.map((r) => [r.rate, r]));
+
 if (args.json) {
-  console.log(JSON.stringify({ fullCount, mountedRows, domNodes, results }, null, 2));
+  console.log(
+    JSON.stringify(
+      { fullCount, mountedRows, domNodes, hover: args.hover, control: control.rows, results },
+      null,
+      2,
+    ),
+  );
 } else {
   console.log(`\nrankings board scroll FPS — ${fullCount} rows after "Show all"`);
-  console.log(`mounted rows: ${mountedRows}   total DOM nodes: ${domNodes}\n`);
-  console.log("CPU throttle   median FPS   samples");
-  console.log("-".repeat(52));
+  console.log(
+    `mounted rows: ${mountedRows}   total DOM nodes: ${domNodes}   ` +
+      `hover: ${args.hover ? "cursor over table" : "cursor parked outside"}`,
+  );
+  console.log(
+    `driver: CDP synthesizeScrollGesture, ${SCROLL_DISTANCE_PX}px @ ` +
+      `${SCROLL_SPEED_PX_S}px/s — no timer in the loop\n`,
+  );
+  console.log("CPU     board FPS   p95 frame   >32ms   | control FPS   headroom");
+  console.log("-".repeat(72));
   for (const r of results) {
+    const c = controlByRate.get(r.rate);
+    const ratio = c ? `${((r.fps / c.fps) * 100).toFixed(0)}% of ceiling` : "—";
     console.log(
-      `${String(r.rate + "x").padEnd(14)} ${r.median.toFixed(1).padEnd(12)} ` +
-        r.samples.map((s) => s.toFixed(1)).join(", "),
+      `${String(r.rate + "x").padEnd(8)}${r.fps.toFixed(1).padEnd(12)}` +
+        `${(r.p95FrameMs.toFixed(1) + "ms").padEnd(12)}${String(r.longFrames).padEnd(8)}| ` +
+        `${(c ? c.fps.toFixed(1) : "—").padEnd(14)}${ratio}` +
+        // A thin sample is a real result (the page was too slow to
+        // deliver many frames), just a coarse one. Marked, not hidden.
+        (r.thinSample ? `   [thin: ${r.frames} frames]` : ""),
     );
   }
   const target = { 1: 50, 4: 30 };
   console.log("");
   for (const r of results) {
     if (target[r.rate] == null) continue;
-    const ok = r.median >= target[r.rate];
+    const ok = r.fps >= target[r.rate];
+    const c = controlByRate.get(r.rate);
+    // A target the CONTROL cannot hit is a statement about the harness
+    // or the hardware, not about the board. Say so rather than reporting
+    // "BELOW" and letting a reader blame the page.
+    const capped = c && c.fps < target[r.rate];
     console.log(
-      `${r.rate}x: ${r.median.toFixed(1)} vs target >=${target[r.rate]} — ${ok ? "MEETS" : "BELOW"}`,
+      `${r.rate}x: ${r.fps.toFixed(1)} vs target >=${target[r.rate]} — ` +
+        (capped
+          ? `INCONCLUSIVE (control only reached ${c.fps.toFixed(1)} here)`
+          : ok
+            ? "MEETS"
+            : "BELOW"),
     );
   }
 }


### PR DESCRIPTION
**This PR's original conclusion was wrong and this body has been rewritten.** It previously said "row windowing does not fix it" and reverted a working implementation on that basis. The number behind that conclusion came from a harness that measured its own scroll loop. With the harness fixed, windowing takes the board from **22 FPS to 59.5 at 1×** and meets the ≥50 target.

## The defect in the instrument

The driver was:

```js
for (let i = 0; i < 30; i++) {
  window.scrollBy(0, 400);
  await new Promise((r) => setTimeout(r, 16));   // <-- this
}
```

That is 30 discrete jumps paced by a timer, not a scroll. The frame counter therefore measured how fast that loop could turn over — bounded **above** by the timer at ~60/s no matter how fast the page was. It is exactly why the 65-row board (32.1) and the 964-row board (28.6) came out indistinguishable, which was the entire basis for "row count is not the driver".

## The fix

CDP `Input.synthesizeScrollGesture` drives the scroll from outside the page; the page only records `requestAnimationFrame` timestamps. **No timer anywhere in the loop.** 9000 px at 2400 px/s. The report now leads with median FPS but also carries p95 frame time and the count of frames over 32 ms, because jank is long frames rather than a low mean.

A trivial-page control runs first at every throttle rate and is printed. That is what makes a board number readable, and it is decisive here: the control holds **60.0 FPS at 1×, 4× AND 6×**. The harness can produce 60 on this hardware, CPU throttling alone does not degrade it, so the board's collapse is the board's.

## Re-measured (3 runs, median)

| board | rows | DOM nodes | 1× | 4× | 6× |
|---|---|---|---|---|---|
| capped | 200 | 6,597 | 32.8 | 9.0 | — |
| "Show all" | 964 | 30,501 | 22–27 | 5.7–6.5 | 4.1 |
| **~60 rows laid out** (window proxy) | 964 | — | **59.5** | **23.3** | **15.0** |
| *control: trivial page* | — | ~1,800 | 60.0 | 60.0 | 59.7 |

**1×: 22 → 59.5, MEETS the ≥50 target.** 4×: 6.0 → 23.3 — still short of ≥30, but ~4× better. The old table's "windowing bought ~2 FPS" was the timer floor absorbing the entire effect.

The window proxy is `display: none` on `:nth-child(n+61)` applied to the live board — the same thing a window achieves by unmounting, measured without needing the implementation.

## It is LAYOUT, not paint, and no CSS reaches it

Every cheap intervention ablated with `!important` overrides on the live board, same driver, baseline re-measured first and last so drift (~10%) is visible. Every CSS arm sits inside that drift:

| suspect removed | 1× | 4× |
|---|---|---|
| baseline | 26.5 / 22.8 | 6.5 / 5.4 |
| `tr:hover .sticky-name` (cursor parked off-table) | 23.4 | 6.3 |
| `.sticky-name` `box-shadow` | 25.2 | 5.2 |
| `.sticky-name` `position: sticky` | 22.4 | 6.2 |
| `thead th` `position: sticky` | 21.4 | 4.4 |
| all sticky, everywhere | 20.6 | 4.7 |
| `table-layout: fixed` | 24.2 | 6.0 |
| `content-visibility: auto` on rows | 22.7 | 6.5 |
| `contain: layout paint style` on rows | 23.4 | 5.7 |
| **`visibility: hidden` rows 61+** — skips PAINT | **29.5** | **9.4** |
| **`display: none` rows 61+** — skips LAYOUT too | **59.5** | **23.3** |

The last two rows are the finding. Skipping *paint* for 900 rows buys ~3 FPS; skipping *layout* buys 33. **The cost is table layout and no containment property reaches it** — which is why `content-visibility` and `contain` did nothing. Neither is honoured on `<tr>` the way it is on a block element.

That closes "can CSS avoid virtualization here" with a measured no.

## And it is not JavaScript

The live board's rendered HTML was snapshotted with every stylesheet inlined and every `<script>` stripped, then reloaded as a static document and scrolled with the identical driver:

| | rows | nodes | 1× | 4× |
|---|---|---|---|---|
| live board (React, hydrated) | 964 | 30,501 | 27.9 | 6.2 |
| static snapshot, **no JS at all** | 964 | 30,475 | 27.5 | 6.9 |

Identical. Nothing runs during the scroll. So the old body's advice — "start by profiling what the page does per frame" — would have led straight to a dead end, and the harness that produced it would have been trusted the whole way.

## Two harness bugs fixed en route, both the same class as the one being retracted

- `MIN_FRAMES` was 30. At 4× the board delivered 29 frames across the whole gesture — under 8 FPS — and the guard **refused the run**. A guard firing on the finding. Now 8, with thin samples flagged in the output rather than suppressed.
- `thinSample` was computed inside the function serialized into the page, where a module-scope constant is a runtime `ReferenceError` rather than a build error. Stamped by the caller now, with a note.

## What this PR now contains

The corrected harness plus the ledger retraction. It does **not** re-land the windowing implementation — that is planned item #2, now live again, and it belongs in its own PR with the one genuine obstacle re-solved: `journey-rankings.spec.js:81` counts rows before/after filtering and asserts the count drops, which pins to the window size under windowing. That assertion should be re-pointed at `aria-rowcount` (the honest observable once a window exists), not deleted. The repo's standing rule against loosening board assertions still applies; what changed is that the trade is now worth making, because the change delivers its goal.

Also worth carrying forward: the 4× target is still missed (23.3 vs ≥30). Windowing is necessary and not sufficient — per-row node reduction (~32 nodes/row today) is the complement, and it now has a measured reason to exist.

New flags: `--capped` (measure without "Show all", which is how the row-count question gets a paired comparison) and `--no-hover` (park the cursor off the table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaMgGfyHGEs38eGJ3kBf6H