### PR TITLE
Production resilience after the 2026-08-12 EMFILE incident — build independence, rollback atomicity, FD limit + monitoring

### DIFF
--- a/.github/workflows/check-sharp-production-now.yml
+++ b/.github/workflows/check-sharp-production-now.yml
@@ -1,67 +1,17 @@
 name: Check Sharp Production Now
 
-# ┌──────────────────────────────────────────────────────────────────┐
-# │  TEMPORARY INCIDENT BRIDGE — REVERT THIS FILE BEFORE MERGING     │
-# │                                                                  │
-# │  On the branch `claude/prod-reliability-fd-incident` ONLY, this  │
-# │  workflow's body is replaced with the read-only FD inventory for │
-# │  the 2026-08-12 EMFILE incident.  Its normal Sharp-population    │
-# │  check is NOT here.                                              │
-# │                                                                  │
-# │  Why: `workflow_dispatch` resolves the workflow id against the   │
-# │  DEFAULT branch, so a new file that exists only on a feature     │
-# │  branch cannot be dispatched — verified, POST .../dispatches     │
-# │  returns 404 for `fd-diagnostics.yml`.  Dispatching THIS file    │
-# │  with `ref: <branch>` runs the branch's version of it, which is  │
-# │  the only way to get host evidence before the incident PR lands. │
-# │                                                                  │
-# │  `.github/workflows/fd-diagnostics.yml` is the permanent home    │
-# │  and is dispatchable normally once merged.  Restore this file    │
-# │  from `origin/main` before the incident PR is marked ready:      │
-# │                                                                  │
-# │      git checkout origin/main -- \                               │
-# │        .github/workflows/check-sharp-production-now.yml          │
-# └──────────────────────────────────────────────────────────────────┘
-#
-# Read-only, same contract as fd-diagnostics.yml: no restart or reload,
-# no deploy or checkout, no application import, no Sharp, no scraper, no
-# payload build, no environment variables printed.  Note that the
-# ORIGINAL version of this workflow does import the application and build
-# two Sharp market payloads on the host — deliberately not done here,
-# because the process under investigation is the one that ran out of file
-# descriptors and must not be given more work.
-
 on:
   workflow_dispatch:
-    inputs:
-      samples:
-        description: "How many FD-count samples to take"
-        required: false
-        default: "10"
-        type: string
-      interval_seconds:
-        description: "Seconds between samples"
-        required: false
-        default: "30"
-        type: string
 
 permissions:
   contents: read
 
-concurrency:
-  # An FD trend measured across a service restart is not a trend.
-  group: production-deploy
-  cancel-in-progress: false
-
 jobs:
   check:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 10
     environment: production
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
       - name: Configure production SSH
         env:
           DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
@@ -78,24 +28,51 @@ jobs:
           ssh-keygen -y -f "$HOME/.ssh/id_ed25519" >/dev/null
           echo "PORT=${DEPLOY_PORT:-22}" >> "$GITHUB_ENV"
 
-      - name: Collect FD forensics (read-only)
+      - name: Inspect Sharp routes and population
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          APP_DIR: ${{ vars.PROD_APP_DIR || '/home/dynasty/trade-calculator' }}
+          VENV_DIR: ${{ vars.PROD_VENV_DIR || '/home/dynasty/.venvs/trade-calculator' }}
           SERVICE_NAME: ${{ vars.PROD_SERVICE_NAME || 'dynasty' }}
-          OLD_PID: ${{ inputs.samples }}
-          FIRST_EMFILE: "2026-08-12 16:47:46"
-          LEAD_MIN: ${{ inputs.interval_seconds }}
         shell: bash
         run: |
           set -Eeuo pipefail
-          # Piped in from the runner's checkout rather than read off the
-          # host: the host's tree is at the DEPLOYED revision, which does
-          # not contain this script yet.  Nothing is written on the host.
+          printf -v REMOTE_ENV 'APP_DIR=%q VENV_DIR=%q SERVICE_NAME=%q' "$APP_DIR" "$VENV_DIR" "$SERVICE_NAME"
           ssh -i "$HOME/.ssh/id_ed25519" \
             -o BatchMode=yes -o StrictHostKeyChecking=yes \
             -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
-            -o ConnectTimeout=15 -o ServerAliveInterval=15 \
             -p "$PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
-            "bash -s -- $(printf %q "$SERVICE_NAME") $(printf %q "$OLD_PID") $(printf %q "$FIRST_EMFILE") $(printf %q "$LEAD_MIN")" \
-            < deploy/diagnostics/fd_forensics.sh
+            "$REMOTE_ENV bash -s" <<'REMOTE'
+          set -Eeuo pipefail
+          cd "$APP_DIR"
+          sudo -n systemctl is-active "$SERVICE_NAME"
+          ALLOW_DEFAULT_LOGIN_DEV=1 "$VENV_DIR/bin/python" - <<'PY'
+          import json
+          import server
+          from src.intel import platform_ledger
+          from src.sharp import service
+
+          service._register_http_routes()
+          market = service.market_payload(
+              window="30d", sort="strength", asset_type="all",
+              platform="all", qualification="all", limit=25,
+          )
+          ffpc = service.market_payload(
+              window="90d", sort="strength", asset_type="all",
+              platform="ffpc", qualification="provisional", limit=25,
+          )
+          print(json.dumps({
+              "routes": sorted(
+                  getattr(route, "path", "")
+                  for route in server.app.routes
+                  if "sharp" in getattr(route, "path", "")
+              ),
+              "coverage": platform_ledger.platform_coverage(),
+              "marketStatus": market.get("status"),
+              "marketAssets": len(market.get("assets") or []),
+              "ffpcStatus": ffpc.get("status"),
+              "ffpcAssets": len(ffpc.get("assets") or []),
+          }, indent=2, sort_keys=True, default=str))
+          PY
+          REMOTE

--- a/.github/workflows/check-sharp-production-now.yml
+++ b/.github/workflows/check-sharp-production-now.yml
@@ -1,17 +1,67 @@
 name: Check Sharp Production Now
 
+# ┌──────────────────────────────────────────────────────────────────┐
+# │  TEMPORARY INCIDENT BRIDGE — REVERT THIS FILE BEFORE MERGING     │
+# │                                                                  │
+# │  On the branch `claude/prod-reliability-fd-incident` ONLY, this  │
+# │  workflow's body is replaced with the read-only FD inventory for │
+# │  the 2026-08-12 EMFILE incident.  Its normal Sharp-population    │
+# │  check is NOT here.                                              │
+# │                                                                  │
+# │  Why: `workflow_dispatch` resolves the workflow id against the   │
+# │  DEFAULT branch, so a new file that exists only on a feature     │
+# │  branch cannot be dispatched — verified, POST .../dispatches     │
+# │  returns 404 for `fd-diagnostics.yml`.  Dispatching THIS file    │
+# │  with `ref: <branch>` runs the branch's version of it, which is  │
+# │  the only way to get host evidence before the incident PR lands. │
+# │                                                                  │
+# │  `.github/workflows/fd-diagnostics.yml` is the permanent home    │
+# │  and is dispatchable normally once merged.  Restore this file    │
+# │  from `origin/main` before the incident PR is marked ready:      │
+# │                                                                  │
+# │      git checkout origin/main -- \                               │
+# │        .github/workflows/check-sharp-production-now.yml          │
+# └──────────────────────────────────────────────────────────────────┘
+#
+# Read-only, same contract as fd-diagnostics.yml: no restart or reload,
+# no deploy or checkout, no application import, no Sharp, no scraper, no
+# payload build, no environment variables printed.  Note that the
+# ORIGINAL version of this workflow does import the application and build
+# two Sharp market payloads on the host — deliberately not done here,
+# because the process under investigation is the one that ran out of file
+# descriptors and must not be given more work.
+
 on:
   workflow_dispatch:
+    inputs:
+      samples:
+        description: "How many FD-count samples to take"
+        required: false
+        default: "10"
+        type: string
+      interval_seconds:
+        description: "Seconds between samples"
+        required: false
+        default: "30"
+        type: string
 
 permissions:
   contents: read
 
+concurrency:
+  # An FD trend measured across a service restart is not a trend.
+  group: production-deploy
+  cancel-in-progress: false
+
 jobs:
   check:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 25
     environment: production
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
       - name: Configure production SSH
         env:
           DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
@@ -28,51 +78,23 @@ jobs:
           ssh-keygen -y -f "$HOME/.ssh/id_ed25519" >/dev/null
           echo "PORT=${DEPLOY_PORT:-22}" >> "$GITHUB_ENV"
 
-      - name: Inspect Sharp routes and population
+      - name: Collect FD inventory (read-only)
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
-          APP_DIR: ${{ vars.PROD_APP_DIR || '/home/dynasty/trade-calculator' }}
-          VENV_DIR: ${{ vars.PROD_VENV_DIR || '/home/dynasty/.venvs/trade-calculator' }}
           SERVICE_NAME: ${{ vars.PROD_SERVICE_NAME || 'dynasty' }}
+          SAMPLES: ${{ inputs.samples }}
+          INTERVAL: ${{ inputs.interval_seconds }}
         shell: bash
         run: |
           set -Eeuo pipefail
-          printf -v REMOTE_ENV 'APP_DIR=%q VENV_DIR=%q SERVICE_NAME=%q' "$APP_DIR" "$VENV_DIR" "$SERVICE_NAME"
+          # Piped in from the runner's checkout rather than read off the
+          # host: the host's tree is at the DEPLOYED revision, which does
+          # not contain this script yet.  Nothing is written on the host.
           ssh -i "$HOME/.ssh/id_ed25519" \
             -o BatchMode=yes -o StrictHostKeyChecking=yes \
             -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+            -o ConnectTimeout=15 -o ServerAliveInterval=15 \
             -p "$PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
-            "$REMOTE_ENV bash -s" <<'REMOTE'
-          set -Eeuo pipefail
-          cd "$APP_DIR"
-          sudo -n systemctl is-active "$SERVICE_NAME"
-          ALLOW_DEFAULT_LOGIN_DEV=1 "$VENV_DIR/bin/python" - <<'PY'
-          import json
-          import server
-          from src.intel import platform_ledger
-          from src.sharp import service
-
-          service._register_http_routes()
-          market = service.market_payload(
-              window="30d", sort="strength", asset_type="all",
-              platform="all", qualification="all", limit=25,
-          )
-          ffpc = service.market_payload(
-              window="90d", sort="strength", asset_type="all",
-              platform="ffpc", qualification="provisional", limit=25,
-          )
-          print(json.dumps({
-              "routes": sorted(
-                  getattr(route, "path", "")
-                  for route in server.app.routes
-                  if "sharp" in getattr(route, "path", "")
-              ),
-              "coverage": platform_ledger.platform_coverage(),
-              "marketStatus": market.get("status"),
-              "marketAssets": len(market.get("assets") or []),
-              "ffpcStatus": ffpc.get("status"),
-              "ffpcAssets": len(ffpc.get("assets") or []),
-          }, indent=2, sort_keys=True, default=str))
-          PY
-          REMOTE
+            "bash -s -- $(printf %q "$SERVICE_NAME") $(printf %q "$SAMPLES") $(printf %q "$INTERVAL")" \
+            < deploy/diagnostics/fd_inventory.sh

--- a/.github/workflows/check-sharp-production-now.yml
+++ b/.github/workflows/check-sharp-production-now.yml
@@ -78,13 +78,14 @@ jobs:
           ssh-keygen -y -f "$HOME/.ssh/id_ed25519" >/dev/null
           echo "PORT=${DEPLOY_PORT:-22}" >> "$GITHUB_ENV"
 
-      - name: Collect FD inventory (read-only)
+      - name: Collect FD forensics (read-only)
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           SERVICE_NAME: ${{ vars.PROD_SERVICE_NAME || 'dynasty' }}
-          SAMPLES: ${{ inputs.samples }}
-          INTERVAL: ${{ inputs.interval_seconds }}
+          OLD_PID: ${{ inputs.samples }}
+          FIRST_EMFILE: "2026-08-12 16:47:46"
+          LEAD_MIN: ${{ inputs.interval_seconds }}
         shell: bash
         run: |
           set -Eeuo pipefail
@@ -96,5 +97,5 @@ jobs:
             -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
             -o ConnectTimeout=15 -o ServerAliveInterval=15 \
             -p "$PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
-            "bash -s -- $(printf %q "$SERVICE_NAME") $(printf %q "$SAMPLES") $(printf %q "$INTERVAL")" \
-            < deploy/diagnostics/fd_inventory.sh
+            "bash -s -- $(printf %q "$SERVICE_NAME") $(printf %q "$OLD_PID") $(printf %q "$FIRST_EMFILE") $(printf %q "$LEAD_MIN")" \
+            < deploy/diagnostics/fd_forensics.sh

