### PR TITLE
Move the palette's ownership index into the palette itself

### DIFF
--- a/docs/performance-optimization.md
+++ b/docs/performance-optimization.md
@@ -1080,14 +1080,84 @@ This also scopes what the `NO_PLAYER_DATA_ROUTE_PREFIXES` work (#759)
 achieved: it removes the multi-MB `/api/data` fetch and the ~1,100-row
 `buildRows` pass from six routes — the dominant cost, and real — but
 **zero bytes of JS**. Removing the bytes needs the import itself to become
-conditional, i.e. splitting `PrivateAppShell` behind the same imperative
-`await import()` idiom `useLazyComponent` (`AppShell.jsx:81`) already uses.
-That is the largest remaining app-owned win and it is bigger than the
-shell-deferral idea.
+conditional.
 
 **Do not reach for `dynamic()` to do it** — `AppShell.jsx:16-72` documents,
 with measurements, that `dynamic()` there puts `{children}` inside a
 Suspense boundary and permanently duplicates every page's DOM.
+
+#### CORRECTION — the 57.7 KB is NOT all AppShell's to remove
+
+The paragraph above (and the PR body it came from) implied that splitting
+the AppShell import would recover all 57.7 KB / 19.4 KB gz. **It would
+not.** Traced statically from `app/layout.jsx`, only **one** of those four
+chunks hangs off AppShell's import of `useDynastyData`:
+
+| chunk | reached from |
+|---|---|
+| `2910` | `components/AppShell.jsx` — **the only edge** |
+| `8805` | `useDynastyData.js` **and** `components/useLeague.js` |
+| `6023` | `useDynastyData.js`, `useTeam.js`, `useTerminal.js` |
+| `2063` | `useLeague.js` |
+
+The surviving edges are the **chrome, not the data layer**:
+`TopBar.jsx:21-22` and `MobileChrome.jsx:21-22` statically import
+`LeagueSwitcher` → `useLeague` → `lib/dynasty-data`, and `TeamSwitcher` →
+`useTeam`. Those three chunks stay on every route no matter what AppShell
+does, because the nav bar renders on every route. Removing them means
+deferring visible chrome and making the switchers pop in after paint.
+
+So the honest ceiling on "make the player pipeline import conditional" is
+chunk 2910 alone — and after the cut below it is **5.3 KB raw / 2.2 KB
+gz**, not 57.7 KB. Weigh that against the remount hazard before attempting
+it: a lazily-loaded `PrivateAppShell` *component* is a trap, because both
+shell branches render at the same position with `{children}` inside
+(`AppShell.jsx:141-146`). When the chunk lands, the element type at that
+position changes and **React remounts every page** — page state discarded,
+effects re-run, fetches fired twice, scroll reset. A different mechanism
+from the `dynamic()` DOM duplication, the same family of damage, and this
+one is plainly visible. A null-rendering leaf bridge that reports upward
+via callback avoids it, at the cost of real complexity for ~2 KB gz.
+
+### The cut that WAS worth taking: waiver-logic out of the root layout
+
+`AppShell.jsx` imported `buildTeamByPlayer` from `lib/waiver-logic.js`
+(33.9 KB of source) for exactly one purpose: a `useMemo` that built the
+`teamByPlayer` ownership index and passed it to `<CommandPalette>`. But
+CommandPalette is **already lazily loaded** (`useLazyComponent`,
+`AppShell.jsx:200`) and only reachable after "/" or Cmd+K. The root layout
+was therefore pulling the whole waiver module into the every-route chunk to
+prepare a prop for a component that usually never loads.
+
+Fix: CommandPalette takes the raw `sleeperTeams` array and builds the index
+itself, so `lib/waiver-logic` follows the component into its lazy chunk.
+Precedent already in the tree — `PlayerPopup.jsx:7,680` does the same.
+
+Measured with `measure-first-load.mjs`, same build flags, before/after:
+
+| | raw | gzipped |
+|---|---|---|
+| always-loaded before | 641.7 KB | 202.0 KB |
+| always-loaded after | **635.1 KB** | **199.7 KB** |
+| delta on **every** route | **−6.6 KB** | **−2.3 KB** |
+
+Chunk `2910` fell 12.0 → 5.3 KB raw. waiver-logic relocated to chunk
+`5145`, which is now preloaded by exactly two routes — `/rankings`
+(`page.jsx:56` imports `buildTeamByPlayer` directly) and `/waivers` (its
+own page) — instead of all 35.
+
+**State the source size and the shipped size separately.** "33.9 KB of
+source leaves the root-layout graph" is true and was the reason to try it,
+but the number that reaches users is 6.6 KB raw / 2.3 KB gz after
+minification and shared-chunk splitting. Quoting the source figure as the
+win would overstate it by 5×. This is the same failure mode as the
+retracted `firstLoadChunks()`, just in the optimistic direction.
+
+The `owner:` token grammar was **untested** before this change — every
+existing CommandPalette case passed `teamByPlayer={null}`, so the prop was
+never exercised. Three tests were added to cover the index the palette now
+builds itself; without them the move could have silently disabled owner
+filtering and nothing would have failed.
 
 ## Rejected (attempted, reverted)
 

--- a/frontend/__tests__/components/shell/CommandPalette.test.jsx
+++ b/frontend/__tests__/components/shell/CommandPalette.test.jsx
@@ -47,11 +47,20 @@ const ROWS = [
   },
 ];
 
