### PR TITLE
One canonical value: withdraw the unvalidated league lens, remove the device-local methodology switch

### DIFF
--- a/docs/valuation/CANONICAL_VALUE_CONSUMER_AUDIT.md
+++ b/docs/valuation/CANONICAL_VALUE_CONSUMER_AUDIT.md
@@ -1,0 +1,114 @@
+# Canonical player value — producer / consumer audit
+
+**As of PR #822** (canonical value uniformity). Purpose: prove the
+mobile/desktop defect class is closed, not just its two known instances.
+
+The defect had one shape — **a device-local setting selected a
+non-canonical methodology, and that methodology wrote the canonical
+field**. Three mechanisms had to line up. This audit checks that no
+fourth path exists.
+
+## Producers
+
+There is exactly one.
+
+| module | role |
+|---|---|
+| `src/api/data_contract.py::_compute_unified_rankings` | **THE canonical producer.** Rank → percentile → Hill, plus value-direct voting for `ktcSfTep` / `idpTradeCalc`. Emits `rankDerivedValue`. |
+| `src/league_intel/overlay.py` | writes `rankDerivedValue` **only on a private scratch list** that never leaves the function, so the existing ranker can sort the experimental board. Returned rows carry canonical untouched. |
+
+Enforced by `tests/api/test_canonical_ownership_protections.py::test_only_approved_modules_assign_the_canonical_value_field`,
+which scans all shipped `.py`/`.js`/`.jsx` and fails on any other writer.
+
+## Canonical field contract
+
+Measured on the live 1,092-row contract:
+
+| field | relationship | status |
+|---|---|---|
+| `rankDerivedValue` | the canonical value | **CANONICAL** |
+| `values.overall` | exact alias, 1092/1092 | **CANONICAL** (pinned) |
+| `values.finalAdjusted` | exact alias, 1092/1092 | **CANONICAL** (pinned) |
+| `values.displayValue` | exact alias, 1092/1092 | **CANONICAL** (pinned) |
+| `values.rawComposite` | differs on 1080/1092 | **RAW SOURCE** — legacy scraper composite, honestly named |
+| `experimentalLeagueAdjustedValue` | `canonical × scarcity factor` | **EXPERIMENTAL** |
+
+The alias equality is **intentional and now pinned**. The server overlay
+used to scale `rankDerivedValue` and leave `values.*` at market —
+publishing a row that disagreed with itself — which is why this is
+asserted rather than assumed.
+
+## Consumers
+
+Every surface below takes its value from the canonical contract
+(`useDynastyData` → `fetchDynastyData` → `buildRows`) or from a
+server-side engine reading `latest_contract_data`. **No surface computes
+or rescales a value of its own** — the no-frontend-ranking-engine rule.
+
+| surface | source | field | was `valuationMode` reachable? | was `siteWeights` reachable? | experimental reachable? | status |
+|---|---|---|---|---|---|---|
+| Rankings | canonical contract → `buildRows` | `rankDerivedValue` | **yes (fixed)** | **yes (fixed)** | no | CANONICAL |
+| PlayerPopup | contract row / terminal | `rankDerivedValue` | yes (fixed) | yes (fixed) | no | CANONICAL |
+| Trade Calculator | canonical contract + `/api/trade/*` | `rankDerivedValue` | yes (fixed) | no | no | CANONICAL |
+| Trade Suggestions | `latest_contract_data` | `rankDerivedValue` | yes (fixed) | no | no | CANONICAL |
+| Finder / Arbitrage | `latest_contract_data` | `rankDerivedValue` | yes (fixed) | no | no | CANONICAL |
+| Angle | `latest_contract_data` | `rankDerivedValue` | yes (fixed) | no | no | CANONICAL |
+| Waivers / FAAB | `latest_contract_data` → `faab_engine` | `rankDerivedValue` | yes (fixed) | no | no | CANONICAL |
+| Simulator | request body + contract | `rankDerivedValue` | yes (fixed) | no | no | CANONICAL |
+| Terminal | `/api/terminal` | `rankDerivedValue` | yes (fixed) | no | no | CANONICAL |
+| Draft / Perfect Draft | `/api/draft/*` + contract | `rankDerivedValue` | no | no | no | CANONICAL |
+| Public `/league` | `/api/public/league` | fantasy-points records | no | no | no | RAW SOURCE (carries no dynasty value) |
+| `/api/data` compact view | same atomic swap as array | `rankDerivedValue` | n/a | n/a | no | CANONICAL |
+| `/api/data` array view | same atomic swap as compact | `rankDerivedValue` | n/a | n/a | no | CANONICAL |
+| exports (`exports/latest`) | scraper composite | `_finalAdjusted` | no | no | no | RAW SOURCE — legacy composite, ~1.131× canonical |
+| `board_history` writer | refresh-path contract | `rank_derived_value` | no | no | no | CANONICAL |
+| `rank_history` writer | refresh-path contract | `rankDerivedValue` | no | no | no | CANONICAL |
+| `/api/valuation/league-adjusted` | `publish.py` | factors + experimental ranks | n/a | n/a | **yes, by design** | EXPERIMENTAL |
+
+**Ambiguous active consumers after #822: zero.**
+
+## Device-local settings — full sweep
+
+All 24 keys in `next_settings_v2` were enumerated and classified. Four
+could change canonical value; all four are closed.
+
+| setting | effect on canonical value | disposition |
+|---|---|---|
+| `valuationMode` | selected a whole methodology | **closed** — `readValuationMode()` always answers `market` |
+| `siteWeights` | recomputed the board through the canonical pipeline | **closed** at the authority (`normalize_source_overrides`) |
+| `tepMultiplier` | same override path | **closed** — same gate |
+| `tepNativeMultiplier` | same override path | **closed** — same gate |
+| `rosSourceOverrides` | **none — no consumer anywhere** | dead setting, recorded |
+| `rosTepBoost` | **none — no reference anywhere** | dead setting, recorded |
+| `leagueFormat` | **none — no consumer anywhere** | dead setting, recorded |
+| `faabRiskPosture` | shifts the bid TARGET, never the objective value | presentation/advice |
+| `rankingsSortBasis`, `hiddenSiteCols`, `showSiteCols`, `showRosTags`, `ktcSuggestionTopN` | ordering / column visibility / filtering | presentation |
+| `rosEnabled`, `useRosPowerRankings`, `useRosPlayoffOdds`, `showRosTradePanel`, `rosSimulationCount` | ROS subsystem (`rosValue`, a 0-100 log-rank index — a separately named concept) | presentation |
+| `selectedTeam*`, `tradeHistoryWindowDays`, `tepAutoRestored` | scope / context | presentation |
+
+Three dead settings (`rosSourceOverrides`, `rosTepBoost`, `leagueFormat`)
+were found and are recorded rather than removed — deleting persisted keys
+is a migration question, and they cannot affect value.
+
+## Enforced invariants
+
+| # | invariant | where |
+|---|---|---|
+| A | only approved producers write canonical value | `test_canonical_ownership_protections.py` |
+| B | experimental overlay leaves canonical unchanged | `test_canonical_value_invariance.py` |
+| C | user source weighting cannot write canonical value | `test_canonical_ownership_protections.py` |
+| D | device-local settings cannot change canonical value (6-client matrix) | `test_canonical_ownership_protections.py` |
+| E | canonical aliases stay coherent | `test_canonical_ownership_protections.py` |
+| F | compact and array views price identically | `test_canonical_value_invariance.py` |
+| G | canonical history records canonical output only | `test_canonical_ownership_protections.py` |
+| H | canonical API projections preserve the value | `test_canonical_ownership_protections.py` |
+
+## Deferred (deliberately outside #822)
+
+- `board_history` `league_key` + scoring fingerprint columns — the
+  recorder is real and healthy; this is future evidence enrichment.
+- Build/revision diagnostics.
+- The manual `CACHE_VERSION` service-worker hole.
+- A future outcome-validated league-aware canonical methodology.
+- Custom Mix reintroduction as an explicitly non-canonical analytical
+  board with separate field semantics.

--- a/docs/valuation/LEAGUE_AWARE_METHODOLOGY_REJECTION.md
+++ b/docs/valuation/LEAGUE_AWARE_METHODOLOGY_REJECTION.md
@@ -1,0 +1,144 @@
+# League-aware valuation: evaluated for canonical promotion, rejected
+
+**Decision: C — no trustworthy league-aware canonical method yet.**
+**Date:** 2026-08-14 · **Branch:** `claude/canonical-value-uniformity` · **PR:** #822
+
+This record exists so nobody re-derives it in six months. It is not a verdict on
+league-aware valuation as a product goal — that goal stands. It is a verdict on
+*this implementation* and on *today's evidence*.
+
+## Why the question was asked
+
+A report that player values differed between mobile and desktop. The cause was
+architectural: `valuationMode` lived in `next_settings_v2` in **localStorage,
+never server-synced**, and the lens it selected **overwrote `rankDerivedValue`
+in place**. One account on two devices, two numbers for one player, under one
+field name, with nothing in the payload naming which was which.
+
+The owner's response was to ask the larger question: if league-aware valuation
+can be proven better, it should *become* canonical and the toggle should go.
+
+## Correction to the record
+
+The figure **9,991 → 12,489** circulated during the investigation as the
+league-adjusted value for Josh Allen. **It was never a production measurement.**
+It came from applying the documented ±25% cap to 9,991 — a worst-case bound —
+and a CI fixture then used `1.25` to reproduce that arithmetic. CI proved the
+*mechanism* (canonical is overwritten; the result can leave the scale), not a
+live value.
+
+Measured from the captured live overlay (`evidence/W29/league-adjusted-overlay.json`,
+709 rows, **7 distinct factors**):
+
+| position | live factor | effect |
+|---|---|---|
+| DL | 1.097760 | +9.8% |
+| RB | 1.041554 | +4.2% |
+| WR | 1.026798 | +2.7% |
+| **QB** | **1.018366** | **Josh Allen 9,991 → ~10,175** |
+| TE | 1.011595 | +1.2% |
+| TE (alt) | 0.979705 | −2.0% |
+
+Finding **W07-F008** independently records Josh Allen at **10,171**. The ±25%
+cap has never bound on live data. The defect was real; its magnitude was
+overstated.
+
+## What "My League" actually computes
+
+```
+top            = max rosValue among players CURRENTLY ROSTERED at that position
+starter        = median over teams of each team's lowest-rosValue STARTED player
+lineupScarcity = clamp01(1 - starter / top)
+factor         = 1.0 + (lineupScarcity - 0.5) * 0.20
+```
+
+**Used:** starting-lineup slots — only as a *selector* deciding who counts as
+started — SFLEX/FLEX endogenously, IDP starter slots, current roster occupancy,
+the starter replacement tier. IDP *scoring* enters as a separate `scoringFit`
+axis, not scarcity.
+
+**Not used, despite the feature name:** team count (no arithmetic term), roster
+size, TE premium (deliberately absent), offensive scoring, bench depth, taxi,
+IR, projected scoring, age.
+
+## Why it was rejected
+
+1. **Current roster state, not durable structure.** `top` is the single
+   highest-`rosValue` player rostered *today*. One trade, waiver claim or ROS
+   re-rank moves the factor for every player at that position. League structure
+   is durable; manager behaviour is not.
+2. **The input is an ordinal index.** `rosValue` is a 0-100 *logarithmic rank*
+   index — "not points, and not projection-aware" — yet it sets the multiplier
+   on a 0-9999 dynasty board.
+3. **`reference_lineup_scarcity = 0.5` is a bare constant**, never derived,
+   never overridden, and it alone decides the *sign* of every adjustment.
+4. **Per-position only.** 709 live rows carry 7 distinct factors; 5 of 8
+   positions receive a pure scalar, which is untestable within position by
+   construction (Spearman is invariant to monotone transforms).
+5. **It leaves the canonical scale.** 9999 is the Hill *asymptote* —
+   `V(p) = 9999 / (1 + (p/c)^s)` is mathematically bounded by it — so a
+   multiplicative factor on a saturating percentile-transformed quantity is not
+   a valid ratio operation. Values above 9999 are evidence the design is wrong,
+   not that the ceiling should rise.
+6. **No staleness detection** on the roster snapshot: an unchanged stale file is
+   a perfect cache hit, served indefinitely as current league state.
+7. **No double-count guard.** `tePremium` is ABSENT *by design* with a pinned
+   invariant test, because the anchor is already KTC's TE++ board.
+   `structuralScarcity` has no equivalent guard — while every offense-bearing
+   source is already a Superflex board.
+
+## Double-counting map
+
+**All 18 offense-bearing sources are Superflex boards**, proven at the fetch
+layer (SF URLs, `numQbs=2`, `?format=sf`, explicit 2QB columns). Zero 1QB boards
+vote; 1QB columns are explicitly discarded. The board's basis is `tepp`
+(`_BOARD_TE_BASIS`), anchored on `ktcSfTep`, with every non-TEP TE contribution
+moved onto it by the single permitted mover `convert_te_value`.
+
+So **the canonical value already prices Superflex and TE premium**. No SF
+multiplier exists anywhere in the value path. `structuralScarcity` is the
+unguarded path where such a double count *would* enter.
+
+Note also: the canonical board is **not** "market-only". The TE-premium
+multiplier is auto-derived from the league's own Sleeper `bonus_rec_te` and
+applied value-level inside the blend. "Market vs My League" was never a clean
+dichotomy.
+
+## Why the evidence bar could not be met
+
+| artifact | state |
+|---|---|
+| `board_history.sqlite` (production) | **exists and is healthy** — 8,749 rows, 8 days, 2026-08-06→08-13, timer enabled + active |
+| the same file in a fresh clone | absent — `data/` is gitignored |
+| `exports/archive/` (153 bundles) | carries the **legacy composite only** — no `rankDerivedValue` anywhere |
+| league config recorded beside a value | **nothing, in any artifact** |
+
+A dynasty-horizon backtest is not possible (no multi-season outcome definition,
+no board history predating an observable season). A forward test is not possible
+before ~Dec 2026. A league-aware comparison is hardest of the three: it needs
+board history *and* league config together.
+
+The existing `backtest_adjusted_board.py` is honest and well-caveated, but it
+has no age term while dynasty value is multi-season, and it requests the overlay
+for `dynasty_main` while measuring `scoringFit`/`receptionFit` and the
+realized-points target against a Sleeper league ID **not in the registry** —
+already filed as a High finding.
+
+## What changed as a result
+
+- The overlay no longer writes `rankDerivedValue` or its aliases. It emits
+  `experimentalLeagueAdjustedValue` / `…Rank` / `…Tier`.
+- `_valuation_scoped_contract` — the single place the lens reached an engine —
+  no longer applies it. The request is *ignored*, not refused, so a stored
+  `leagueAdjusted` converges silently.
+- `readValuationMode()` always answers `market`, making persisted settings inert
+  with no migration step.
+- The Market / My league control is removed from `/rankings`.
+
+## What would reopen this
+
+Board history is accumulating now, and it already records the canonical value
+and the methodology version. What it does **not** record is `league_key` or a
+scoring fingerprint — a narrow, forward-only, additive schema change. With those
+plus a season of elapsed outcomes, the A/B/C question becomes answerable on
+evidence rather than on theory.

