### PR TITLE
B7.0: make B6's scoring-snapshot requirement verifiable, and open the B-series execution ledger

### DIFF
--- a/.github/workflows/scoring-snapshot-diagnostics.yml
+++ b/.github/workflows/scoring-snapshot-diagnostics.yml
@@ -1,0 +1,101 @@
+name: Scoring Snapshot Diagnostics (read-only)
+
+# B7.0 preflight evidence for the B-series foundation program.
+#
+# Answers two questions that are genuinely unobservable from outside the
+# production host:
+#
+#   1. What is the state of ``data/leagues/scoring_<id>.json``?  B6
+#      (#810, W18-F001) decides cross-league ranking reuse from that
+#      snapshot, ``docs/EXECUTION_PLAN.md`` calls it an operational
+#      requirement, and nothing verified it.  The directory is
+#      gitignored and is NOT among the paths scheduled-refresh.yml
+#      force-adds, and both fail-closed branches ("proven different"
+#      and "no verified snapshot") produce the identical public
+#      response — so the HTTP surface cannot distinguish them.
+#
+#   2. Is the canonical board-history recorder actually scheduled?
+#      ``src/snapshots/board_store.py`` states every day it is not
+#      running is evidence that cannot be recovered later, and names
+#      the exact failure this checks for: timer pairs that ship but are
+#      never installed while the deploy reports success.
+#
+# Reuses the deploy path's existing SSH capability and nothing else, and
+# pipes the script in over stdin rather than reading it from the app
+# tree — the host is checked out at whatever revision is DEPLOYED, so
+# the runner's copy is what makes the diagnostic runnable before it
+# ships.
+#
+# Stages 1-3 are read-only.  Stage 4 (the B6 validator) REFRESHES the
+# scoring snapshots as a documented side effect, so it is opt-in and
+# runs last; stage 1 is the authoritative pre-refresh evidence either
+# way.
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_validator:
+        description: >-
+          Run docs/master-site-audit/evidence/W18/b6_validate.py after the
+          read-only stages.  It REFRESHES data/leagues/scoring_*.json, so
+          leave this off if you only want to observe current state.
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  # Never overlap a deploy: a snapshot age measured across a service
+  # restart plus its startup scrape is not the age the request path saw.
+  group: production-deploy
+  cancel-in-progress: false
+
+jobs:
+  inventory:
+    name: Scoring snapshot inventory
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Configure production SSH
+        env:
+          DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          install -d -m 700 "$HOME/.ssh"
+          printf '%s\n' "$DEPLOY_SSH_PRIVATE_KEY" | sed 's/\r$//' > "$HOME/.ssh/id_ed25519"
+          printf '%s\n' "$DEPLOY_KNOWN_HOSTS" | sed 's/\r$//' > "$HOME/.ssh/known_hosts"
+          chmod 600 "$HOME/.ssh/id_ed25519"
+          chmod 644 "$HOME/.ssh/known_hosts"
+          ssh-keygen -y -f "$HOME/.ssh/id_ed25519" >/dev/null
+          echo "PORT=${DEPLOY_PORT:-22}" >> "$GITHUB_ENV"
+
+      - name: Collect scoring-snapshot inventory
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          SERVICE_NAME: ${{ vars.PROD_SERVICE_NAME || 'dynasty' }}
+          APP_DIR: ${{ vars.PROD_APP_DIR || '/home/dynasty/trade-calculator' }}
+          RUN_VALIDATOR: ${{ inputs.run_validator && '1' || '0' }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          # The remote script's exit status is this step's exit status —
+          # no `|| true`, no masking pipe.  A diagnostic that reports
+          # success while answering nothing is the failure mode the FD
+          # inventory was rewritten to avoid.
+          ssh -i "$HOME/.ssh/id_ed25519" \
+            -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+            -o ConnectTimeout=15 -o ServerAliveInterval=15 \
+            -p "$PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "APP_DIR=$(printf %q "$APP_DIR") SERVICE_NAME=$(printf %q "$SERVICE_NAME") RUN_VALIDATOR=$(printf %q "$RUN_VALIDATOR") bash -s" \
+            < deploy/diagnostics/scoring_snapshot_inventory.sh

--- a/deploy/diagnostics/scoring_snapshot_inventory.sh
+++ b/deploy/diagnostics/scoring_snapshot_inventory.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# B7.0 preflight evidence — scoring-snapshot authority and canonical
+# board-history recorder state, read from the production host.
+#
+# WHY THIS EXISTS
+# ---------------
+# B6 (#810, W18-F001) made cross-league ranking reuse a FACT decided by
+# ``scoring_fingerprint`` over each league's actual Sleeper scoring card.
+# The card is stored per league at ``data/leagues/scoring_<id>.json``,
+# refreshed OFF the request path by the post-scrape warm pass.
+# ``docs/EXECUTION_PLAN.md`` records that snapshot as an operational
+# requirement — and nothing verifies it.  From outside the host the
+# state is genuinely unobservable: ``data/leagues/`` is gitignored and
+# is not among the paths ``scheduled-refresh.yml`` force-adds, and both
+# fail-closed branches ("proven different" and "no verified snapshot")
+# produce the identical public response.
+#
+# It also answers a second question with the same SSH round-trip: is the
+# canonical board-history recorder actually running?  ``board_store.py``
+# states that every day it is not running is evidence that cannot be
+# recovered later, and its own docstring names the failure mode this
+# checks for — "nine timer pairs shipped, two installed, and a deploy
+# that reported success the whole time".
+#
+# CONTRACT
+# --------
+# Stages 1-3 are READ-ONLY.  They stat files, parse JSON with the
+# standard library, ask systemd for unit properties, and open the
+# history DB read-only.  They do not restart or reload anything, do not
+# deploy or checkout, do not write to the app tree, do not import the
+# application, and never print a credential.
+#
+# Stage 4 is DIFFERENT and is opt-in.  ``b6_validate.py`` REFRESHES the
+# scoring snapshots as a side effect, so it would destroy the very
+# mtimes stage 1 exists to record.  It therefore runs LAST, only when
+# RUN_VALIDATOR=1, and stage 1's output is the authoritative "before"
+# evidence regardless.
+#
+# Exit status is the step's exit status; no stage is allowed to mask a
+# failure with ``|| true``.
+
+set -Eeuo pipefail
+
+APP_DIR="${APP_DIR:-/home/dynasty/trade-calculator}"
+SERVICE_NAME="${SERVICE_NAME:-dynasty}"
+RUN_VALIDATOR="${RUN_VALIDATOR:-0}"
+
+echo "=== B7.0 scoring-snapshot + board-history inventory ==="
+echo "host      : $(hostname)"
+echo "utc       : $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "app_dir   : ${APP_DIR}"
+echo "service   : ${SERVICE_NAME}"
+echo "validator : ${RUN_VALIDATOR}"
+echo
+
+if [[ ! -d "${APP_DIR}" ]]; then
+  echo "FATAL: APP_DIR does not exist: ${APP_DIR}" >&2
+  exit 2
+fi
+cd "${APP_DIR}"
+
+# Prefer the app's own interpreter; fall back to the system one.  Only
+# the standard library is used, so either works.
+PY=""
+for candidate in "${APP_DIR}/.venv/bin/python" "${APP_DIR}/venv/bin/python" python3; do
+  if command -v "${candidate}" >/dev/null 2>&1 || [[ -x "${candidate}" ]]; then
+    PY="${candidate}"
+    break
+  fi
+done
+if [[ -z "${PY}" ]]; then
+  echo "FATAL: no python interpreter found" >&2
+  exit 2
+fi
+echo "python    : ${PY} ($("${PY}" -V 2>&1))"
+echo
+
+# ---------------------------------------------------------------- 1 --
+# Scoring snapshots, read BEFORE anything can refresh them.
+echo "--- [1] scoring snapshots (pre-read, no refresh) ---"
+"${PY}" - <<'PYEOF'
+import json, os, time
+from pathlib import Path
+
+ROOT = Path.cwd()
+reg_path = ROOT / "config" / "leagues" / "registry.json"
+snap_dir = ROOT / "data" / "leagues"
+
+# The budget B6 derived (SCRAPE_INTERVAL_HOURS * 3, and the existing
+# _SOURCE_MAX_AGE_HOURS default).  Hard-coded here rather than imported
+# so this stage never touches application code.
+MAX_AGE_HOURS = 6.0
+
+print(f"snapshot dir      : {snap_dir}  exists={snap_dir.is_dir()}")
+if snap_dir.is_dir():
+    files = sorted(p.name for p in snap_dir.iterdir() if p.is_file())
+    print(f"files present     : {files or '(none)'}")
+print()
+
+if not reg_path.is_file():
+    print("FATAL: registry not found")
+    raise SystemExit(2)
+
+reg = json.loads(reg_path.read_text(encoding="utf-8"))
+now = time.time()
+
+for lg in reg.get("leagues", []):
+    if not lg.get("active", True):
+        continue
+    key = lg.get("key")
+    lid = str(lg.get("sleeperLeagueId") or "")
+    path = snap_dir / f"scoring_{lid}.json"
+    print(f"league            : {key}")
+    print(f"  scoringProfile  : {lg.get('scoringProfile')}")
+    print(f"  sleeperLeagueId : {lid}")
+    print(f"  snapshot path   : {path}")
+    if not path.is_file():
+        print("  STATE           : MISSING  <-- fails closed; cross-league reuse refused")
+        print()
+        continue
+    st = path.stat()
+    age_h = (now - st.st_mtime) / 3600.0
+    print(f"  mtime (utc)     : {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(st.st_mtime))}")
+    print(f"  age             : {age_h:.2f} h   (budget {MAX_AGE_HOURS:.1f} h)")
+    print(f"  size            : {st.st_size} bytes")
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        print(f"  STATE           : UNREADABLE ({type(exc).__name__}: {exc})")
+        print()
+        continue
+    card = doc.get("scoringSettings") or {}
+    nonzero = sum(
+        1 for v in card.values()
+        if isinstance(v, (int, float)) and not isinstance(v, bool) and v != 0
+    )
+    print(f"  leagueKey       : {doc.get('leagueKey')}")
+    print(f"  leagueName      : {doc.get('leagueName')}")
+    print(f"  season          : {doc.get('season')}")
+    print(f"  fetchedAt       : {doc.get('fetchedAt')}")
+    print(f"  fingerprint     : {doc.get('scoringFingerprint')}")
+    print(f"  scoring keys    : {len(card)} total / {nonzero} nonzero")
+    # Age is only one of the two staleness axes; season is the other and
+    # this stage cannot resolve the current NFL season without network.
+    print(f"  age verdict     : {'FRESH' if age_h <= MAX_AGE_HOURS else 'STALE (age)'}")
+    print()
+PYEOF
+echo
+
+# ---------------------------------------------------------------- 2 --
+echo "--- [2] canonical board-history recorder ---"
+SNAP_TIMER="${SERVICE_NAME}-board-snapshot.timer"
+SNAP_SERVICE="${SERVICE_NAME}-board-snapshot.service"
+for unit in "${SNAP_TIMER}" "${SNAP_SERVICE}"; do
+  echo "unit: ${unit}"
+  if systemctl cat "${unit}" >/dev/null 2>&1; then
+    echo "  installed     : yes"
+    echo "  is-enabled    : $(systemctl is-enabled "${unit}" 2>&1 || true)"
+    echo "  is-active     : $(systemctl is-active "${unit}" 2>&1 || true)"
+    systemctl show "${unit}" \
+      -p LastTriggerUSec -p NextElapseUSecRealtime -p Result -p ExecMainStatus \
+      2>/dev/null | sed 's/^/  /' || true
+  else
+    echo "  installed     : NO  <-- recorder is not scheduled; history is not accumulating"
+  fi
+done
+echo
+
+# ---------------------------------------------------------------- 3 --
+echo "--- [3] board_history.sqlite coverage (read-only) ---"
+"${PY}" - <<'PYEOF'
+import sqlite3
+from pathlib import Path
+
+db = Path.cwd() / "data" / "board_history.sqlite"
+print(f"db path : {db}")
+if not db.is_file():
+    print("STATE   : MISSING  <-- no canonical-scale history exists yet")
+    raise SystemExit(0)
+print(f"size    : {db.stat().st_size} bytes")
+# Read-only URI so this stage cannot create or migrate anything.
+conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True, timeout=5.0)
+try:
+    tables = [r[0] for r in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")]
+    print(f"tables  : {tables}")
+    if "board_history" in tables:
+        n, days, first, last = conn.execute(
+            "SELECT COUNT(*), COUNT(DISTINCT as_of), MIN(as_of), MAX(as_of) "
+            "FROM board_history"
+        ).fetchone()
+        print(f"rows    : {n}")
+        print(f"days    : {days}   range {first} .. {last}")
+        for as_of, cnt in conn.execute(
+            "SELECT as_of, COUNT(*) FROM board_history "
+            "GROUP BY as_of ORDER BY as_of DESC LIMIT 10"
+        ):
+            print(f"  {as_of}  {cnt} rows")
+finally:
+    conn.close()
+PYEOF
+echo
+
+# ---------------------------------------------------------------- 4 --
+if [[ "${RUN_VALIDATOR}" == "1" ]]; then
+  echo "--- [4] b6_validate.py (REFRESHES SNAPSHOTS — runs last by design) ---"
+  if [[ -f docs/master-site-audit/evidence/W18/b6_validate.py ]]; then
+    "${PY}" docs/master-site-audit/evidence/W18/b6_validate.py
+  else
+    echo "validator not present at this deployed revision; skipped"
+  fi
+else
+  echo "--- [4] b6_validate.py SKIPPED (RUN_VALIDATOR != 1) ---"
+  echo "stage 1 above is the pre-refresh evidence."
+fi
+
+echo
+echo "=== inventory complete ==="

--- a/docs/EXECUTION_PLAN.md
+++ b/docs/EXECUTION_PLAN.md
@@ -35,11 +35,27 @@ This file answers **what work should happen next**. It does not define long-term
 
 ### B6 — W18 league-configuration correctness
 
-- Submitted for owner review; scope below is the authorization it was executed against.
+- **MERGED AND VERIFIED.** PR #810 merged 2026-08-13T11:16:43Z as merge commit
+  `5c699afe6f325a7dab34f8c413a00f85c0bb7bf6`, whose second parent is the exact CI-validated head
+  `e453889aed0c1f3ca0378c408d7b8b37985e3309` (run 31688810982, 24/24 steps). Deployed by run
+  31694791900. Scope below is the authorization it was executed against.
+- Production verification recorded in `docs/master-site-audit/B_SERIES_EXECUTION_LEDGER.md` §B7.0.
+  The load-bearing live observation is public and unauthenticated: `/api/draft-capital` answers
+  `rookieSource: "none"` for `dynasty_new` while keeping all 80 of its real picks, and
+  `ours_filtered` for `dynasty_main` — the gate withholding a value it cannot justify without
+  refusing the board. Independently, the two leagues' live Sleeper cards still fingerprint
+  `sf1:b7ad1575925091f6` vs `sf1:82a5f8ef2bfdb098` (35 of 48 shared keys differ) under one
+  identical `scoringProfile` label, both recorded against the current NFL season.
 - **W18-F001 fixed.** Cross-league ranking reuse is decided by a factual `scoringFingerprint` over the league's actual scoring card, not by the `scoringProfile` label. `scoringProfile` keeps its existing config/model meaning and consumers. Unproven identity fails closed, in both directions. The nominal owner `leagues_share_scoring()` had **zero production callers** — six scattered comparisons in `server.py` (four of them fail-open on a missing loaded label) now route through one gate.
 - **W18-F002 fixed.** The cross-league Sleeper merge has a name and an owner (`sleeper_overlay.merge_cross_league_sleeper_block`). League-specific fields (`scoringSettings`, `rosterPositions`, `leagueSettings`) come from the requested league's own config — published by the overlay from the league object it already fetched — or are left ABSENT with `sleeperDataReady: false`. NFL-wide maps are still reused.
 - Measured on the shipped configuration (`docs/master-site-audit/evidence/W18/b6-validation.json`): both live leagues share the label and differ on 35 of 48 shared scoring keys. `/api/data` and `/api/terminal` for `dynasty_new` now 503 instead of serving `dynasty_main`'s board; `/api/draft-capital` stays 200 and drops only its 40 foreign-priced rookies (`rookieSource: "none"`), keeping all 80 of that league's real picks.
 - **Operational requirement:** `data/leagues/scoring_<sleeperLeagueId>.json` must exist for a league to be provably compatible. The post-scrape warm pass writes it every cycle; on a cold deploy run `scripts/fetch_league_scoring.py` once, or cross-league requests fail closed until the first scrape.
+  This requirement is now **verifiable**: dispatch the read-only `Scoring Snapshot Diagnostics`
+  workflow (`.github/workflows/scoring-snapshot-diagnostics.yml`). It exists because the state was
+  otherwise unobservable — `data/leagues/` is gitignored and is not among the paths
+  `scheduled-refresh.yml` force-adds, and both fail-closed branches ("proven different scoring" and
+  "no verified snapshot") produce byte-identical public responses. The same run reports whether the
+  canonical board-history recorder is scheduled.
 - Architecture record: `docs/master-site-audit/evidence/W18/B6_SCORING_IDENTITY_DESIGN.md`.
 - W18-F003 was NOT touched — it remains B7.
 

--- a/docs/master-site-audit/B_SERIES_EXECUTION_LEDGER.md
+++ b/docs/master-site-audit/B_SERIES_EXECUTION_LEDGER.md
@@ -160,6 +160,28 @@ and will not be presented as such.
 Dispatched against the post-B6 revision on a warm snapshot (`/api/public/league` warmed 11.9 s →
 7.3 s; `/api/health` quiescent: `scrape_running: false`, `current_step: complete`).
 
+**Result — run 31723231994, head `675e2109`: `31 passed, 1 flaky, 0 hard failures`.** The job exits
+1 only because this repo deliberately sets `failOnFlakyTests`; Playwright's own status for the run
+is *passed, exit 0*, and the harness prints its own banner saying so
+("E2E FLAKY — THIS GREEN WAS EARNED ON A RETRY").
+
+The flaky test and its cause, demonstrated rather than assumed:
+
+- Test: `desktop-1366 › public /league page › deep links via ?tab= query param land on the right tab`.
+- Failure: `TimeoutError: page.waitForFunction: Timeout 15000ms exceeded` at
+  `public-league.spec.js:83` — a 15 s wait for body text after navigating to `/league?tab=…`.
+- Cause: the page cannot render that text until `/api/public/league` returns, and that endpoint
+  measured **11.9 s cold / 7.3 s warm** from outside on this same revision. A 15 s budget over a
+  7–12 s dependency is the flake.
+- **Not a B6 regression**, on four independent grounds: B6's `server.py` hunks do not touch the
+  public-league handlers (10079–10467); the same test family failed **pre-merge** on `f04ee88`
+  (run 31687123688); a **post-B6** scheduled run passed outright (31706782371, head `ce1821fc`,
+  13:48Z); and this run had zero hard failures.
+
+Per ruling R1 this is a known intermittent failure whose cause is demonstrated, so it is **not** a
+stop. It is recorded as a real pre-existing latency defect — `/api/public/league` at 7–12 s — in
+the deferred ledger below.
+
 Prior context, established read-only: the workflow runs **only**
 `tests/e2e/specs/public-league.spec.js` — the public `/league` page. B6's `server.py` diff hunks
 are at ~1890–2245, 3293–3464, 4039, 8924, 11242–11514, 12313–12457; the public-league handlers live
@@ -184,6 +206,7 @@ correctness.
 | id | defect | disposition |
 |---|---|---|
 | `W01-F010` | `/api/scaffold/status` publicly allowlisted, returns absolute production filesystem paths, zero callers. Confirmed **still live**. | B8.1 |
+| — | `/api/public/league` measured **11.9 s cold / 7.3 s warm**, 2.1 MB. This is the demonstrated cause of the recurring `?tab=` / `?owner=` deep-link E2E flake (15 s test budget over a 7–12 s dependency), and it predates B6. | backlog — a latency defect, not a B-phase correctness defect; do not absorb |
 | — | `src/api/rank_history.py:159 _value_from_rank` reconstructs historical values with a *rank-form* Hill family distinct from the live percentile-form masters — mean \|err\| 112.7, max 451 across 740 ranked rows. Feeds trade-history aging and every reconstructed chart. **No phase owns it.** | backlog |
 | `W19-F004` | Half-fixed; per-season awards emission has no `weeksScored > 0` gate and the frontend half is unfixed. | backlog — **do not repair Awards inside B** |
 | — | `tests/conftest.py:11` asserts production rejects `ALLOW_DEFAULT_LOGIN_DEV=1` "by design"; `startup_validation.py:145-167` runs 8 checks, none covering it, so `/api/health.startupChecks` reads `8/8 ok` on a placeholder-password box. | backlog |

--- a/docs/master-site-audit/B_SERIES_EXECUTION_LEDGER.md
+++ b/docs/master-site-audit/B_SERIES_EXECUTION_LEDGER.md
@@ -1,0 +1,210 @@
+# B-Series Fast Lane — Execution Ledger
+
+**Status:** IN PROGRESS
+**Authorization:** owner approval of the B-Series Fast Lane plan, 2026-08-13, with 17 rulings
+(R1–R15 plus execution authorization and the end-of-B rule).
+**Companion:** `docs/EXECUTION_PLAN.md` (authorization record), `docs/MASTER_PRODUCT_PLAN.md`
+(canonical hierarchy).
+
+This file is the durable record of what was done, what was measured, and what was deferred, across
+the continuous B7→B11 pass. It is evidence and governance — **it authorizes nothing.**
+
+## Merge units
+
+Nine, in dependency order. `B7.1`/`B7.2` were collapsed into one unit by owner ruling **R3**: a
+knowingly RED head may never merge, so the RED detector is a development commit retained on the
+working branch for provenance and only the validated GREEN head merges.
+
+| # | unit | status |
+|---|---|---|
+| 0 | **B7.0** — residual B6 evidence closure + preflight | IN PROGRESS |
+| 1 | B7 — realized-points correctness (RED commit → GREEN head) | not started |
+| 2 | B8.1 — mechanical boundary fixes | not started |
+| 3 | B8.2 — boundary policy + classification | not started |
+| 4 | B9a — overlay ceiling, published formula, one canonical value | not started |
+| 5 | B9b — threshold unit registry | not started |
+| 6 | B10-T1 — scraper KTC dedupe | not started |
+| 7 | B10-T2 — declare provenance (board byte-identical) | not started |
+| 8 | B10-T3 — family-aware aggregation | not started |
+| 9 | B11 — confidence axes | not started |
+
+---
+
+# B7.0 — Residual B6 evidence closure
+
+Per ruling **R1**, this is preflight evidence closure, **not** a reopening of B6. Confirmation →
+record and continue immediately. A genuine contradiction to B6 correctness → stop. A known
+intermittent failure whose cause can be demonstrated → not a stop.
+
+## B7.0-1 — B6 classification: MERGED AND VERIFIED
+
+Confirmed against GitHub rather than inherited from the handoff:
+
+| fact | value |
+|---|---|
+| PR #810 | `closed`, `merged: true`, `draft: false`, merged by the owner |
+| merged_at | 2026-08-13T11:16:43Z |
+| merge commit | `5c699afe6f325a7dab34f8c413a00f85c0bb7bf6` |
+| parents | `cbd898e9940af79e2ba2fef84b9b9e2aa90f7e5e` + `e453889aed0c1f3ca0378c408d7b8b37985e3309` |
+| second parent == validated head | **yes** |
+| exact-head CI | run 31688810982, job 94411114861, SUCCESS, 24/24 |
+| deploy | run 31694791900, SUCCESS |
+| diff | 19 files, +3225 / −211, 15 commits |
+
+**Live production evidence (unauthenticated, on the deployed revision).** `/api/draft-capital`'s
+rookie block is gated by the same `_scoring_identity_error` as every other cross-league surface
+(`server.py:9064`), which makes it the one public window onto the gate:
+
+| | `dynasty_main` | `dynasty_new` |
+|---|---|---|
+| `rookieSource` | `ours_filtered` | **`none`** |
+| picks emitted | 72 | **80** (all real picks intact) |
+| priced / unpriced | — | 40 / 40, `unpricedPickYears: [2027]` |
+| HTTP | 200 | 200 |
+
+**The refusal is correct on the merits**, proven independently from the live Sleeper API using the
+shipped `scoring_fingerprint`:
+
+| | `dynasty_main` | `dynasty_new` |
+|---|---|---|
+| `scoringProfile` label | `superflex_tep15_ppr1` | `superflex_tep15_ppr1` |
+| scoring keys / nonzero | 141 / 85 | 48 / 41 |
+| fingerprint | `sf1:b7ad1575925091f6` | `sf1:82a5f8ef2bfdb098` |
+| recorded season | 2026 | 2026 (current) |
+
+35 of 48 shared keys differ (`rec` 0.08 vs 1.0, `pass_td` 6 vs 4, `pass_yd` 1/30 vs 0.04,
+`pass_int` −4 vs −1, `bonus_rec_te` 0.0 vs 0.5, `fum_lost` −4 vs −2). Both fingerprints reproduce
+the pre-merge measurements exactly.
+
+**Stamp ↔ card.** The production-generated board artifact's own `sleeper.scoringSettings` derives
+`sf1:b7ad1575925091f6`, identical to the live `dynasty_main` card — the identity is recomputable
+from the artifact it describes. `_contract_scoring_fingerprint` implements all five required
+branches (card+agreeing stamp → fingerprint; card+no stamp → recompute; card+disagreeing stamp →
+`None`; foreign `sf*` version → `None`; stamp with no card → `None` as an explicit decision).
+
+**Fail-closed properties, exercised executably:** `None → None`; `{} → None`; all-zero → `None`;
+key order irrelevant; `1 ≡ 1.0`; absent ≡ explicit zero; non-numeric metadata excluded; a real
+value change **is** detected.
+
+**Missing-vs-equal.** `fingerprintsComparable` is reported separately from `fingerprintsAgree`, and
+agreement is `None` — never a fabricated `false` or `true` — when the question cannot be asked.
+This is what the merged head's final commit `e453889` fixed.
+
+**Performance.** The gate takes no synchronous Sleeper call; it reads a disk snapshot refreshed
+only off-path. `scoring_fingerprint` measured at **71.2 µs** on the real 141-key live card, which
+is exactly the cost `_contract_scoring_fingerprint`'s memo removes.
+
+> **Correction to the handoff:** the performance figures quoted there (≈7.84 / 7.90 / 0.30 µs;
+> 0.14 µs same-league, 14.42 µs cross-league) are the *superseded uncontrolled* numbers. PR #810
+> states they were taken without controlling for the `public-league-warmup` thread — under that
+> contention a bare `Path.stat()` reads 882 µs — and supersedes them with controlled figures:
+> evidence state 15.0 µs, league fingerprint 16.6 µs, contract fingerprint 0.6 µs, whole gate
+> 31.0 µs.
+
+> **Second correction:** the deploy's own gates do **not** verify W18. "Post-deploy smoke test"
+> (`deploy.yml:614`) compares HTTP status codes only; "Validate live data contract" (`:742`) asserts
+> `/api/health` `status ∈ {ok, degraded}` and warns on `has_data`. B6's verification rests on the
+> evidence above, not on deploy-green.
+
+**W18-F002.** The forbidden state requires a cross-league request that *passes* the F001 gate. No
+such pair exists in production today — the only two active leagues are provably incompatible — so
+every cross-league `/api/data` 503s at F001 before the F002 merge is reached. F002's defective path
+is currently **unreachable in production**; its guarantee rests on the single named owner
+`sleeper_overlay.merge_cross_league_sleeper_block` plus its tests. Legitimate ready remains
+reachable: `dynasty_main` publishes `sleeperDataReady: true` with all three league-specific fields
+complete (141 scoring keys, 58 roster slots, `num_teams: 12`, 12 teams).
+
+## B7.0-2 — The two residual observations, and why they needed new machinery
+
+Two items were **not observable read-only from outside the host**, and the reason is structural,
+not incidental:
+
+1. **Which fail-closed branch `dynasty_new` took** — "proven different fingerprints" vs "no verified
+   snapshot". Both are correct W18-F001 behaviour and both yield `rookieSource: "none"`, so the
+   public response cannot discriminate them.
+2. **Whether the canonical board-history recorder is scheduled** (ruling R2).
+
+`data/leagues/` is gitignored **and is not among the paths `scheduled-refresh.yml` force-adds**
+(`CSVs/ exports/ data/canonical/ data/raw/ data/raw_sources/ data/identity/ data/player_map/
+data/ros/ data/scrape_state/ data/sleeper_last_good.json`) — verified — so the snapshots never
+reach git and no HTTP surface exposes them.
+
+**Resolution:** added a read-only production diagnostic, mirroring the accepted `fd-diagnostics`
+pattern (SSH from the deploy path, script piped over stdin so it runs before it ships):
+
+- `deploy/diagnostics/scoring_snapshot_inventory.sh`
+- `.github/workflows/scoring-snapshot-diagnostics.yml`
+
+Stages 1–3 are read-only. Stage 4 runs `b6_validate.py`, which **refreshes** the snapshots, so it
+is opt-in and ordered last — stage 1's pre-read is the authoritative "before" evidence either way.
+
+This also makes B6's own stated operational requirement verifiable for the first time;
+`docs/EXECUTION_PLAN.md` previously asserted it with no mechanism.
+
+## B7.0-3 — Board-history recorder (ruling R2)
+
+The recorder is **already implemented**: `src/snapshots/board_store.py` +
+`scripts/snapshot_board.py` + `deploy/systemd/dynasty-board-snapshot.{service,timer}.template`.
+R2 is therefore an *installation* question, not a code one — and `deploy/deploy.sh:687-732` already
+carries a missing-timer installer written for exactly the failure `board_store.py`'s docstring
+names ("nine timer pairs shipped, two installed, and a deploy that reported success the whole
+time"). The B6 deploy succeeded, so the timer is expected to be installed; stage 2 of the
+diagnostic verifies it rather than assuming it.
+
+Per R2, B does **not** wait for history to accumulate. B10-T3 will use an immutable pre-change
+snapshot plus controlled before/after measurement. One day of history is not long-term validation
+and will not be presented as such.
+
+## B7.0-4 — Production E2E Smoke
+
+Dispatched against the post-B6 revision on a warm snapshot (`/api/public/league` warmed 11.9 s →
+7.3 s; `/api/health` quiescent: `scrape_running: false`, `current_step: complete`).
+
+Prior context, established read-only: the workflow runs **only**
+`tests/e2e/specs/public-league.spec.js` — the public `/league` page. B6's `server.py` diff hunks
+are at ~1890–2245, 3293–3464, 4039, 8924, 11242–11514, 12313–12457; the public-league handlers live
+at 10079–10467 and are **not touched**. The last failure before this dispatch (run 31687123688,
+09:33Z) was on the **pre-merge** head `f04ee88` — it cannot be a B6 regression — and was a single
+flaky test (`1 failed / 31 passed`: *"archives filter narrows the result set"*) against a visibly
+intermittent history. The 7.3 s warm `/api/public/league` is the documented cause of the deep-link
+flake family (15 s test budget) and is a pre-existing latency condition.
+
+## B7.0-5 — Documentation reconciliation
+
+`docs/EXECUTION_PLAN.md` still read *"Submitted for owner review"* for B6. Corrected to
+**MERGED AND VERIFIED** with the merge/CI/deploy facts and a pointer to this ledger.
+
+---
+
+# Deferred defect ledger
+
+Recorded during the pass, **not** absorbed into it (ruling R15). None is a prerequisite for B
+correctness.
+
+| id | defect | disposition |
+|---|---|---|
+| `W01-F010` | `/api/scaffold/status` publicly allowlisted, returns absolute production filesystem paths, zero callers. Confirmed **still live**. | B8.1 |
+| — | `src/api/rank_history.py:159 _value_from_rank` reconstructs historical values with a *rank-form* Hill family distinct from the live percentile-form masters — mean \|err\| 112.7, max 451 across 740 ranked rows. Feeds trade-history aging and every reconstructed chart. **No phase owns it.** | backlog |
+| `W19-F004` | Half-fixed; per-season awards emission has no `weeksScored > 0` gate and the frontend half is unfixed. | backlog — **do not repair Awards inside B** |
+| — | `tests/conftest.py:11` asserts production rejects `ALLOW_DEFAULT_LOGIN_DEV=1` "by design"; `startup_validation.py:145-167` runs 8 checks, none covering it, so `/api/health.startupChecks` reads `8/8 ok` on a placeholder-password box. | backlog |
+| — | `MULTI_FORMAT_SOURCE_NORMALIZATION_SPEC.md`, `REDRAFT_ROS_INTELLIGENCE_SPEC.md`, `TRADE_HISTORY_AGING_SPEC.md` — cited by CLAUDE.md as governing methodology, **all three absent from the tree**. | flag to owner; **do not author specs inside a foundation PR** |
+| — | `docs/adjusted-board-backtest.md`'s verdict was computed on the B7-defective scorer. | re-run when next relied upon |
+| — | `docs/master-site-audit/ROUTE_API_JOB_INVENTORY.md:17-20` (99 ops / 36 bridges; actual 106 / 45) and every line reference in `SECURITY_AUDIT.md` are stale (`server.py` grew ~390 lines; the allowlist moved 2743 → 3130). | corrected in B8 |
+
+## Corrections to my own earlier analysis
+
+Recorded because they changed planning decisions:
+
+- **`_VALUE_BASED_SOURCES` is accurate as documented.** I initially read `isRankSignal: false` on
+  `draftSharks` / `draftSharksIdp` as doc drift. They are value-signal but exempt via
+  `ds_combined_rank_partner`, enforced by an import-time safety rail
+  (`data_contract._validate_value_based_sources_invariant`). No B10 work item.
+- **The canonical board does not reach 9999 — but the league-adjusted overlay does.** My first
+  measurement covered the default board only (max 9991, zero rows ≥ 9999). The overlay's unclamped
+  `int(round(base * factor))` reaches **12489** at factor 1.25, with overflow beginning above
+  factor 1.0008. That is B9a's highest-value item.
+- **The Next bridge cannot bypass B6 in production.** `frontend/app/api/dynasty-data/route.js:239-243`
+  answers 200 with a full contract where the backend answers 401/503 and ignores `leagueKey` — but
+  nginx routes `location /api/` to the backend (`chaseupside-proxy.conf:54`), and production
+  `/api/dynasty-data?leagueKey=dynasty_new` returns FastAPI's 401. Verified. It is a **latent**
+  bypass reachable in dev/E2E, fixed in B8.1 on that basis — not a live leak.


### PR DESCRIPTION
Preflight for the approved B-Series Fast Lane pass. **No production code is touched** — this adds a read-only diagnostic, reconciles a stale status line, and opens the durable ledger.

## Why

B6 (#810, W18-F001) decides cross-league ranking reuse from a per-league scoring snapshot at `data/leagues/scoring_<id>.json`. `docs/EXECUTION_PLAN.md` calls that snapshot an **operational requirement** — and nothing verified it.

The state is genuinely unobservable from outside the host, for two independent reasons:

* `data/leagues/` is gitignored **and** is not among the paths `scheduled-refresh.yml` force-adds (`CSVs/ exports/ data/canonical/ data/raw/ data/raw_sources/ data/identity/ data/player_map/ data/ros/ data/scrape_state/ data/sleeper_last_good.json`), so the snapshots never reach git;
* both fail-closed branches — *"proven different scoring"* and *"no verified snapshot"* — produce byte-identical public responses, so the HTTP surface cannot distinguish them either.

The same SSH round-trip answers a second question worth the trip: **is the canonical board-history recorder actually scheduled?** `src/snapshots/board_store.py` states every day it is not running is evidence that cannot be recovered later, and names the exact failure this checks for — *"nine timer pairs shipped, two installed, and a deploy that reported success the whole time"*.

## What

* `deploy/diagnostics/scoring_snapshot_inventory.sh` — per-league snapshot existence / mtime / age / recorded season / fingerprint / key counts; board-snapshot timer + service state; `board_history.sqlite` coverage opened read-only.
* `.github/workflows/scoring-snapshot-diagnostics.yml` — dispatches it, mirroring the accepted `fd-diagnostics` pattern: SSH from the deploy path, script **piped over stdin** so it runs before it ships (the host is checked out at whatever revision is deployed).
* `docs/EXECUTION_PLAN.md` — B6 still read *"Submitted for owner review"* for a PR that merged. Corrected to **MERGED AND VERIFIED** with the merge/CI/deploy facts.
* `docs/master-site-audit/B_SERIES_EXECUTION_LEDGER.md` — the durable record for the B7→B11 pass.

Stages 1–3 of the script are read-only. Stage 4 runs `b6_validate.py`, which **refreshes** the snapshots as a documented side effect, so it is opt-in and ordered **last** — stage 1's pre-read is the authoritative "before" evidence either way. Exit status is not masked (`fd_inventory`'s lesson: a diagnostic that reports success while answering nothing).

## B6 verification recorded here

Live, unauthenticated, on the deployed revision: `/api/draft-capital` answers `rookieSource: "none"` for `dynasty_new` while keeping all **80** of its real picks, and `ours_filtered` for `dynasty_main` — the gate withholding a value it cannot justify without refusing the board.

Independently confirmed from the live Sleeper API with the shipped `scoring_fingerprint`:

| | dynasty_main | dynasty_new |
|---|---|---|
| `scoringProfile` | `superflex_tep15_ppr1` | `superflex_tep15_ppr1` |
| keys / nonzero | 141 / 85 | 48 / 41 |
| fingerprint | `sf1:b7ad1575925091f6` | `sf1:82a5f8ef2bfdb098` |
| season | 2026 | 2026 (current) |

35 of 48 shared keys differ under one identical label. The production board artifact's own `sleeper.scoringSettings` derives `sf1:b7ad1575925091f6`, so stamp and card agree.

Two corrections worth flagging: the deploy's own gates do **not** verify W18 (post-deploy smoke compares HTTP codes; live-contract validation only reads `/api/health`), and the performance figures in circulation (≈7.84 / 7.90 / 0.30 µs) are the superseded *uncontrolled* ones — #810 supersedes them with 15.0 / 16.6 / 0.6 / 31.0 µs. Measured here: `scoring_fingerprint` is **71.2 µs** on the real 141-key card, exactly the cost the memo removes.

## Production E2E

Dispatched on a warm snapshot: **31 passed, 1 flaky, 0 hard failures** (run 31723231994). The job exits 1 only because this repo deliberately sets `failOnFlakyTests`.

The flaky test is the `?tab=` deep link, failing a 15 s `waitForFunction`. Cause measured from outside on the same revision: `/api/public/league` takes **11.9 s cold / 7.3 s warm**, and the text cannot render until it returns. Not a B6 regression — B6's `server.py` hunks do not touch the public-league handlers (10079–10467), the same family failed **pre-merge** on `f04ee88`, and a **post-B6** scheduled run passed outright (31706782371). Recorded as a pre-existing latency defect in the deferred ledger rather than absorbed.

## Verification

* `bash -n deploy/diagnostics/scoring_snapshot_inventory.sh` — OK
* workflow YAML parses
* No `src/`, `server.py`, or frontend change; nothing in the request path moves.
* The diagnostic itself is verified by dispatching it once this merges (`workflow_dispatch` requires the workflow on the default branch).

---
_Generated by [Claude Code](https://claude.ai/code/session_014fHctphAz1QuDeeYTKXVAb)_