+// Raw Sleeper team array. The palette builds its own {byId, byName}
+// index from this — it does NOT take a prebuilt one, so that
+// `lib/waiver-logic` stays behind the palette's lazy chunk instead of
+// riding the root layout into every route's bundle.
+const SLEEPER_TEAMS = [
+  { name: "Brisket Bros", ownerId: "u1", players: ["Justin Jefferson"], playerIds: [] },
+  { name: "Rival Squad", ownerId: "u2", players: ["Jahmyr Gibbs"], playerIds: [] },
+];
+
 function palette(props = {}) {
   return render(
     <CommandPalette
       rows={ROWS}
-      teamByPlayer={null}
+      sleeperTeams={null}
       isOpen
       onClose={() => {}}
       onSelect={() => {}}
@@ -94,6 +103,36 @@ describe("player search (legacy semantics preserved)", () => {
     await user.keyboard("wr min");
     expect(screen.getByText("Justin Jefferson")).toBeInTheDocument();
     expect(screen.queryByText("Jahmyr Gibbs")).toBeNull();
+  });
+});
+
+// The `owner:` grammar was previously UNTESTED here — every case passed
+// `teamByPlayer={null}`, so the prop was never exercised at all. Since
+// the palette now builds that index itself from `sleeperTeams`, these
+// are what prove the move preserved the behaviour rather than quietly
+// disabling owner filtering.
+describe("owner: tokens — the index the palette builds itself", () => {
+  it("filters to one manager's players from the raw team array", async () => {
+    const user = userEvent.setup();
+    palette({ sleeperTeams: SLEEPER_TEAMS });
+    await user.keyboard("owner:brisket");
+    expect(screen.getByText("Justin Jefferson")).toBeInTheDocument();
+    expect(screen.queryByText("Jahmyr Gibbs")).toBeNull();
+  });
+
+  it("composes with the other tokens (owner: + pos:)", async () => {
+    const user = userEvent.setup();
+    palette({ sleeperTeams: SLEEPER_TEAMS });
+    await user.keyboard("owner:rival pos:rb");
+    expect(screen.getByText("Jahmyr Gibbs")).toBeInTheDocument();
+    expect(screen.queryByText("Justin Jefferson")).toBeNull();
+  });
+
+  it("without teams, owner: matches nobody rather than throwing", async () => {
+    const user = userEvent.setup();
+    palette(); // sleeperTeams = null — the /league and pre-load case
+    await user.keyboard("owner:brisket");
+    expect(screen.getByText(/No results/)).toBeInTheDocument();
   });
 });
 

--- a/frontend/components/AppShell.jsx
+++ b/frontend/components/AppShell.jsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
 import { useDynastyData } from "@/components/useDynastyData";
-import { buildTeamByPlayer } from "@/lib/waiver-logic";
 // Both live in the ROOT LAYOUT, so a static import puts them in the
 // chunk set every one of ~90 routes downloads and parses — 69 KB of it,
 // measured. Neither is reachable until the user acts: PlayerPopup needs
@@ -254,13 +253,11 @@ function InnerAppShell({ loading, error, rows, siteKeys, rawData, privateDataEna
     setSearchOpen(true);
   }, [searchEnabled]);
 
