### PR TITLE
Hotfix: the watchdog timer gate must read the MONOTONIC next-elapse

### DIFF
--- a/deploy/diagnostics/fd_inventory.sh
+++ b/deploy/diagnostics/fd_inventory.sh
@@ -315,9 +315,59 @@ journal_errno24() {
   echo "count: ${cnt:-0}"
   echo "-- journal retention window --"
   sudo -n "${JOURNALCTL}" -u "${SERVICE_NAME}" --no-pager -o short-iso -n 1 2>/dev/null | tail -1
-  sudo -n "${JOURNALCTL}" -u "${SERVICE_NAME}" --no-pager -o short-iso 2>/dev/null | head -1
+  # `head -1` closes the pipe on a journal that is still streaming, so
+  # journalctl dies of SIGPIPE and `pipefail` reports 141 — a spurious
+  # non-zero on a section that printed its evidence correctly.  Read the
+  # whole stream and take the first line in the shell instead, so the
+  # status reflects the journal, not the reader.
+  local oldest rc=0
+  oldest="$(sudo -n "${JOURNALCTL}" -u "${SERVICE_NAME}" --no-pager -o short-iso 2>/dev/null)" || rc=$?
+  printf '%s\n' "${oldest}" | sed -n '1p'
+  # A journalctl that genuinely failed still degrades this optional
+  # section; only the reader's SIGPIPE is gone.
+  return "${rc}"
 }
 run_optional "earliest Errno 24 in the retained journal" journal_errno24
+
+# ── optional: the watchdog, read directly ───────────────────────────
+# The DEPLOY gate verifies these; this reads them independently so the
+# two are not the same statement twice.
+#
+# Both NextElapse properties are printed, deliberately.  The unit ships
+# `OnBootSec` + `OnUnitActiveSec`, which are MONOTONIC bases, so
+# systemd computes `NextElapseUSecMonotonic`; `NextElapseUSecRealtime`
+# is the CALENDAR next-elapse and is zero for a timer with no calendar
+# event.  Reading only the realtime field is how a correctly scheduled
+# timer reads as "no next activation".
+watchdog_state() {
+  local timer="dynasty-healthcheck.timer" svc="dynasty-healthcheck.service"
+  local prop
+  for prop in LoadState ActiveState UnitFileState \
+              NextElapseUSecRealtime NextElapseUSecMonotonic LastTriggerUSec; do
+    printf '%-26s %s\n' "timer.${prop}" \
+      "$(sudo -n "${SYSTEMCTL}" show "${timer}" -p "${prop}" --value 2>/dev/null)"
+  done
+  printf '%-26s %s\n' "service.LoadState" \
+    "$(sudo -n "${SYSTEMCTL}" show "${svc}" -p LoadState --value 2>/dev/null)"
+
+  local installed="${RISKIT_LIB_DIR:-/usr/local/lib/riskit}/dynasty-healthcheck.sh"
+  if [[ -r "${installed}" ]]; then
+    printf '%-26s %s\n' "watchdog.path" "${installed}"
+    printf '%-26s %s\n' "watchdog.owner" "$(stat -c '%U:%G' "${installed}")"
+    printf '%-26s %s\n' "watchdog.mode" "$(stat -c '%a' "${installed}")"
+    local th
+    for th in 'FD_WARN:-256' 'FD_CRIT:-512' 'FD_EMERG:-768'; do
+      if grep -q "${th}" "${installed}"; then
+        printf '%-26s %s\n' "watchdog.${th%%:*}" "present (${th#*:-})"
+      else
+        printf '%-26s %s\n' "watchdog.${th%%:*}" "MISSING"
+      fi
+    done
+  else
+    printf '%-26s %s\n' "watchdog.path" "${installed} (unreadable)"
+  fi
+}
+run_optional "watchdog units and installed executable" watchdog_state
 
 # ── required: the trend ─────────────────────────────────────────────
 # A single number cannot distinguish a healthy steady state from the

--- a/deploy/reconcile-runtime-controls.sh
+++ b/deploy/reconcile-runtime-controls.sh
@@ -240,6 +240,22 @@ _rc_install_if_different() {
   return 0
 }
 
