### PR TITLE
B5 / W06: canonical identity repairs (F001, F004, F007, F009) + F002 refuted

### DIFF
--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -59,6 +59,7 @@ import sys
 _SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 if _SCRIPT_DIR not in sys.path:
     sys.path.insert(0, _SCRIPT_DIR)
+from src.utils.name_clean import is_first_name_variant  # noqa: E402
 from src.utils.name_clean import resolve_idp_position as _resolve_idp_position  # noqa: E402
 from src.utils.age import age_from_birthdate as _age_from_birthdate  # noqa: E402
 from src.utils.owner_names import owner_label as _owner_label  # noqa: E402
@@ -4811,8 +4812,67 @@ async def run(progress_callback=None):
         _by_norm_name[_norm] = _primary
         _merged_name_variants += 1
 
+    # ── Second rung: first-name drift (W06-F001) ─────────────────────
+    #
+    # The pass above merges on ``normalize_lookup_name``, which folds
+    # punctuation and initials but NOT first-name variants: "Matt Hibner"
+    # and "Matthew Hibner" normalize differently, so one human occupied
+    # two rows — a resolved row and an unresolved ghost holding the
+    # vendor votes (6 of them for Hibner, 1 for Jam/Jamarion Miller).
+    #
+    # Repaired at the creation path rather than hidden at render time,
+    # and by a RULE rather than by adding two more names to
+    # ``CANONICAL_NAME_ALIASES``, which would have fixed these two
+    # players and left the next pair to be found by another audit.
+    #
+    # The IDENTITY GATE is what makes this safe, not the name rule.
+    # ``is_first_name_variant`` is deliberately permissive enough to
+    # match "Chris Smith" / "Christian Smith", who may be two people —
+    # so a merge additionally requires that exactly one side carries a
+    # ``_sleeperId`` and the other carries none. Two independently
+    # identified players both have ids, so they can never be fused. An
+    # ambiguous ghost (matching more than one identified row) is left
+    # alone: an explicit ghost is better than a confident wrong merge.
+    _identified = {
+        _n for _n, _e in players_json.items() if isinstance(_e, dict) and _e.get("_sleeperId")
+    }
+    _ghosts = [
+        _n for _n, _e in players_json.items() if isinstance(_e, dict) and not _e.get("_sleeperId")
+    ]
+    _merged_first_name_variants = 0
+    for _ghost in sorted(_ghosts):
+        if _ghost not in players_json:
+            continue
+        _matches = [_n for _n in _identified if is_first_name_variant(_ghost, _n)]
+        if len(_matches) != 1:
+            if len(_matches) > 1 and DEBUG:
+                print(f"  [Dedup] ambiguous first-name ghost {_ghost!r} -> {_matches}; left alone")
+            continue
+        _primary = _matches[0]
+        _p_entry = players_json.get(_primary)
+        _s_entry = players_json.get(_ghost)
+        if not isinstance(_p_entry, dict) or not isinstance(_s_entry, dict):
+            continue
+        for _k, _v in _s_entry.items():
+            if str(_k).startswith("_"):
+                continue
+            if (
+                _k not in _p_entry
+                and isinstance(_v, (int, float))
+                and _v is not None
+                and float(_v) > 0
+            ):
+                _p_entry[_k] = _v
+        players_json[_primary] = _p_entry
+        players_json.pop(_ghost, None)
+        _pos_map.pop(_ghost, None)
+        _player_id_map.pop(_ghost, None)
+        _merged_first_name_variants += 1
+
     if DEBUG and _merged_name_variants:
         print(f"  [Dedup] Merged {_merged_name_variants} punctuation/initial name variants")
+    if DEBUG and _merged_first_name_variants:
+        print(f"  [Dedup] Merged {_merged_first_name_variants} first-name variant ghosts")
 
     # Backfill IDP positions for players that only came in through IDP-specific feeds.
     # This keeps IDP filters/coverage accurate even for deep-tier defenders not rostered.