--- a/.github/workflows/fd-diagnostics.yml
+++ b/.github/workflows/fd-diagnostics.yml
@@ -1,0 +1,94 @@
+name: FD Diagnostics (read-only)
+
+# Out-of-process file-descriptor evidence for the 2026-08-12 incident.
+#
+# Why a workflow rather than an application endpoint: the incident made
+# the backend unable to answer requests at all, so anything served BY the
+# process is unavailable exactly when it matters.  The evidence has to
+# come from outside it.  The deploy path already holds working SSH to the
+# host, so this reuses that capability and nothing else.
+#
+# READ-ONLY by construction.  It runs one script,
+# deploy/diagnostics/fd_inventory.sh, which reads /proc, asks systemd for
+# properties, lists sockets and greps the journal.  It does not restart
+# or reload anything, does not deploy or checkout, does not import the
+# application, does not run Sharp or a scraper or a payload build, and
+# does not print environment variables or command lines.
+#
+# It also does not PROVOKE work: FD samples are passive observations of
+# whatever the process does on its own schedule, and the timer listing at
+# the end names what could have run during the window without firing any
+# of it.
+
+on:
+  workflow_dispatch:
+    inputs:
+      samples:
+        description: "How many FD-count samples to take"
+        required: false
+        default: "10"
+        type: string
+      interval_seconds:
+        description: "Seconds between samples"
+        required: false
+        default: "30"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  # Never overlap with a deploy — not because this would break one, but
+  # because an FD trend measured across a service restart is not a trend.
+  group: production-deploy
+  cancel-in-progress: false
+
+jobs:
+  inventory:
+    name: FD inventory
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Configure production SSH
+        env:
+          DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          install -d -m 700 "$HOME/.ssh"
+          printf '%s\n' "$DEPLOY_SSH_PRIVATE_KEY" | sed 's/\r$//' > "$HOME/.ssh/id_ed25519"
+          printf '%s\n' "$DEPLOY_KNOWN_HOSTS" | sed 's/\r$//' > "$HOME/.ssh/known_hosts"
+          chmod 600 "$HOME/.ssh/id_ed25519"
+          chmod 644 "$HOME/.ssh/known_hosts"
+          ssh-keygen -y -f "$HOME/.ssh/id_ed25519" >/dev/null
+          echo "PORT=${DEPLOY_PORT:-22}" >> "$GITHUB_ENV"
+
+      - name: Collect FD inventory
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          SERVICE_NAME: ${{ vars.PROD_SERVICE_NAME || 'dynasty' }}
+          SAMPLES: ${{ inputs.samples }}
+          INTERVAL: ${{ inputs.interval_seconds }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          # The script is piped in and run from stdin rather than read
+          # from the app tree on the host: the host is checked out at
+          # whatever revision is DEPLOYED, which will not contain this
+          # file until the incident PR merges.  Sending the runner's copy
+          # means the diagnostic can run before it ships, and it touches
+          # nothing on disk.
+          ssh -i "$HOME/.ssh/id_ed25519" \
+            -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+            -o ConnectTimeout=15 -o ServerAliveInterval=15 \
+            -p "$PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "SERVICE_NAME=$(printf %q "$SERVICE_NAME") bash -s -- $(printf %q "$SERVICE_NAME") $(printf %q "$SAMPLES") $(printf %q "$INTERVAL")" \
+            < deploy/diagnostics/fd_inventory.sh

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -309,11 +309,26 @@ verify_frontend_build_manifest() {
     exit 1
   fi
 
-  local build_manifest="${dist_dir}/build-manifest.json"
-  if [[ ! -f "${build_manifest}" ]]; then
-    error "Missing build-manifest.json at ${build_manifest}"
-    exit 1
-  fi
+  # Runtime-critical manifests — see the same block in rollback.sh for
+  # the incident this comes from.  Kept behaviourally identical to that
+  # copy (the two implementations are required to match); only the
+  # failure verb differs, `exit` here vs `return` there.
+  local required_runtime_artifacts=(
+    "BUILD_ID"
+    "build-manifest.json"
+    "app-path-routes-manifest.json"
+    "prerender-manifest.json"
+    "routes-manifest.json"
+    "required-server-files.json"
+  )
+  local artifact
+  for artifact in "${required_runtime_artifacts[@]}"; do
+    if [[ ! -f "${dist_dir}/${artifact}" ]]; then
+      error "Incomplete frontend build: missing ${artifact} in ${dist_dir}"
+      error "This build cannot start; refusing to treat it as usable."
+      exit 1
+    fi
+  done
 
   log "Verifying frontend build manifest references: ${dist_dir}"
   python3 - "${dist_dir}" <<'PY' || {

--- a/deploy/diagnostics/fd_forensics.sh
+++ b/deploy/diagnostics/fd_forensics.sh
@@ -41,8 +41,17 @@ done
 J() { sudo -n "${JOURNALCTL}" "$@" 2>/dev/null; }
 section() { printf '\n===== %s =====\n' "$*"; }
 
-# Journal timestamps are host-local; keep every window in the same
-# vocabulary rather than converting and risking an off-by-two-hours.
+# CORRECTED after the first run.  `date -d` here resolves in the shell's
+# timezone.  When this is piped in over ssh the shell is the HOST's, so
+# it agrees with the journal — but the first run computed a window that
+# selected nothing and every resource-family count came back 0.  A zero
+# that means "wrong window" must not be read as "this family was idle",
+# so the window is now stated explicitly with its offset and the counts
+# below are labelled with the window they were taken over.
+#
+# The `_PID=` queries above are unaffected: they are exact journal-field
+# matches with no time window, which is why the valuable evidence — the
+# 20 lines before the first EMFILE — survived the bug.
 SINCE="$(date -d "${FIRST_EMFILE} -${LEAD_MIN} min" '+%Y-%m-%d %H:%M:%S' 2>/dev/null)"
 UNTIL="$(date -d "${FIRST_EMFILE} +2 min" '+%Y-%m-%d %H:%M:%S' 2>/dev/null)"
 if [[ -z "${SINCE}" ]]; then
@@ -50,7 +59,8 @@ if [[ -z "${SINCE}" ]]; then
   exit 3
 fi
 echo "service=${SERVICE_NAME} old_pid=${OLD_PID}"
-echo "window: ${SINCE}  ->  ${UNTIL}  (local time, ${LEAD_MIN}m lead)"
+echo "window: ${SINCE}  ->  ${UNTIL}  (${LEAD_MIN}m lead; tz=$(date +%Z), journal tz must match)"
+echo "sanity: lines in window = $(J -u "${SERVICE_NAME}" --since "${SINCE}" --until "${UNTIL}" --no-pager | wc -l) (0 means the window is wrong, NOT that the service was idle)"
 
 section "lifetime of the exhausted process"
 # _PID= is an indexed journal field, so this is exact rather than a grep.

--- a/deploy/diagnostics/fd_forensics.sh
+++ b/deploy/diagnostics/fd_forensics.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Bounded historical forensics for the 2026-08-12 EMFILE incident.
+#
+# The exhausted process (default PID 887292) is gone, so this reads the
+# journal it left behind.  One pass, one question: what was the
+# application DOING in the ~20 minutes before its first
+# `OSError: [Errno 24] Too many open files`.
+#
+# Established already, and not re-litigated here:
+#   - EMFILE at socket.accept() wedged the process (proven)
+#   - soft LimitNOFILE was 1024, hard 524288
+#   - the replacement process sits at ~16 FDs, flat
+#   - 1,212 Errno 24 events from PID 887292; first at 16:47:46 CEST
+#
+# NOT established: what accumulated.  If this pass names no defensible
+# suspect, the search stops — the process is gone and no amount of
+# staring reconstructs a descriptor table nobody captured.
+#
+# READ-ONLY.  Same contract as fd_inventory.sh: journal reads and
+# nothing else.  No restart, no deploy, no application import, no
+# background work triggered, no environment printed.
+#
+# Usage:
+#   fd_forensics.sh [service] [old_pid] [first_emfile_local] [lead_minutes]
+# e.g.
+#   fd_forensics.sh dynasty 887292 "2026-08-12 16:47:46" 20
+
+set -uo pipefail
+
+SERVICE_NAME="${1:-dynasty}"
+OLD_PID="${2:-887292}"
+FIRST_EMFILE="${3:-2026-08-12 16:47:46}"
+LEAD_MIN="${4:-20}"
+
+JOURNALCTL=""
+for c in /bin/journalctl /usr/bin/journalctl; do
+  [[ -x "$c" ]] && JOURNALCTL="$c" && break
+done
+[[ -n "${JOURNALCTL}" ]] || { echo "journalctl not found" >&2; exit 2; }
+
+J() { sudo -n "${JOURNALCTL}" "$@" 2>/dev/null; }
+section() { printf '\n===== %s =====\n' "$*"; }
+
+# Journal timestamps are host-local; keep every window in the same
+# vocabulary rather than converting and risking an off-by-two-hours.
+SINCE="$(date -d "${FIRST_EMFILE} -${LEAD_MIN} min" '+%Y-%m-%d %H:%M:%S' 2>/dev/null)"
+UNTIL="$(date -d "${FIRST_EMFILE} +2 min" '+%Y-%m-%d %H:%M:%S' 2>/dev/null)"
+if [[ -z "${SINCE}" ]]; then
+  echo "Could not parse FIRST_EMFILE='${FIRST_EMFILE}'" >&2
+  exit 3
+fi
+echo "service=${SERVICE_NAME} old_pid=${OLD_PID}"
+echo "window: ${SINCE}  ->  ${UNTIL}  (local time, ${LEAD_MIN}m lead)"
+
+section "lifetime of the exhausted process"
+# _PID= is an indexed journal field, so this is exact rather than a grep.
+echo "-- first retained line for PID ${OLD_PID} --"
+J _PID="${OLD_PID}" -o short-iso --no-pager | head -3
+echo "-- last line for PID ${OLD_PID} --"
+J _PID="${OLD_PID}" -o short-iso --no-pager | tail -3
+echo "-- total retained lines for that PID --"
+J _PID="${OLD_PID}" --no-pager | wc -l
+
+section "EMFILE onset"
+echo "-- first 5 Errno 24 lines, with timestamps --"
+J _PID="${OLD_PID}" -o short-iso --no-pager | grep -n 'Errno 24' | head -5
+echo "-- what the 20 lines BEFORE the first Errno 24 say --"
+# The lines immediately preceding exhaustion are the highest-value
+# evidence in the whole pass: whatever was running when the last
+# descriptor went.
+J _PID="${OLD_PID}" -o short-iso --no-pager \
+  | awk '/Errno 24/{exit} {buf[NR]=$0} END{for(i=(NR>20?NR-19:1);i<=NR;i++) print buf[i]}'
+
+section "application activity in the lead window"
+echo "-- line volume per minute (a burst is a lead) --"
+J -u "${SERVICE_NAME}" --since "${SINCE}" --until "${UNTIL}" -o short-iso --no-pager \
+  | awk '{split($1,a,"T"); split(a[2],b,":"); print a[1]"T"b[1]":"b[2]}' \
+  | uniq -c | tail -30
+
+section "resource families named in the lead window"
+# Counts only — one line per family, so a runaway is obvious without
+# dumping the log.  These are the families worth suspecting for a
+# descriptor accumulation in this codebase.
+declare -A PATTERNS=(
+  [scrape/pool-build]='scrape|pool|contract build|build_api_data|rebuild'
+  [sleeper-api]='sleeper|api\.sleeper'
+  [external-sources]='ktc|dynastydaddy|fantasycalc|dlf|idptradecalc|idpshow|fantasypros|yahoo|otcffb|flock'
+  [public-league-snapshot]='public_league|public-league|snapshot'
+  [sharp]='sharp|ffpc|cohort|roster_collect'
+  [playwright/browser]='playwright|chromium|browser|headless'
+  [subprocess]='subprocess|Popen|spawn'
+  [http-retry]='retry|retrying|backoff|timeout|timed out'
+  [connection-errors]='ConnectionError|ConnectionReset|RemoteDisconnected|SSLError|Max retries'
+  [session-construction]='new session|Session\(|client created|connector'
+  [bdvm]='bdvm|projection'
+  [warnings]='WARNING|ERROR|Traceback'
+)
+for k in "${!PATTERNS[@]}"; do
+  n="$(J -u "${SERVICE_NAME}" --since "${SINCE}" --until "${UNTIL}" --no-pager \
+        | grep -icE "${PATTERNS[$k]}" || true)"
+  printf '  %-24s %s\n' "$k" "${n:-0}"
+done
+
+section "most repeated message shapes in the lead window"
+# Strip timestamps/pids/numbers so identical messages collapse; a leak
+# usually shows up as one line repeated thousands of times.
+J -u "${SERVICE_NAME}" --since "${SINCE}" --until "${UNTIL}" --no-pager \
+  | sed -E 's/^[A-Za-z]{3} [0-9 ]{2} [0-9:]{8} [^ ]+ [^:]+: //' \
+  | sed -E 's/[0-9]+/N/g' \
+  | sort | uniq -c | sort -rn | head -15
+
+section "scheduled units that ran near the onset"
+# Correlation, not provocation — nothing is started here.
+J --since "${SINCE}" --until "${UNTIL}" -o short-iso --no-pager \
+  | grep -iE 'systemd\[1\].*(Starting|Started|Finished)' \
+  | grep -viE "${SERVICE_NAME}\.service" \
+  | head -30
+
+section "the service's own restarts around the incident"
+J -u "${SERVICE_NAME}" -o short-iso --no-pager \
+  | grep -iE 'Started|Stopped|Main process exited|Failed with result|Consumed' \
+  | tail -20
+
+echo
+echo "fd_forensics complete (read-only; nothing was modified)."

--- a/deploy/diagnostics/fd_inventory.sh
+++ b/deploy/diagnostics/fd_inventory.sh
@@ -32,7 +32,7 @@
 # already doing on its own schedule and never provokes work.
 #
 # Usage:
-#   sudo -n deploy/diagnostics/fd_inventory.sh [service] [samples] [interval_s]
+#   deploy/diagnostics/fd_inventory.sh [service] [samples] [interval_s]
 #
 # Defaults: dynasty, 10 samples, 30 s apart (a 5-minute window).
 
@@ -72,16 +72,31 @@ if [[ -z "${PID}" || "${PID}" == "0" ]]; then
 fi
 echo "resolved PID=${PID}"
 
+section "who is looking, and who owns the process"
+# The first run of this script failed here, usefully.  It used `sudo -n`
+# for the /proc reads, and the host grants NOPASSWD sudo for exactly four
+# binaries — systemctl, journalctl, install, chown — so `sudo -n cat`
+# and `sudo -n bash` were refused ("sudo: a password is required") and
+# the readability guard stopped the run.
+#
+# sudo was never needed: the service runs as `User=__APP_USER__` and the
+# deploy connects as that same user, so it OWNS the process and can read
+# /proc/PID/* directly.  sudo is now used only for the two allowlisted
+# binaries.  Printing both identities makes that assumption checkable
+# instead of load-bearing-and-invisible.
+echo "ssh user:     $(id -un)"
+echo "process user: $(stat -c '%U' "/proc/${PID}" 2>/dev/null || echo '<unreadable>')"
+
 section "kernel-enforced limits for the running process"
 # systemd's LimitNOFILE is what was CONFIGURED; /proc/PID/limits is what
 # the process actually got.  They can differ.
-sudo -n cat "/proc/${PID}/limits" 2>/dev/null | sed -n '1p;/open files/p'
+cat "/proc/${PID}/limits" 2>/dev/null | sed -n '1p;/open files/p'
 
 section "system-wide file-nr (allocated / free / max)"
 cat /proc/sys/fs/file-nr 2>/dev/null || true
 
 section "process and thread counts"
-printf 'threads: '; sudo -n cat "/proc/${PID}/status" 2>/dev/null | awk '/^Threads:/{print $2}'
+printf 'threads: '; cat "/proc/${PID}/status" 2>/dev/null | awk '/^Threads:/{print $2}'
 printf 'children: '; pgrep -P "${PID}" 2>/dev/null | wc -l
 
 section "readability guard"
@@ -90,7 +105,7 @@ section "readability guard"
 # descriptors", which is not a possible state for a running server.  A
 # zero that means "could not look" must never be presented as a
 # measurement, so establish readability first and stop if it fails.
-_probe="$(sudo -n bash -c 'find "/proc/$1/fd" -maxdepth 1 -type l 2>/dev/null | wc -l' _ "${PID}")"
+_probe="$(bash -c 'find "/proc/$1/fd" -maxdepth 1 -type l 2>/dev/null | wc -l' _ "${PID}")"
 if [[ "${_probe}" -eq 0 ]]; then
   echo "Cannot read /proc/${PID}/fd (permission, or the process exited)." >&2
   echo "Every count below would be a false zero. Stopping." >&2
@@ -102,7 +117,7 @@ section "FD type breakdown"
 # This is the answer we came for.  Every /proc/PID/fd entry is a symlink
 # whose target names its kind: socket:[…], pipe:[…], anon_inode:[…]
 # (epoll, eventfd, inotify, timerfd), /dev/…, or a regular path.
-sudo -n bash -c '
+bash -c '
   pid="$1"
   total=0
   declare -A kinds
@@ -127,7 +142,7 @@ sudo -n bash -c '
 section "regular files held open, by directory"
 # A leak of regular files usually points at one directory. Paths only —
 # never contents.
-sudo -n bash -c '
+bash -c '
   find "/proc/$1/fd" -maxdepth 1 -type l -exec readlink {} \; 2>/dev/null \
     | grep -E "^/" | grep -vE "^/(dev|proc|sys)/" \
     | xargs -r -n1 dirname 2>/dev/null | sort | uniq -c | sort -rn | head -20
@@ -137,10 +152,10 @@ section "sockets owned by this process, by state"
 if command -v ss >/dev/null 2>&1; then
   # -p attributes sockets to the pid; we filter to ours and count states
   # rather than dumping peer addresses.
-  sudo -n ss -tanp 2>/dev/null | grep "pid=${PID}," \
+  ss -tanp 2>/dev/null | grep "pid=${PID}," \
     | awk '{print $1}' | sort | uniq -c | sort -rn
   echo "-- top peer ports (destination), to spot one chatty dependency --"
-  sudo -n ss -tanp 2>/dev/null | grep "pid=${PID}," \
+  ss -tanp 2>/dev/null | grep "pid=${PID}," \
     | awk '{print $5}' | sed 's/.*://' | sort | uniq -c | sort -rn | head -10
 else
   echo "ss not installed"
@@ -148,7 +163,7 @@ fi
 
 section "lsof summary (if installed)"
 if command -v lsof >/dev/null 2>&1; then
-  sudo -n lsof -nP -p "${PID}" 2>/dev/null | awk 'NR>1{print $5}' | sort | uniq -c | sort -rn | head -15
+  lsof -nP -p "${PID}" 2>/dev/null | awk 'NR>1{print $5}' | sort | uniq -c | sort -rn | head -15
 else
   echo "lsof not installed"
 fi
@@ -179,7 +194,7 @@ section "FD count samples (${SAMPLES} x ${INTERVAL}s)"
 # whatever the process does on its own schedule.
 echo "utc_time            total  sockets  files  anon   pipes"
 for ((i = 0; i < SAMPLES; i++)); do
-  sudo -n bash -c '
+  bash -c '
     pid="$1"
     t=0; s=0; f=0; a=0; p=0
     while IFS= read -r link; do

--- a/deploy/diagnostics/fd_inventory.sh
+++ b/deploy/diagnostics/fd_inventory.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Read-only file-descriptor evidence for the 2026-08-12 incident.
+#
+# On that date the production FastAPI process stopped answering.  The
+# deploy's own journal capture showed why:
+#
+#     [ERROR] socket.accept() out of system resource
+#     File "/usr/lib/python3.12/asyncio/selector_events.py", line 178,
+#       in _accept_connection
+#     File "/usr/lib/python3.12/socket.py", line 295, in accept
+#     OSError: [Errno 24] Too many open files
+#
+# EMFILE at accept() explains the outside signature exactly: the kernel
+# completes the TCP handshake into the listen backlog, so nginx connects
+# in 0.4 ms, and the application can never accept the connection, so
+# nginx waits its full 300 s proxy_read_timeout for bytes that never
+# come.
+#
+# What is NOT established is WHAT accumulated.  "Descriptor leak" is a
+# hypothesis until this script names the type.  That is the whole job
+# here: inventory, not theory, and no application fix before the
+# inventory says what grows.
+#
+# CONTRACT — this script is READ-ONLY.  It must never:
+#   restart or reload a service, deploy, checkout, or write to the app
+#   tree; import the application; run Sharp, scrapers, or any payload
+#   build; trigger background work; or print environment variables,
+#   command lines, or anything else that can carry a credential.
+#
+# It reads /proc, asks systemd for properties, lists sockets, and greps
+# the journal.  Sampling is passive: it observes whatever the process is
+# already doing on its own schedule and never provokes work.
+#
+# Usage:
+#   sudo -n deploy/diagnostics/fd_inventory.sh [service] [samples] [interval_s]
+#
+# Defaults: dynasty, 10 samples, 30 s apart (a 5-minute window).
+
+set -uo pipefail
+
+SERVICE_NAME="${1:-${SERVICE_NAME:-dynasty}}"
+SAMPLES="${2:-10}"
+INTERVAL="${3:-30}"
+
+SYSTEMCTL=""
+for c in /bin/systemctl /usr/bin/systemctl; do
+  [[ -x "$c" ]] && SYSTEMCTL="$c" && break
+done
+JOURNALCTL=""
+for c in /bin/journalctl /usr/bin/journalctl; do
+  [[ -x "$c" ]] && JOURNALCTL="$c" && break
+done
+
+section() { printf '\n===== %s =====\n' "$*"; }
+
+if [[ -z "${SYSTEMCTL}" ]]; then
+  echo "systemctl not found; cannot resolve the service." >&2
+  exit 2
+fi
+
+section "service identity and limits"
+# ActiveEnterTimestamp dates the CURRENT process: an FD count means
+# nothing without knowing how long it has been accumulating.
+sudo -n "${SYSTEMCTL}" show "${SERVICE_NAME}" \
+  -p MainPID -p LimitNOFILE -p LimitNOFILESoft -p ActiveEnterTimestamp \
+  -p NRestarts -p TasksCurrent -p TasksMax -p MemoryCurrent
+
+PID="$(sudo -n "${SYSTEMCTL}" show "${SERVICE_NAME}" -p MainPID --value)"
+if [[ -z "${PID}" || "${PID}" == "0" ]]; then
+  echo "Service ${SERVICE_NAME} has no MainPID (not running?)." >&2
+  exit 3
+fi
+echo "resolved PID=${PID}"
+
+section "kernel-enforced limits for the running process"
+# systemd's LimitNOFILE is what was CONFIGURED; /proc/PID/limits is what
+# the process actually got.  They can differ.
+sudo -n cat "/proc/${PID}/limits" 2>/dev/null | sed -n '1p;/open files/p'
+
+section "system-wide file-nr (allocated / free / max)"
+cat /proc/sys/fs/file-nr 2>/dev/null || true
+
+section "process and thread counts"
+printf 'threads: '; sudo -n cat "/proc/${PID}/status" 2>/dev/null | awk '/^Threads:/{print $2}'
+printf 'children: '; pgrep -P "${PID}" 2>/dev/null | wc -l
+
+section "readability guard"
+# A denied read of /proc/PID/fd makes `find -type l` yield NOTHING, and
+# every count below would then report 0 — "the process holds no
+# descriptors", which is not a possible state for a running server.  A
+# zero that means "could not look" must never be presented as a
+# measurement, so establish readability first and stop if it fails.
+_probe="$(sudo -n bash -c 'find "/proc/$1/fd" -maxdepth 1 -type l 2>/dev/null | wc -l' _ "${PID}")"
+if [[ "${_probe}" -eq 0 ]]; then
+  echo "Cannot read /proc/${PID}/fd (permission, or the process exited)." >&2
+  echo "Every count below would be a false zero. Stopping." >&2
+  exit 4
+fi
+echo "ok: /proc/${PID}/fd is readable (${_probe} entries on first look)"
+
+section "FD type breakdown"
+# This is the answer we came for.  Every /proc/PID/fd entry is a symlink
+# whose target names its kind: socket:[…], pipe:[…], anon_inode:[…]
+# (epoll, eventfd, inotify, timerfd), /dev/…, or a regular path.
+sudo -n bash -c '
+  pid="$1"
+  total=0
+  declare -A kinds
+  while IFS= read -r link; do
+    tgt="$(readlink "$link" 2>/dev/null)" || continue
+    total=$((total+1))
+    case "$tgt" in
+      socket:*)      k="socket" ;;
+      pipe:*)        k="pipe" ;;
+      anon_inode:*)  k="anon_inode:${tgt#anon_inode:}" ;;
+      /dev/*)        k="dev" ;;
+      /proc/*)       k="proc" ;;
+      /memfd:*)      k="memfd" ;;
+      *)             k="file" ;;
+    esac
+    kinds["$k"]=$(( ${kinds["$k"]:-0} + 1 ))
+  done < <(find "/proc/$pid/fd" -maxdepth 1 -type l 2>/dev/null)
+  echo "total_fds=$total"
+  for k in "${!kinds[@]}"; do printf "  %-28s %s\n" "$k" "${kinds[$k]}"; done | sort -k2 -rn
+' _ "${PID}"
+
+section "regular files held open, by directory"
+# A leak of regular files usually points at one directory. Paths only —
+# never contents.
+sudo -n bash -c '
+  find "/proc/$1/fd" -maxdepth 1 -type l -exec readlink {} \; 2>/dev/null \
+    | grep -E "^/" | grep -vE "^/(dev|proc|sys)/" \
+    | xargs -r -n1 dirname 2>/dev/null | sort | uniq -c | sort -rn | head -20
+' _ "${PID}"
+
+section "sockets owned by this process, by state"
+if command -v ss >/dev/null 2>&1; then
+  # -p attributes sockets to the pid; we filter to ours and count states
+  # rather than dumping peer addresses.
+  sudo -n ss -tanp 2>/dev/null | grep "pid=${PID}," \
+    | awk '{print $1}' | sort | uniq -c | sort -rn
+  echo "-- top peer ports (destination), to spot one chatty dependency --"
+  sudo -n ss -tanp 2>/dev/null | grep "pid=${PID}," \
+    | awk '{print $5}' | sed 's/.*://' | sort | uniq -c | sort -rn | head -10
+else
+  echo "ss not installed"
+fi
+
+section "lsof summary (if installed)"
+if command -v lsof >/dev/null 2>&1; then
+  sudo -n lsof -nP -p "${PID}" 2>/dev/null | awk 'NR>1{print $5}' | sort | uniq -c | sort -rn | head -15
+else
+  echo "lsof not installed"
+fi
+
+section "earliest Errno 24 in the retained journal"
+if [[ -n "${JOURNALCTL}" ]]; then
+  # First occurrence dates the onset; the count and last occurrence say
+  # whether it is over.
+  first="$(sudo -n "${JOURNALCTL}" -u "${SERVICE_NAME}" --no-pager -o short-iso 2>/dev/null \
+    | grep -m1 'Errno 24' || true)"
+  echo "first: ${first:-<none in retained journal>}"
+  last="$(sudo -n "${JOURNALCTL}" -u "${SERVICE_NAME}" --no-pager -o short-iso 2>/dev/null \
+    | grep 'Errno 24' | tail -1 || true)"
+  echo "last:  ${last:-<none>}"
+  cnt="$(sudo -n "${JOURNALCTL}" -u "${SERVICE_NAME}" --no-pager 2>/dev/null \
+    | grep -c 'Errno 24' || true)"
+  echo "count: ${cnt:-0}"
+  echo "-- journal retention window --"
+  sudo -n "${JOURNALCTL}" -u "${SERVICE_NAME}" --no-pager -o short-iso -n 1 2>/dev/null | tail -1
+  sudo -n "${JOURNALCTL}" -u "${SERVICE_NAME}" --no-pager -o short-iso 2>/dev/null | head -1
+else
+  echo "journalctl not found"
+fi
+
+section "FD count samples (${SAMPLES} x ${INTERVAL}s)"
+# Trend, not a snapshot: a single number cannot distinguish a healthy
+# steady state from the middle of an accumulation.  Passive — we watch
+# whatever the process does on its own schedule.
+echo "utc_time            total  sockets  files  anon   pipes"
+for ((i = 0; i < SAMPLES; i++)); do
+  sudo -n bash -c '
+    pid="$1"
+    t=0; s=0; f=0; a=0; p=0
+    while IFS= read -r link; do
+      tgt="$(readlink "$link" 2>/dev/null)" || continue
+      t=$((t+1))
+      case "$tgt" in
+        socket:*) s=$((s+1)) ;;
+        pipe:*) p=$((p+1)) ;;
+        anon_inode:*) a=$((a+1)) ;;
+        /*) f=$((f+1)) ;;
+      esac
+    done < <(find "/proc/$pid/fd" -maxdepth 1 -type l 2>/dev/null)
+    printf "%s  %5d  %7d  %5d  %5d  %5d\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$t" "$s" "$f" "$a" "$p"
+  ' _ "${PID}"
+  (( i < SAMPLES - 1 )) && sleep "${INTERVAL}"
+done
+
+section "scheduled work in the observation window"
+# Correlation without provocation: name the timers that could have run
+# during the samples above.  We do not fire any of them.
+sudo -n "${SYSTEMCTL}" list-timers --all --no-pager 2>/dev/null \
+  | head -25 || true
+
+echo
+echo "fd_inventory complete (read-only; nothing was modified)."

--- a/deploy/diagnostics/fd_inventory.sh
+++ b/deploy/diagnostics/fd_inventory.sh
@@ -92,7 +92,14 @@ section "kernel-enforced limits for the running process"
 # the process actually got.  They can differ.
 cat "/proc/${PID}/limits" 2>/dev/null | sed -n '1p;/open files/p'
 
-section "system-wide file-nr (allocated / free / max)"
+section "system-wide file-nr (allocated / unused / max)"
+# The three fields are ALLOCATED, UNUSED-but-allocated, and MAX — not
+# "free".  On modern kernels the middle column is essentially always 0
+# because freed structures are returned immediately rather than kept on a
+# free list, so reading it as "free descriptors remaining" inverts the
+# meaning entirely.  Only the first and third are informative here, and
+# both are system-wide: neither one can show a per-process exhaustion,
+# which is what EMFILE actually was.
 cat /proc/sys/fs/file-nr 2>/dev/null || true
 
 section "process and thread counts"
@@ -161,7 +168,12 @@ else
   echo "ss not installed"
 fi
 
-section "lsof summary (if installed)"
+section "lsof type summary (NOT an FD count)"
+# Cross-check only.  `lsof` lists more than open descriptors — memory
+# mappings (mem), the text segment (txt), cwd and rtd all appear with
+# type REG — so its REG row count is NOT the number of open regular-file
+# descriptors and will exceed it.  /proc/PID/fd above is canonical; this
+# is here to name WHAT is open, not how many.
 if command -v lsof >/dev/null 2>&1; then
   lsof -nP -p "${PID}" 2>/dev/null | awk 'NR>1{print $5}' | sort | uniq -c | sort -rn | head -15
 else

--- a/deploy/diagnostics/playwright_fd_probe.py
+++ b/deploy/diagnostics/playwright_fd_probe.py
@@ -1,0 +1,165 @@
+"""Does the PARENT python process leak descriptors across Playwright cycles?
+
+RESULT, 2026-08-12: NO.  Parent FDs return to baseline after every
+cycle — normal, exception, and cancellation alike.
+
+    baseline                       6  (pipe=2)
+    mid-cycle, browser open        8  (pipe=4)   <- driver stdio pipes
+    after close                    6  (pipe=2)
+    after exception cycle x3       6  (pipe=2)
+    after cancellation cycle x3    6  (pipe=2)
+    11 cycles total                +0
+
+The mid-cycle reading is why the flat line is trustworthy: it proves this
+instrument CAN see Playwright's descriptors.  Without it, "6 forever"
+would be indistinguishable from an instrument that sees nothing — the
+same false-zero trap the fd_inventory readability guard exists for.
+
+So `async with async_playwright()`'s __aexit__ reclaims the parent's
+pipes even when control unwinds past `await browser.close()` — which it
+does in `Dynasty Scraper.py`, where close() is the last statement of the
+block rather than a finally.  A child Chromium orphan (the subject of
+d7d4edff8) is a real and separate concern; it is not parent FD growth.
+
+Not a CI gate: it needs a real browser and takes ~2 minutes.  Run by
+hand if the lead is ever reopened.
+
+
+Isolated local process. Never touches production, never runs the real
+scraper. It reproduces only the lifecycle shape found in
+`Dynasty Scraper.py`:
+
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(...)
+        context = await browser.new_context(...)
+        ...
+        await browser.close()      # last statement, NOT a finally
+
+The question is narrow and is the one the owner posed: a child Chromium
+leak does not automatically explain FD growth in the FastAPI PARENT. So
+measure the parent's own /proc/self/fd across repeated cycles, including
+the paths that skip `close()`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from collections import Counter
+
+FD = f"/proc/{os.getpid()}/fd"
+
+
+def snapshot() -> tuple[int, Counter]:
+    kinds = Counter()
+    total = 0
+    for name in os.listdir(FD):
+        try:
+            tgt = os.readlink(os.path.join(FD, name))
+        except OSError:
+            continue
+        total += 1
+        if tgt.startswith("socket:"):
+            kinds["socket"] += 1
+        elif tgt.startswith("pipe:"):
+            kinds["pipe"] += 1
+        elif tgt.startswith("anon_inode:"):
+            kinds["anon_inode"] += 1
+        elif tgt.startswith("/dev/"):
+            kinds["dev"] += 1
+        else:
+            kinds["file"] += 1
+    return total, kinds
+
+
+def report(label: str) -> int:
+    total, kinds = snapshot()
+    detail = " ".join(f"{k}={v}" for k, v in sorted(kinds.items()))
+    print(f"  {label:<44} fds={total:<4} {detail}", flush=True)
+    return total
+
+
+async def cycle(mode: str) -> None:
+    """One scrape-shaped browser cycle.
+
+    mode:
+      normal    launch -> context -> page -> close  (the happy path)
+      raise     an exception between launch and close, so control unwinds
+                past `await browser.close()` exactly as a mid-scrape
+                failure would
+      cancel    the task is cancelled mid-cycle — the 2-hourly scrape
+                timeout path
+    """
+    from playwright.async_api import async_playwright
+
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(
+            headless=True,
+            executable_path="/opt/pw-browsers/chromium-1194/chrome-linux/chrome",
+        )
+        context = await browser.new_context(
+            user_agent="probe", viewport={"width": 1280, "height": 900}
+        )
+        page = await context.new_page()
+        await page.goto("about:blank")
+        if mode == "normal" and os.environ.get("PROBE_MIDCYCLE"):
+            # Sensitivity check.  A count that never moves could mean "no
+            # leak" or "this instrument cannot see Playwright's
+            # descriptors at all".  Measuring WITH the browser open
+            # distinguishes them: if the number does not rise here, every
+            # flat reading below is worthless.
+            report("    >> MID-CYCLE (browser open)")
+        if mode == "raise":
+            raise RuntimeError("simulated mid-scrape failure")
+        if mode == "cancel":
+            await asyncio.sleep(3600)  # cancelled from outside
+        await page.close()
+        await browser.close()
+
+
+async def main() -> int:
+    print("Playwright parent-FD probe — isolated process, no production contact\n")
+    base = report("baseline (before any playwright import)")
+
+    print("\n-- normal cycles: launch -> context -> page -> close --")
+    counts = []
+    for i in range(1, 6):
+        await cycle("normal")
+        counts.append(report(f"after normal cycle {i}"))
+
+    print("\n-- exception path: unwinds past `await browser.close()` --")
+    for i in range(1, 4):
+        try:
+            await cycle("raise")
+        except RuntimeError:
+            pass
+        counts.append(report(f"after exception cycle {i}"))
+
+    print("\n-- cancellation path: the scrape-timeout shape --")
+    for i in range(1, 4):
+        task = asyncio.create_task(cycle("cancel"))
+        await asyncio.sleep(4)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        counts.append(report(f"after cancelled cycle {i}"))
+
+    await asyncio.sleep(2)
+    final = report("\n  final, after settle")
+
+    print("\n" + "=" * 72)
+    steady = counts[2:6]  # ignore the first cycles' one-off driver setup
+    print(f"baseline={base}  after-first-cycle={counts[0]}  final={final}")
+    print(f"steady-state window across cycles 3..6: {steady}")
+    growth = final - counts[0]
+    print(f"growth after the first cycle: {growth:+d} fds over {len(counts)} cycles")
+    verdict = "MONOTONIC GROWTH" if growth >= len(counts) else "NO MONOTONIC GROWTH"
+    print(f"VERDICT: {verdict}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/deploy/rollback.sh
+++ b/deploy/rollback.sh
@@ -170,11 +170,37 @@ verify_frontend_build_manifest() {
     error "Frontend build dir does not exist: ${dist_dir}"
     return 1
   fi
-  local build_manifest="${dist_dir}/build-manifest.json"
-  if [[ ! -f "${build_manifest}" ]]; then
-    error "Missing build-manifest.json at ${build_manifest}"
-    return 1
-  fi
+  # Runtime-critical manifests: the files `next start` opens to boot.
+  #
+  # Checking only manifest-REFERENCED chunks is not enough, and that gap
+  # is what let a failed build pass verification on 2026-08-12.  An
+  # aborted export writes `build-manifest.json` early and never reaches
+  # `prerender-manifest.json`, so the reference walk below found all 52
+  # assets it knew about, reported OK, and the swapped-in build then
+  # crashed the frontend with:
+  #
+  #   Error: ENOENT: no such file or directory,
+  #     open '.../frontend/.next/prerender-manifest.json'
+  #
+  # These six are every root-level artifact a successful build produces
+  # that the server loads at startup.  Presence, not content — this is a
+  # completeness check on the staging dir, not a schema validator.
+  local required_runtime_artifacts=(
+    "BUILD_ID"
+    "build-manifest.json"
+    "app-path-routes-manifest.json"
+    "prerender-manifest.json"
+    "routes-manifest.json"
+    "required-server-files.json"
+  )
+  local artifact
+  for artifact in "${required_runtime_artifacts[@]}"; do
+    if [[ ! -f "${dist_dir}/${artifact}" ]]; then
+      error "Incomplete frontend build: missing ${artifact} in ${dist_dir}"
+      error "This build cannot start; refusing to treat it as usable."
+      return 1
+    fi
+  done
   log "Verifying frontend build manifest references: ${dist_dir}"
   python3 - "${dist_dir}" <<'PY' || return 1
 import json
@@ -343,10 +369,41 @@ maybe_rebuild_frontend_after_rollback() {
   fi
 
   log "Rebuilding rolled-back frontend bundle into staging dir: ${staging_dir}"
+  # The exit status is captured EXPLICITLY, and that is the whole fix for
+  # the 2026-08-12 swap-a-broken-build defect.
+  #
+  # This subshell is identical to the one in deploy.sh, and on the deploy
+  # path `set -e` aborted correctly.  Here it did not, because
+  # `main()` calls this function as `if ! maybe_rebuild_frontend_after_rollback`
+  # — and bash disables errexit for the entire body of a function invoked
+  # as a condition.  So a `npm run build` that exited 1 was discarded and
+  # execution fell through to the verify-and-swap below.  Measured:
+  #
+  #   17:22:19.122  Next.js build worker exited with code: 1
+  #   17:22:19.268  [verify-build] OK: 52 manifest-referenced asset(s)
+  #   17:22:49.577  Rolled-back frontend build swapped into place
+  #   17:22:51.704  Frontend service failed to start
+  #                 ENOENT .next/prerender-manifest.json
+  #
+  # 80 ms between "the build failed" and "verify it anyway", then an
+  # incomplete staging dir replaced the last known-good .next and took
+  # the frontend down for 2.5 minutes on top of the backend outage.
+  #
+  # `|| build_rc=$?` rather than a bare call, so this stays correct
+  # whether or not errexit happens to be active at the call site.  The
+  # two scripts must not be able to diverge on this again.
+  local build_rc=0
   (
     cd "${frontend_dir}"
     NEXT_DIST_DIR="${FRONTEND_STAGING_DIR_NAME}" npm run build
-  )
+  ) || build_rc=$?
+
+  if (( build_rc != 0 )); then
+    error "Rollback frontend build failed (exit ${build_rc}); leaving the live frontend untouched."
+    error "Staging dir ${staging_dir} is incomplete and will NOT be swapped in."
+    rm -rf "${staging_dir}"
+    return 1
+  fi
 
   verify_frontend_build_manifest "${staging_dir}" || return 1
 
@@ -486,4 +543,10 @@ main() {
   log "Rollback complete. Active revision: ${rollback_target}"
 }
 
-main "$@"
+# Run main only when EXECUTED, not when sourced.  Sourcing is how
+# `tests/deploy/test_rollback_frontend_atomicity.py` drives the real
+# functions against a fixture frontend; without this guard, importing
+# them would launch an actual rollback.  No effect on normal execution.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/deploy/systemd/dynasty-healthcheck.sh
+++ b/deploy/systemd/dynasty-healthcheck.sh
@@ -66,6 +66,88 @@ read_failures() {
     printf '%s' "${n}"
 }
 
+# ── FD utilisation watch (2026-08-12 incident) ───────────────────────
+# The backend exhausted its file descriptors and wedged: `socket.accept()`
+# raised `OSError: [Errno 24] Too many open files` 1,212 times from PID
+# 887292, first at 16:47:46 local.  The kernel kept completing TCP
+# handshakes into the listen backlog, so nginx connected in 0.4 ms and
+# then waited its full 300 s `proxy_read_timeout` for bytes that never
+# came.  Nothing anywhere reported the descriptor count on the way up.
+#
+# This lives HERE, in the existing minutely root-run healthcheck, rather
+# than in a new subsystem or an application endpoint — the whole point is
+# that it must work when the process cannot answer HTTP, which is exactly
+# when an /api/ metric is unavailable.  It runs BEFORE the liveness
+# branch so it reports on every tick, alive or not.
+#
+# It only ever REPORTS.  No restart on a threshold: the liveness rule
+# above is the only thing allowed to restart this service, and adding a
+# second independent restart trigger during an incident repair is how you
+# get a bounce loop nobody predicted.
+#
+# Thresholds are absolute, not a percentage of the limit.  A healthy
+# process measures ~16 descriptors, so 80% of an 8192 soft limit would
+# be a 400x excursion — an alarm that only fires once the situation is
+# already unrecoverable.  256 is ~16x normal: far outside anything this
+# workload does, far below anything that breaks.
+FD_WARN="${FD_WARN:-256}"
+FD_CRIT="${FD_CRIT:-512}"
+FD_EMERG="${FD_EMERG:-768}"
+FD_TIER_FILE="${HEALTH_STATE_DIR}/fd-tier"
+
+fd_watch() {
+    local pid soft total tier prev sockets files anon uptime
+    pid="$(systemctl show "${HEALTH_SERVICE}.service" -p MainPID --value 2>/dev/null)"
+    [[ -n "${pid}" && "${pid}" != "0" ]] || return 0
+
+    # /proc/PID/fd is the canonical count of OPEN DESCRIPTORS.  Deliberately
+    # not lsof: its output also carries memory mappings, cwd and the text
+    # segment, so counting its REG rows answers a different question.
+    total="$(find "/proc/${pid}/fd" -maxdepth 1 -type l 2>/dev/null | wc -l)"
+    # A denied or vanished /proc yields 0 from `find`, and "0 descriptors"
+    # is not a state a running server can be in — report nothing rather
+    # than a false all-clear.
+    (( total > 0 )) || return 0
+
+    # The kernel's soft limit for THIS process, not the unit's declared
+    # value: a drop-in or a manual ulimit can make them differ, and EMFILE
+    # is raised against the kernel's.
+    soft="$(awk '/^Max open files/{print $4}' "/proc/${pid}/limits" 2>/dev/null)"
+    [[ "${soft}" =~ ^[0-9]+$ ]] || soft=0
+
+    if   (( total >= FD_EMERG )); then tier=EMERGENCY
+    elif (( total >= FD_CRIT ));  then tier=CRITICAL
+    elif (( total >= FD_WARN ));  then tier=WARNING
+    else tier=OK
+    fi
+
+    prev="$(cat "${FD_TIER_FILE}" 2>/dev/null || echo OK)"
+    printf '%s\n' "${tier}" > "${FD_TIER_FILE}"
+    [[ "${tier}" == "${prev}" ]] && return 0   # transitions only, not every minute
+
+    if [[ "${tier}" == "OK" ]]; then
+        log "fd: recovered — ${total} descriptors (was ${prev})"
+        return 0
+    fi
+
+    # Only pay for the breakdown when something is actually wrong.  Which
+    # KIND is growing is the question a responder needs answered first,
+    # and it is unrecoverable once the process is gone.
+    sockets=0; files=0; anon=0
+    while IFS= read -r l; do
+        case "$(readlink "$l" 2>/dev/null)" in
+            socket:*)     sockets=$((sockets+1)) ;;
+            anon_inode:*) anon=$((anon+1)) ;;
+            /*)           files=$((files+1)) ;;
+        esac
+    done < <(find "/proc/${pid}/fd" -maxdepth 1 -type l 2>/dev/null)
+    uptime="$(systemctl show "${HEALTH_SERVICE}.service" -p ActiveEnterTimestamp --value 2>/dev/null)"
+
+    log "fd ${tier}: pid=${pid} fds=${total} soft_limit=${soft} used=$(( soft > 0 ? total * 100 / soft : 0 ))% sockets=${sockets} files=${files} anon=${anon} up_since='${uptime}' (report only — not restarting)"
+}
+
+fd_watch || true
+
 # LIVENESS probe: no -f — any HTTP status is proof of life.  rc != 0
 # means curl got no usable HTTP response (connection refused, timeout,
 # empty reply, ...) and only that counts as a liveness failure.

--- a/deploy/systemd/dynasty.service.template
+++ b/deploy/systemd/dynasty.service.template
@@ -38,6 +38,29 @@ EnvironmentFile=-__APP_DIR__/.env
 MemoryHigh=2560M
 MemoryMax=3G
 
+# ── File descriptors ────────────────────────────────────────────────
+# This unit set no LimitNOFILE, so the process inherited the distro's
+# 1024 SOFT default (hard 524288) — and 1024 is the number EMFILE is
+# raised against.  On 2026-08-12 the backend hit it: 1,212
+# `OSError: [Errno 24] Too many open files` from `socket.accept()`,
+# after which the kernel kept completing TCP handshakes into the listen
+# backlog while the application answered nothing, so nginx connected in
+# 0.4 ms and waited its full 300 s read timeout.
+#
+# `soft:hard` is systemd's documented syntax for the split (systemd.exec,
+# verified against systemd 255 rather than assumed).  Raising the soft
+# limit and leaving the hard limit alone means the process can open more
+# without granting it a larger ceiling than the host already permitted.
+#
+# 8192 is DEFENCE IN DEPTH, NOT THE FIX.  A healthy process measures
+# ~16 descriptors; 1024 was not a tight budget, it was a floor something
+# managed to reach.  Whatever accumulated is unresolved, and a bigger
+# number buys time to notice rather than removing the failure mode —
+# which is why the minutely healthcheck now reports FD utilisation
+# (deploy/systemd/dynasty-healthcheck.sh) with absolute thresholds far
+# below this limit.
+LimitNOFILE=8192:524288
+
 # ── Sandbox-lite hardening ──────────────────────────────────────────
 # PrivateTmp gives the service (and Playwright browser profiles) an
 # isolated /tmp.  Stronger knobs are deliberately NOT enabled:

--- a/frontend/__tests__/server-backend.test.js
+++ b/frontend/__tests__/server-backend.test.js
@@ -1,0 +1,112 @@
+// The server-side backend fetch must be BOUNDED.
+//
+// The 2026-08-12 production incident: the FastAPI process exhausted its
+// file descriptors, so it accepted TCP connections and answered nothing.
+// Every server component fetched it with `try { await fetch(…) } catch`,
+// which handles a REFUSED connection and not silence — Node's fetch
+// bounds the connect phase, not the response. `next build` hung
+// generating /league, gave up after 3 x 60 s, and failed the deploy.
+//
+// The full-build acceptance test lives in
+// `scripts/hanging-backend.mjs` + `npm run build`; it takes minutes and
+// is recorded in the incident PR. This file is the cheap gate that runs
+// on every PR: it pins the property that made the build hang, not the
+// build.
+
+import { describe, expect, it, afterEach, vi } from "vitest";
+
+import { backendOrigin, fetchBackendJson } from "../lib/server-backend.js";
+
+const REAL_FETCH = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = REAL_FETCH;
+  delete process.env.BACKEND_API_URL;
+  delete process.env.BACKEND_SERVER_FETCH_TIMEOUT_MS;
+  vi.restoreAllMocks();
+});
+
+describe("the request carries a bound", () => {
+  it("passes an AbortSignal on every call", async () => {
+    let seen = null;
+    globalThis.fetch = async (_url, init) => {
+      seen = init;
+      return { ok: true, json: async () => ({ league: {} }) };
+    };
+    await fetchBackendJson("/api/public/league/overview", { revalidate: 60 });
+    expect(seen?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("still asks Next to cache — the bound is not a cache opt-out", async () => {
+    let seen = null;
+    globalThis.fetch = async (_url, init) => {
+      seen = init;
+      return { ok: true, json: async () => ({ league: {} }) };
+    };
+    await fetchBackendJson("/api/public/league/overview", { revalidate: 60 });
+    expect(seen?.next).toEqual({ revalidate: 60 });
+  });
+
+  it("gives up on a backend that accepts and never answers", async () => {
+    process.env.BACKEND_SERVER_FETCH_TIMEOUT_MS = "40";
+    // The incident, in one line: a promise that never settles on its
+    // own. Only the signal can end this.
+    globalThis.fetch = (_url, init) =>
+      new Promise((_resolve, reject) => {
+        init.signal.addEventListener("abort", () => reject(init.signal.reason));
+      });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const started = Date.now();
+    const out = await fetchBackendJson("/api/public/league/overview");
+    const elapsed = Date.now() - started;
+
+    expect(out).toBeNull();
+    expect(elapsed).toBeLessThan(2000);
+  });
+});
+
+describe("failure is one answer, not four", () => {
+  it("returns null when the connection is refused", async () => {
+    globalThis.fetch = async () => {
+      throw Object.assign(new Error("connect ECONNREFUSED"), { name: "TypeError" });
+    };
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(await fetchBackendJson("/api/public/league/overview")).toBeNull();
+  });
+
+  it("returns null on a non-ok status", async () => {
+    globalThis.fetch = async () => ({ ok: false, status: 503, json: async () => ({}) });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(await fetchBackendJson("/api/public/league/overview")).toBeNull();
+  });
+
+  it("returns null on a body that is not JSON", async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => {
+        throw new SyntaxError("Unexpected token <");
+      },
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(await fetchBackendJson("/api/public/league/overview")).toBeNull();
+  });
+
+  it("passes a healthy payload through untouched", async () => {
+    const payload = { contractVersion: "x", league: { leagueName: "L" }, data: {} };
+    globalThis.fetch = async () => ({ ok: true, json: async () => payload });
+    expect(await fetchBackendJson("/api/public/league/overview")).toEqual(payload);
+  });
+});
+
+describe("the origin is derived, not concatenated", () => {
+  it("keeps protocol and host and drops any path", () => {
+    process.env.BACKEND_API_URL = "http://10.0.0.4:8000/api/leftover";
+    expect(backendOrigin()).toBe("http://10.0.0.4:8000");
+  });
+
+  it("falls back to loopback on an unparseable value", () => {
+    process.env.BACKEND_API_URL = "not a url";
+    expect(backendOrigin()).toBe("http://127.0.0.1:8000");
+  });
+});

--- a/frontend/app/league/page.jsx
+++ b/frontend/app/league/page.jsx
@@ -13,18 +13,10 @@
 // /api/public/league endpoint.
 
 import { cache } from "react";
+import { connection } from "next/server";
 import LeagueClient from "./LeagueClient.jsx";
+import { fetchBackendJson } from "../../lib/server-backend.js";
 import { DEFAULT_TAB, normalizeTabKey, sectionForTab } from "./tabs.js";
-
-function _backend() {
-  const base = process.env.BACKEND_API_URL || "http://127.0.0.1:8000";
-  try {
-    const u = new URL(base);
-    return `${u.protocol}//${u.host}`;
-  } catch {
-    return "http://127.0.0.1:8000";
-  }
-}
 
 // Fetch ONE public-contract section.  Shape: {contractVersion, league,
 // section, data} — every section response carries the ``league`` block,
@@ -61,17 +53,41 @@ function _backend() {
 // React cache(): ``generateMetadata`` and the page body both await the
 // overview section during one render pass, and de-duping that is the
 // difference between one backend call and two.
+//
+// BUILD INDEPENDENCE (2026-08-12 incident).  `await connection()` is the
+// first thing here, and it is load-bearing rather than decorative.
+//
+// This route is already dynamic — the production build stamps it `ƒ`,
+// server-rendered on demand — but Next still EVALUATES it during
+// `next build` to discover that, and `generateMetadata` runs in the same
+// pass.  So the build issued this fetch.  With the backend accepting
+// connections and never answering, the render hung, Next killed it at
+// its 60 s page-generation limit, retried twice, and failed the build:
+//
+//     Failed to build /league/page: /league after 3 attempts.
+//     Export encountered an error on /league/page: /league, exiting the build.
+//
+// `connection()` aborts the render at THIS line during prerendering, so
+// the fetch is never issued and the build cannot depend on a live
+// FastAPI process. At request time it resolves immediately and costs
+// nothing. That is the mechanism, not a longer timeout — the previous
+// note in this file assumed a dynamic route was already exempt from the
+// build, and it is not.
+//
+// Placed inside `fetchSection` rather than at the top of the page and
+// again in `generateMetadata`: this is the single choke point for every
+// backend call on this route, so a future caller cannot forget it.
+//
+// The fetch itself is bounded by `lib/server-backend.js` (8 s), which is
+// the separate, request-time half of the same incident: a wedged backend
+// must not hold a visitor's connection either.
 const fetchSection = cache(async function fetchSection(section) {
-  const url = `${_backend()}/api/public/league/${encodeURIComponent(section)}`;
-  try {
-    const res = await fetch(url, { next: { revalidate: 60 } });
-    if (!res.ok) return null;
-    const data = await res.json();
-    if (!data || typeof data !== "object" || !data.league) return null;
-    return data;
-  } catch {
-    return null;
-  }
+  await connection();
+  const data = await fetchBackendJson(`/api/public/league/${encodeURIComponent(section)}`, {
+    revalidate: 60,
+  });
+  if (!data || typeof data !== "object" || !data.league) return null;
+  return data;
 });
 
 export async function generateMetadata() {

--- a/frontend/app/league/page.jsx
+++ b/frontend/app/league/page.jsx
@@ -78,9 +78,11 @@ import { DEFAULT_TAB, normalizeTabKey, sectionForTab } from "./tabs.js";
 // again in `generateMetadata`: this is the single choke point for every
 // backend call on this route, so a future caller cannot forget it.
 //
-// The fetch itself is bounded by `lib/server-backend.js` (8 s), which is
+// The fetch itself is bounded by `lib/server-backend.js` (3 s), which is
 // the separate, request-time half of the same incident: a wedged backend
-// must not hold a visitor's connection either.
+// must not hold a visitor's connection either.  The budget lives there,
+// not here — this comment names it only for orientation, and it said 8 s
+// for one revision after the value moved.
 const fetchSection = cache(async function fetchSection(section) {
   await connection();
   const data = await fetchBackendJson(`/api/public/league/${encodeURIComponent(section)}`, {

--- a/frontend/app/sitemap.js
+++ b/frontend/app/sitemap.js
@@ -4,17 +4,23 @@
 // manager + matchup + player indexes from the backend so every
 // deep-linked page (franchise, rivalry, matchup recap, player
 // journey) gets its own entry.  Falls back to just the static routes
-// if the backend is unreachable at build time.
+// if the backend gives no usable answer at build time.
+//
+// That fallback used to cover only an UNREACHABLE backend.  The three
+// fetches below ran unbounded, so a backend that accepted connections
+// and never answered — the 2026-08-12 file-descriptor exhaustion — left
+// them pending rather than falling back, three times in sequence.  This
+// route stays statically generated (`revalidate` 10 m); what changed is
+// that each fetch now has a bounded budget, so "no usable answer"
+// includes silence and the documented fallback actually happens.
+//
+// Deliberately NOT given the `connection()` treatment that
+// `app/league/page.jsx` got: a sitemap is legitimately static, and
+// forcing it to render per request to fix a timeout would be a product
+// change dressed as a repair.  A build during an outage emits the static
+// routes only, for one revalidate window.
 
-function _backend() {
-  const base = process.env.BACKEND_API_URL || "http://127.0.0.1:8000";
-  try {
-    const u = new URL(base);
-    return `${u.protocol}//${u.host}`;
-  } catch {
-    return "http://127.0.0.1:8000";
-  }
-}
+import { fetchBackendJson } from "../lib/server-backend.js";
 
 function _origin() {
   return (
@@ -25,15 +31,7 @@ function _origin() {
 }
 
 async function _fetchJson(path) {
-  try {
-    const res = await fetch(`${_backend()}${path}`, {
-      next: { revalidate: 600 },
-    });
-    if (!res.ok) return null;
-    return await res.json();
-  } catch {
-    return null;
-  }
+  return fetchBackendJson(path, { revalidate: 600 });
 }
 
 export default async function sitemap() {

--- a/frontend/lib/server-backend.js
+++ b/frontend/lib/server-backend.js
@@ -1,0 +1,106 @@
+// The one way a SERVER component talks to the FastAPI backend.
+//
+// Every server-side caller had the same shape:
+//
+//     try { const res = await fetch(url, {next:{revalidate}}); … }
+//     catch { return null }
+//
+// which handles a REFUSED connection — microseconds, `catch`, `null` —
+// and does nothing at all about SILENCE.  Node's `fetch` bounds the
+// connect phase and not the response, so a backend that accepts the
+// socket and never writes leaves the await pending forever.
+//
+// That is not hypothetical.  On 2026-08-12 the production FastAPI
+// process exhausted its file descriptors (`OSError: [Errno 24] Too many
+// open files`, raised from `socket.accept()`), so the kernel completed
+// every handshake into the listen backlog and the application answered
+// nothing.  `next build` then hung generating /league, gave up after
+// 3 x 60 s, and failed the deploy — the deploy that would have restarted
+// the wedged process.  Reproduced locally against
+// `scripts/hanging-backend.mjs`: byte-identical failure, 225 s.
+//
+// So: one helper, one bounded budget, one place to change it.
+//
+// `null` means "no usable answer" and deliberately does not distinguish
+// refused / timed out / 500 / malformed.  Every call site already
+// branches on exactly that, and the callers' fallback — let the client
+// fetch it — is the same in all four cases.  The reason is logged, not
+// returned, because a page that renders differently per failure mode is
+// four render paths nobody tests.
+
+const DEFAULT_TIMEOUT_MS = 8000;
+
+// 8 s is `VERIFY_CURL_TIMEOUT` from `deploy/verify-deploy.sh` — this
+// repo's already-declared "the backend should have answered by now"
+// budget for the deploy's own probes.  Reused rather than invented so
+// there is one number to move.
+//
+// It is deliberately NOT the 20 s that `deploy.yml`'s smoke test allows
+// `/api/public/league`.  That allowance exists because the public-league
+// snapshot is ALWAYS cold right after a restart — the first request
+// kicks a multi-season Sleeper rebuild "that can take minutes" — and the
+// deploy is willing to WAIT for warm because it is verifying, once.  A
+// visitor is not.  When the snapshot is cold the right answer is to give
+// up in seconds and let the client fetch it, which is the path this page
+// already takes on any other failure.
+//
+// Overridable for an operator who wants to trade latency for SSR
+// coverage on a slow box; not something a page should choose per call.
+function defaultTimeoutMs() {
+  const raw = process.env.BACKEND_SERVER_FETCH_TIMEOUT_MS;
+  if (!raw) return DEFAULT_TIMEOUT_MS;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_TIMEOUT_MS;
+}
+
+// Origin only — path and query come from the caller.  Was copy-pasted
+// into sitemap.js, league/page.jsx and every league sub-route.
+export function backendOrigin() {
+  const base = process.env.BACKEND_API_URL || "http://127.0.0.1:8000";
+  try {
+    const u = new URL(base);
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return "http://127.0.0.1:8000";
+  }
+}
+
+/**
+ * Fetch JSON from the backend with a bounded response budget.
+ *
+ * @param {string} path      absolute path, e.g. "/api/public/league"
+ * @param {object} [opts]
+ * @param {number} [opts.revalidate]  seconds for Next's Data Cache
+ * @param {number} [opts.timeoutMs]   override the default budget
+ * @returns {Promise<any|null>} parsed JSON, or null on any failure
+ */
+export async function fetchBackendJson(path, opts = {}) {
+  const { revalidate, timeoutMs } = opts;
+  const url = `${backendOrigin()}${path}`;
+  const budget = timeoutMs ?? defaultTimeoutMs();
+
+  const init = { signal: AbortSignal.timeout(budget) };
+  if (revalidate !== undefined) init.next = { revalidate };
+
+  // `signal` composes with Next's Data Cache: `patch-fetch` forwards it
+  // on a live request and drops it when revalidating in the background,
+  // and the cache opt-out conditions key on `cache: no-store|no-cache`,
+  // not on the presence of a signal.  Verified against next@16.2.12
+  // rather than assumed — a helper that silently disabled caching would
+  // trade a hang for a 2 MB re-fetch on every render.
+  try {
+    const res = await fetch(url, init);
+    if (!res.ok) {
+      console.warn(`[server-backend] ${path} -> HTTP ${res.status}`);
+      return null;
+    }
+    return await res.json();
+  } catch (err) {
+    // TimeoutError is the case this helper exists for; name it, because
+    // "the backend is slow" and "the backend is gone" want different
+    // operator responses even though the page renders identically.
+    const kind = err?.name === "TimeoutError" ? `no response in ${budget}ms` : err?.name || "error";
+    console.warn(`[server-backend] ${path} -> ${kind}`);
+    return null;
+  }
+}