+
+# Is there a FUTURE monotonic activation?
+#
+# systemd pretty-prints timespan properties, so a scheduled value looks
+# like "2w 3d 2h 8min 32.168902s" rather than a raw integer.  Every
+# rendering that means "nothing scheduled" is rejected; anything else is
+# a real next-elapse.
+_rc_monotonic_elapse_is_scheduled() {
+  local value="$1"
+  [[ -n "${value}" ]] || return 1
+  case "${value}" in
+    0|0s|0us|n/a|infinity) return 1 ;;
+  esac
+  return 0
+}
+
 # ── the two entry points ─────────────────────────────────────────────
 # Both are thin wrappers that scope this file's shell options to their
 # own call and hand the caller back exactly what it had.
@@ -435,18 +451,60 @@ _verify_runtime_controls() {
 
   # watchdog units must be loaded, enabled and ACTIVE.
   local timer="dynasty-healthcheck.timer" svc="dynasty-healthcheck.service"
-  local ls_t as_t ufs_t next ls_s
+  local ls_t as_t ufs_t next_rt next_mono ls_s
   ls_t="$(_rc_sudo "$SC" show "${timer}" -p LoadState --value)"
   as_t="$(_rc_sudo "$SC" show "${timer}" -p ActiveState --value)"
   ufs_t="$(_rc_sudo "$SC" show "${timer}" -p UnitFileState --value)"
-  next="$(_rc_sudo "$SC" show "${timer}" -p NextElapseUSecRealtime --value)"
+  next_rt="$(_rc_sudo "$SC" show "${timer}" -p NextElapseUSecRealtime --value)"
   ls_s="$(_rc_sudo "$SC" show "${svc}" -p LoadState --value)"
-  _rc_log "watchdog: timer load=${ls_t} active=${as_t} file=${ufs_t} next=${next:-none}; service load=${ls_s}"
+
+  # THE SCHEDULED-NEXT PROPERTY IS THE MONOTONIC ONE.
+  #
+  # systemd's Timer interface exposes two next-elapse properties, and
+  # which one it populates follows the timer's BASE:
+  #
+  #   NextElapseUSecRealtime   — next CLOCK_REALTIME/calendar event.
+  #                              Empty when the unit has no OnCalendar.
+  #   NextElapseUSecMonotonic  — next CLOCK_MONOTONIC event, i.e. what
+  #                              OnBootSec / OnUnitActiveSec produce.
+  #
+  # dynasty-healthcheck.timer ships OnBootSec=3min + OnUnitActiveSec=1min,
+  # both monotonic, so the realtime field is empty by construction.
+  # Measured on production 2026-08-13, an hour into the timer firing
+  # every 60 s without interruption:
+  #
+  #   timer.NextElapseUSecRealtime    (empty)
+  #   timer.NextElapseUSecMonotonic   2w 3d 2h 8min 32.168902s
+  #   timer.LastTriggerUSec           Thu 2026-08-13 04:16:02 CEST
+  #
+  # So gating on the realtime field was not a first-activation race — it
+  # is simply the wrong property, and it never becomes non-empty for this
+  # timer.  It failed the #813 deploy against a perfectly scheduled
+  # watchdog.
+  #
+  # LastTriggerUSec is deliberately NOT accepted as a substitute: a past
+  # trigger says the timer HAS run, not that another run is scheduled.
+  # It is logged as context and never gates.
+  local last_trigger attempt
+  last_trigger="$(_rc_sudo "$SC" show "${timer}" -p LastTriggerUSec --value)"
+  # Bounded re-read: defense in depth for a genuine activation-settling
+  # window right after `enable --now`, not the mechanism being relied on.
+  for attempt in 1 2 3 4 5; do
+    next_mono="$(_rc_sudo "$SC" show "${timer}" -p NextElapseUSecMonotonic --value)"
+    if _rc_monotonic_elapse_is_scheduled "${next_mono}"; then break; fi
+    (( attempt < 5 )) && sleep 1
+  done
+
+  _rc_log "watchdog: timer load=${ls_t} active=${as_t} file=${ufs_t}"
+  _rc_log "watchdog: next(monotonic)=${next_mono:-<empty>} next(realtime)=${next_rt:-<empty>} last=${last_trigger:-<never>}; service load=${ls_s}"
   [[ "${ls_t}"  == "loaded"  ]] || { _rc_err "${timer} LoadState=${ls_t}";      rc=1; }
   [[ "${ls_s}"  == "loaded"  ]] || { _rc_err "${svc} LoadState=${ls_s}";        rc=1; }
   [[ "${ufs_t}" == "enabled" ]] || { _rc_err "${timer} UnitFileState=${ufs_t}"; rc=1; }
   [[ "${as_t}"  == "active"  ]] || { _rc_err "${timer} ActiveState=${as_t}";    rc=1; }
-  [[ -n "${next}" && "${next}" != "0" ]] || { _rc_err "${timer} has no next activation"; rc=1; }
+  if ! _rc_monotonic_elapse_is_scheduled "${next_mono}"; then
+    _rc_err "${timer} has no future monotonic activation (NextElapseUSecMonotonic='${next_mono:-<empty>}')"
+    rc=1
+  fi
 
   # the INSTALLED executable, not the checkout copy.
   local installed="${RISKIT_LIB_DIR:-/usr/local/lib/riskit}/dynasty-healthcheck.sh"

--- a/tests/deploy/test_rollback_first_deploy.py
+++ b/tests/deploy/test_rollback_first_deploy.py
@@ -150,7 +150,8 @@ case "${cmd}" in
     printf 'enabled\\n' > "${state}/units/${unit}.UnitFileState"
     if [[ "${now}" == "true" ]]; then
       printf 'active\\n' > "${state}/units/${unit}.ActiveState"
-      printf '1786000000000000\\n' > "${state}/units/${unit}.NextElapseUSecRealtime"
+      printf '\\n' > "${state}/units/${unit}.NextElapseUSecRealtime"
+      printf '2w 3d 2h 8min 32.168902s\\n' > "${state}/units/${unit}.NextElapseUSecMonotonic"
     fi
     svc="${unit%.timer}.service"
     printf 'loaded\\n' > "${state}/units/${svc}.LoadState"
@@ -517,10 +518,12 @@ class TestProductionCannotBeWeakenedByInheritedEnvironment:
 
     An inherited ``RC_WATCHDOG_OWNER`` alone is inert — the values are
     constants unless a harness explicitly sets
-    ``RC_ALLOW_TEST_OVERRIDES=1``.  On the forward path deploy.sh also
-    unsets both, so the override branch is unreachable there.  rollback.sh
-    deliberately does not scrub, because this suite drives it end to end;
-    it relies on the gate plus a warning that lands in the rollback log.
+    ``RC_ALLOW_TEST_OVERRIDES=1``.  BOTH production entry points —
+    deploy.sh and rollback.sh — additionally unset the flag and every
+    override before sourcing, so the override branch is unreachable
+    during a real deploy or rollback.  This suite drives rollback.sh end
+    to end against those production constants and doubles the privileged
+    command layer instead.
     """
 
     def test_an_inherited_override_does_not_reach_the_reconciler(self):

--- a/tests/deploy/test_runtime_convergence.py
+++ b/tests/deploy/test_runtime_convergence.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import grp
 import os
 import pwd
+import re
 import shutil
 import subprocess
 import textwrap
@@ -112,7 +113,12 @@ case "${cmd}" in
     printf 'enabled\\n' > "${state}/units/${unit}.UnitFileState"
     if [[ "${now}" == "true" ]]; then
       printf 'active\\n' > "${state}/units/${unit}.ActiveState"
-      printf '1786000000000000\\n' > "${state}/units/${unit}.NextElapseUSecRealtime"
+      # A monotonic-base timer (OnBootSec/OnUnitActiveSec) leaves the
+      # REALTIME field empty and populates the MONOTONIC one, pretty-
+      # printed as a timespan.  Measured on production 2026-08-13.
+      printf '\\n' > "${state}/units/${unit}.NextElapseUSecRealtime"
+      printf '2w 3d 2h 8min 32.168902s\\n' > "${state}/units/${unit}.NextElapseUSecMonotonic"
+      printf 'Thu 2026-08-13 04:16:02 CEST\\n' > "${state}/units/${unit}.LastTriggerUSec"
     fi
     svc="${unit%.timer}.service"
     if [[ -f "${SYSTEMD_UNIT_DIR}/${svc}" ]]; then
@@ -558,3 +564,115 @@ class TestUnauthorizedPrivilegeIsRefusedBeforeSudo:
         r = host.run_snippet('_rc_sudo /usr/bin/stat -c %U /etc/hostname; echo "rc=$?"')
         assert "rc=126" in r.stdout, r.stdout + r.stderr
         assert "not in the authorized set" in r.stderr
+
+
+class TestTheTimerGateReadsTheRightNextElapseProperty:
+    """The #813 deploy failed here, on a perfectly scheduled watchdog.
+
+    systemd exposes two next-elapse properties and populates the one
+    matching the timer's BASE.  ``dynasty-healthcheck.timer`` ships
+    ``OnBootSec`` + ``OnUnitActiveSec`` — both MONOTONIC — so
+    ``NextElapseUSecRealtime`` is empty by construction and
+    ``NextElapseUSecMonotonic`` carries the schedule.  Measured on
+    production 2026-08-13, an hour into the timer firing every 60 s:
+
+        timer.NextElapseUSecRealtime    (empty)
+        timer.NextElapseUSecMonotonic   2w 3d 2h 8min 32.168902s
+        timer.LastTriggerUSec           Thu 2026-08-13 04:16:02 CEST
+
+    So this was never a first-activation race — the realtime field never
+    becomes non-empty for this unit.
+    """
+
+    def test_realtime_zero_with_a_monotonic_next_passes(self, host):
+        host.converge()
+        host.set_unit_state(
+            "dynasty-healthcheck.timer",
+            NextElapseUSecRealtime="0",
+            NextElapseUSecMonotonic="2w 3d 2h 8min 32.168902s",
+        )
+
+        r = host.run("verify_runtime_controls")
+
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "live runtime controls verified" in r.stdout
+
+    def test_realtime_empty_with_a_monotonic_next_passes(self, host):
+        """Production's actual shape."""
+        host.converge()
+        host.set_unit_state(
+            "dynasty-healthcheck.timer",
+            NextElapseUSecRealtime="",
+            NextElapseUSecMonotonic="2w 3d 2h 8min 32.168902s",
+        )
+
+        r = host.run("verify_runtime_controls")
+
+        assert r.returncode == 0, r.stdout + r.stderr
+
+    def test_no_monotonic_next_fails_after_the_bounded_retry(self, host):
+        """The retry is defense in depth for an activation-settling
+        window, not a way to eventually accept nothing."""
+        host.converge()
+        host.set_unit_state(
+            "dynasty-healthcheck.timer",
+            NextElapseUSecRealtime="",
+            NextElapseUSecMonotonic="0",
+        )
+
+        r = host.run("verify_runtime_controls")
+
+        assert r.returncode != 0
+        assert "no future monotonic activation" in r.stderr
+
+    def test_an_empty_monotonic_next_also_fails(self, host):
+        host.converge()
+        host.set_unit_state(
+            "dynasty-healthcheck.timer",
+            NextElapseUSecRealtime="",
+            NextElapseUSecMonotonic="",
+        )
+
+        r = host.run("verify_runtime_controls")
+
+        assert r.returncode != 0
+        assert "no future monotonic activation" in r.stderr
+
+    def test_loaded_enabled_active_is_not_enough_without_a_future_run(self, host):
+        """A timer can be all three and still have nothing scheduled."""
+        host.converge()
+        host.set_unit_state(
+            "dynasty-healthcheck.timer",
+            LoadState="loaded",
+            ActiveState="active",
+            UnitFileState="enabled",
+            NextElapseUSecMonotonic="0",
+        )
+
+        r = host.run("verify_runtime_controls")
+
+        assert r.returncode != 0
+        assert "no future monotonic activation" in r.stderr
+
+    def test_a_past_trigger_is_not_accepted_as_future_scheduling(self, host):
+        """LastTriggerUSec says the timer HAS run, not that it WILL."""
+        host.converge()
+        host.set_unit_state(
+            "dynasty-healthcheck.timer",
+            NextElapseUSecMonotonic="0",
+            LastTriggerUSec="Thu 2026-08-13 04:16:02 CEST",
+        )
+
+        r = host.run("verify_runtime_controls")
+
+        assert r.returncode != 0, "a past trigger was accepted as proof of future scheduling"
+
+    def test_the_verifier_never_gates_on_the_realtime_property(self):
+        """Read as code: the realtime value may be logged, never tested."""
+        code = re.sub(r"#.*", "", RECONCILER.read_text())
+        gating = [
+            ln
+            for ln in code.splitlines()
+            if "NextElapseUSecRealtime" in ln and ("rc=1" in ln or "_rc_err" in ln)
+        ]
+        assert not gating, f"realtime property still gates: {gating}"

--- a/tests/deploy/test_runtime_reconciler_wiring.py
+++ b/tests/deploy/test_runtime_reconciler_wiring.py
@@ -193,3 +193,25 @@ class TestScopeIsHeld:
             ), f"{script.name} runs the full hardening installer"
             for unrelated in ("nginx", "riskit-backup", "riskit-uptime", "certbot"):
                 assert unrelated not in body, f"{script.name} touches {unrelated}"
