### PR TITLE
B7 / W18-F003: realized points measured against the league host, not against itself

### DIFF
--- a/docs/audits/decision-intelligence-audit-2026-08-04.status.json
+++ b/docs/audits/decision-intelligence-audit-2026-08-04.status.json
@@ -543,16 +543,16 @@
    "auditEvidence": "`src/nfl_data/realized_points.py:78-99 _SIMPLE_KEYS` has no entry for `rec_0_4`/`rec_5_9`/`rec_10_19`/`rec_20_29`/`rec_30_39`/`rec_40p`, and `compute_weekly_points` (`:323-420`) has no other branch for them. The live league card carries all six at nonzero rates: `rec_0_4=0.17, rec_5_9=0.42, rec_10_19=0.67, rec_20_29=0.92, rec_30_39=1.17, rec_40p=1.92` (exports/latest/dynasty_data_2026-08-04.json \u2192",
    "auditId": "B-2",
    "path": "src/nfl_data/realized_points.py",
-   "signature": "\"rec\": (\"receptions\", \"Rec\")",
+   "signature": "\"rec\": ((\"receptions\",), \"Rec\")",
    "status": "open",
-   "verifiedBy": "_SIMPLE_KEYS carries flat 'rec' and no rec_0_4 / rec_5_9 / rec_10_19 band keys, so the active reception-band rules score nothing.",
+   "verifiedBy": "_SIMPLE_KEYS carries flat 'rec' and no rec_0_4 / rec_5_9 / rec_10_19 band keys, so the active reception-band rules score nothing.\n\nSIGNATURE RESPELLED 2026-08-13 (B7), STATUS DELIBERATELY UNCHANGED. B7 converted _SIMPLE_KEYS to candidate columns \u2014 `\"rec\": (\"receptions\", \"Rec\")` became `\"rec\": ((\"receptions\",), \"Rec\")` \u2014 so the old needle stopped matching and the probe flipped to signature_absent. That is the case this module's own docstring warns about: an absent signature means the cited MECHANISM changed, not that the defect is fixed. It is not fixed. The six reception-band rules still score nothing; what B7 changed is that they are now DECLARED \u2014 scoring_coverage reports them UNSCORABLE with a reason and describe_gaps surfaces them, instead of silently contributing zero. Honest disclosure is not scoring, and closing C29 on a respelling would have been exactly the unchecked-claim failure this gate exists to prevent.",
    "closedBy": null,
    "measuredEffect": null,
    "batch": null,
    "probe": {
     "result": "signature_present",
     "path": "src/nfl_data/realized_points.py",
-    "needle": "\"rec\": (\"receptions\", \"Rec\")"
+    "needle": "\"rec\": ((\"receptions\",), \"Rec\")"
    }
   },
   {

--- a/docs/master-site-audit/B_SERIES_EXECUTION_LEDGER.md
+++ b/docs/master-site-audit/B_SERIES_EXECUTION_LEDGER.md
@@ -141,6 +141,53 @@ is opt-in and ordered last — stage 1's pre-read is the authoritative "before" 
 This also makes B6's own stated operational requirement verifiable for the first time;
 `docs/EXECUTION_PLAN.md` previously asserted it with no mechanism.
 
+## B7.0-2b — RESULT: both residuals CLOSED with direct production evidence
+
+Diagnostic run **31725087238** (job 94535586970), SUCCESS, read-only stages only.
+
+**Residual 1 — which fail-closed branch `dynasty_new` takes. ANSWERED: proven-different.**
+Both snapshots exist and are **FRESH**, read before anything refreshed them:
+
+| | `dynasty_main` | `dynasty_new` |
+|---|---|---|
+| mtime (UTC) | 2026-08-13T17:33:17Z | 2026-08-13T17:33Z |
+| age vs 6.0 h budget | **0.04 h** | **0.04 h** |
+| recorded season | **2026** (current) | **2026** (current) |
+| fingerprint | `sf1:b7ad1575925091f6` | `sf1:82a5f8ef2bfdb098` |
+| scoring keys | 141 / 85 nonzero | 48 / 41 nonzero |
+| verdict | FRESH | FRESH |
+
+So the warm pass **is** writing snapshots on every cycle, and `dynasty_new`'s refusal is the
+"**proven different fingerprints**" branch — not "no verified snapshot". Both fingerprints match
+the values measured independently from the live Sleeper API earlier in B7.0, from a completely
+different vantage point. B6's operational requirement is satisfied on production and now has a
+standing verification mechanism.
+
+**Residual 2 — the board-history recorder (ruling R2). ANSWERED: already running.**
+
+```
+dynasty-board-snapshot.timer  installed=yes  enabled  active
+    LastTriggerUSec = 2026-08-13 09:12:51 CEST   Result=success
+    NextElapse      = 2026-08-14 09:11:06 CEST
+data/board_history.sqlite     2,846,720 bytes   tables: board_history, meta
+    rows = 8,749   days = 8   range 2026-08-06 .. 2026-08-13  (~1,092-1,095/day)
+```
+
+(The `.service` unit reading `disabled`/`inactive` is correct for a timer-activated oneshot: the
+timer is enabled and active, the service runs on trigger and exits. `Result=success`,
+`ExecMainStatus=0`.)
+
+> **Correction to the reconnaissance, and it materially improves B10.** The recon reported
+> "`data/board_history.sqlite` does not exist on this checkout" and concluded that **B10-T3 would
+> be unfalsifiable against the past**. That was true of the *container's clone* and false of
+> *production*: the recorder has been running since at least 2026-08-06 and holds **8 days of
+> canonical-scale history**. B10-T3 therefore has a real historical baseline to measure against,
+> and R2's "start the recorder" is already satisfied — what remains is capturing the **immutable
+> pre-B10 snapshot**, which is now a copy rather than a bootstrap.
+
+**B7.0 verdict: B6 correctness CONFIRMED, not contradicted.** Per ruling R1, recorded and
+continuing immediately into B7.
+
 ## B7.0-3 — Board-history recorder (ruling R2)
 
 The recorder is **already implemented**: `src/snapshots/board_store.py` +

--- a/scripts/audit_status.py
+++ b/scripts/audit_status.py
@@ -447,11 +447,24 @@ _FINDINGS: dict[str, tuple[str, str | None, str | None, str, str]] = {
     "C29": (
         "B-2",
         "src/nfl_data/realized_points.py",
-        '"rec": ("receptions", "Rec")',
+        '"rec": (("receptions",), "Rec")',
         OPEN,
         "_SIMPLE_KEYS carries flat 'rec' and no rec_0_4 / rec_5_9 / "
         "rec_10_19 band keys, so the active reception-band rules score "
-        "nothing.",
+        "nothing.\n\n"
+        "SIGNATURE RESPELLED 2026-08-13 (B7), STATUS DELIBERATELY UNCHANGED. "
+        "B7 converted _SIMPLE_KEYS to candidate columns — "
+        '`"rec": ("receptions", "Rec")` became '
+        '`"rec": (("receptions",), "Rec")` — so the old needle stopped '
+        "matching and the probe flipped to signature_absent. That is the "
+        "case this module's own docstring warns about: an absent signature "
+        "means the cited MECHANISM changed, not that the defect is fixed. "
+        "It is not fixed. The six reception-band rules still score nothing; "
+        "what B7 changed is that they are now DECLARED — scoring_coverage "
+        "reports them UNSCORABLE with a reason and describe_gaps surfaces "
+        "them, instead of silently contributing zero. Honest disclosure is "
+        "not scoring, and closing C29 on a respelling would have been "
+        "exactly the unchecked-claim failure this gate exists to prevent.",
     ),
     "C30": (
         "P-1",

--- a/server.py
+++ b/server.py
@@ -12046,10 +12046,41 @@ async def get_player_realized(sleeper_id: str, request: Request):
     except LeagueResolutionError as err:
         return err.json_response()
 
-    # Pull the Sleeper scoring settings from the overlay or primary
-    # contract — whichever belongs to this league.
-    sleeper_block = (latest_contract_data or {}).get("sleeper") or {}
-    scoring_settings = sleeper_block.get("scoringSettings") or {}
+    # Scoring settings for the REQUESTED league.
+    #
+    # This used to read ``latest_contract_data["sleeper"]["scoringSettings"]``
+    # unconditionally — the LOADED league's card — so asking about a
+    # player in a second league scored their weeks under the first
+    # league's rules and stamped the answer with the requested
+    # ``leagueKey``. That is the W18-F002 shape (requested-league
+    # identity over another league's config) on a route B6 did not
+    # enumerate.
+    #
+    # The per-league snapshot is the right owner. It is deliberately not
+    # freshness-gated here: freshness governs whether one league's
+    # RANKINGS may be reused for another, and this is not that question
+    # — it is "what are this league's own scoring rules", where a stored
+    # card is the best available answer and a stale one is still that
+    # league's. The contract is used only when it demonstrably belongs
+    # to the requested league.
+    scoring_settings = _league_registry.scoring_settings_for_league(league_cfg) or {}
+    if not scoring_settings:
+        _loaded_meta = (latest_contract_data or {}).get("meta") or {}
+        if str(_loaded_meta.get("leagueKey") or "") == league_cfg.key:
+            scoring_settings = ((latest_contract_data or {}).get("sleeper") or {}).get(
+                "scoringSettings"
+            ) or {}
+    if not scoring_settings:
+        return JSONResponse(
+            content={
+                "sleeperId": sleeper_id,
+                "leagueKey": league_cfg.key,
+                "reason": "no_scoring_settings_for_league",
+                "weeks": [],
+                "totalPoints": 0.0,
+                "weekCount": 0,
+            }
+        )
 
     # Fetch weekly stats via nfl_data_ingest (already flag-gated —
     # returns [] when nfl_data_ingest is off).  We scope to the
@@ -12076,7 +12107,25 @@ async def get_player_realized(sleeper_id: str, request: Request):
     # Find this player's GSIS via the unified mapper, then filter.
     from src.identity import unified_mapper as _um
 
-    players_dir = sleeper_block.get("players") or sleeper_block.get("playerDict")
+    # The MASTER Sleeper player directory — ``{player_id: {gsis_id,
+    # full_name, position, ...}}``, which is what ``resolve_player``
+    # indexes.
+    #
+    # This used to read ``sleeper_block["players"]`` / ``["playerDict"]``.
+    # The contract's sleeper block has NEITHER key (it carries
+    # ``idToPlayer`` / ``playerIds`` / ``positions``), so ``players_dir``
+    # was always ``None`` and every request returned
+    # ``reason: "unmapped_player"`` — a well-formed 200 that answered
+    # nothing, for every player, always. ``idToPlayer`` could not have
+    # substituted either: it is ``{id: name}`` and carries no
+    # ``gsis_id``, which is the join key the weekly stat rows use.
+    #
+    # ``fetch_nfl_players`` is the existing process-cached full dump
+    # (~5 MB once per process, ``{}`` on any failure), so this adds no
+    # new download path and no second cache.
+    from src.public_league.sleeper_client import fetch_nfl_players as _fetch_nfl_players
+
+    players_dir = _fetch_nfl_players()
     resolved = _um.resolve_player(players_dir, sleeper_id=str(sleeper_id))
     if resolved is None or not resolved.gsis_id:
         return JSONResponse(

--- a/src/league_comparison/sleeper_stats.py
+++ b/src/league_comparison/sleeper_stats.py
@@ -74,7 +74,17 @@ _FIELD_MAP: dict[str, str] = {
     # "def_*".  The realized-points engine reads from def_* columns.
     "idp_tkl_solo": "def_tackles_solo",
     "idp_tkl_ast": "def_tackle_assists",
-    "idp_tkl": "def_tackles",
+    # ``idp_tkl`` is DELIBERATELY NOT MAPPED (2026-08-13, B7 / W18-F003).
+    # It used to become ``def_tackles``, and the two do not mean the same
+    # thing: Sleeper's ``idp_tkl`` is COMBINED tackles, while
+    # ``realized_points._tackle_view`` reads a published ``def_tackles``
+    # as the pre-2025 gamebook SOLO total.  Writing combined into the
+    # solo slot inflated both — a 5-solo/3-assist line became solo 8,
+    # combined 11 — on every row that reached the engine through this
+    # fallback path.
+    #
+    # Nothing is lost by dropping it: ``_tackle_view`` derives combined
+    # as solo + assists, and both of those map correctly above.
     "idp_tkl_loss": "def_tackles_for_loss",
     "idp_sack": "def_sacks",
     "idp_sack_yd": "def_sack_yards",

--- a/src/nfl_data/realized_points.py
+++ b/src/nfl_data/realized_points.py
@@ -130,6 +130,39 @@ _SIMPLE_KEYS: dict[str, tuple[tuple[str, ...], str]] = {
     "kr_yd": (("kickoff_return_yards",), "KR Yds"),
     "pr_yd": (("punt_return_yards",), "PR Yds"),
     "st_td": (("special_teams_tds",), "ST TD"),
+    # ADDED 2026-08-13 (B7 / W18-F003).  KICKER.  The engine read no
+    # kicker key at all, so every kicker scored a well-formed 0.000 with
+    # no reason and no flag -- and dynasty_main starts K:1.  Nothing here
+    # needs play-by-play: the weekly feed carries the made/missed bands,
+    # total made-FG distance, and PATs outright.
+    "xpm": (("pat_made",), "XP Made"),
+    "xpmiss": (("pat_missed",), "XP Miss"),
+    "fgm_yds": (("fg_made_distance",), "FG Yds"),
+    "fgmiss": (("fg_missed",), "FG Miss"),
+    "fgm": (("fg_made",), "FG Made"),
+}
+
+#: Distance-banded kicker rules → the feed's own bands.  Separate from
+#: ``_SIMPLE_KEYS`` because a Sleeper band can span more than one nflverse
+#: band: ``fgm_50p`` means 50+, which the feed splits into ``fg_made_50_59``
+#: and ``fg_made_60_``.  Candidate columns pick the FIRST present, so a
+#: sum needs its own structure — getting this wrong would silently drop
+#: every 60-yard kick from a league that pays for 50+.
+_FG_BAND_KEYS: dict[str, tuple[tuple[str, ...], str]] = {
+    "fgm_0_19": (("fg_made_0_19",), "FG 0-19"),
+    "fgm_20_29": (("fg_made_20_29",), "FG 20-29"),
+    "fgm_30_39": (("fg_made_30_39",), "FG 30-39"),
+    "fgm_40_49": (("fg_made_40_49",), "FG 40-49"),
+    "fgm_50_59": (("fg_made_50_59",), "FG 50-59"),
+    "fgm_60p": (("fg_made_60_",), "FG 60+"),
+    "fgm_50p": (("fg_made_50_59", "fg_made_60_"), "FG 50+"),
+    "fgmiss_0_19": (("fg_missed_0_19",), "FG Miss 0-19"),
+    "fgmiss_20_29": (("fg_missed_20_29",), "FG Miss 20-29"),
+    "fgmiss_30_39": (("fg_missed_30_39",), "FG Miss 30-39"),
+    "fgmiss_40_49": (("fg_missed_40_49",), "FG Miss 40-49"),
+    "fgmiss_50_59": (("fg_missed_50_59",), "FG Miss 50-59"),
+    "fgmiss_60p": (("fg_missed_60_",), "FG Miss 60+"),
+    "fgmiss_50p": (("fg_missed_50_59", "fg_missed_60_"), "FG Miss 50+"),
 }
 
 
@@ -417,6 +450,20 @@ def compute_weekly_points(
         if pts_per == 0.0:
             continue
         stat = _first_num(stat_row, stat_columns)
+        if stat == 0:
+            continue
+        contribution = stat * pts_per
+        breakdown.append((label, stat, contribution))
+        total += contribution
+
+    # Distance-banded kicker rules.  SUMMED across the feed's bands, not
+    # first-present, because one Sleeper band can cover several of the
+    # feed's (see _FG_BAND_KEYS).
+    for key, (band_columns, label) in _FG_BAND_KEYS.items():
+        pts_per = scoring.get(key, 0.0)
+        if pts_per == 0.0:
+            continue
+        stat = sum(_num(stat_row.get(col)) for col in band_columns)
         if stat == 0:
             continue
         contribution = stat * pts_per

--- a/src/nfl_data/realized_points.py
+++ b/src/nfl_data/realized_points.py
@@ -75,26 +75,61 @@ from src.scoring.sleeper_ingest import KEY_ALIASES as _SLEEPER_KEY_ALIASES
 # Split into simple_keys (direct column read) and bonus_keys
 # (threshold-based boolean).
 
-_SIMPLE_KEYS: dict[str, tuple[str, str]] = {
-    # (stat_row_key, human_label)
-    "pass_yd": ("passing_yards", "Pass Yds"),
-    "pass_td": ("passing_tds", "Pass TD"),
-    "pass_int": ("interceptions", "INT"),
-    "pass_sack": ("sacks", "Sacks Taken"),
-    "rush_yd": ("rushing_yards", "Rush Yds"),
-    "rush_td": ("rushing_tds", "Rush TD"),
-    "rec": ("receptions", "Rec"),
-    "rec_yd": ("receiving_yards", "Rec Yds"),
-    "rec_td": ("receiving_tds", "Rec TD"),
-    "fum_lost": ("fumbles_lost", "Fum Lost"),
+# CORRECTED 2026-08-13 (B7 / W18-F003).  Three of these read columns the
+# 2025 unified nflverse release renamed, and failed exactly the way the
+# IDP block below failed before its own 2026-07-27 correction:
+# ``stat_row.get`` returns None, ``_num`` turns it into 0.0, and the rule
+# is skipped as though the player had recorded nothing.  The offense half
+# was simply missed by that repair.
+#
+# These three are PENALTIES, so the silent skip inflates rather than
+# understates — the same football scored 18.00 points higher spelled the
+# modern way on dynasty_main's card (pass_int -4, pass_sack -1,
+# fum_lost -4), with the INT / Sacks Taken / Fum Lost lines absent from
+# the breakdown entirely.  Measured across 636 host player-weeks: 208
+# points never charged, and 81% of the QB signed error.
+#
+# Now a CANDIDATE TUPLE, the shape ``_IDP_KEYS`` already uses and the
+# shape the comment above that block already claimed both shared.  Live
+# name first so a modern row wins; the retired name is kept second so a
+# backfill over an older season still scores.  This also removes the
+# reason ``src/bdvm/baseline.py::_RAW_ALIASES`` and
+# ``src/nfl_data/actuals_store.py`` each carry a private copy of the same
+# rename — the engine now absorbs it for every caller.
+_SIMPLE_KEYS: dict[str, tuple[tuple[str, ...], str]] = {
+    # (candidate stat_row keys, human_label)
+    "pass_yd": (("passing_yards",), "Pass Yds"),
+    "pass_td": (("passing_tds",), "Pass TD"),
+    "pass_int": (("passing_interceptions", "interceptions"), "INT"),
+    "pass_sack": (("sacks_suffered", "sacks"), "Sacks Taken"),
+    "rush_yd": (("rushing_yards",), "Rush Yds"),
+    "rush_td": (("rushing_tds",), "Rush TD"),
+    "rec": (("receptions",), "Rec"),
+    "rec_yd": (("receiving_yards",), "Rec Yds"),
+    "rec_td": (("receiving_tds",), "Rec TD"),
+    "fum_lost": (("fumbles_lost_total", "fumbles_lost"), "Fum Lost"),
     # ADDED 2026-07-28.  Per-play scoring the engine never read, found
     # by src/nfl_data/scoring_coverage.py.  Both columns are on the
     # unified feed and both rules are live in dynasty_main: pass_cmp at
     # 0.15/completion (1,762 unscored points across 2025) and rush_att
     # at 0.08/carry (1,225).  ``pass_inc`` is the third of this family
     # and is derived rather than read — see below.
-    "pass_cmp": ("completions", "Completions"),
-    "rush_att": ("carries", "Rush Att"),
+    "pass_cmp": (("completions",), "Completions"),
+    "rush_att": (("carries",), "Rush Att"),
+    # ADDED 2026-08-13 (B7 / W18-F003).  PLAYER special teams, landing
+    # with the ``st_``/``kr_yd``/``pr_yd`` reclassification in
+    # scoring_coverage.  These were treated as belonging to an asset
+    # class this platform does not value; they are paid to the RB, WR, TE
+    # and LB it ranks and starts.  Measured over 1,339 host player-weeks
+    # on dynasty_main's card: kr_yd 69 rows / 150.77 pts, pr_yd 29 /
+    # 22.43, st_td 4 / 24.00.
+    #
+    # DST's ``def_kr_yd`` / ``def_pr_yd`` / ``def_st_td`` are a different
+    # rule family for an asset class this board genuinely does not value,
+    # and stay unscored.
+    "kr_yd": (("kickoff_return_yards",), "KR Yds"),
+    "pr_yd": (("punt_return_yards",), "PR Yds"),
+    "st_td": (("special_teams_tds",), "ST TD"),
 }
 
 
@@ -123,12 +158,37 @@ _FIRST_DOWN_BONUS_KEYS: dict[str, str] = {
     "TE": "bonus_fd_te",
 }
 
-#: Columns summed to get a player's total first downs.
+#: Columns summed to get a player's total first downs.  Mirrored by
+#: ``first_down_rate.FIRST_DOWN_COLUMNS``, which uses it as a PRESENCE
+#: check ("does this line supply first downs at all"), so it stays flat.
 _FIRST_DOWN_COLUMNS: tuple[str, ...] = (
     "passing_first_downs",
     "rushing_first_downs",
     "receiving_first_downs",
 )
+
+# ADDED 2026-08-13 (B7 / W18-F003).  The two feeds do not mean the same
+# thing by "first down".  **Sleeper EXCLUDES scoring plays** from
+# ``pass_fd`` / ``rush_fd`` / ``rec_fd``; nflverse's ``*_first_downs``
+# INCLUDE them.  Summing the nflverse columns therefore over-counts by
+# exactly the player's touchdown count in that play type.
+#
+# Host-verified on the golden fixtures, 3/3 exact: Josh Allen 2025 wk14
+# carries ``bonus_fd_qb = 13`` with ``pass_fd 10 + rush_fd 3`` and 4
+# touchdowns, where the raw columns sum to 17.  CMC +2 on 2 TDs; Diggs
+# +0 on 0 TDs.
+#
+# This one is an OVER-charge, opposite in sign to the renamed-column and
+# reception-band defects.  That is why it cannot be deferred: on the
+# measured sample RB net error is ~0% only because these cancel, so
+# repairing the understatements alone would invert RB direction.  The
+# same argument the module header at ``scoring_coverage.py`` makes about
+# partial corrections to relative quantities.
+_FIRST_DOWN_TD_COLUMNS: dict[str, str] = {
+    "passing_first_downs": "passing_tds",
+    "rushing_first_downs": "rushing_tds",
+    "receiving_first_downs": "receiving_tds",
+}
 
 
 # Defensive scoring keys → nflverse ``def_*`` stat columns.  Only
@@ -350,12 +410,13 @@ def compute_weekly_points(
     breakdown: list[tuple[str, float, float]] = []
     total = 0.0
 
-    # Simple keys — direct stat × points.
-    for key, (stat_key, label) in _SIMPLE_KEYS.items():
+    # Simple keys — direct stat × points.  Candidate columns, so a
+    # vendor rename cannot silently drop a live rule (see _SIMPLE_KEYS).
+    for key, (stat_columns, label) in _SIMPLE_KEYS.items():
         pts_per = scoring.get(key, 0.0)
         if pts_per == 0.0:
             continue
-        stat = _num(stat_row.get(stat_key))
+        stat = _first_num(stat_row, stat_columns)
         if stat == 0:
             continue
         contribution = stat * pts_per
@@ -390,7 +451,13 @@ def compute_weekly_points(
     if fd_key:
         fd_rate = scoring.get(fd_key, 0.0)
         if fd_rate != 0.0:
-            first_downs = sum(_num(stat_row.get(c)) for c in _FIRST_DOWN_COLUMNS)
+            # Per play type, and clamped at zero on each pair: a
+            # malformed row must never turn a bonus into a penalty.
+            first_downs = 0.0
+            for fd_col in _FIRST_DOWN_COLUMNS:
+                gained = _num(stat_row.get(fd_col))
+                scoring_plays = _num(stat_row.get(_FIRST_DOWN_TD_COLUMNS[fd_col]))
+                first_downs += max(0.0, gained - scoring_plays)
             if first_downs:
                 contribution = first_downs * fd_rate
                 breakdown.append(("First Downs", first_downs, contribution))

--- a/src/nfl_data/realized_points.py
+++ b/src/nfl_data/realized_points.py
@@ -65,6 +65,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from src.league_intel.scorer import score_stat_line as _score_stat_line
 from src.scoring.sleeper_ingest import KEY_ALIASES as _SLEEPER_KEY_ALIASES
 
 
@@ -413,6 +414,122 @@ def _tackle_view(stat_row: dict[str, Any]) -> tuple[float, float, float]:
     return solo, assists, solo + assists
 
 
+#: Per-game tackle-volume thresholds, on COMBINED tackles.
+_IDP_TACKLE_THRESHOLDS: tuple[tuple[str, int, str], ...] = (
+    ("idp_tkl_5p", 5, "5+ Tkl"),
+    ("idp_tkl_10p", 10, "10+ Tkl"),
+)
+
+#: Yardage thresholds.  Sleeper publishes these as COUNTS on its own
+#: stat line (``rush_40p: 1.0``), which is why the normalizer emits 1.0
+#: rather than the qualifying yardage.
+_YARDAGE_THRESHOLDS: tuple[tuple[str, str, int, str], ...] = (
+    ("bonus_pass_yd_300", "passing_yards", 300, "300+ Pass"),
+    ("bonus_pass_yd_400", "passing_yards", 400, "400+ Pass"),
+    ("bonus_rush_yd_100", "rushing_yards", 100, "100+ Rush"),
+    ("bonus_rush_yd_200", "rushing_yards", 200, "200+ Rush"),
+    ("bonus_rec_yd_100", "receiving_yards", 100, "100+ Rec"),
+    ("bonus_rec_yd_200", "receiving_yards", 200, "200+ Rec"),
+)
+
+#: Two-point conversions.
+_TWO_PT_KEYS: tuple[tuple[str, str, str], ...] = (
+    ("pass_2pt", "passing_2pt_conversions", "Pass 2pt"),
+    ("rush_2pt", "rushing_2pt_conversions", "Rush 2pt"),
+    ("rec_2pt", "receiving_2pt_conversions", "Rec 2pt"),
+)
+
+#: Sleeper scoring key → the label the breakdown shows.  Assembled from
+#: the mapping tables plus the derived rules that have no table.
+_SLEEPER_KEY_LABELS: dict[str, str] = {
+    **{k: label for k, (_cols, label) in _SIMPLE_KEYS.items()},
+    **{k: label for k, (_cols, label) in _FG_BAND_KEYS.items()},
+    **{k: label for k, (_cols, label) in _IDP_KEYS.items()},
+    **dict(_IDP_TACKLE_KEYS),
+    **{k: label for (k, _t, label) in _IDP_TACKLE_THRESHOLDS},
+    **{k: label for (k, _c, _t, label) in _YARDAGE_THRESHOLDS},
+    **{k: label for (k, _c, label) in _TWO_PT_KEYS},
+    "pass_inc": "Incompletions",
+    "bonus_rec_te": "TE Rec Bonus",
+    **{k: "First Downs" for k in _FIRST_DOWN_BONUS_KEYS.values()},
+}
+
+
+def sleeper_stat_line_from_row(
+    stat_row: dict[str, Any],
+    *,
+    position: str | None = None,
+) -> dict[str, float]:
+    """Normalize a provider stat row into a SLEEPER-KEYED stat line.
+
+    This is the source→canonical half of realized scoring, and it is
+    deliberately **scoring-independent**: normalization is about DATA,
+    scoring is about RULES, and mixing them is what produced W18-F003.
+    An allow-list scorer keyed on provider column names skips a rule in
+    silence the moment a vendor renames a column, because a missing
+    column and a rule that scores nothing are the same thing to it.
+
+    Emitting the host's own vocabulary removes that failure mode
+    structurally: after this, a missing key is a missing STAT, and the
+    canonical scorer's dot product cannot drop a rule the line carries.
+    Sleeper's real stat lines already publish the derived keys this
+    emits — ``bonus_fd_qb: 13.0``, ``pass_inc: 6.0``, ``rush_40p: 1.0``
+    are all stats on the host's wire format, not scorer inventions.
+
+    Only NONZERO stats are emitted, matching what the host publishes and
+    keeping the breakdown to events that happened.
+    """
+    line: dict[str, float] = {}
+    pos = (position or str(stat_row.get("position") or "")).upper()
+
+    def _put(key: str, value: float) -> None:
+        if value:
+            line[key] = value
+
+    for key, (columns, _label) in _SIMPLE_KEYS.items():
+        _put(key, _first_num(stat_row, columns))
+
+    # Banded kicker rules are SUMMED: one Sleeper band can span several
+    # of the feed's (``fgm_50p`` covers 50-59 and 60+).
+    for key, (columns, _label) in _FG_BAND_KEYS.items():
+        _put(key, sum(_num(stat_row.get(col)) for col in columns))
+
+    # Incompletions — derived. nflverse publishes attempts and
+    # completions; Sleeper charges the difference.  Clamped so a
+    # malformed row can never award points for a penalty rule.
+    _put("pass_inc", max(0.0, _num(stat_row.get("attempts")) - _num(stat_row.get("completions"))))
+
+    # Position-scoped rules.  The rate lives on a position-specific KEY,
+    # so the position decision belongs here, in normalization.
+    if pos == "TE":
+        _put("bonus_rec_te", _num(stat_row.get("receptions")))
+    fd_key = _FIRST_DOWN_BONUS_KEYS.get(pos)
+    if fd_key:
+        first_downs = 0.0
+        for fd_col in _FIRST_DOWN_COLUMNS:
+            gained = _num(stat_row.get(fd_col))
+            scoring_plays = _num(stat_row.get(_FIRST_DOWN_TD_COLUMNS[fd_col]))
+            first_downs += max(0.0, gained - scoring_plays)
+        _put(fd_key, first_downs)
+
+    if _is_idp_position(pos):
+        for key, (columns, _label) in _IDP_KEYS.items():
+            _put(key, _first_num(stat_row, columns))
+        solo, assists, combined = _tackle_view(stat_row)
+        for (key, _label), stat in zip(_IDP_TACKLE_KEYS, (solo, assists, combined)):
+            _put(key, stat)
+        for key, threshold, _label in _IDP_TACKLE_THRESHOLDS:
+            _put(key, 1.0 if combined >= threshold else 0.0)
+
+    for key, column, threshold, _label in _YARDAGE_THRESHOLDS:
+        _put(key, 1.0 if _num(stat_row.get(column)) >= threshold else 0.0)
+
+    for key, column, _label in _TWO_PT_KEYS:
+        _put(key, _num(stat_row.get(column)))
+
+    return line
+
+
 def compute_weekly_points(
     stat_row: dict[str, Any] | None,
     scoring_settings: dict[str, Any] | None,
@@ -421,9 +538,24 @@ def compute_weekly_points(
 ) -> RealizedPoints | None:
     """Return realized fantasy points for one player-week.
 
-    ``position`` lets us apply position-specific bonuses (e.g.
-    ``bonus_rec_te`` adds per-reception points to TEs only).
-    Missing position → only applies position-agnostic rules.
+    Two stages, and the split is the point (B7 / W18-F003):
+
+    1. :func:`sleeper_stat_line_from_row` normalizes the provider row
+       into the host's own stat vocabulary;
+    2. ``src.league_intel.scorer.score_stat_line`` — the canonical
+       scorer, validated against Sleeper's own ``players_points`` over
+       1,339 player-weeks at max |Δ| 0.0050 — scores it.
+
+    Before this, the two engines were inverted: the host-validated one
+    had a single non-test caller and the allow-list one reached every
+    production consumer while having no host-truth test at all.  A dot
+    product over ``stat_line ∩ scoring_settings`` cannot silently skip a
+    live rule; an allow-list keyed on vendor column names does exactly
+    that, which is what W18-F003 measured.
+
+    ``position`` still matters, but only to NORMALIZATION: it selects
+    which position-scoped key a stat lands on (``bonus_fd_qb`` vs
+    ``bonus_fd_rb``), and whether IDP rules apply at all.
     """
     if not stat_row:
         return None
@@ -436,169 +568,32 @@ def compute_weekly_points(
             fantasy_points=0.0,
             breakdown=[("no_scoring_settings", 0.0, 0.0)],
         )
+
     scoring = {str(k): _num(v) for k, v in scoring_settings.items()}
+    # Alias rates are copied onto the canonical key the normalizer emits.
+    # Sleeper ships several spellings for one IDP rule and a league card
+    # may carry either; the canonical scorer matches on key equality, so
+    # the reconciliation has to happen before it runs.
     for alias, canonical in _SCORING_KEY_ALIASES.items():
         if alias in scoring and canonical not in scoring:
             scoring[canonical] = scoring[alias]
-    breakdown: list[tuple[str, float, float]] = []
-    total = 0.0
 
-    # Simple keys — direct stat × points.  Candidate columns, so a
-    # vendor rename cannot silently drop a live rule (see _SIMPLE_KEYS).
-    for key, (stat_columns, label) in _SIMPLE_KEYS.items():
-        pts_per = scoring.get(key, 0.0)
-        if pts_per == 0.0:
-            continue
-        stat = _first_num(stat_row, stat_columns)
-        if stat == 0:
-            continue
-        contribution = stat * pts_per
-        breakdown.append((label, stat, contribution))
-        total += contribution
+    stat_line = sleeper_stat_line_from_row(stat_row, position=position)
+    result = _score_stat_line(stat_line, scoring)
 
-    # Distance-banded kicker rules.  SUMMED across the feed's bands, not
-    # first-present, because one Sleeper band can cover several of the
-    # feed's (see _FG_BAND_KEYS).
-    for key, (band_columns, label) in _FG_BAND_KEYS.items():
-        pts_per = scoring.get(key, 0.0)
-        if pts_per == 0.0:
-            continue
-        stat = sum(_num(stat_row.get(col)) for col in band_columns)
-        if stat == 0:
-            continue
-        contribution = stat * pts_per
-        breakdown.append((label, stat, contribution))
-        total += contribution
-
-    # Incompletions — derived, not a column.  nflverse publishes
-    # attempts and completions; Sleeper charges the difference.  Guarded
-    # against a negative result so a malformed row can never award
-    # points for a penalty rule (dynasty_main pays -0.22/incompletion).
-    inc_rate = scoring.get("pass_inc", 0.0)
-    if inc_rate != 0.0:
-        incompletions = _num(stat_row.get("attempts")) - _num(stat_row.get("completions"))
-        if incompletions > 0:
-            contribution = incompletions * inc_rate
-            breakdown.append(("Incompletions", incompletions, contribution))
-            total += contribution
-
-    # Position-specific bonus rec (TE premium).
-    pos = (position or str(stat_row.get("position") or "")).upper()
-    te_bonus = scoring.get("bonus_rec_te", 0.0)
-    if pos == "TE" and te_bonus:
-        recs = _num(stat_row.get("receptions"))
-        if recs:
-            breakdown.append(("TE Rec Bonus", recs, recs * te_bonus))
-            total += recs * te_bonus
-
-    # Position-scoped first-down bonus.  See _FIRST_DOWN_BONUS_KEYS for
-    # why all three columns are summed and why this is keyed on position
-    # rather than play type.
-    fd_key = _FIRST_DOWN_BONUS_KEYS.get(pos)
-    if fd_key:
-        fd_rate = scoring.get(fd_key, 0.0)
-        if fd_rate != 0.0:
-            # Per play type, and clamped at zero on each pair: a
-            # malformed row must never turn a bonus into a penalty.
-            first_downs = 0.0
-            for fd_col in _FIRST_DOWN_COLUMNS:
-                gained = _num(stat_row.get(fd_col))
-                scoring_plays = _num(stat_row.get(_FIRST_DOWN_TD_COLUMNS[fd_col]))
-                first_downs += max(0.0, gained - scoring_plays)
-            if first_downs:
-                contribution = first_downs * fd_rate
-                breakdown.append(("First Downs", first_downs, contribution))
-                total += contribution
-
-    # IDP keys — only fire for defensive positions.  Sleeper's
-    # stacked-scoring stance: a sack on a solo tackle credits
-    # ``idp_sack`` + ``idp_sack_yd`` + ``idp_hit`` + ``idp_tkl_loss``
-    # + ``idp_tkl_solo`` simultaneously when each category is set on
-    # the league.  Each ``def_*`` column on the nflverse defensive
-    # stat row tracks one event-stat independently, so iterating each
-    # _IDP_KEYS entry separately produces the correct stacked total
-    # without any explicit "stack bonus" logic.
-    if _is_idp_position(pos):
-        for key, (stat_keys, label) in _IDP_KEYS.items():
-            pts_per = scoring.get(key, 0.0)
-            if pts_per == 0.0:
-                continue
-            stat = _first_num(stat_row, stat_keys)
-            if stat == 0:
-                continue
-            contribution = stat * pts_per
-            breakdown.append((label, stat, contribution))
-            total += contribution
-
-        # Tackles come from _tackle_view, not a column read — nflverse
-        # publishes no combined-tackle column, and its ``solo`` column
-        # is unassisted-only.  See the note above _IDP_KEYS.
-        tackle_stats = _tackle_view(stat_row)
-        for (key, label), stat in zip(_IDP_TACKLE_KEYS, tackle_stats):
-            pts_per = scoring.get(key, 0.0)
-            if pts_per == 0.0 or stat == 0:
-                continue
-            contribution = stat * pts_per
-            breakdown.append((label, stat, contribution))
-            total += contribution
-
-        # Per-game tackle-volume thresholds (Sleeper exposes these
-        # as ``idp_tkl_5p`` and ``idp_tkl_10p`` for ≥5 and ≥10 combined
-        # tackles in a single game).  Read off the per-game combined
-        # tackle count.
-        for key, thresh, label in [
-            ("idp_tkl_5p", 5, "5+ Tkl"),
-            ("idp_tkl_10p", 10, "10+ Tkl"),
-        ]:
-            pts_per = scoring.get(key, 0.0)
-            if pts_per == 0.0:
-                continue
-            # Sleeper's 5+/10+ thresholds are on COMBINED tackles, which
-            # is the third element of the view.  This previously read
-            # ``def_tackles`` — the gamebook solo count pre-2025, and
-            # absent entirely after, so the bonus stopped firing.
-            tkls = tackle_stats[2]
-            if tkls >= thresh:
-                breakdown.append((label, tkls, pts_per))
-                total += pts_per
-
-    # Threshold bonuses.
-    for key, (stat_key, thresh, label) in [
-        ("bonus_pass_yd_300", ("passing_yards", 300, "300+ Pass")),
-        ("bonus_pass_yd_400", ("passing_yards", 400, "400+ Pass")),
-        ("bonus_rush_yd_100", ("rushing_yards", 100, "100+ Rush")),
-        ("bonus_rush_yd_200", ("rushing_yards", 200, "200+ Rush")),
-        ("bonus_rec_yd_100", ("receiving_yards", 100, "100+ Rec")),
-        ("bonus_rec_yd_200", ("receiving_yards", 200, "200+ Rec")),
-    ]:
-        pts_per = scoring.get(key, 0.0)
-        if pts_per == 0.0:
-            continue
-        stat = _num(stat_row.get(stat_key))
-        if stat >= thresh:
-            breakdown.append((label, stat, pts_per))
-            total += pts_per
-
-    # 2-point conversions (Sleeper tracks these separately in some
-    # dumps; we tolerate absence).
-    for key, stat_key, label in [
-        ("pass_2pt", "passing_2pt_conversions", "Pass 2pt"),
-        ("rush_2pt", "rushing_2pt_conversions", "Rush 2pt"),
-        ("rec_2pt", "receiving_2pt_conversions", "Rec 2pt"),
-    ]:
-        pts_per = scoring.get(key, 0.0)
-        if pts_per == 0.0:
-            continue
-        stat = _num(stat_row.get(stat_key))
-        if stat:
-            contribution = stat * pts_per
-            breakdown.append((label, stat, contribution))
-            total += contribution
+    # Breakdown keeps its human labels; an unlabelled key falls back to
+    # its scoring key rather than being dropped, so a rule that moves the
+    # total can never be missing from the audit trail.
+    breakdown: list[tuple[str, float, float]] = [
+        (_SLEEPER_KEY_LABELS.get(c.scoring_key, c.scoring_key), c.raw_stat, c.awarded_points)
+        for c in result.components
+        if c.awarded_points
+    ]
 
     return RealizedPoints(
         season=season,
         week=week,
-        fantasy_points=total,
+        fantasy_points=result.total_points,
         breakdown=breakdown,
     )
 

--- a/src/nfl_data/scoring_coverage.py
+++ b/src/nfl_data/scoring_coverage.py
@@ -79,7 +79,24 @@ _MAXIMAL_ROW: dict[str, Any] = {
     "week": 1,
     "passing_yards": 600,
     "passing_tds": 6,
+    # CORRECTED 2026-08-13 (B7 / W18-F003).  These three carried ONLY the
+    # pre-2025 spellings, so the probe asked the engine a question no
+    # production row asks it.  Three rules mapped to columns the unified
+    # release had renamed therefore classified SCORED — behaviourally
+    # true of the probe, factually false of every real row — and `gap`
+    # came back empty, so no warning reached /api/league-comparison or
+    # Provenance.inputs_complete.  The auditor was defeated by exactly
+    # the defect it exists to catch.
+    #
+    # The probe must be written in the vocabulary the FEED ships, not the
+    # one the engine happens to read; that is what makes this guard catch
+    # the NEXT rename rather than ratify it.  Both spellings are present
+    # because the engine legitimately accepts both (candidate columns in
+    # `realized_points._SIMPLE_KEYS`) and a backfill over an older season
+    # still supplies the retired name.
+    "passing_interceptions": 2,
     "interceptions": 2,
+    "sacks_suffered": 3,
     "sacks": 3,
     "completions": 45,
     "attempts": 60,
@@ -95,7 +112,15 @@ _MAXIMAL_ROW: dict[str, Any] = {
     "receiving_tds": 3,
     "receiving_first_downs": 15,
     "receiving_2pt_conversions": 2,
+    "fumbles_lost_total": 2,
     "fumbles_lost": 2,
+    # PLAYER special teams, added with the st_/kr_yd/pr_yd
+    # reclassification.  Without these the probe cannot fire the newly
+    # scored rules and they read as false GAPs — the undersized-row
+    # hazard this row's own docstring warns about.
+    "kickoff_return_yards": 120,
+    "punt_return_yards": 60,
+    "special_teams_tds": 1,
     "def_tackles_solo": 15,
     "def_tackles_with_assist": 8,
     "def_tackle_assists": 8,
@@ -114,8 +139,24 @@ _MAXIMAL_ROW: dict[str, Any] = {
 }
 
 #: Key prefixes belonging to asset classes this platform does not value.
-#: Team defense, kickers and special teams are not tradeable assets on
-#: this board, so their rules are correctly ignored.
+#: Team defense and kickers are not tradeable assets on this board, so
+#: their rules are correctly ignored.
+#
+# CORRECTED 2026-08-13 (B7 / W18-F003).  ``st_``, ``kr_yd`` and ``pr_yd``
+# were in this tuple, which says "an asset class this platform does not
+# value".  They are not: they are paid to the RB, WR, TE and LB this
+# board ranks, values and starts.  Measured over 1,339 host player-weeks
+# on dynasty_main's live card: ``kr_yd`` 69 rows / 150.77 pts,
+# ``st_tkl_solo`` 32 / 49.21, ``pr_yd`` 29 / 22.43, ``st_td`` 4 / 24.00 —
+# earned by K, LB, RB, TE and WR.
+#
+# NOT_APPLICABLE was the most silent state available: it suppresses a key
+# from ``describe_gaps`` AND from ``Provenance.inputGaps``, so these were
+# not scored, not warned about, and not even recorded as unscorable.
+#
+# The DST spellings keep this classification and are listed separately —
+# ``st_`` never matched ``def_st_``, which has its own entry, so the
+# player/DST split is a prefix change and nothing more.
 _NOT_APPLICABLE_PREFIXES: tuple[str, ...] = (
     "pts_allow",
     "yds_allow",
@@ -123,7 +164,6 @@ _NOT_APPLICABLE_PREFIXES: tuple[str, ...] = (
     "fgmiss",
     "xpm",
     "xpmiss",
-    "st_",
     "def_st_",
     "def_3_and_out",
     "def_4_and_stop",
@@ -133,9 +173,11 @@ _NOT_APPLICABLE_PREFIXES: tuple[str, ...] = (
     "def_2pt",
     "def_td",
     "def_pass_def",
+    # Ownership of this one is not settled by any artifact in the tree —
+    # whether a field-goal return is credited to a player or to the team
+    # defense. Left NOT_APPLICABLE rather than guessed; revisit with
+    # evidence rather than by preference.
     "fg_ret_yd",
-    "kr_yd",
-    "pr_yd",
     "blk_kick",
 )
 
@@ -191,6 +233,19 @@ UNSCORABLE_REASONS: dict[str, str] = {
     "pass_int_td": "pick-six thrown is not a column on the weekly feed",
     "idp_blk_kick": "blocked kicks are not a column on the weekly defensive feed",
     "idp_pass_def_3p": "per-game PD threshold; nflverse PD counts are season-aggregated on some releases",
+    # ADDED 2026-08-13 (B7 / W18-F003), with the prefix change above.
+    # These three are PLAYER special-teams rules — real points for
+    # players this board values — but the weekly feed publishes no
+    # special-teams tackle, forced-fumble or fumble-recovery column, so
+    # they are genuinely unscorable rather than a gap. Declared, so they
+    # reach describe_gaps() and Provenance.inputGaps instead of vanishing.
+    #
+    # Their siblings kr_yd / pr_yd / st_td ARE on the feed
+    # (kickoff_return_yards / punt_return_yards / special_teams_tds) and
+    # are now scored, so they must NOT appear here.
+    "st_tkl_solo": "special-teams tackles are not a column on the weekly feed",
+    "st_ff": "special-teams forced fumbles are not a column on the weekly feed",
+    "st_fum_rec": "special-teams fumble recoveries are not a column on the weekly feed",
 }
 
 

--- a/src/nfl_data/scoring_coverage.py
+++ b/src/nfl_data/scoring_coverage.py
@@ -121,6 +121,24 @@ _MAXIMAL_ROW: dict[str, Any] = {
     "kickoff_return_yards": 120,
     "punt_return_yards": 60,
     "special_teams_tds": 1,
+    # KICKER, added with the fgm/fgmiss/xpm/xpmiss reclassification.
+    "pat_made": 6,
+    "pat_missed": 2,
+    "fg_made": 5,
+    "fg_missed": 3,
+    "fg_made_distance": 210,
+    "fg_made_0_19": 1,
+    "fg_made_20_29": 1,
+    "fg_made_30_39": 1,
+    "fg_made_40_49": 1,
+    "fg_made_50_59": 1,
+    "fg_made_60_": 1,
+    "fg_missed_0_19": 1,
+    "fg_missed_20_29": 1,
+    "fg_missed_30_39": 1,
+    "fg_missed_40_49": 1,
+    "fg_missed_50_59": 1,
+    "fg_missed_60_": 1,
     "def_tackles_solo": 15,
     "def_tackles_with_assist": 8,
     "def_tackle_assists": 8,
@@ -157,13 +175,17 @@ _MAXIMAL_ROW: dict[str, Any] = {
 # The DST spellings keep this classification and are listed separately —
 # ``st_`` never matched ``def_st_``, which has its own entry, so the
 # player/DST split is a prefix change and nothing more.
+# CORRECTED 2026-08-13 (B7 / W18-F003), second part: the KICKER family
+# (fgm*, fgmiss*, xpm, xpmiss) also left this tuple.  The engine read no
+# kicker key at all, so every kicker scored a well-formed 0.000 with no
+# reason and no flag, and NOT_APPLICABLE kept that silent -- while
+# config/leagues/registry.json gives dynasty_main "K": 1 as a starting
+# slot, so it is a legitimate question a user can ask.  All of it is on
+# the weekly feed (fg_made_*/fg_missed_*/fg_made_distance/pat_made/
+# pat_missed), so none of it needed play-by-play.
 _NOT_APPLICABLE_PREFIXES: tuple[str, ...] = (
     "pts_allow",
     "yds_allow",
-    "fgm",
-    "fgmiss",
-    "xpm",
-    "xpmiss",
     "def_st_",
     "def_3_and_out",
     "def_4_and_stop",

--- a/tests/api/test_realized_points_endpoint.py
+++ b/tests/api/test_realized_points_endpoint.py
@@ -108,3 +108,128 @@ def test_the_filter_finds_real_weeks_on_the_live_file():
     assert (
         len(_filter(rows, gsis)) > 0
     ), "the filter matched no weeks for a GSIS id taken from the data itself"
+
+
+# ── The route itself (W18-F004 / B7) ──────────────────────────────────
+#
+# Everything above exercises a COPY of the endpoint's filter. The
+# docstring says that copy is "kept in one place so this test and
+# server.py cannot drift apart silently" — but a copy is precisely the
+# thing that can drift, and while it sat here two other defects lived in
+# the real handler untested:
+#
+#   * ``players_dir`` read ``sleeper_block["players"]`` / ``["playerDict"]``.
+#     The contract's sleeper block has neither key, so the directory was
+#     always ``None`` and EVERY request returned ``unmapped_player`` — a
+#     well-formed 200 answering nothing, for every player, always.
+#   * ``scoring_settings`` came from the LOADED contract rather than the
+#     REQUESTED league, so a player in a second league was scored under
+#     the first league's rules and stamped with the requested leagueKey.
+#
+# These call the real route.
+
+
+@pytest.fixture
+def realized_client(tmp_path, monkeypatch):
+    """A two-league app with per-league scoring snapshots installed."""
+    import json as _json
+
+    from fastapi.testclient import TestClient
+
+    import server
+    from src.api import league_registry
+    from tests.api.scoring_fixture import (
+        OTHER_SCORING_CARD,
+        SCORING_CARD,
+        install_scoring_snapshots,
+    )
+
+    path = tmp_path / "registry.json"
+    path.write_text(
+        _json.dumps(
+            {
+                "defaultLeagueKey": "main",
+                "leagues": [
+                    {
+                        "key": "main",
+                        "displayName": "Main",
+                        "sleeperLeagueId": "L-MAIN",
+                        "active": True,
+                        "rosterSettings": {"teamCount": 12},
+                    },
+                    {
+                        "key": "side",
+                        "displayName": "Side",
+                        "sleeperLeagueId": "L-SIDE",
+                        "active": True,
+                        "rosterSettings": {"teamCount": 10},
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+    # The two leagues score DIFFERENTLY — that is the point.
+    install_scoring_snapshots(
+        tmp_path, monkeypatch, {"L-MAIN": SCORING_CARD, "L-SIDE": OTHER_SCORING_CARD}
+    )
+    monkeypatch.setattr(server, "_is_authenticated", lambda request: True)
+    monkeypatch.setattr(server, "_get_auth_session", lambda request: {"username": "t"})
+
+    # One player, one week, one reception — enough to tell the two cards
+    # apart (rec 1.0 vs 0.08).
+    monkeypatch.setattr(
+        "src.nfl_data.ingest.fetch_weekly_stats",
+        lambda years: [
+            {
+                "player_id": "00-0000001",
+                "season": 2025,
+                "week": 1,
+                "position": "WR",
+                "receptions": 10,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        "src.public_league.sleeper_client.fetch_nfl_players",
+        lambda: {
+            "999": {
+                "player_id": "999",
+                "gsis_id": "00-0000001",
+                "full_name": "Test Player",
+                "position": "WR",
+                "team": "BUF",
+            }
+        },
+    )
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        yield c
+    league_registry.reload_registry()
+
+
+def test_the_route_resolves_a_player_instead_of_answering_unmapped(realized_client):
+    body = realized_client.get("/api/player/999/realized?leagueKey=main").json()
+    assert body.get("reason") != "unmapped_player", (
+        "the route still cannot resolve a player — players_dir is not the "
+        "master Sleeper directory"
+    )
+    assert body.get("gsisId") == "00-0000001"
+    assert body.get("weekCount"), "resolved the player but matched no weeks"
+
+
+def test_each_league_is_scored_under_its_own_card(realized_client):
+    """The requested league's rules, not the loaded contract's."""
+    main = realized_client.get("/api/player/999/realized?leagueKey=main").json()
+    side = realized_client.get("/api/player/999/realized?leagueKey=side").json()
+
+    assert main["leagueKey"] == "main"
+    assert side["leagueKey"] == "side"
+    # 10 receptions at rec 1.0 vs rec 0.08 — 10.0 against 0.8.
+    assert main["totalPoints"] == pytest.approx(10.0, abs=1e-6)
+    assert side["totalPoints"] == pytest.approx(0.8, abs=1e-6)
+    assert main["totalPoints"] != side["totalPoints"], (
+        "both leagues scored identically — the route is using one league's "
+        "card for the other, which is the W18-F002 shape on this route"
+    )

--- a/tests/league_comparison/test_sleeper_stats.py
+++ b/tests/league_comparison/test_sleeper_stats.py
@@ -55,7 +55,12 @@ def test_translate_stats_maps_idp_keys():
             "idp_int": 1,
         }
     )
-    assert out["def_tackles"] == 6
+    # ``idp_tkl`` must NOT become ``def_tackles``.  Sleeper's idp_tkl is
+    # COMBINED; ``realized_points._tackle_view`` reads a published
+    # ``def_tackles`` as the pre-2025 gamebook SOLO total, so the old
+    # mapping wrote combined into the solo slot and inflated both.
+    # Combined is derived from solo + assists, which map correctly.
+    assert "def_tackles" not in out
     assert out["def_tackles_solo"] == 4
     assert out["def_tackle_assists"] == 2
     assert out["def_sacks"] == 1

--- a/tests/nfl_data/test_realized_points_host_truth.py
+++ b/tests/nfl_data/test_realized_points_host_truth.py
@@ -117,62 +117,95 @@ class TestFirstDownBonusMatchesHost:
     """
 
     @pytest.mark.parametrize(
-        ("player_id", "name", "position"),
-        [("4984", "Josh Allen", "QB")],
+        ("player_id", "name", "position", "bonus_key"),
+        [("4984", "Josh Allen", "QB", "bonus_fd_qb")],
     )
-    def test_first_down_count_excludes_touchdowns(self, player_id, name, position):
+    def test_engine_first_down_count_matches_host(
+        self, dynasty_main_card, player_id, name, position, bonus_key
+    ):
         host = json.loads(
             (EVIDENCE / "sleeper_stats_2025_wk14.json").read_text(encoding="utf-8")
         )
         line = host.get(player_id) or {}
         assert line, f"fixture missing {name}"
 
-        host_first_downs = float(line.get("pass_fd", 0)) + float(line.get("rush_fd", 0))
+        host_first_downs = float(line["bonus_fd_qb"])
         touchdowns = float(line.get("pass_td", 0)) + float(line.get("rush_td", 0))
-        # The host's own bonus stat agrees with its own first-down counts.
-        assert float(line["bonus_fd_qb"]) == pytest.approx(host_first_downs, abs=1e-6)
+        # The host's own bonus stat agrees with its own play-type counts,
+        # which is what establishes that it excludes scoring plays.
+        assert host_first_downs == pytest.approx(
+            float(line.get("pass_fd", 0)) + float(line.get("rush_fd", 0)), abs=1e-6
+        )
         assert touchdowns > 0, "fixture must include a scoring player to be meaningful"
 
-        # nflverse spells the same week with TD plays folded in.
+        # The same week as nflverse spells it: first-down columns with TD
+        # plays folded in.  Only first-down inputs, so the breakdown line
+        # under test is isolated.
         nflverse_row = {
             "passing_first_downs": float(line.get("pass_fd", 0)) + float(line.get("pass_td", 0)),
             "rushing_first_downs": float(line.get("rush_fd", 0)) + float(line.get("rush_td", 0)),
+            "passing_tds": float(line.get("pass_td", 0)),
+            "rushing_tds": float(line.get("rush_td", 0)),
         }
-        engine_first_downs = sum(nflverse_row.values())
-
-        assert engine_first_downs == pytest.approx(host_first_downs, abs=1e-6), (
-            f"{name}: engine counts {engine_first_downs:.0f} first downs where the host "
-            f"counts {host_first_downs:.0f} — over by exactly the {touchdowns:.0f} "
-            "touchdowns, because nflverse includes scoring plays and Sleeper does not"
+        result = compute_weekly_points(
+            nflverse_row, {bonus_key: dynasty_main_card[bonus_key]}, position=position
+        )
+        counted = next(
+            (stat for (label, stat, _pts) in result.breakdown if label == "First Downs"),
+            None,
+        )
+        assert counted is not None, "engine emitted no First Downs line"
+        assert counted == pytest.approx(host_first_downs, abs=1e-6), (
+            f"{name}: engine counts {counted:.0f} first downs where the host counts "
+            f"{host_first_downs:.0f} — over by exactly the {touchdowns:.0f} touchdowns, "
+            "because nflverse includes scoring plays and Sleeper does not"
         )
 
 
 class TestCoverageAuditorIsNotFooled:
     """The guard must not be defeated by the defect it exists to catch.
 
-    ``engine_reads_key`` probes with ``_MAXIMAL_ROW``.  That row is
-    written in the engine's own vocabulary, so a rule mapped to a column
-    the feed no longer publishes reads as SCORED — behaviourally true of
-    the probe, factually false of every production row.
+    ``engine_reads_key`` probes with ``_MAXIMAL_ROW``.  While that row
+    was written only in the engine's own vocabulary, a rule mapped to a
+    column the feed no longer published read as SCORED — behaviourally
+    true of the probe, factually false of every production row — and the
+    audit reported an empty gap set.
+
+    The durable requirement is therefore about the PROBE, not about any
+    one key: the probe must be written in the vocabulary the feed ships,
+    so this guard catches the NEXT rename instead of ratifying it. A test
+    asserting "``pass_int`` is not SCORED" would only encode the symptom,
+    and would go false the moment the mapping is repaired.
     """
 
-    @pytest.mark.parametrize("key", ["pass_int", "pass_sack", "fum_lost"])
-    def test_a_rule_mapped_to_a_dead_column_is_not_reported_as_scored(self, key):
-        assert classify(key) is not Coverage.SCORED, (
-            f"{key!r} is classified SCORED, but its column was renamed and no "
-            "production row can satisfy it — the auditor is probing a vocabulary "
-            "the feed does not ship"
+    @pytest.mark.parametrize(("dead", "live"), sorted(RENAMED_COLUMNS.items()))
+    def test_the_probe_row_speaks_the_feeds_vocabulary(self, dead, live):
+        from src.nfl_data.scoring_coverage import _MAXIMAL_ROW
+
+        assert live in _MAXIMAL_ROW, (
+            f"the probe row does not carry {live!r} — the name the live feed "
+            f"publishes — so a rule mapped only to the retired {dead!r} would be "
+            "classified SCORED and no gap would ever be reported"
         )
 
-    def test_the_live_card_reports_the_dead_mappings(self, dynasty_main_card):
-        audit = audit_scoring_settings(dynasty_main_card)
-        surfaced = set(audit[Coverage.GAP]) | set(audit[Coverage.UNSCORABLE])
-        missing = {"pass_int", "pass_sack", "fum_lost"} - surfaced
-        assert not missing, (
-            f"{sorted(missing)} are worth real points on the live card and are "
-            "reported nowhere — not scored, not a gap, not unscorable, so no "
-            "warning reaches /api/league-comparison or Provenance.inputs_complete"
+    @pytest.mark.parametrize("key", ["pass_int", "pass_sack", "fum_lost"])
+    def test_a_repaired_rule_scores_from_the_live_column_alone(
+        self, key, dynasty_main_card
+    ):
+        """SCORED must be earned on a row the feed could actually produce."""
+        column = {
+            "pass_int": "passing_interceptions",
+            "pass_sack": "sacks_suffered",
+            "fum_lost": "fumbles_lost_total",
+        }[key]
+        row = {"passing_yards": 100, column: 2}
+        with_rule = compute_weekly_points(row, {key: dynasty_main_card[key]}, position="QB")
+        without = compute_weekly_points(row, {}, position="QB")
+        assert with_rule.fantasy_points != pytest.approx(without.fantasy_points, abs=1e-6), (
+            f"{key!r} scored nothing from {column!r}, the only spelling the 2025 "
+            "unified release publishes"
         )
+        assert classify(key) is Coverage.SCORED
 
 
 class TestEveryNonzeroRuleIsAccountedFor:

--- a/tests/nfl_data/test_realized_points_host_truth.py
+++ b/tests/nfl_data/test_realized_points_host_truth.py
@@ -1,0 +1,235 @@
+"""B7 / W18-F003 — realized points measured against the LEAGUE HOST.
+
+WHY THIS FILE EXISTS
+--------------------
+``src/league_intel/scorer.py::score_stat_line`` is validated against
+Sleeper's own ``players_points`` (``tests/league_intel/test_golden_scoring.py``,
+1,339 player-weeks, max |Δ| 0.0050) and has one non-test caller.
+``src/nfl_data/realized_points.py::compute_weekly_points`` reaches every
+production consumer of realized points and **has no host-truth test at
+all**.  That absence is the finding, not a gap in coverage: every
+existing test of the production engine asserts against hand-computed
+expectations written in the same vocabulary the engine reads, so a
+column the feed stopped publishing looks correct from inside.
+
+Each test below pins ONE root cause with the host's own arithmetic, and
+each is expected to FAIL until the B7 repair lands.  They are written
+against real committed fixtures and the real live scoring card — no
+synthetic rates, because a synthetic rate cannot show that the engine
+disagrees with the league.
+
+Fixtures: ``docs/master-site-audit/evidence/W18/``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.nfl_data.realized_points import compute_weekly_points
+from src.nfl_data.scoring_coverage import Coverage, audit_scoring_settings, classify
+
+EVIDENCE = Path(__file__).resolve().parents[2] / "docs" / "master-site-audit" / "evidence" / "W18"
+
+#: The three columns the 2025 unified nflverse release renamed.  The
+#: engine still asks for the left-hand name; the feed only publishes the
+#: right-hand one, so ``stat_row.get`` returns ``None`` -> 0.0 and the
+#: rule is skipped in silence.
+RENAMED_COLUMNS = {
+    "interceptions": "passing_interceptions",
+    "sacks": "sacks_suffered",
+    "fumbles_lost": "fumbles_lost_total",
+}
+
+
+def _live_card(league_file: str) -> dict:
+    doc = json.loads((EVIDENCE / league_file).read_text(encoding="utf-8"))
+    return doc.get("scoring_settings") or {}
+
+
+@pytest.fixture(scope="module")
+def dynasty_main_card() -> dict:
+    return _live_card("sleeper_league_1312006700437352448.json")
+
+
+@pytest.fixture(scope="module")
+def dynasty_new_card() -> dict:
+    return _live_card("sleeper_league_dynasty_new.json")
+
+
+class TestRenamedColumnsStillScore:
+    """The same football, spelled the way the live feed spells it."""
+
+    def test_penalties_are_charged_under_live_column_names(self, dynasty_main_card):
+        base = {
+            "passing_yards": 300,
+            "passing_tds": 2,
+            "completions": 25,
+            "attempts": 35,
+            "rushing_yards": 20,
+            "carries": 4,
+        }
+        legacy = dict(base, interceptions=3, sacks=2, fumbles_lost=1)
+        live = dict(base, passing_interceptions=3, sacks_suffered=2, fumbles_lost_total=1)
+
+        legacy_pts = compute_weekly_points(legacy, dynasty_main_card, position="QB")
+        live_pts = compute_weekly_points(live, dynasty_main_card, position="QB")
+
+        # The rules are worth real points on the live card: -4 / -1 / -4.
+        expected_penalty = (
+            3 * dynasty_main_card["pass_int"]
+            + 2 * dynasty_main_card["pass_sack"]
+            + 1 * dynasty_main_card["fum_lost"]
+        )
+        assert expected_penalty < 0
+
+        assert live_pts.fantasy_points == pytest.approx(
+            legacy_pts.fantasy_points, abs=1e-6
+        ), (
+            "the same football scored differently depending on how the feed spells "
+            f"its columns: legacy={legacy_pts.fantasy_points:.2f} "
+            f"live={live_pts.fantasy_points:.2f}; the live row is missing "
+            f"{abs(expected_penalty):.2f} points of penalties"
+        )
+
+    @pytest.mark.parametrize(("dead", "live"), sorted(RENAMED_COLUMNS.items()))
+    def test_each_renamed_column_is_read(self, dynasty_main_card, dead, live):
+        """A rule the card pays for must respond to the column the feed ships."""
+        row = {"passing_yards": 100, live: 2}
+        scored = compute_weekly_points(row, dynasty_main_card, position="QB")
+        baseline = compute_weekly_points(
+            {"passing_yards": 100}, dynasty_main_card, position="QB"
+        )
+        assert scored.fantasy_points != pytest.approx(baseline.fantasy_points, abs=1e-6), (
+            f"{live!r} changed nothing — the engine only reads the retired {dead!r}"
+        )
+
+
+class TestFirstDownBonusMatchesHost:
+    """Sleeper EXCLUDES touchdown plays from pass_fd/rush_fd/rec_fd.
+
+    nflverse's ``*_first_downs`` INCLUDE them, so the position-scoped
+    first-down bonus over-charges by exactly the player's touchdown
+    count — an over-statement, opposite in sign to the other defects,
+    which is why a partial repair makes some positions worse.
+    """
+
+    @pytest.mark.parametrize(
+        ("player_id", "name", "position"),
+        [("4984", "Josh Allen", "QB")],
+    )
+    def test_first_down_count_excludes_touchdowns(self, player_id, name, position):
+        host = json.loads(
+            (EVIDENCE / "sleeper_stats_2025_wk14.json").read_text(encoding="utf-8")
+        )
+        line = host.get(player_id) or {}
+        assert line, f"fixture missing {name}"
+
+        host_first_downs = float(line.get("pass_fd", 0)) + float(line.get("rush_fd", 0))
+        touchdowns = float(line.get("pass_td", 0)) + float(line.get("rush_td", 0))
+        # The host's own bonus stat agrees with its own first-down counts.
+        assert float(line["bonus_fd_qb"]) == pytest.approx(host_first_downs, abs=1e-6)
+        assert touchdowns > 0, "fixture must include a scoring player to be meaningful"
+
+        # nflverse spells the same week with TD plays folded in.
+        nflverse_row = {
+            "passing_first_downs": float(line.get("pass_fd", 0)) + float(line.get("pass_td", 0)),
+            "rushing_first_downs": float(line.get("rush_fd", 0)) + float(line.get("rush_td", 0)),
+        }
+        engine_first_downs = sum(nflverse_row.values())
+
+        assert engine_first_downs == pytest.approx(host_first_downs, abs=1e-6), (
+            f"{name}: engine counts {engine_first_downs:.0f} first downs where the host "
+            f"counts {host_first_downs:.0f} — over by exactly the {touchdowns:.0f} "
+            "touchdowns, because nflverse includes scoring plays and Sleeper does not"
+        )
+
+
+class TestCoverageAuditorIsNotFooled:
+    """The guard must not be defeated by the defect it exists to catch.
+
+    ``engine_reads_key`` probes with ``_MAXIMAL_ROW``.  That row is
+    written in the engine's own vocabulary, so a rule mapped to a column
+    the feed no longer publishes reads as SCORED — behaviourally true of
+    the probe, factually false of every production row.
+    """
+
+    @pytest.mark.parametrize("key", ["pass_int", "pass_sack", "fum_lost"])
+    def test_a_rule_mapped_to_a_dead_column_is_not_reported_as_scored(self, key):
+        assert classify(key) is not Coverage.SCORED, (
+            f"{key!r} is classified SCORED, but its column was renamed and no "
+            "production row can satisfy it — the auditor is probing a vocabulary "
+            "the feed does not ship"
+        )
+
+    def test_the_live_card_reports_the_dead_mappings(self, dynasty_main_card):
+        audit = audit_scoring_settings(dynasty_main_card)
+        surfaced = set(audit[Coverage.GAP]) | set(audit[Coverage.UNSCORABLE])
+        missing = {"pass_int", "pass_sack", "fum_lost"} - surfaced
+        assert not missing, (
+            f"{sorted(missing)} are worth real points on the live card and are "
+            "reported nowhere — not scored, not a gap, not unscorable, so no "
+            "warning reaches /api/league-comparison or Provenance.inputs_complete"
+        )
+
+
+class TestEveryNonzeroRuleIsAccountedFor:
+    """The structural requirement W18-F003 asks for, on BOTH live cards.
+
+    ``dynasty_new`` is included deliberately: it is absent from the CI
+    fixture today, and its card yields empty gap AND empty unscorable
+    sets — zero disclosure of anything.
+    """
+
+    @pytest.mark.parametrize("league", ["dynasty_main", "dynasty_new"])
+    def test_no_nonzero_rule_is_silently_dropped(self, league, request):
+        card = request.getfixturevalue(f"{league}_card")
+        assert card, f"{league} card fixture is empty"
+        audit = audit_scoring_settings(card)
+        accounted = (
+            set(audit[Coverage.SCORED])
+            | set(audit[Coverage.NOT_APPLICABLE])
+            | set(audit[Coverage.UNSCORABLE])
+        )
+        gaps = set(audit[Coverage.GAP])
+        nonzero = {
+            k
+            for k, v in card.items()
+            if isinstance(v, (int, float)) and not isinstance(v, bool) and v != 0
+        }
+        unaccounted = nonzero - accounted - gaps
+        assert not unaccounted, f"{league}: {sorted(unaccounted)} classified as nothing"
+        assert not gaps, (
+            f"{league}: {sorted(gaps)} are scorable from data already on the feed "
+            "and are not scored"
+        )
+
+
+class TestPlayerSpecialTeamsIsNotAnUnvaluedAssetClass:
+    """``kr_yd`` / ``pr_yd`` / ``st_*`` are earned by RB, WR, TE and LB.
+
+    They are currently classified NOT_APPLICABLE — the state reserved
+    for team defense and kickers, asset classes this platform does not
+    value — which suppresses them from ``describe_gaps`` AND from
+    ``Provenance.inputGaps``.  DST's ``def_st_*`` / ``def_kr_*`` /
+    ``def_pr_*`` keep that classification correctly.
+    """
+
+    @pytest.mark.parametrize("key", ["kr_yd", "pr_yd", "st_td", "st_tkl_solo"])
+    def test_player_special_teams_is_not_not_applicable(self, key, dynasty_main_card):
+        if not dynasty_main_card.get(key):
+            pytest.skip(f"{key} is not paid on this card")
+        assert classify(key) is not Coverage.NOT_APPLICABLE, (
+            f"{key!r} is paid {dynasty_main_card[key]}/event to players this platform "
+            "ranks and starts; NOT_APPLICABLE hides it from every disclosure surface"
+        )
+
+    @pytest.mark.parametrize("key", ["def_st_td", "def_kr_yd", "def_pr_yd"])
+    def test_dst_special_teams_stays_not_applicable(self, key, dynasty_main_card):
+        if not dynasty_main_card.get(key):
+            pytest.skip(f"{key} is not paid on this card")
+        assert classify(key) is Coverage.NOT_APPLICABLE, (
+            f"{key!r} is a team-defense rule and this platform values no DST asset"
+        )

--- a/tests/nfl_data/test_realized_points_host_truth.py
+++ b/tests/nfl_data/test_realized_points_host_truth.py
@@ -260,6 +260,85 @@ class TestPlayerSpecialTeamsIsNotAnUnvaluedAssetClass:
         ), f"{key!r} is a team-defense rule and this platform values no DST asset"
 
 
+class TestTheCanonicalScorerIsTheOwner:
+    """One active realized-scoring owner, and it is the validated one.
+
+    W18-F003's root cause was two engines with inverted validation: the
+    host-validated dot product had a single non-test caller while the
+    allow-list engine reached every production consumer with no
+    host-truth test at all. The repair is not "map the renamed columns"
+    — it is to make the validated scorer the owner and reduce the other
+    to normalization, so the drift CLASS cannot recur.
+    """
+
+    def test_production_entry_point_delegates_to_the_canonical_scorer(self, dynasty_main_card):
+        from src.league_intel.scorer import score_stat_line
+        from src.nfl_data.realized_points import sleeper_stat_line_from_row
+
+        row = {
+            "passing_yards": 300,
+            "passing_tds": 2,
+            "passing_interceptions": 1,
+            "sacks_suffered": 2,
+            "completions": 25,
+            "attempts": 35,
+            "rushing_yards": 40,
+            "carries": 6,
+            "passing_first_downs": 12,
+            "rushing_first_downs": 3,
+        }
+        produced = compute_weekly_points(row, dynasty_main_card, position="QB")
+        canonical = score_stat_line(
+            sleeper_stat_line_from_row(row, position="QB"), dynasty_main_card
+        )
+        assert produced.fantasy_points == pytest.approx(canonical.total_points, abs=1e-9), (
+            "the production entry point no longer agrees with the canonical scorer — "
+            "a second scoring owner has reappeared"
+        )
+
+    def test_normalization_is_independent_of_scoring(self):
+        """The normalizer must not consult the league's rates.
+
+        Mixing them is what produced the defect: an engine keyed on
+        provider column names treats "column missing" and "rule scores
+        nothing" as the same event, so a vendor rename disappears a live
+        rule in silence.
+        """
+        from src.nfl_data.realized_points import sleeper_stat_line_from_row
+
+        row = {"passing_yards": 300, "passing_interceptions": 2, "receptions": 4}
+        assert sleeper_stat_line_from_row(row, position="WR") == sleeper_stat_line_from_row(
+            row, position="WR"
+        )
+        line = sleeper_stat_line_from_row(row, position="WR")
+        # Stats the row carries are present regardless of whether any
+        # league pays for them.
+        assert line["pass_yd"] == 300
+        assert line["pass_int"] == 2
+        assert line["rec"] == 4
+
+    def test_a_rule_the_line_carries_can_never_be_skipped(self, dynasty_main_card):
+        """The structural guarantee a dot product gives and an allow-list does not."""
+        from src.nfl_data.realized_points import sleeper_stat_line_from_row
+
+        row = {
+            "passing_yards": 300,
+            "passing_interceptions": 3,
+            "sacks_suffered": 2,
+            "fumbles_lost_total": 1,
+        }
+        line = sleeper_stat_line_from_row(row, position="QB")
+        result = compute_weekly_points(row, dynasty_main_card, position="QB")
+        scored_keys = {
+            k for k in line if k in dynasty_main_card and float(dynasty_main_card[k]) != 0.0
+        }
+        # Every such key contributed something the breakdown can show.
+        assert len(result.breakdown) >= len(scored_keys), (
+            f"{len(scored_keys)} paid stats on the line produced only "
+            f"{len(result.breakdown)} breakdown rows"
+        )
+
+
 class TestKickersAreScoredNotSilentlyZeroed:
     """A kicker used to score a well-formed ``0.000`` with no reason.
 

--- a/tests/nfl_data/test_realized_points_host_truth.py
+++ b/tests/nfl_data/test_realized_points_host_truth.py
@@ -258,3 +258,60 @@ class TestPlayerSpecialTeamsIsNotAnUnvaluedAssetClass:
         assert (
             classify(key) is Coverage.NOT_APPLICABLE
         ), f"{key!r} is a team-defense rule and this platform values no DST asset"
+
+
+class TestKickersAreScoredNotSilentlyZeroed:
+    """A kicker used to score a well-formed ``0.000`` with no reason.
+
+    ``config/leagues/registry.json`` gives ``dynasty_main`` ``"K": 1`` as
+    a starting slot, so "what did my kicker score" is a question a user
+    can legitimately ask — and every kicker answered zero. All of it is
+    on the weekly feed, so none of it needed play-by-play.
+    """
+
+    def test_a_real_kicker_week_scores(self, dynasty_main_card):
+        # Two made FGs (20-29 and 30-39) for 65 total yards, three PATs.
+        row = {
+            "fg_made": 2,
+            "fg_made_20_29": 1,
+            "fg_made_30_39": 1,
+            "fg_made_distance": 65,
+            "pat_made": 3,
+            "pat_missed": 0,
+        }
+        result = compute_weekly_points(row, dynasty_main_card, position="K")
+        assert result is not None
+        assert result.fantasy_points > 0, (
+            "a kicker with three PATs and 65 yards of made field goals scored "
+            "zero — the silent 0.000 this repair exists to remove"
+        )
+        expected = 3 * dynasty_main_card["xpm"] + 65 * dynasty_main_card["fgm_yds"]
+        assert result.fantasy_points == pytest.approx(expected, abs=1e-6)
+
+    def test_a_banded_rule_spanning_two_feed_bands_counts_both(self, dynasty_new_card):
+        """``fgm_50p`` means 50+; the feed splits that into 50-59 and 60+."""
+        if not dynasty_new_card.get("fgm_50p"):
+            pytest.skip("fgm_50p is not paid on this card")
+        row = {"fg_made_50_59": 1, "fg_made_60_": 1}
+        result = compute_weekly_points(row, dynasty_new_card, position="K")
+        assert result.fantasy_points == pytest.approx(
+            2 * dynasty_new_card["fgm_50p"], abs=1e-6
+        ), "a 60-yard kick was dropped from a league that pays for 50+"
+
+    @pytest.mark.parametrize("league", ["dynasty_main", "dynasty_new"])
+    def test_kicker_rules_are_no_longer_an_unvalued_asset_class(self, league, request):
+        card = request.getfixturevalue(f"{league}_card")
+        kicker_keys = [
+            k
+            for k, v in card.items()
+            if v
+            and isinstance(v, (int, float))
+            and not isinstance(v, bool)
+            and (k.startswith(("fgm", "fgmiss")) or k in {"xpm", "xpmiss"})
+        ]
+        assert kicker_keys, f"{league} pays no kicker rules; fixture is not meaningful"
+        wrong = [k for k in kicker_keys if classify(k) is Coverage.NOT_APPLICABLE]
+        assert not wrong, (
+            f"{league}: {sorted(wrong)} are still classified as belonging to an asset "
+            "class this platform does not value"
+        )

--- a/tests/nfl_data/test_realized_points_host_truth.py
+++ b/tests/nfl_data/test_realized_points_host_truth.py
@@ -85,9 +85,7 @@ class TestRenamedColumnsStillScore:
         )
         assert expected_penalty < 0
 
-        assert live_pts.fantasy_points == pytest.approx(
-            legacy_pts.fantasy_points, abs=1e-6
-        ), (
+        assert live_pts.fantasy_points == pytest.approx(legacy_pts.fantasy_points, abs=1e-6), (
             "the same football scored differently depending on how the feed spells "
             f"its columns: legacy={legacy_pts.fantasy_points:.2f} "
             f"live={live_pts.fantasy_points:.2f}; the live row is missing "
@@ -99,12 +97,10 @@ class TestRenamedColumnsStillScore:
         """A rule the card pays for must respond to the column the feed ships."""
         row = {"passing_yards": 100, live: 2}
         scored = compute_weekly_points(row, dynasty_main_card, position="QB")
-        baseline = compute_weekly_points(
-            {"passing_yards": 100}, dynasty_main_card, position="QB"
-        )
-        assert scored.fantasy_points != pytest.approx(baseline.fantasy_points, abs=1e-6), (
-            f"{live!r} changed nothing — the engine only reads the retired {dead!r}"
-        )
+        baseline = compute_weekly_points({"passing_yards": 100}, dynasty_main_card, position="QB")
+        assert scored.fantasy_points != pytest.approx(
+            baseline.fantasy_points, abs=1e-6
+        ), f"{live!r} changed nothing — the engine only reads the retired {dead!r}"
 
 
 class TestFirstDownBonusMatchesHost:
@@ -123,9 +119,7 @@ class TestFirstDownBonusMatchesHost:
     def test_engine_first_down_count_matches_host(
         self, dynasty_main_card, player_id, name, position, bonus_key
     ):
-        host = json.loads(
-            (EVIDENCE / "sleeper_stats_2025_wk14.json").read_text(encoding="utf-8")
-        )
+        host = json.loads((EVIDENCE / "sleeper_stats_2025_wk14.json").read_text(encoding="utf-8"))
         line = host.get(player_id) or {}
         assert line, f"fixture missing {name}"
 
@@ -189,9 +183,7 @@ class TestCoverageAuditorIsNotFooled:
         )
 
     @pytest.mark.parametrize("key", ["pass_int", "pass_sack", "fum_lost"])
-    def test_a_repaired_rule_scores_from_the_live_column_alone(
-        self, key, dynasty_main_card
-    ):
+    def test_a_repaired_rule_scores_from_the_live_column_alone(self, key, dynasty_main_card):
         """SCORED must be earned on a row the feed could actually produce."""
         column = {
             "pass_int": "passing_interceptions",
@@ -263,6 +255,6 @@ class TestPlayerSpecialTeamsIsNotAnUnvaluedAssetClass:
     def test_dst_special_teams_stays_not_applicable(self, key, dynasty_main_card):
         if not dynasty_main_card.get(key):
             pytest.skip(f"{key} is not paid on this card")
-        assert classify(key) is Coverage.NOT_APPLICABLE, (
-            f"{key!r} is a team-defense rule and this platform values no DST asset"
-        )
+        assert (
+            classify(key) is Coverage.NOT_APPLICABLE
+        ), f"{key!r} is a team-defense rule and this platform values no DST asset"


### PR DESCRIPTION
Work in progress on the B7 merge unit — the scorer repairs below are complete and green; kicker scoring, the reception-band decision, and `/api/player/{id}/realized` (W18-F004) still to land in this same PR before it is proposed for merge.

## Root cause

Two scorers, and their validation is inverted.

| engine | host-validated | production reach |
|---|---|---|
| `league_intel/scorer.py::score_stat_line` | **yes** — 1,339 player-weeks, max \|Δ\| 0.0050 | **one** non-test caller |
| `nfl_data/realized_points.py::compute_weekly_points` | **no host-truth test existed** | every realized-points consumer |

Every existing test of the production engine asserts hand-computed expectations written *in the same vocabulary the engine reads*, so a column the feed stopped publishing still looked correct from inside. That absence is the finding.

## RED → GREEN

Per the exact-head rule, the RED commit is retained on the branch for provenance and is never merged alone; only the validated GREEN head merges.

`f740d81` **RED** — 13 failing, 5 passing. `530e0d0`/`38ee6fa` **GREEN** — 20/20 host-truth, **1223 tests pass** across `nfl_data`, `league_intel`, `league_comparison`, `bdvm`. **No test was weakened, skipped or re-marked.**

## What was wrong

**(b) Renamed columns.** `pass_int`/`pass_sack`/`fum_lost` mapped to `interceptions`/`sacks`/`fumbles_lost`, which the 2025 unified release renamed. `stat_row.get` → `None` → `0.0` → rule skipped in silence. The same football scored **18.00 points higher** spelled the modern way, with `INT`, `Sacks Taken` and `Fum Lost` absent from the breakdown entirely.

The fix was already in the file: `_first_num`'s docstring says candidate lists are "what absorbs nflverse's 2025 renames", and `_IDP_KEYS` already used that shape — the comment above it even claimed both blocks shared it. The offense half was simply missed by the 2026-07-27 correction that fixed the identical class for defense. Live name first, retired name second, which is why the 33 existing tests written in the old spelling still pass **unchanged**.

**(e) First downs — an OVER-charge.** Sleeper *excludes* scoring plays from `pass_fd`/`rush_fd`/`rec_fd`; nflverse's `*_first_downs` *include* them, so the position-scoped bonus over-charged by exactly the player's touchdown count. Josh Allen 2025 wk14: host 13, engine 17, TDs 4. Now subtracted per play type, clamped at zero per pair.

This had to land with (b): on the measured sample RB net error is ~0% **only because they cancel**, so repairing the understatements alone would have inverted RB direction.

**(d) The auditor was defeated by the defect it exists to catch.** `_MAXIMAL_ROW` carried only pre-2025 spellings, so `engine_reads_key` asked a question no production row asks and classified all three dead mappings `SCORED`. `gap == {}` on the live card — no warning reached `/api/league-comparison` or `Provenance.inputs_complete`. The probe now speaks the vocabulary the **feed** ships, which is what makes it catch the *next* rename instead of ratifying it.

**(f) Player special teams.** `st_`/`kr_yd`/`pr_yd` sat in `_NOT_APPLICABLE_PREFIXES` — "an asset class this platform does not value" — although they are paid to the RB, WR, TE and LB this board ranks and starts, and that state suppressed them from `describe_gaps` **and** `Provenance.inputGaps`. Measured on 1,339 host player-weeks: `kr_yd` 69 rows/150.77 pts, `st_tkl_solo` 32/49.21, `pr_yd` 29/22.43, `st_td` 4/24.00.

`kr_yd`/`pr_yd`/`st_td` are on the feed and are now scored; `st_tkl_solo`/`st_ff`/`st_fum_rec` are not and are now declared `UNSCORABLE` with reasons. **Both halves had to land together** — `classify()` tests `NOT_APPLICABLE` before `UNSCORABLE`, so the prefix change alone would have turned them into `GAP`s and broken the live-cards guard. DST's `def_st_`/`def_kr_`/`def_pr_` keep the classification, pinned by passing controls. `fg_ret_yd` is left `NOT_APPLICABLE` because no artifact in the tree settles whether it is a player or team-defense rule — flagged rather than guessed.

**(B7-N3) The Sleeper fallback wrote combined tackles into the solo slot.** `_FIELD_MAP` mapped `idp_tkl` → `def_tackles`, but `_tackle_view` reads a published `def_tackles` as the pre-2025 gamebook **solo** total. A 5-solo/3-assist line scored as solo 8, combined 11. Entry dropped — `_tackle_view` derives combined from solo + assists, both of which map correctly. `test_translate_stats_maps_idp_keys` asserted the wrong mapping and is corrected rather than worked around.

**(B7-N2) resolved as a side effect.** The candidate-column repair means the Sleeper-fallback and nflverse row sources now score the *same rules* (both −8.00 on the same football). Previously the fallback charged three penalties the nflverse path silently skipped, so two seasons of one league could be scored under different effective rules and then compared.

## Measured result

| | before | after |
|---|---|---|
| `dynasty_main` scored / unscorable / gap | 34 / 8 / 0 | **37 / 11 / 0** |
| `dynasty_new` scored / unscorable | 13 / **0** | **14 / 2** |

`dynasty_main`'s `gap 0` is now *earned* rather than *fooled*. `dynasty_new` went from disclosing **nothing at all** to naming its unscorable rules — it is also absent from the CI fixture today and is now covered by the new suite.

## Still to land in this PR

- kicker scoring, with `/api/player/{id}/realized` (W18-F004) — the kicker repair is unobservable without the route, and the route without a K guard would ship a confident `0.000` for every kicker;
- the reception-band decision (week-grain `reception_depth`, or keep the explicit `UNSCORABLE` declaration it already carries);
- promoting `score_stat_line` to the scoring core with `realized_points` reduced to a source→stat-key normalizer.

---
_Generated by [Claude Code](https://claude.ai/code/session_014fHctphAz1QuDeeYTKXVAb)_