### PR TITLE
infra: the unit suite must not wait on the live site (CI timeouts during the /api outage)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -135,6 +135,15 @@ jobs:
         shell: bash
         env:
           ALLOW_DEFAULT_LOGIN_DEV: "1"
+          # Same policy as pr-validation.yml, and it matters more here:
+          # ``server`` enables its uptime watchdog by default, so every
+          # TestClient probes the live site and its shutdown joins that
+          # thread.  With production's ``/api/`` wedged, this step ran
+          # long enough to burn the job's 20-minute budget — which would
+          # block the very deploy that could fix production.
+          # ``tests/conftest.py`` sets the same default; stated here so
+          # the policy is visible in the workflow.
+          UPTIME_CHECK_ENABLED: "0"
         run: |
           set -Eeuo pipefail
           # Hard gate: real code regressions block the deploy.  Data-
@@ -150,6 +159,8 @@ jobs:
         shell: bash
         env:
           ALLOW_DEFAULT_LOGIN_DEV: "1"
+          # Advisory, but it spends the same job budget.
+          UPTIME_CHECK_ENABLED: "0"
         run: |
           set -Eeuo pipefail
           python -m pytest tests/ -q --tb=short -m livedata

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -187,6 +187,19 @@ jobs:
         shell: bash
         env:
           ALLOW_DEFAULT_LOGIN_DEV: "1"
+          # The hard gate must not depend on the live site being up.
+          # ``server`` enables its uptime watchdog by default, so every
+          # TestClient used to fire a real request at production and its
+          # shutdown joined that thread.  Measured 2026-08-12 during a
+          # production ``/api/`` outage: 6.07s per client, and this job
+          # was killed at its 20-minute budget three times running —
+          # including on a previously-green commit.  An outage must fail
+          # a health check, not time out an unrelated PR.
+          #
+          # ``tests/conftest.py`` sets the same default via
+          # ``setdefault``; this line is here so the CI policy is visible
+          # in the workflow rather than inherited by accident.
+          UPTIME_CHECK_ENABLED: "0"
         run: |
           set -Eeuo pipefail
           # Hard gate: everything EXCEPT data-coupled tests.  A real
@@ -205,6 +218,10 @@ jobs:
         shell: bash
         env:
           ALLOW_DEFAULT_LOGIN_DEV: "1"
+          # Same reason as the hard gate above.  This step is advisory,
+          # but it runs in the same job and so spends the same 20-minute
+          # budget.
+          UPTIME_CHECK_ENABLED: "0"
         run: |
           set -Eeuo pipefail
           python -m pytest tests/ -q --tb=short -m livedata

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -70,6 +70,14 @@ jobs:
         shell: bash
         env:
           ALLOW_DEFAULT_LOGIN_DEV: "1"
+          # Same policy as pr-validation.yml / deploy.yml.  This job has
+          # the tightest budget (10 minutes) and its whole purpose is to
+          # notice breakage, so it must not be the thing an outage
+          # silences: ``server`` enables its uptime watchdog by default,
+          # every TestClient then probes the live site, and its shutdown
+          # joins that thread.  ``tests/conftest.py`` sets the same
+          # default; stated here so the policy is visible.
+          UPTIME_CHECK_ENABLED: "0"
         run: |
           set -Eeuo pipefail
           # Hard-gate on code tests only, matching pr-validation.yml.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,29 @@ import pytest
 # production rejects ALLOW_DEFAULT_LOGIN_DEV=1 by design.
 os.environ.setdefault("ALLOW_DEFAULT_LOGIN_DEV", "1")
 