+
+
+class TestBothPathsUseTheCorrectedVerifier:
+    """One verifier, and the timer gate lives inside it.
+
+    If either path grew its own timer check, the #813 failure could come
+    back on one side only — which is the hardest kind to notice.
+    """
+
+    def test_both_scripts_call_the_shared_verifier(self):
+        assert "verify_runtime_state" in _main_body(DEPLOY)
+        assert "verify_runtime_controls" in _main_body(ROLLBACK)
+
+    def test_neither_script_checks_a_timer_property_itself(self):
+        for script in (DEPLOY, ROLLBACK):
+            text = script.read_text()
+            for prop in ("NextElapseUSecMonotonic", "NextElapseUSecRealtime", "LastTriggerUSec"):
+                assert prop not in text, f"{script.name} inspects {prop} itself"
+
+    def test_the_monotonic_predicate_is_defined_once(self):
+        code = RECONCILER.read_text()
+        assert code.count("_rc_monotonic_elapse_is_scheduled()") == 1


### PR DESCRIPTION
## What went wrong

The #813 deploy (run `31656492377`, merge commit `048e49ee45…`) failed its own live-verification gate **on a perfectly scheduled watchdog**:

```
[reconcile] systemd limits OK: 8192:524288
[reconcile] /proc/1570816/limits OK: 8192:524288
[reconcile][ERROR] ***-healthcheck.timer has no next activation
[reconcile] watchdog: timer load=loaded active=active file=enabled next=none; service load=loaded
[reconcile][ERROR] LIVE runtime verification FAILED
```