--- a/frontend/lib/server-backend.js
+++ b/frontend/lib/server-backend.js
@@ -1,6 +1,16 @@
-// The one way a SERVER component talks to the FastAPI backend.
+// Bounded backend reads for SERVER-RENDERED pages and metadata.
 //
-// Every server-side caller had the same shape:
+// Scope, stated narrowly because it was overstated once: this covers the
+// server components and metadata functions that read the backend during
+// a render or a build — `app/league/page.jsx` and `app/sitemap.js`
+// today.  It is NOT a consolidation of every frontend-to-backend call.
+// The Next API bridge routes under `app/api/**/route.js` also read
+// `BACKEND_API_URL` and are deliberately untouched: they run per request
+// on behalf of a browser that has its own timeout and retry behaviour,
+// they never run during `next build`, and rewriting them would be a
+// broad proxy change with none of the evidence that motivated this one.
+//
+// Every server-side render caller had the same shape:
 //
 //     try { const res = await fetch(url, {next:{revalidate}}); … }
 //     catch { return null }
@@ -28,21 +38,36 @@
 // returned, because a page that renders differently per failure mode is
 // four render paths nobody tests.
 
-const DEFAULT_TIMEOUT_MS = 8000;
+const DEFAULT_TIMEOUT_MS = 3000;
 
