### PR TITLE
Decide the watchdog timer's infinity transition from live systemd state, not a sleep

### DIFF
--- a/.github/workflows/fd-diagnostics.yml
+++ b/.github/workflows/fd-diagnostics.yml
@@ -33,6 +33,14 @@ on:
         required: false
         default: "30"
         type: string
+      watchdog_window_seconds:
+        description: >-
+          Seconds to poll the watchdog timer/service tuple at 5Hz, to
+          observe the infinity-while-executing transition. 0 = off
+          (static properties still print). >=130 crosses two firings.
+        required: false
+        default: "0"
+        type: string
 
 permissions:
   contents: read
@@ -76,6 +84,7 @@ jobs:
           SERVICE_NAME: ${{ vars.PROD_SERVICE_NAME || 'dynasty' }}
           SAMPLES: ${{ inputs.samples }}
           INTERVAL: ${{ inputs.interval_seconds }}
+          WATCHDOG_WINDOW: ${{ inputs.watchdog_window_seconds }}
         shell: bash
         run: |
           set -Eeuo pipefail
@@ -100,5 +109,5 @@ jobs:
             -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
             -o ConnectTimeout=15 -o ServerAliveInterval=15 \
             -p "$PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
-            "SERVICE_NAME=$(printf %q "$SERVICE_NAME") bash -s -- $(printf %q "$SERVICE_NAME") $(printf %q "$SAMPLES") $(printf %q "$INTERVAL")" \
+            "SERVICE_NAME=$(printf %q "$SERVICE_NAME") bash -s -- $(printf %q "$SERVICE_NAME") $(printf %q "$SAMPLES") $(printf %q "$INTERVAL") $(printf %q "$WATCHDOG_WINDOW")" \
             < deploy/diagnostics/fd_inventory.sh

--- a/deploy/diagnostics/fd_inventory.sh
+++ b/deploy/diagnostics/fd_inventory.sh
@@ -369,6 +369,64 @@ watchdog_state() {
 }
 run_optional "watchdog units and installed executable" watchdog_state
 
+# ── optional: the timer contract ACROSS a firing boundary ───────────
+# `watchdog_state` above reads the timer once.  One read cannot see the
+# state that matters here: while the triggered oneshot is executing,
+# systemd has no next activation to report and answers
+# `NextElapseUSecMonotonic=infinity`.  A verifier that samples once
+# therefore passes or fails on where its read landed relative to a
+# 60-second cadence.
+#
+# So this samples the whole tuple every second for longer than one
+# period, which guarantees crossing at least one boundary, and prints
+# every sample rather than a summary — the transition IS the evidence.
+#
+# `TimersMonotonic` is the property that distinguishes "no next
+# activation because the unit is running right now" from "no next
+# activation because this timer has no recurring schedule": it lists the
+# monotonic timer definitions systemd actually loaded, so it is present
+# for a healthy timer whatever its momentary next-elapse says.  It is
+# read live rather than inferred from the unit file in the repository,
+# because what shipped and what is loaded are different claims.
+#
+# Still read-only: `systemctl show` computes nothing and starts nothing.
+WATCHDOG_CONTRACT_SAMPLES="${WATCHDOG_CONTRACT_SAMPLES:-75}"
+
+watchdog_timer_contract() {
+  local timer="dynasty-healthcheck.timer" svc="dynasty-healthcheck.service"
+  local prop
+  for prop in Unit TimersMonotonic TimersCalendar AccuracyUSec RandomizedDelayUSec; do
+    printf '%-30s %s\n' "timer.${prop}" \
+      "$(sudo -n "${SYSTEMCTL}" show "${timer}" -p "${prop}" --value 2>/dev/null)"
+  done
+  for prop in Type TimeoutStartUSec ActiveState SubState Result; do
+    printf '%-30s %s\n' "service.${prop}" \
+      "$(sudo -n "${SYSTEMCTL}" show "${svc}" -p "${prop}" --value 2>/dev/null)"
+  done
+
+  printf '\nsampling %s x 1s (cadence is 60s, so this crosses a boundary)\n\n' \
+    "${WATCHDOG_CONTRACT_SAMPLES}"
+  printf '%-21s %-8s %-10s %-30s %s\n' \
+    utc_time timer.Act svc.Act/Sub next_monotonic last_trigger
+  local i timer_out svc_out t_active next_mono last_trig s_active s_sub
+  for ((i = 0; i < WATCHDOG_CONTRACT_SAMPLES; i++)); do
+    timer_out="$(sudo -n "${SYSTEMCTL}" show "${timer}" \
+      -p ActiveState -p NextElapseUSecMonotonic -p LastTriggerUSec 2>/dev/null)"
+    svc_out="$(sudo -n "${SYSTEMCTL}" show "${svc}" \
+      -p ActiveState -p SubState 2>/dev/null)"
+    t_active="$(printf '%s\n' "${timer_out}" | sed -n 's/^ActiveState=//p')"
+    next_mono="$(printf '%s\n' "${timer_out}" | sed -n 's/^NextElapseUSecMonotonic=//p')"
+    last_trig="$(printf '%s\n' "${timer_out}" | sed -n 's/^LastTriggerUSec=//p')"
+    s_active="$(printf '%s\n' "${svc_out}" | sed -n 's/^ActiveState=//p')"
+    s_sub="$(printf '%s\n' "${svc_out}" | sed -n 's/^SubState=//p')"
+    printf '%-21s %-8s %-10s %-30s %s\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${t_active:-<empty>}" \
+      "${s_active:-?}/${s_sub:-?}" "${next_mono:-<empty>}" "${last_trig:-<empty>}"
+    sleep 1
+  done
+}
+run_optional "watchdog timer contract across a firing boundary" watchdog_timer_contract
+
 # ── required: the trend ─────────────────────────────────────────────
 # A single number cannot distinguish a healthy steady state from the
 # middle of an accumulation.  Passive — we watch whatever the process

--- a/deploy/diagnostics/fd_inventory.sh
+++ b/deploy/diagnostics/fd_inventory.sh
@@ -49,9 +49,11 @@
 # statement is the verdict on the accumulator.
 #
 # Usage:
-#   deploy/diagnostics/fd_inventory.sh [service] [samples] [interval_s]
+#   deploy/diagnostics/fd_inventory.sh \
+#     [service] [samples] [interval_s] [watchdog_window_s]
 #
-# Defaults: dynasty, 10 samples, 30 s apart (a 5-minute window).
+# Defaults: dynasty, 10 samples, 30 s apart (a 5-minute window), and no
+# watchdog boundary sampling (see WATCHDOG_CONTRACT_WINDOW_S below).
 
 set -uo pipefail
 
@@ -390,7 +392,16 @@ run_optional "watchdog units and installed executable" watchdog_state
 # because what shipped and what is loaded are different claims.
 #
 # Still read-only: `systemctl show` computes nothing and starts nothing.
-WATCHDOG_CONTRACT_WINDOW_S="${WATCHDOG_CONTRACT_WINDOW_S:-150}"
+#
+# OPT-IN, and OFF by default.  The window is wall-clock time this script
+# spends doing nothing else, so a default of "long enough to cross two
+# boundaries" would add two and a half minutes to every FD inventory —
+# and to every test that runs this script.  The static properties above
+# print regardless; only the sampling loop is gated.  A zero window says
+# so out loud rather than skipping silently, because a section that
+# prints nothing and a section that was not asked to run must not read
+# the same.
+WATCHDOG_CONTRACT_WINDOW_S="${WATCHDOG_CONTRACT_WINDOW_S:-${4:-0}}"
 
 watchdog_timer_contract() {
   local timer="dynasty-healthcheck.timer" svc="dynasty-healthcheck.service"
@@ -413,6 +424,14 @@ watchdog_timer_contract() {
   # quiet one.
   printf '\npolling %ss at 5Hz, printing on change (cadence is 60s)\n\n' \
     "${WATCHDOG_CONTRACT_WINDOW_S}"
+  if (( WATCHDOG_CONTRACT_WINDOW_S <= 0 )); then
+    printf '\nboundary sampling NOT REQUESTED (window=%ss).  Pass a window as\n' \
+      "${WATCHDOG_CONTRACT_WINDOW_S}"
+    printf 'the 4th argument (>= 130s crosses two firings) to observe the\n'
+    printf 'infinity/executing transition.\n'
+    return 0
+  fi
+
   # `recurring` is sampled too, not just read once up front.  The
   # verifier requires the recurring base to be present at the moment it
   # looks, so whether systemd keeps reporting it WHILE the unit runs is

--- a/deploy/diagnostics/fd_inventory.sh
+++ b/deploy/diagnostics/fd_inventory.sh
@@ -390,7 +390,7 @@ run_optional "watchdog units and installed executable" watchdog_state
 # because what shipped and what is loaded are different claims.
 #
 # Still read-only: `systemctl show` computes nothing and starts nothing.
-WATCHDOG_CONTRACT_SAMPLES="${WATCHDOG_CONTRACT_SAMPLES:-75}"
+WATCHDOG_CONTRACT_WINDOW_S="${WATCHDOG_CONTRACT_WINDOW_S:-150}"
 
 watchdog_timer_contract() {
   local timer="dynasty-healthcheck.timer" svc="dynasty-healthcheck.service"
@@ -404,12 +404,21 @@ watchdog_timer_contract() {
       "$(sudo -n "${SYSTEMCTL}" show "${svc}" -p "${prop}" --value 2>/dev/null)"
   done
 
-  printf '\nsampling %s x 1s (cadence is 60s, so this crosses a boundary)\n\n' \
-    "${WATCHDOG_CONTRACT_SAMPLES}"
-  printf '%-21s %-8s %-10s %-30s %s\n' \
+  # The execution itself is SHORT — a 1 Hz sampler crossed a boundary
+  # without ever landing inside one (run 31677718502).  So poll at 5 Hz
+  # for longer than two periods and print on CHANGE rather than on a
+  # fixed cadence: the transition is a handful of samples wide and a
+  # summary would average it away.  A heartbeat row every 5 s keeps the
+  # steady state visible so a silent probe is distinguishable from a
+  # quiet one.
+  printf '\npolling %ss at 5Hz, printing on change (cadence is 60s)\n\n' \
+    "${WATCHDOG_CONTRACT_WINDOW_S}"
+  printf '%-21s %-8s %-14s %-32s %s\n' \
     utc_time timer.Act svc.Act/Sub next_monotonic last_trigger
-  local i timer_out svc_out t_active next_mono last_trig s_active s_sub
-  for ((i = 0; i < WATCHDOG_CONTRACT_SAMPLES; i++)); do
+  local polls i timer_out svc_out t_active next_mono last_trig s_active s_sub
+  local prev="" cur reason
+  polls=$(( WATCHDOG_CONTRACT_WINDOW_S * 5 ))
+  for ((i = 0; i < polls; i++)); do
     timer_out="$(sudo -n "${SYSTEMCTL}" show "${timer}" \
       -p ActiveState -p NextElapseUSecMonotonic -p LastTriggerUSec 2>/dev/null)"
     svc_out="$(sudo -n "${SYSTEMCTL}" show "${svc}" \
@@ -419,10 +428,18 @@ watchdog_timer_contract() {
     last_trig="$(printf '%s\n' "${timer_out}" | sed -n 's/^LastTriggerUSec=//p')"
     s_active="$(printf '%s\n' "${svc_out}" | sed -n 's/^ActiveState=//p')"
     s_sub="$(printf '%s\n' "${svc_out}" | sed -n 's/^SubState=//p')"
-    printf '%-21s %-8s %-10s %-30s %s\n' \
-      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${t_active:-<empty>}" \
-      "${s_active:-?}/${s_sub:-?}" "${next_mono:-<empty>}" "${last_trig:-<empty>}"
-    sleep 1
+    cur="${t_active}|${next_mono}|${last_trig}|${s_active}|${s_sub}"
+    reason=""
+    [[ "${cur}" != "${prev}" ]] && reason="change"
+    (( i % 25 == 0 )) && reason="${reason:-heartbeat}"
+    if [[ -n "${reason}" ]]; then
+      printf '%-21s %-8s %-14s %-32s %s  [%s]\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${t_active:-<empty>}" \
+        "${s_active:-?}/${s_sub:-?}" "${next_mono:-<empty>}" \
+        "${last_trig:-<empty>}" "${reason}"
+    fi
+    prev="${cur}"
+    sleep 0.2
   done
 }
 run_optional "watchdog timer contract across a firing boundary" watchdog_timer_contract

--- a/deploy/diagnostics/fd_inventory.sh
+++ b/deploy/diagnostics/fd_inventory.sh
@@ -413,29 +413,41 @@ watchdog_timer_contract() {
   # quiet one.
   printf '\npolling %ss at 5Hz, printing on change (cadence is 60s)\n\n' \
     "${WATCHDOG_CONTRACT_WINDOW_S}"
-  printf '%-21s %-8s %-14s %-32s %s\n' \
-    utc_time timer.Act svc.Act/Sub next_monotonic last_trigger
+  # `recurring` is sampled too, not just read once up front.  The
+  # verifier requires the recurring base to be present at the moment it
+  # looks, so whether systemd keeps reporting it WHILE the unit runs is
+  # the difference between a fail-closed check and a new false-negative
+  # in the same 0.2 s window as the old one.
+  printf '%-21s %-8s %-17s %-32s %-9s %s\n' \
+    utc_time timer.Act svc.Act/Sub next_monotonic recurring last_trigger
   local polls i timer_out svc_out t_active next_mono last_trig s_active s_sub
-  local prev="" cur reason
+  local timers_mono recurring prev="" cur reason
   polls=$(( WATCHDOG_CONTRACT_WINDOW_S * 5 ))
   for ((i = 0; i < polls; i++)); do
     timer_out="$(sudo -n "${SYSTEMCTL}" show "${timer}" \
       -p ActiveState -p NextElapseUSecMonotonic -p LastTriggerUSec 2>/dev/null)"
     svc_out="$(sudo -n "${SYSTEMCTL}" show "${svc}" \
       -p ActiveState -p SubState 2>/dev/null)"
+    timers_mono="$(sudo -n "${SYSTEMCTL}" show "${timer}" \
+      -p TimersMonotonic --value 2>/dev/null)"
     t_active="$(printf '%s\n' "${timer_out}" | sed -n 's/^ActiveState=//p')"
     next_mono="$(printf '%s\n' "${timer_out}" | sed -n 's/^NextElapseUSecMonotonic=//p')"
     last_trig="$(printf '%s\n' "${timer_out}" | sed -n 's/^LastTriggerUSec=//p')"
     s_active="$(printf '%s\n' "${svc_out}" | sed -n 's/^ActiveState=//p')"
     s_sub="$(printf '%s\n' "${svc_out}" | sed -n 's/^SubState=//p')"
-    cur="${t_active}|${next_mono}|${last_trig}|${s_active}|${s_sub}"
+    case "${timers_mono}" in
+      *OnUnitActiveUSec=*|*OnUnitInactiveUSec=*) recurring=yes ;;
+      "") recurring=EMPTY ;;
+      *) recurring=NO ;;
+    esac
+    cur="${t_active}|${next_mono}|${last_trig}|${s_active}|${s_sub}|${recurring}"
     reason=""
     [[ "${cur}" != "${prev}" ]] && reason="change"
     (( i % 25 == 0 )) && reason="${reason:-heartbeat}"
     if [[ -n "${reason}" ]]; then
-      printf '%-21s %-8s %-14s %-32s %s  [%s]\n' \
+      printf '%-21s %-8s %-17s %-32s %-9s %s  [%s]\n' \
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${t_active:-<empty>}" \
-        "${s_active:-?}/${s_sub:-?}" "${next_mono:-<empty>}" \
+        "${s_active:-?}/${s_sub:-?}" "${next_mono:-<empty>}" "${recurring}" \
         "${last_trig:-<empty>}" "${reason}"
     fi
     prev="${cur}"

--- a/deploy/reconcile-runtime-controls.sh
+++ b/deploy/reconcile-runtime-controls.sh
@@ -247,6 +247,10 @@ _rc_install_if_different() {
 # like "2w 3d 2h 8min 32.168902s" rather than a raw integer.  Every
 # rendering that means "nothing scheduled" is rejected; anything else is
 # a real next-elapse.
+#
+# `infinity` is rejected HERE and handled one level up, in
+# _verify_runtime_controls, because it is the only one of these
+# renderings with a legitimate explanation.
 _rc_monotonic_elapse_is_scheduled() {
   local value="$1"
   [[ -n "${value}" ]] || return 1
@@ -254,6 +258,51 @@ _rc_monotonic_elapse_is_scheduled() {
     0|0s|0us|n/a|infinity) return 1 ;;
   esac
   return 0
+}
+
+# Does the timer carry a RECURRING monotonic schedule, right now, per
+# systemd — not per the unit file in this checkout?
+#
+# `TimersMonotonic` lists the monotonic timer definitions systemd
+# actually loaded — one entry per directive, each on its own line.
+# Measured on production 2026-08-13:
+#
+#   timer.TimersMonotonic  { OnUnitActiveUSec=1min ; next_elapse=2w 3d 7h 19min 55.xxxs }
+#                          { OnBootUSec=3min ; next_elapse=3min }
+#
+# The recurring bases are the two that re-arm from the triggered unit's
+# own activity; `OnBootUSec` alone fires once per boot and would leave a
+# timer that looks enabled and never runs again.  Requiring one of them
+# is what makes "no next activation because it is running right now"
+# separable from "no next activation because there is no schedule".
+#
+# Substring match rather than a parse: the surrounding rendering of this
+# property is a systemd version detail, the base NAME is the contract.
+_rc_timer_has_recurring_monotonic_schedule() {
+  local value="$1"
+  [[ "${value}" == *OnUnitActiveUSec=* || "${value}" == *OnUnitInactiveUSec=* ]]
+}
+
+# Is the triggered unit genuinely EXECUTING at this instant?
+#
+# The healthcheck is `Type=oneshot`, so while its ExecStart runs systemd
+# reports ActiveState=activating / SubState=start, and once it exits,
+# inactive/dead.  `active`+`exited` is a FINISHED oneshot that declared
+# RemainAfterExit — not execution — so it is excluded by name rather
+# than by falling through a wildcard.
+#
+# This is the ONLY thing that can excuse a missing next activation, so
+# it is decided on the service's own live state and never inferred from
+# the timer's.
+_rc_service_is_executing() {
+  local active="$1" sub="$2"
+  case "${active}" in
+    activating|deactivating) return 0 ;;
+  esac
+  case "${sub}" in
+    start|start-pre|start-post|running|reload) return 0 ;;
+  esac
+  return 1
 }
 
 # ── the two entry points ─────────────────────────────────────────────