Everything the reconciler was written to do had already worked. The gate rejected on one check.

## The real cause — not a race

systemd's Timer interface exposes two next-elapse properties, and populates the one matching the timer's **base**:

| property | meaning |
|---|---|
| `NextElapseUSecRealtime` | next `CLOCK_REALTIME`/calendar event — empty when the unit has no `OnCalendar` |
| `NextElapseUSecMonotonic` | next `CLOCK_MONOTONIC` event — what `OnBootSec` / `OnUnitActiveSec` produce |

`dynasty-healthcheck.timer` ships `OnBootSec=3min` + `OnUnitActiveSec=1min`. Both monotonic. The realtime field is empty **by construction** and never becomes populated.

Read directly on production 2026-08-13, an hour into the timer firing every 60 s without interruption:

```
timer.LoadState                 loaded
timer.ActiveState               active
timer.UnitFileState             enabled
timer.NextElapseUSecRealtime    (empty)
timer.NextElapseUSecMonotonic   2w 3d 2h 8min 32.168902s
timer.LastTriggerUSec           Thu 2026-08-13 04:16:02 CEST
service.LoadState               loaded
```

An earlier "first-activation race" diagnosis was wrong: the realtime field is still empty an hour later. The gate was reading the wrong property.

## The change

The timer contract is now: timer `LoadState=loaded`, service `LoadState=loaded`, `UnitFileState=enabled`, `ActiveState=active`, and a **non-zero `NextElapseUSecMonotonic`**, with a bounded re-read (5 × 1 s) as defense in depth for a genuine activation-settling window rather than as the mechanism being relied on.