-// 8 s is `VERIFY_CURL_TIMEOUT` from `deploy/verify-deploy.sh` — this
-// repo's already-declared "the backend should have answered by now"
-// budget for the deploy's own probes.  Reused rather than invented so
-// there is one number to move.
+// This is a VISITOR-FACING budget, so it comes from the site's
+// interactive performance standard, not from an operational one:
 //
-// It is deliberately NOT the 20 s that `deploy.yml`'s smoke test allows
-// `/api/public/league`.  That allowance exists because the public-league
-// snapshot is ALWAYS cold right after a restart — the first request
-// kicks a multi-season Sleeper rebuild "that can take minutes" — and the
-// deploy is willing to WAIT for warm because it is verifying, once.  A
-// visitor is not.  When the snapshot is cold the right answer is to give
-// up in seconds and let the client fetch it, which is the path this page
-// already takes on any other failure.
+//   <=1 s  warm/cached target
+//   <=2 s  normal production p95 where architectural
+//   <=3 s  preferred supported cold/useful path
+//   <=5 s  absolute interactive useful-state failure ceiling
+//
+// 3 s is the "cold but still useful" rung, and this fetch is exactly
+// that case: the page has a working client-side fallback, so the cost of
+// giving up early is one extra client round trip, while the cost of
+// waiting is the whole document.  Measured against a hanging backend the
+// document completes in ~3.1 s, inside the 5 s ceiling with room spare.
+//
+// An earlier revision used 8 s, taken from `VERIFY_CURL_TIMEOUT` in
+// `deploy/verify-deploy.sh`.  That was the wrong source: it is a DEPLOY
+// VERIFICATION budget — a machine confirming a release, once, willing to
+// wait — and reusing it here quietly imported an operational tolerance
+// into a human-facing path.  It also blew the 5 s ceiling outright
+// (8.05 s measured).  Deploy and verification budgets stay independent
+// and may be longer; they are not evidence about what a visitor should
+// wait.
+//
+// Same reasoning rules out the 20 s `deploy.yml` allows
+// `/api/public/league`.  That exists because the public-league snapshot
+// is ALWAYS cold after a restart — the first request kicks a
+// multi-season Sleeper rebuild "that can take minutes" — and the deploy
+// polls until warm. A visitor cannot be asked to hold that open.
 //
 // Overridable for an operator who wants to trade latency for SSR
 // coverage on a slow box; not something a page should choose per call.