+# ── The suite does not depend on the live site being up ───────────────
+# ``server`` reads UPTIME_CHECK_ENABLED at import (production default
+# True) and its lifespan runs ``check_uptime_once`` — a blocking
+# ``urlopen`` against UPTIME_CHECK_URL — on a worker thread the shutdown
+# then joins.  Every ``TestClient`` therefore made a real request to
+# production and every ``__exit__`` waited on it.
+#
+# Measured 2026-08-12, while production's ``/api/`` was accepting
+# connections and not answering: 6.07s per TestClient, of which startup
+# was 0.009s.  Two tests went 12.59s → 1.94s with the watchdog off.  The
+# whole ``PR Validation`` job stopped fitting in its 20-minute budget and
+# was killed three times — including on a previously-green commit — so a
+# production outage read as a broken pull request instead of failing
+# anything honestly.
+#
+# ``setdefault``, not an assignment: a test that wants the watchdog sets
+# the variable itself, and the production default is untouched.  The
+# boundary is here rather than a pytest sniff inside ``server`` — product
+# code must not behave differently because it suspects it is under test.
+# ``.github/workflows/pr-validation.yml`` states it again in the
+# unit-test step so the CI policy is visible rather than inherited.
+os.environ.setdefault("UPTIME_CHECK_ENABLED", "0")
+
 # ── Sleeper league context isolation ──────────────────────────────────
 # ``src/api/data_contract.py::_resolve_league_context`` reads the
 # operator's Sleeper league to derive the roster count (rookie-pick