systemd pretty-prints timespans, so the predicate rejects every "nothing scheduled" rendering (empty, `0`, `0s`, `0us`, `n/a`, `infinity`) and accepts anything else.

`LastTriggerUSec` is logged as context and **deliberately not** accepted as a substitute — a past trigger says the timer *has* run, not that another run is scheduled. `NextElapseUSecRealtime` is still logged, never tested.

## Also in this narrow PR

**Read-only watchdog probe** in `fd_inventory.sh` — the deploy gate verifies the watchdog units and executable; this reads them independently so post-deploy verification is not the same statement made twice. It prints both next-elapse properties, which is how the evidence above was obtained.

**SIGPIPE (`exit 141`)** — `journalctl … | head -1` closed the pipe on a still-streaming journal, so journalctl died of SIGPIPE and `pipefail` reported 141 on a section that had printed its evidence correctly. The stream is now read whole and the first line taken in the shell, with journalctl's status captured explicitly, so a genuinely failing journalctl still degrades the section and only the reader's SIGPIPE is gone.

**Stale docstring** — `test_rollback_first_deploy.py` still described `rollback.sh` as deliberately not scrubbing test seams; it has scrubbed since #813.

## Tests — 177 in `tests/deploy`, root and unprivileged

The fake `systemctl` now emits production's property shape, so **the suite reproduces the #813 deploy failure directly**: against the pre-hotfix verifier, `test_a_correctly_converged_host_verifies` fails — a correctly converged host rejected.