--- a/frontend/scripts/hanging-backend.mjs
+++ b/frontend/scripts/hanging-backend.mjs
@@ -1,0 +1,47 @@
+// A backend that accepts TCP connections and never answers.
+//
+// This is the production failure mode of 2026-08-12, reduced to a
+// harness.  The FastAPI process had exhausted its file descriptors
+// (`OSError: [Errno 24] Too many open files` raised from
+// `socket.accept()`), so the kernel completed every handshake into the
+// listen backlog and the application never wrote a byte.  From the
+// outside that is indistinguishable from a very slow server: nginx
+// connected in 0.4 ms and then waited its full 300 s
+// `proxy_read_timeout`.
+//
+// It is NOT the same as "the backend is down".  A refused connection
+// fails in microseconds and every caller here already handles it.
+// Silence is the case that hangs.
+//
+// Usage:
+//   node scripts/hanging-backend.mjs [port]
+//
+// Then point the frontend at it and build:
+//   BACKEND_API_URL=http://127.0.0.1:8123 npm run build
+//
+// The socket is held open deliberately — do not add a timeout here.
+
+import net from "node:net";
+
+const port = Number(process.argv[2] || 8123);
+const held = [];
+
+const server = net.createServer((socket) => {
+  // Keep a reference so the socket is not garbage collected, and never
+  // write to it.  `setKeepAlive` stops the OS from tearing the
+  // connection down on its own, which would turn this into a
+  // connection-reset test instead of a hang test.
+  socket.setKeepAlive(true);
+  held.push(socket);
+});
+
+server.listen(port, "127.0.0.1", () => {
+  process.stdout.write(`hanging-backend listening on 127.0.0.1:${port}\n`);
+});
+
+for (const sig of ["SIGINT", "SIGTERM"]) {
+  process.on(sig, () => {
+    for (const s of held) s.destroy();
+    server.close(() => process.exit(0));
+  });
+}

