### PR TITLE
B3: remove the IDP market corridor's hard band cap (W02-F003)

### DIFF
--- a/docs/master-site-audit/REBASELINE_2026-08-11.md
+++ b/docs/master-site-audit/REBASELINE_2026-08-11.md
@@ -260,6 +260,59 @@ mostly acting as a *ceiling* on IDP value. That is the opposite of the
 give — a rationale CLAUDE.md already records as stale, since the
 calibration post-pass it names was removed. Strongest B3 candidate.
 
+## W02-F003 — the IDP market corridor clamp
+
+**REPAIRED IN B3.** Reproduced first on a fresh pin (code `2449af9ac`,
+board `dynasty_data_2026-08-11.json` sha256₁₆ `8fb6ede274171aee`, a
+DIFFERENT board from B2's — the B2 numbers stay attached to the B2 pin).
+The finding reproduced identically: 183/329 ranked IDP rows clamped
+(55.6%), 100% capped by the hard band, 100% on the band edge, only
+`bandPct` 0.15, 23 up / 160 down.
+
+Root cause: a hard constant overrode the board-derived per-bucket P90
+band. Empirical bands were 0.5183–0.6504 against a 0.15 cap in every
+bucket, all above the minimum-sample threshold, so the derived number was
+computed and discarded 183 times out of 183 — and 55.6% of the ranked IDP
+board was served at exactly `idpTradeCalc × 0.85` or `× 1.15`.
+
+The cap's stated purpose predeceased it. The corridor was built
+2026-04-21 (#198) to contain the IDP calibration post-pass; that pass was
+retired 2026-04-23 (#251), two days later. The cap arrived 2026-05-02
+(#375/#376), nine days after that. The hazard it names is now covered
+without an anchor by the single-source haircut (#496).
+
+Mandatory anchor-lineage check: all four IDP anchor-chain members are
+voting sources in the blend the corridor clamps, the fallback never
+fires, and `idpTradeCalc` was the anchor on **183/183** clamped rows while
+also voting on **183/183**. Its contribution is 0.721× the median of the
+other sources on those rows, which is why 160 of 183 clamps pulled values
+down.
+
+Repair: remove the IDP entry from
+`_MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS`, not retune it — criterion 6
+was low sensitivity to arbitrary constants, and 0.15 decided every clamp.
+Measured against candidates B/C/D/E on the same pin: the same code then
+clamps 32 rows (9.7%), all in the board tail, none with five or more
+sources, flat across confidence buckets (8.3/10.0/9.8% vs the capped
+63.9/45.8/60.7% — which was **inverted**, overriding the board's
+best-supported rows at the highest rate). Board composition barely moves:
+top-100 IDP 9 either way, top-200 43 → 41, top-400 130 either way.
+
+Not claimed: the empirical machinery was never dead (a tighter synthetic
+board reaches it, pinned by test), and the corridor is not removed —
+candidate E was measured alongside and the tail rail is what the corridor
+was designed for. Residual recorded: the band is derived from the drift
+it bounds, so a board that drifted as a whole would widen its own band.
+
+Full evidence: `evidence/W02/B3_MARKET_CORRIDOR_EVIDENCE.md`. Pinned by
+`tests/api/test_market_corridor_characterization.py` (15) plus the
+rewritten cap tests in `tests/api/test_market_corridor_clamp.py` (31).
+
+Still open after B3: the anchor is still a voter on the remaining 9.7%;
+the confidence-bucket dependency is now LIVE for the first time (the band
+that decides clamps is derived per bucket); C17's OFFENSE half; the IDP
+master's 1.552× fit-scale claim; W30-F023.
+
 ## Not done here
 
 - `verify_closure.py --rerun` over the 338 safe reproductions. It needs the full stack

--- a/docs/master-site-audit/evidence/W02/B3_MARKET_CORRIDOR_EVIDENCE.md
+++ b/docs/master-site-audit/evidence/W02/B3_MARKET_CORRIDOR_EVIDENCE.md
@@ -258,6 +258,21 @@ substitute, and that is pinned by
 
 ## 10. Gates
 
-Recorded in the B3 checkpoint report; full Python hard gate, frontend
-suite, build and bundle budgets, ruff, coercion ratchet, audit-status drift
-and exact-HEAD CI.
+Measured at B3 HEAD `c1c6de9c5`, quiescent tree.
+
+| gate | result |
+|---|---|
+| `tests/api/test_market_corridor_characterization.py` + `test_market_corridor_clamp.py` | 7 RED on the cap removal → **46 passed** |
+| full `pytest tests/ -q -x -m "not livedata"` | **6,913 passed / 0 failed**, 278 deselected, 294 subtests (1,371 s = 22m50s) |
+| `vitest run` (frontend) | **2,010 passed / 0 failed**, 121 files — unchanged, the repair is backend-only |
+| `npm --prefix frontend run build` | compiled; **all 14 route bundle budgets under** |
+| `ruff check .` | All checks passed |
+| `ruff format --check .` | 1,009 files already formatted |
+| `scripts/check_decision_coercions.py` | clean in the files this change touches |
+| `scripts/audit_status.py` | no drift (21 closed / 19 open / 2 needs_review / 1 deferred) |
+| CI `Validate PR` on the pushed HEAD | **green** ([run 31490169550](https://github.com/jasonleetucker-code/riskittogetthebrisket/actions/runs/31490169550)) |
+
+The Python delta from B2's 6,898 is exactly +15 — the new characterization
+file. No existing test changed state; the seven that went red were
+rewritten in the same commit as the repair, which is the record of what
+the change did.

--- a/docs/master-site-audit/evidence/W02/B3_MARKET_CORRIDOR_EVIDENCE.md
+++ b/docs/master-site-audit/evidence/W02/B3_MARKET_CORRIDOR_EVIDENCE.md
@@ -1,0 +1,263 @@
+# B3 — W02-F003: the IDP market corridor
+
+**Phase**: B3 (authorized 2026-08-11, after PR #787 merged)
+**Scope**: W02-F003 only.
+**Not done, and not authorized**: no `promote`/`apply`, no Hill champion
+constant change, no `PERCENTILE_REFERENCE_N` change, no W30-F023 tail-clamp
+work, no source-weight change, no adaptive weighting, no B4. The B2
+coordinate-pool architecture is untouched.
+
+---
+
+## 1. The B3 pin
+
+B2 was integrated first (PR #787 merged as `2449af9ac`) and the branch
+re-cut from it, so this is not another measurement on the stale B2
+baseline.
+
+| item | value |
+|---|---|
+| code | `2449af9ac` |
+| board | `exports/latest/dynasty_data_2026-08-11.json` |
+| board sha256₁₆ | `8fb6ede274171aee` (834,861 B) |
+| scraped | 2026-08-11T11:32:57Z |
+| source CSVs | 24, all hashed |
+| champion model | registry v2 — GLOBAL 0.1120/0.725, OFFENSE 0.1100/1.110, IDP 0.0830/1.110, ROOKIE 0.1530/0.885 |
+
+**This is a different board from B2's** (`a495c049fa69f141`). The B2
+numbers remain attached to the B2 pin; nothing was recomputed across the
+data refresh and presented as the same experiment. Every candidate below
+was measured on this one pin.
+
+Harnesses: `b3_corridor_measure.py` (`--pin` / `--reproduce`),
+`b3_candidate_policies.py`. Raw output: `b3_corridor_reproduction.txt`
+(before), `b3_corridor_after.txt` (after), `b3_candidate_policies.txt`,
+`b3_corridor_report.json`, `b3_candidate_policies.json`.
+
+## 2. Reproduction — W02-F003 CONFIRMED on the fresh pin
+
+Identical to the B2 measurement, so the finding is not an artifact of
+either snapshot:
+
+- **183 of 329** ranked IDP rows clamped = **55.6%**
+- `cappedByMaxBand` on **183/183 (100%)**
+- landing exactly on the band edge on **183/183 (100%)**
+- only `bandPct = 0.15` observed
+- direction **23 up / 160 down** — predominantly a ceiling
+
+Three things the finding did not record.
+
+**The per-bucket machinery is unreachable on this board, not merely
+dominated.** Empirical bands: high 0.6504 (n=36), low 0.6316 (n=173),
+medium 0.5183 (n=120), overall 0.6201 — 3.5× to 4.3× the cap, in *every*
+bucket, all three above the 30-row minimum so the small-sample fallback
+never fires either.
+
+**The corridor, not the blend, determined the value.** Unclamped distance
+from the anchor was median 0.2264 / p90 0.6483 / max 0.8261; after the
+clamp it was exactly 0.15 on every clamped row. 55.6% of the ranked IDP
+board was served at precisely `idpTradeCalc × 0.85` or `× 1.15`. Served
+effect: 193 rows differed with the corridor on, mean |14.45%|, p90 30.5%,
+max 52.0%.
+
+**The anchor is not independent evidence** (§5, mandatory). All four
+members of the IDP anchor chain — `idpTradeCalc`, `dlfIdp`, `idpShow`,
+`fantasyProsIdp` — are voting sources in the blend the corridor clamps.
+In practice the fallback never fires: `idpTradeCalc` was the anchor on
+**183/183** clamped rows, and on **183/183** it also voted in that row's
+blend. So it received a direct contribution *and* a post-blend veto.
+
+The vote-share isolate — computed from the stamped per-source
+contributions, so the IDP ladder that `idpTradeCalc` also seeds as backbone
+stays intact — puts its contribution at **0.721×** the median of the other
+sources on those rows (p10 0.452, p90 1.184). It prices them below its
+peers, which is why 160 of 183 clamps pulled values *down*. Clamped rows
+were thin: median 3 stamped sources, minimum 2.
+
+The whole-board leave-`idpTradeCalc`-out rebuild is reported as an **upper
+bound only**: dropping it empties the shared-market ladder and changes
+every other IDP source's coordinates, so it is not "the same model minus
+one vote". The vote-share figure is the isolate.
+
+## 3. The stale rationale — §6
+
+Dated from the tree, not inferred:
+
+| date | commit | event |
+|---|---|---|
+| 2026-04-21 | #198 | corridor added, rationale "contain the IDP calibration post-pass's 3-4× DB-bucket multipliers" |
+| **2026-04-23** | **#251** | **"remove: retire IDP calibration end-to-end"** |
+| 2026-05-02 | #375 | hard cap added at 0.25 |
+| 2026-05-02 | #376 | cap tightened 0.25 → 0.15, same day |
+| 2026-05-16 | #464 | offense exempted |
+| 2026-05-19 | #496 | single-source haircut (retain 30%) — an anchor-free mechanism for the same hazard |
+| 2026-08-04 | — | "never binds" note recorded |
+
+**The mechanism the corridor exists to contain was retired two days after
+the corridor was built**, and the cap that came to decide 100% of clamps
+arrived nine days after that. Confirmed absent today: no
+`_apply_idp_calibration_post_pass`, no `config/idp_calibration.json`, with
+two existing test files asserting they stay gone.
+
+So the corridor has been an orphaned safety mechanism for ~3.5 months, and
+its docstring still names a dead mechanism as its sole purpose. Whether
+*another* current mechanism requires it: the single-source explosion it
+describes is now handled by `_SINGLE_SOURCE_VALUE_RETENTION` (#496), which
+needs no anchor.
+
+## 4. The confidence-bucket dependency — §7
+
+**Not blocking, and the reason is measurable.** The corridor derives its
+band per confidence bucket, but the derived number was discarded on every
+row, so bucket quality could not invalidate a band that was never used. B3
+is therefore not blocked by the separately-tracked confidence work. The
+dependency becomes live the moment the empirical band decides anything —
+which, after the repair in §6, it does. That is a stated consequence, not
+a hidden one: the corridor's behaviour now depends on confidence-bucket
+semantics for the first time in practice.
+
+What the buckets showed about *who* was being clamped is the finding that
+matters, because it is the inverse of what a safety mechanism should do:
+
+| bucket | ranked IDP | clamped | rate | up/down |
+|---|---|---|---|---|
+| high | 36 | 23 | **63.9%** | 6/17 |
+| medium | 120 | 55 | 45.8% | 11/44 |
+| low | 173 | 105 | 60.7% | 6/99 |
+
+"High" means two or more sources with a tight percentile spread. The
+corridor overrode the board's **best-supported** IDP opinions at the
+highest rate, toward the one source that disagreed — and that source was
+one of the voters. By source count the concentration was sharper still:
+3-source rows 100/112 = **89.3%**, 5-source 26.2%, 6-source 25.0%.
+
+## 5. Evaluation criteria — declared before the candidates (§10)
+
+Printed by the harness before any number and not adjusted afterwards:
+
+1. **Pathology containment** — does it still catch a value that is *wrong*
+   rather than merely contested?
+2. **Preservation of well-evidenced disagreement** — a policy that
+   overrides thick, agreeing rows at a *higher* rate than thin ones is
+   inverted.
+3. **No hidden second weighting of the anchor** — `idpTradeCalc` already
+   votes; a second bite is a cost, not a feature.
+4. **Robustness to one missing source.**
+5. **Understandable provenance.**
+6. **Low sensitivity to arbitrary constants.**
+7. **Board coherence** — composition should not move for reasons unrelated
+   to evidence.
+
+Explicitly **not** a criterion: which board looks right. No per-player
+ground truth for dynasty IDP value exists on this timeframe, so a candidate
+selected on plausibility would be selected on nothing.
+
+## 6. Candidate policies, measured on one pin (§9)
+
+`A`, `B`, `E` are true pipeline runs (`E` via the existing
+`suppress_market_corridor_clamp`; `B` by clearing the cap dict for one
+in-process build, asserted restored). `C` and `D` are post-hoc derivations
+from `B`'s drift data and are labelled as such — they do not exist in
+production and B3 does not authorize shipping a candidate to measure it.
+
+| | rows | share | up/down | median &#124;Δ&#124; | max | confidence high/med/low | zones top/mid/tail |
+|---|---|---|---|---|---|---|---|
+| **A** current, P90 capped at 0.15 | 183/329 | 55.6% | 23/160 | 8.3% | 52.0% | 63.9 / 45.8 / 60.7 | 25 / 64 / 94 |
+| **B** P90, no hard cap | 32/329 | 9.7% | 0/32 | 2.0% | 10.7% | 8.3 / 10.0 / 9.8 | 0 / 0 / 32 |
+| **C** evidence-gated (post-hoc) | 17/329 | 5.2% | 0/17 | 1.6% | 10.7% | 0 / 0 / 9.8 | 0 / 0 / 17 |
+| **D** rail at 2× board P90 (post-hoc) | 0/329 | 0% | — | — | — | — | — |
+| **E** no corridor | 0/329 | 0% | — | — | — | — | — |
+
+Source-count incidence: **A** 3→100/112, 4→36/60, 5→32/122, 6→2/8.
+**B** 3→26/112, 4→3/60, **5→0/122, 6→0/8**.
+
+Board composition, true runs only — top-100 IDP **9** in all three;
+top-200 **43** (A) vs **41** (B and E); top-400 **130** in all three.
+
+**Candidate D returning zero is a result, not a null.** No row on this
+board drifts more than 2× the board's own P90, so the runaway the corridor
+was built to contain does not exist here.
+
+Against the criteria: **B** dominates **A** on 1 (it still catches the tail
+outliers; D shows there is nothing more extreme to catch), 2 (flat instead
+of inverted), 3 (9.7% instead of 55.6% of the board decided by the anchor),
+6 (no hand-set constant at all), and ties on 7. **C** is stricter still but
+adds two new hand-set thresholds, losing on 6 to buy little on 2. **E**
+gives up 1 entirely.
+
+## 7. The repair
+
+**Remove the IDP entry from `_MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS`.**
+The dict is now empty; the facility is kept because the mechanism is
+generic and a future asset class may need it.
+
+Removing rather than retuning is the point. Criterion 6 was low sensitivity
+to arbitrary constants, and `0.15` decided every clamp — replacing it with
+a different hand-set number reproduces the defect at a new value.
+
+Post-repair measurement on the same pin: **32 rows (9.7%)**, `cappedByMaxBand`
+**0/32**, `bandPct` now varying by bucket (0.5183 / 0.6316 / 0.6504), all
+32 on the band edge, all downward, clamp rate flat across buckets
+(8.3 / 10.0 / 9.8%), **zero rows with five or more sources**. Served-value
+effect: 32 rows differ, mean |3.27%|, median 1.95%, max 10.68% — the
+largest being Will Johnson 1,386 → 1,238.
+
+**RED → GREEN.** Seven characterization tests went red on the removal —
+four in `test_market_corridor_characterization.py`, three in
+`test_market_corridor_clamp.py` — and were rewritten against the measured
+behaviour with the reason recorded in each assertion message. The
+extreme-outlier test still passes: the Vikings-LB case is still caught, now
+at the board's own band edge (2,520) instead of a constant's (3,060). 46
+tests green across both files.
+
+### What this deliberately is not
+
+* **Not "the empirical machinery was dead."** A tighter synthetic board
+  reaches it, pinned by `test_a_tight_board_uses_the_empirical_band_not_the_cap`.
+  The cap's dominance was a property of this market's IDP disagreement.
+* **Not removing the corridor.** Candidates D and E were measured; the tail
+  rail is the behaviour the corridor was designed for and it survives.
+* **Not a fix for the anchor lineage.** `idpTradeCalc` still both votes and
+  anchors. The repair shrinks the second bite from 55.6% of the board to
+  9.7%; it does not eliminate it. See §9.
+
+### Residual, stated rather than hidden
+
+The band is derived from the same drift distribution it bounds, so a board
+that drifted *as a whole* would widen its own band and catch nothing. That
+is a property of the empirical design, not of this removal, and it is why
+the cap facility is kept rather than deleted.
+
+## 8. Downstream (§14)
+
+The change is a pure value change on 32 deep-tail IDP rows (max 10.7%),
+flowing through `rankDerivedValue` — the single value every engine reads.
+`consensus_edge/fair_value.py` already suppresses the corridor by design,
+so it is unaffected. Rankings, `/api/data`, `/trade`, finder/suggestions,
+waivers/FAAB, Team Strength inputs and value-history provenance all consume
+the same field and are covered by the full suite in §10. Missing stays
+missing: rows with no resolvable anchor are skipped, never clamped to a
+substitute, and that is pinned by
+`test_a_row_with_no_anchor_is_never_clamped`.
+
+## 9. Still open after B3
+
+* **The anchor is still a voter.** 9.7% of the ranked IDP board is still
+  decided by a source that also votes in it. Whether the corridor should
+  anchor on a leave-one-out blend, or on a genuinely external source, is a
+  design question B3 did not have authorization to settle.
+* **The confidence-bucket dependency is now live** (§4). The band that
+  decides clamps is derived per bucket, and bucket semantics are tracked
+  separately (W03-F004).
+* **C17's other half** — the OFFENSE master at a median 0.76 of `ktcSfTep`
+  raw — is untouched by both B2 and B3.
+* **The IDP master's 1.552× fit-scale claim** remains un-derived, and now
+  matters differently: after B2 that master prices zero rows on the default
+  board.
+* **W30-F023** (tail clamp) is untouched and open.
+
+## 10. Gates
+
+Recorded in the B3 checkpoint report; full Python hard gate, frontend
+suite, build and bundle budgets, ruff, coercion ratchet, audit-status drift
+and exact-HEAD CI.

--- a/docs/master-site-audit/evidence/W02/b3_candidate_policies.json
+++ b/docs/master-site-audit/evidence/W02/b3_candidate_policies.json
@@ -1,0 +1,90 @@
+{
+ "criteria": "EVALUATION CRITERIA \u2014 declared before any candidate is measured (B3 \u00a710).\nNot a score. Where no objective ground truth exists the tradeoff is\nreported, not invented.\n\n 1. Pathology containment. Does the policy still catch a value that is\n    wrong rather than merely contested \u2014 the single-source explosion the\n    corridor was built for?\n 2. Preservation of well-evidenced disagreement. A row where several\n    independent sources agree with each other and disagree with one\n    dissenting source is the board working, not failing. A policy that\n    overrides those rows at a HIGHER rate than thin rows is inverted.\n 3. No hidden second weighting of the anchor. `idpTradeCalc` already\n    votes. A policy that also lets it veto gives it two bites; the size\n    of the second bite is a cost, not a feature.\n 4. Robustness to one missing source. Behaviour should not hinge on\n    whether one board happened to cover a player.\n 5. Understandable provenance. A reader must be able to see why a value\n    is what it is.\n 6. Low sensitivity to arbitrary constants. A policy whose entire\n    behaviour is decided by one hand-set number is fragile by\n    construction.\n 7. Board coherence. Positional and top-of-board composition should not\n    move for reasons unrelated to evidence.\n\nNOT a criterion: which board \"looks right\". No objective per-player ground\ntruth for dynasty IDP value exists on this timeframe, so any candidate\nselected on eyeball plausibility would be selected on nothing.",
+ "results": [
+  {
+   "label": "A  current (bucket P90 capped at 0.15)",
+   "affected": 183,
+   "population": 329,
+   "up": 23,
+   "down": 160,
+   "medianAbsMovePct": 8.290155440414507,
+   "p90AbsMovePct": 30.49921996879875,
+   "maxAbsMovePct": 51.95402298850575,
+   "byFamily": {
+    "dl_edge": 74,
+    "lb": 34,
+    "db": 75
+   },
+   "byConfidence": {
+    "medium": 55,
+    "low": 105,
+    "high": 23
+   },
+   "bySourceCount": {
+    "5": 32,
+    "3": 100,
+    "4": 36,
+    "2": 13,
+    "6": 2
+   }
+  },
+  {
+   "label": "B  uncapped (bucket P90, no hard maximum)",
+   "affected": 32,
+   "population": 329,
+   "up": 0,
+   "down": 32,
+   "medianAbsMovePct": 1.9546520719311964,
+   "p90AbsMovePct": 8.508977361436378,
+   "maxAbsMovePct": 10.678210678210679,
+   "byFamily": {
+    "dl_edge": 14,
+    "db": 15,
+    "lb": 3
+   },
+   "byConfidence": {
+    "low": 17,
+    "medium": 12,
+    "high": 3
+   },
+   "bySourceCount": {
+    "3": 26,
+    "4": 3,
+    "2": 3
+   }
+  },
+  {
+   "label": "C  evidence-gated empirical band",
+   "affected": 17,
+   "population": 329,
+   "up": 0,
+   "down": 17,
+   "medianAbsMovePct": 1.56128024980484,
+   "p90AbsMovePct": 2.349256068911511,
+   "maxAbsMovePct": 10.678210678210679,
+   "byFamily": {
+    "dl_edge": 10,
+    "db": 5,
+    "lb": 2
+   },
+   "byConfidence": {
+    "low": 17
+   },
+   "bySourceCount": {
+    "3": 11,
+    "4": 3,
+    "2": 3
+   }
+  },
+  {
+   "label": "D  safety rail only",
+   "affected": 0,
+   "population": 329
+  },
+  {
+   "label": "E  no corridor",
+   "affected": 0,
+   "population": 329
+  }
+ ]
+}

--- a/docs/master-site-audit/evidence/W02/b3_candidate_policies.py
+++ b/docs/master-site-audit/evidence/W02/b3_candidate_policies.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""B3 §9-§10 — evaluation criteria first, then candidate corridor policies.
+
+Run on ONE pinned board so every candidate sees identical inputs.
+
+CRITERIA ARE DECLARED BEFORE THE NUMBERS (§10). They are printed first and
+are not adjusted afterwards; where no objective ground truth exists the
+tradeoff is reported rather than scored.
+
+Candidates:
+
+  A  current       per-bucket P90, capped at 0.15          true pipeline run
+  B  uncapped      per-bucket P90, no hard maximum         true pipeline run
+  C  evidence-     empirical band, and only clamp rows     post-hoc on B
+     gated         carrying enough independent evidence
+  D  safety rail   clamp only genuinely pathological       post-hoc on B
+                   drift, not normal disagreement
+  E  none          no corridor at all                      true pipeline run
+
+A, B and E are real pipeline builds (E via the existing
+``suppress_market_corridor_clamp``; B by patching the module's cap dict
+in-process for the duration of one build — a diagnostic, never written to
+disk). C and D are derived post-hoc from the same drift data and are
+labelled as such: they do not yet exist in production, so measuring them
+truly would mean shipping them, which §9 explicitly does not authorize.
+The post-hoc derivation is exact for "which rows would clamp and to what
+value"; it does not re-run the downstream passes, so its rank and
+composition figures are computed by re-sorting the value column.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import statistics
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(ROOT))
+OUT = Path(__file__).resolve().parent
+
+IDP_FAMILY = {
+    "dl_edge": {"DL", "EDGE", "DE", "DT"},
+    "lb": {"LB"},
+    "db": {"DB", "CB", "S"},
+}
+
+CRITERIA = """
+EVALUATION CRITERIA — declared before any candidate is measured (B3 §10).
+Not a score. Where no objective ground truth exists the tradeoff is
+reported, not invented.
+
+ 1. Pathology containment. Does the policy still catch a value that is
+    wrong rather than merely contested — the single-source explosion the
+    corridor was built for?
+ 2. Preservation of well-evidenced disagreement. A row where several
+    independent sources agree with each other and disagree with one
+    dissenting source is the board working, not failing. A policy that
+    overrides those rows at a HIGHER rate than thin rows is inverted.
+ 3. No hidden second weighting of the anchor. `idpTradeCalc` already
+    votes. A policy that also lets it veto gives it two bites; the size
+    of the second bite is a cost, not a feature.
+ 4. Robustness to one missing source. Behaviour should not hinge on
+    whether one board happened to cover a player.
+ 5. Understandable provenance. A reader must be able to see why a value
+    is what it is.
+ 6. Low sensitivity to arbitrary constants. A policy whose entire
+    behaviour is decided by one hand-set number is fragile by
+    construction.
+ 7. Board coherence. Positional and top-of-board composition should not
+    move for reasons unrelated to evidence.
+
+NOT a criterion: which board "looks right". No objective per-player ground
+truth for dynasty IDP value exists on this timeframe, so any candidate
+selected on eyeball plausibility would be selected on nothing.
+"""
+
+
+def board_path() -> Path:
+    files = sorted((ROOT / "exports" / "latest").glob("dynasty_data_*.json"), reverse=True)
+    if not files:
+        raise SystemExit("no exported board")
+    return files[0]
+
+
+def build(**kwargs) -> dict:
+    from src.api.data_contract import build_api_data_contract
+
+    raw = json.loads(board_path().read_bytes())
+    with contextlib.redirect_stdout(io.StringIO()):
+        return build_api_data_contract(raw, **kwargs)
+
+
+def rows_by_name(contract: dict) -> dict[str, dict]:
+    return {str(r.get("displayName")): r for r in contract.get("playersArray") or []}
+
+
+def _q(vals: list[float], p: float) -> float:
+    if not vals:
+        return float("nan")
+    s = sorted(vals)
+    return s[min(len(s) - 1, int(round(p * (len(s) - 1))))]
+
+
+def _pct(a: int, b: int) -> str:
+    return f"{100.0 * a / b:.1f}%" if b else "n/a"
+
+
+def family(row: dict) -> str:
+    pos = str(row.get("position") or "").upper()
+    for name, members in IDP_FAMILY.items():
+        if pos in members:
+            return name
+    return "other"
+
+
+def describe(label: str, note: str, clamps: list[dict], base: dict[str, dict]) -> dict:
+    """clamps: [{name, anchor, original, clamped, direction, band, bucket, sources}]"""
+    pop = [
+        r for r in base.values() if r.get("assetClass") == "idp" and r.get("canonicalConsensusRank")
+    ]
+    print(f"\n── {label} ── {note}")
+    if not clamps:
+        print(f"  rows affected: 0 of {len(pop)} ranked IDP rows")
+        return {"label": label, "affected": 0, "population": len(pop)}
+    up = sum(1 for c in clamps if c["direction"] == "up")
+    moves = [100.0 * (c["clamped"] - c["original"]) / c["original"] for c in clamps]
+    absmoves = [abs(m) for m in moves]
+    print(
+        f"  rows affected: {len(clamps)} of {len(pop)} ranked IDP rows "
+        f"({_pct(len(clamps), len(pop))})   up {up} / down {len(clamps) - up}"
+    )
+    print(
+        f"  |Δvalue%|: median={statistics.median(absmoves):.1f} "
+        f"p90={_q(absmoves, 0.90):.1f} max={max(absmoves):.1f}   "
+        f"signed median={statistics.median(moves):+.1f}"
+    )
+    by_fam: dict[str, int] = {}
+    for c in clamps:
+        by_fam[c["family"]] = by_fam.get(c["family"], 0) + 1
+    fam_pop: dict[str, int] = {}
+    for r in pop:
+        fam_pop[family(r)] = fam_pop.get(family(r), 0) + 1
+    print(
+        "  by family: "
+        + "  ".join(
+            f"{k} {by_fam.get(k, 0)}/{fam_pop.get(k, 0)}" for k in ("dl_edge", "lb", "db", "other")
+        )
+    )
+    by_bucket: dict[str, int] = {}
+    for c in clamps:
+        by_bucket[c["bucket"]] = by_bucket.get(c["bucket"], 0) + 1
+    bucket_pop: dict[str, int] = {}
+    for r in pop:
+        b = str(r.get("confidenceBucket") or "")
+        bucket_pop[b] = bucket_pop.get(b, 0) + 1
+    print(
+        "  by confidence: "
+        + "  ".join(
+            f"{b} {by_bucket.get(b, 0)}/{bucket_pop.get(b, 0)}"
+            f" ({_pct(by_bucket.get(b, 0), bucket_pop.get(b, 0))})"
+            for b in ("high", "medium", "low")
+        )
+    )
+    by_src: dict[int, int] = {}
+    for c in clamps:
+        by_src[c["sources"]] = by_src.get(c["sources"], 0) + 1
+    src_pop: dict[int, int] = {}
+    for r in pop:
+        n = len(r.get("sourceRankMeta") or {})
+        src_pop[n] = src_pop.get(n, 0) + 1
+    print(
+        "  by source count: "
+        + "  ".join(
+            f"{n}→{by_src.get(n, 0)}/{src_pop.get(n, 0)}" for n in sorted(src_pop) if src_pop[n]
+        )
+    )
+    thirds = sorted(pop, key=lambda r: r.get("canonicalConsensusRank") or 10**6)
+    cut = max(1, len(thirds) // 3)
+    zones = {"top": thirds[:cut], "mid": thirds[cut : 2 * cut], "tail": thirds[2 * cut :]}
+    names = {c["name"] for c in clamps}
+    print(
+        "  by board zone: "
+        + "  ".join(
+            f"{z} {sum(1 for r in rs if str(r.get('displayName')) in names)}/{len(rs)}"
+            for z, rs in zones.items()
+        )
+    )
+    print("  largest 6 moves:")
+    for c in sorted(clamps, key=lambda c: -abs(c["clamped"] - c["original"]))[:6]:
+        print(
+            f"    {c['name'][:26]:<26} {c['original']:>5} → {c['clamped']:>5} "
+            f"(anchor {c['anchor']:>5}, {c['bucket']}, {c['sources']} src)"
+        )
+    return {
+        "label": label,
+        "affected": len(clamps),
+        "population": len(pop),
+        "up": up,
+        "down": len(clamps) - up,
+        "medianAbsMovePct": statistics.median(absmoves),
+        "p90AbsMovePct": _q(absmoves, 0.90),
+        "maxAbsMovePct": max(absmoves),
+        "byFamily": by_fam,
+        "byConfidence": by_bucket,
+        "bySourceCount": {str(k): v for k, v in by_src.items()},
+    }
+
+
+def clamp_records(contract: dict) -> list[dict]:
+    out = []
+    for r in contract.get("playersArray") or []:
+        c = r.get("marketCorridorClamp")
+        if not c:
+            continue
+        out.append(
+            {
+                "name": str(r.get("displayName")),
+                "anchor": c["marketAnchor"],
+                "original": c["originalValue"],
+                "clamped": c["clampedValue"],
+                "direction": c["direction"],
+                "band": c["bandPct"],
+                "bucket": c["confidenceBucket"],
+                "sources": len(r.get("sourceRankMeta") or {}),
+                "family": family(r),
+                "cappedByMaxBand": c["cappedByMaxBand"],
+            }
+        )
+    return out
+
+
+def main() -> int:
+    import src.api.data_contract as dc
+
+    print(CRITERIA)
+    print(f"pinned board: {board_path().relative_to(ROOT)}")
+
+    a_contract = build()
+    base = rows_by_name(a_contract)
+    a = clamp_records(a_contract)
+
+    # B — same code, hard cap removed for one build only.
+    original_cap = dict(dc._MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS)
+    try:
+        dc._MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS.clear()
+        b_contract = build()
+        b = clamp_records(b_contract)
+    finally:
+        dc._MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS.clear()
+        dc._MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS.update(original_cap)
+    assert dc._MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS == {"idp": 0.15}, "cap not restored"
+
+    results = []
+    results.append(
+        describe(
+            "A  current (bucket P90 capped at 0.15)",
+            "true pipeline run — the shipped policy",
+            a,
+            base,
+        )
+    )
+    results.append(
+        describe(
+            "B  uncapped (bucket P90, no hard maximum)",
+            "true pipeline run — the empirical machinery allowed to decide",
+            b,
+            base,
+        )
+    )
+
+    # C — evidence-gated: keep B's empirical band, but only clamp rows that
+    # do NOT carry independent corroboration. A row where >=3 sources voted
+    # and confidence is high/medium is the board working.
+    c = [r for r in b if not (r["sources"] >= 3 and r["bucket"] in ("high", "medium"))]
+    results.append(
+        describe(
+            "C  evidence-gated empirical band",
+            "POST-HOC on B — clamp only rows without independent corroboration "
+            "(<3 sources or low confidence)",
+            c,
+            base,
+        )
+    )
+
+    # D — safety rail: only genuinely pathological drift. Threshold declared
+    # structurally (2x the board's own P90 drift) rather than hand-picked.
+    drifts = [abs(r["original"] - r["anchor"]) / r["anchor"] for r in b]
+    rail = 2.0 * _q(drifts, 0.90) if drifts else 1.0
+    d = [r for r in b if abs(r["original"] - r["anchor"]) / r["anchor"] > rail]
+    results.append(
+        describe(
+            "D  safety rail only",
+            f"POST-HOC on B — clamp only drift > {rail:.3f} (2x the board's own P90 drift)",
+            d,
+            base,
+        )
+    )
+
+    results.append(describe("E  no corridor", "true pipeline run via suppress flag", [], base))
+
+    # composition, true runs only
+    print("\n── board composition, true pipeline runs only ──")
+    e_contract = build(suppress_market_corridor_clamp=True)
+    for label, contract in (
+        ("A current", a_contract),
+        ("B uncapped", b_contract),
+        ("E none", e_contract),
+    ):
+        ranked = [r for r in contract.get("playersArray") or [] if r.get("canonicalConsensusRank")]
+        ranked.sort(key=lambda r: r["canonicalConsensusRank"])
+        line = []
+        for n in (100, 200, 400):
+            top = ranked[:n]
+            idp = sum(1 for r in top if r.get("assetClass") == "idp")
+            line.append(f"top{n} IDP {idp}")
+        print(f"  {label:<12} " + "   ".join(line))
+
+    (OUT / "b3_candidate_policies.json").write_text(
+        json.dumps({"criteria": CRITERIA.strip(), "results": results}, indent=1)
+    )
+    print(f"\nwrote {OUT / 'b3_candidate_policies.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/master-site-audit/evidence/W02/b3_candidate_policies.txt
+++ b/docs/master-site-audit/evidence/W02/b3_candidate_policies.txt
@@ -1,0 +1,88 @@
+
+EVALUATION CRITERIA — declared before any candidate is measured (B3 §10).
+Not a score. Where no objective ground truth exists the tradeoff is
+reported, not invented.
+
+ 1. Pathology containment. Does the policy still catch a value that is
+    wrong rather than merely contested — the single-source explosion the
+    corridor was built for?
+ 2. Preservation of well-evidenced disagreement. A row where several
+    independent sources agree with each other and disagree with one
+    dissenting source is the board working, not failing. A policy that
+    overrides those rows at a HIGHER rate than thin rows is inverted.
+ 3. No hidden second weighting of the anchor. `idpTradeCalc` already
+    votes. A policy that also lets it veto gives it two bites; the size
+    of the second bite is a cost, not a feature.
+ 4. Robustness to one missing source. Behaviour should not hinge on
+    whether one board happened to cover a player.
+ 5. Understandable provenance. A reader must be able to see why a value
+    is what it is.
+ 6. Low sensitivity to arbitrary constants. A policy whose entire
+    behaviour is decided by one hand-set number is fragile by
+    construction.
+ 7. Board coherence. Positional and top-of-board composition should not
+    move for reasons unrelated to evidence.
+
+NOT a criterion: which board "looks right". No objective per-player ground
+truth for dynasty IDP value exists on this timeframe, so any candidate
+selected on eyeball plausibility would be selected on nothing.
+
+pinned board: exports/latest/dynasty_data_2026-08-11.json
+
+── A  current (bucket P90 capped at 0.15) ── true pipeline run — the shipped policy
+  rows affected: 183 of 329 ranked IDP rows (55.6%)   up 23 / down 160
+  |Δvalue%|: median=8.3 p90=30.5 max=52.0   signed median=-5.2
+  by family: dl_edge 74/129  lb 34/91  db 75/109  other 0/0
+  by confidence: high 23/36 (63.9%)  medium 55/120 (45.8%)  low 105/173 (60.7%)
+  by source count: 2→13/27  3→100/112  4→36/60  5→32/122  6→2/8
+  by board zone: top 25/109  mid 64/109  tail 94/111
+  largest 6 moves:
+    Abdul Carter                3654 →  4598 (anchor  5409, medium, 5 src)
+    Jalon Walker                1838 →  2755 (anchor  3241, low, 5 src)
+    Byron Young                 1740 →  2644 (anchor  3111, low, 5 src)
+    Nick Herbig                 1727 →  2620 (anchor  3082, low, 5 src)
+    Jamien Sherwood             3198 →  2462 (anchor  2141, medium, 5 src)
+    Chase Young                 1828 →  2506 (anchor  2948, low, 5 src)
+
+── B  uncapped (bucket P90, no hard maximum) ── true pipeline run — the empirical machinery allowed to decide
+  rows affected: 32 of 329 ranked IDP rows (9.7%)   up 0 / down 32
+  |Δvalue%|: median=2.0 p90=8.5 max=10.7   signed median=-2.0
+  by family: dl_edge 14/129  lb 3/91  db 15/109  other 0/0
+  by confidence: high 3/36 (8.3%)  medium 12/120 (10.0%)  low 17/173 (9.8%)
+  by source count: 2→3/27  3→26/112  4→3/60  5→0/122  6→0/8
+  by board zone: top 0/109  mid 0/109  tail 32/111
+  largest 6 moves:
+    Will Johnson                1386 →  1238 (anchor   759, low, 2 src)
+    Ji'Ayir Brown               1278 →  1162 (anchor   765, medium, 3 src)
+    DJ Wonnum                   1281 →  1172 (anchor   772, medium, 3 src)
+    Ja'Quan McMillian           1281 →  1172 (anchor   772, medium, 3 src)
+    Christian Benford           1285 →  1187 (anchor   782, medium, 3 src)
+    Jaycee Horn                 1286 →  1190 (anchor   784, medium, 3 src)
+
+── C  evidence-gated empirical band ── POST-HOC on B — clamp only rows without independent corroboration (<3 sources or low confidence)
+  rows affected: 17 of 329 ranked IDP rows (5.2%)   up 0 / down 17
+  |Δvalue%|: median=1.6 p90=2.3 max=10.7   signed median=-1.6
+  by family: dl_edge 10/129  lb 2/91  db 5/109  other 0/0
+  by confidence: high 0/36 (0.0%)  medium 0/120 (0.0%)  low 17/173 (9.8%)
+  by source count: 2→3/27  3→11/112  4→3/60  5→0/122  6→0/8
+  by board zone: top 0/109  mid 0/109  tail 17/111
+  largest 6 moves:
+    Will Johnson                1386 →  1238 (anchor   759, low, 2 src)
+    Nate Wiggins                1298 →  1243 (anchor   762, low, 2 src)
+    Osa Odighizuwa              1277 →  1247 (anchor   764, low, 4 src)
+    Keyron Crawford             1279 →  1251 (anchor   767, low, 3 src)
+    Keyshaun Elliott            1281 →  1253 (anchor   768, low, 4 src)
+    Gabe Jacas                  1279 →  1253 (anchor   768, low, 4 src)
+
+── D  safety rail only ── POST-HOC on B — clamp only drift > 1.341 (2x the board's own P90 drift)
+  rows affected: 0 of 329 ranked IDP rows
+
+── E  no corridor ── true pipeline run via suppress flag
+  rows affected: 0 of 329 ranked IDP rows
+
+── board composition, true pipeline runs only ──
+  A current    top100 IDP 9   top200 IDP 43   top400 IDP 130
+  B uncapped   top100 IDP 9   top200 IDP 41   top400 IDP 130
+  E none       top100 IDP 9   top200 IDP 41   top400 IDP 130
+
+wrote /home/user/riskittogetthebrisket/docs/master-site-audit/evidence/W02/b3_candidate_policies.json

--- a/docs/master-site-audit/evidence/W02/b3_corridor_after.txt
+++ b/docs/master-site-audit/evidence/W02/b3_corridor_after.txt
@@ -1,0 +1,96 @@
+== B3 pin ==
+  code   1e88c6863  dirty=True
+  board  exports/latest/dynasty_data_2026-08-11.json  sha256_16=8fb6ede274171aee  834861 B  scraped=2026-08-11T11:32:57.431111
+  csvs   24 hashed
+  champ  v2 (champion) params={'HILL_GLOBAL_PERCENTILE_C': 0.112, 'HILL_GLOBAL_PERCENTILE_S': 0.725, 'HILL_PERCENTILE_C': 0.11, 'HILL_PERCENTILE_S': 1.11, 'IDP_HILL_PERCENTILE_C': 0.083, 'IDP_HILL_PERCENTILE_S': 1.11, 'HILL_ROOKIE_PERCENTILE_C': 0.153, 'HILL_ROOKIE_PERCENTILE_S': 0.885}
+
+== corridor configuration as shipped ==
+  primary anchors      {'offense': 'ktcSfTep', 'idp': 'idpTradeCalc'}
+  fallback chains      {'offense': ['ktcSfTep', 'idpTradeCalc', 'dynastyDaddySf', 'fantasyProsFitzmaurice', 'yahooBoone'], 'idp': ['idpTradeCalc', 'dlfIdp', 'idpShow', 'fantasyProsIdp']}
+  percentile           0.9
+  min bucket n         30
+  hard max band        {}
+
+  anchor sources that are ALSO voting members of the blend they clamp:
+    idpTradeCalc       voting=True
+    dlfIdp             voting=True
+    idpShow            voting=True
+    fantasyProsIdp     voting=True
+
+== W02-F003 reproduction ==
+  clamped 32 rows — 9.7% of 329 ranked IDP rows; asset classes {'idp': 32}
+  non-offense ranked rows the clamp iterates: 359 (picks reach the loop and are dropped by having no anchor chain)
+  cappedByMaxBand      0/32 (0.0%)
+  distinct bandPct     [0.5183, 0.6316, 0.6504]
+  on the band edge     32/32 (100.0%)
+  direction            up 0 (value was BELOW anchor) / down 32 (value was ABOVE anchor)
+
+== empirical bucket P90s the hard cap overrides ==
+  overall  n=329   P90=0.6201   (cap None)
+  high     n=36    P90=0.6504   own band   cap wins=False
+  low      n=173   P90=0.6316   own band   cap wins=False
+  medium   n=120   P90=0.5183   own band   cap wins=False
+
+== who gets clamped ==
+  bucket     ranked IDP  clamped    rate   up/down
+  high               36        3    8.3%       0/3
+  medium            120       12   10.0%      0/12
+  low               173       17    9.8%      0/17
+  sources    ranked IDP  clamped    rate
+  2                  27        3   11.1%
+  3                 112       26   23.2%
+  4                  60        3    5.0%
+  5                 122        0    0.0%
+  6                   8        0    0.0%
+
+== anchor lineage on clamped rows ==
+  anchor=idpTradeCalc               32 rows
+  rows where the anchor source ALSO voted in this row's blend: 32/32 (100.0%)
+
+== corridor's share of the served value ==
+  rows whose SERVED value differs with the corridor on: 32
+  |Δ%| mean=3.27 median=1.95 p90=8.51 max=10.68
+  largest 10:
+    Will Johnson               unclamped  1386 → served  1238  (-10.7%)
+    Ji'Ayir Brown              unclamped  1278 → served  1162  (-9.1%)
+    DJ Wonnum                  unclamped  1281 → served  1172  (-8.5%)
+    Ja'Quan McMillian          unclamped  1281 → served  1172  (-8.5%)
+    Christian Benford          unclamped  1285 → served  1187  (-7.6%)
+    Jaycee Horn                unclamped  1286 → served  1190  (-7.5%)
+    Tarheeb Still              unclamped  1290 → served  1202  (-6.8%)
+    Kamari Ramsey              unclamped  1294 → served  1218  (-5.9%)
+    Genesis Smith              unclamped  1299 → served  1233  (-5.1%)
+    Geno Stone                 unclamped  1302 → served  1242  (-4.6%)
+
+== distance from the anchor, before and after the corridor ==
+  unclamped |value − anchor| / anchor : median=0.6523 p90=0.6706 max=0.8261
+  clamped   |value − anchor| / anchor : median=0.6313 p90=0.6322 max=0.6508
+  → 32 of 329 ranked IDP rows (9.7%) are served at exactly idpTradeCalc × 0.85 or × 1.15
+
+== idpTradeCalc's direct share of the vote on clamped rows ==
+  sources stamped per clamped row: median=3 min=2 max=4
+  idpTradeCalc contribution ÷ median of the other sources: n=32 median=0.457 p10=0.450 p90=0.482
+  (>1 means IDPTC prices the row ABOVE its peers — and the corridor then pulls the blend back toward IDPTC as well)
+
+== leave-IDPTC-out WHOLE-BOARD rebuild (DIAGNOSTIC ONLY) ==
+  CAVEAT, load-bearing: idpTradeCalc is also the IDP BACKBONE, so
+  dropping it empties the shared-market ladder and every translated
+  IDP source falls back to a raw IDP-local rank. This board is
+  therefore NOT 'the same model minus one vote' — it is an UPPER
+  BOUND on idpTradeCalc's influence, and the vote-share block above
+  is the isolate.
+  player                       blend     LOO  anchor unclamp  served
+  Will Johnson                  1386       0     759    1386    1238
+  Taron Johnson                 1325    1636     871    1325    1322
+  Oluwafemi Oladejo             1322    1635     864    1322    1312
+  Christen Miller               1308    1632     832    1308    1263
+  Geno Stone                    1302    1630     818    1302    1242
+  Genesis Smith                 1299    1629     812    1299    1233
+  Nate Wiggins                  1298       0     762    1298    1243
+  Kamari Ramsey                 1294    1627     802    1294    1218
+  Tarheeb Still                 1290    1625     792    1290    1202
+  Daron Payne                   1288    1625     789    1288    1287
+  Brandon Dorlus                1287    1623     785    1287    1281
+  Dayo Odeyingbo                1286    1622     783    1286    1278
+
+wrote /home/user/riskittogetthebrisket/docs/master-site-audit/evidence/W02/b3_corridor_report.json

--- a/docs/master-site-audit/evidence/W02/b3_corridor_measure.py
+++ b/docs/master-site-audit/evidence/W02/b3_corridor_measure.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""B3 — pin the baseline and reproduce W02-F003 (IDP market corridor clamp).
+
+Two things, deliberately in one script so the numbers can never be quoted
+against a different tree than the one that produced them:
+
+  ``--pin``       record the exact B3 inputs — code SHA + dirty state, the
+                  board snapshot and its hash, every source CSV hash and
+                  mtime, contract freshness stamps, and the ACTIVE champion
+                  model version and constants.
+  ``--reproduce`` measure the corridor's current behaviour on that pin, and
+                  the anchor-lineage question B3 §5 makes mandatory.
+
+The lineage question is the reason this is not just a counter. The corridor
+anchors IDP rows to ``idpTradeCalc``, and ``idpTradeCalc`` is a *voting
+member of the blend being clamped*. Every fallback anchor
+(``dlfIdp`` / ``idpShow`` / ``fantasyProsIdp``) is too. So the "market
+anchor" is not independent evidence about the row — it is one of the
+inputs, given a second, post-blend veto. This script quantifies that by
+building three boards from ONE pinned payload:
+
+  clamped          the production board
+  unclamped        ``suppress_market_corridor_clamp=True``
+  no-IDPTC         ``suppress`` + ``idpTradeCalc`` dropped from voting
+
+Nothing here changes production. ``suppress_market_corridor_clamp`` is an
+existing parameter with an existing caller (``consensus_edge/fair_value``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import hashlib
+import io
+import json
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(ROOT))
+
+OUT = Path(__file__).resolve().parent
+CSV_DIR = ROOT / "CSVs" / "site_raw"
+
+
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=ROOT, capture_output=True, text=True, check=False
+    ).stdout.strip()
+
+
+def latest_board() -> Path:
+    files = sorted((ROOT / "exports" / "latest").glob("dynasty_data_*.json"), reverse=True)
+    if not files:
+        raise SystemExit("no exported board under exports/latest")
+    return files[0]
+
+
+def pin() -> dict:
+    board = latest_board()
+    from src.model_registry.hill_masters import MODEL_ID, load_or_seed_registry
+
+    reg = load_or_seed_registry()
+    champ = reg.champion
+    raw = json.loads(board.read_bytes())
+
+    snapshot = {
+        "phase": "B3",
+        "codeSha": _git("rev-parse", "HEAD"),
+        "codeSubject": _git("log", "-1", "--format=%s"),
+        "dirty": bool(_git("status", "--porcelain")),
+        "board": {
+            "path": str(board.relative_to(ROOT)),
+            "sha256_16": _sha(board),
+            "bytes": board.stat().st_size,
+            "mtime": board.stat().st_mtime,
+            "scrapeTimestamp": raw.get("scrapeTimestamp"),
+            "date": raw.get("date"),
+            "playerCount": len(raw.get("players") or {}),
+        },
+        "sourceCsvs": {
+            p.name: {"sha256_16": _sha(p), "bytes": p.stat().st_size, "mtime": p.stat().st_mtime}
+            for p in sorted(CSV_DIR.glob("*.csv"))
+        },
+        "championModel": {
+            "modelId": MODEL_ID,
+            "version": champ.version,
+            "status": champ.status,
+            "producer": champ.producer,
+            "fittedAt": champ.fitted_at,
+            "promotedAt": getattr(champ, "promoted_at", None),
+            "appliedAt": getattr(champ, "applied_at", None),
+            "params": dict(champ.params),
+        },
+        "registryVersions": [v.version for v in reg.versions],
+    }
+    return snapshot
+
+
+# ── contract builds ────────────────────────────────────────────────────
+
+
+def build(board: Path, **kwargs) -> dict:
+    from src.api.data_contract import build_api_data_contract
+
+    raw = json.loads(board.read_bytes())
+    with contextlib.redirect_stdout(io.StringIO()):
+        return build_api_data_contract(raw, **kwargs)
+
+
+def _pct(part: int, whole: int) -> str:
+    return f"{100.0 * part / whole:.1f}%" if whole else "n/a"
+
+
+def _q(vals: list[float], p: float) -> float:
+    if not vals:
+        return float("nan")
+    s = sorted(vals)
+    return s[min(len(s) - 1, int(round(p * (len(s) - 1))))]
+
+
+def reproduce() -> None:
+    from src.api.data_contract import (
+        _MARKET_ANCHOR_BY_ASSET_CLASS,
+        _MARKET_ANCHOR_FALLBACKS,
+        _MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS,
+        _MARKET_CORRIDOR_MIN_BUCKET_N,
+        _MARKET_CORRIDOR_PERCENTILE,
+        _RANKING_SOURCES,
+    )
+
+    board = latest_board()
+    print("== B3 pin ==")
+    snap = pin()
+    print(f"  code   {snap['codeSha'][:9]}  dirty={snap['dirty']}")
+    print(
+        f"  board  {snap['board']['path']}  sha256_16={snap['board']['sha256_16']}  "
+        f"{snap['board']['bytes']} B  scraped={snap['board']['scrapeTimestamp']}"
+    )
+    print(f"  csvs   {len(snap['sourceCsvs'])} hashed")
+    print(
+        f"  champ  v{snap['championModel']['version']} "
+        f"({snap['championModel']['status']}) params={snap['championModel']['params']}"
+    )
+
+    print("\n== corridor configuration as shipped ==")
+    print(f"  primary anchors      {_MARKET_ANCHOR_BY_ASSET_CLASS}")
+    print(f"  fallback chains      {_MARKET_ANCHOR_FALLBACKS}")
+    print(f"  percentile           {_MARKET_CORRIDOR_PERCENTILE}")
+    print(f"  min bucket n         {_MARKET_CORRIDOR_MIN_BUCKET_N}")
+    print(f"  hard max band        {_MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS}")
+
+    voting = {str(s.get("key") or "") for s in _RANKING_SOURCES}
+    idp_chain = _MARKET_ANCHOR_FALLBACKS.get("idp") or []
+    print("\n  anchor sources that are ALSO voting members of the blend they clamp:")
+    for key in idp_chain:
+        print(f"    {key:<18} voting={key in voting}")
+
+    clamped = build(board)
+    unclamped = build(board, suppress_market_corridor_clamp=True)
+
+    rows_c = {r.get("displayName"): r for r in clamped.get("playersArray") or []}
+    rows_u = {r.get("displayName"): r for r in unclamped.get("playersArray") or []}
+
+    # ── prevalence ──
+    clamps = [r for r in rows_c.values() if r.get("marketCorridorClamp")]
+    ranked_idp = [
+        r
+        for r in rows_c.values()
+        if r.get("assetClass") == "idp" and r.get("canonicalConsensusRank")
+    ]
+    eligible_non_offense = [
+        r
+        for r in rows_c.values()
+        if str(r.get("assetClass") or "") != "offense" and r.get("canonicalConsensusRank")
+    ]
+    by_class: dict[str, int] = {}
+    for r in clamps:
+        by_class[str(r.get("assetClass"))] = by_class.get(str(r.get("assetClass")), 0) + 1
+
+    print("\n== W02-F003 reproduction ==")
+    print(
+        f"  clamped {len(clamps)} rows — {_pct(len(clamps), len(ranked_idp))} of "
+        f"{len(ranked_idp)} ranked IDP rows; asset classes {by_class}"
+    )
+    print(
+        f"  non-offense ranked rows the clamp iterates: {len(eligible_non_offense)} "
+        "(picks reach the loop and are dropped by having no anchor chain)"
+    )
+    capped = sum(1 for r in clamps if (r["marketCorridorClamp"] or {}).get("cappedByMaxBand"))
+    bands = sorted({(r["marketCorridorClamp"] or {}).get("bandPct") for r in clamps})
+    up = sum(1 for r in clamps if r["marketCorridorClamp"]["direction"] == "up")
+    down = sum(1 for r in clamps if r["marketCorridorClamp"]["direction"] == "down")
+    on_edge = 0
+    for r in clamps:
+        c = r["marketCorridorClamp"]
+        sign = 1 if c["direction"] == "down" else -1
+        edge = c["marketAnchor"] * (1.0 + sign * c["bandPct"])
+        if abs(round(edge) - c["clampedValue"]) <= 1:
+            on_edge += 1
+    print(f"  cappedByMaxBand      {capped}/{len(clamps)} ({_pct(capped, len(clamps))})")
+    print(f"  distinct bandPct     {bands}")
+    print(f"  on the band edge     {on_edge}/{len(clamps)} ({_pct(on_edge, len(clamps))})")
+    print(
+        f"  direction            up {up} (value was BELOW anchor) / "
+        f"down {down} (value was ABOVE anchor)"
+    )
+
+    # ── the empirical band the cap overrides ──
+    print("\n== empirical bucket P90s the hard cap overrides ==")
+    drifts_by_bucket: dict[str, list[float]] = {}
+    overall: list[float] = []
+    for r in rows_u.values():
+        if not r.get("canonicalConsensusRank"):
+            continue
+        if str(r.get("assetClass") or "") == "offense":
+            continue
+        from src.api.data_contract import _market_anchor_for_row
+
+        anchor, _src = _market_anchor_for_row(r)
+        if anchor is None:
+            continue
+        try:
+            v = float(r.get("rankDerivedValue") or 0.0)
+        except (TypeError, ValueError):
+            continue
+        if v <= 0:
+            continue
+        d = abs(v - anchor) / anchor
+        drifts_by_bucket.setdefault(str(r.get("confidenceBucket") or "low"), []).append(d)
+        overall.append(d)
+    cap = _MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS.get("idp")
+    print(f"  overall  n={len(overall):<5} P90={_q(overall, 0.90):.4f}   (cap {cap})")
+    for bucket, vals in sorted(drifts_by_bucket.items()):
+        used_own = len(vals) >= _MARKET_CORRIDOR_MIN_BUCKET_N
+        print(
+            f"  {bucket:<8} n={len(vals):<5} P90={_q(vals, 0.90):.4f}   "
+            f"{'own band' if used_own else 'FALLS BACK to overall'}   "
+            f"cap wins={_q(vals, 0.90) > (cap or 0)}"
+        )
+
+    # ── anchor lineage ──
+    print("\n== anchor lineage on clamped rows ==")
+    src_counts: dict[str, int] = {}
+    anchor_also_voted = 0
+    for r in clamps:
+        s = str(r["marketCorridorClamp"].get("marketSource"))
+        src_counts[s] = src_counts.get(s, 0) + 1
+        meta = r.get("sourceRankMeta") or {}
+        if s in meta:
+            anchor_also_voted += 1
+    for s, n in sorted(src_counts.items(), key=lambda kv: -kv[1]):
+        print(f"  anchor={s:<24} {n:>4} rows")
+    print(
+        f"  rows where the anchor source ALSO voted in this row's blend: "
+        f"{anchor_also_voted}/{len(clamps)} ({_pct(anchor_also_voted, len(clamps))})"
+    )
+
+    # ── how much of the served value the corridor owns ──
+    print("\n== corridor's share of the served value ==")
+    moved: list[tuple[str, float, float, float]] = []
+    for name, rc in rows_c.items():
+        ru = rows_u.get(name)
+        if ru is None:
+            continue
+        vc, vu = rc.get("rankDerivedValue"), ru.get("rankDerivedValue")
+        if vc is None or vu is None or vu == 0:
+            continue
+        if vc != vu:
+            moved.append((name, vu, vc, 100.0 * (vc - vu) / vu))
+    print(f"  rows whose SERVED value differs with the corridor on: {len(moved)}")
+    if moved:
+        pcts = [abs(m[3]) for m in moved]
+        print(
+            f"  |Δ%| mean={statistics.fmean(pcts):.2f} median={statistics.median(pcts):.2f} "
+            f"p90={_q(pcts, 0.90):.2f} max={max(pcts):.2f}"
+        )
+        print("  largest 10:")
+        for name, vu, vc, p in sorted(moved, key=lambda m: -abs(m[2] - m[1]))[:10]:
+            print(f"    {name:<26} unclamped {vu:>5} → served {vc:>5}  ({p:+.1f}%)")
+
+    # ── where the corridor leaves the row relative to the anchor ──
+    #
+    # The sharpest statement of the defect. By construction a clamped row
+    # ends at exactly ``anchor × (1 ± band)``, so for those rows the blend
+    # does not determine the value at all — the anchor does, to within a
+    # fixed constant.
+    print("\n== distance from the anchor, before and after the corridor ==")
+    pre = [
+        abs(r["marketCorridorClamp"]["originalValue"] - r["marketCorridorClamp"]["marketAnchor"])
+        / r["marketCorridorClamp"]["marketAnchor"]
+        for r in clamps
+    ]
+    post = [
+        abs(r["marketCorridorClamp"]["clampedValue"] - r["marketCorridorClamp"]["marketAnchor"])
+        / r["marketCorridorClamp"]["marketAnchor"]
+        for r in clamps
+    ]
+    print(
+        f"  unclamped |value − anchor| / anchor : median={statistics.median(pre):.4f} "
+        f"p90={_q(pre, 0.90):.4f} max={max(pre):.4f}"
+    )
+    print(
+        f"  clamped   |value − anchor| / anchor : median={statistics.median(post):.4f} "
+        f"p90={_q(post, 0.90):.4f} max={max(post):.4f}"
+    )
+    print(
+        f"  → {len(clamps)} of {len(ranked_idp)} ranked IDP rows "
+        f"({_pct(len(clamps), len(ranked_idp))}) are served at exactly "
+        "idpTradeCalc × 0.85 or × 1.15"
+    )
+
+    # ── IDPTC's DIRECT share of the vote it then vetoes ──
+    #
+    # Uses the stamped per-source contributions — the actual inputs to
+    # aggregation — rather than rebuilding the board, so the IDP ladder
+    # (which idpTradeCalc also seeds as backbone) stays intact. This
+    # isolates the vote, which the whole-board rebuild below cannot.
+    print("\n== idpTradeCalc's direct share of the vote on clamped rows ==")
+    ratios: list[float] = []
+    n_sources: list[int] = []
+    for r in clamps:
+        meta = r.get("sourceRankMeta") or {}
+        own = (meta.get("idpTradeCalc") or {}).get("valueContribution")
+        peers = [
+            m["valueContribution"]
+            for k, m in meta.items()
+            if k != "idpTradeCalc"
+            and isinstance(m, dict)
+            and isinstance(m.get("valueContribution"), (int, float))
+            and m["valueContribution"] > 0
+        ]
+        n_sources.append(len(meta))
+        if own and peers:
+            ratios.append(float(own) / statistics.median(peers))
+    print(
+        f"  sources stamped per clamped row: median={statistics.median(n_sources):.0f} "
+        f"min={min(n_sources)} max={max(n_sources)}"
+    )
+    print(
+        f"  idpTradeCalc contribution ÷ median of the other sources: n={len(ratios)} "
+        f"median={statistics.median(ratios):.3f} p10={_q(ratios, 0.10):.3f} "
+        f"p90={_q(ratios, 0.90):.3f}"
+    )
+    print(
+        "  (>1 means IDPTC prices the row ABOVE its peers — and the corridor "
+        "then pulls the blend back toward IDPTC as well)"
+    )
+
+    # ── leave-IDPTC-out diagnostic (B3 section 5 / 11) ──
+    print("\n== leave-IDPTC-out WHOLE-BOARD rebuild (DIAGNOSTIC ONLY) ==")
+    print(
+        "  CAVEAT, load-bearing: idpTradeCalc is also the IDP BACKBONE, so\n"
+        "  dropping it empties the shared-market ladder and every translated\n"
+        "  IDP source falls back to a raw IDP-local rank. This board is\n"
+        "  therefore NOT 'the same model minus one vote' — it is an UPPER\n"
+        "  BOUND on idpTradeCalc's influence, and the vote-share block above\n"
+        "  is the isolate."
+    )
+    no_idptc = build(
+        board,
+        suppress_market_corridor_clamp=True,
+        source_overrides={"idpTradeCalc": {"include": False}},
+    )
+    rows_n = {r.get("displayName"): r for r in no_idptc.get("playersArray") or []}
+    print(f"  {'player':<26} {'blend':>7} {'LOO':>7} {'anchor':>7} {'unclamp':>7} {'served':>7}")
+    sample = sorted(clamps, key=lambda r: -(r["marketCorridorClamp"]["originalValue"]))[:12]
+    for r in sample:
+        name = str(r.get("displayName"))
+        c = r["marketCorridorClamp"]
+        ru = rows_u.get(name) or {}
+        rn = rows_n.get(name) or {}
+        print(
+            f"  {name[:26]:<26} {c['originalValue']:>7} "
+            f"{(rn.get('rankDerivedValue') or 0):>7} {c['marketAnchor']:>7} "
+            f"{(ru.get('rankDerivedValue') or 0):>7} {(r.get('rankDerivedValue') or 0):>7}"
+        )
+
+    payload = {
+        "pin": snap,
+        "corridorConfig": {
+            "primaryAnchors": _MARKET_ANCHOR_BY_ASSET_CLASS,
+            "fallbackChains": _MARKET_ANCHOR_FALLBACKS,
+            "percentile": _MARKET_CORRIDOR_PERCENTILE,
+            "minBucketN": _MARKET_CORRIDOR_MIN_BUCKET_N,
+            "maxBand": _MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS,
+            "idpChainAllVoting": all(k in voting for k in idp_chain),
+        },
+        "reproduction": {
+            "clampedRows": len(clamps),
+            "rankedIdpRows": len(ranked_idp),
+            "clampRate": len(clamps) / len(ranked_idp) if ranked_idp else None,
+            "cappedByMaxBand": capped,
+            "onBandEdge": on_edge,
+            "distinctBandPct": [b for b in bands],
+            "up": up,
+            "down": down,
+            "anchorAlsoVoted": anchor_also_voted,
+            "anchorSourceCounts": src_counts,
+            "servedRowsMovedByCorridor": len(moved),
+            "bucketP90": {k: _q(v, 0.90) for k, v in drifts_by_bucket.items()},
+            "bucketN": {k: len(v) for k, v in drifts_by_bucket.items()},
+            "overallP90": _q(overall, 0.90),
+        },
+    }
+    (OUT / "b3_corridor_report.json").write_text(json.dumps(payload, indent=1))
+    print(f"\nwrote {OUT / 'b3_corridor_report.json'}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pin", action="store_true")
+    ap.add_argument("--reproduce", action="store_true")
+    args = ap.parse_args()
+    if args.pin:
+        print(json.dumps(pin(), indent=1))
+        return 0
+    if args.reproduce:
+        reproduce()
+        return 0
+    ap.error("pass --pin or --reproduce")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/master-site-audit/evidence/W02/b3_corridor_measure.py
+++ b/docs/master-site-audit/evidence/W02/b3_corridor_measure.py
@@ -243,7 +243,7 @@ def reproduce() -> None:
         print(
             f"  {bucket:<8} n={len(vals):<5} P90={_q(vals, 0.90):.4f}   "
             f"{'own band' if used_own else 'FALLS BACK to overall'}   "
-            f"cap wins={_q(vals, 0.90) > (cap or 0)}"
+            f"cap wins={cap is not None and _q(vals, 0.90) > cap}"
         )
 
     # ── who gets clamped: by confidence bucket and by source count ──

--- a/docs/master-site-audit/evidence/W02/b3_corridor_measure.py
+++ b/docs/master-site-audit/evidence/W02/b3_corridor_measure.py
@@ -246,6 +246,33 @@ def reproduce() -> None:
             f"cap wins={_q(vals, 0.90) > (cap or 0)}"
         )
 
+    # ── who gets clamped: by confidence bucket and by source count ──
+    #
+    # ``confidenceBucket`` is INTER-SOURCE agreement (high = >=2 sources
+    # with a tight percentile spread). The corridor uses it to pick a
+    # band. If high-confidence rows are clamped MORE, the corridor is
+    # preferentially overriding the board's best-supported opinions with
+    # a single dissenting source.
+    print("\n== who gets clamped ==")
+    print(f"  {'bucket':<10} {'ranked IDP':>10} {'clamped':>8} {'rate':>7} {'up/down':>9}")
+    for bucket in ("high", "medium", "low", "none"):
+        pop = [r for r in ranked_idp if str(r.get("confidenceBucket") or "") == bucket]
+        cl = [r for r in pop if r.get("marketCorridorClamp")]
+        if not pop:
+            continue
+        u = sum(1 for r in cl if r["marketCorridorClamp"]["direction"] == "up")
+        print(
+            f"  {bucket:<10} {len(pop):>10} {len(cl):>8} {_pct(len(cl), len(pop)):>7} "
+            f"{f'{u}/{len(cl) - u}':>9}"
+        )
+    print(f"  {'sources':<10} {'ranked IDP':>10} {'clamped':>8} {'rate':>7}")
+    for n in (1, 2, 3, 4, 5, 6):
+        pop = [r for r in ranked_idp if len(r.get("sourceRankMeta") or {}) == n]
+        if not pop:
+            continue
+        cl = [r for r in pop if r.get("marketCorridorClamp")]
+        print(f"  {n:<10} {len(pop):>10} {len(cl):>8} {_pct(len(cl), len(pop)):>7}")
+
     # ── anchor lineage ──
     print("\n== anchor lineage on clamped rows ==")
     src_counts: dict[str, int] = {}

--- a/docs/master-site-audit/evidence/W02/b3_corridor_report.json
+++ b/docs/master-site-audit/evidence/W02/b3_corridor_report.json
@@ -1,8 +1,8 @@
 {
  "pin": {
   "phase": "B3",
-  "codeSha": "2449af9ac3e2614e27a0dc2cac46acf3a404790f",
-  "codeSubject": "Merge PR #787: B2 \u2014 route the Hill master by the rank's coordinate pool (W02-F001)",
+  "codeSha": "8a0592e8af2153e86ea01c6ead9f98f56ace42e3",
+  "codeSubject": "evidence(B3): pin the B3 baseline and reproduce W02-F003 with anchor lineage",
   "dirty": true,
   "board": {
    "path": "exports/latest/dynasty_data_2026-08-11.json",

--- a/docs/master-site-audit/evidence/W02/b3_corridor_report.json
+++ b/docs/master-site-audit/evidence/W02/b3_corridor_report.json
@@ -1,0 +1,219 @@
+{
+ "pin": {
+  "phase": "B3",
+  "codeSha": "2449af9ac3e2614e27a0dc2cac46acf3a404790f",
+  "codeSubject": "Merge PR #787: B2 \u2014 route the Hill master by the rank's coordinate pool (W02-F001)",
+  "dirty": true,
+  "board": {
+   "path": "exports/latest/dynasty_data_2026-08-11.json",
+   "sha256_16": "8fb6ede274171aee",
+   "bytes": 834861,
+   "mtime": 1786448566.2751555,
+   "scrapeTimestamp": "2026-08-11T11:32:57.431111",
+   "date": "2026-08-11",
+   "playerCount": 1074
+  },
+  "sourceCsvs": {
+   "dlfIdp.csv": {
+    "sha256_16": "9bf471c7222ad7d2",
+    "bytes": 3528,
+    "mtime": 1786401006.7137527
+   },
+   "dlfRookieIdp.csv": {
+    "sha256_16": "53dea29be05656dc",
+    "bytes": 575,
+    "mtime": 1786401006.7157583
+   },
+   "dlfRookieSf.csv": {
+    "sha256_16": "7b3109d1cf8eee82",
+    "bytes": 1111,
+    "mtime": 1786448566.2151556
+   },
+   "dlfSf.csv": {
+    "sha256_16": "20ec2e95239e8e5b",
+    "bytes": 5872,
+    "mtime": 1786401006.7157583
+   },
+   "draftSharksIdp.csv": {
+    "sha256_16": "f5fe62320c7e1837",
+    "bytes": 22026,
+    "mtime": 1786401006.7157583
+   },
+   "draftSharksRosIdp.csv": {
+    "sha256_16": "659e6a97771b0cb2",
+    "bytes": 12423,
+    "mtime": 1786440245.6273458
+   },
+   "draftSharksRosSf.csv": {
+    "sha256_16": "83dc969830487b22",
+    "bytes": 7273,
+    "mtime": 1786440245.6273458
+   },
+   "draftSharksSf.csv": {
+    "sha256_16": "2a656d65e0514479",
+    "bytes": 163609,
+    "mtime": 1786401006.7217526
+   },
+   "dynastyDaddySf.csv": {
+    "sha256_16": "d9f57b19c9626a48",
+    "bytes": 8503,
+    "mtime": 1786448566.2151556
+   },
+   "dynastyNerdsSfTep.csv": {
+    "sha256_16": "fe232d5ef61c7379",
+    "bytes": 10255,
+    "mtime": 1786401006.7217526
+   },
+   "fantasyCalc.csv": {
+    "sha256_16": "fc1fe584c0edf761",
+    "bytes": 9111,
+    "mtime": 1786448566.2151556
+   },
+   "fantasyNavigatorSf.csv": {
+    "sha256_16": "45208ef97e0e016d",
+    "bytes": 17978,
+    "mtime": 1786401006.7217526
+   },
+   "fantasyProsFitzmaurice.csv": {
+    "sha256_16": "a834e5f371c49970",
+    "bytes": 8505,
+    "mtime": 1786401006.7217526
+   },
+   "fantasyProsIdp.csv": {
+    "sha256_16": "01a17ce73c2a579f",
+    "bytes": 10513,
+    "mtime": 1786401006.7257528
+   },
+   "fantasyProsSf.csv": {
+    "sha256_16": "e7e91d2b6ae3ce1d",
+    "bytes": 14004,
+    "mtime": 1786440245.6313457
+   },
+   "flockFantasySf.csv": {
+    "sha256_16": "31c9923a82417f82",
+    "bytes": 9276,
+    "mtime": 1786440245.6313457
+   },
+   "flockFantasySfRookies.csv": {
+    "sha256_16": "e1cf340a54a7b289",
+    "bytes": 1694,
+    "mtime": 1786401006.7257528
+   },
+   "idpShow.csv": {
+    "sha256_16": "fbcfc0f16236b046",
+    "bytes": 7670,
+    "mtime": 1786401006.7257528
+   },
+   "idpTradeCalc.csv": {
+    "sha256_16": "00a43e7aaa6ce0d9",
+    "bytes": 19660,
+    "mtime": 1786401006.7257528
+   },
+   "ktc.csv": {
+    "sha256_16": "4c7fab0cc7bb1ebd",
+    "bytes": 9856,
+    "mtime": 1786448566.2151556
+   },
+   "ktcSfTep.csv": {
+    "sha256_16": "92b7414d58535b67",
+    "bytes": 9863,
+    "mtime": 1786448566.2151556
+   },
+   "otcffbSf.csv": {
+    "sha256_16": "c1348395d72924bd",
+    "bytes": 10164,
+    "mtime": 1786448566.2151556
+   },
+   "pfkDynasty.csv": {
+    "sha256_16": "dbeec7c1b0adb640",
+    "bytes": 15210,
+    "mtime": 1786440245.6313457
+   },
+   "yahooBoone.csv": {
+    "sha256_16": "27cdfd58e4f4e7db",
+    "bytes": 10774,
+    "mtime": 1786401006.7297528
+   }
+  },
+  "championModel": {
+   "modelId": "hill_scope_masters",
+   "version": 2,
+   "status": "champion",
+   "producer": "scripts/fit_hill_curve_percentile.py @ 3df9cc4",
+   "fittedAt": "2026-07-28T09:08:00.219336+00:00",
+   "promotedAt": "2026-07-29T23:35:35.519297+00:00",
+   "appliedAt": null,
+   "params": {
+    "HILL_GLOBAL_PERCENTILE_C": 0.112,
+    "HILL_GLOBAL_PERCENTILE_S": 0.725,
+    "HILL_PERCENTILE_C": 0.11,
+    "HILL_PERCENTILE_S": 1.11,
+    "IDP_HILL_PERCENTILE_C": 0.083,
+    "IDP_HILL_PERCENTILE_S": 1.11,
+    "HILL_ROOKIE_PERCENTILE_C": 0.153,
+    "HILL_ROOKIE_PERCENTILE_S": 0.885
+   }
+  },
+  "registryVersions": [
+   1,
+   2,
+   3,
+   4
+  ]
+ },
+ "corridorConfig": {
+  "primaryAnchors": {
+   "offense": "ktcSfTep",
+   "idp": "idpTradeCalc"
+  },
+  "fallbackChains": {
+   "offense": [
+    "ktcSfTep",
+    "idpTradeCalc",
+    "dynastyDaddySf",
+    "fantasyProsFitzmaurice",
+    "yahooBoone"
+   ],
+   "idp": [
+    "idpTradeCalc",
+    "dlfIdp",
+    "idpShow",
+    "fantasyProsIdp"
+   ]
+  },
+  "percentile": 0.9,
+  "minBucketN": 30,
+  "maxBand": {
+   "idp": 0.15
+  },
+  "idpChainAllVoting": true
+ },
+ "reproduction": {
+  "clampedRows": 183,
+  "rankedIdpRows": 329,
+  "clampRate": 0.5562310030395137,
+  "cappedByMaxBand": 183,
+  "onBandEdge": 183,
+  "distinctBandPct": [
+   0.15
+  ],
+  "up": 23,
+  "down": 160,
+  "anchorAlsoVoted": 183,
+  "anchorSourceCounts": {
+   "idpTradeCalc": 183
+  },
+  "servedRowsMovedByCorridor": 193,
+  "bucketP90": {
+   "medium": 0.5183066361556065,
+   "high": 0.6503856041131105,
+   "low": 0.6316455696202532
+  },
+  "bucketN": {
+   "medium": 120,
+   "high": 36,
+   "low": 173
+  },
+  "overallP90": 0.6200527704485488
+ }
+}

--- a/docs/master-site-audit/evidence/W02/b3_corridor_report.json
+++ b/docs/master-site-audit/evidence/W02/b3_corridor_report.json
@@ -1,8 +1,8 @@
 {
  "pin": {
   "phase": "B3",
-  "codeSha": "8a0592e8af2153e86ea01c6ead9f98f56ace42e3",
-  "codeSubject": "evidence(B3): pin the B3 baseline and reproduce W02-F003 with anchor lineage",
+  "codeSha": "1e88c6863c8674e7478c4bf8c71d1297cccec454",
+  "codeSubject": "evidence(B3): candidate corridor policies measured, and the hard cap is the whole defect",
   "dirty": true,
   "board": {
    "path": "exports/latest/dynasty_data_2026-08-11.json",
@@ -183,27 +183,27 @@
   },
   "percentile": 0.9,
   "minBucketN": 30,
-  "maxBand": {
-   "idp": 0.15
-  },
+  "maxBand": {},
   "idpChainAllVoting": true
  },
  "reproduction": {
-  "clampedRows": 183,
+  "clampedRows": 32,
   "rankedIdpRows": 329,
-  "clampRate": 0.5562310030395137,
-  "cappedByMaxBand": 183,
-  "onBandEdge": 183,
+  "clampRate": 0.0972644376899696,
+  "cappedByMaxBand": 0,
+  "onBandEdge": 32,
   "distinctBandPct": [
-   0.15
+   0.5183,
+   0.6316,
+   0.6504
   ],
-  "up": 23,
-  "down": 160,
-  "anchorAlsoVoted": 183,
+  "up": 0,
+  "down": 32,
+  "anchorAlsoVoted": 32,
   "anchorSourceCounts": {
-   "idpTradeCalc": 183
+   "idpTradeCalc": 32
   },
-  "servedRowsMovedByCorridor": 193,
+  "servedRowsMovedByCorridor": 32,
   "bucketP90": {
    "medium": 0.5183066361556065,
    "high": 0.6503856041131105,

--- a/docs/master-site-audit/evidence/W02/b3_corridor_reproduction.txt
+++ b/docs/master-site-audit/evidence/W02/b3_corridor_reproduction.txt
@@ -1,5 +1,5 @@
 == B3 pin ==
-  code   2449af9ac  dirty=True
+  code   8a0592e8a  dirty=True
   board  exports/latest/dynasty_data_2026-08-11.json  sha256_16=8fb6ede274171aee  834861 B  scraped=2026-08-11T11:32:57.431111
   csvs   24 hashed
   champ  v2 (champion) params={'HILL_GLOBAL_PERCENTILE_C': 0.112, 'HILL_GLOBAL_PERCENTILE_S': 0.725, 'HILL_PERCENTILE_C': 0.11, 'HILL_PERCENTILE_S': 1.11, 'IDP_HILL_PERCENTILE_C': 0.083, 'IDP_HILL_PERCENTILE_S': 1.11, 'HILL_ROOKIE_PERCENTILE_C': 0.153, 'HILL_ROOKIE_PERCENTILE_S': 0.885}
@@ -30,6 +30,18 @@
   high     n=36    P90=0.6504   own band   cap wins=True
   low      n=173   P90=0.6316   own band   cap wins=True
   medium   n=120   P90=0.5183   own band   cap wins=True
+
+== who gets clamped ==
+  bucket     ranked IDP  clamped    rate   up/down
+  high               36       23   63.9%      6/17
+  medium            120       55   45.8%     11/44
+  low               173      105   60.7%      6/99
+  sources    ranked IDP  clamped    rate
+  2                  27       13   48.1%
+  3                 112      100   89.3%
+  4                  60       36   60.0%
+  5                 122       32   26.2%
+  6                   8        2   25.0%
 
 == anchor lineage on clamped rows ==
   anchor=idpTradeCalc              183 rows

--- a/docs/master-site-audit/evidence/W02/b3_corridor_reproduction.txt
+++ b/docs/master-site-audit/evidence/W02/b3_corridor_reproduction.txt
@@ -1,0 +1,84 @@
+== B3 pin ==
+  code   2449af9ac  dirty=True
+  board  exports/latest/dynasty_data_2026-08-11.json  sha256_16=8fb6ede274171aee  834861 B  scraped=2026-08-11T11:32:57.431111
+  csvs   24 hashed
+  champ  v2 (champion) params={'HILL_GLOBAL_PERCENTILE_C': 0.112, 'HILL_GLOBAL_PERCENTILE_S': 0.725, 'HILL_PERCENTILE_C': 0.11, 'HILL_PERCENTILE_S': 1.11, 'IDP_HILL_PERCENTILE_C': 0.083, 'IDP_HILL_PERCENTILE_S': 1.11, 'HILL_ROOKIE_PERCENTILE_C': 0.153, 'HILL_ROOKIE_PERCENTILE_S': 0.885}
+
+== corridor configuration as shipped ==
+  primary anchors      {'offense': 'ktcSfTep', 'idp': 'idpTradeCalc'}
+  fallback chains      {'offense': ['ktcSfTep', 'idpTradeCalc', 'dynastyDaddySf', 'fantasyProsFitzmaurice', 'yahooBoone'], 'idp': ['idpTradeCalc', 'dlfIdp', 'idpShow', 'fantasyProsIdp']}
+  percentile           0.9
+  min bucket n         30
+  hard max band        {'idp': 0.15}
+
+  anchor sources that are ALSO voting members of the blend they clamp:
+    idpTradeCalc       voting=True
+    dlfIdp             voting=True
+    idpShow            voting=True
+    fantasyProsIdp     voting=True
+
+== W02-F003 reproduction ==
+  clamped 183 rows — 55.6% of 329 ranked IDP rows; asset classes {'idp': 183}
+  non-offense ranked rows the clamp iterates: 359 (picks reach the loop and are dropped by having no anchor chain)
+  cappedByMaxBand      183/183 (100.0%)
+  distinct bandPct     [0.15]
+  on the band edge     183/183 (100.0%)
+  direction            up 23 (value was BELOW anchor) / down 160 (value was ABOVE anchor)
+
+== empirical bucket P90s the hard cap overrides ==
+  overall  n=329   P90=0.6201   (cap 0.15)
+  high     n=36    P90=0.6504   own band   cap wins=True
+  low      n=173   P90=0.6316   own band   cap wins=True
+  medium   n=120   P90=0.5183   own band   cap wins=True
+
+== anchor lineage on clamped rows ==
+  anchor=idpTradeCalc              183 rows
+  rows where the anchor source ALSO voted in this row's blend: 183/183 (100.0%)
+
+== corridor's share of the served value ==
+  rows whose SERVED value differs with the corridor on: 193
+  |Δ%| mean=14.45 median=7.05 p90=30.48 max=51.95
+  largest 10:
+    Abdul Carter               unclamped  3654 → served  4598  (+25.8%)
+    Jalon Walker               unclamped  1838 → served  2755  (+49.9%)
+    Byron Young                unclamped  1740 → served  2644  (+52.0%)
+    Nick Herbig                unclamped  1727 → served  2620  (+51.7%)
+    Jamien Sherwood            unclamped  3198 → served  2462  (-23.0%)
+    Chase Young                unclamped  1828 → served  2506  (+37.1%)
+    Dallas Turner              unclamped  3022 → served  3539  (+17.1%)
+    Will Johnson               unclamped  1386 → served   873  (-37.0%)
+    Nate Wiggins               unclamped  1298 → served   876  (-32.5%)
+    Ji'Ayir Brown              unclamped  1278 → served   880  (-31.1%)
+
+== distance from the anchor, before and after the corridor ==
+  unclamped |value − anchor| / anchor : median=0.2264 p90=0.6483 max=0.8261
+  clamped   |value − anchor| / anchor : median=0.1500 p90=0.1504 max=0.1506
+  → 183 of 329 ranked IDP rows (55.6%) are served at exactly idpTradeCalc × 0.85 or × 1.15
+
+== idpTradeCalc's direct share of the vote on clamped rows ==
+  sources stamped per clamped row: median=3 min=2 max=6
+  idpTradeCalc contribution ÷ median of the other sources: n=183 median=0.721 p10=0.452 p90=1.184
+  (>1 means IDPTC prices the row ABOVE its peers — and the corridor then pulls the blend back toward IDPTC as well)
+
+== leave-IDPTC-out WHOLE-BOARD rebuild (DIAGNOSTIC ONLY) ==
+  CAVEAT, load-bearing: idpTradeCalc is also the IDP BACKBONE, so
+  dropping it empties the shared-market ladder and every translated
+  IDP source falls back to a raw IDP-local rank. This board is
+  therefore NOT 'the same model minus one vote' — it is an UPPER
+  BOUND on idpTradeCalc's influence, and the vote-share block above
+  is the isolate.
+  player                       blend     LOO  anchor unclamp  served
+  Abdul Carter                  3654    2493    5409    3654    4598
+  Jacob Rodriguez               3517    3239    4169    3517    3544
+  Jamien Sherwood               3198    4522    2141    3198    2462
+  Dallas Turner                 3022    2327    4164    3022    3539
+  Nik Bonitto                   2814    2397    3593    2814    3054
+  Josh Hines-Allen              2704    2150    3596    2704    3057
+  Rueben Bain                   2636    2199    3458    2636    2939
+  Tuli Tuipulotu                2618    2263    3220    2618    2737
+  Nate Landman                  2572    5230    3127    2572    2658
+  Brian Branch                  2569    5430    3200    2569    2720
+  Daiyan Henley                 2548    3278    1984    2548    2282
+  George Karlaftis              2481    4441    3043    2481    2587
+
+wrote /home/user/riskittogetthebrisket/docs/master-site-audit/evidence/W02/b3_corridor_report.json

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -4719,23 +4719,52 @@ _MARKET_CORRIDOR_PERCENTILE: float = 0.90
 # can't get an unrepresentative band.
 _MARKET_CORRIDOR_MIN_BUCKET_N: int = 30
 
-# Hard ceiling on the corridor band per asset class.  The dynamic
-# bucket-P90 still controls clamp behaviour for normal cases; this
-# cap is a safety rail that prevents a wide bucket distribution from
-# letting truly-extreme outliers escape the clamp entirely.
+# Hard ceiling on the corridor band per asset class.  **EMPTY since
+# B3 (2026-08-11): the IDP entry of 0.15 was removed.**  The facility
+# is kept because the mechanism is generic and a future asset class
+# may need it; nothing populates it today.
 #
-# IDP cap is 0.15 (±15% of IDPTradeCalc): IDPTC is the retail IDP
-# market, so blended values that drift further than that aren't
-# tradeable in real leagues regardless of how many other sources
-# disagree.  Cases like a Vikings LB priced at 1,900 internal vs
-# 3,600 on IDPTC (47% drift) clamp to the band edge (3,060) instead
-# of riding through on a wide bucket P90.  Offense has no cap
-# because offense rows are not clamped at all (see
-# ``_apply_market_corridor_clamp`` — the clamp only contains the
-# IDP calibration runaway; offense has no calibration post-pass).
-_MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS: dict[str, float] = {
-    "idp": 0.15,
-}
+# It was introduced (#375/#376, 2026-05-02) so a wide bucket
+# distribution could not let a truly-extreme outlier escape — the
+# Vikings-LB case, 1,900 internal against 3,600 on IDPTC.  Measured
+# on the 2026-08-11 board, that is not what it does.  It decided
+# EVERY clamp: 183 of 329 ranked IDP rows (55.6%), all capped, all
+# landing on exactly ``idpTradeCalc × 0.85`` or ``× 1.15``, because
+# the empirical bucket bands run 0.5183–0.6504 — 3.5× to 4.3× the
+# cap — in every bucket, all of them above the min-sample threshold.
+# So the board-derived band was computed and then discarded 183 times
+# out of 183, and the served value of most of the ranked IDP board
+# was a constant times one source.
+#
+# The distributional evidence is what settles it.  With the cap gone
+# the same code clamps 32 rows (9.7%), every one of them in the board
+# tail, none with five or more sources, median move 2.0% — which is
+# the tail safety rail the corridor was designed to be.  With the cap
+# the clamp rate is INVERTED against the board's own confidence:
+# 63.9% of high-confidence rows against 45.8% of medium, i.e. it
+# overrode the rows where our sources agree most tightly, in favour
+# of the one source that disagreed — and that source
+# (``idpTradeCalc``) is itself a voting member of the blend being
+# clamped, so it was getting a direct contribution and then a
+# post-blend veto.
+#
+# Two things this deliberately does NOT rely on.  It is not "the
+# empirical machinery was dead": a tighter synthetic board reaches it
+# (pinned in ``test_market_corridor_characterization``), so the cap's
+# dominance was a property of this market's IDP disagreement.  And it
+# is not "the corridor is unnecessary": the corridor still runs, and
+# the hazard the cap was aimed at is separately covered by the
+# single-source haircut (``_SINGLE_SOURCE_VALUE_RETENTION``, #496).
+#
+# Residual, stated rather than hidden: the band is derived from the
+# same drift distribution it bounds, so a board that drifted as a
+# whole would widen its own band and catch nothing.  That is a
+# property of the empirical design, not of this removal, and it is
+# the reason the facility below is kept rather than deleted.
+#
+# Full evidence: ``docs/master-site-audit/evidence/W02/``
+#   ``B3_MARKET_CORRIDOR_EVIDENCE.md``.
+_MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS: dict[str, float] = {}
 
 
 def _market_anchor_value_for_row(row: dict[str, Any]) -> float | None:

--- a/tests/api/test_market_corridor_characterization.py
+++ b/tests/api/test_market_corridor_characterization.py
@@ -1,0 +1,322 @@
+"""W02-F003 — what the IDP market corridor does today, pinned.
+
+These are **characterization** tests, and the distinction matters. They are
+GREEN at the B3 baseline by construction: their job is to make the
+corridor's current behaviour impossible to change silently, so that any
+candidate policy's effect shows up as a test diff rather than as a number
+someone has to notice. They are not assertions that the behaviour is
+correct — §2 of the B3 authorization records most of it as the defect.
+
+The existing `test_market_corridor_clamp.py` covers the mechanism's happy
+path. What was missing, and what B3 needs before touching anything, is a
+pinned record of the *live* distribution: how much of the IDP board the
+corridor decides, which band it uses, where clamped rows land, which way
+they move, and what the anchor actually is.
+
+Everything drives `build_api_data_contract` — the production entry point.
+The synthetic cases build a raw payload and let the real pipeline run;
+none of them re-implements the corridor formula, because a test that
+re-implements the thing it is testing pins the copy rather than the code.
+
+Measured at the B3 pin (code `2449af9ac`, board sha256₁₆
+`8fb6ede274171aee`). Bounds are deliberately loose where the underlying
+quantity is a property of this week's market data rather than of the code
+— a tight assertion there goes red when sources agree more closely, which
+is noise. Where the quantity is a property of the CODE (every clamp capped,
+every clamp on the band edge, the anchor being a voting source) the
+assertion is exact.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from functools import lru_cache
+from pathlib import Path
+
+from src.api.data_contract import (
+    _MARKET_ANCHOR_BY_ASSET_CLASS,
+    _MARKET_ANCHOR_FALLBACKS,
+    _MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS,
+    _MARKET_CORRIDOR_MIN_BUCKET_N,
+    _MARKET_CORRIDOR_PERCENTILE,
+    _RANKING_SOURCES,
+    build_api_data_contract,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _live() -> dict | None:
+    files = sorted((REPO / "exports" / "latest").glob("dynasty_data_*.json"), reverse=True)
+    if not files:
+        return None
+    raw = json.loads(files[0].read_text(encoding="utf-8"))
+    with contextlib.redirect_stdout(io.StringIO()):
+        return build_api_data_contract(raw)
+
+
+@lru_cache(maxsize=1)
+def live() -> dict | None:
+    return _live()
+
+
+# ── the configuration itself ───────────────────────────────────────────
+
+
+class TestCorridorConfiguration(unittest.TestCase):
+    def test_the_hard_cap_is_idp_only_and_is_the_value_b3_measured(self) -> None:
+        self.assertEqual(_MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS, {"idp": 0.15})
+
+    def test_the_empirical_machinery_is_still_configured(self) -> None:
+        self.assertEqual(_MARKET_CORRIDOR_PERCENTILE, 0.90)
+        self.assertEqual(_MARKET_CORRIDOR_MIN_BUCKET_N, 30)
+
+    def test_every_idp_anchor_is_a_voting_source_in_the_blend_it_clamps(self) -> None:
+        """The lineage fact, pinned at the registry level.
+
+        `idpTradeCalc` anchors the corridor AND votes in the blend the
+        corridor constrains; so does every fallback. This is not a
+        statement that the corridor is wrong — it is the reason the
+        corridor cannot be described as independent market evidence, and
+        it must not become true-by-accident of some future source.
+        """
+        voting = {str(s.get("key") or "") for s in _RANKING_SOURCES}
+        chain = _MARKET_ANCHOR_FALLBACKS["idp"]
+        self.assertEqual(chain, ["idpTradeCalc", "dlfIdp", "idpShow", "fantasyProsIdp"])
+        for key in chain:
+            self.assertIn(
+                key,
+                voting,
+                f"{key} anchors the IDP corridor but no longer votes — the "
+                "lineage claim in the B3 evidence needs re-deriving",
+            )
+        self.assertEqual(_MARKET_ANCHOR_BY_ASSET_CLASS["idp"], "idpTradeCalc")
+
+
+# ── the live distribution ──────────────────────────────────────────────
+
+
+class TestLiveCorridorDistribution(unittest.TestCase):
+    """Pins what the corridor decides on the board production serves."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contract = live()
+
+    def _rows(self) -> list[dict]:
+        if self.contract is None:
+            self.skipTest("no exported board to build from")
+        return list(self.contract.get("playersArray") or [])
+
+    def _clamped(self) -> list[dict]:
+        return [r for r in self._rows() if r.get("marketCorridorClamp")]
+
+    def _ranked_idp(self) -> list[dict]:
+        return [
+            r
+            for r in self._rows()
+            if r.get("assetClass") == "idp" and r.get("canonicalConsensusRank")
+        ]
+
+    def test_the_corridor_decides_a_large_share_of_the_ranked_idp_board(self) -> None:
+        """B3 measured 183/329 = 55.6%. The share is market-dependent; that
+        it is a *large* share is the finding."""
+        clamped, pop = self._clamped(), self._ranked_idp()
+        self.assertGreater(len(pop), 50, "too few ranked IDP rows to characterize")
+        rate = len(clamped) / len(pop)
+        self.assertGreater(
+            rate,
+            0.25,
+            f"clamp rate collapsed to {rate:.1%} — if this is a deliberate "
+            "policy change, update this characterization with the evidence",
+        )
+
+    def test_only_idp_rows_are_clamped(self) -> None:
+        """Offense is exempt by an explicit guard; picks reach the loop and
+        are dropped for having no anchor chain, which is a different
+        mechanism and worth pinning separately."""
+        classes = {str(r.get("assetClass")) for r in self._clamped()}
+        self.assertEqual(classes, {"idp"})
+
+    def test_every_clamp_is_capped_by_the_hard_band_not_the_bucket_p90(self) -> None:
+        """The defect in one assertion: the per-bucket empirical band is
+        computed and then discarded on every single row."""
+        clamped = self._clamped()
+        self.assertTrue(clamped)
+        for r in clamped:
+            c = r["marketCorridorClamp"]
+            self.assertTrue(c["cappedByMaxBand"], f"{r.get('displayName')} used a bucket band")
+            self.assertEqual(c["bandPct"], 0.15)
+
+    def test_every_clamped_row_lands_exactly_on_the_band_edge(self) -> None:
+        """So a clamped row's value is `anchor × (1 ± band)` — the blend
+        does not determine it."""
+        for r in self._clamped():
+            c = r["marketCorridorClamp"]
+            sign = 1 if c["direction"] == "down" else -1
+            edge = c["marketAnchor"] * (1.0 + sign * c["bandPct"])
+            self.assertLessEqual(
+                abs(round(edge) - c["clampedValue"]),
+                1,
+                f"{r.get('displayName')} did not land on the band edge",
+            )
+
+    def test_the_corridor_now_acts_predominantly_as_a_ceiling(self) -> None:
+        """B3 measured 23 up / 160 down. Pre-B2 it was 57/74, so the
+        direction flipped when the curve-routing repair raised IDP values."""
+        clamped = self._clamped()
+        down = sum(1 for r in clamped if r["marketCorridorClamp"]["direction"] == "down")
+        self.assertGreater(
+            down / len(clamped),
+            0.60,
+            "the corridor is no longer predominantly a ceiling — re-derive "
+            "the B3 direction finding before relying on it",
+        )
+
+    def test_the_anchor_is_idptradecalc_and_it_also_voted(self) -> None:
+        """The double-count, on live rows: on every clamped row the anchor
+        source also contributed to the blend being clamped."""
+        clamped = self._clamped()
+        also_voted = 0
+        for r in clamped:
+            source = str(r["marketCorridorClamp"].get("marketSource"))
+            self.assertEqual(source, "idpTradeCalc")
+            if source in (r.get("sourceRankMeta") or {}):
+                also_voted += 1
+        self.assertEqual(
+            also_voted,
+            len(clamped),
+            "some clamped row was anchored to a source that did not vote on "
+            "it — the fallback chain has started firing, which changes the "
+            "lineage analysis",
+        )
+
+    def test_suppressing_the_corridor_changes_the_served_board(self) -> None:
+        """Guards the measurement route itself. `consensus_edge` relies on
+        this flag; if it stopped doing anything, the fair-value board would
+        silently become anchor-contaminated again."""
+        if self.contract is None:
+            self.skipTest("no exported board to build from")
+        files = sorted((REPO / "exports" / "latest").glob("dynasty_data_*.json"), reverse=True)
+        raw = json.loads(files[0].read_text(encoding="utf-8"))
+        with contextlib.redirect_stdout(io.StringIO()):
+            unclamped = build_api_data_contract(raw, suppress_market_corridor_clamp=True)
+        self.assertFalse(
+            [r for r in unclamped.get("playersArray") or [] if r.get("marketCorridorClamp")]
+        )
+        served = {
+            r.get("displayName"): r.get("rankDerivedValue")
+            for r in self.contract.get("playersArray") or []
+        }
+        without = {
+            r.get("displayName"): r.get("rankDerivedValue")
+            for r in unclamped.get("playersArray") or []
+        }
+        moved = [k for k, v in served.items() if k in without and without[k] != v]
+        self.assertGreater(len(moved), 50, "the corridor moved almost nothing")
+
+
+# ── deterministic mechanism cases through the production path ──────────
+
+IDP_POSITIONS = ("DL", "LB", "DB")
+
+
+def _payload(rows: list[tuple[str, str, dict]]) -> dict:
+    players: dict[str, dict] = {}
+    for name, pos, sites in rows:
+        row = {"_canonicalSiteValues": dict(sites), "position": pos, "age": 25}
+        row.update(sites)
+        players[name] = row
+    return {
+        "version": "corridor-fixture",
+        "date": "2026-08-11",
+        "settings": {},
+        "sites": {},
+        "maxValues": {},
+        "players": players,
+    }
+
+
+def _build(rows: list[tuple[str, str, dict]], **kwargs) -> dict[str, dict]:
+    with tempfile.TemporaryDirectory() as tmp, contextlib.redirect_stdout(io.StringIO()):
+        contract = build_api_data_contract(_payload(rows), csv_root=Path(tmp), **kwargs)
+    return {str(r.get("displayName")): r for r in contract.get("playersArray") or []}
+
+
+class TestCorridorMechanismOnSyntheticBoards(unittest.TestCase):
+    """Cases the live board cannot exhibit on demand."""
+
+    @staticmethod
+    def _rows(idp_extra: dict | None = None) -> list[tuple[str, str, dict]]:
+        rows: list[tuple[str, str, dict]] = []
+        market = 9000
+        for i in range(40):
+            rows.append(
+                (
+                    f"Off {i + 1:02d}",
+                    "WR",
+                    {"ktcSfTep": market, "idpTradeCalc": market, "dlfSf": market},
+                )
+            )
+            market -= 90
+        for i in range(40):
+            sites = {"idpTradeCalc": market, "dlfIdp": market, "idpShow": market}
+            if idp_extra and i == 0:
+                sites.update(idp_extra)
+            rows.append((f"Idp {i + 1:02d}", "LB", sites))
+            market -= 70
+        return rows
+
+    def test_a_row_with_no_anchor_is_never_clamped(self) -> None:
+        """`_market_anchor_for_row` returns (None, None) when nothing in the
+        chain contributed, and the caller must skip rather than invent a
+        band. Missing is not zero."""
+        rows = self._rows()
+        rows.append(("Anchorless DB", "DB", {"draftSharksIdp": 40}))
+        built = _build(rows)
+        row = built["Anchorless DB"]
+        self.assertIsNone(row.get("marketCorridorClamp"))
+
+    def test_picks_reach_the_loop_and_are_dropped_for_having_no_chain(self) -> None:
+        """The offense guard is `assetClass == "offense"`, so picks are NOT
+        exempted by it — they survive to `_market_anchor_for_row` and are
+        dropped there because `_MARKET_ANCHOR_FALLBACKS` has no pick key.
+        Two different mechanisms with the same visible outcome; pinned so a
+        future pick anchor does not silently start clamping picks."""
+        self.assertNotIn("pick", _MARKET_ANCHOR_FALLBACKS)
+        if live() is not None:
+            picks = [
+                r
+                for r in live().get("playersArray") or []
+                if r.get("assetClass") == "pick" and r.get("marketCorridorClamp")
+            ]
+            self.assertEqual(picks, [])
+
+    def test_offense_rows_are_never_clamped_even_when_they_drift(self) -> None:
+        built = _build(self._rows())
+        for name, row in built.items():
+            if row.get("assetClass") == "offense":
+                self.assertIsNone(row.get("marketCorridorClamp"), name)
+
+    def test_a_tight_board_uses_the_empirical_band_not_the_cap(self) -> None:
+        """The percentile machinery is live code, not dead code — it is
+        this week's unusually wide IDP disagreement that makes the cap win
+        every time on the real board. Proven here rather than asserted, so
+        the B3 conclusion says 'unreachable on this board', not 'dead'."""
+        built = _build(self._rows())
+        clamps = [r["marketCorridorClamp"] for r in built.values() if r.get("marketCorridorClamp")]
+        if not clamps:
+            self.skipTest("tight fixture produced no clamps, which is the point")
+        self.assertTrue(
+            any(not c["cappedByMaxBand"] for c in clamps),
+            "even a tight synthetic board is capped — the empirical band may "
+            "genuinely be unreachable, which would change the B3 conclusion",
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/api/test_market_corridor_characterization.py
+++ b/tests/api/test_market_corridor_characterization.py
@@ -1,11 +1,15 @@
 """W02-F003 — what the IDP market corridor does today, pinned.
 
-These are **characterization** tests, and the distinction matters. They are
-GREEN at the B3 baseline by construction: their job is to make the
-corridor's current behaviour impossible to change silently, so that any
-candidate policy's effect shows up as a test diff rather than as a number
-someone has to notice. They are not assertions that the behaviour is
-correct — §2 of the B3 authorization records most of it as the defect.
+These began as **characterization** tests, written GREEN against the
+pre-repair board so that any candidate policy's effect would show up as a
+test diff rather than as a number someone had to notice. They did exactly
+that: removing the hard cap turned seven of them red, four here and three
+in `test_market_corridor_clamp.py`, and each was then rewritten against
+the measured post-repair behaviour with the reason recorded in the
+assertion message. That RED set is the change's receipt.
+
+They still are not assertions that any of this is *correct* — they pin
+what the pipeline does so the next change has to argue with them.
 
 The existing `test_market_corridor_clamp.py` covers the mechanism's happy
 path. What was missing, and what B3 needs before touching anything, is a
@@ -22,7 +26,7 @@ Measured at the B3 pin (code `2449af9ac`, board sha256₁₆
 `8fb6ede274171aee`). Bounds are deliberately loose where the underlying
 quantity is a property of this week's market data rather than of the code
 — a tight assertion there goes red when sources agree more closely, which
-is noise. Where the quantity is a property of the CODE (every clamp capped,
+is noise. Where the quantity is a property of the CODE (no clamp capped,
 every clamp on the band edge, the anchor being a voting source) the
 assertion is exact.
 """
@@ -68,8 +72,11 @@ def live() -> dict | None:
 
 
 class TestCorridorConfiguration(unittest.TestCase):
-    def test_the_hard_cap_is_idp_only_and_is_the_value_b3_measured(self) -> None:
-        self.assertEqual(_MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS, {"idp": 0.15})
+    def test_no_asset_class_carries_a_hard_cap_after_b3(self) -> None:
+        """The B3 repair. The facility is kept — the mechanism is
+        generic — but nothing populates it, so the band is whatever the
+        board's own drift distribution produces."""
+        self.assertEqual(_MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS, {})
 
     def test_the_empirical_machinery_is_still_configured(self) -> None:
         self.assertEqual(_MARKET_CORRIDOR_PERCENTILE, 0.90)
@@ -122,17 +129,48 @@ class TestLiveCorridorDistribution(unittest.TestCase):
             if r.get("assetClass") == "idp" and r.get("canonicalConsensusRank")
         ]
 
-    def test_the_corridor_decides_a_large_share_of_the_ranked_idp_board(self) -> None:
-        """B3 measured 183/329 = 55.6%. The share is market-dependent; that
-        it is a *large* share is the finding."""
+    def test_the_corridor_is_a_tail_rail_not_a_majority_of_the_board(self) -> None:
+        """The B3 repair's headline effect.
+
+        Before: 183/329 = 55.6%, reaching 25 of the top third. After:
+        32/329 = 9.7%, entirely in the tail. The exact share is
+        market-dependent, so this asserts the *shape* — a minority of
+        rows, and none near the top of the board.
+        """
         clamped, pop = self._clamped(), self._ranked_idp()
         self.assertGreater(len(pop), 50, "too few ranked IDP rows to characterize")
         rate = len(clamped) / len(pop)
-        self.assertGreater(
+        self.assertLess(
             rate,
             0.25,
-            f"clamp rate collapsed to {rate:.1%} — if this is a deliberate "
-            "policy change, update this characterization with the evidence",
+            f"the corridor is back to deciding {rate:.1%} of the ranked IDP "
+            "board — B3 reduced it to a tail rail; re-derive before accepting",
+        )
+        ranked = sorted(pop, key=lambda r: r["canonicalConsensusRank"])
+        top_third = {str(r.get("displayName")) for r in ranked[: max(1, len(ranked) // 3)]}
+        in_top = [r for r in clamped if str(r.get("displayName")) in top_third]
+        self.assertEqual(
+            in_top,
+            [],
+            f"{len(in_top)} clamped rows are in the top third of the IDP "
+            "board — the corridor is overriding well-ranked players again",
+        )
+
+    def test_the_corridor_no_longer_overrides_well_covered_rows(self) -> None:
+        """Criterion 2 of the B3 evaluation, as a test.
+
+        With the cap in place the clamp rate was INVERTED against the
+        board's own confidence — 63.9% of high-confidence rows against
+        45.8% of medium — and 89.3% of 3-source rows were clamped while
+        5-source rows were 26.2%. After the repair no row with five or
+        more contributing sources is clamped at all.
+        """
+        thick = [r for r in self._clamped() if len(r.get("sourceRankMeta") or {}) >= 5]
+        self.assertEqual(
+            [str(r.get("displayName")) for r in thick],
+            [],
+            "a row backed by five or more sources was overridden toward a "
+            "single anchor source that is itself one of those sources",
         )
 
     def test_only_idp_rows_are_clamped(self) -> None:
@@ -142,15 +180,19 @@ class TestLiveCorridorDistribution(unittest.TestCase):
         classes = {str(r.get("assetClass")) for r in self._clamped()}
         self.assertEqual(classes, {"idp"})
 
-    def test_every_clamp_is_capped_by_the_hard_band_not_the_bucket_p90(self) -> None:
-        """The defect in one assertion: the per-bucket empirical band is
-        computed and then discarded on every single row."""
+    def test_every_clamp_now_uses_the_board_derived_band(self) -> None:
+        """The inverse of the defect. Before B3 every clamp reported
+        ``cappedByMaxBand: True`` and ``bandPct: 0.15``; the empirical
+        band was computed and discarded 183 times out of 183."""
         clamped = self._clamped()
         self.assertTrue(clamped)
         for r in clamped:
             c = r["marketCorridorClamp"]
-            self.assertTrue(c["cappedByMaxBand"], f"{r.get('displayName')} used a bucket band")
-            self.assertEqual(c["bandPct"], 0.15)
+            self.assertFalse(
+                c["cappedByMaxBand"], f"{r.get('displayName')} was capped by a hard band"
+            )
+            self.assertIsNone(c["maxBandPct"])
+            self.assertGreater(c["bandPct"], 0.15)
 
     def test_every_clamped_row_lands_exactly_on_the_band_edge(self) -> None:
         """So a clamped row's value is `anchor × (1 ± band)` — the blend
@@ -217,7 +259,7 @@ class TestLiveCorridorDistribution(unittest.TestCase):
             for r in unclamped.get("playersArray") or []
         }
         moved = [k for k, v in served.items() if k in without and without[k] != v]
-        self.assertGreater(len(moved), 50, "the corridor moved almost nothing")
+        self.assertGreater(len(moved), 10, "the corridor moved almost nothing")
 
 
 # ── deterministic mechanism cases through the production path ──────────

--- a/tests/api/test_market_corridor_clamp.py
+++ b/tests/api/test_market_corridor_clamp.py
@@ -525,10 +525,17 @@ class TestIdpMaxBandCap(unittest.TestCase):
     bucket P90 are still untouched.
     """
 
-    def test_idp_cap_constant_is_set(self):
-        """Cap is configured for IDP and lives at 15% by default."""
-        self.assertIn("idp", _MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS)
-        self.assertEqual(_MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS["idp"], 0.15)
+    def test_no_asset_class_carries_a_hard_cap(self):
+        """B3 (2026-08-11) removed the IDP entry; nothing replaced it.
+
+        The facility is kept because the mechanism is generic, but on
+        the live board the 0.15 cap decided EVERY clamp — 183 of 329
+        ranked IDP rows, all landing on ``idpTradeCalc × 0.85`` or
+        ``× 1.15`` — while the board-derived bucket bands (0.5183 to
+        0.6504) were computed and discarded every time. Evidence:
+        ``docs/master-site-audit/evidence/W02/B3_MARKET_CORRIDOR_EVIDENCE.md``.
+        """
+        self.assertEqual(_MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS, {})
 
     def test_offense_has_no_cap(self):
         """Offense has no cap because offense rows are not clamped at
@@ -569,18 +576,20 @@ class TestIdpMaxBandCap(unittest.TestCase):
         rows.append(outlier)
         _apply_market_corridor_clamp(rows, players_by_name={})
 
-        # Without the cap, bucket P90 would be ~0.30 → clamp to
-        # 3600 × 0.70 = 2520.  WITH the cap at 0.15, clamp is to
-        # 3600 × 0.85 = 3060.  The cap should bind.
+        # The outlier is STILL caught — which is the point of the test
+        # and the reason B3 removed the cap rather than the corridor.
+        # It now clamps to the band the board itself produced
+        # (bucket P90 ≈ 0.30 → 3600 × 0.70 = 2520) instead of to a
+        # hand-set constant (3600 × 0.85 = 3060).
         self.assertIn("marketCorridorClamp", outlier)
         stamp = outlier["marketCorridorClamp"]
         self.assertEqual(stamp["direction"], "up")
         self.assertEqual(stamp["originalValue"], 1900)
         self.assertEqual(stamp["marketAnchor"], 3600)
-        self.assertEqual(stamp["bandPct"], 0.15)
-        self.assertTrue(stamp["cappedByMaxBand"])
-        self.assertEqual(stamp["maxBandPct"], 0.15)
-        self.assertEqual(outlier["rankDerivedValue"], 3060)
+        self.assertFalse(stamp["cappedByMaxBand"])
+        self.assertIsNone(stamp["maxBandPct"])
+        self.assertAlmostEqual(stamp["bandPct"], 0.30, places=2)
+        self.assertEqual(outlier["rankDerivedValue"], 2520)
 
     def test_idp_inside_cap_uses_bucket_p90(self):
         """When the bucket P90 is below the cap, the existing dynamic
@@ -614,9 +623,10 @@ class TestIdpMaxBandCap(unittest.TestCase):
         # Clamp = 5000 × (1 − 0.10) = 4500.
         self.assertEqual(outlier["rankDerivedValue"], 4500)
 
-    def test_idp_cap_applies_in_both_directions(self):
-        """Over-valued outliers also clamp to the 15% cap edge above
-        IDPTC, not just below it."""
+    def test_the_corridor_applies_in_both_directions(self):
+        """Over-valued outliers clamp to the band edge above the anchor,
+        not just below it.  Symmetry is a property of the mechanism and
+        survived the B3 cap removal."""
         rows = []
         # 39 IDPs with 30% drift to widen the bucket band past 0.15.
         for i in range(39):
@@ -641,10 +651,10 @@ class TestIdpMaxBandCap(unittest.TestCase):
         _apply_market_corridor_clamp(rows, players_by_name={})
         stamp = over["marketCorridorClamp"]
         self.assertEqual(stamp["direction"], "down")
-        self.assertTrue(stamp["cappedByMaxBand"])
-        self.assertEqual(stamp["bandPct"], 0.15)
-        # Clamp = 5000 × 1.15 = 5750.
-        self.assertEqual(over["rankDerivedValue"], 5750)
+        self.assertFalse(stamp["cappedByMaxBand"])
+        self.assertAlmostEqual(stamp["bandPct"], 0.30, places=2)
+        # Clamp = 5000 × 1.30 = 6500, the board's own band edge.
+        self.assertEqual(over["rankDerivedValue"], 6500)
 
     def test_offense_rows_are_never_clamped(self):
         """Offense is fully exempt from the corridor clamp.


### PR DESCRIPTION
## What this is

B3, executed against the authorization of 2026-08-11. Scope is **W02-F003 only**. B2 was integrated first (#787 merged as `2449af9ac`) and this branch re-cut from it, so nothing here is another measurement on the stale B2 baseline.

**Not done and not authorized**: no `promote`/`apply`, no Hill champion constant change, no `PERCENTILE_REFERENCE_N` change, no W30-F023 tail-clamp work, no source-weight change, no B4. Champion is still registry v2. The B2 coordinate-pool routing is untouched.

## The B3 pin

Code `2449af9ac`, board `dynasty_data_2026-08-11.json` sha256₁₆ `8fb6ede274171aee` (834,861 B, scraped 11:32:57Z), 24 source CSVs hashed. **This is a different board from B2's** (`a495c049fa69f141`) — the B2 numbers stay attached to the B2 pin; nothing was recomputed across the refresh and presented as the same experiment.

## Reproduction — confirmed on the fresh pin

Identical to B2, so the finding is not an artifact of either snapshot: **183/329 ranked IDP rows clamped (55.6%)**, `cappedByMaxBand` 183/183, on the band edge 183/183, only `bandPct` 0.15, direction 23 up / 160 down.

Three things the finding did not record:

- **The per-bucket machinery is unreachable on this board, not merely dominated.** Empirical bands high 0.6504 (n=36), low 0.6316 (n=173), medium 0.5183 (n=120) — 3.5×–4.3× the cap, in *every* bucket, all above the 30-row minimum so the small-sample fallback never fires either.
- **The corridor, not the blend, decided the value.** Unclamped distance from anchor was median 0.2264 / p90 0.6483 / max 0.8261; after the clamp, exactly 0.15 on every clamped row. 55.6% of the ranked IDP board was served at precisely `idpTradeCalc × 0.85` or `× 1.15`.
- **The anchor is not independent evidence** (§5, mandatory). All four IDP anchor-chain members are voting sources in the blend the corridor clamps. The fallback never fires: `idpTradeCalc` was the anchor on **183/183** clamped rows and also voted on **183/183**. Its contribution is **0.721×** the median of the other sources on those rows, which is why 160 of 183 clamps pulled values *down*.

## The stale rationale, dated from the tree

| date | commit | event |
|---|---|---|
| 2026-04-21 | #198 | corridor added to contain the IDP calibration post-pass |
| **2026-04-23** | **#251** | **IDP calibration retired end-to-end** |
| 2026-05-02 | #375/#376 | cap added at 0.25, tightened to 0.15 the same day |
| 2026-05-19 | #496 | single-source haircut — an anchor-free mechanism for the same hazard |

**The mechanism the corridor exists to contain was retired two days after the corridor was built**, and the cap that came to decide 100% of clamps arrived nine days after that.

## Candidates, criteria declared first

| | rows | share | up/down | median &#124;Δ&#124; | confidence high/med/low | zones top/mid/tail |
|---|---|---|---|---|---|---|
| **A** current, capped 0.15 | 183/329 | 55.6% | 23/160 | 8.3% | 63.9 / 45.8 / 60.7 | 25 / 64 / 94 |
| **B** P90, no cap | 32/329 | 9.7% | 0/32 | 2.0% | 8.3 / 10.0 / 9.8 | 0 / 0 / 32 |
| **C** evidence-gated (post-hoc) | 17/329 | 5.2% | 0/17 | 1.6% | 0 / 0 / 9.8 | 0 / 0 / 17 |
| **D** rail at 2× board P90 (post-hoc) | 0/329 | — | — | — | — | — |
| **E** no corridor | 0/329 | — | — | — | — | — |

With the cap the clamp rate was **inverted** against the board's own confidence — it overrode 63.9% of the rows where our sources agree most tightly, in favour of the one source that disagreed and also voted. Source-count incidence with the cap: 3→100/112 (89.3%), 5→32/122. Without: 3→26/112, **5→0/122, 6→0/8**.

Candidate D returning zero is a result: no row drifts more than 2× the board's own P90, so the runaway the corridor was built for does not exist here.

## The repair

Remove the IDP entry from `_MARKET_CORRIDOR_MAX_BAND_BY_ASSET_CLASS`. Removing rather than retuning is the point — criterion 6 was low sensitivity to arbitrary constants, and `0.15` decided every clamp, so a different hand-set number reproduces the defect at a new value. The facility is kept because the mechanism is generic.

Post-repair on the same pin: 32 rows, 0 capped, `bandPct` varying by bucket, all on the band edge, flat across confidence, **zero rows with 5+ sources**. Served effect 32 rows, mean |3.27%|, max 10.68%. Composition: top-100 IDP 9 either way, top-200 43 → 41, top-400 130 either way.

**Deliberately not claimed**: the empirical machinery was never dead (a tighter synthetic board reaches it — pinned by test), and the corridor is not removed (D and E were measured; the tail rail is what it was designed for). **Residual stated**: the band is derived from the drift it bounds, so a board that drifted as a whole would widen its own band.

## RED → GREEN

Seven characterization tests went red on the removal — four in `test_market_corridor_characterization.py`, three in `test_market_corridor_clamp.py` — and were rewritten against measured behaviour with the reason in each assertion message. The extreme-outlier test still passes: the Vikings-LB case is still caught, now at the board's own band edge (2,520) instead of a constant's (3,060). 46 green across both files.

## Still open after B3

The anchor is still a voter on the remaining 9.7%; the confidence-bucket dependency is now **live for the first time**; C17's OFFENSE half; the IDP master's 1.552× fit-scale claim; W30-F023.

## Gates

Frontend 2,010/0 across 121 files; build compiled with all 14 bundle budgets under; ruff check clean; ruff format 1,009 files; coercion ratchet clean; `audit_status.py` no drift. Full Python hard gate re-running after a container restart — result posted here.

Full evidence: `docs/master-site-audit/evidence/W02/B3_MARKET_CORRIDOR_EVIDENCE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5wQHShfWkNrY5duSKTB4K

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5wQHShfWkNrY5duSKTB4K)_