**RED: 7 of 29** convergence tests fail against the pre-hotfix verifier. Six new cases pin the contract:

- realtime `0` + monotonic next → **PASS**
- realtime empty + monotonic next → **PASS** (production's actual shape)
- monotonic still `0` through the bounded retry → **FAIL**
- monotonic empty → **FAIL**
- loaded + enabled + active with no future monotonic activation → **FAIL**
- a past `LastTriggerUSec` with monotonic `0` → **FAIL** (not accepted as future scheduling)
- plus a static check that the realtime property never appears in a gating expression

Existing limit / `/proc` / watchdog-ownership / mode / threshold failures still fail closed. Three wiring tests pin that deploy and rollback share the corrected verifier and that neither inspects a timer property itself.

## Scope

No HTTP-client changes. No Sleeper-session changes. No nginx / backup / uptime work. No product-feature work.

## Deployment note — the gate is failing every scheduled refresh

Refresh workflows push to `main` on a schedule, and every such push deploys. Each deploy reconciles, swaps the frontend, **restarts the backend**, then fails this gate. Four consecutive failures so far, each leaving production on the newer revision with a new PID:

| deploy run | revision | result | MainPID after restart |
|---|---|---|---|
| `31656492377` | `048e49ee45` (#813 merge) | failed at gate | 1570816 |
| `31660882725` | `29982f62e0` (`chore(dlf)`) | failed at gate | 1642739 |
| `31663451414` | `b7d8849eff` (`chore: automated data refresh`) | failed at gate | 1685137 |
| `31667078177` | `89f0895740` (`chore(dlf)`) | failed at gate | 1744736 |

Every failure is the same line — `has no next activation` — including on a timer that had been firing every 60 s for over an hour, which is the clearest confirmation that the property, not the timing, is wrong.

Routes stay healthy throughout (`/` 200, `/api/health` 200, `/api/status` 200, `/league` 200, `/api/data` 401), and no rollback has occurred. But `record_success_state` has never run, so the host's last-successful marker still points at the pre-#813 revision. It has **not** been touched, and no bare rollback has been invoked. The next deploy should record the current live revision as its `PRE_DEPLOY_REV` so an auto-rollback returns to a working state rather than the older recorded-success revision.