--- a/frontend/scripts/mock-backend.mjs
+++ b/frontend/scripts/mock-backend.mjs
@@ -1,0 +1,67 @@
+// A backend that answers /api/public/league/* with a valid payload.
+//
+// The counterpart to `hanging-backend.mjs`.  Together they let the
+// /league route be checked at both ends of the 2026-08-12 incident
+// without a real FastAPI process:
+//
+//   hanging-backend  → the build must still succeed, and a request must
+//                      degrade in seconds rather than hang
+//   mock-backend     → a healthy backend must still be server-rendered,
+//                      because that is the behaviour the incident repair
+//                      is not allowed to trade away
+//
+// The payload shape is the public contract's section envelope:
+// {contractVersion, league, section, data} — see
+// `app/league/page.jsx::fetchSection`, which rejects anything without a
+// `league` block.
+//
+// Usage:
+//   node scripts/mock-backend.mjs [port]
+
+import http from "node:http";
+
+const port = Number(process.argv[2] || 8124);
+
+// Deliberately unmistakable: if these strings reach the served HTML,
+// they can only have come from a server-side fetch of this process.
+const LEAGUE_NAME = "MOCK LEAGUE SSR PROBE";
+const SEASON_RANGE = "2024-2026";
+
+function sectionPayload(section) {
+  return {
+    contractVersion: "mock.v1",
+    league: {
+      leagueName: LEAGUE_NAME,
+      seasonsCovered: [2024, 2025, 2026],
+      managers: [{ ownerId: "owner-1", displayName: "Mock Manager" }],
+    },
+    section,
+    data: {
+      seasonRangeLabel: SEASON_RANGE,
+      currentChampion: { displayName: "Mock Champ" },
+    },
+  };
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://127.0.0.1:${port}`);
+  const m = url.pathname.match(/^\/api\/public\/league\/([^/]+)$/);
+  if (m) {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify(sectionPayload(decodeURIComponent(m[1]))));
+    return;
+  }
+  if (url.pathname === "/api/public/league") {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ...sectionPayload("overview"), sections: {} }));
+    return;
+  }
+  res.writeHead(404, { "content-type": "application/json" });
+  res.end(JSON.stringify({ error: "not_found" }));
+});
+
+server.listen(port, "127.0.0.1", () => {
+  process.stdout.write(`mock-backend listening on 127.0.0.1:${port}\n`);
+});
+
+export { LEAGUE_NAME, SEASON_RANGE };