-  // League-scoped ownership index for the command palette's owner: tokens.
-  // Rows are scoring-profile-scoped and never carry the owner; the
-  // join happens here at render time (CLAUDE.md split).
-  const teamByPlayer = useMemo(
-    () => buildTeamByPlayer(rawData?.sleeper?.teams || []),
-    [rawData?.sleeper?.teams],
-  );
+  // NOTE: the command palette's `owner:` ownership index is built INSIDE
+  // CommandPalette, not here. It used to be a memo at this spot, which
+  // meant the root layout statically imported `lib/waiver-logic` (33.9 KB
+  // of source) purely to feed a lazily-loaded component — putting it in
+  // the chunk every route downloads. See CommandPalette.jsx's header.
 
   // Global keyboard shortcuts for search: "/" (legacy, preserved) and
   // Cmd/Ctrl+K (the standard command-palette chord — R1 additive).
@@ -328,7 +325,7 @@ function InnerAppShell({ loading, error, rows, siteKeys, rawData, privateDataEna
       {searchEnabled && searchOpen && CommandPalette && (
         <CommandPalette
           rows={rows}
-          teamByPlayer={teamByPlayer}
+          sleeperTeams={rawData?.sleeper?.teams || null}
           isOpen={searchOpen}
           onClose={() => setSearchOpen(false)}
           onSelect={(row) => openPlayerPopup(row)}

--- a/frontend/components/shell/CommandPalette.jsx
+++ b/frontend/components/shell/CommandPalette.jsx
@@ -24,7 +24,25 @@
  * stack come for free.
  *
  * Props (superset of GlobalSearch's contract):
- *   rows, teamByPlayer, isOpen, onClose, onSelect(row)
+ *   rows, sleeperTeams, isOpen, onClose, onSelect(row)
+ *
+ * ⚠ `sleeperTeams` — the RAW team array — not the prebuilt
+ * `{byId, byName}` index it used to take. The index is built HERE.
+ *
+ * That is a bundle boundary, not a style preference. `buildTeamByPlayer`
+ * lives in `lib/waiver-logic.js` (33.9 KB of source), and AppShell — the
+ * ROOT LAYOUT — imported it solely to build this prop. So the whole
+ * waiver module landed in the chunk every route downloads (measured:
+ * chunk 2910, 12.0 KB raw / 4.5 KB gz, in the always-loaded intersection
+ * of all 35 routes) to serve a palette that is itself lazily loaded and
+ * only reachable after "/" or Cmd+K.
+ *
+ * Building the index inside the lazy component moves that import behind
+ * the same gate as the component. Precedent: `PlayerPopup.jsx:7,680`
+ * already imports `buildTeamByPlayer` itself for the same reason.
+ *
+ * Keep it this way. Hoisting the memo back into a caller re-attaches
+ * waiver-logic to whatever chunk that caller sits in.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
@@ -32,6 +50,7 @@ import { Icon, Modal } from "@/components/ds";
 import { resolvedRank } from "@/lib/dynasty-data";
 import { matchesQuery } from "@/lib/player-filters";
 import { paletteTargets } from "@/lib/nav-model";
+import { buildTeamByPlayer } from "@/lib/waiver-logic";
 
 const MAX_PLAYERS = 12;
 const MAX_NAV = 6;
@@ -56,12 +75,21 @@ function matchNavTargets(query) {
 
 export default function CommandPalette({
   rows = [],
-  teamByPlayer = null,
+  sleeperTeams = null,
   isOpen,
   onClose,
   onSelect,
 }) {
   const router = useRouter();
+
+  // League-scoped ownership index for the `owner:` / `team:` tokens.
+  // Rows are scoring-profile-scoped and never carry the owner, so the
+  // join happens at render time (CLAUDE.md's scoringProfile/leagueKey
+  // split). Built here rather than passed in — see the header.
+  const teamByPlayer = useMemo(
+    () => (sleeperTeams ? buildTeamByPlayer(sleeperTeams) : null),
+    [sleeperTeams],
+  );
   const [query, setQuery] = useState("");
   const [selectedIdx, setSelectedIdx] = useState(0);
   const inputRef = useRef(null);


### PR DESCRIPTION
Stacked on #761 — it needs that PR's `measure-first-load.mjs` to prove anything, and this is the first cut that instrument justified. Merge #761 first.

## The problem

`AppShell.jsx` — the **root layout** — imported `buildTeamByPlayer` from `lib/waiver-logic.js` (33.9 KB of source) for exactly one purpose: a `useMemo` that built the `teamByPlayer` ownership index and passed it to `<CommandPalette>`.

But CommandPalette is **already lazily loaded** (`useLazyComponent`, `AppShell.jsx:200`) and only reachable after `/` or Cmd+K. So the root layout was pulling the whole waiver module into the chunk every route downloads, in order to prepare a prop for a component that usually never loads.

## The change

CommandPalette takes the raw `sleeperTeams` array and builds the index itself, so `lib/waiver-logic` follows the component into its lazy chunk. Precedent already in the tree: `PlayerPopup.jsx:7,680` imports `buildTeamByPlayer` for the same reason.

## Measured, before and after, same build flags

| | raw | gzipped |
|---|---|---|
| always-loaded before | 641.7 KB | 202.0 KB |
| always-loaded after | **635.1 KB** | **199.7 KB** |
| delta on **every** route | **−6.6 KB** | **−2.3 KB** |

Chunk `2910` fell 12.0 → 5.3 KB raw. waiver-logic relocated to chunk `5145`, now preloaded by exactly two routes — `/rankings` (`page.jsx:56` imports `buildTeamByPlayer` directly) and `/waivers` (its own page) — instead of all 35.

Chunk identity was confirmed by fingerprint, not inferred: waiver-logic's four verdict literals (`"considering"`, `"marginal"`, `"obvious"`, `"reasonable"`) are the only strings in it that survive minification, and they co-occur in exactly one chunk before and after.

## Two things worth stating plainly

**The source size and the shipped size are different numbers, and only one of them reaches users.** "33.9 KB of source leaves the root-layout graph" is true and was the reason to try this. What actually ships, after minification and shared-chunk splitting, is 6.6 KB raw / 2.3 KB gz. Quoting the source figure as the win would overstate it 5×. Same failure mode as the retracted `firstLoadChunks()`, in the optimistic direction.

**The `owner:` grammar was untested.** Every existing CommandPalette case passed `teamByPlayer={null}`, so the prop was never exercised at all. Three tests were added covering the index the palette now builds. Without them this move could have silently disabled owner filtering and nothing would have failed.

## Correction to #761's framing, carried into the ledger

#761's body claims the conditional AppShell import is worth 57.7 KB raw / 19.4 KB gz. **That is an overstatement.** Traced statically from `app/layout.jsx`, only one of those four chunks hangs off AppShell:

| chunk | reached from |
|---|---|
| `2910` | `components/AppShell.jsx` — **the only edge** |
| `8805` | `useDynastyData.js` **and** `components/useLeague.js` |
| `6023` | `useDynastyData.js`, `useTeam.js`, `useTerminal.js` |
| `2063` | `useLeague.js` |

The surviving edges are the **chrome, not the data layer**: `TopBar.jsx:21-22` and `MobileChrome.jsx:21-22` statically import `LeagueSwitcher` → `useLeague` → `lib/dynasty-data`, and `TeamSwitcher` → `useTeam`. Those chunks stay on every route no matter what AppShell does, because the nav bar renders on every route.

So the honest ceiling on "make the player pipeline import conditional" is chunk 2910 alone — and after this PR that is **5.3 KB raw / 2.2 KB gz**, not 57.7 KB. The ledger now documents that alongside the hazard: a lazily-loaded `PrivateAppShell` *component* would remount every page in the app, because both shell branches render at the same position with `{children}` inside (`AppShell.jsx:141-146`), so the element type at that position changes when the chunk lands. ~2 KB gz is not worth that.

## Verification

- `npx vitest run` — **117 files, 1989 tests, all pass** (14 in the CommandPalette spec, including the 3 new `owner:` cases)
- `npm run check:bundles` — all 14 page budgets under; `/more` still has its 1.9 KB headroom, `/rankings` gained 0.4 KB of headroom
- `measure-first-load.mjs` before/after on identical `--webpack` builds; its exclusion control passed both times

## Not claimed

That this is a large win. It is 2.3 KB gz per route. It is here because it is free — no lazy-loading gymnastics, no new abstraction, one prop changed — and because measuring it is what corrected the 57.7 KB figure that was about to justify a much riskier change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaMgGfyHGEs38eGJ3kBf6H

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaMgGfyHGEs38eGJ3kBf6H)_