@@ -485,25 +534,91 @@ _verify_runtime_controls() {
   # LastTriggerUSec is deliberately NOT accepted as a substitute: a past
   # trigger says the timer HAS run, not that another run is scheduled.
   # It is logged as context and never gates.
-  local last_trigger attempt
+  #
+  # AND THE NEXT-ELAPSE IS NOT ALWAYS READABLE, EVEN WHEN HEALTHY.
+  #
+  # While the triggered oneshot is executing there is no next activation
+  # to compute, and systemd answers `NextElapseUSecMonotonic=infinity`.
+  # Observed on production 2026-08-13T06:29:24Z, six seconds after a
+  # LastTriggerUSec of 08:29:18 CEST, on a timer that had been firing
+  # every 60 s for hours.  The #814 gate rejected `infinity` outright, so
+  # it passed only because its read happened to land between firings: a
+  # healthy deploy could be failed by nothing worse than its own timing.
+  # `TimeoutStartSec=90` on the service bounds how long that window can
+  # last, which is far longer than any re-read worth spending on it.
+  #
+  # Sleeping past the execution is therefore the wrong fix.  The state is
+  # DECIDABLE from live systemd properties, so it is decided:
+  #
+  #   finite next-elapse                     → scheduled.  Pass.
+  #   infinity + service executing + the
+  #     timer's recurring monotonic schedule
+  #     still loaded                         → a transition, not a fault.
+  #                                            Pass.
+  #   infinity + service inactive/failed     → nothing is running and
+  #                                            nothing is scheduled. Fail.
+  #   empty / 0 / n-a                        → fail, whatever is running:
+  #                                            those are not transitions.
+  #   recurring monotonic schedule absent    → fail, whatever the
+  #                                            next-elapse says.
+  #
+  # All four facts are re-read TOGETHER each attempt.  Reading them apart
+  # invents its own race: a service that finishes between two reads
+  # yields "infinity" beside "not executing" and fails a timer that just
+  # re-armed correctly.
+  #
+  # The loop RE-READS through a transition rather than accepting it on
+  # sight, and the ordering is deliberate.  A measured healthcheck
+  # execution is ~0.2 s wide, so one re-read almost always lands after
+  # the timer has re-armed and the run passes on a real next-elapse —
+  # the ordinary path never needs the excuse at all.  Only an execution
+  # outlasting the whole bounded window falls through to the transition
+  # branch below, which is the case that branch exists for.
+  #
+  # Re-reading is also why the excuse can stay strict.  Sampling the
+  # host at 5 Hz showed `TimersMonotonic` still carrying
+  # `OnUnitActiveUSec` on every `activating/start` sample, so requiring
+  # it mid-execution is a check the healthy state passes rather than a
+  # second false-negative.  The same capture showed execution does NOT
+  # always report `infinity`: at 07:50:45 the service was executing while
+  # the timer still advertised the PREVIOUS finite next-elapse, systemd
+  # not having recomputed it yet.  That row passes on the finite value,
+  # which is the correct answer for it and another reason the finite
+  # branch is tried first.
+  local last_trigger attempt timers_mono svc_active svc_sub
   last_trigger="$(_rc_sudo "$SC" show "${timer}" -p LastTriggerUSec --value)"
-  # Bounded re-read: defense in depth for a genuine activation-settling
-  # window right after `enable --now`, not the mechanism being relied on.
   for attempt in 1 2 3 4 5; do
     next_mono="$(_rc_sudo "$SC" show "${timer}" -p NextElapseUSecMonotonic --value)"
+    timers_mono="$(_rc_sudo "$SC" show "${timer}" -p TimersMonotonic --value)"
+    svc_active="$(_rc_sudo "$SC" show "${svc}" -p ActiveState --value)"
+    svc_sub="$(_rc_sudo "$SC" show "${svc}" -p SubState --value)"
     if _rc_monotonic_elapse_is_scheduled "${next_mono}"; then break; fi
     (( attempt < 5 )) && sleep 1
   done
 
   _rc_log "watchdog: timer load=${ls_t} active=${as_t} file=${ufs_t}"
-  _rc_log "watchdog: next(monotonic)=${next_mono:-<empty>} next(realtime)=${next_rt:-<empty>} last=${last_trigger:-<never>}; service load=${ls_s}"
+  _rc_log "watchdog: next(monotonic)=${next_mono:-<empty>} next(realtime)=${next_rt:-<empty>} last=${last_trigger:-<never>}; service load=${ls_s} state=${svc_active:-<empty>}/${svc_sub:-<empty>}"
+  _rc_log "watchdog: timers(monotonic)=${timers_mono:-<empty>}"
   [[ "${ls_t}"  == "loaded"  ]] || { _rc_err "${timer} LoadState=${ls_t}";      rc=1; }
   [[ "${ls_s}"  == "loaded"  ]] || { _rc_err "${svc} LoadState=${ls_s}";        rc=1; }
   [[ "${ufs_t}" == "enabled" ]] || { _rc_err "${timer} UnitFileState=${ufs_t}"; rc=1; }
   [[ "${as_t}"  == "active"  ]] || { _rc_err "${timer} ActiveState=${as_t}";    rc=1; }
-  if ! _rc_monotonic_elapse_is_scheduled "${next_mono}"; then
-    _rc_err "${timer} has no future monotonic activation (NextElapseUSecMonotonic='${next_mono:-<empty>}')"
+
+  # Checked unconditionally, not only on the `infinity` branch: a timer
+  # whose recurring schedule is gone runs at most once more and then
+  # never again, and it reports a perfectly finite next-elapse until it
+  # does.  A next-elapse is a symptom; this is the schedule itself.
+  if ! _rc_timer_has_recurring_monotonic_schedule "${timers_mono}"; then
+    _rc_err "${timer} declares no recurring monotonic schedule (TimersMonotonic='${timers_mono:-<empty>}') — it cannot keep firing"
     rc=1
+  elif ! _rc_monotonic_elapse_is_scheduled "${next_mono}"; then
+    if [[ "${next_mono}" == "infinity" ]] \
+       && _rc_service_is_executing "${svc_active}" "${svc_sub}"; then
+      _rc_log "watchdog: no next activation while ${svc} is executing (${svc_active}/${svc_sub}) — recurring schedule intact, accepting"
+    else
+      _rc_err "${timer} has no future monotonic activation (NextElapseUSecMonotonic='${next_mono:-<empty>}', ${svc} ${svc_active:-<empty>}/${svc_sub:-<empty>})"
+      rc=1
+    fi
   fi
 
   # the INSTALLED executable, not the checkout copy.

--- a/tests/deploy/test_runtime_convergence.py
+++ b/tests/deploy/test_runtime_convergence.py
@@ -70,6 +70,15 @@ FAKE_SUDO = """#!/usr/bin/env bash
 exec "$@"
 """
 
+# What production's systemd reports for the loaded monotonic schedule.
+# Two entries, one per timer directive in dynasty-healthcheck.timer, each
+# printed on its own line by `systemctl show --value`.  The recurring one
+# is OnUnitActiveUSec; OnBootUSec fires once per boot and re-arms nothing.
+FAKE_TIMERS_MONOTONIC = (
+    "{ OnBootUSec=3min ; next_elapse=Thu 2026-08-13 08:39:21 CEST }\n"
+    "{ OnUnitActiveUSec=1min ; next_elapse=Thu 2026-08-13 08:39:21 CEST }"
+)
+
 FAKE_SYSTEMCTL = """#!/usr/bin/env bash
 # Minimal systemctl state machine.  State lives in $FAKE_SYSTEMCTL_STATE.
 set -uo pipefail
@@ -94,6 +103,10 @@ case "${cmd}" in
     done
     f="${state}/units/${unit}.${prop}"
     if [[ -f "${f}" ]]; then cat "${f}"; else printf '\\n'; fi
+    # One-step transition: a `.next` file makes THIS read return the
+    # current value and every later read return the queued one, so a
+    # test can model a state that resolves while the verifier re-reads.
+    if [[ -f "${f}.next" ]]; then mv "${f}.next" "${f}"; fi
     exit 0
     ;;
   enable)
@@ -119,10 +132,14 @@ case "${cmd}" in
       printf '\\n' > "${state}/units/${unit}.NextElapseUSecRealtime"
       printf '2w 3d 2h 8min 32.168902s\\n' > "${state}/units/${unit}.NextElapseUSecMonotonic"
       printf 'Thu 2026-08-13 04:16:02 CEST\\n' > "${state}/units/${unit}.LastTriggerUSec"
+      printf '%s\\n' "${FAKE_TIMERS_MONOTONIC}" > "${state}/units/${unit}.TimersMonotonic"
     fi
     svc="${unit%.timer}.service"
     if [[ -f "${SYSTEMD_UNIT_DIR}/${svc}" ]]; then
       printf 'loaded\\n' > "${state}/units/${svc}.LoadState"
+      # A Type=oneshot triggered unit at rest between firings.
+      printf 'inactive\\n' > "${state}/units/${svc}.ActiveState"
+      printf 'dead\\n'     > "${state}/units/${svc}.SubState"
     fi
     exit 0
     ;;
@@ -200,6 +217,11 @@ class Host:
         for prop, value in props.items():
             (self.state / "units" / f"{unit}.{prop}").write_text(value + "\n")
 
+    def queue_unit_state(self, unit: str, **props: str) -> None:
+        """Value the NEXT read of this property switches to."""
+        for prop, value in props.items():
+            (self.state / "units" / f"{unit}.{prop}.next").write_text(value + "\n")
+
     def set_limits(
         self, *, soft: str, hard: str, proc_soft: str | None = None, proc_hard: str | None = None
     ) -> None:
@@ -229,6 +251,7 @@ class Host:
             "RC_ALLOW_TEST_OVERRIDES": "1",
             "RC_WATCHDOG_OWNER": WATCHDOG_OWNER,
             "FAKE_SYSTEMCTL_STATE": str(self.state),
+            "FAKE_TIMERS_MONOTONIC": FAKE_TIMERS_MONOTONIC,
         }
 
     def run(self, func: str, env_extra: dict[str, str] | None = None):
@@ -676,3 +699,232 @@ class TestTheTimerGateReadsTheRightNextElapseProperty:
             if "NextElapseUSecRealtime" in ln and ("rc=1" in ln or "_rc_err" in ln)
         ]
         assert not gating, f"realtime property still gates: {gating}"
+
+
+class TestTheInfinityTransitionIsDecidedNotSlept:
+    """A running watchdog has no next activation, and that is not a fault.
+
+    While the ``Type=oneshot`` healthcheck executes, systemd has nothing
+    to compute a next elapse from and answers ``infinity``.  Observed on
+    production 2026-08-13T06:29:24Z, six seconds after a LastTriggerUSec
+    of 08:29:18 CEST, on a timer that had been firing every 60 s for
+    hours::
+
+        timer.NextElapseUSecMonotonic   infinity
+        service.ActiveState/SubState    activating/start
+
+    The #814 gate rejected ``infinity`` outright, so a healthy deploy
+    could be failed by where its read landed in the cadence.  Waiting it
+    out is the wrong fix — ``TimeoutStartSec=90`` bounds the window at
+    far longer than any deploy should sleep — so the state is decided
+    from live properties instead.
+
+    The excuse is narrow by construction: ``infinity`` passes ONLY while
+    the triggered unit is genuinely executing AND the timer's recurring
+    monotonic schedule is still loaded.  Neither is inferred from the
+    unit file in this checkout.
+    """
+
+    EXECUTING = {"ActiveState": "activating", "SubState": "start"}
+    AT_REST = {"ActiveState": "inactive", "SubState": "dead"}
+    FAILED = {"ActiveState": "failed", "SubState": "failed"}
+    # A schedule with no recurring base: fires once per boot, then never.
+    BOOT_ONLY = "{ OnBootUSec=3min ; next_elapse=Thu 2026-08-13 08:39:21 CEST }"
+
+    @staticmethod
+    def _seed(host, *, next_mono, service, timers_monotonic=FAKE_TIMERS_MONOTONIC):
+        host.converge()
+        host.set_unit_state(
+            "dynasty-healthcheck.timer",
+            NextElapseUSecRealtime="",
+            NextElapseUSecMonotonic=next_mono,
+            TimersMonotonic=timers_monotonic,
+        )
+        host.set_unit_state("dynasty-healthcheck.service", **service)
+
+    # 1 ─────────────────────────────────────────────────────────────────
+    def test_finite_next_with_the_service_at_rest_passes(self, host):
+        """The steady state: between firings, nothing is running."""
+        self._seed(host, next_mono="2w 3d 2h 8min 32.168902s", service=self.AT_REST)
+
+        r = host.run("verify_runtime_controls")
+
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "live runtime controls verified" in r.stdout
+
+    # 2 ─────────────────────────────────────────────────────────────────
+    def test_infinity_while_the_service_executes_passes(self, host):
+        """Production's observed transition, reproduced verbatim."""
+        self._seed(host, next_mono="infinity", service=self.EXECUTING)
+
+        r = host.run("verify_runtime_controls")
+
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "live runtime controls verified" in r.stdout
+        assert "no next activation while" in r.stdout, (
+            "the transition passed silently — a reader cannot tell this run "
+            "from one with a real next elapse"
+        )
+
+    # 3 ─────────────────────────────────────────────────────────────────
+    def test_infinity_with_the_service_inactive_fails(self, host):
+        """Nothing running and nothing scheduled is a dead watchdog."""
+        self._seed(host, next_mono="infinity", service=self.AT_REST)
+
+        r = host.run("verify_runtime_controls")
+
+        assert r.returncode != 0
+        assert "no future monotonic activation" in r.stderr
+        assert "inactive/dead" in r.stderr
+
+    # 4 ─────────────────────────────────────────────────────────────────
+    def test_infinity_with_the_service_failed_fails(self, host):
+        """A failed unit is emphatically not 'currently executing'."""
+        self._seed(host, next_mono="infinity", service=self.FAILED)
+
+        r = host.run("verify_runtime_controls")
+
+        assert r.returncode != 0
+        assert "no future monotonic activation" in r.stderr
+
+    # 5 ─────────────────────────────────────────────────────────────────
+    def test_infinity_while_executing_without_a_recurring_schedule_fails(self, host):
+        """Executing excuses a missing next elapse only if another one
+        is coming.  With no recurring base, this run is the last one."""
+        self._seed(
+            host,
+            next_mono="infinity",
+            service=self.EXECUTING,
+            timers_monotonic=self.BOOT_ONLY,
+        )
+
+        r = host.run("verify_runtime_controls")
+
+        assert r.returncode != 0
+        assert "no recurring monotonic schedule" in r.stderr
+
+    # 6 ─────────────────────────────────────────────────────────────────
+    def test_zero_next_with_the_service_inactive_fails(self, host):
+        self._seed(host, next_mono="0", service=self.AT_REST)
+
+        r = host.run("verify_runtime_controls")
+
+        assert r.returncode != 0
+        assert "no future monotonic activation" in r.stderr
+
+    # 7 ─────────────────────────────────────────────────────────────────
+    def test_empty_next_with_the_service_inactive_fails(self, host):
+        self._seed(host, next_mono="", service=self.AT_REST)
+
+        r = host.run("verify_runtime_controls")
+
+        assert r.returncode != 0
+        assert "no future monotonic activation" in r.stderr
+
+    # 8 ─────────────────────────────────────────────────────────────────
+    def test_a_past_trigger_does_not_independently_create_a_pass(self, host):
+        """A recent LastTriggerUSec is the most tempting wrong answer:
+        it is present, it looks like health, and it says only that the
+        timer HAS run.  Paired here with the strongest possible context —
+        a live recurring schedule — so nothing but the executing check
+        can be what fails it."""
+        self._seed(host, next_mono="infinity", service=self.AT_REST)
+        host.set_unit_state(
+            "dynasty-healthcheck.timer",
+            LastTriggerUSec="Thu 2026-08-13 08:38:21 CEST",
+        )
+
+        r = host.run("verify_runtime_controls")
+
+        assert r.returncode != 0, "a past trigger was accepted as proof of future scheduling"
+
+    # 9 ─────────────────────────────────────────────────────────────────
+    def test_zero_next_while_executing_still_fails(self, host):
+        """Only `infinity` is a transition.  A zero next-elapse is not
+        excused by a running service — that pairing is not something a
+        healthy timer produces, and widening the excuse to cover it would
+        make the gate unfalsifiable during any execution."""
+        self._seed(host, next_mono="0", service=self.EXECUTING)
+
+        r = host.run("verify_runtime_controls")
+
+        assert r.returncode != 0
+        assert "no future monotonic activation" in r.stderr
+
+    # 10 ────────────────────────────────────────────────────────────────
+    def test_a_finite_next_does_not_excuse_a_missing_recurring_schedule(self, host):
+        """The schedule is checked whatever the next-elapse says: a timer
+        that lost its recurring base reports a perfectly finite next
+        elapse right up until the last time it ever fires."""
+        self._seed(
+            host,
+            next_mono="2w 3d 2h 8min 32.168902s",
+            service=self.AT_REST,
+            timers_monotonic=self.BOOT_ONLY,
+        )
+
+        r = host.run("verify_runtime_controls")
+
+        assert r.returncode != 0
+        assert "no recurring monotonic schedule" in r.stderr
+
+    # 11 ────────────────────────────────────────────────────────────────
+    def test_a_transition_that_resolves_passes_on_the_real_next_elapse(self, host):
+        """The ordinary case must not need the excuse at all.
+
+        A real execution is ~0.2 s wide, so by the time the verifier
+        re-reads, the timer has re-armed.  This models exactly that: the
+        first read sees the transition, the next sees a live next-elapse.
+        It must pass as branch A — silently, on the real value — rather
+        than as an accepted transition, because that is what keeps the
+        common path off `TimersMonotonic`'s behaviour mid-execution,
+        which was never captured.
+        """
+        self._seed(host, next_mono="infinity", service=self.EXECUTING)
+        host.queue_unit_state(
+            "dynasty-healthcheck.timer",
+            NextElapseUSecMonotonic="2w 3d 2h 8min 32.168902s",
+        )
+        host.queue_unit_state(
+            "dynasty-healthcheck.service", ActiveState="inactive", SubState="dead"
+        )
+
+        r = host.run("verify_runtime_controls")
+
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "live runtime controls verified" in r.stdout
+        assert (
+            "no next activation while" not in r.stdout
+        ), "passed via the transition excuse when a real next-elapse was available"
+
+    # 12 ────────────────────────────────────────────────────────────────
+    def test_executing_with_a_stale_finite_next_elapse_passes(self, host):
+        """Executing does not imply `infinity`, which is easy to get
+        backwards.  Observed on the host at 2026-08-13T07:50:45Z: the
+        service was `activating/start` while the timer still advertised
+        the PREVIOUS finite next-elapse, systemd not having recomputed
+        it yet.  A gate keyed on 'executing means no next elapse' would
+        have been wrong about that row; a finite value is a finite
+        value."""
+        self._seed(host, next_mono="2w 3d 7h 42min 14.209473s", service=self.EXECUTING)
+
+        r = host.run("verify_runtime_controls")
+
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "no next activation while" not in r.stdout
+
+    # 13 ────────────────────────────────────────────────────────────────
+    def test_an_empty_timers_monotonic_fails(self, host):
+        """Missing is never healthy: a systemd that reports no monotonic
+        timers at all has not told us the schedule is fine."""
+        self._seed(
+            host,
+            next_mono="2w 3d 2h 8min 32.168902s",
+            service=self.AT_REST,
+            timers_monotonic="",
+        )
+
+        r = host.run("verify_runtime_controls")
+
+        assert r.returncode != 0
+        assert "no recurring monotonic schedule" in r.stderr

--- a/tests/deploy/test_runtime_reconciler_wiring.py
+++ b/tests/deploy/test_runtime_reconciler_wiring.py
@@ -209,9 +209,30 @@ class TestBothPathsUseTheCorrectedVerifier:
     def test_neither_script_checks_a_timer_property_itself(self):
         for script in (DEPLOY, ROLLBACK):
             text = script.read_text()
-            for prop in ("NextElapseUSecMonotonic", "NextElapseUSecRealtime", "LastTriggerUSec"):
+            for prop in (
+                "NextElapseUSecMonotonic",
+                "NextElapseUSecRealtime",
+                "LastTriggerUSec",
+                "TimersMonotonic",
+            ):
                 assert prop not in text, f"{script.name} inspects {prop} itself"
 
     def test_the_monotonic_predicate_is_defined_once(self):
         code = RECONCILER.read_text()
         assert code.count("_rc_monotonic_elapse_is_scheduled()") == 1
+
+    def test_the_infinity_transition_helpers_are_defined_once(self):
+        """The `infinity` excuse is the narrowest part of the contract.
+        Two copies is how one of them stays permissive."""
+        code = RECONCILER.read_text()
+        assert code.count("_rc_timer_has_recurring_monotonic_schedule()") == 1
+        assert code.count("_rc_service_is_executing()") == 1
+
+    def test_neither_script_can_excuse_a_missing_activation_itself(self):
+        """Both `infinity` and the executing states are decided in one
+        place.  A script that pattern-matched them itself would be a
+        second contract with no tests behind it."""
+        for script in (DEPLOY, ROLLBACK):
+            text = script.read_text()
+            for token in ("infinity", "activating", "SubState"):
+                assert token not in text, f"{script.name} decides {token!r} itself"


### PR DESCRIPTION
Post-incident deployment-reliability follow-up. The FD incident itself is **closed** — this does not reopen it, and changes nothing about the FD controls, the watchdog, the HTTP client or any product path.

## The defect

`deploy/reconcile-runtime-controls.sh` gates a deploy on the watchdog timer having a future activation. It read `NextElapseUSecMonotonic` and rejected `infinity` outright.

`infinity` is what systemd reports while the triggered oneshot is **executing** — there is no next activation to compute yet. So a completely healthy deploy could fail on nothing worse than where its single read landed inside a 60-second cadence. `TimeoutStartSec=90` on the service bounds that window at far longer than any re-read worth spending, so waiting it out was not an option either.

## Measured on production first, read-only

The verifier was not changed until the live behaviour was observed. `deploy/diagnostics/fd_inventory.sh` grew a probe that polls the tuple at 5 Hz and prints on change; run against the host it caught the transition on **four consecutive firings**:

```
utc_time              timer.Act svc.Act/Sub       next_monotonic                   recurring
2026-08-13T07:48:42Z  active   inactive/dead     2w 3d 7h 40min 13.942772s        yes
2026-08-13T07:48:45Z  active   activating/start  infinity                         yes
2026-08-13T07:48:45Z  active   inactive/dead     2w 3d 7h 41min 14.190173s        yes
2026-08-13T07:49:45Z  active   activating/start  infinity                         yes
2026-08-13T07:49:45Z  active   inactive/dead     2w 3d 7h 42min 14.209473s        yes
2026-08-13T07:50:45Z  active   activating/start  2w 3d 7h 42min 14.209473s        yes
2026-08-13T07:50:45Z  active   inactive/dead     2w 3d 7h 43min 14.231639s        yes
```

Four facts came out of it, none of which were safe to assume:

* `infinity` appears **only** while the service is `activating/start` — never with it at rest;
* the window is roughly 0.2 s wide, which is why a 1 Hz sampler crossed a boundary without once landing inside one, and why the deploy's single read usually misses it;
* execution does **not** always report `infinity`. At 07:50:45 the service was executing while the timer still advertised the *previous* finite next-elapse, systemd not having recomputed it. So `infinity` is sufficient to indicate the transition but not necessary — a gate keyed on "executing implies infinity" would have been wrong;
* `TimersMonotonic` keeps reporting the recurring base **throughout**, including on every `activating/start` sample:

```
timer.TimersMonotonic  { OnUnitActiveUSec=1min ; next_elapse=2w 3d 7h 40min 13.942772s }
                       { OnBootUSec=3min ; next_elapse=3min }
```

That last one is load-bearing: it is what makes requiring the recurring schedule a check the healthy state passes, rather than a new false-negative in the same 0.2 s window as the old one.

## The live-state contract

Decided from systemd, not slept through, and not softened into "`infinity` is fine":

| live state | verdict |
|---|---|
| finite next-elapse | **pass** |
| `infinity` + triggered service executing + recurring monotonic schedule loaded | **pass**, logged explicitly as a transition |
| `infinity` + service inactive or failed | **fail** |
| empty / `0` / `n/a`, whatever the service is doing | **fail** |
| no recurring monotonic schedule, whatever the next-elapse says | **fail** |

Details worth knowing before touching it:

* **The recurring-schedule check is unconditional**, not scoped to the `infinity` branch. A timer that lost its recurring base reports a perfectly finite next-elapse right up until the last time it ever fires — the next-elapse is a symptom, `TimersMonotonic` is the schedule itself.
* **Executing is decided on the service's own state**, never inferred from the timer's. `active`+`exited` (a finished oneshot with `RemainAfterExit`) is excluded by name rather than by falling through a wildcard.
* **All four properties are re-read together each attempt.** Reading them apart invents a second race: a service that finishes between two reads yields `infinity` beside "not executing" and fails a timer that just re-armed correctly.
* **The loop re-reads *through* a transition rather than accepting it on sight.** A real execution is ~0.2 s wide, so the ordinary deploy passes on a genuine next-elapse and never needs the excuse at all.
* **`LastTriggerUSec` still never gates.** It is logged as context only; a past trigger says the timer *has* run, not that another run is scheduled.
* Only `infinity` is a transition. A zero next-elapse is not excused by a running service — widening the excuse there would make the gate unfalsifiable during any execution.

## RED → GREEN

Reverting **only** the reconciler (`git stash push -- deploy/reconcile-runtime-controls.sh`) and running the new coverage against the pre-fix #814 gate:

```
6 failed, 60 passed in 58.93s
FAILED ...::TestTheInfinityTransitionIsDecidedNotSlept::test_infinity_while_the_service_executes_passes
FAILED ...::TestTheInfinityTransitionIsDecidedNotSlept::test_infinity_with_the_service_inactive_fails
FAILED ...::TestTheInfinityTransitionIsDecidedNotSlept::test_infinity_while_executing_without_a_recurring_schedule_fails
FAILED ...::TestTheInfinityTransitionIsDecidedNotSlept::test_a_finite_next_does_not_excuse_a_missing_recurring_schedule
FAILED ...::TestTheInfinityTransitionIsDecidedNotSlept::test_an_empty_timers_monotonic_fails
FAILED ...::TestBothPathsUseTheCorrectedVerifier::test_the_infinity_transition_helpers_are_defined_once
```

The first is the false-negative this PR exists to fix. Two of the others are a defect the old gate *already* had and nobody had noticed: it passed a timer with **no recurring schedule at all**.

GREEN with the fix restored: `202 passed in 76.35s` (whole `tests/deploy`).

Cases pinned (`TestTheInfinityTransitionIsDecidedNotSlept`, 13 tests):

1. finite next + service at rest → pass
2. `infinity` + service executing + live recurring schedule → pass, and says so in the log
3. `infinity` + service inactive → fail
4. `infinity` + service failed → fail
5. `infinity` + executing but no recurring schedule → fail
6. zero next + service inactive → fail
7. empty next + service inactive → fail
8. a past `LastTriggerUSec` does not independently create a pass
9. zero next while executing still fails
10. a finite next does not excuse a missing recurring schedule
11. a transition that RESOLVES passes on the real next-elapse, not on the excuse
12. executing with a stale finite next-elapse passes (the 07:50:45 row)
13. an empty `TimersMonotonic` fails

The fixture reproduces production's strings verbatim — `infinity`, `activating`/`start`, and the two-entry `TimersMonotonic` — rather than modelling the state some other way. Case 11 needed a fake-`systemctl` addition: a queued `.next` value so a property can change between reads, which is how a real transition resolves.

Deploy and rollback continue to share one verifier, pinned in `test_runtime_reconciler_wiring.py`: neither script inspects a timer property itself, neither decides `infinity`/`activating`/`SubState` itself, and each helper is defined exactly once.

## Scope

Five files. The shared reconciler's timer gate and its two new helpers; the convergence and wiring tests; the read-only diagnostic that produced the evidence, plus the one workflow input that reaches its new window argument.

The boundary probe is **opt-in and off by default**. Left on, its window is wall-clock time every FD inventory — and every test that runs the script — would spend doing nothing else; a zero window says so out loud rather than skipping silently.

Not touched: `deploy.sh`, `rollback.sh`, the HTTP client, Sleeper sessions, nginx, backups, the watchdog script and its thresholds, and every product path.

The intermittent public `/league` `teamAssignment` empty-assignments defect found during the same verification is tracked separately in #815 and is deliberately not addressed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_012e7gcLKkmAEz8erFp5c9Qr)_