--- a/docs/master-site-audit/evidence/W06/b5_identity_metrics.py
+++ b/docs/master-site-audit/evidence/W06/b5_identity_metrics.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""B5 — canonical identity metrics, before and after.
+
+One harness for every dimension B5 has to report on, so "did identity
+repair move something" is answered by re-running one command rather than
+by assembling a fresh argument each time.
+
+Deliberately reports UNRESOLVED as its own category everywhere. The point
+of this phase is not a higher match rate — a confident wrong match is
+worse than an explicit miss — so any metric that could be improved by
+matching more aggressively is paired with one that gets worse when the
+matching is wrong.
+
+  ``--out NAME``   write ``b5_metrics_NAME.json`` (default ``baseline``)
+  ``--compare A B``  diff two previously written snapshots
+
+Nothing here changes production.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import csv
+import io
+import json
+import re
+import subprocess
+import sys
+import unicodedata
+from collections import Counter, defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(ROOT))
+OUT = Path(__file__).resolve().parent
+CSV_DIR = ROOT / "CSVs" / "site_raw"
+
+SUFFIX_RE = re.compile(r"\b(jr|sr|ii|iii|iv|v)\.?$", re.IGNORECASE)
+PUNCT_RE = re.compile(r"[.'\-]")
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=ROOT, capture_output=True, text=True, check=False
+    ).stdout.strip()
+
+
+def latest_board() -> Path:
+    return sorted((ROOT / "exports" / "latest").glob("dynasty_data_*.json"), reverse=True)[0]
+
+
+def build():
+    from src.api.data_contract import build_api_data_contract
+
+    raw = json.loads(latest_board().read_bytes())
+    with contextlib.redirect_stdout(io.StringIO()):
+        return build_api_data_contract(raw)
+
+
+def _norm(name: str) -> str:
+    from src.utils import normalize_player_name
+
+    return normalize_player_name(name or "")
+
+
+def _strip_accents(s: str) -> str:
+    return "".join(c for c in unicodedata.normalize("NFKD", s) if not unicodedata.combining(c))
+
+
+def csv_id_columns() -> dict[str, dict]:
+    """Which source CSVs ship a provider ID, and whether the loader sees it.
+
+    The alias tuple is imported rather than restated: a copy here would
+    keep passing after the production tuple changed, which is the whole
+    failure mode W06-F009 is about.
+    """
+    from src.api import data_contract as dc
+    from src.api.data_contract import _SOURCE_CSV_PATHS
+
+    # Read the production resolver, never a copy of it. Before W06-F009
+    # this scraped a literal tuple out of the loader's source text, which
+    # is exactly the brittleness the repair removed — and it duly went
+    # stale the moment the tuple did.
+    tokens = sorted(dc._SLEEPER_ID_TOKENS)
+
+    out = {}
+    for key, spec in _SOURCE_CSV_PATHS.items():
+        rel = spec if isinstance(spec, str) else spec.get("path")
+        p = ROOT / str(rel)
+        if not p.is_file():
+            continue
+        hdr = next(csv.reader(p.open(encoding="utf-8-sig")), [])
+        idish = [c for c in hdr if "sleeper" in c.lower() or c.lower().endswith("_id")]
+        if not idish:
+            continue
+        rows = sum(1 for _ in p.open(encoding="utf-8-sig")) - 1
+        out[key] = {
+            "columns": idish,
+            "rows": rows,
+            "visibleToLoader": [
+                c for c in idish if dc._normalize_header_token(c) in dc._SLEEPER_ID_TOKENS
+            ],
+        }
+    return {"acceptedTokens": tokens, "sources": out}
+
+
+def metrics() -> dict:
+    contract = build()
+    rows = contract.get("playersArray") or []
+    players = contract.get("players") or {}
+
+    served = [r for r in rows if r.get("canonicalConsensusRank") is not None]
+    picks = [r for r in rows if str(r.get("assetClass") or "") == "pick"]
+    idp = [r for r in rows if str(r.get("assetClass") or "") == "idp"]
+    offense = [r for r in rows if str(r.get("assetClass") or "") == "offense"]
+    rookies = [r for r in rows if r.get("rookie")]
+
+    # ── identity resolution state ──
+    with_pid = [r for r in rows if str(r.get("playerId") or "").strip()]
+    without_pid = [r for r in rows if not str(r.get("playerId") or "").strip()]
+    # A pick legitimately has no Sleeper id; separate it out so "unresolved"
+    # counts players only.
+    player_rows = [r for r in rows if str(r.get("assetClass") or "") != "pick"]
+    players_without_pid = [r for r in player_rows if not str(r.get("playerId") or "").strip()]
+
+    quarantined = [r for r in rows if r.get("quarantined")]
+    flag_counts = Counter()
+    for r in rows:
+        for f in r.get("anomalyFlags") or []:
+            flag_counts[str(f)] += 1
+
+    # ── duplicate / ghost detection, independent of the contract's own ──
+    #
+    # Computed here rather than read off the contract, because whether the
+    # contract's detectors can fire is itself a B5 finding (W06-F002). A
+    # metric sourced from the mechanism under test proves nothing.
+    from src.utils.name_clean import canonical_position_group
+
+    by_posaware: dict[str, list[str]] = defaultdict(list)
+    by_norm: dict[str, list[str]] = defaultdict(list)
+    for r in rows:
+        if str(r.get("assetClass") or "") == "pick":
+            continue
+        nm = str(r.get("canonicalName") or r.get("displayName") or "")
+        n = _norm(nm)
+        if not n:
+            continue
+        grp = canonical_position_group(r.get("position"))
+        by_posaware[f"{n}::{grp}"].append(nm)
+        by_norm[n].append(nm)
+
+    dup_posaware = {k: v for k, v in by_posaware.items() if len(v) > 1}
+    dup_norm = {k: v for k, v in by_norm.items() if len(v) > 1}
+
+    # Ghost pairs: same normalized name, one row resolved (has a playerId
+    # and a value) and another not — the W06-F001 shape.
+    pid_by_norm: dict[str, list[dict]] = defaultdict(list)
+    for r in player_rows:
+        n = _norm(str(r.get("canonicalName") or r.get("displayName") or ""))
+        if n:
+            pid_by_norm[n].append(r)
+    ghost_pairs = []
+    for n, group in pid_by_norm.items():
+        if len(group) < 2:
+            continue
+        resolved = [g for g in group if str(g.get("playerId") or "").strip()]
+        unresolved = [g for g in group if not str(g.get("playerId") or "").strip()]
+        if resolved and unresolved:
+            ghost_pairs.append(
+                {
+                    "norm": n,
+                    "resolved": [str(g.get("displayName")) for g in resolved],
+                    "ghost": [str(g.get("displayName")) for g in unresolved],
+                }
+            )
+
+    # ── name-shape cohorts ──
+    suffixed, punctuated, accented = [], [], []
+    for r in player_rows:
+        nm = str(r.get("displayName") or "")
+        if SUFFIX_RE.search(nm.strip()):
+            suffixed.append(nm)
+        if PUNCT_RE.search(nm):
+            punctuated.append(nm)
+        if _strip_accents(nm) != nm:
+            accented.append(nm)
+
+    # Similar-but-distinct: same last name + same first initial, different
+    # normalized name. The population a careless fuzzy matcher would merge.
+    surname_initial: dict[str, set[str]] = defaultdict(set)
+    for r in player_rows:
+        n = _norm(str(r.get("displayName") or ""))
+        parts = n.split()
+        if len(parts) >= 2:
+            surname_initial[f"{parts[-1]}|{parts[0][:1]}"].add(n)
+    near_name_clusters = {k: sorted(v) for k, v in surname_initial.items() if len(v) > 1}
+
+    # ── source coverage ──
+    coverage = {}
+    for r in rows:
+        for k, v in (r.get("canonicalSiteValues") or {}).items():
+            try:
+                fv = float(v)
+            except (TypeError, ValueError):
+                continue
+            if fv > 0:
+                coverage[str(k)] = coverage.get(str(k), 0) + 1
+
+    matched_via = Counter()
+    for r in rows:
+        audit = r.get("sourceAudit")
+        if isinstance(audit, dict):
+            matched_via[str(audit.get("reason") or "none")] += 1
+
+    return {
+        "codeSha": _git("rev-parse", "HEAD"),
+        "board": latest_board().name,
+        "counts": {
+            "rows": len(rows),
+            "servedRows": len(served),
+            "legacyPlayersDict": len(players),
+            "playerRows": len(player_rows),
+            "picks": len(picks),
+            "offense": len(offense),
+            "idp": len(idp),
+            "rookies": len(rookies),
+        },
+        "identity": {
+            "rowsWithPlayerId": len(with_pid),
+            "rowsWithoutPlayerId": len(without_pid),
+            "playerRowsWithoutPlayerId": len(players_without_pid),
+            "playerRowsWithoutPlayerIdNames": sorted(
+                str(r.get("displayName")) for r in players_without_pid
+            )[:60],
+            "quarantined": len(quarantined),
+            "anomalyFlags": dict(flag_counts),
+        },
+        "duplicates": {
+            "positionAwareDuplicateKeys": len(dup_posaware),
+            "positionAwareDuplicates": {k: v for k, v in list(dup_posaware.items())[:40]},
+            "crossUniverseNameCollisions": len(dup_norm) - len(dup_posaware),
+            "ghostPairs": len(ghost_pairs),
+            "ghostPairDetail": ghost_pairs[:40],
+        },
+        "nameShapes": {
+            "suffixed": len(suffixed),
+            "suffixedSample": sorted(suffixed)[:20],
+            "punctuated": len(punctuated),
+            "accented": len(accented),
+            "accentedSample": sorted(accented)[:20],
+            "nearNameClusters": len(near_name_clusters),
+            "nearNameClusterSample": dict(list(near_name_clusters.items())[:15]),
+        },
+        "sourceCoverage": dict(sorted(coverage.items())),
+        "matchedVia": dict(matched_via),
+        "providerIdColumns": csv_id_columns(),
+    }
+
+
+def compare(a: dict, b: dict) -> None:
+    def walk(pa, pb, path=""):
+        if isinstance(pa, dict) and isinstance(pb, dict):
+            for k in sorted(set(pa) | set(pb)):
+                walk(pa.get(k), pb.get(k), f"{path}.{k}" if path else k)
+            return
+        if isinstance(pa, (int, float)) and isinstance(pb, (int, float)) and pa != pb:
+            print(f"  {path:<52}{pa} -> {pb}  ({pb - pa:+})")
+        elif isinstance(pa, list) and isinstance(pb, list) and len(pa) != len(pb):
+            print(f"  {path:<52}len {len(pa)} -> {len(pb)}")
+
+    print("== identity metric deltas ==")
+    walk(a, b)
+    print("  (no line above = every numeric metric identical)")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="baseline")
+    ap.add_argument("--compare", nargs=2, metavar=("A", "B"))
+    args = ap.parse_args()
+
+    if args.compare:
+        a = json.loads((OUT / f"b5_metrics_{args.compare[0]}.json").read_text())
+        b = json.loads((OUT / f"b5_metrics_{args.compare[1]}.json").read_text())
+        compare(a, b)
+        return 0
+
+    m = metrics()
+    path = OUT / f"b5_metrics_{args.out}.json"
+    path.write_text(json.dumps(m, indent=1, default=str))
+
+    c, i, d, n = m["counts"], m["identity"], m["duplicates"], m["nameShapes"]
+    print(f"== B5 identity metrics ({args.out}) — {m['board']} @ {m['codeSha'][:9]} ==")
+    print(
+        f"  rows {c['rows']}  served {c['servedRows']}  players {c['playerRows']}  picks {c['picks']}"
+    )
+    print(f"  offense {c['offense']}  idp {c['idp']}  rookies {c['rookies']}")
+    print(f"\n  rows with playerId          {i['rowsWithPlayerId']}")
+    print(f"  rows without playerId       {i['rowsWithoutPlayerId']}  (picks {c['picks']})")
+    print(f"  PLAYER rows without id      {i['playerRowsWithoutPlayerId']}   <- unresolved")
+    print(f"  quarantined                 {i['quarantined']}")
+    print(f"  anomaly flags               {i['anomalyFlags'] or 'none'}")
+    print(f"\n  position-aware duplicates   {d['positionAwareDuplicateKeys']}")
+    print(f"  cross-universe collisions   {d['crossUniverseNameCollisions']}")
+    print(f"  ghost pairs                 {d['ghostPairs']}")
+    for g in d["ghostPairDetail"][:10]:
+        print(f"    {g['norm']:<28}resolved={g['resolved']}  ghost={g['ghost']}")
+    print(f"\n  suffixed names              {n['suffixed']}")
+    print(f"  punctuated names            {n['punctuated']}")
+    print(f"  accented names              {n['accented']}")
+    print(f"  near-name clusters          {n['nearNameClusters']}")
+    pid = m["providerIdColumns"]
+    print(f"\n  accepted id tokens          {pid['acceptedTokens']}")
+    for k, v in pid["sources"].items():
+        print(
+            f"    {k:<22}rows={v['rows']:<5}cols={v['columns']}  "
+            f"visible={v['visibleToLoader'] or 'NONE'}"
+        )
+    print(f"\nwrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/master-site-audit/evidence/W06/b5_metrics_after_all.json
+++ b/docs/master-site-audit/evidence/W06/b5_metrics_after_all.json
@@ -1,0 +1,171 @@
+{
+ "codeSha": "029966963fb5c984bda819e4ec1e3603466e1258",
+ "board": "dynasty_data_2026-08-12.json",
+ "counts": {
+  "rows": 1095,
+  "servedRows": 740,
+  "legacyPlayersDict": 1095,
+  "playerRows": 951,
+  "picks": 144,
+  "offense": 553,
+  "idp": 398,
+  "rookies": 181
+ },
+ "identity": {
+  "rowsWithPlayerId": 940,
+  "rowsWithoutPlayerId": 155,
+  "playerRowsWithoutPlayerId": 11,
+  "playerRowsWithoutPlayerIdNames": [
+   "Barika Kpeenu",
+   "Chip Trayanum",
+   "Donoven McCulley",
+   "Jamarion Miller",
+   "Matayo Uiagalelei",
+   "Matthew Hibner",
+   "Rob Henry",
+   "Rod Moore",
+   "Suntarine Perkins",
+   "Trinidad Chambliss",
+   "Whit Weeks"
+  ],
+  "quarantined": 1,
+  "anomalyFlags": {
+   "suspicious_disagreement": 58,
+   "unsupported_position": 1
+  }
+ },
+ "duplicates": {
+  "positionAwareDuplicateKeys": 0,
+  "positionAwareDuplicates": {},
+  "crossUniverseNameCollisions": 0,
+  "ghostPairs": 0,
+  "ghostPairDetail": []
+ },
+ "nameShapes": {
+  "suffixed": 0,
+  "suffixedSample": [],
+  "punctuated": 51,
+  "accented": 0,
+  "accentedSample": [],
+  "nearNameClusters": 49,
+  "nearNameClusterSample": {
+   "brown|a": [
+    "aj brown",
+    "amon ra st brown"
+   ],
+   "smith|a": [
+    "ainias smith",
+    "arian smith"
+   ],
+   "robinson|b": [
+    "bijan robinson",
+    "brian robinson"
+   ],
+   "thompson|b": [
+    "brenen thompson",
+    "bryan thompson"
+   ],
+   "young|b": [
+    "bryce young",
+    "byron young"
+   ],
+   "johnson|c": [
+    "chris johnson",
+    "cj gardner johnson"
+   ],
+   "young|c": [
+    "chase young",
+    "colbie young"
+   ],
+   "allen|c": [
+    "cj allen",
+    "cyrus allen"
+   ],
+   "turner|d": [
+    "dallas turner",
+    "dj turner"
+   ],
+   "bailey|d": [
+    "dan bailey",
+    "david bailey"
+   ],
+   "robinson|d": [
+    "darius robinson",
+    "demarcus robinson"
+   ],
+   "walker|d": [
+    "david walker",
+    "devontez walker"
+   ],
+   "lawrence|d": [
+    "demarcus lawrence",
+    "dexter lawrence"
+   ],
+   "davis|d": [
+    "demario davis",
+    "derius davis"
+   ],
+   "brown|d": [
+    "derrick brown",
+    "dyami brown"
+   ]
+  }
+ },
+ "sourceCoverage": {
+  "dlfIdp": 172,
+  "dlfRookieIdp": 29,
+  "dlfRookieSf": 108,
+  "dlfSf": 279,
+  "draftSharks": 399,
+  "draftSharksIdp": 143,
+  "dynastyDaddySf": 369,
+  "dynastyNerdsSfTep": 293,
+  "fantasyCalc": 390,
+  "fantasyNavigatorSf": 457,
+  "fantasyProsFitzmaurice": 299,
+  "fantasyProsIdp": 148,
+  "fantasyProsSf": 475,
+  "flockFantasySf": 414,
+  "flockFantasySfRookies": 76,
+  "idpShow": 349,
+  "idpTradeCalc": 911,
+  "ktc": 609,
+  "ktcSfTep": 501,
+  "otcffbSf": 439,
+  "pfkDynasty": 475,
+  "yahooBoone": 402
+ },
+ "matchedVia": {
+  "partial_coverage": 305,
+  "no_source_match": 106,
+  "matching_failure_other_sources_eligible": 74,
+  "structurally_single_source": 21,
+  "fully_matched": 589
+ },
+ "providerIdColumns": {
+  "acceptedTokens": [
+   "sleeperid",
+   "sleeperplayerid"
+  ],
+  "sources": {
+   "dynastyNerdsSfTep": {
+    "columns": [
+     "SleeperId"
+    ],
+    "rows": 294,
+    "visibleToLoader": [
+     "SleeperId"
+    ]
+   },
+   "pfkDynasty": {
+    "columns": [
+     "sleeper_id"
+    ],
+    "rows": 496,
+    "visibleToLoader": [
+     "sleeper_id"
+    ]
+   }
+  }
+ }
+}

--- a/docs/master-site-audit/evidence/W06/b5_metrics_after_f009.json
+++ b/docs/master-site-audit/evidence/W06/b5_metrics_after_f009.json
@@ -1,0 +1,171 @@
+{
+ "codeSha": "8403b093edbbfc3937b4562e90d2cdf5d8d9e2b1",
+ "board": "dynasty_data_2026-08-12.json",
+ "counts": {
+  "rows": 1095,
+  "servedRows": 740,
+  "legacyPlayersDict": 1095,
+  "playerRows": 951,
+  "picks": 144,
+  "offense": 553,
+  "idp": 398,
+  "rookies": 181
+ },
+ "identity": {
+  "rowsWithPlayerId": 940,
+  "rowsWithoutPlayerId": 155,
+  "playerRowsWithoutPlayerId": 11,
+  "playerRowsWithoutPlayerIdNames": [
+   "Barika Kpeenu",
+   "Chip Trayanum",
+   "Donoven McCulley",
+   "Jamarion Miller",
+   "Matayo Uiagalelei",
+   "Matthew Hibner",
+   "Rob Henry",
+   "Rod Moore",
+   "Suntarine Perkins",
+   "Trinidad Chambliss",
+   "Whit Weeks"
+  ],
+  "quarantined": 1,
+  "anomalyFlags": {
+   "suspicious_disagreement": 58,
+   "unsupported_position": 1
+  }
+ },
+ "duplicates": {
+  "positionAwareDuplicateKeys": 0,
+  "positionAwareDuplicates": {},
+  "crossUniverseNameCollisions": 0,
+  "ghostPairs": 0,
+  "ghostPairDetail": []
+ },
+ "nameShapes": {
+  "suffixed": 0,
+  "suffixedSample": [],
+  "punctuated": 51,
+  "accented": 0,
+  "accentedSample": [],
+  "nearNameClusters": 49,
+  "nearNameClusterSample": {
+   "brown|a": [
+    "aj brown",
+    "amon ra st brown"
+   ],
+   "smith|a": [
+    "ainias smith",
+    "arian smith"
+   ],
+   "robinson|b": [
+    "bijan robinson",
+    "brian robinson"
+   ],
+   "thompson|b": [
+    "brenen thompson",
+    "bryan thompson"
+   ],
+   "young|b": [
+    "bryce young",
+    "byron young"
+   ],
+   "johnson|c": [
+    "chris johnson",
+    "cj gardner johnson"
+   ],
+   "young|c": [
+    "chase young",
+    "colbie young"
+   ],
+   "allen|c": [
+    "cj allen",
+    "cyrus allen"
+   ],
+   "turner|d": [
+    "dallas turner",
+    "dj turner"
+   ],
+   "bailey|d": [
+    "dan bailey",
+    "david bailey"
+   ],
+   "robinson|d": [
+    "darius robinson",
+    "demarcus robinson"
+   ],
+   "walker|d": [
+    "david walker",
+    "devontez walker"
+   ],
+   "lawrence|d": [
+    "demarcus lawrence",
+    "dexter lawrence"
+   ],
+   "davis|d": [
+    "demario davis",
+    "derius davis"
+   ],
+   "brown|d": [
+    "derrick brown",
+    "dyami brown"
+   ]
+  }
+ },
+ "sourceCoverage": {
+  "dlfIdp": 172,
+  "dlfRookieIdp": 29,
+  "dlfRookieSf": 108,
+  "dlfSf": 279,
+  "draftSharks": 399,
+  "draftSharksIdp": 143,
+  "dynastyDaddySf": 369,
+  "dynastyNerdsSfTep": 293,
+  "fantasyCalc": 390,
+  "fantasyNavigatorSf": 457,
+  "fantasyProsFitzmaurice": 299,
+  "fantasyProsIdp": 148,
+  "fantasyProsSf": 475,
+  "flockFantasySf": 414,
+  "flockFantasySfRookies": 76,
+  "idpShow": 349,
+  "idpTradeCalc": 911,
+  "ktc": 609,
+  "ktcSfTep": 501,
+  "otcffbSf": 439,
+  "pfkDynasty": 475,
+  "yahooBoone": 402
+ },
+ "matchedVia": {
+  "partial_coverage": 305,
+  "no_source_match": 106,
+  "matching_failure_other_sources_eligible": 74,
+  "structurally_single_source": 21,
+  "fully_matched": 589
+ },
+ "providerIdColumns": {
+  "acceptedTokens": [
+   "sleeperid",
+   "sleeperplayerid"
+  ],
+  "sources": {
+   "dynastyNerdsSfTep": {
+    "columns": [
+     "SleeperId"
+    ],
+    "rows": 294,
+    "visibleToLoader": [
+     "SleeperId"
+    ]
+   },
+   "pfkDynasty": {
+    "columns": [
+     "sleeper_id"
+    ],
+    "rows": 496,
+    "visibleToLoader": [
+     "sleeper_id"
+    ]
+   }
+  }
+ }
+}

--- a/docs/master-site-audit/evidence/W06/b5_metrics_baseline.json
+++ b/docs/master-site-audit/evidence/W06/b5_metrics_baseline.json
@@ -1,0 +1,170 @@
+{
+ "codeSha": "8403b093edbbfc3937b4562e90d2cdf5d8d9e2b1",
+ "board": "dynasty_data_2026-08-12.json",
+ "counts": {
+  "rows": 1095,
+  "servedRows": 740,
+  "legacyPlayersDict": 1095,
+  "playerRows": 951,
+  "picks": 144,
+  "offense": 553,
+  "idp": 398,
+  "rookies": 181
+ },
+ "identity": {
+  "rowsWithPlayerId": 940,
+  "rowsWithoutPlayerId": 155,
+  "playerRowsWithoutPlayerId": 11,
+  "playerRowsWithoutPlayerIdNames": [
+   "Barika Kpeenu",
+   "Chip Trayanum",
+   "Donoven McCulley",
+   "Jamarion Miller",
+   "Matayo Uiagalelei",
+   "Matthew Hibner",
+   "Rob Henry",
+   "Rod Moore",
+   "Suntarine Perkins",
+   "Trinidad Chambliss",
+   "Whit Weeks"
+  ],
+  "quarantined": 1,
+  "anomalyFlags": {
+   "suspicious_disagreement": 58,
+   "unsupported_position": 1
+  }
+ },
+ "duplicates": {
+  "positionAwareDuplicateKeys": 0,
+  "positionAwareDuplicates": {},
+  "crossUniverseNameCollisions": 0,
+  "ghostPairs": 0,
+  "ghostPairDetail": []
+ },
+ "nameShapes": {
+  "suffixed": 0,
+  "suffixedSample": [],
+  "punctuated": 51,
+  "accented": 0,
+  "accentedSample": [],
+  "nearNameClusters": 49,
+  "nearNameClusterSample": {
+   "brown|a": [
+    "aj brown",
+    "amon ra st brown"
+   ],
+   "smith|a": [
+    "ainias smith",
+    "arian smith"
+   ],
+   "robinson|b": [
+    "bijan robinson",
+    "brian robinson"
+   ],
+   "thompson|b": [
+    "brenen thompson",
+    "bryan thompson"
+   ],
+   "young|b": [
+    "bryce young",
+    "byron young"
+   ],
+   "johnson|c": [
+    "chris johnson",
+    "cj gardner johnson"
+   ],
+   "young|c": [
+    "chase young",
+    "colbie young"
+   ],
+   "allen|c": [
+    "cj allen",
+    "cyrus allen"
+   ],
+   "turner|d": [
+    "dallas turner",
+    "dj turner"
+   ],
+   "bailey|d": [
+    "dan bailey",
+    "david bailey"
+   ],
+   "robinson|d": [
+    "darius robinson",
+    "demarcus robinson"
+   ],
+   "walker|d": [
+    "david walker",
+    "devontez walker"
+   ],
+   "lawrence|d": [
+    "demarcus lawrence",
+    "dexter lawrence"
+   ],
+   "davis|d": [
+    "demario davis",
+    "derius davis"
+   ],
+   "brown|d": [
+    "derrick brown",
+    "dyami brown"
+   ]
+  }
+ },
+ "sourceCoverage": {
+  "dlfIdp": 172,
+  "dlfRookieIdp": 29,
+  "dlfRookieSf": 108,
+  "dlfSf": 279,
+  "draftSharks": 399,
+  "draftSharksIdp": 143,
+  "dynastyDaddySf": 369,
+  "dynastyNerdsSfTep": 293,
+  "fantasyCalc": 390,
+  "fantasyNavigatorSf": 457,
+  "fantasyProsFitzmaurice": 299,
+  "fantasyProsIdp": 148,
+  "fantasyProsSf": 475,
+  "flockFantasySf": 414,
+  "flockFantasySfRookies": 76,
+  "idpShow": 349,
+  "idpTradeCalc": 911,
+  "ktc": 609,
+  "ktcSfTep": 501,
+  "otcffbSf": 439,
+  "pfkDynasty": 475,
+  "yahooBoone": 402
+ },
+ "matchedVia": {
+  "partial_coverage": 305,
+  "no_source_match": 106,
+  "matching_failure_other_sources_eligible": 74,
+  "structurally_single_source": 21,
+  "fully_matched": 589
+ },
+ "providerIdColumns": {
+  "aliasTuple": [
+   "sleeper_id",
+   "sleeperId",
+   "sleeper_player_id"
+  ],
+  "sources": {
+   "dynastyNerdsSfTep": {
+    "columns": [
+     "SleeperId"
+    ],
+    "rows": 294,
+    "visibleToLoader": []
+   },
+   "pfkDynasty": {
+    "columns": [
+     "sleeper_id"
+    ],
+    "rows": 496,
+    "visibleToLoader": [
+     "sleeper_id"
+    ]
+   }
+  }
+ }
+}

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -292,6 +292,64 @@ _QUARANTINE_FLAGS = {
 #     name,rank CSVs (lower is better, stamped as a synthetic monotonic
 #     value via _RANK_TO_SYNTHETIC_VALUE so the downstream descending
 #     sort in _compute_unified_rankings produces the correct ordinal)
+# ── Provider-ID column resolution (W06-F009) ─────────────────────────
+#
+# A vendor CSV that ships a Sleeper player id gives ID-grade identity,
+# which survives the vendor/Sleeper name drift that breaks a name join
+# ("Kenneth Gainwell" vs "Kenny Gainwell").  The loader used to find that
+# column by testing the header against a hand-maintained tuple of literal
+# spellings, which failed closed: ``dynastyNerdsSfTep.csv`` ships
+# ``SleeperId`` — a spelling nobody had added — so all 294 of its rows
+# carried no id and the source joined by name only, silently.
+#
+# The root cause is the enumerated-literal list, not the missing entry.
+# Columns are matched on a NORMALIZED token (casefold, drop separators)
+# so every reasonable spelling of the same field resolves, while a
+# different field does not: ``sleeper_id_source`` normalizes to
+# ``sleeperidsource`` and is correctly ignored.  Being conservative here
+# is the point — attaching the wrong id is a confident wrong match, which
+# is worse than the miss it replaces.
+#
+# Measured at the time of the repair: the ID join recovers **0 rows** on
+# the live board (the name cascade already resolved 293 of 294 and the
+# two agreed on all 290 overlaps, zero contradictions).  This buys
+# resilience, not match rate.
+_SLEEPER_ID_TOKENS: frozenset[str] = frozenset(
+    {
+        "sleeperid",
+        "sleeperplayerid",
+    }
+)
+
+
+def _normalize_header_token(column: object) -> str:
+    """Casefold a CSV header and drop separators, for token matching.
+
+    ``"Sleeper Id"``, ``"sleeper_id"``, ``"SleeperId"`` and
+    ``"sleeper-id"`` all become ``"sleeperid"``.  Anything carrying extra
+    words keeps them, so it will not collide with a bare field name.
+    """
+    s = str(column or "").strip().lower()
+    return "".join(ch for ch in s if ch.isalnum())
+
+
+def _pick_provider_id(csvrow: dict[str, Any], tokens: frozenset[str]) -> str:
+    """First non-empty value whose header normalizes into ``tokens``.
+
+    Iteration order follows the row's own key order, so a CSV carrying two
+    accepted spellings resolves deterministically to the first one rather
+    than to whichever the set happened to yield.
+    """
+    if not isinstance(csvrow, dict):
+        return ""
+    for key, value in csvrow.items():
+        if value in (None, ""):
+            continue
+        if _normalize_header_token(key) in tokens:
+            return str(value)
+    return ""
+
+
 _SOURCE_CSV_PATHS: dict[str, Any] = {
     "ktc": "CSVs/site_raw/ktc.csv",
     # KeepTradeCut Superflex + TE Premium (level 2 / "TE++") sub-board.
@@ -3627,12 +3685,6 @@ def _parse_source_csv_cached(
         "3D Value +",
         "boone_value",
     )
-    # Optional Sleeper player-id column (today only pfkDynasty emits
-    # one).  When present it gives ID-grade identity that survives
-    # vendor/Sleeper name-spelling drift ("Kenneth Gainwell" vs
-    # "Kenny Gainwell") — the enrichment tries the ID join before the
-    # canonical-name cascade (Codex review on PR #532).
-    _SLEEPER_ID_ALIASES = ("sleeper_id", "sleeperId", "sleeper_player_id")
 
     def _pick(csvrow: dict[str, Any], aliases: tuple[str, ...]) -> str:
         for k in aliases:
@@ -3727,7 +3779,7 @@ def _parse_source_csv_cached(
                                 native_val = nv
                         except (TypeError, ValueError):
                             native_val = None
-                    sid = _pick(csvrow, _SLEEPER_ID_ALIASES).strip()
+                    sid = _pick_provider_id(csvrow, _SLEEPER_ID_TOKENS).strip()
                     csv_lookup.setdefault(key, []).append(
                         (name, synthetic, rank_val, native_val, sid or None)
                     )
@@ -3752,7 +3804,7 @@ def _parse_source_csv_cached(
                                 orig_rank = rv
                         except (TypeError, ValueError):
                             orig_rank = None
-                    sid = _pick(csvrow, _SLEEPER_ID_ALIASES).strip()
+                    sid = _pick_provider_id(csvrow, _SLEEPER_ID_TOKENS).strip()
                     try:
                         csv_lookup.setdefault(key, []).append(
                             (name, int(float(val)), orig_rank, None, sid or None)

--- a/src/identity/unified_mapper.py
+++ b/src/identity/unified_mapper.py
@@ -9,12 +9,18 @@ firehoses) keys on a different ID than Sleeper uses.  Without a
 single resolver every integration re-invents the mapping, each
 gets it subtly wrong, and we have N silent miss rates to debug.
 
-The three-layer match ladder (in ``resolve_player``) is:
+The match ladder (in ``resolve_player``) is:
 
+    0. Manual override by Sleeper ID.    confidence=1.00
     1. Exact external ID match.          confidence=1.00
     2. Exact normalized name + team.     confidence=0.98
     3. Exact normalized name + position. confidence=0.93
     4. Fuzzy normalized name only.       confidence=0.75..0.90
+
+The override sits ABOVE the exact-ID match, not below it (W06-F004).
+Below, it could only ever fire for ids Sleeper had never heard of — so
+the one case overrides exist for, "the directory has this player wrong",
+was the one case it could not serve.
 
 Anything below the configured ``min_confidence`` is rejected and
 counted in the unmapped-miss metric so we can observe drift.
@@ -106,10 +112,18 @@ def _load_overrides(path: Path | None = None) -> dict[str, dict[str, Any]]:
         if not isinstance(raw, dict):
             _LOGGER.warning("id_overrides.json root must be a dict; ignoring")
             return {}
-        # Normalize keys to strings.
+        # Normalize keys to strings.  Underscore-prefixed keys are
+        # documentation scaffolding (``_comment``, ``_example_entry_only``
+        # — both shipped in the real file) and must never be treated as
+        # live overrides: the override rung now outranks the directory,
+        # so an example entry would be one edit away from resolving a
+        # player (W06-F004).
         for k, v in raw.items():
+            key = str(k)
+            if key.startswith("_"):
+                continue
             if isinstance(v, dict):
-                _OVERRIDES_CACHE[str(k)] = dict(v)
+                _OVERRIDES_CACHE[key] = dict(v)
         return dict(_OVERRIDES_CACHE)
 
 
@@ -245,6 +259,7 @@ def resolve_player(
     position: str | None = None,
     min_confidence: float = 0.85,
     overrides_path: Path | None = None,
+    _index: dict | None = None,
 ) -> ResolvedPlayer | None:
     """Resolve any subset of ID signals into a canonical player.
 
@@ -256,9 +271,14 @@ def resolve_player(
     Returns ``None`` if no match above ``min_confidence`` is found;
     metrics are bumped either way so coverage can be observed.
 
+    ``_index`` is an internal seam for :func:`resolve_many` to pass a
+    directory index it already built (W06-F007). Callers should leave it
+    unset; it is a pure function of ``players_dir``, so supplying it
+    changes nothing but the cost.
+
     Ladder order:
-      1. ``sleeper_id`` exact.
-      2. Manual override by ``sleeper_id``.
+      1. Manual override by ``sleeper_id`` (merged over the directory).
+      2. ``sleeper_id`` exact.
       3. ``gsis_id`` exact.
       4. ``espn_id`` exact.
       5. Normalized name + team + position.
@@ -266,33 +286,57 @@ def resolve_player(
       7. Fuzzy name only.
     """
     _bump("resolve_attempts")
-    idx = _index_directory(players_dir)
+    idx = _index if _index is not None else _index_directory(players_dir)
     overrides = _load_overrides(overrides_path)
 
-    # 1. Exact Sleeper ID.
+    # 1. Manual override by Sleeper ID — ABOVE the directory (W06-F004).
+    #
+    # This rung used to sit below the exact-ID match, which made it
+    # unreachable for exactly the case it exists to serve: an operator
+    # pins a player BECAUSE the directory has them wrong, and the
+    # directory then won. It only ever fired for ids Sleeper had never
+    # heard of, and the test covering it used such an id, so nothing
+    # caught the inversion.
+    #
+    # The override MERGES over the directory record rather than replacing
+    # it. Replacing was survivable while the rung was unreachable, but
+    # promoted above the directory a partial entry (say ``{"team": "MIA"}``)
+    # would blank the name, position and every other id — turning a
+    # resolved player into an anonymous row. An override says "this field
+    # is wrong", not "forget everything you know".
+    if sleeper_id:
+        sid = str(sleeper_id).strip()
+        if sid and sid in overrides:
+            ov = overrides[sid]
+            base = idx["by_sleeper_id"].get(sid) or {}
+            _bump("resolved_override")
+
+            def _field(name: str, *base_keys: str) -> str:
+                if ov.get(name) not in (None, ""):
+                    return str(ov[name])
+                for bk in base_keys or (name,):
+                    if base.get(bk) not in (None, ""):
+                        return str(base[bk])
+                return ""
+
+            return ResolvedPlayer(
+                sleeper_id=sid,
+                gsis_id=_field("gsis_id"),
+                espn_id=_field("espn_id"),
+                full_name=_field("full_name", "full_name", "search_full_name"),
+                position=_field("position"),
+                team=_field("team"),
+                confidence=1.00,
+                match_method="manual_override",
+            )
+
+    # 2. Exact Sleeper ID.
     if sleeper_id:
         sid = str(sleeper_id).strip()
         if sid and sid in idx["by_sleeper_id"]:
             p = idx["by_sleeper_id"][sid]
             _bump("resolved_exact_id")
             return _to_resolved(p, confidence=1.00, method="sleeper_id")
-
-    # 2. Manual override by Sleeper ID.
-    if sleeper_id:
-        sid = str(sleeper_id).strip()
-        if sid and sid in overrides:
-            ov = overrides[sid]
-            _bump("resolved_override")
-            return ResolvedPlayer(
-                sleeper_id=sid,
-                gsis_id=str(ov.get("gsis_id") or ""),
-                espn_id=str(ov.get("espn_id") or ""),
-                full_name=str(ov.get("full_name") or ""),
-                position=str(ov.get("position") or ""),
-                team=str(ov.get("team") or ""),
-                confidence=1.00,
-                match_method="manual_override",
-            )
 
     # 3. Exact GSIS ID.
     if gsis_id:
@@ -408,9 +452,20 @@ def resolve_many(
 
     Used by nightly jobs (injury feed, nflverse weekly ingest) so
     the mapper's internal index is built once, not per-row.
+
+    W06-F007: that last sentence was false for as long as it existed.
+    ``resolve_player`` re-indexed the entire Sleeper directory on every
+    call, so a batch of N rows walked the ~11k-entry directory N times —
+    the cost this function was written to avoid. The index is a pure
+    function of ``players_dir``, so it is built here and passed down;
+    ``test_resolve_many_returns_what_it_did_before_the_hoist`` pins that
+    the results are identical to the per-row path, because a
+    performance repair that quietly changes identity resolution would be
+    a far worse bug than the one it fixes.
     """
     resolved: list[ResolvedPlayer] = []
     unresolved: list[dict[str, Any]] = []
+    idx = _index_directory(players_dir)
     for row in inputs:
         if not isinstance(row, dict):
             continue
@@ -423,6 +478,7 @@ def resolve_many(
             team=row.get("team"),
             position=row.get("position"),
             min_confidence=min_confidence,
+            _index=idx,
         )
         if got:
             resolved.append(got)

--- a/src/utils/name_clean.py
+++ b/src/utils/name_clean.py
@@ -733,3 +733,56 @@ def normalize_position_family(pos: str | None) -> str:
         if t_base.startswith(prefix):
             return prefix
     return t
+
+
+# ── First-name variant equivalence (W06-F001) ────────────────────────
+
+#: Shortest first-name prefix that may stand in for a longer name.
+#: Two characters would let "Ty Johnson" absorb "Tyler Johnson", who are
+#: different people; single letters are an INITIAL and belong to the
+#: initial-matching rung, which carries its own guards.
+_MIN_VARIANT_PREFIX = 3
+
+
+def is_first_name_variant(a: object, b: object) -> bool:
+    """Are these two names the same human under first-name drift?
+
+    The board's merge key is a canonical NAME. ``CANONICAL_NAME_ALIASES``
+    carries hand-written pairs (Kenneth→Kenny, Chig→Chigoziem) and had
+    none for Matt↔Matthew or Jam↔Jamarion, so one human occupied two
+    board rows — a resolved row and an unresolved ghost holding stranded
+    vendor votes (W06-F001). Enumerating more pairs would fix those two
+    players and nothing else; this states the RULE instead.
+
+    True only when every one of these holds:
+
+    * both names have at least two parts;
+    * everything after the first name matches exactly (surname AND any
+      middle parts — "Chris Del Rio" is not "Christian Rio");
+    * the first names differ, and the shorter is a strict prefix of the
+      longer;
+    * the shorter first name is at least :data:`_MIN_VARIANT_PREFIX`
+      characters.
+
+    **This is deliberately not sufficient on its own to merge two rows.**
+    "Chris Smith" and "Christian Smith" satisfy it and may well be two
+    people. The caller must additionally establish that only one of them
+    carries an identity — merging a resolved row with an *unidentified*
+    one cannot silently fuse two known players, because two known
+    players both carry ids. A confident wrong merge is worse than the
+    ghost it would have removed, so the rule is the cheap half of the
+    test and the identity gate is the load-bearing half.
+    """
+    a_parts = str(a or "").strip().lower().split()
+    b_parts = str(b or "").strip().lower().split()
+    if len(a_parts) < 2 or len(b_parts) < 2:
+        return False
+    if a_parts[1:] != b_parts[1:]:
+        return False
+    first_a, first_b = a_parts[0], b_parts[0]
+    if first_a == first_b:
+        return False
+    shorter, longer = sorted((first_a, first_b), key=len)
+    if len(shorter) < _MIN_VARIANT_PREFIX:
+        return False
+    return longer.startswith(shorter)

--- a/tests/api/test_first_name_variant_ghosts.py
+++ b/tests/api/test_first_name_variant_ghosts.py
@@ -1,0 +1,170 @@
+"""W06-F001 — one human must not occupy a resolved row and a ghost row.
+
+The board's merge key is a canonical NAME. The scraper's dedup pass folds
+punctuation and initial variants by ``normalize_lookup_name``, which does
+NOT fold first-name drift: "Matt Hibner" and "Matthew Hibner" normalize
+differently, so the vendor spelling became its own row — unresolved, with
+no position, no rank, no value, and holding the vendor votes that should
+have counted for the real player.
+
+Reproduced on the 2026-08-12 board before the repair:
+
+    Matthew Hibner   ghost, 6 stranded source votes  <- Matt Hibner (TE, 13324)
+    Jamarion Miller  ghost, 1 stranded source vote   <- Jam Miller  (RB, 13403)
+
+Exactly the two players the finding named, still live.
+
+The repair is a RULE, not two more entries in ``CANONICAL_NAME_ALIASES``
+— enumerating these two would have fixed these two and left the next pair
+for the next audit. The rule lives in ``src/utils/name_clean.py`` because
+that module is the canonical owner of name handling for both the scraper
+and the identity matcher.
+
+**The identity gate is the load-bearing half.** ``is_first_name_variant``
+is permissive enough to match "Chris Smith" / "Christian Smith", who may
+be two people. A merge additionally requires that exactly one side carries
+a Sleeper id and the other carries none — two independently identified
+players both have ids and can never be fused — and an ambiguous ghost is
+left alone. An explicit ghost beats a confident wrong merge.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.utils.name_clean import is_first_name_variant
+
+
+class TestTheRuleMatchesRealDrift(unittest.TestCase):
+    def test_the_two_live_ghosts(self):
+        self.assertTrue(is_first_name_variant("Matt Hibner", "Matthew Hibner"))
+        self.assertTrue(is_first_name_variant("Jam Miller", "Jamarion Miller"))
+
+    def test_it_is_symmetric(self):
+        self.assertEqual(
+            is_first_name_variant("Matt Hibner", "Matthew Hibner"),
+            is_first_name_variant("Matthew Hibner", "Matt Hibner"),
+        )
+
+    def test_common_shortenings(self):
+        for a, b in (("Rob Henry", "Robert Henry"), ("Chris Jones", "Christian Jones")):
+            self.assertTrue(is_first_name_variant(a, b), f"{a} / {b}")
+
+
+class TestTheRuleRefusesDistinctPlayers(unittest.TestCase):
+    """The direction that matters. Every one of these is a real board pair."""
+
+    def test_different_first_names_never_match(self):
+        for a, b in (
+            ("Rob Henry", "Derrick Henry"),
+            ("Rob Henry", "Hunter Henry"),
+            ("Christen Miller", "Jamarion Miller"),
+            ("Kendre Miller", "Ventrell Miller"),
+            ("Suntarine Perkins", "Harold Perkins"),
+            ("Elijah Moore", "Skyy Moore"),
+        ):
+            self.assertFalse(is_first_name_variant(a, b), f"{a} / {b} were treated as one player")
+
+    def test_a_two_letter_prefix_is_not_enough(self):
+        """ "Ty Johnson" and "Tyler Johnson" are different people."""
+        self.assertFalse(is_first_name_variant("Ty Johnson", "Tyler Johnson"))
+
+    def test_an_initial_is_not_a_variant(self):
+        self.assertFalse(is_first_name_variant("J Smith", "Jamarion Smith"))
+
+    def test_surnames_must_match_exactly(self):
+        self.assertFalse(is_first_name_variant("Matt Smith", "Matthew Jones"))
+
+    def test_middle_parts_must_match(self):
+        self.assertFalse(is_first_name_variant("Chris Del Rio", "Christian Rio"))
+
+    def test_identical_names_are_not_a_variant_pair(self):
+        self.assertFalse(is_first_name_variant("Matt Hibner", "Matt Hibner"))
+
+    def test_single_token_names_are_refused(self):
+        self.assertFalse(is_first_name_variant("Matthew", "Matt"))
+        self.assertFalse(is_first_name_variant("", ""))
+
+    def test_kenneth_kenny_is_not_a_prefix_pair(self):
+        """Handled by CANONICAL_NAME_ALIASES, and correctly NOT by this rule.
+
+        "Kenny" is not a prefix of "Kenneth", so the prefix rule declines
+        it. That is the right answer: an authoritative alias belongs in
+        the alias table, and this rule must not grow into a general
+        nickname guesser.
+        """
+        self.assertFalse(is_first_name_variant("Kenneth Walker", "Kenny Walker"))
+
+
+class TestTheGateBlocksWhatTheRuleCannot(unittest.TestCase):
+    """The caller-side contract, stated as a test so it cannot be dropped.
+
+    Simulates the scraper's gate: merge only when exactly one candidate
+    matches AND the ghost has no id while the candidate does.
+    """
+
+    @staticmethod
+    def _merge(players: dict) -> dict:
+        identified = {n for n, e in players.items() if e.get("_sleeperId")}
+        ghosts = [n for n, e in players.items() if not e.get("_sleeperId")]
+        out = {k: dict(v) for k, v in players.items()}
+        for ghost in sorted(ghosts):
+            matches = [n for n in identified if is_first_name_variant(ghost, n)]
+            if len(matches) != 1:
+                continue
+            primary = matches[0]
+            for k, v in out[ghost].items():
+                if not str(k).startswith("_") and k not in out[primary]:
+                    out[primary][k] = v
+            out.pop(ghost)
+        return out
+
+    def test_the_ghost_is_absorbed_and_its_votes_survive(self):
+        got = self._merge(
+            {
+                "Matt Hibner": {"_sleeperId": "13324", "ktc": 100},
+                "Matthew Hibner": {"dlfSf": 250, "idpTradeCalc": 300},
+            }
+        )
+        self.assertEqual(set(got), {"Matt Hibner"})
+        self.assertEqual(got["Matt Hibner"]["dlfSf"], 250)
+        self.assertEqual(got["Matt Hibner"]["idpTradeCalc"], 300)
+        self.assertEqual(got["Matt Hibner"]["ktc"], 100)
+
+    def test_two_identified_players_are_never_fused(self):
+        """Even when the name rule says yes."""
+        got = self._merge(
+            {
+                "Chris Smith": {"_sleeperId": "111"},
+                "Christian Smith": {"_sleeperId": "222"},
+            }
+        )
+        self.assertEqual(set(got), {"Chris Smith", "Christian Smith"})
+
+    def test_an_ambiguous_ghost_is_left_alone(self):
+        """Two identified rows both prefix the ghost — refuse, don't guess.
+
+        Note what does NOT count as ambiguous: "Matt Smith" identified,
+        "Matthias Smith" identified, "Matthew Smith" a ghost. Only "Matt"
+        prefixes "Matthew" ("Matthias" does not), so that is a single
+        match and merging it is correct. Ambiguity requires two genuine
+        prefix candidates, which is rare precisely because the prefix
+        rule is strict.
+        """
+        got = self._merge(
+            {
+                "Chris Smith": {"_sleeperId": "111"},
+                "Christ Smith": {"_sleeperId": "222"},
+                "Christian Smith": {"dlfSf": 10},
+            }
+        )
+        self.assertIn("Christian Smith", got)
+        self.assertEqual(len(got), 3)
+
+    def test_a_ghost_with_no_match_stays_a_ghost(self):
+        got = self._merge({"Barika Kpeenu": {}, "Matt Hibner": {"_sleeperId": "13324"}})
+        self.assertEqual(set(got), {"Barika Kpeenu", "Matt Hibner"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/api/test_provider_id_columns.py
+++ b/tests/api/test_provider_id_columns.py
@@ -1,0 +1,131 @@
+"""W06-F009 — provider-ID columns must be found whatever they are spelled.
+
+The loader picked the Sleeper-id column out of a CSV by testing the header
+against a hand-maintained tuple of literal spellings:
+
+    _SLEEPER_ID_ALIASES = ("sleeper_id", "sleeperId", "sleeper_player_id")
+
+``dynastyNerdsSfTep.csv`` ships ``SleeperId`` — a spelling nobody added —
+so all 294 of its rows carried no ID and the source joined by name only.
+The defect is not that one spelling was missing. It is that an
+enumerated-literal list silently fails closed: a source can start
+publishing ID-grade identity and the pipeline keeps ignoring it with no
+warning, no metric, and no failing test.
+
+Measured before the repair (``b5_id_join_probe``): the ID join would have
+recovered **0 rows** on the 2026-08-12 board, because the name cascade
+already resolved 293 of 294 and the two agreed on all 290 overlaps with
+**zero contradictions**. So this repair buys resilience, not match rate —
+ID-grade identity survives the vendor/Sleeper name drift that breaks a
+name join ("Kenneth Gainwell" vs "Kenny Gainwell"), and nothing on the
+current board moves. That is the desired shape: an identity repair whose
+immediate blast radius is zero is one that cannot have introduced a
+false positive.
+"""
+
+from __future__ import annotations
+
+import csv
+import unittest
+from pathlib import Path
+
+from src.api import data_contract as dc
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+class TestTheColumnIsFoundWhateverItIsCalled(unittest.TestCase):
+    def test_common_spellings_all_resolve(self):
+        for spelling in (
+            "sleeper_id",
+            "sleeperId",
+            "SleeperId",
+            "SLEEPER_ID",
+            "Sleeper Id",
+            "sleeper-id",
+            "sleeper_player_id",
+            "SleeperPlayerId",
+        ):
+            got = dc._pick_provider_id({spelling: "1234"}, dc._SLEEPER_ID_TOKENS)
+            self.assertEqual(got, "1234", f"{spelling!r} was not recognised")
+
+    def test_unrelated_columns_are_not_swept_in(self):
+        """The failure mode in the other direction.
+
+        A normalizing matcher that is too loose starts claiming columns
+        that merely mention the word — which would attach a wrong ID and
+        produce a confident wrong match, the outcome this phase ranks as
+        worse than a miss.
+        """
+        for spelling in (
+            "sleeper_id_source",
+            "old_sleeper_id",
+            "sleeper_team_id",
+            "sleeper",
+            "id",
+            "espn_id",
+            "gsis_id",
+        ):
+            got = dc._pick_provider_id({spelling: "1234"}, dc._SLEEPER_ID_TOKENS)
+            self.assertEqual(got, "", f"{spelling!r} was wrongly treated as a Sleeper id")
+
+    def test_blank_and_missing_are_not_values(self):
+        self.assertEqual(dc._pick_provider_id({"SleeperId": ""}, dc._SLEEPER_ID_TOKENS), "")
+        self.assertEqual(dc._pick_provider_id({"SleeperId": None}, dc._SLEEPER_ID_TOKENS), "")
+        self.assertEqual(dc._pick_provider_id({}, dc._SLEEPER_ID_TOKENS), "")
+
+    def test_an_explicit_spelling_still_wins_over_a_normalized_one(self):
+        """Determinism when a CSV carries two spellings at once."""
+        row = {"sleeper_id": "111", "SleeperId": "222"}
+        self.assertEqual(dc._pick_provider_id(row, dc._SLEEPER_ID_TOKENS), "111")
+
+
+class TestTheLiveSourcesAreCovered(unittest.TestCase):
+    """The regression that would have caught W06-F009 when it appeared.
+
+    Reads the real CSV headers rather than a fixture: the defect was a
+    mismatch between what vendors publish and what the loader enumerates,
+    and only the real headers can express that.
+    """
+
+    def _headers(self):
+        out = {}
+        for key, spec in dc._SOURCE_CSV_PATHS.items():
+            rel = spec if isinstance(spec, str) else spec.get("path")
+            p = REPO / str(rel)
+            if not p.is_file():
+                continue
+            hdr = next(csv.reader(p.open(encoding="utf-8-sig")), [])
+            out[key] = hdr
+        return out
+
+    def test_every_published_sleeper_id_column_is_visible(self):
+        missed = []
+        for key, hdr in self._headers().items():
+            for col in hdr:
+                norm = dc._normalize_header_token(col)
+                looks_like_sleeper_id = norm in dc._SLEEPER_ID_TOKENS
+                mentions = "sleeper" in col.lower() and "id" in col.lower()
+                if mentions and not looks_like_sleeper_id:
+                    # Not automatically a defect — could be a genuinely
+                    # different field — but it must be a deliberate call,
+                    # so surface it rather than let it pass silently.
+                    missed.append((key, col))
+        self.assertEqual(
+            missed,
+            [],
+            "a source publishes a sleeper-id-shaped column the loader does not "
+            f"recognise: {missed}. Add the normalized token to _SLEEPER_ID_TOKENS "
+            "or record why it is a different field.",
+        )
+
+    def test_dynasty_nerds_is_the_source_this_finding_was_about(self):
+        hdr = self._headers().get("dynastyNerdsSfTep")
+        if hdr is None:
+            self.skipTest("dynastyNerdsSfTep CSV not present")
+        self.assertIn("SleeperId", hdr)
+        self.assertEqual(dc._pick_provider_id({"SleeperId": "4034"}, dc._SLEEPER_ID_TOKENS), "4034")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/identity/test_unified_mapper.py
+++ b/tests/identity/test_unified_mapper.py
@@ -213,3 +213,150 @@ def test_resolve_many_batches_inputs(sleeper_dir):
     assert len(resolved) == 2
     assert len(unresolved) == 1
     assert unresolved[0]["name"] == "Nobody"
+
+
+# ── W06-F004 / W06-F007 ───────────────────────────────────────────────
+
+
+def test_override_beats_the_directory_it_exists_to_override(sleeper_dir, tmp_path):
+    """W06-F004. The override rung sat BELOW the exact-ID rung.
+
+    ``test_manual_override_short_circuits_mapper`` above passes today and
+    always did — but it overrides id ``99999``, which is not in the
+    fixture directory, so it never reaches the contested case. An
+    override for an id the directory ALREADY knows could never fire,
+    which is precisely the case overrides exist for: "the directory has
+    this player wrong, use mine".
+    """
+    overrides_file = tmp_path / "id_overrides.json"
+    overrides_file.write_text(
+        json.dumps({"4017": {"team": "MIA", "position": "TE"}}),
+        encoding="utf-8",
+    )
+    unified_mapper.reload_overrides()
+    got = unified_mapper.resolve_player(
+        sleeper_dir, sleeper_id="4017", overrides_path=overrides_file
+    )
+    assert got is not None
+    assert got.match_method == "manual_override"
+    assert got.team == "MIA"
+    assert got.position == "TE"
+
+
+def test_a_partial_override_does_not_blank_the_rest_of_the_identity(sleeper_dir, tmp_path):
+    """Promoting the override must not DEGRADE a resolved player.
+
+    The override rung built a ResolvedPlayer purely from the override
+    dict, so a partial entry emitted empty strings for everything it did
+    not mention. Below the exact-ID rung that was invisible; above it,
+    it would turn a fully-resolved Josh Allen into a nameless row —
+    trading one identity defect for a worse one. So the override MERGES
+    over the directory record rather than replacing it.
+    """
+    overrides_file = tmp_path / "id_overrides.json"
+    overrides_file.write_text(json.dumps({"4017": {"team": "MIA"}}), encoding="utf-8")
+    unified_mapper.reload_overrides()
+    got = unified_mapper.resolve_player(
+        sleeper_dir, sleeper_id="4017", overrides_path=overrides_file
+    )
+    assert got.team == "MIA"
+    assert got.full_name == "Josh Allen"
+    assert got.position == "QB"
+    assert got.gsis_id == "00-0034857"
+
+
+def test_override_for_an_unknown_id_still_works_verbatim(sleeper_dir, tmp_path):
+    """The original use case must survive the reordering."""
+    overrides_file = tmp_path / "id_overrides.json"
+    overrides_file.write_text(
+        json.dumps({"99999": {"full_name": "Practice Squad Guy", "position": "WR", "team": "SF"}}),
+        encoding="utf-8",
+    )
+    unified_mapper.reload_overrides()
+    got = unified_mapper.resolve_player(
+        sleeper_dir, sleeper_id="99999", overrides_path=overrides_file
+    )
+    assert got.full_name == "Practice Squad Guy"
+    assert got.match_method == "manual_override"
+
+
+def test_scaffolding_keys_are_not_overrides(tmp_path):
+    """The shipped file is all comment/example scaffolding.
+
+    ``_load_overrides`` kept any dict-valued key, so
+    ``_example_entry_only`` was loaded as a live override. Harmless while
+    no sleeper id equals that string — but with the rung promoted above
+    the directory, scaffolding must not be one edit away from resolving
+    a player.
+    """
+    overrides_file = tmp_path / "id_overrides.json"
+    overrides_file.write_text(
+        json.dumps(
+            {
+                "_comment": "prose",
+                "_example_entry_only": {"full_name": "Example Player"},
+                "4017": {"team": "MIA"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    unified_mapper.reload_overrides()
+    loaded = unified_mapper._load_overrides(overrides_file)
+    assert set(loaded) == {"4017"}
+
+
+def test_resolve_many_indexes_the_directory_once(sleeper_dir):
+    """W06-F007. ``resolve_many``'s docstring claimed the index is built
+    once, not per-row. It called ``resolve_player`` per row, and that
+    re-indexed the whole directory every time.
+
+    Asserted by counting real calls rather than by timing, so it cannot
+    flake on a loaded machine.
+    """
+    calls = {"n": 0}
+    original = unified_mapper._index_directory
+
+    def counting(*args, **kwargs):
+        calls["n"] += 1
+        return original(*args, **kwargs)
+
+    unified_mapper._index_directory = counting
+    try:
+        rows = [{"sleeper_id": sid} for sid in ("4017", "9479", "6794")] * 4
+        resolved, unresolved = unified_mapper.resolve_many(sleeper_dir, rows)
+    finally:
+        unified_mapper._index_directory = original
+
+    assert len(resolved) == 12
+    assert unresolved == []
+    assert calls["n"] == 1, f"directory re-indexed {calls['n']}x for {len(rows)} rows"
+
+
+def test_resolve_many_returns_what_it_did_before_the_hoist(sleeper_dir):
+    """The hoist must be behaviour-preserving, not merely faster.
+
+    Compares the batch resolver against per-row ``resolve_player`` calls
+    on the same inputs — including a miss and a name-ladder hit, so the
+    comparison covers more than the exact-ID rung.
+    """
+    rows = [
+        {"sleeper_id": "4017"},
+        {"gsis_id": "00-0039196"},
+        {"name": "Josh Allen", "position": "LB"},
+        {"name": "Nobody At All", "position": "K"},
+    ]
+    batch_resolved, batch_unresolved = unified_mapper.resolve_many(sleeper_dir, rows)
+    one_by_one = [
+        unified_mapper.resolve_player(
+            sleeper_dir,
+            sleeper_id=r.get("sleeper_id"),
+            gsis_id=r.get("gsis_id"),
+            name=r.get("name"),
+            position=r.get("position"),
+        )
+        for r in rows
+    ]
+    assert [r.to_dict() for r in batch_resolved] == [
+        r.to_dict() for r in one_by_one if r is not None
+    ]
+    assert len(batch_unresolved) == sum(1 for r in one_by_one if r is None)


### PR DESCRIPTION
## Verdict

**B5 / W06 VERIFIED FIXED — READY FOR OWNER REVIEW.**

Four root-cause repairs, each committed separately. One finding refuted by executable evidence rather than repaired.

## Dispositions

| finding | disposition |
|---|---|
| **W06-F001** ghost rows | **FIXED** — reproduced live (both named players), repaired at the creation path |
| **W06-F004** ID-override rung | **FIXED** — override promoted above exact-ID, merged not replaced |
| **W06-F007** `_index_directory` | **FIXED** — 12 rebuilds for 12 rows → 1, proven behaviour-preserving |
| **W06-F009** SleeperId alias | **FIXED** — token matching replaces the literal list |
| **W06-F002** duplicate detectors | **REFUTED** — both detectors *can* fire; see below |

## W06-F002 is not what it says

The finding claims "both identity-duplicate detectors on the contract are **structurally unable to fire**". Fed the exact shapes they describe:

```
Check 0 (position-aware duplicate)  -> duplicateCanonicalIdentityCount = 1, both rows flagged
Check 1 (cross-universe collision)  -> crossUniverseCollisionCount = 1, both rows flagged
```

Both fire. They report 0 on the live board because the board genuinely has 0 such cases — confirmed independently by a detector in `b5_identity_metrics.py` that does **not** use the contract's own checks (a metric sourced from the mechanism under test proves nothing).

My first probe on Check 1 showed 0 — because my fixture omitted `assetClass`, which it gates on. Corrected before concluding anything.

What survives is cosmetic: `audit_identity.py` renders a permanently empty near-name section because that rule was **deliberately retired** — documented in-tree as a pure noise generator producing 40+ false positives per build, superseded by the position-aware check. Re-enabling a rule measured as a false-positive generator is exactly what this phase forbids, so it is recorded, not rebuilt.

## W06-F001 — reproduced live, exactly as named

```
Matthew Hibner    ghost, 6 stranded source votes   <- Matt Hibner (TE, 13324)
Jamarion Miller   ghost, 1 stranded source vote    <- Jam Miller  (RB, 13403)
```

Both ghosts carry no position, rank or value, so those vendor votes counted for nobody. The Sleeper roster holds only the short forms.

**Root cause:** the merge key is a canonical NAME; the dedup pass folds punctuation and initials via `normalize_lookup_name`, which does not fold first-name drift.

Repaired by a **rule** in `src/utils/name_clean.py`, not by adding two aliases — enumerating these two would fix these two and leave the next pair for the next audit, which is how the table came to have Kenneth→Kenny but not Matt→Matthew.

**The identity gate is the load-bearing half, not the name rule.** `is_first_name_variant` is deliberately permissive enough to match "Chris Smith"/"Christian Smith", who may be two people. A merge additionally requires exactly one side carrying a `_sleeperId` and the other none — two identified players both have ids and can never be fused — and an ambiguous ghost is left alone.

**Measured before wiring in:** the gated rule merges **exactly 2 pairs**, both named ghosts, **0 ambiguous**, and **0 resolved-vs-resolved matches** across all 940 identified rows.

## W06-F004 — the override could never fire

`id_overrides.json` exists so an operator can say "the directory has this player wrong". It sat *below* the exact-ID rung, so for any id the directory knows, the directory won. It only ever applied to ids Sleeper had never heard of — and the existing test used exactly such an id, so nothing caught the inversion.

Promoted above exact-ID, and now **merges over** the directory record. Replacing was survivable while unreachable; promoted, a partial entry like `{"team": "MIA"}` would blank the name, position and every other id — trading one identity defect for a worse one.

`_load_overrides` now skips `_`-prefixed keys. The shipped file is entirely scaffolding, and `_example_entry_only` was already being loaded as a live override.

**Scope, reported not done:** this module is **not on the board path**. `id_overrides.json` is read only here and by `playerctx/normalize.py`, so the finding's other half — "cannot influence the board at all" — is true and structural. Wiring it into the board is a design change, not a defect repair.

## W06-F007 — no competing semantics to reconcile

Only one `_index_directory` exists, so there was nothing to prove canonical between rival implementations; the index is a pure function of `players_dir`. `resolve_many`'s docstring claimed the index is built once — measured at **12 rebuilds for 12 rows**. Hoisted, with a test pinning that batch results are **identical** to the per-row path across the exact-ID, GSIS, name-ladder and miss rungs.

## W06-F009 — the alias list failed closed

`dynastyNerdsSfTep.csv` ships `SleeperId`; the loader's literal tuple didn't list it, so 294 rows joined by name only with no warning or metric. Columns now match on a normalized token; `sleeper_id_source` still correctly does not.

**Measured impact: zero rows.** The name cascade already resolved 293/294 and the two agree on all 290 overlaps with **zero contradictions**. This buys resilience, not match rate — and an identity repair with zero blast radius is one that cannot have introduced a false positive.

## Identity metrics — before vs after

Every numeric metric is **identical**, with one intended exception:

```
providerIdColumns.sources.dynastyNerdsSfTep.visibleToLoader   0 -> 1
```

| | baseline | after |
|---|---|---|
| rows / served / players / picks | 1095 / 740 / 951 / 144 | unchanged |
| offense / IDP / rookies | 553 / 398 / 181 | unchanged |
| rows with playerId | 940 | unchanged |
| **player rows unresolved** | **11** | unchanged |
| quarantined | 1 | unchanged |
| position-aware duplicates | 0 | unchanged |
| cross-universe collisions | 0 | unchanged |
| suffixed / punctuated / accented | 0 / 51 / 0 | unchanged |
| near-name clusters | 49 | unchanged |
| source coverage (all 21) | — | unchanged |

**Board/ranking movement: none.** No value or rank changed.

**Honest caveat on F001:** the ghost merge runs in `Dynasty Scraper.py`, which does not execute in this pass, so the current board still shows both ghosts. The repair takes effect on the next scrape. Its behaviour is proven by simulation over the live name set (exactly 2 merges) and by 15 unit tests — not by a changed board. Saying otherwise would overclaim.

Suffix/accent counts of 0 are real, not harness bugs: `strip_display_suffix` deliberately strips generational suffixes, and each stripped name resolves to exactly one row.

## Non-scope honoured

No Hill parameters, tail policy, source weights, TEP or scoring touched. B3/B4 not reopened. No adaptive weighting, no product features, no UI cleanup, no B6.

## Gates

| gate | result |
|---|---|
| Python suite | **6,946 passed**, 0 failed |
| identity + playerctx + consumers | 376 passed |
| livedata | 253 passed, 25 skipped |
| frontend | 2,016 passed / 122 files |
| ruff format + check | clean |
| coercion ratchet | clean in touched files |
| `audit_status` | no drift |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012e7gcLKkmAEz8erFp5c9Qr

---
_Generated by [Claude Code](https://claude.ai/code/session_012e7gcLKkmAEz8erFp5c9Qr)_