### PR TITLE
Measure first-load JS with an instrument that can be checked

### DIFF
--- a/docs/performance-optimization.md
+++ b/docs/performance-optimization.md
@@ -995,6 +995,100 @@ One known tail: `/draft` hits ~0.18 in roughly 1 run in 5, attributed
 to a `DIV.muted` block collapsing 361×166 → 0 at ~900ms.  Pre-existing,
 not round 6's doing, and not yet fixed.
 
+## 2026-08-05 — first-load JS, measured truthfully at last
+
+Planned item #1 ("the framework baseline every route pays") was blocked on
+not having an instrument that could be trusted. It has one now:
+`frontend/scripts/measure-first-load.mjs`. The numbers below are its
+output, and anyone can re-run it.
+
+### The measurement
+
+35 routes, `--webpack` production build, Next 16.2.12:
+
+| | raw | gzipped |
+|---|---|---|
+| **ALWAYS LOADED** (intersection of every route) | **641.7 KB** | **202.0 KB** |
+| — framework (Next runtime, react-dom, polyfills, webpack) | 528.6 KB | 162.7 KB |
+| — app-owned | 113.2 KB | 39.3 KB |
+
+Heaviest route-specific slices on top of that: `/draft` 142.7 KB raw
+(41.8 gz), `/rankings` 108.9 (37.7), `/` 93.5 (29.1), `/trade` 89.0 (30.9),
+`/waivers` 74.1 (26.5).
+
+**These supersede the ledger's earlier framework figures**, which were
+measured on Next 15.5.22 by the retracted instrument. Cite these instead.
+
+### Why this instrument can be trusted where the last two could not
+
+It reads the `<script src>` tags out of each route's **prerendered HTML**
+(`.next/server/app/**.html`) — Next's own statement of what the browser
+fetches before the page is interactive — and intersects across routes. A
+chunk appears there only if that route actually preloads it.
+
+That is exactly the property the retracted metrics lacked.
+`firstLoadChunks()` read a manifest Next 16 stopped emitting; its
+replacement treated everything in `static/chunks/` as always-loaded, which
+is how it scored round 6's refactor as +213 KB shared while `/league`'s
+slice actually fell 163.4 → 37.8 KB.
+
+**The control makes that concrete, and it can fail.** This build has
+513 KB of chunks on disk that NO route preloads —
+`ad2866b8.*` (193.4 KB, html2canvas behind `await import()` in
+ScreenshotFab), `framework-*` (185.2 KB) and `main-*` (134.4 KB), the
+latter two being pages-router artifacts the app router never loads. The
+old metric counted all three against every route. The instrument asserts
+at least one such chunk exists and exits non-zero if not.
+
+*A note on how that control was arrived at, because the first version was
+worthless:* it originally asserted no always-loaded chunk had
+`html2canvas` in its URL. Webpack content-hashes that chunk to
+`ad2866b8.<hash>.js`, so the string never appears in a filename and the
+check **could not fail**. It passed, and it meant nothing. Grepping for
+`html2canvas` finds only the import specifier inside the shell chunk. A
+control that cannot fail reads as verification and is worse than none.
+
+### Where the 641.7 KB actually goes, and what is worth cutting
+
+* **Framework is 528.6 KB raw / 162.7 KB gz of it, and it is not
+  app-shaped.** Next's client runtime (217.1 KB) + react-dom (195.2 KB) +
+  polyfills (110.0 KB, `noModule` so modern browsers skip it — call the
+  modern floor 531.7 KB raw). Nothing in this repo's control.
+* **App-owned is 113.2 KB raw / 39.3 KB gz**, and the single biggest piece
+  is chunk `5827` at 36.0 KB raw / 12.2 KB gz — the shell chrome: TopBar,
+  MobileChrome, NavMenu, both switchers, ScreenshotFab, StaleDataBanner
+  (identified by marker strings `shell-topbar`, `team-switcher`,
+  `screenshot-fab`, `stale-data-banner`).
+
+So **deferring shell components caps out at ~12 KB gz**. That is the
+honest ceiling on the ledger's "mount on interaction" idea — worth
+knowing before anyone spends a week on it.
+
+### The bigger finding: a runtime gate is not a bundling gate
+
+`PUBLIC_ONLY_ROUTE_PREFIXES` stops `/league` from *calling*
+`useDynastyData()`. It does not stop it from *downloading* it: the import
+in `AppShell.jsx` is static, so the player-data pipeline is in the graph
+unconditionally. Verified against this build — chunks `8805`
+(`lib/dynasty-data`, markers `playersArray`/`dynasty-data`), `6023`
+(`useSettings`/trade-logic), `2910` (`useDynastyData`/`useAuth`) and
+`2063` (`useUserState`/`useLeague`) all appear in `/league`'s route HTML.
+Together **57.7 KB raw / 19.4 KB gz shipped to a page forbidden to use
+them.**
+
+This also scopes what the `NO_PLAYER_DATA_ROUTE_PREFIXES` work (#759)
+achieved: it removes the multi-MB `/api/data` fetch and the ~1,100-row
+`buildRows` pass from six routes — the dominant cost, and real — but
+**zero bytes of JS**. Removing the bytes needs the import itself to become
+conditional, i.e. splitting `PrivateAppShell` behind the same imperative
+`await import()` idiom `useLazyComponent` (`AppShell.jsx:81`) already uses.
+That is the largest remaining app-owned win and it is bigger than the
+shell-deferral idea.
+
+**Do not reach for `dynamic()` to do it** — `AppShell.jsx:16-72` documents,
+with measurements, that `dynamic()` there puts `{children}` inside a
+Suspense boundary and permanently duplicates every page's DOM.
+
 ## Rejected (attempted, reverted)
 
 ### Browser revalidation via `If-None-Match`/`304` — **not safe as-is**

--- a/frontend/scripts/measure-first-load.mjs
+++ b/frontend/scripts/measure-first-load.mjs
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+/**
+ * Per-route first-load JS — the measurement that replaces firstLoadChunks().
+ *
+ * WHY A THIRD INSTRUMENT
+ * ----------------------
+ * `firstLoadChunks()` was RETRACTED: it read a build manifest Next 16 no
+ * longer emits. Its disk-derived replacement was worse — it treated every
+ * file in `static/chunks/` as always-loaded, so it counted DYNAMIC-import
+ * chunks against every route and scored round 6's own refactor as +213 KB
+ * shared while `/league`'s slice actually fell 163.4 -> 37.8 KB. It
+ * reported an improvement as a regression, confidently.
+ *
+ * The lesson is not "measure harder", it is "measure something that
+ * cannot lie about which chunks a route loads".
+ *
+ * WHAT THIS MEASURES
+ * ------------------
+ * The `<script src>` tags in each route's PRERENDERED HTML
+ * (`.next/server/app/**.html`). That list is Next's own statement of what
+ * the browser fetches before the page is interactive — a chunk only
+ * appears there if the route actually preloads it.
+ *
+ *   ALWAYS-LOADED = the intersection across every route
+ *   ROUTE-SPECIFIC = that route's chunks minus the intersection
+ *
+ * The control that proves it is honest: `html2canvas` is a ~198 KB chunk
+ * pulled in by `await import("html2canvas")` in ScreenshotFab. It sits
+ * directly in `static/chunks/`, so the retracted disk-derived metric
+ * counted it on every route. It must NOT appear in the intersection here
+ * — and the script asserts that, rather than trusting it.
+ *
+ * `_global-error.html` is EXCLUDED from the intersection: the global error
+ * boundary bypasses the root layout, so it loads a strict subset and would
+ * drag the intersection down to a set no real route has.
+ *
+ * IT REFUSES TO REPORT WHAT IT DID NOT MEASURE
+ * --------------------------------------------
+ * Same posture as `assertGateIsMeasuring()` in check-bundle-sizes.mjs.
+ * Exits non-zero if there is no build, no route HTML, no script tags, or
+ * if a referenced chunk is missing from disk. A zero here means "I could
+ * not measure", never "there is nothing to load".
+ *
+ * TURBOPACK: like the bundle-size gate, this needs the `--webpack` build
+ * (`npm run build:nocheck`). Under Turbopack the prerendered HTML has no
+ * stable per-route chunk attribution. It says so and exits rather than
+ * guessing.
+ *
+ * USAGE
+ *   node frontend/scripts/measure-first-load.mjs [--json] [--top N]
+ */
+import fs from "node:fs";
+import path from "node:path";
+import zlib from "node:zlib";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const NEXT_DIR = path.join(HERE, "..", ".next");
+const APP_HTML_DIR = path.join(NEXT_DIR, "server", "app");
+const STATIC_DIR = path.join(NEXT_DIR, "static");
+
+// Bypasses the root layout, so its chunk set is a strict subset of every
+// real route's. Including it would silently shrink the intersection.
+const EXCLUDE_HTML = new Set(["_global-error.html"]);
+
+// The control below proves the instrument DISCRIMINATES — that it counts
+// what a route preloads rather than everything on disk, which is precisely
+// what the retracted metric got wrong.
+//
+// The first version of this control asserted that no always-loaded chunk
+// had "html2canvas" in its URL. That was VACUOUS: webpack content-hashes
+// that chunk to `ad2866b8.<hash>.js`, so the string never appears in a
+// filename and the check could not fail. (Grepping for it finds only the
+// import SPECIFIER inside the shell chunk.) A control that cannot fail is
+// worse than none — it reads as verification.
+//
+// The real invariant: `.next/static/chunks/` contains large chunks that no
+// route preloads, and the instrument must exclude them. Measured on this
+// build: html2canvas at 196 KB (`ad2866b8.*`), plus `framework-*` 188 KB
+// and `main-*` 136 KB, which are pages-router artifacts the app router
+// never loads. All three are in ZERO route HTMLs.
+const CONTROL_MIN_EXCLUDED_KB = 100;
+
+function parseArgs(argv) {
+  const out = { json: false, top: 12 };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--json") out.json = true;
+    else if (argv[i] === "--top") out.top = Number(argv[++i]);
+  }
+  return out;
+}
+
+function die(msg) {
+  console.error(`[measure-first-load] REFUSING TO REPORT\n\n${msg}\n`);
+  process.exit(2);
+}
+
+function walkHtml(dir, acc = []) {
+  if (!fs.existsSync(dir)) return acc;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walkHtml(full, acc);
+    else if (entry.name.endsWith(".html")) acc.push(full);
+  }
+  return acc;
+}
+
+const args = parseArgs(process.argv.slice(2));
+
+if (!fs.existsSync(NEXT_DIR)) {
+  die(`No build at ${NEXT_DIR}.\nRun: npm run build:nocheck`);
+}
+
+const htmlFiles = walkHtml(APP_HTML_DIR).filter(
+  (f) => !EXCLUDE_HTML.has(path.basename(f)),
+);
+if (htmlFiles.length === 0) {
+  die(
+    `No prerendered route HTML under ${APP_HTML_DIR}.\n` +
+      `Under Next 16's DEFAULT builder (Turbopack) this directory is not\n` +
+      `produced in a form this instrument can attribute. Build with\n` +
+      `--webpack (npm run build:nocheck), the same requirement\n` +
+      `check-bundle-sizes.mjs already declares.`,
+  );
+}
+
+// route name -> Set(chunk url)
+const byRoute = new Map();
+const SCRIPT_SRC = /<script[^>]+src="([^"]+)"/g;
+for (const file of htmlFiles) {
+  const html = fs.readFileSync(file, "utf8");
+  const chunks = new Set();
+  for (const m of html.matchAll(SCRIPT_SRC)) {
+    const src = m[1];
+    if (src.startsWith("/_next/static/")) chunks.add(src);
+  }
+  const route =
+    "/" +
+    path
+      .relative(APP_HTML_DIR, file)
+      .replace(/\.html$/, "")
+      .replace(/\\/g, "/");
+  byRoute.set(route === "/index" ? "/" : route, chunks);
+}
+
+const totalScriptTags = [...byRoute.values()].reduce((n, s) => n + s.size, 0);
+if (totalScriptTags === 0) {
+  die(
+    `Found ${htmlFiles.length} route HTML files but ZERO <script src> tags\n` +
+      `pointing at /_next/static/. The HTML shape changed; this parser is\n` +
+      `measuring nothing and would report 0 KB for every route.`,
+  );
+}
+
+// Intersection = loaded by EVERY route.
+let always = null;
+for (const chunks of byRoute.values()) {
+  always = always === null ? new Set(chunks) : new Set([...always].filter((c) => chunks.has(c)));
+}
+
+const sizeCache = new Map();
+function sizeOf(url) {
+  if (sizeCache.has(url)) return sizeCache.get(url);
+  const rel = url.replace(/^\/_next\/static\//, "");
+  const file = path.join(STATIC_DIR, rel);
+  if (!fs.existsSync(file)) {
+    die(
+      `Route HTML references ${url} but ${file} does not exist.\n` +
+        `Sizes would be understated by an unknown amount.`,
+    );
+  }
+  const buf = fs.readFileSync(file);
+  const rec = { raw: buf.length, gz: zlib.gzipSync(buf).length };
+  sizeCache.set(url, rec);
+  return rec;
+}
+
+const alwaysList = [...always]
+  .map((url) => ({ url, ...sizeOf(url) }))
+  .sort((a, b) => b.raw - a.raw);
+
+// ── Control: prove the instrument excludes what routes do not preload ──
+const chunkDir = path.join(STATIC_DIR, "chunks");
+const onDisk = fs.existsSync(chunkDir)
+  ? fs
+      .readdirSync(chunkDir)
+      .filter((f) => f.endsWith(".js"))
+      .map((f) => ({ name: f, raw: fs.statSync(path.join(chunkDir, f)).size }))
+  : [];
+const alwaysNames = new Set(alwaysList.map((c) => path.basename(c.url)));
+const excludedLarge = onDisk
+  .filter((c) => c.raw >= CONTROL_MIN_EXCLUDED_KB * 1024 && !alwaysNames.has(c.name))
+  .sort((a, b) => b.raw - a.raw);
+
+if (onDisk.length === 0) {
+  die(`No chunks found under ${chunkDir}; the control cannot run.`);
+}
+if (excludedLarge.length === 0) {
+  die(
+    `Control failed: every chunk >= ${CONTROL_MIN_EXCLUDED_KB} KB on disk is in the\n` +
+      `ALWAYS-LOADED set. This build should contain large chunks no route\n` +
+      `preloads (dynamic imports, pages-router artifacts). Either they\n` +
+      `regressed into the shared graph, or this instrument has started\n` +
+      `counting everything on disk like the retracted metric did.`,
+  );
+}
+
+const sum = (list, k) => list.reduce((n, c) => n + c[k], 0);
+const alwaysRaw = sum(alwaysList, "raw");
+const alwaysGz = sum(alwaysList, "gz");
+
+// Framework vs app-owned. The framework chunks are the Next client
+// runtime, react-dom, polyfills and webpack's own runtime; everything
+// else in the intersection is code this repo wrote or imported.
+const FRAMEWORK = /(polyfills|webpack-|main-app-|framework-)/;
+const isFramework = (c) => FRAMEWORK.test(c.url) || c.raw > 150_000;
+const framework = alwaysList.filter(isFramework);
+const appOwned = alwaysList.filter((c) => !isFramework(c));
+
+const routes = [...byRoute.entries()]
+  .map(([route, chunks]) => {
+    const own = [...chunks].filter((c) => !always.has(c)).map((url) => ({ url, ...sizeOf(url) }));
+    return { route, raw: sum(own, "raw"), gz: sum(own, "gz"), count: own.length };
+  })
+  .sort((a, b) => b.raw - a.raw);
+
+const kb = (n) => (n / 1024).toFixed(1);
+
+if (args.json) {
+  console.log(
+    JSON.stringify(
+      {
+        routeCount: byRoute.size,
+        alwaysLoaded: { raw: alwaysRaw, gz: alwaysGz, chunks: alwaysList },
+        framework: { raw: sum(framework, "raw"), gz: sum(framework, "gz") },
+        appOwned: { raw: sum(appOwned, "raw"), gz: sum(appOwned, "gz") },
+        routes,
+      },
+      null,
+      2,
+    ),
+  );
+} else {
+  console.log(`\nfirst-load JS — ${byRoute.size} routes measured from prerendered HTML\n`);
+  console.log(`ALWAYS LOADED (intersection of every route)`);
+  console.log(`  ${kb(alwaysRaw)} KB raw   ${kb(alwaysGz)} KB gzipped   ${alwaysList.length} chunks`);
+  console.log(
+    `    framework  ${kb(sum(framework, "raw"))} KB raw / ${kb(sum(framework, "gz"))} KB gz`,
+  );
+  console.log(
+    `    app-owned  ${kb(sum(appOwned, "raw"))} KB raw / ${kb(sum(appOwned, "gz"))} KB gz\n`,
+  );
+  console.log(`  largest always-loaded chunks:`);
+  for (const c of alwaysList.slice(0, args.top)) {
+    console.log(`    ${kb(c.raw).padStart(8)} KB  ${kb(c.gz).padStart(7)} KB gz  ${c.url.replace("/_next/static/chunks/", "")}`);
+  }
+  console.log(`\nROUTE-SPECIFIC (on top of the above)`);
+  console.log(`  ${"route".padEnd(34)} ${"raw".padStart(9)} ${"gz".padStart(9)}  chunks`);
+  console.log("  " + "-".repeat(66));
+  for (const r of routes.slice(0, args.top)) {
+    console.log(
+      `  ${r.route.padEnd(34)} ${(kb(r.raw) + " KB").padStart(9)} ${(kb(r.gz) + " KB").padStart(9)}  ${r.count}`,
+    );
+  }
+  console.log(
+    `\ncontrol: ${excludedLarge.length} chunk(s) >= ${CONTROL_MIN_EXCLUDED_KB} KB on disk are correctly` +
+      ` EXCLUDED (no route preloads them):`,
+  );
+  for (const c of excludedLarge.slice(0, 4)) {
+    console.log(`    ${kb(c.raw).padStart(8)} KB  ${c.name}`);
+  }
+}


### PR DESCRIPTION
> **Body revised 2026-08-06.** The original claimed the conditional `useDynastyData` import was worth the full 57.7 KB raw / 19.4 KB gz. That was an overstatement and is corrected in "What is actually cuttable" below. Nothing about the instrument or the 641.7 KB measurement changes — the correction is to an inference I drew from it, which was about to justify a much riskier change than the bytes warrant.

Planned item #1 ("the framework baseline every route pays") was blocked on not having an instrument anyone could trust. Two previous ones were wrong: `firstLoadChunks()` read a manifest Next 16 stopped emitting, and its replacement treated everything in `static/chunks/` as always-loaded — which is how it scored round 6's refactor as **+213 KB shared** while `/league`'s slice actually *fell* 163.4 → 37.8 KB. It reported an improvement as a regression, confidently.

## The measurement

35 routes, `--webpack` build, Next 16.2.12:

| | raw | gzipped |
|---|---|---|
| **ALWAYS LOADED** (intersection of every route) | **641.7 KB** | **202.0 KB** |
| — framework (Next runtime, react-dom, polyfills, webpack) | 528.6 KB | 162.7 KB |
| — app-owned | 113.2 KB | 39.3 KB |

Heaviest route slices on top: `/draft` 142.7 KB raw, `/rankings` 108.9, `/` 93.5, `/trade` 89.0. These **supersede the ledger's framework figures**, which were Next 15.5.22 numbers from the retracted instrument.

## Why this one can be trusted

It reads the `<script src>` tags out of each route's **prerendered HTML** (`.next/server/app/**.html`) — Next's own statement of what the browser fetches before the page is interactive — and intersects across routes. A chunk appears there only if that route actually preloads it, so a dynamic import cannot masquerade as shared.

`_global-error.html` is excluded: it bypasses the root layout, loads a strict subset, and would silently shrink the intersection to a set no real route has.

## The control, and why the first one was worthless

The instrument asserts that large chunks no route preloads are excluded. This build has 513 KB of them: `ad2866b8.*` (193.4 KB, html2canvas behind `await import()` in ScreenshotFab), `framework-*` (185.2 KB) and `main-*` (134.4 KB), the latter two being pages-router artifacts the app router never loads. The old metric counted all three against every route.

My first version of that control asserted no always-loaded chunk had `html2canvas` in its URL. Webpack content-hashes that chunk to `ad2866b8.<hash>.js`, so the string never appears in a filename and the check **could not fail**. It passed, and it meant nothing. A control that cannot fail reads as verification and is worse than none. The replacement is anchored on a property of the build rather than a filename, and the script exits non-zero when it cannot measure — same posture as `assertGateIsMeasuring()` in `check-bundle-sizes.mjs`.

## What is actually cuttable

**Framework is 528.6 KB of the 641.7 and is not this repo's code.** Next's client runtime (217.1 KB) + react-dom (195.2 KB) + polyfills (110.0 KB, `noModule` so modern browsers skip it — call the modern floor 531.7 KB raw).

**App-owned is 113.2 KB raw / 39.3 KB gz.** The biggest single piece is chunk `5827` at 36.0 KB raw / 12.2 KB gz — the shell chrome (TopBar, MobileChrome, NavMenu, both switchers, ScreenshotFab, StaleDataBanner). So "defer shell components on interaction" **caps out around 12 KB gz**, worth knowing before someone spends a week on it.

### A runtime gate is not a bundling gate — and the correction

`PUBLIC_ONLY_ROUTE_PREFIXES` stops `/league` from *calling* `useDynastyData()`. It does not stop it from *downloading* it: the import in `AppShell.jsx` is static, so the pipeline is in the graph unconditionally. Verified against this build — chunks `8805`, `6023`, `2910` and `2063` all appear in `/league`'s route HTML. **57.7 KB raw / 19.4 KB gz downloaded by a page forbidden to use it.**

That figure is correct as a statement of what `/league` wastes. **What was wrong is the implication that making AppShell's import conditional would recover it.** Traced statically from `app/layout.jsx`, only one of those chunks has AppShell as its reason:

| chunk | reached from |
|---|---|
| `2910` | `components/AppShell.jsx` — **the only edge** |
| `8805` | `useDynastyData.js` **and** `components/useLeague.js` |
| `6023` | `useDynastyData.js`, `useTeam.js`, `useTerminal.js` |
| `2063` | `useLeague.js` |

The surviving edges are the **chrome, not the data layer**: `TopBar.jsx:21-22` and `MobileChrome.jsx:21-22` statically import `LeagueSwitcher` → `useLeague` → `lib/dynasty-data`, and `TeamSwitcher` → `useTeam`. The nav bar renders on every route, so those three chunks stay put no matter what AppShell does. Removing them means deferring visible chrome and making the switchers pop in after paint — a different trade, and not the one this section originally described.

**So the ceiling on a conditional AppShell import is chunk 2910 alone: 12.0 KB raw / 4.5 KB gz.** #763 (stacked on this branch) then takes 6.6 KB raw / 2.3 KB gz of that out of the every-route set by moving `lib/waiver-logic` behind the already-lazy CommandPalette, leaving **5.3 KB raw / 2.2 KB gz** as what remains.

At that size it is worth naming the hazard rather than pursuing it: a lazily-loaded `PrivateAppShell` **component** would remount every page in the app. Both shell branches render at the same position with `{children}` inside (`AppShell.jsx:141-146`), so when the chunk lands the element type at that position changes — page state discarded, effects re-run, fetches fired twice, scroll reset. A null-rendering leaf bridge avoids it, at real complexity for ~2 KB gz. Both the corrected attribution and the hazard are recorded in `docs/performance-optimization.md` on #763.

### And do not reach for `dynamic()`

`AppShell.jsx:16-72` documents with measurements that `dynamic()` there puts `{children}` inside a Suspense boundary and permanently duplicates every page's DOM. The imperative `await import()` idiom in `useLazyComponent` is the one to use.

## Scoping #759 honestly

Gating six routes out of the data pipeline removes the multi-MB `/api/data` fetch and the ~1,100-row `buildRows` pass — the dominant cost, and real — but **zero bytes of JS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaMgGfyHGEs38eGJ3kBf6H