--- a/tests/deploy/test_fd_hardening.py
+++ b/tests/deploy/test_fd_hardening.py
@@ -1,0 +1,151 @@
+"""File-descriptor hardening and observability, pinned.
+
+Incident of 2026-08-12.  ``socket.accept()`` raised
+``OSError: [Errno 24] Too many open files`` 1,212 times from PID 887292,
+first at 16:47:46 local.  The kernel kept completing TCP handshakes into
+the listen backlog while the application answered nothing, so nginx
+connected in 0.4 ms and then waited its full 300 s ``proxy_read_timeout``.
+
+Two facts, and the gap between them is what these tests hold open:
+
+* the unit declared no ``LimitNOFILE``, so the process ran with the
+  distro's **1024 soft** default — the number EMFILE is raised against;
+* nothing anywhere reported the descriptor count on the way up, so the
+  first signal was total unavailability.
+
+What accumulated is **unresolved**.  A healthy process measures ~16
+descriptors and stayed flat across a full observation window, so 1024
+was not a tight budget — it was a floor something managed to reach.
+These tests therefore pin *defence in depth and visibility*, and
+deliberately do not pretend to pin a fix.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UNIT = REPO_ROOT / "deploy" / "systemd" / "dynasty.service.template"
+HEALTHCHECK = REPO_ROOT / "deploy" / "systemd" / "dynasty-healthcheck.sh"
+INVENTORY = REPO_ROOT / "deploy" / "diagnostics" / "fd_inventory.sh"
+
+
+class TestTheUnitDeclaresAnExplicitFileDescriptorLimit:
+    def test_limitnofile_is_set(self):
+        assert re.search(r"^LimitNOFILE=", UNIT.read_text(), re.M), (
+            "dynasty.service.template sets no LimitNOFILE, so the process "
+            "inherits the distro's 1024 soft default — the limit EMFILE was "
+            "raised against on 2026-08-12"
+        )
+
+    def test_the_soft_limit_is_raised_and_the_hard_limit_is_not(self):
+        """``soft:hard`` — systemd.exec's documented split.
+
+        Raising the soft limit lets the process open more; leaving the
+        hard limit at what the host already permitted means this grants
+        no new ceiling.
+        """
+        m = re.search(r"^LimitNOFILE=(\d+):(\d+)\s*$", UNIT.read_text(), re.M)
+        assert m, "LimitNOFILE should use systemd's soft:hard form"
+        soft, hard = int(m.group(1)), int(m.group(2))
+        assert soft > 1024, f"soft limit {soft} is not above the 1024 default that failed"
+        assert soft <= hard, f"soft {soft} exceeds hard {hard}"
+        assert hard == 524288, (
+            f"hard limit changed to {hard}; it was 524288 before the incident and "
+            "raising it is a separate decision from raising the soft limit"
+        )
+
+    def test_the_limit_is_documented_as_defence_not_a_fix(self):
+        """A number without its reasoning gets 'tuned' away later."""
+        text = UNIT.read_text()
+        assert "Errno 24" in text, "the limit does not reference the incident that motivated it"
+        assert "NOT THE FIX" in text.upper(), (
+            "nothing records that this is defence in depth — a later reader "
+            "will take it for the root-cause repair"
+        )
+
+
+class TestSomethingWatchesTheDescriptorCount:
+    """It must work when the process cannot answer HTTP.
+
+    That is the whole requirement: during the incident the backend served
+    nothing, so any metric exposed by the application itself would have
+    been unavailable exactly when it was needed.
+    """
+
+    def test_the_watch_lives_in_the_out_of_process_healthcheck(self):
+        text = HEALTHCHECK.read_text()
+        assert "fd_watch" in text, (
+            "no FD watch in the minutely healthcheck — the only monitor here "
+            "that does not depend on the backend answering"
+        )
+
+    def test_it_reads_proc_rather_than_asking_the_application(self):
+        text = HEALTHCHECK.read_text()
+        assert "/proc/${pid}/fd" in text
+        assert "/api/fd" not in text, (
+            "the FD count must not come from an application endpoint; the "
+            "process being unable to answer is the condition being watched"
+        )
+
+    def test_thresholds_are_absolute_and_far_below_the_limit(self):
+        """80% of 8192 would only fire once it is already unrecoverable.
+
+        Normal is ~16 descriptors, so the alarm belongs near normal, not
+        near the ceiling.
+        """
+        text = HEALTHCHECK.read_text()
+        warn = int(re.search(r'FD_WARN="\$\{FD_WARN:-(\d+)\}"', text).group(1))
+        crit = int(re.search(r'FD_CRIT="\$\{FD_CRIT:-(\d+)\}"', text).group(1))
+        emerg = int(re.search(r'FD_EMERG="\$\{FD_EMERG:-(\d+)\}"', text).group(1))
+        assert warn < crit < emerg, "thresholds must escalate"
+        assert warn <= 256, f"warning at {warn} is too late for a ~16-descriptor baseline"
+        assert emerg <= 1024, (
+            f"emergency at {emerg} is above the 1024 that actually failed — the "
+            "alarm would arrive after the outage"
+        )
+
+    def test_it_reports_and_never_restarts(self):
+        """The liveness rule is the only thing allowed to restart.
+
+        A second, independent restart trigger added during an incident
+        repair is how a bounce loop nobody predicted gets shipped.
+        """
+        text = HEALTHCHECK.read_text()
+        fd_block = text[text.index("fd_watch()") : text.index("# LIVENESS probe")]
+        assert (
+            "systemctl restart" not in fd_block
+        ), "the FD watch restarts the service; it must only report"
+
+    def test_a_warning_names_which_kind_of_descriptor_is_growing(self):
+        """Which family grows is the first question a responder has.
+
+        It is also unrecoverable once the process is gone — which is
+        precisely why this incident's cause is unresolved.
+        """
+        text = HEALTHCHECK.read_text()
+        for field in ("sockets=", "files=", "anon=", "soft_limit="):
+            assert field in text, f"FD warning does not report {field}"
+
+
+class TestTheDiagnosticDoesNotMisreadItsOwnEvidence:
+    def test_file_nr_is_not_labelled_free(self):
+        """The middle column is unused-but-allocated, not 'free'.
+
+        On modern kernels it is essentially always 0, so reading it as
+        remaining capacity inverts the meaning.
+        """
+        text = INVENTORY.read_text()
+        assert "allocated / free / max" not in text
+        assert "allocated / unused / max" in text
+
+    def test_lsof_is_not_presented_as_an_fd_count(self):
+        """lsof lists mappings, cwd and the text segment too.
+
+        Its REG rows exceed the open regular-file descriptors, so the
+        canonical count has to come from /proc/PID/fd.
+        """
+        text = INVENTORY.read_text()
+        assert "NOT an FD count" in text
+        assert "canonical" in text

--- a/tests/deploy/test_rollback_frontend_atomicity.py
+++ b/tests/deploy/test_rollback_frontend_atomicity.py
@@ -259,9 +259,7 @@ class TestBothScriptsAgree:
 
     def test_the_rollback_build_status_is_read(self):
         text = ROLLBACK_SH.read_text()
-        assert "build_rc" in text, (
-            "rollback.sh no longer captures its frontend build's exit status"
-        )
+        assert "build_rc" in text, "rollback.sh no longer captures its frontend build's exit status"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/deploy/test_rollback_frontend_atomicity.py
+++ b/tests/deploy/test_rollback_frontend_atomicity.py
@@ -1,0 +1,270 @@
+"""A failed frontend build must never replace the serviceable one.
+
+Incident of 2026-08-12, defect 4 of 4.  During the auto-rollback the
+frontend rebuild exited 1, and 80 ms later the rollback verified and
+swapped that incomplete staging directory over the last known-good
+``.next``::
+
+    17:22:19.122  Next.js build worker exited with code: 1
+    17:22:19.268  [verify-build] OK: 52 manifest-referenced asset(s)
+    17:22:49.577  Rolled-back frontend build swapped into place
+    17:22:51.704  Frontend service failed to start
+                  ENOENT .../frontend/.next/prerender-manifest.json
+
+The frontend was then down from 17:22:49 until the second rollback
+finished at 17:25:22 — two and a half minutes of self-inflicted outage
+on top of the backend one.
+
+Two independent holes, and the tests below cover both:
+
+* ``rollback.sh`` ran ``npm run build`` in a subshell whose exit status
+  nothing read.  ``deploy.sh`` has the identical subshell and DID abort,
+  because on that path ``set -e`` was live; here ``main()`` calls the
+  function as ``if ! maybe_rebuild_frontend_after_rollback``, and bash
+  disables errexit for the whole body of a function invoked as a
+  condition.  Same code, opposite behaviour.
+* ``verify_frontend_build_manifest`` walked the assets that the manifests
+  REFERENCE, and required only ``build-manifest.json`` to exist.  An
+  aborted export writes that file early and never reaches
+  ``prerender-manifest.json``, so a build that could not start passed
+  verification.
+
+These drive the REAL functions from ``deploy/rollback.sh`` (sourced, not
+reimplemented — a copy would pass while production still broke) against a
+fixture frontend whose ``npm`` is a stub script we control.  The
+invariant under test is the one the incident violated:
+
+    if the staged build is not usable, the live .next is untouched
+    and still serviceable.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROLLBACK_SH = REPO_ROOT / "deploy" / "rollback.sh"
+
+# Every root-level artifact a successful `next build` leaves behind that
+# `next start` opens at boot.  Kept in step with the list in
+# deploy/rollback.sh + deploy/deploy.sh.
+RUNTIME_ARTIFACTS = (
+    "BUILD_ID",
+    "build-manifest.json",
+    "app-path-routes-manifest.json",
+    "prerender-manifest.json",
+    "routes-manifest.json",
+    "required-server-files.json",
+)
+
+KNOWN_GOOD_MARKER = "this-is-the-serviceable-build"
+
+
+def _write_dist(dist: Path, *, marker: str, omit: tuple[str, ...] = ()) -> None:
+    """Write a build output that looks like a real one."""
+    dist.mkdir(parents=True, exist_ok=True)
+    (dist / "static").mkdir(exist_ok=True)
+    (dist / "static" / "app.js").write_text("//js\n")
+    (dist / "MARKER").write_text(marker)
+    for name in RUNTIME_ARTIFACTS:
+        if name in omit:
+            continue
+        if name == "BUILD_ID":
+            (dist / name).write_text("build-id\n")
+        elif name == "build-manifest.json":
+            # One real reference so the asset walk has something to do.
+            (dist / name).write_text(json.dumps({"pages": {"/": ["static/app.js"]}}))
+        else:
+            (dist / name).write_text("{}")
+
+
+@pytest.fixture
+def frontend(tmp_path: Path) -> Path:
+    """An app dir with a serviceable .next and a scriptable `npm`."""
+    app_dir = tmp_path / "app"
+    fe = app_dir / "frontend"
+    fe.mkdir(parents=True)
+    (fe / "package.json").write_text(json.dumps({"name": "fixture"}))
+    _write_dist(fe / ".next", marker=KNOWN_GOOD_MARKER)
+    return app_dir
+
+
+def _stub_npm(bin_dir: Path, *, build_exit: int, produce: str) -> None:
+    """A stand-in `npm` whose build outcome the test chooses.
+
+    ``produce`` is one of: ``complete`` (a full build), ``partial`` (an
+    aborted export — manifests written early, prerender-manifest never
+    reached, which is exactly what production had), or ``none``.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    omit = "prerender-manifest.json" if produce == "partial" else ""
+    script = textwrap.dedent(f"""\
+        #!/usr/bin/env bash
+        # `npm ci` / `npm install` are no-ops here.
+        if [[ "$1" != "run" ]]; then exit 0; fi
+        dist="${{NEXT_DIST_DIR:-.next}}"
+        if [[ "{produce}" != "none" ]]; then
+          mkdir -p "$dist/static"
+          echo '//js' > "$dist/static/app.js"
+          echo 'this-is-the-STAGED-build' > "$dist/MARKER"
+          echo 'build-id' > "$dist/BUILD_ID"
+          echo '{{"pages": {{"/": ["static/app.js"]}}}}' > "$dist/build-manifest.json"
+          for f in app-path-routes-manifest.json prerender-manifest.json \\
+                   routes-manifest.json required-server-files.json; do
+            if [[ "$f" == "{omit}" ]]; then continue; fi
+            echo '{{}}' > "$dist/$f"
+          done
+        fi
+        exit {build_exit}
+        """)
+    npm = bin_dir / "npm"
+    npm.write_text(script)
+    npm.chmod(0o755)
+
+
+def _run_rebuild(app_dir: Path, bin_dir: Path) -> subprocess.CompletedProcess:
+    """Source rollback.sh and run the real rebuild-and-swap function.
+
+    ``systemctl`` is absent from PATH, so the function's
+    ``sudo -n systemctl cat`` probe fails and the service stop/start
+    branch is skipped — the swap itself still runs, which is the part
+    under test.
+
+    The call form is load-bearing and must match ``main()``'s::
+
+        if ! maybe_rebuild_frontend_after_rollback; then
+
+    Bash disables ``errexit`` for the entire body of a function invoked
+    as a condition, and that suppression is *the* mechanism of this
+    incident.  An earlier version of this harness called the function
+    plainly, which left ``set -e`` active, so the failing build aborted
+    on its own and the test passed against the UNFIXED script — proving
+    nothing.  Calling it exactly as production does is what makes the
+    RED real.
+    """
+    driver = textwrap.dedent(f"""\
+        set -Eeuo pipefail
+        export APP_DIR={app_dir!s}
+        export APP_NAME=fixture
+        export SERVICE_NAME=fixture
+        export PATH={bin_dir!s}:$PATH
+        source {ROLLBACK_SH!s}
+        rc=0
+        if ! maybe_rebuild_frontend_after_rollback; then rc=1; fi
+        echo "FUNC_RC=$rc"
+        """)
+    env = dict(os.environ, APP_DIR=str(app_dir))
+    return subprocess.run(
+        ["bash", "-c", driver], capture_output=True, text=True, env=env, timeout=120
+    )
+
+
+def _live_marker(app_dir: Path) -> str | None:
+    p = app_dir / "frontend" / ".next" / "MARKER"
+    return p.read_text().strip() if p.exists() else None
+
+
+def _live_is_serviceable(app_dir: Path) -> bool:
+    dist = app_dir / "frontend" / ".next"
+    return all((dist / name).exists() for name in RUNTIME_ARTIFACTS)
+
+
+class TestAFailedStagedBuildCannotReachTheLiveDirectory:
+    def test_a_nonzero_build_leaves_the_known_good_build_in_place(self, frontend, tmp_path):
+        """The incident, exactly: build exits 1, output is partial."""
+        bin_dir = tmp_path / "bin"
+        _stub_npm(bin_dir, build_exit=1, produce="partial")
+
+        result = _run_rebuild(frontend, bin_dir)
+
+        assert "FUNC_RC=0" not in result.stdout, (
+            "the rollback reported success after its frontend build failed:\n"
+            f"{result.stdout}\n{result.stderr}"
+        )
+        assert _live_marker(frontend) == KNOWN_GOOD_MARKER, (
+            "a FAILED staged build replaced the serviceable frontend — this is "
+            "the 2026-08-12 defect"
+        )
+        assert _live_is_serviceable(frontend)
+
+    def test_the_incomplete_staging_dir_is_not_left_behind(self, frontend, tmp_path):
+        """A half-built .next.new must not be inherited by the next run."""
+        bin_dir = tmp_path / "bin"
+        _stub_npm(bin_dir, build_exit=1, produce="partial")
+        _run_rebuild(frontend, bin_dir)
+        assert not (frontend / "frontend" / ".next.new").exists()
+
+
+class TestAnIncompleteBuildIsNotUsableEvenWhenItExitsZero:
+    """Exit status is necessary, not sufficient.
+
+    A build can report success and still be missing what `next start`
+    opens — and the reference-walk check passed on exactly such a
+    directory in production.
+    """
+
+    def test_missing_prerender_manifest_blocks_the_swap(self, frontend, tmp_path):
+        bin_dir = tmp_path / "bin"
+        _stub_npm(bin_dir, build_exit=0, produce="partial")
+
+        result = _run_rebuild(frontend, bin_dir)
+
+        assert "FUNC_RC=0" not in result.stdout, (
+            "a build with no prerender-manifest.json was accepted; "
+            "next start would ENOENT on it:\n" + result.stdout + result.stderr
+        )
+        assert _live_marker(frontend) == KNOWN_GOOD_MARKER
+        assert _live_is_serviceable(frontend)
+
+
+class TestASuccessfulBuildStillSwaps:
+    """The guard must not be a blanket refusal.
+
+    Without this, every test above passes on a rollback that never
+    swaps anything — which would be a different outage.
+    """
+
+    def test_a_complete_build_replaces_the_live_directory(self, frontend, tmp_path):
+        bin_dir = tmp_path / "bin"
+        _stub_npm(bin_dir, build_exit=0, produce="complete")
+
+        result = _run_rebuild(frontend, bin_dir)
+
+        assert "FUNC_RC=0" in result.stdout, (
+            "a healthy rollback build did not complete:\n" + result.stdout + result.stderr
+        )
+        assert _live_marker(frontend) == "this-is-the-STAGED-build"
+        assert _live_is_serviceable(frontend)
+
+
+class TestBothScriptsAgree:
+    """deploy.sh and rollback.sh must not diverge on this again.
+
+    Their own comments require the two verifiers to stay behaviourally
+    identical; the incident happened in the gap between them.
+    """
+
+    @pytest.mark.parametrize("script", ["deploy.sh", "rollback.sh"])
+    def test_each_requires_the_runtime_artifacts(self, script):
+        text = (REPO_ROOT / "deploy" / script).read_text()
+        for name in RUNTIME_ARTIFACTS:
+            assert f'"{name}"' in text, f"{script} does not require {name}"
+
+    def test_the_rollback_build_status_is_read(self):
+        text = ROLLBACK_SH.read_text()
+        assert "build_rc" in text, (
+            "rollback.sh no longer captures its frontend build's exit status"
+        )
+
+
+@pytest.fixture(autouse=True)
+def _no_stray_dirs(tmp_path):
+    yield
+    shutil.rmtree(tmp_path, ignore_errors=True)


### PR DESCRIPTION
**EMFILE failure mechanism confirmed. FD accumulation source unresolved.**

File-descriptor exhaustion is proven. The resource family that caused the accumulation is not — and one authorized follow-up has now closed the only lead without finding it.

On 2026-08-12 the FastAPI process exhausted its file descriptors. `socket.accept()` raised `OSError: [Errno 24] Too many open files` **1,212 times** from PID 887292, first at **16:47:46 CEST**, against a **1024 soft limit** the unit never declared. The kernel kept completing TCP handshakes into the listen backlog while the application answered nothing, so nginx connected in 0.4 ms and then waited its full 300 s `proxy_read_timeout`.

Four separable repairs, each with its own RED→GREEN evidence. **None of them is the accumulation fix**, because no accumulation source has been identified.

---

## 1. Frontend build independence — `f5cb570bb`

The outage **blocked its own remedy**. `next build` hung generating `/league`, gave up after 3 × 60 s, and failed the deploy that would have restarted the wedged process.

**RED** (`scripts/hanging-backend.mjs` — accepts, never writes): exit 1 after 225 s, byte-identical to production. **GREEN**: exit 0, route table unchanged, zero failures.

- **The build evaluated the route.** `/league` is already `ƒ`, but Next evaluates it during `next build` to discover that, and `generateMetadata` runs in the same pass. `await connection()` now aborts the render before the fetch. Not a longer timeout — the endpoint is documented in `deploy.yml` as taking *minutes* when cold.
- **The fetch had no bound.** `try { await fetch() } catch` handles refusal, not silence. `frontend/lib/server-backend.js` bounds it at **3 s**.

**Scope:** server-render and build-time backend reads only (`app/league/page.jsx`, `app/sitemap.js`). The `app/api/**/route.js` bridge routes also read `BACKEND_API_URL` and are deliberately untouched.

| | |
|---|---|
| healthy backend | 200, TTFB **0.134 s**, `<title>MOCK LEAGUE SSR PROBE · 2024-2026</title>` |
| hanging backend, 3 runs | **3.05 / 3.02 / 3.02 s**, 200, 42,556 bytes |

3 s is the interactive standard's cold-but-useful rung, chosen because the page has a working client fallback. An earlier revision used 8 s from `VERIFY_CURL_TIMEOUT` — a *deploy-verification* budget, and 8.05 s measured, over the 5 s ceiling. Deploy budgets stay independent.

## 2. Rollback atomicity — `84af7f72a`

```
17:22:19.122  Next.js build worker exited with code: 1
17:22:19.268  [verify-build] OK: 52 manifest-referenced asset(s)
17:22:49.577  Rolled-back frontend build swapped into place
17:22:51.704  Frontend service failed to start — ENOENT .next/prerender-manifest.json
```

**80 ms** after the build exited 1, an incomplete `.next.new` replaced the last known-good `.next`. Frontend down 17:22:49 → 17:25:22.

- `rollback.sh` ran `npm run build` in a subshell nothing read. `deploy.sh` has the identical subshell and *did* abort — because `main()` calls this one as `if ! maybe_rebuild_frontend_after_rollback`, and **bash disables errexit for the whole body of a function invoked as a condition**. Now `|| build_rc=$?`.
- The verifier walked manifest-*referenced* assets and required only `build-manifest.json`. Both scripts now require the six root artifacts `next start` opens at boot.

**RED 5 failed / 2 passed → GREEN 7 passed**, driving the real sourced functions. *The first harness called the function plainly, which left errexit active — it passed against the unfixed script and proved nothing.* It now uses production's call form.

## 3. Explicit `LimitNOFILE` — `17d232d75`

`LimitNOFILE=8192:524288` (systemd.exec's soft:hard split, checked against systemd 255). Hard limit unchanged: this grants no new ceiling.

**Defence in depth, not the fix** — stated in the unit and pinned by test. A healthy process measures ~16 descriptors, so 1024 was never a tight budget.

## 4. Out-of-process FD monitoring — `17d232d75`

In `dynasty-healthcheck.sh`, the existing minutely root-run timer. That placement *is* the requirement: during the incident the backend answered nothing, so any metric served by the process would have been unavailable exactly when needed. Reads `/proc/PID/fd`; reports PID, count, kernel soft limit, utilisation, uptime, and socket/file/anon breakdown; transitions only.

Thresholds **256 / 512 / 768**, absolute. 80 % of 8192 would be a 400× excursion from a ~16 baseline. **It only reports.** The liveness rule stays the only thing allowed to restart.

## The one lead, and why it is closed

Forensics put the **Playwright/Chromium launch** as the last application line before exhaustion, followed by 13 minutes of silence, on a process 3h00m old against a 2-hourly scrape.

Lifecycle inspected: in `Dynasty Scraper.py` `await browser.close()` is the **last statement** of the `async with async_playwright()` block, not a `finally`. An exception or a cancellation unwinds past it — the same shape `d7d4edff8` repaired for orphaned Chromium *descendants*.

But a child orphan is not parent FD growth, so it was measured — isolated local process, never the production scraper (`deploy/diagnostics/playwright_fd_probe.py`):

| point | parent fds |
|---|---|
| baseline | 6 (pipe=2) |
| **mid-cycle, browser open** | **8 (pipe=4)** ← driver stdio pipes |
| after close | 6 (pipe=2) |
| after exception cycle × 3 | 6 (pipe=2) |
| after cancellation cycle × 3 | 6 (pipe=2) |
| **11 cycles** | **+0** |

The mid-cycle reading is what makes the flat line worth anything: a count that never moves could equally mean "no leak" or "this instrument sees nothing". Watching it rise to 8 and fall back distinguishes them.

`async_playwright().__aexit__` reclaims the parent's pipes even when control skips `browser.close()`.

**PLAYWRIGHT LEAD NOT REPRODUCED — ACCUMULATION SOURCE REMAINS UNRESOLVED.** No application fix. The lead is closed; the incident's accumulation source is not, and is now monitored rather than guessed at.

**One correction to the record:** every resource-family count in the forensics run returned 0, and that was my bug, not a finding — `date -d` resolves in the shell's timezone, the journal is host-local, and the window selected nothing. The script now prints its window and a sanity count. The `_PID=` queries were exact-match and unaffected, which is why the useful evidence survived.

## Gates

| gate | result |
|---|---|
| `tests/deploy/` + `tests/infra/` | **96 passed** |
| rollback atomicity | 7 passed (RED 5 failed) |
| FD hardening | 11 passed |
| frontend helper (vitest) | 9 passed |
| hanging-backend production build | **exit 0**, 0 failures |
| `ruff check .` / `ruff format --check` | clean |
| shell syntax, all deploy scripts | OK |

## Workflow cleanup

`check-sharp-production-now.yml` is restored from `origin/main` — `git diff origin/main` on that path is **empty**, so its Sharp purpose is byte-identical. `fd-diagnostics.yml` stays as the permanent read-only diagnostic, dispatchable normally once this merges.