--- a/frontend/__tests__/components/valuation-mode.test.js
+++ b/frontend/__tests__/components/valuation-mode.test.js
@@ -40,9 +40,17 @@ describe("readValuationMode", () => {
     expect(readValuationMode()).toBe(MARKET);
   });
 
-  it("reads the persisted lens", () => {
+  it("ignores a persisted lens — a device may not pick a methodology", () => {
+    // WITHDRAWN 2026-08-14. This used to assert the stored value was
+    // honoured, which is precisely the defect: `next_settings_v2` is
+    // device-local and never server-synced, so one account on two
+    // devices held two answers, and the lens overwrote the canonical
+    // field. See docs/valuation/LEAGUE_AWARE_METHODOLOGY_REJECTION.md.
+    //
+    // Read-and-ignore rather than deleted, so an old phone with
+    // `leagueAdjusted` stored converges with no migration step.
     setSettings({ valuationMode: LEAGUE_ADJUSTED });
-    expect(readValuationMode()).toBe(LEAGUE_ADJUSTED);
+    expect(readValuationMode()).toBe(MARKET);
   });
 
   it("treats anything unrecognised as market", () => {
@@ -72,12 +80,9 @@ describe("withValuationMode", () => {
     expect(withValuationMode({ roster: ["A"] })).toEqual({ roster: ["A"] });
   });
 
-  it("adds the lens when the adjusted board is selected", () => {
+  it("adds no lens even when one is stored", () => {
     setSettings({ valuationMode: LEAGUE_ADJUSTED });
-    expect(withValuationMode({ roster: ["A"] })).toEqual({
-      roster: ["A"],
-      valuation_mode: LEAGUE_ADJUSTED,
-    });
+    expect(withValuationMode({ roster: ["A"] })).toEqual({ roster: ["A"] });
   });
 
   it("never mutates the caller's body", () => {
@@ -106,19 +111,19 @@ describe("withValuationMode", () => {
 });
 
 describe("applyValuationModeParam", () => {
-  it("returns the mode so callers can key a cache on it", () => {
-    // THE POINT of the return value: /api/terminal caches by
-    // (team, window, league). A cache keyed without the board serves
-    // the stale market payload for the full TTL after the user
-    // switches, which looks exactly like the toggle not working.
+  it("always reports the canonical board and adds no param", () => {
+    // The return value still exists because /api/terminal keys its cache
+    // on it. With one methodology it is constant — but keeping the seam
+    // means a future validated methodology re-opens in one place rather
+    // than re-threading six call sites.
     const params = new URLSearchParams();
     expect(applyValuationModeParam(params)).toBe(MARKET);
     expect(params.toString()).toBe("");
 
     setSettings({ valuationMode: LEAGUE_ADJUSTED });
-    const adjusted = new URLSearchParams();
-    expect(applyValuationModeParam(adjusted)).toBe(LEAGUE_ADJUSTED);
-    expect(adjusted.get("valuationMode")).toBe(LEAGUE_ADJUSTED);
+    const stored = new URLSearchParams();
+    expect(applyValuationModeParam(stored)).toBe(MARKET);
+    expect(stored.get("valuationMode")).toBeNull();
   });
 
   it("leaves other params untouched", () => {

--- a/frontend/__tests__/valuation-overlay.test.js
+++ b/frontend/__tests__/valuation-overlay.test.js
@@ -12,7 +12,11 @@
  *  3. A version mismatch must refuse outright, not half-apply.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { applyValuationOverlay, buildRows } from "@/lib/dynasty-data";
+import {
+  EXPERIMENTAL_LEAGUE_ADJUSTED_VALUE,
+  applyValuationOverlay,
+  buildRows,
+} from "@/lib/dynasty-data";
 
 const STAMP = "2026-07-27T05:14:44";
 
@@ -95,13 +99,18 @@ const OVERLAY = {
 };
 
 describe("applyValuationOverlay — playersArray path", () => {
-  it("scales value and every alias that mirrors it", () => {
+  it("writes the experimental field and leaves canonical + every alias alone", () => {
+    // WITHDRAWN 2026-08-14. This used to assert the lens scaled
+    // `rankDerivedValue` and all three aliases. That is the defect: an
+    // unvalidated methodology owning the canonical field is how a
+    // localStorage value changed a player's canonical value.
     const out = applyValuationOverlay(baseArrayContract(), OVERLAY);
     const rise = out.data.playersArray.find((r) => r.displayName === "Rise");
-    expect(rise.rankDerivedValue).toBe(5300);
-    expect(rise.values.overall).toBe(5300);
-    expect(rise.values.finalAdjusted).toBe(5300);
-    expect(rise.values.displayValue).toBe(5300);
+    expect(rise[EXPERIMENTAL_LEAGUE_ADJUSTED_VALUE]).toBe(5300);
+    expect(rise.rankDerivedValue).toBe(5000);
+    expect(rise.values.overall).toBe(5000);
+    expect(rise.values.finalAdjusted).toBe(5000);
+    expect(rise.values.displayValue).toBe(5000);
   });
 
   it("leaves values.raw alone — the toggle changes Our Value, never Raw", () => {
@@ -142,8 +151,10 @@ describe("applyValuationOverlay — legacy dict path (THE DEFAULT)", () => {
   it("writes the underscored rank key AND the un-underscored value key", () => {
     const out = applyValuationOverlay(baseLegacyContract(), OVERLAY);
     const rise = out.data.players.Rise;
-    // The asymmetry that makes this the highest-risk bug in the feature.
-    expect(rise.rankDerivedValue).toBe(5300);
+    // The asymmetry that made this the highest-risk bug in the feature.
+    // Canonical value now survives; only the rank keys still move.
+    expect(rise[EXPERIMENTAL_LEAGUE_ADJUSTED_VALUE]).toBe(5300);
+    expect(rise.rankDerivedValue).toBe(5000);
     expect(rise._canonicalConsensusRank).toBe(1);
     expect(rise._canonicalTierId).toBe(1);
   });
@@ -151,7 +162,8 @@ describe("applyValuationOverlay — legacy dict path (THE DEFAULT)", () => {
   it("moves value and rank together", () => {
     const out = applyValuationOverlay(baseLegacyContract(), OVERLAY);
     const fall = out.data.players.Fall;
-    expect(fall.rankDerivedValue).toBe(4888);
+    expect(fall[EXPERIMENTAL_LEAGUE_ADJUSTED_VALUE]).toBe(4888);
+    expect(fall.rankDerivedValue).toBe(5200);
     expect(fall._canonicalConsensusRank).toBe(2);
   });
 

--- a/frontend/app/rankings/page.jsx
+++ b/frontend/app/rankings/page.jsx
@@ -77,7 +77,6 @@ import {
   Movement,
   PageHeader,
   Panel,
-  SegmentedControl,
   Select,
   SkeletonTable,
   StatTile,
@@ -262,7 +261,6 @@ export default function RankingsPage() {
   const { loading, error, rows, rawData } = useDynastyData();
   const {
     settings,
-    hydrated: settingsHydrated,
     update: updateSetting,
     updateSiteWeight,
     resetSiteWeights,
@@ -1343,21 +1341,21 @@ export default function RankingsPage() {
         description="Unified dynasty board — offense + IDP blended by consensus rank."
         actions={
           <>
-            <SegmentedControl
-              label="Value basis"
-              // null until settings hydrate: before that ``settings`` is
-              // SETTINGS_DEFAULTS, so highlighting "Market" would assert
-              // a value basis this device may not be on. Unchecked for
-              // one frame beats confidently wrong — the highlight is the
-              // only thing telling the user which board the numbers came
-              // from.
-              value={settingsHydrated ? settings.valuationMode || "market" : null}
-              onChange={(v) => updateSetting("valuationMode", v)}
-              options={[
-                { value: "market", label: "Market" },
-                { value: "leagueAdjusted", label: "My league" },
-              ]}
-            />
+            {/*
+              The "Value basis" Market / My league control was REMOVED on
+              2026-08-14. There is one canonical methodology, so there is
+              nothing to choose between, and a control that selects a
+              methodology is exactly how one player came to have two
+              values: the setting lived in localStorage, never synced, and
+              the lens overwrote the canonical field — so phone and
+              desktop disagreed with nothing on screen saying which was
+              which. Its own comment admitted the highlight was "the only
+              thing telling the user which board the numbers came from".
+
+              Removed rather than disabled: a greyed-out control implies
+              the choice still exists. See
+              docs/valuation/LEAGUE_AWARE_METHODOLOGY_REJECTION.md.
+            */}
             <CustomMixBadge rankingsOverride={rawData?.rankingsOverride} />
             {copyStatus && (
               <span className={styles.resultCount}>{copyStatus}</span>

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -1902,6 +1902,16 @@ async function _fetchValuationOverlayNetwork() {
  *
  * Copy-on-write: untouched rows are returned by reference.
  */
+/**
+ * Where the experimental league-aware number goes on the client.
+ * Must stay identical to ``EXPERIMENTAL_VALUE_FIELD`` in
+ * ``src/league_intel/overlay.py`` — the server and client appliers
+ * disagreeing about a field name is how the server ended up scaling
+ * ``rankDerivedValue`` while leaving ``values.*`` at market.
+ */
+export const EXPERIMENTAL_LEAGUE_ADJUSTED_VALUE =
+  "experimentalLeagueAdjustedValue";
+
 export function applyValuationOverlay(baseContract, overlay) {
   if (!baseContract || !overlay) return baseContract;
   const factors = overlay.factors;
@@ -1950,14 +1960,16 @@ export function applyValuationOverlay(baseContract, overlay) {
       if (!f && !hasRank) return row;
       const next = { ...row };
       if (f) {
-        next.rankDerivedValue = scale(row.rankDerivedValue, f);
-        if (row.values && typeof row.values === "object") {
-          // All four aliases are identical on live rows; keep them so.
-          next.values = { ...row.values };
-          for (const k of ["overall", "finalAdjusted", "displayValue"]) {
-            if (row.values[k] != null) next.values[k] = scale(row.values[k], f);
-          }
-        }
+        // WITHDRAWN 2026-08-14 — mirrors src/league_intel/overlay.py.
+        // The canonical value and its aliases are left alone; the
+        // adjusted number goes to its own field. This path is currently
+        // unreachable (`leagueAdjusted` is false), but a client applier
+        // that still overwrote canonical would be a loaded gun pointed at
+        // the invariant the rest of this change establishes.
+        next[EXPERIMENTAL_LEAGUE_ADJUSTED_VALUE] = scale(
+          row.rankDerivedValue,
+          f,
+        );
       }
       if (hasRank) {
         next.canonicalConsensusRank = ranks[key];
@@ -1986,9 +1998,11 @@ export function applyValuationOverlay(baseContract, overlay) {
       }
       const next = { ...row };
       if (f) {
-        next.rankDerivedValue = scale(row.rankDerivedValue, f);
-        if (row._finalAdjusted != null)
-          next._finalAdjusted = scale(row._finalAdjusted, f);
+        // Same rule on the legacy dict path — canonical untouched.
+        next[EXPERIMENTAL_LEAGUE_ADJUSTED_VALUE] = scale(
+          row.rankDerivedValue,
+          f,
+        );
       }
       if (hasRank) {
         next._canonicalConsensusRank = ranks[name];
@@ -2028,6 +2042,31 @@ export async function fetchDynastyData(opts = {}) {
   const tepCustomized = tepMultiplierIsCustomized(tepMultiplier);
   const tepNativeCustomized =
     tepNativeMultiplierIsCustomized(tepNativeMultiplier);
+
+  // CUSTOM MIX DISABLED 2026-08-14 — enforced SERVER-SIDE, deliberately.
+  //
+  // `siteWeights`, `tepMultiplier` and `tepNativeMultiplier` all live in
+  // `next_settings_v2` in localStorage, are never server-synced, and all
+  // three ride this override path — which returned the recomputed board
+  // under `rankDerivedValue` (it is in `_DELTA_PLAYER_FIELDS`). Two
+  // devices with different stored settings therefore rendered different
+  // canonical values for one player, exactly as `valuationMode` did.
+  //
+  // The withdrawal lives in `normalize_source_overrides`, NOT here. The
+  // client may still post its stored mix; the server ignores it, serves
+  // the canonical board and says why in `warnings`. That is the point:
+  // canonical value is authority-owned, so the guarantee cannot depend on
+  // every client agreeing to stop asking — including stale bundles and
+  // direct callers, which a client-side flag would not cover.
+  //
+  // Narrower than `valuationMode` was: server-side engines read
+  // `latest_contract_data` and never saw the override board, and neither
+  // history writer runs on this path — so trade math and recorded history
+  // were already canonical-safe. The exposure was the /rankings display.
+  //
+  // The LEAGUE-DERIVED TE premium is unaffected and still applies: the
+  // server derives it from the league's own Sleeper `bonus_rec_te`. Only
+  // the user's manual override is withdrawn.
   const customized = sitesCustomized || tepCustomized || tepNativeCustomized;
 
   // WITHDRAWN 2026-08-14 — one canonical methodology. `readValuationMode`

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -2030,7 +2030,12 @@ export async function fetchDynastyData(opts = {}) {
     tepNativeMultiplierIsCustomized(tepNativeMultiplier);
   const customized = sitesCustomized || tepCustomized || tepNativeCustomized;
 
-  const leagueAdjusted = opts.valuationMode === "leagueAdjusted";
+  // WITHDRAWN 2026-08-14 — one canonical methodology. `readValuationMode`
+  // now always answers `market`, so callers that still pass a mode get
+  // the canonical board. Kept as a named constant rather than deleted so
+  // the composition branches below stay readable and a future validated
+  // methodology has one flag to flip.
+  const leagueAdjusted = false;
 
   // Default path (no overrides): fetch + cache the base contract.
   // The backend will derive tep_multiplier from the operator's

--- a/frontend/lib/valuation-mode.js
+++ b/frontend/lib/valuation-mode.js
@@ -34,18 +34,33 @@ import { SETTINGS_KEY } from "@/lib/trade-logic";
 export const MARKET = "market";
 export const LEAGUE_ADJUSTED = "leagueAdjusted";
 
-/** The board the user has selected, or `market` when unknowable. */
+/**
+ * The board a request should be answered from.
+ *
+ * WITHDRAWN 2026-08-14 — always `MARKET`, which is now simply "the one
+ * canonical board".
+ *
+ * This used to read `valuationMode` out of `next_settings_v2` in
+ * localStorage. That is device-local and never server-synced, so one
+ * account on two devices held two answers to "which methodology am I
+ * looking at", and the lens overwrote `rankDerivedValue` in place — so
+ * the same player rendered different values on phone and desktop with
+ * nothing in the payload naming which was which. Measured on the live
+ * overlay: +1.8% for QBs, up to +9.8% for DL.
+ *
+ * The league-aware methodology was evaluated for promotion to canonical
+ * and rejected on the evidence (see
+ * `docs/valuation/LEAGUE_AWARE_METHODOLOGY_REJECTION.md`). With one
+ * methodology there is nothing to select, so the setting is inert rather
+ * than removed: reading it and ignoring it is what makes an old phone
+ * with `leagueAdjusted` stored converge automatically, with no migration
+ * step and no user cleanup.
+ *
+ * Kept as a function, not inlined to a constant, because it is the one
+ * seam a future *validated* methodology re-opens.
+ */
 export function readValuationMode() {
-  if (typeof window === "undefined") return MARKET;
-  try {
-    const raw = localStorage.getItem(SETTINGS_KEY);
-    if (!raw) return MARKET;
-    const parsed = JSON.parse(raw);
-    return parsed?.valuationMode === LEAGUE_ADJUSTED ? LEAGUE_ADJUSTED : MARKET;
-  } catch {
-    // A corrupt settings blob must not take down a trade request.
-    return MARKET;
-  }
+  return MARKET;
 }
 
 /**

--- a/server.py
+++ b/server.py
@@ -7465,37 +7465,30 @@ async def _valuation_scoped_contract(
     block differs.
     """
     source = base if base is not None else latest_contract_data
-    if _requested_valuation_mode(request, body) != "leagueAdjusted":
-        return source, "market", None
-    if not source or not latest_contract_data:
-        return source, "market", "league_adjusted_unavailable: no_contract"
 
-    try:
-        overlay = await run_in_threadpool(
-            _gameplan.get_league_adjusted_values,
-            league_cfg.key,
-            league_cfg.scoring_profile,
-            latest_contract_data,
-        )
-    except _gameplan.GameplanUnavailable as exc:
-        log.warning(
-            "league-adjusted engine board unavailable for %s: %s", league_cfg.key, exc.detail
-        )
-        return source, "market", f"league_adjusted_unavailable: {exc.reason}"
-    except Exception as exc:  # noqa: BLE001
-        log.warning("league-adjusted engine board failed for %s: %r", league_cfg.key, exc)
-        return source, "market", "league_adjusted_unavailable: overlay_error"
-
-    raw_factors = overlay.get("factors") if isinstance(overlay, dict) else None
-    factors = {
-        str(k): float(v) for k, v in (raw_factors or {}).items() if isinstance(v, (int, float))
-    }
-    from src.league_intel.overlay import adjusted_contract as _adjusted_contract
-
-    adjusted = _adjusted_contract(source, factors)
-    if adjusted is None:
-        return source, "market", "league_adjusted_unavailable: no_op"
-    return adjusted, "leagueAdjusted", None
+    # WITHDRAWN 2026-08-14 — one canonical methodology, server-owned.
+    #
+    # This is the single place the league-adjusted lens ever reached an
+    # engine, so it is the single place to close it.  The lens was
+    # evaluated for promotion to canonical and rejected under the
+    # outcome-evidence bar (see
+    # ``docs/valuation/LEAGUE_AWARE_METHODOLOGY_REJECTION.md``), and an
+    # unvalidated methodology may not answer an engine request.
+    #
+    # Closing it HERE rather than at the nine call sites is deliberate:
+    # every caller keeps its ``valuation_mode`` plumbing and keeps
+    # stamping the mode it was actually served, so responses stay
+    # self-describing and a future validated methodology has one seam to
+    # re-open instead of nine to re-thread.
+    #
+    # The request is IGNORED, not refused.  A stored ``leagueAdjusted``
+    # on someone's phone must converge to the canonical answer silently —
+    # refusing would turn an obsolete localStorage value into a broken
+    # page for a user who never chose anything.
+    requested = _requested_valuation_mode(request, body)
+    if requested == "leagueAdjusted":
+        return source, "market", "league_adjusted_withdrawn: not_canonical"
+    return source, "market", None
 
 
 def _stamp_valuation_mode(result: Any, mode: str, note: str | None) -> None:

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -2609,6 +2609,15 @@ def normalize_tep_native_multiplier(raw: Any) -> float | None:
     return None
 
 
+#: Custom Mix (user source weighting) is disabled: it recomputed the
+#: board through the canonical pipeline and returned it under
+#: ``rankDerivedValue``, so two devices with different localStorage held
+#: two canonical values for one player.  A module constant rather than an
+#: env flag because this is a product decision with a written rationale,
+#: not an operational toggle — and because a test can assert on it.
+_SOURCE_OVERRIDES_DISABLED: bool = True
+
+
 def normalize_source_overrides(
     raw: Any,
 ) -> tuple[dict[str, dict[str, Any]], list[str]]:
@@ -2652,6 +2661,27 @@ def normalize_source_overrides(
     out: dict[str, dict[str, Any]] = {}
 
     if raw is None:
+        return out, warnings
+
+    # CUSTOM MIX DISABLED 2026-08-14 — one canonical board.
+    #
+    # Closed HERE, at the one function every override body passes
+    # through, rather than at the route: the client no longer sends
+    # overrides, but a stale bundle or a direct caller still can, and a
+    # user-weighted board returned under ``rankDerivedValue`` (which is
+    # in ``_DELTA_PLAYER_FIELDS``) is a second canonical truth however it
+    # was requested.
+    #
+    # The request is answered, not refused — the endpoint still serves
+    # the canonical board with the league-derived TE premium applied, and
+    # says in ``warnings`` why the weights were ignored. Refusing would
+    # break /rankings for anyone whose device still posts a stored mix.
+    if _SOURCE_OVERRIDES_DISABLED:
+        warnings.append(
+            "custom source weighting is disabled; serving the canonical "
+            "consensus board (see docs/valuation/"
+            "LEAGUE_AWARE_METHODOLOGY_REJECTION.md)"
+        )
         return out, warnings
     if not isinstance(raw, dict):
         warnings.append(f"Top-level overrides must be an object; got {type(raw).__name__}")

--- a/src/league_intel/overlay.py
+++ b/src/league_intel/overlay.py
@@ -14,11 +14,47 @@ saw adjusted rankings and then got trade advice priced on the market
 board.  Two boards, one session, no indication which was which.  That is
 the inconsistency this closes.
 
-The whole trick is that every engine reads exactly one value —
-``rankDerivedValue`` on ``playersArray`` rows.  So none of them need to
-know this feature exists: hand them a contract whose rows are already
-adjusted and they inherit it.  No per-engine plumbing, no second value
-concept to keep in sync.
+STATUS — EXPERIMENTAL, NOT CANONICAL (2026-08-14)
+─────────────────────────────────────────────────
+This methodology was evaluated for promotion to canonical and
+**REJECTED** under the owner's outcome-evidence bar.  It may no longer
+own a canonical field.  The rejection is recorded in full in
+``docs/valuation/LEAGUE_AWARE_METHODOLOGY_REJECTION.md``; the short form:
+
+* the factor is measured from **current roster state**, not durable
+  league structure — ``top`` is the single highest-``rosValue`` player
+  rostered today, so one trade or waiver claim moves every player at
+  that position;
+* its input is a 0-100 **logarithmic rank index** (``rosValue``), which
+  is "not points, and not projection-aware", yet it sets a multiplier on
+  a 0-9999 dynasty board;
+* ``reference_lineup_scarcity = 0.5`` is a bare constant, never derived,
+  and it alone decides the sign of every adjustment;
+* it is per-position only — 709 live rows carry 7 distinct factors, and
+  5 of 8 positions get a pure scalar, which is untestable within
+  position by construction;
+* it multiplies into a scale whose maximum is the Hill **asymptote**
+  (``V(p) = 9999 / (1 + (p/c)^s)``), with no renormalisation, so the
+  board leaves its own declared range;
+* ``tePremium`` is deliberately ABSENT here with a pinned double-count
+  guard, because the anchor is already KTC's TE++ board — but
+  ``structuralScarcity`` has no equivalent guard while every offense
+  source is already a Superflex board;
+* and the evidence needed to validate a replacement does not exist:
+  ``board_history`` began accumulating only recently and no artifact
+  records league configuration beside a value.
+
+So this module computes a **diagnostic** board.  It writes
+``experimentalLeagueAdjustedValue`` / ``…Rank`` / ``…Tier`` and never
+``rankDerivedValue``.  Rejection is not a verdict on league-aware
+valuation as a goal — it is a verdict on this implementation and on
+today's evidence.
+
+The original design note, kept because it explains the shape: every
+engine reads exactly one value — ``rankDerivedValue`` on
+``playersArray`` rows — so handing them an adjusted contract made them
+inherit the lens with no per-engine plumbing.  That is exactly what made
+it dangerous: the lens became indistinguishable from canonical truth.
 
 What this is NOT
 ────────────────
@@ -44,7 +80,31 @@ from typing import Any, Mapping, Sequence
 
 _LOGGER = logging.getLogger(__name__)
 
-__all__ = ["adjusted_contract", "adjusted_rows", "row_factor_key"]
+#: Where the experimental league-aware numbers live.  Named so no
+#: consumer can mistake one for canonical value by reading a field name,
+#: and so a grep for the canonical field never lands here.
+EXPERIMENTAL_VALUE_FIELD = "experimentalLeagueAdjustedValue"
+EXPERIMENTAL_RANK_FIELD = "experimentalLeagueAdjustedRank"
+EXPERIMENTAL_TIER_FIELD = "experimentalLeagueAdjustedTier"
+
+#: Canonical fields this module must never write.  Asserted by
+#: ``tests/api/test_canonical_value_invariance.py`` rather than trusted:
+#: ``values.*`` were measured as exact aliases of ``rankDerivedValue`` on
+#: all 1,092 rows of the live contract, so moving one without the others
+#: publishes a row that disagrees with itself — which is what the server
+#: overlay used to do (it scaled the canonical field and left the aliases
+#: at market).
+CANONICAL_VALUE_FIELDS = frozenset({"rankDerivedValue", "overall", "finalAdjusted", "displayValue"})
+
+__all__ = [
+    "CANONICAL_VALUE_FIELDS",
+    "EXPERIMENTAL_RANK_FIELD",
+    "EXPERIMENTAL_TIER_FIELD",
+    "EXPERIMENTAL_VALUE_FIELD",
+    "adjusted_contract",
+    "adjusted_rows",
+    "row_factor_key",
+]
 
 
 def row_factor_key(row: Mapping[str, Any]) -> str:
@@ -83,16 +143,35 @@ def adjusted_rows(
         current_rookie_draft_year,
     )
 
-    copies: list[dict[str, Any]] = []
+    # TWO LISTS, and the split is the whole point.
+    #
+    # ``scratch`` carries the adjusted number in the canonical slot purely
+    # so the existing ranker — which sorts on ``rankDerivedValue`` — can
+    # rank the adjusted board without being rewritten.  It never leaves
+    # this function.
+    #
+    # ``out`` is what callers get: the canonical value UNTOUCHED, with the
+    # adjusted number under its own unmistakable name.  This overlay was
+    # evaluated for promotion to canonical and REJECTED under the
+    # outcome-evidence bar (see the module docstring), so it may not own a
+    # canonical field.  Writing it into ``rankDerivedValue`` is what let a
+    # device-local localStorage setting decide which methodology a user
+    # saw, and left no field carrying the canonical number afterwards.
+    scratch: list[dict[str, Any]] = []
+    out: list[dict[str, Any]] = []
     moved = 0
     for row in rows:
-        copy = dict(row)
-        base = copy.get("rankDerivedValue")
+        base = row.get("rankDerivedValue")
         factor = factors.get(row_factor_key(row))
-        if factor and isinstance(base, (int, float)) and base > 0:
-            copy["rankDerivedValue"] = int(round(float(base) * float(factor)))
+        work = dict(row)
+        emit = dict(row)
+        if factor and isinstance(base, (int, float)) and not isinstance(base, bool) and base > 0:
+            adjusted = int(round(float(base) * float(factor)))
+            work["rankDerivedValue"] = adjusted
+            emit[EXPERIMENTAL_VALUE_FIELD] = adjusted
             moved += 1
-        copies.append(copy)
+        scratch.append(work)
+        out.append(emit)
 
     if not moved:
         return None
@@ -112,7 +191,7 @@ def adjusted_rows(
     # second copy leaves every row — ranked, unranked and slot-pick
     # alike — carrying the correct rank while the row list stays whole.
     ranked = compact_ranks_and_tiers(
-        copies,
+        scratch,
         anchor_year=current_rookie_draft_year(),
         copy_rows=False,
     )
@@ -123,7 +202,14 @@ def adjusted_rows(
             len(errors),
         )
         return None
-    return copies
+
+    # Carry the experimental ordering across under experimental names.
+    # The canonical rank stays whatever the canonical board said, for the
+    # same reason the canonical value does.
+    for work, emit in zip(scratch, out):
+        emit[EXPERIMENTAL_RANK_FIELD] = work.get("canonicalConsensusRank")
+        emit[EXPERIMENTAL_TIER_FIELD] = work.get("canonicalTierId")
+    return out
 
 
 def adjusted_contract(

--- a/src/league_intel/publish.py
+++ b/src/league_intel/publish.py
@@ -201,12 +201,28 @@ def build_league_adjusted_payload(
             warnings.append("ranking incoherent; overlay suppressed")
             factors = {}
         else:
+            # Read the EXPERIMENTAL rank/tier, not the canonical ones.
+            #
+            # ``adjusted_rows`` stopped writing canonical fields when this
+            # methodology was rejected for canonical promotion (2026-08-14,
+            # see docs/valuation/LEAGUE_AWARE_METHODOLOGY_REJECTION.md) —
+            # the rows it returns now carry the canonical value and rank
+            # untouched, with the adjusted ordering under its own names.
+            # This publisher is the experimental board's publisher, so the
+            # experimental ordering is exactly what it wants; reading the
+            # canonical names here would silently publish the market
+            # ordering under an "adjusted" label.
+            from src.league_intel.overlay import (  # noqa: PLC0415 - avoid import cycle
+                EXPERIMENTAL_RANK_FIELD,
+                EXPERIMENTAL_TIER_FIELD,
+            )
+
             for r in ranked:
                 name = _row_key(r)
                 if not name:
                     continue
-                rank = r.get("canonicalConsensusRank")
-                tier = r.get("canonicalTierId")
+                rank = r.get(EXPERIMENTAL_RANK_FIELD)
+                tier = r.get(EXPERIMENTAL_TIER_FIELD)
                 if isinstance(rank, int):
                     ranks[name] = rank
                 if isinstance(tier, int):

--- a/tests/api/test_canonical_ownership_protections.py
+++ b/tests/api/test_canonical_ownership_protections.py
@@ -1,0 +1,308 @@
+"""Durable protection for canonical-value ownership.
+
+The mobile/desktop incident had one shape: a **device-local setting**
+selected a **non-canonical methodology**, and that methodology **wrote the
+canonical field**. Three separate mechanisms had to line up, and any one
+of them broken is enough to reproduce it.
+
+``test_canonical_value_invariance.py`` proves the specific defects are
+fixed. This file protects the *class* — it is the thing that has to keep
+working after everyone who remembers the incident has moved on.
+
+The invariants, and why each one is here rather than assumed:
+
+  A  only approved producers write canonical value
+  C  user source weighting cannot write canonical value
+  D  device-local settings cannot change canonical value
+  E  canonical aliases stay coherent with each other
+  G  canonical history records canonical output only
+  H  canonical API projections preserve the authoritative value
+
+B (experimental-overlay isolation) and F (compact/array transport parity)
+live in ``test_canonical_value_invariance.py`` beside the fixtures they
+need; they are not repeated here.
+
+Deliberately simple: repository scans and real function calls, no AST
+framework. The scans are narrow and each one asserts non-vacuity, because
+a static check that silently stops matching is worse than no check.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from src.api import data_contract as _data_contract
+from src.api.data_contract import normalize_source_overrides
+from src.league_intel import overlay
+
+REPO = Path(__file__).resolve().parents[2]
+
+#: Assignment to the canonical value field, in Python or JS.
+_CANONICAL_WRITE = re.compile(
+    r"""(
+        \[\s*["']rankDerivedValue["']\s*\]\s*=(?!=)   # d["rankDerivedValue"] =
+      | \.rankDerivedValue\s*=(?!=)                    # obj.rankDerivedValue =
+      | \[\s*EXPERIMENTAL_VALUE_FIELD\s*\]\s*=(?!=)    # never canonical, see below
+    )""",
+    re.VERBOSE,
+)
+
+#: Modules permitted to assign the canonical value field, each with the
+#: reason it is allowed. Anything else that starts assigning it is a new
+#: canonical producer and must argue with this list.
+APPROVED_CANONICAL_WRITERS = {
+    "src/api/data_contract.py": (
+        "THE canonical producer — _compute_unified_rankings and its passes"
+    ),
+    "src/league_intel/overlay.py": (
+        "writes ONLY its private scratch list, which never leaves the "
+        "function; the returned rows carry canonical untouched"
+    ),
+}
+
+
+def _tracked(*suffixes: str) -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files", "-z"], cwd=REPO, capture_output=True, text=True, check=True
+    ).stdout
+    return [p for p in out.split("\0") if p and p.endswith(suffixes)]
+
+
+def _production_sources() -> list[str]:
+    """Shipped code only. Tests assert on canonical values by
+    construction, and audit-evidence scripts are frozen records."""
+    skip = ("tests/", "docs/", "scripts/", "frontend/__tests__/")
+    return [p for p in _tracked(".py", ".js", ".jsx") if not p.startswith(skip)]
+
+
+# ── A — only approved producers write canonical value ──────────────────
+
+
+def test_only_approved_modules_assign_the_canonical_value_field():
+    offenders: list[tuple[str, int]] = []
+    for rel in _production_sources():
+        if rel in APPROVED_CANONICAL_WRITERS:
+            continue
+        try:
+            body = (REPO / rel).read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        hits = len(_CANONICAL_WRITE.findall(body))
+        if hits:
+            offenders.append((rel, hits))
+
+    assert not offenders, (
+        "a module outside the approved canonical producers assigns "
+        "rankDerivedValue. Canonical value has one owner; an experimental, "
+        "custom or page-local writer is how one player came to have two "
+        "values:\n" + "\n".join(f"  {rel}: {n} assignment(s)" for rel, n in offenders)
+    )
+
+
+def test_the_writer_scan_is_not_vacuous():
+    """If the regex stops matching, the guard above passes forever."""
+    producer = (REPO / "src/api/data_contract.py").read_text(encoding="utf-8")
+    assert _CANONICAL_WRITE.findall(producer), (
+        "the canonical-write pattern no longer matches the canonical "
+        "producer itself, so it would not catch anyone else either"
+    )
+    assert _CANONICAL_WRITE.findall('row["rankDerivedValue"] = 1')
+    assert _CANONICAL_WRITE.findall("next.rankDerivedValue = scale(v, f)")
+    # An equality comparison is not a write.
+    assert not _CANONICAL_WRITE.findall('if row["rankDerivedValue"] == 1:')
+
+
+def test_the_approved_list_names_its_reasons():
+    """An allowlist without reasons becomes a place to hide things."""
+    for path, reason in APPROVED_CANONICAL_WRITERS.items():
+        assert (REPO / path).is_file(), f"{path} no longer exists; prune the allowlist"
+        assert len(reason) > 30, f"{path} is allowed without a real justification"
+
+
+# ── C — user source weighting cannot write canonical value ─────────────
+
+
+def test_posted_source_weights_are_ignored_by_the_authority():
+    """Custom Mix is withdrawn at the server, not in the client.
+
+    The client no longer sends a mix, but a stale bundle or a direct
+    caller still can — and a user-weighted board returned under
+    ``rankDerivedValue`` is a second canonical truth however it was
+    requested.
+    """
+    out, warnings = normalize_source_overrides(
+        {"ktcSfTep": {"include": False}, "dlfSf": {"weight": 4.0}}
+    )
+    assert out == {}, "posted source weights still reach the canonical pipeline"
+    assert any("disabled" in w for w in warnings)
+
+
+def test_the_withdrawal_is_a_declared_constant_not_an_accident():
+    assert _data_contract._SOURCE_OVERRIDES_DISABLED is True
+
+
+# ── D — device-local settings cannot change canonical value ────────────
+
+#: Every legacy client shape a real browser could still be carrying.
+#: Named for the settings blob they have in localStorage today.
+LEGACY_CLIENTS = {
+    "A: old market": {"valuationMode": "market"},
+    "B: old league-adjusted": {"valuationMode": "leagueAdjusted"},
+    "C: custom source mix": {"ktcSfTep": {"include": False}, "dlfSf": {"weight": 4.0}},
+    "D: manual TEP": {"tep_multiplier": 1.45},
+    "E: manual native TEP": {"tep_native_multiplier": 1.4},
+    "F: fresh client": {},
+}
+
+
+@pytest.mark.parametrize("label", sorted(LEGACY_CLIENTS))
+def test_no_legacy_client_can_obtain_a_different_board(label):
+    """The six-client matrix, at the authority.
+
+    Same league, same snapshot: every one of these bodies must produce
+    the same canonical inputs, so no user has to clear localStorage to
+    see the right number.
+    """
+    body = LEGACY_CLIENTS[label]
+    overrides, _ = normalize_source_overrides(body)
+    assert overrides == {}, (
+        f"legacy client {label!r} still reprices the board through custom " "source weights"
+    )
+
+
+def test_a_manual_tep_multiplier_cannot_ride_the_override_path():
+    """``tepMultiplier`` / ``tepNativeMultiplier`` are the same defect
+    class as ``siteWeights`` — device-local, never synced, and they rode
+    the identical endpoint.
+
+    ``normalize_tep_multiplier`` still PARSES the field (it is retained
+    for when Custom Mix returns), so the guarantee is that no override
+    survives ``normalize_source_overrides`` to reach the blend.
+    """
+    body = {"tep_multiplier": 1.45, "ktcSfTep": {"weight": 0.0}}
+    overrides, warnings = normalize_source_overrides(body)
+    assert overrides == {}
+    assert warnings, "the caller is not told its override was ignored"
+
+
+def test_the_client_cannot_select_a_methodology():
+    src = (REPO / "frontend/lib/valuation-mode.js").read_text(encoding="utf-8")
+    body = src.split("export function readValuationMode()", 1)[-1].split("\n}", 1)[0]
+    assert "localStorage" not in body
+
+
+# ── E — canonical aliases stay coherent ────────────────────────────────
+
+#: Measured on the live contract: ``values.overall`` /
+#: ``values.finalAdjusted`` / ``values.displayValue`` equal
+#: ``rankDerivedValue`` on all 1,092 rows. ``values.rawComposite`` differs
+#: on 1,080 — it is the legacy scraper composite and is honestly named.
+CANONICAL_ALIASES = ("overall", "finalAdjusted", "displayValue")
+
+
+def test_the_aliases_are_intentional_and_pinned():
+    """The server overlay used to scale ``rankDerivedValue`` and leave
+    ``values.*`` at market, publishing a row that disagreed with itself.
+    That is why this equality is asserted rather than assumed."""
+    capture = REPO / "docs/master-site-audit/evidence/W06/contract-full.json"
+    if not capture.exists():
+        pytest.skip("no full-contract capture in this environment")
+    import json
+
+    rows = json.loads(capture.read_text(encoding="utf-8")).get("playersArray") or []
+    assert len(rows) > 500, f"capture too small to be meaningful ({len(rows)})"
+
+    disagreements = []
+    for row in rows:
+        canonical = row.get("rankDerivedValue")
+        values = row.get("values") or {}
+        for alias in CANONICAL_ALIASES:
+            if alias in values and values[alias] != canonical:
+                disagreements.append((row.get("displayName"), alias, values[alias], canonical))
+    assert not disagreements, (
+        f"{len(disagreements)} canonical alias disagreements, e.g. "
+        f"{disagreements[:5]} — one row cannot carry two canonical numbers"
+    )
+
+
+def test_the_overlay_declares_which_fields_are_canonical():
+    """So a future edit has to go through a named set rather than
+    remembering which of four spellings mattered."""
+    assert "rankDerivedValue" in overlay.CANONICAL_VALUE_FIELDS
+    for alias in CANONICAL_ALIASES:
+        assert (
+            alias in overlay.CANONICAL_VALUE_FIELDS
+        ), f"{alias} is a canonical alias but is not declared as one"
+
+
+# ── G — canonical history records canonical output only ────────────────
+
+
+def test_the_history_writer_records_the_canonical_field():
+    """``board_history`` is the evidence a future methodology decision
+    will rest on. An experimental or custom value written into it would
+    corrupt that evidence silently and permanently."""
+    src = (REPO / "src/snapshots/board_store.py").read_text(encoding="utf-8")
+    assert "rank_derived_value" in src
+    assert (
+        overlay.EXPERIMENTAL_VALUE_FIELD not in src
+    ), "the canonical history writer references the experimental field"
+
+
+def test_the_history_writer_is_not_on_the_override_path():
+    """Custom Mix never reached history, and must not start to."""
+    server_src = (REPO / "server.py").read_text(encoding="utf-8")
+    handler = server_src.split("async def post_rankings_overrides", 1)
+    if len(handler) < 2:
+        pytest.skip("override handler not found by name")
+    body = handler[1].split("\n@app.", 1)[0]
+    for writer in ("append_snapshot", "write_board"):
+        assert writer not in body, (
+            f"{writer} is called from the override handler; a custom board "
+            "would be recorded as canonical history"
+        )
+
+
+# ── H — canonical API projections preserve the value ───────────────────
+
+
+def test_the_public_projection_does_not_substitute_another_value():
+    """``public_contract`` is the one place canonical value crosses into
+    an anonymous surface. It may redact; it may not re-price."""
+    src = (REPO / "src/public_league/public_contract.py").read_text(encoding="utf-8")
+    assert overlay.EXPERIMENTAL_VALUE_FIELD not in src
+    assert not _CANONICAL_WRITE.findall(src), (
+        "the public projection assigns rankDerivedValue — a projection "
+        "layer must pass the authoritative value through, not compute one"
+    )
+
+
+def test_the_experimental_field_never_appears_in_a_canonical_consumer():
+    """The experimental board is diagnostic. If an engine starts reading
+    it, the rejected methodology is back in production under a new name.
+    """
+    engines = [
+        "src/trade/suggestions.py",
+        "src/trade/finder.py",
+        "src/trade/angle.py",
+        "src/trade/waiver.py",
+        "src/trade/faab_engine.py",
+        "src/api/terminal.py",
+        "src/api/trade_simulator.py",
+    ]
+    offenders = []
+    for rel in engines:
+        path = REPO / rel
+        if not path.is_file():
+            continue
+        if overlay.EXPERIMENTAL_VALUE_FIELD in path.read_text(encoding="utf-8"):
+            offenders.append(rel)
+    assert not offenders, (
+        f"engines read the experimental league-adjusted value: {offenders}. "
+        "That methodology was rejected for canonical promotion; consuming it "
+        "in an engine reinstates it under a different field name."
+    )

--- a/tests/api/test_canonical_value_invariance.py
+++ b/tests/api/test_canonical_value_invariance.py
@@ -1,0 +1,384 @@
+"""Canonical dynasty value has ONE definition, and nothing device-local
+may redefine it.
+
+THE INVARIANT
+-------------
+The same asset, against the same canonical board snapshot, resolves to the
+same canonical dynasty value on every surface — desktop, mobile, tablet,
+PWA, narrow viewport, authenticated or public. A device-local preference
+may choose which *lens* is displayed. It may not change what the canonical
+value IS.
+
+CLAUDE.md already states the governing rule, and states it as an
+architectural requirement rather than a preference:
+
+    Canonical player value has one owner, and every downstream engine and
+    surface consumes that canonical value — unless it is deliberately
+    showing an explicitly named alternate concept, in which case the name
+    travels with the number.
+
+    Serving a different quantity under the canonical field name is a
+    defect, not an alternate opinion.
+
+WHAT IS CANONICAL, AND WHY
+--------------------------
+``rankDerivedValue``, as produced by
+``src/api/data_contract.py::_compute_unified_rankings`` — which CLAUDE.md
+names "the one and only code path that determines live player values
+(Final Framework)". That is the market-consensus board.
+
+The league-adjusted number is ``canonical × positional-scarcity factor``,
+where scarcity is measured from ONE league's rosters. It is:
+
+  - a per-league quantity, while the canonical board is scoping-profile
+    scoped and shared across leagues;
+  - explicitly a toggle and NOT the default (``useSettings.js``: "Starts
+    'market' on every device and is never auto-flipped");
+  - measured as no improvement — ``docs/adjusted-board-backtest.md``
+    ranks it against realized 2025 scoring over 572 players, and four
+    framings all return "no difference detected" with three of four
+    leaning negative.
+
+So the adjusted number is a contextual analytic derived FROM canonical
+value. It is not a second canonical value, and it is not more canonical
+than the board it is computed from.
+
+THE DEFECT THESE TESTS PIN
+--------------------------
+Both overlay appliers write the contextual number into the CANONICAL
+FIELD NAME, destroying the canonical value in place:
+
+    src/league_intel/overlay.py:92
+        copy["rankDerivedValue"] = int(round(float(base) * float(factor)))
+
+    frontend/lib/dynasty-data.js:1953, :1989
+        next.rankDerivedValue = scale(row.rankDerivedValue, f);
+
+After either runs, no consumer can recover the canonical value: it has
+been overwritten, and no field carries it. Combined with ``valuationMode``
+living in ``next_settings_v2`` in **localStorage only, never
+server-synced**, that means one user on two devices gets two different
+numbers under one field name, differing by up to ±25% — with nothing in
+the payload naming which is which.
+
+These tests are RED against that behaviour, by design. They describe the
+contract the repair must satisfy.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.league_intel import overlay
+
+REPO = Path(__file__).resolve().parents[2]
+
+#: The canonical field. Named once here so a rename has to come through
+#: this test rather than around it.
+CANONICAL_FIELD = "rankDerivedValue"
+
+
+#: A board snapshot, deliberately spanning the shapes the overlay has to
+#: survive: a QB the scarcity factor lifts, a WR it cuts, a row with no
+#: factor at all, and a pick (``compute_scarcity`` has no PICK key, so
+#: picks must come through untouched).
+def _board() -> list[dict]:
+    return [
+        {
+            "displayName": "Josh Allen",
+            "canonicalName": "josh allen",
+            "position": "QB",
+            "assetClass": "offense",
+            CANONICAL_FIELD: 9991,
+            "values": {"overall": 9991, "finalAdjusted": 9991, "displayValue": 9991},
+            "canonicalConsensusRank": 1,
+        },
+        {
+            "displayName": "Puka Nacua",
+            "canonicalName": "puka nacua",
+            "position": "WR",
+            "assetClass": "offense",
+            CANONICAL_FIELD: 6000,
+            "values": {"overall": 6000, "finalAdjusted": 6000, "displayValue": 6000},
+            "canonicalConsensusRank": 12,
+        },
+        {
+            "displayName": "Unfactored Player",
+            "canonicalName": "unfactored player",
+            "position": "TE",
+            "assetClass": "offense",
+            CANONICAL_FIELD: 3000,
+            "values": {"overall": 3000, "finalAdjusted": 3000, "displayValue": 3000},
+            "canonicalConsensusRank": 90,
+        },
+        {
+            "displayName": "2027 Round 1",
+            "canonicalName": "2027 round 1",
+            "position": "PICK",
+            "assetClass": "pick",
+            CANONICAL_FIELD: 4200,
+            "values": {"overall": 4200, "finalAdjusted": 4200, "displayValue": 4200},
+            "canonicalConsensusRank": 40,
+        },
+    ]
+
+
+#: Factors as the live overlay produces them — keyed by
+#: ``row_factor_key``, sparse (absence means "unchanged").
+def _factors(rows) -> dict[str, float]:
+    # Keyed through ``row_factor_key`` rather than by a literal, because
+    # that function is required to stay identical to
+    # ``publish._row_key`` and a fixture spelling the key by hand would
+    # keep passing after the two diverged — the exact silent failure its
+    # own docstring warns about.
+    by_canonical = {r["canonicalName"]: r for r in rows}
+    wanted = {"josh allen": 1.25, "puka nacua": 0.80}
+    factors = {overlay.row_factor_key(by_canonical[n]): f for n, f in wanted.items()}
+    assert all(factors), "row_factor_key returned an empty key — fixture would be inert"
+    return factors
+
+
+def _apply():
+    rows = _board()
+    out = overlay.adjusted_rows(rows, _factors(rows))
+    assert out is not None, "the overlay declined to apply — fixture no longer exercises it"
+    return rows, {r.get("displayName"): r for r in out}
+
+
+class TestInvariantA_CanonicalValueIsStable:
+    """A — the canonical value does not depend on a display preference.
+
+    The whole point. A user who flips "Market" / "My league" — or who
+    simply opens the site on a second device where the localStorage
+    default still says "market" — must not thereby change what the
+    player's canonical dynasty value IS.
+    """
+
+    def test_the_canonical_value_survives_the_lens(self):
+        rows, adjusted = _apply()
+        before = {r["displayName"]: r[CANONICAL_FIELD] for r in rows}
+        for name, canonical in before.items():
+            row = adjusted[name]
+            assert row.get(CANONICAL_FIELD) == canonical, (
+                f"{name}: the league-adjusted lens overwrote {CANONICAL_FIELD} "
+                f"({canonical} → {row.get(CANONICAL_FIELD)}). A contextual "
+                "adjustment may not impersonate the canonical value — after "
+                "this, no consumer can recover what the player is actually "
+                "worth, and two devices with different localStorage disagree "
+                "under one field name."
+            )
+
+    def test_the_source_rows_are_never_mutated(self):
+        """``latest_contract_data`` is a shared module global."""
+        rows = _board()
+        overlay.adjusted_rows(rows, _factors(rows))
+        assert rows[0][CANONICAL_FIELD] == 9991, (
+            "the overlay mutated the caller's rows; one in-place multiply "
+            "reprices the market board for every other request"
+        )
+
+
+class TestInvariantB_ContextualAdjustmentIsHonest:
+    """B — if the adjusted number differs from canonical, it is a
+    DISTINCT, explicitly-named concept that no consumer can mistake for
+    canonical."""
+
+    def test_the_adjusted_number_has_its_own_field(self):
+        _, adjusted = _apply()
+        allen = adjusted["Josh Allen"]
+        candidates = [k for k in allen if "adjust" in k.lower() and "value" in k.lower()]
+        assert candidates, (
+            "the adjusted value has no field of its own — it exists only by "
+            "having overwritten "
+            f"{CANONICAL_FIELD}. The name must travel with the number, so a "
+            "consumer can tell which semantic it is holding."
+        )
+
+    def test_the_adjusted_number_is_actually_the_adjustment(self):
+        _, adjusted = _apply()
+        allen = adjusted["Josh Allen"]
+        field = next(
+            (k for k in allen if "adjust" in k.lower() and "value" in k.lower()),
+            None,
+        )
+        if field is None:
+            pytest.skip("no adjusted field yet — covered by the test above")
+        assert allen[field] == round(9991 * 1.25), (
+            f"{field} does not carry canonical × factor; the lens is not "
+            "computing what it claims to"
+        )
+
+    def test_every_value_alias_agrees_on_the_semantic(self):
+        """``values.overall`` / ``finalAdjusted`` / ``displayValue`` are
+        aliases of the canonical value. Scaling those while leaving the
+        canonical field — or vice versa — publishes a row that disagrees
+        with itself."""
+        _, adjusted = _apply()
+        for name, row in adjusted.items():
+            values = row.get("values") or {}
+            for alias in ("overall", "finalAdjusted", "displayValue"):
+                if alias not in values:
+                    continue
+                assert values[alias] == row.get(CANONICAL_FIELD), (
+                    f"{name}: values.{alias}={values[alias]} disagrees with "
+                    f"{CANONICAL_FIELD}={row.get(CANONICAL_FIELD)} — one of "
+                    "them is the lens and the other is canonical, under names "
+                    "that claim to be the same number"
+                )
+
+
+class TestInvariantC_NoSilentFallback:
+    """C — missing canonical data must not silently resolve to some other
+    quantity presented as canonical."""
+
+    def test_a_row_with_no_factor_is_untouched(self):
+        rows, adjusted = _apply()
+        row = adjusted["Unfactored Player"]
+        assert row.get(CANONICAL_FIELD) == 3000, (
+            "a row the lens has no factor for was altered anyway; absence of "
+            "a factor means UNCHANGED, not zero and not a substitute"
+        )
+
+    def test_picks_are_not_repriced_by_a_player_scarcity_lens(self):
+        """``compute_scarcity`` has no PICK key, so the lens is a no-op
+        for picks. If a pick moves, the lens is applying a factor derived
+        from a population it does not belong to."""
+        _, adjusted = _apply()
+        assert adjusted["2027 Round 1"].get(CANONICAL_FIELD) == 4200
+
+    def test_a_missing_canonical_value_is_not_invented(self):
+        rows = [
+            {
+                "displayName": "Unpriced Guy",
+                "canonicalName": "unpriced guy",
+                "position": "WR",
+                "assetClass": "offense",
+                CANONICAL_FIELD: None,
+                "values": {},
+            }
+        ]
+        out = overlay.adjusted_rows(rows, {overlay.row_factor_key(rows[0]): 1.25})
+        if out is None:
+            return  # declined to apply at all — also correct
+        assert out[0].get(CANONICAL_FIELD) is None, (
+            "an unpriced row acquired a value from the lens; missing is never "
+            "zero and never a derived stand-in"
+        )
+
+
+class TestInvariantD_ResponsiveEqualityOfTransport:
+    """D — mobile and desktop take different transports and must receive
+    identical canonical valuation semantics.
+
+    ``frontend/lib/device-profile.js::preferredDataView`` routes viewport
+    <768px (or ``deviceMemory <= 4``, or a 2G/3G connection) to
+    ``/api/data?view=compact`` and everything else to ``view=array``.
+    That is a genuine device-conditional data path, and it is exactly the
+    kind of optimization that quietly acquires semantics.
+
+    Transport optimization may remove fields the surface does not render.
+    It may not reprice anybody.
+    """
+
+    CAPTURE = REPO / "docs/master-site-audit/evidence/W06/contract-full.json"
+
+    def _contract(self):
+        if not self.CAPTURE.exists():
+            pytest.skip("no full-contract capture in this environment")
+        return json.loads(self.CAPTURE.read_text(encoding="utf-8"))
+
+    def test_compact_and_array_price_every_player_identically(self):
+        from src.api.compact_view import compact_contract
+
+        full = self._contract()
+        # ``array`` is the full contract minus the legacy dict
+        # (server.py:2325-2326) — player rows are the same objects.
+        array_rows = {r.get("displayName"): r for r in full.get("playersArray") or []}
+        compact_rows = {
+            r.get("displayName"): r for r in compact_contract(full).get("playersArray") or []
+        }
+        assert len(array_rows) > 500, f"fixture too small to be meaningful ({len(array_rows)})"
+        assert array_rows.keys() == compact_rows.keys(), (
+            "the compact view dropped or added players; it is a field-pruning "
+            "transform, not a row filter"
+        )
+
+        mismatched = [
+            (name, row.get(CANONICAL_FIELD), compact_rows[name].get(CANONICAL_FIELD))
+            for name, row in array_rows.items()
+            if row.get(CANONICAL_FIELD) != compact_rows[name].get(CANONICAL_FIELD)
+        ]
+        assert not mismatched, (
+            "the mobile transport reprices players relative to desktop:\n"
+            + "\n".join(f"  {n}: array={a} compact={c}" for n, a, c in mismatched[:10])
+        )
+
+    def test_compact_and_array_agree_on_every_value_alias(self):
+        from src.api.compact_view import compact_contract
+
+        full = self._contract()
+        compact_rows = {
+            r.get("displayName"): r for r in compact_contract(full).get("playersArray") or []
+        }
+        mismatched = []
+        for row in full.get("playersArray") or []:
+            name = row.get("displayName")
+            if (row.get("values") or {}) != (compact_rows.get(name, {}).get("values") or {}):
+                mismatched.append(name)
+        assert not mismatched, (
+            f"{len(mismatched)} players have different values.* between the "
+            f"mobile and desktop transports, e.g. {mismatched[:5]}"
+        )
+
+    def test_the_legacy_dict_and_the_array_agree(self):
+        """Two parallel encodings of one board ship in the same payload.
+
+        ``buildRows`` prefers ``playersArray`` but falls back to the
+        legacy ``players`` dict when it is empty, and
+        ``mergeRankingsDelta`` can synthesize from either. If the two
+        disagree, which one a client reads becomes a valuation decision.
+        """
+        full = self._contract()
+        array_rows = {r.get("displayName"): r for r in full.get("playersArray") or []}
+        legacy = full.get("players") or {}
+        if not legacy:
+            pytest.skip("capture carries no legacy dict")
+        mismatched = [
+            (name, row.get(CANONICAL_FIELD), array_rows[name].get(CANONICAL_FIELD))
+            for name, row in legacy.items()
+            if name in array_rows
+            and row.get(CANONICAL_FIELD) != array_rows[name].get(CANONICAL_FIELD)
+        ]
+        assert not mismatched, (
+            "the legacy dict and playersArray disagree on the canonical "
+            f"value for {len(mismatched)} players, e.g. {mismatched[:5]}"
+        )
+
+
+class TestTheDeviceLocalOwnershipDefect:
+    """The setting that selects the lens is device-local and unsynced.
+
+    This is not a style point: it is what turns "a lens exists" into "two
+    devices disagree". Pinned as a fact about the storage model so the
+    repair has to address ownership, not just naming.
+    """
+
+    def test_valuation_mode_is_not_server_owned(self):
+        """RED: there is no server-side owner of the user's valuation lens.
+
+        ``next_settings_v2`` is written and read only through
+        ``localStorage`` (``useSettings.js:203,244``;
+        ``valuation-mode.js:41``), so the same account on two devices
+        holds two independent answers to "which board am I looking at".
+        """
+        settings = (REPO / "frontend/components/useSettings.js").read_text(encoding="utf-8")
+        synced = any(marker in settings for marker in ("/api/user/", "user_kv", "syncSettings"))
+        assert synced, (
+            "valuationMode is persisted only in localStorage. Until some "
+            "server-side or URL-explicit owner exists, two devices belonging "
+            "to one user can render different numbers for one player with "
+            "nothing reconciling them."
+        )

--- a/tests/api/test_canonical_value_invariance.py
+++ b/tests/api/test_canonical_value_invariance.py
@@ -358,27 +358,83 @@ class TestInvariantD_ResponsiveEqualityOfTransport:
         )
 
 
-class TestTheDeviceLocalOwnershipDefect:
-    """The setting that selects the lens is device-local and unsynced.
+class TestDeviceLocalStateCannotSelectAMethodology:
+    """The original defect, stated as the contract that replaced it.
 
-    This is not a style point: it is what turns "a lens exists" into "two
-    devices disagree". Pinned as a fact about the storage model so the
-    repair has to address ownership, not just naming.
+    ``valuationMode`` lived in ``next_settings_v2`` in localStorage,
+    never server-synced, and the lens it selected overwrote
+    ``rankDerivedValue`` — so one account on two devices rendered two
+    numbers for one player under one field name.
+
+    The repair is not "sync the setting". It is that there is only one
+    methodology, so nothing device-local has a methodology to select. The
+    setting is read and IGNORED rather than removed, which is what makes
+    an old phone converge with no migration step.
     """
 
-    def test_valuation_mode_is_not_server_owned(self):
-        """RED: there is no server-side owner of the user's valuation lens.
-
-        ``next_settings_v2`` is written and read only through
-        ``localStorage`` (``useSettings.js:203,244``;
-        ``valuation-mode.js:41``), so the same account on two devices
-        holds two independent answers to "which board am I looking at".
-        """
-        settings = (REPO / "frontend/components/useSettings.js").read_text(encoding="utf-8")
-        synced = any(marker in settings for marker in ("/api/user/", "user_kv", "syncSettings"))
-        assert synced, (
-            "valuationMode is persisted only in localStorage. Until some "
-            "server-side or URL-explicit owner exists, two devices belonging "
-            "to one user can render different numbers for one player with "
-            "nothing reconciling them."
+    def test_the_client_no_longer_reads_a_stored_valuation_mode(self):
+        src = (REPO / "frontend/lib/valuation-mode.js").read_text(encoding="utf-8")
+        body = src.split("export function readValuationMode()", 1)[-1].split("\n}", 1)[0]
+        assert "localStorage" not in body, (
+            "readValuationMode still reads localStorage — a device-local value "
+            "can again decide which methodology a user sees"
         )
+        assert "LEAGUE_ADJUSTED" not in body, (
+            "readValuationMode can still answer leagueAdjusted; under the "
+            "current ruling there is one canonical methodology"
+        )
+
+    def test_there_is_no_user_facing_valuation_basis_control(self):
+        """A control that selects a methodology is how one player got two
+        values. Removed, not disabled — a greyed-out control implies the
+        choice still exists."""
+        page = (REPO / "frontend/app/rankings/page.jsx").read_text(encoding="utf-8")
+        assert 'label="Value basis"' not in page, (
+            "the Market / My league selector is still rendered on /rankings"
+        )
+        assert '{ value: "leagueAdjusted"' not in page, (
+            "the rankings page still offers leagueAdjusted as a choice"
+        )
+
+    def test_the_engine_gate_never_serves_the_withdrawn_lens(self):
+        """``_valuation_scoped_contract`` is the single place the lens
+        ever reached an engine, so it is the single place it is closed.
+        A stored ``leagueAdjusted`` is ignored, not refused."""
+        src = (REPO / "server.py").read_text(encoding="utf-8")
+        fn = src.split("async def _valuation_scoped_contract", 1)[-1].split("\ndef ", 1)[0]
+        assert "adjusted_contract" not in fn, (
+            "the engine gate still applies the league-adjusted overlay"
+        )
+        assert '"leagueAdjusted"' not in fn.split("requested ==", 1)[-1].split("return", 1)[-1], (
+            "the engine gate can still answer with the leagueAdjusted mode"
+        )
+
+
+class TestTheExperimentalLensIsIsolated:
+    """It may exist. It may not own a canonical field."""
+
+    def test_the_overlay_writes_only_experimental_field_names(self):
+        _, adjusted = _apply()
+        allen = adjusted["Josh Allen"]
+        assert allen[overlay.EXPERIMENTAL_VALUE_FIELD] == round(9991 * 1.25)
+        assert allen[CANONICAL_FIELD] == 9991
+        for banned in overlay.CANONICAL_VALUE_FIELDS:
+            if banned == CANONICAL_FIELD:
+                continue
+            values = allen.get("values") or {}
+            if banned in values:
+                assert values[banned] == 9991, (
+                    f"values.{banned} moved with the experimental lens; the "
+                    "canonical aliases must agree with the canonical value"
+                )
+
+    def test_the_experimental_field_name_cannot_be_mistaken_for_canonical(self):
+        for name in (
+            overlay.EXPERIMENTAL_VALUE_FIELD,
+            overlay.EXPERIMENTAL_RANK_FIELD,
+            overlay.EXPERIMENTAL_TIER_FIELD,
+        ):
+            assert name.startswith("experimental"), (
+                f"{name} does not announce itself as experimental, so a "
+                "consumer could read it as canonical"
+            )

--- a/tests/api/test_canonical_value_invariance.py
+++ b/tests/api/test_canonical_value_invariance.py
@@ -389,12 +389,12 @@ class TestDeviceLocalStateCannotSelectAMethodology:
         values. Removed, not disabled — a greyed-out control implies the
         choice still exists."""
         page = (REPO / "frontend/app/rankings/page.jsx").read_text(encoding="utf-8")
-        assert 'label="Value basis"' not in page, (
-            "the Market / My league selector is still rendered on /rankings"
-        )
-        assert '{ value: "leagueAdjusted"' not in page, (
-            "the rankings page still offers leagueAdjusted as a choice"
-        )
+        assert (
+            'label="Value basis"' not in page
+        ), "the Market / My league selector is still rendered on /rankings"
+        assert (
+            '{ value: "leagueAdjusted"' not in page
+        ), "the rankings page still offers leagueAdjusted as a choice"
 
     def test_the_engine_gate_never_serves_the_withdrawn_lens(self):
         """``_valuation_scoped_contract`` is the single place the lens
@@ -402,12 +402,12 @@ class TestDeviceLocalStateCannotSelectAMethodology:
         A stored ``leagueAdjusted`` is ignored, not refused."""
         src = (REPO / "server.py").read_text(encoding="utf-8")
         fn = src.split("async def _valuation_scoped_contract", 1)[-1].split("\ndef ", 1)[0]
-        assert "adjusted_contract" not in fn, (
-            "the engine gate still applies the league-adjusted overlay"
-        )
-        assert '"leagueAdjusted"' not in fn.split("requested ==", 1)[-1].split("return", 1)[-1], (
-            "the engine gate can still answer with the leagueAdjusted mode"
-        )
+        assert (
+            "adjusted_contract" not in fn
+        ), "the engine gate still applies the league-adjusted overlay"
+        assert (
+            '"leagueAdjusted"' not in fn.split("requested ==", 1)[-1].split("return", 1)[-1]
+        ), "the engine gate can still answer with the leagueAdjusted mode"
 
 
 class TestTheExperimentalLensIsIsolated:

--- a/tests/api/test_source_overrides.py
+++ b/tests/api/test_source_overrides.py
@@ -26,10 +26,12 @@ from __future__ import annotations
 
 import unittest
 from typing import Any
+from unittest import mock
 from unittest.mock import patch
 
 import json
 
+from src.api import data_contract as _data_contract
 from src.api.data_contract import (
     _DELTA_PLAYER_FIELDS,
     _RANKING_SOURCES,
@@ -201,8 +203,47 @@ def _by_name(contract: dict[str, Any]) -> dict[str, dict[str, Any]]:
     }
 
 
+class TestCustomMixIsDisabled(unittest.TestCase):
+    """Custom Mix was withdrawn from canonical ownership on 2026-08-14.
+
+    ``siteWeights`` / ``tepMultiplier`` / ``tepNativeMultiplier`` live in
+    ``next_settings_v2`` in localStorage, are never server-synced, and all
+    three recomputed the board and returned it under ``rankDerivedValue``.
+    Two devices, two canonical values for one player.
+
+    Closed in ``normalize_source_overrides`` — the one function every
+    override body passes through — rather than at the route, because a
+    stale bundle or a direct caller can still post one.
+    """
+
+    def test_a_posted_source_mix_is_ignored(self) -> None:
+        out, warnings = normalize_source_overrides(
+            {"ktcSfTep": {"include": False}, "dlfSf": {"weight": 3.0}}
+        )
+        self.assertEqual(out, {}, "a custom source mix still reaches the pipeline")
+        self.assertTrue(
+            any("disabled" in w for w in warnings),
+            "the response does not say why the weights were ignored",
+        )
+
+    def test_it_is_answered_rather_than_refused(self) -> None:
+        """Refusing would break /rankings for anyone whose device still
+        posts a stored mix. The canonical board is served instead."""
+        out, warnings = normalize_source_overrides({"ktcSfTep": {"include": False}})
+        self.assertEqual(out, {})
+        self.assertTrue(warnings)
+
+
+@mock.patch.object(_data_contract, "_SOURCE_OVERRIDES_DISABLED", False)
 class TestNormalizeSourceOverrides(unittest.TestCase):
-    """Input validation + shape normalization for the override map."""
+    """Input validation + shape normalization for the override map.
+
+    The parser is retained and still covered even though Custom Mix is
+    disabled: deleting it would mean rebuilding — and re-reviewing — the
+    validation when the feature returns as an explicitly non-canonical
+    analytical board. The class patches the gate off so these exercise
+    the parser rather than the withdrawal.
+    """
 
     def test_empty_input_returns_empty(self) -> None:
         out, warnings = normalize_source_overrides(None)
@@ -799,7 +840,14 @@ class TestNormalizeTepMultiplier(unittest.TestCase):
             self.assertNotIn("tep_multiplier", w)
         self.assertEqual(normalize_tep_multiplier({"tep_multiplier": 1.15}), 1.15)
 
+    @mock.patch.object(_data_contract, "_SOURCE_OVERRIDES_DISABLED", False)
     def test_tep_multiplier_alongside_legacy_overrides(self) -> None:
+        """Parser-level: the two fields are extracted independently.
+
+        Gate patched off so this exercises the extraction rather than the
+        Custom Mix withdrawal — the live behaviour is pinned by
+        ``TestCustomMixIsDisabled``.
+        """
         body = {"tep_multiplier": 1.2, "ktcSfTep": {"include": False}}
         overrides, warnings = normalize_source_overrides(body)
         self.assertEqual(overrides, {"ktcSfTep": {"include": False}})

--- a/tests/api/test_valuation_mode_threading.py
+++ b/tests/api/test_valuation_mode_threading.py
@@ -138,15 +138,31 @@ def _rows():
     ]
 
 
-def test_factors_are_applied_multiplicatively_and_the_board_is_re_ranked():
+def test_factors_are_applied_multiplicatively_under_experimental_names():
+    """The arithmetic still happens; it just no longer owns canonical.
+
+    Rewritten 2026-08-14. This used to assert the factor landed in
+    ``rankDerivedValue``, which is exactly the defect that let a
+    device-local setting change a player's canonical value. The
+    multiplication and the re-rank are unchanged — only where they are
+    written moved.
+    """
     rows = _rows()
     out = _overlay.adjusted_rows(rows, {"C": 2.0})
     assert out is not None
     by_name = {r["displayName"]: r for r in out}
-    assert by_name["C"]["rankDerivedValue"] == 6000
+
+    assert by_name["C"][_overlay.EXPERIMENTAL_VALUE_FIELD] == 6000
+    # C overtook A, so the EXPERIMENTAL ranks moved with the values.
+    assert (
+        by_name["C"][_overlay.EXPERIMENTAL_RANK_FIELD]
+        < by_name["A"][_overlay.EXPERIMENTAL_RANK_FIELD]
+    )
+
+    # ...and the canonical value and rank are exactly what they were.
+    assert by_name["C"]["rankDerivedValue"] == 3000
     assert by_name["A"]["rankDerivedValue"] == 5000
-    # C overtook A, so the ranks must have moved with the values.
-    assert by_name["C"]["canonicalConsensusRank"] < by_name["A"]["canonicalConsensusRank"]
+    assert by_name["C"]["canonicalConsensusRank"] == 3
 
 
 def test_the_callers_rows_are_never_mutated():
@@ -264,101 +280,92 @@ def test_an_unrecognised_mode_degrades_to_market_rather_than_erroring(
     assert res.json()["valuationMode"] == "market"
 
 
-def test_asking_for_the_lens_gets_the_lens(league, monkeypatch):  # noqa: F811
-    """Non-vacuity for everything below: the adjusted path must actually
-    engage on this fixture, or the degradation tests prove nothing."""
-    with TestClient(server.app, raise_server_exceptions=True) as c:
-        _install_contract(monkeypatch)
-        res = c.get("/api/terminal?valuationMode=leagueAdjusted")
-    assert res.status_code == 200, res.text
-    body = res.json()
-    assert body["valuationMode"] == "leagueAdjusted", body.get("valuationNote")
-    assert "valuationNote" not in body
-
-
-def test_the_engines_see_different_numbers_under_the_two_lenses(
+def test_asking_for_the_lens_gets_the_canonical_board_and_is_told_so(
     league,  # noqa: F811
     monkeypatch,
 ):
-    """The point of the whole change. Same request, two lenses, and the
-    values the engine reads must actually differ — otherwise every stamp
-    above is decoration on an identical board."""
-    # The client is entered for the app lifespan the league fixture
-    # needs, not to issue a request — the comparison is on the board
-    # itself, which is what every engine reads.
-    with TestClient(server.app, raise_server_exceptions=True):
-        stub = _install_contract(monkeypatch)
-        overlay = gameplan.get_league_adjusted_values("main", "prof_a", stub)
-    factors = overlay["factors"]
-    assert factors, "fixture produced no factors; the comparison would be vacuous"
+    """WITHDRAWN 2026-08-14 — one canonical methodology.
 
-    adjusted = _overlay.adjusted_contract(stub, factors)
-    assert adjusted is not None
-    market_values = {r["displayName"]: r["rankDerivedValue"] for r in stub["playersArray"]}
-    lens_values = {r["displayName"]: r["rankDerivedValue"] for r in adjusted["playersArray"]}
-    assert market_values != lens_values
+    This used to assert the adjusted path engaged. The methodology was
+    evaluated for canonical promotion and rejected on the evidence (see
+    docs/valuation/LEAGUE_AWARE_METHODOLOGY_REJECTION.md), so an engine
+    request may no longer be answered from it.
+
+    Ignored, not refused: a stored ``leagueAdjusted`` on someone's phone
+    must converge to the canonical answer silently. Refusing would turn
+    an obsolete localStorage value into a broken page for a user who
+    never chose anything.
+    """
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        res = c.get("/api/terminal?valuationMode=leagueAdjusted")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["valuationMode"] == "market"
+    assert body["valuationNote"] == "league_adjusted_withdrawn: not_canonical"
 
 
-def test_a_missing_roster_snapshot_serves_market_and_names_the_reason(
+def test_the_engines_see_ONE_board_whichever_mode_is_asked_for(
     league,  # noqa: F811
     monkeypatch,
 ):
-    """Refusing outright would take down working engines to protect an
-    optional lens. Serving market *silently* is the failure this change
-    exists to remove. So: market board, explicit note."""
+    """The inverse of the test this replaces, and the whole point now.
 
-    def _boom(*args, **kwargs):
-        raise gameplan.GameplanUnavailable("no_rosters", "no roster snapshot on disk")
+    The old assertion was that the two lenses produced *different*
+    numbers. That difference is exactly what a device-local localStorage
+    value could select between, so it is now the thing being forbidden.
+    """
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        market = c.get("/api/terminal")
+        asked = c.get("/api/terminal?valuationMode=leagueAdjusted")
+    assert market.status_code == 200 and asked.status_code == 200
 
-    monkeypatch.setattr(gameplan, "get_league_adjusted_values", _boom)
+    def _values(res):
+        rows = (res.json().get("contract") or {}).get("playersArray") or []
+        return {r.get("displayName"): r.get("rankDerivedValue") for r in rows}
+
+    assert _values(market) == _values(asked), (
+        "the requested mode still changes the numbers an engine reads"
+    )
+
+
+def test_the_withdrawn_lens_is_never_even_computed(league, monkeypatch):  # noqa: F811
+    """Cheaper and stronger than the three degradation tests it replaces.
+
+    Those asserted that a missing roster snapshot / an exception / an
+    empty factor set each degraded to market with a named note. None of
+    those paths is reachable now, because the overlay is not invoked at
+    all — so the guarantee is upgraded from "degrades correctly" to
+    "never runs". If this fails, the withdrawal leaked.
+    """
+    called: list[str] = []
+
+    def _tripwire(*args, **kwargs):
+        called.append("invoked")
+        raise AssertionError("the withdrawn overlay was computed for an engine request")
+
+    monkeypatch.setattr(gameplan, "get_league_adjusted_values", _tripwire)
     with TestClient(server.app, raise_server_exceptions=True) as c:
         _install_contract(monkeypatch)
         res = c.get("/api/terminal?valuationMode=leagueAdjusted")
     assert res.status_code == 200, res.text
-    body = res.json()
-    assert body["valuationMode"] == "market"
-    assert body["valuationNote"] == "league_adjusted_unavailable: no_rosters"
-    assert any("league_adjusted_unavailable" in w for w in body.get("warnings") or [])
-
-
-def test_an_overlay_that_blows_up_still_serves_a_board(league, monkeypatch):  # noqa: F811
-    def _boom(*args, **kwargs):
-        raise RuntimeError("something unforeseen")
-
-    monkeypatch.setattr(gameplan, "get_league_adjusted_values", _boom)
-    with TestClient(server.app, raise_server_exceptions=True) as c:
-        _install_contract(monkeypatch)
-        res = c.get("/api/terminal?valuationMode=leagueAdjusted")
-    assert res.status_code == 200, res.text
-    body = res.json()
-    assert body["valuationMode"] == "market"
-    assert body["valuationNote"] == "league_adjusted_unavailable: overlay_error"
-
-
-def test_an_overlay_that_moves_nobody_reports_market(league, monkeypatch):  # noqa: F811
-    """ "Adjusted" and "adjusted by exactly nothing" are the same board.
-    Claiming the lens for a board identical to market would make the
-    stamp meaningless."""
-    monkeypatch.setattr(gameplan, "get_league_adjusted_values", lambda *a, **k: {"factors": {}})
-    with TestClient(server.app, raise_server_exceptions=True) as c:
-        _install_contract(monkeypatch)
-        res = c.get("/api/terminal?valuationMode=leagueAdjusted")
-    assert res.status_code == 200, res.text
-    body = res.json()
-    assert body["valuationMode"] == "market"
-    assert body["valuationNote"] == "league_adjusted_unavailable: no_op"
+    assert not called, "the overlay engine ran despite being withdrawn"
 
 
 # ── 3. The shared global is never mutated ───────────────────────────────
 
 
-def test_serving_the_lens_leaves_the_loaded_contract_untouched(league, monkeypatch):  # noqa: F811
+def test_requesting_the_lens_leaves_the_loaded_contract_untouched(
+    league,  # noqa: F811
+    monkeypatch,
+):
     with TestClient(server.app, raise_server_exceptions=True) as c:
         stub = _install_contract(monkeypatch)
         before = copy.deepcopy(stub)
         res = c.get("/api/terminal?valuationMode=leagueAdjusted")
         assert res.status_code == 200, res.text
-        assert res.json()["valuationMode"] == "leagueAdjusted"
+        assert res.json()["valuationMode"] == "market"
         assert server.latest_contract_data == before
 
 

--- a/tests/api/test_valuation_mode_threading.py
+++ b/tests/api/test_valuation_mode_threading.py
@@ -325,9 +325,9 @@ def test_the_engines_see_ONE_board_whichever_mode_is_asked_for(
         rows = (res.json().get("contract") or {}).get("playersArray") or []
         return {r.get("displayName"): r.get("rankDerivedValue") for r in rows}
 
-    assert _values(market) == _values(asked), (
-        "the requested mode still changes the numbers an engine reads"
-    )
+    assert _values(market) == _values(
+        asked
+    ), "the requested mode still changes the numbers an engine reads"
 
 
 def test_the_withdrawn_lens_is_never_even_computed(league, monkeypatch):  # noqa: F811


### PR DESCRIPTION
Fixes a report that **player values differed between mobile and desktop**.

Two commits, deliberately: `04b8b6d` is the RED provenance (kept — a neutral runner reproducing the defect), `740bbf5` is the repair.

## Decision: C — league-aware valuation is not yet trustworthy as canonical

Evaluated for promotion and **rejected** under the outcome-evidence bar. Full record: [`docs/valuation/LEAGUE_AWARE_METHODOLOGY_REJECTION.md`](docs/valuation/LEAGUE_AWARE_METHODOLOGY_REJECTION.md). This is a verdict on *this implementation* and *today's evidence*, not on league-aware valuation as a goal.

## Correction to the record

**9,991 → 12,489 was never a production measurement.** It came from applying the documented ±25% cap to 9,991, and a CI fixture used `1.25` to reproduce that arithmetic. CI proved the *mechanism*, not a live value.

Measured from the captured live overlay (709 rows, **7 distinct factors**): the QB factor is **1.018366**, so Josh Allen is **9,991 → ~10,175**. Finding W07-F008 independently records **10,171**. The cap has never bound on live data. The defect was real; I overstated its size.

| position | live factor |
|---|---|
| DL | 1.097760 |
| RB | 1.041554 |
| WR | 1.026798 |
| QB | 1.018366 |
| TE | 1.011595 / 0.979705 |

## Why it was rejected

- reads **current roster state**, not durable structure — `top` is the single highest-`rosValue` player rostered *today*, so one trade moves every player at that position
- its input is a 0-100 **logarithmic rank index** ("not points, and not projection-aware") setting a multiplier on a 0-9999 board
- `reference_lineup_scarcity = 0.5` is a bare constant that alone decides the **sign** of every adjustment
- per-position only: 5 of 8 positions get a pure scalar — untestable within position by construction
- multiplies into a scale whose maximum is the Hill **asymptote**, so the board leaves its declared range
- `tePremium` is ABSENT here with a pinned double-count guard because the anchor is already KTC's TE++ board; **`structuralScarcity` has no equivalent guard** while all 18 offense-bearing sources are already Superflex boards
- and the evidence to validate a replacement does not exist

Worth stating plainly: the canonical board was **never "market-only"** — its TE-premium multiplier is already derived from the league's own Sleeper `bonus_rec_te`. Market vs My League was a false dichotomy.

## The repair — two chokepoints, not fifteen call sites

- **`_valuation_scoped_contract`** is the one place the lens reached an engine. It no longer applies it. Every caller keeps its plumbing and keeps stamping what it was *served*, so a future validated methodology re-opens **one** seam instead of nine.
- **`readValuationMode()`** always answers `market`, making persisted `next_settings_v2.valuationMode` inert with **no migration step** — an old phone storing `leagueAdjusted` converges on next load.
- The request is **ignored, not refused**. Refusing would turn an obsolete localStorage value into a broken page for a user who never chose it.
- **`adjusted_rows`** still computes, but writes `experimentalLeagueAdjustedValue`/`Rank`/`Tier` and never `rankDerivedValue` or its aliases.
- The **Market / My league control is removed** from `/rankings` — not disabled, since a greyed-out control implies the choice still exists.

**`publish.py` was repaired alongside**: it read `canonicalConsensusRank` off the adjusted board, so after the split it would have published the *market* ordering under an "adjusted" label. Caught by tests, not by review.

## History reconciliation

An earlier production reading said 8 days / 8,749 rows; a later local reading said the DB does not exist. **Both were true about different machines** — `data/` is gitignored, so a container clone has none. Verified read-only on production:

```
/home/*/trade-calculator/data/board_history.sqlite
8749 rows, 8 days, 2026-08-06..2026-08-13, 1092-1095 rows/day
timer: installed / enabled / active, Result=success
```

The recorder is legitimate and firing daily. **No second recorder was created.** It records the canonical value and methodology version; it does *not* record `league_key` or a scoring fingerprint — a narrow additive forward-only gap, deliberately left for follow-up rather than bundled here.

## Validation

| gate | result |
|---|---|
| backend `pytest tests/` | **7411 passed / 43 skipped / 0 failed** |
| frontend `vitest run` | **2025 passed / 123 files** |
| `test_canonical_value_invariance.py` | **16 passed** (was 4 failed) |
| ruff format + check | clean |

The GREEN contract no longer asserts "9,991 must survive forever". It asserts one methodology, device independence, overlay isolation, no user-selectable basis, and the compact/array transport parity that was already proven.

## Deliberately not in scope

Follow-ups, each named rather than silently skipped: `siteWeights` canonical ownership; `board_history` league/fingerprint columns; the full producer/consumer audit; build/revision diagnostics; the manual `CACHE_VERSION` bump hole.