--- a/tests/infra/test_unit_suite_does_not_probe_production.py
+++ b/tests/infra/test_unit_suite_does_not_probe_production.py
@@ -1,0 +1,147 @@
+"""The hard unit suite must not depend on the live site being up.
+
+Measured incident, 2026-08-12: production's ``/api/`` stopped responding
+(nginx and the Next frontend stayed healthy; the FastAPI upstream
+accepted connections and never answered). Within roughly half an hour
+``PR Validation`` stopped fitting in its 20-minute job budget and was
+killed three times in a row, and the local suite went from ~13 minutes to
+~37. The cause was not any product change — the previously-green commit
+timed out identically when re-run.
+
+The mechanism is this file's subject. ``server`` reads
+``UPTIME_CHECK_ENABLED`` at import (default **True**) and the lifespan
+starts ``uptime_watchdog_loop``, which runs a blocking
+``check_uptime_once`` on a worker thread via ``asyncio.to_thread``.
+Every ``TestClient`` therefore fired a real request at
+``https://chaseupside.com/api/health`` and, because the loop's shutdown
+joins that thread, every ``TestClient.__exit__`` waited on it. Profiled:
+6.07 s per client, of which startup was 0.009 s. Disabling the watchdog
+took the same two tests from 12.59 s to 1.94 s.
+
+So a production outage could not fail CI honestly — it made CI time out,
+which reads like a broken pull request.
+
+The rule these tests pin:
+
+* a **pure unit test** makes no external uptime request at all;
+* the watchdog itself stays testable — a test that wants it enables it
+  explicitly and controls its network dependency;
+* production runtime is untouched: the watchdog remains enabled by
+  default outside the test environment.
+
+Deliberately NOT solved by sniffing for pytest inside ``server``.
+Production code should not behave differently because it suspects it is
+being tested; the boundary is an explicit environment default set by the
+test bootstrap, and stated again in the CI workflow so the policy is
+visible rather than inherited by accident.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import unittest
+
+from fastapi.testclient import TestClient
+
+import server
+
+
+class TestThePureUnitSuiteIsSelfContained(unittest.TestCase):
+    """What the suite must guarantee."""
+
+    def test_the_watchdog_is_disabled_for_unit_tests(self):
+        self.assertFalse(
+            server.UPTIME_CHECK_ENABLED,
+            "the unit suite starts the production uptime watchdog, so every "
+            "TestClient waits on the live site",
+        )
+
+    def test_the_test_environment_sets_it_explicitly(self):
+        """An explicit boundary, not an accident of the ambient env."""
+        self.assertEqual(os.environ.get("UPTIME_CHECK_ENABLED"), "0")
+
+    def test_no_uptime_probe_happens_during_a_client_lifespan(self):
+        """The behavioural assertion, not just the config one."""
+        calls: list[float] = []
+        original = server.check_uptime_once
+
+        def _record():
+            calls.append(time.time())
+            return (True, None, 200)
+
+        server.check_uptime_once = _record
+        self.addCleanup(setattr, server, "check_uptime_once", original)
+
+        with TestClient(server.app):
+            pass
+
+        self.assertEqual(
+            calls,
+            [],
+            "a unit-test client probed the configured uptime URL " f"({server.UPTIME_CHECK_URL!r})",
+        )
+
+    def test_a_client_lifespan_is_not_paying_a_network_wait(self):
+        """Guards the symptom directly, in case the mechanism moves.
+
+        The pre-fix cost was 6.07 s per client, essentially all of it in
+        ``__exit__``. The bound is deliberately loose — this is a
+        regression tripwire for a seconds-scale wait, not a benchmark.
+        """
+        start = time.perf_counter()
+        with TestClient(server.app):
+            pass
+        elapsed = time.perf_counter() - start
+        self.assertLess(
+            elapsed,
+            3.0,
+            f"a TestClient lifespan took {elapsed:.2f}s — the suite is waiting "
+            "on something external again",
+        )
+
+
+class TestTheWatchdogItselfRemainsTestable(unittest.TestCase):
+    """Disabling it by default must not make it unverifiable.
+
+    A test that wants the watchdog turns it on explicitly and supplies
+    its own probe — no live host involved either way.
+    """
+
+    def test_enabling_it_explicitly_runs_the_probe(self):
+        calls: list[int] = []
+        original_flag = server.UPTIME_CHECK_ENABLED
+        original_probe = server.check_uptime_once
+        original_interval = server.UPTIME_CHECK_INTERVAL_SEC
+
+        def _probe():
+            calls.append(1)
+            return (True, None, 200)
+
+        server.UPTIME_CHECK_ENABLED = True
+        server.check_uptime_once = _probe
+        # Keep the loop from sleeping for its production interval while
+        # the client is open.
+        server.UPTIME_CHECK_INTERVAL_SEC = 3600
+        self.addCleanup(setattr, server, "UPTIME_CHECK_INTERVAL_SEC", original_interval)
+        self.addCleanup(setattr, server, "check_uptime_once", original_probe)
+        self.addCleanup(setattr, server, "UPTIME_CHECK_ENABLED", original_flag)
+
+        with TestClient(server.app):
+            deadline = time.time() + 5.0
+            while not calls and time.time() < deadline:
+                time.sleep(0.05)
+
+        self.assertTrue(
+            calls,
+            "the watchdog did not run its probe even when explicitly enabled — "
+            "disabling it by default has made the feature untestable",
+        )
+
+    def test_the_probe_target_is_still_configured_for_production(self):
+        """The default is not removed, only switched off under test."""
+        self.assertTrue(server.UPTIME_CHECK_URL)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Narrow infrastructure fix, split out of the B6 branch. **No production code is touched, and nothing is deleted.**

`git diff --numstat origin/main...HEAD` — 206 additions, 0 deletions:

| file | + |
|---|---|
| `tests/infra/test_unit_suite_does_not_probe_production.py` (new) | 147 |
| `tests/conftest.py` | 23 |
| `.github/workflows/pr-validation.yml` | 17 |
| `.github/workflows/deploy.yml` | 11 |
| `.github/workflows/smoke-test.yml` | 8 |

**147 of those 206 lines are the new regression test.** The behavioural change is **59 lines of test-bootstrap and CI configuration**, of which one line does the work (`os.environ.setdefault(...)`); the rest is comment explaining why. An earlier version of this description said "59 insertions, 0 deletions" without that split, which read as if the whole diff were 59 lines. Corrected.

## What broke, and why it looked like a code defect

`server` reads `UPTIME_CHECK_ENABLED` at import (production default **True**) and the lifespan starts `uptime_watchdog_loop`, which runs a blocking `check_uptime_once` — a `urllib.request.urlopen` against `UPTIME_CHECK_URL` — on a worker thread via `asyncio.to_thread`. The loop's shutdown **joins that thread**.

So every `TestClient` fired a real request at `https://chaseupside.com/api/health`, and every `TestClient.__exit__` waited on it.

That is invisible while the site is up. On 2026-08-12 production's `/api/` began accepting connections without answering, and the consequence was that CI stopped being able to report anything: `PR Validation` was killed at its 20-minute budget three times running — including on a previously-green commit, which is what proved it was not the pull request under test.

**An outage should fail a health check. It should not time out an unrelated PR.**

To be precise about causation, because the two are easy to conflate: this coupling did **not** cause the FastAPI process to wedge. It caused CI's ability to report to depend on that outage. This PR fixes the second thing only.

## Measured

| | watchdog on | watchdog off |
|---|---|---|
| two tests, isolated | 12.59 s | 1.94 s |
| per `TestClient` | 6.07 s (startup 0.009 s) | — |
| `tests/api/test_league_routing.py`, 27 tests | **125.26 s** | **4.64 s** |
| full hard gate, local | ~37 min during the outage | **9 m 32 s** (6952 passed, 294 subtests, 278 deselected) |

**Exact-head CI, run [31619148117](https://github.com/jasonleetucker-code/riskittogetthebrisket/actions/runs/31619148117) on `cffdf8b8`: all 20 steps green in 13 m 15 s, with production's `/api/` still wedged at the time of the run.** The hard-gate step took **5 m 55 s**. That is the causal confirmation — the same job, on the same broken production, that was being killed at 20 minutes.

## The repair

Two halves, both explicit configuration:

1. **`tests/conftest.py`** — `os.environ.setdefault("UPTIME_CHECK_ENABLED", "0")`, next to the existing `ALLOW_DEFAULT_LOGIN_DEV` boundary and before anything imports `server`.
2. **The three workflows that run the whole unit suite** state the same value in the step env, so the CI policy is visible rather than inherited: `pr-validation.yml`, `deploy.yml` (where a timeout would block the very deploy that could fix production) and `smoke-test.yml` (tightest budget at 10 minutes, and its only job is to notice breakage).

Deliberately **not** solved by sniffing for pytest inside `server` — product code must not behave differently because it suspects it is under test — and deliberately **not** solved by raising `timeout-minutes`, which would hide the coupling and still hand CI a false signal.

`setdefault`, not an assignment: a test that wants the watchdog sets the variable itself. Verified the production default is untouched:

```
$ env -u UPTIME_CHECK_ENABLED ALLOW_DEFAULT_LOGIN_DEV=1 python -c "import server; print(server.UPTIME_CHECK_ENABLED)"
True
```

## Tests

`tests/infra/test_unit_suite_does_not_probe_production.py` pins both halves — the second is what stops this from being a feature deletion:

* **the suite is self-contained** — the flag is off, the environment sets it *explicitly* rather than by ambient accident, no `check_uptime_once` call happens during a client lifespan, and a lifespan takes under 3 s (a loose tripwire on the symptom itself, in case the mechanism moves);
* **the watchdog is still testable** — a test that enables it explicitly and supplies its own probe still sees the probe run, and `UPTIME_CHECK_URL` is still configured.

RED before the change — 4 failed / 2 passed:

```
AssertionError: True is not false : the unit suite starts the production uptime watchdog,
  so every TestClient waits on the live site
AssertionError: None != '0'
AssertionError: + [] : a unit-test client probed the configured uptime URL
  ('https://chaseupside.com/api/health')
AssertionError: 5.791843440998491 not less than 3.0 : a TestClient lifespan took 5.79s
```

GREEN after: 6 passed in 0.75 s.

## Gates

| gate | result |
|---|---|
| exact-head `PR Validation` (run 31619148117) | **success**, 13 m 15 s, all 20 steps |
| `pytest tests/ -q -m "not livedata"` (local) | 6952 passed, 294 subtests, 278 deselected — 572.81 s |
| `ruff check .` | all checks passed |
| `ruff format --check tests/` | 493 files already formatted |
| `scripts/check_decision_coercions.py` | clean |
| `scripts/audit_status.py` | no drift |
| workflow YAML parse (all three edited) | OK |

## Note on production

Production `/api/` was still not answering when this PR was opened. This change does not fix that and does not claim to. Evidence gathered from outside the host:

* `GET /` → **200 in 0.96 s** (nginx healthy, box up, Next upstream serving)
* `GET /api/health` → connects in 0.0004 s, then **nothing for exactly 300.7 s**, then an empty reply — `/api/`'s `proxy_read_timeout` is 300 s
* the same block sets `proxy_connect_timeout 5s`, so a *stopped* backend would 502 within ~5 s

The upstream socket accepts and the application never writes a response: the FastAPI process is **wedged, not down**. Resolving that needs host access.