### PR TITLE
B9: one canonical dynasty value, a scale that is enforced, and thresholds that carry their unit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1346,16 +1346,36 @@ Two consequences worth knowing before touching this:
   position alone and never reads the consensus value, so it composes exactly
   against any board — including one the user re-weighted. Absolute values would
   carry the default board's numbers into a board the server never computed.
-- **The two overlays are composed SERVER-SIDE, never on the client.** With
-  source overrides active the valuation overlay's ranks are the ranks of
-  `default_consensus × factor`, but the correct answer is
-  `overridden_consensus × factor` — a board the client cannot construct because
-  it never had the overridden consensus in the first place. So
-  `POST /api/rankings/overrides?view=delta` accepts `valuation_mode` and
-  computes it, and asking for the lens is what narrows that response's scope
-  from scoring-profile to leagueKey (it 503s on a league mismatch exactly like
-  `/api/valuation/league-adjusted`). The full view refuses the field explicitly
-  rather than ignoring it, which would return a market board labelled adjusted.
+- **The server-side composition is GONE (B9a).** `POST /api/rankings/overrides`
+  used to accept `valuation_mode` and multiply the league factors into
+  `rankDerivedValue` after the override pipeline, so the endpoint could serve a
+  board that was both re-weighted and league-adjusted. The arithmetic was right
+  — `overridden_consensus × factor` is a board the client cannot construct — but
+  #822 rejected that methodology for promotion to canonical and ruled it **may
+  not own a canonical field**, and this path was the one place still writing it.
+
+  It also breached the scale. The ±25% bound is applied to the **factor**
+  (`league_intel/adjustment.py`), never to the **product**, so canonical values
+  left their declared 1–9999 range: measured on the 2026-08-14 board, **10,160**
+  under the real factor set and **12,471** at the cap, both published under
+  `rankDerivedValue`. 9,999 is the Hill **asymptote**, so those are numbers the
+  curve defining the scale cannot produce.
+
+  The request is now **ignored, not refused** — the same convergence rule the
+  engine gate uses, so a stored `leagueAdjusted` on someone's phone quietly
+  returns to the canonical answer. `meta.valuationMode` is always `"market"`
+  with `valuationNote: "league_adjusted_withdrawn: not_canonical"`.
+  `apply_valuation_factors` and the `valuation_factors` parameter are **deleted**
+  rather than left unreferenced, so there is no seam to re-thread by accident.
+
+  Two consequences: asking for the lens **no longer narrows scope** (nothing
+  league-scoped is computed, so no 503 on a league mismatch), and the response
+  is **cacheable** again (the memo excluded it only because gameplan freshness
+  was unseeable). The full and delta views now answer identically.
+
+  Pinned by `tests/api/test_canonical_value_scale_contract.py` (the scale is a
+  contract on every published path, plus the structural absence of the seam) and
+  `tests/api/test_league_adjusted_endpoint.py` §4.
 
 Regression tests: `frontend/__tests__/valuation-overlay.test.js` (both
 materializer key sets — the legacy dict uses `_canonicalConsensusRank` but
@@ -1363,36 +1383,50 @@ materializer key sets — the legacy dict uses `_canonicalConsensusRank` but
 `tests/league_intel/test_publish.py` (caller-row isolation, dense contiguous
 ranks, anchor-slot-pick exclusion).
 
-### The lens reaches the engines: `valuation_mode`
+### `valuation_mode`: accepted, ignored, and stamped
 
-The overlay above is for the *client* to multiply onto a board it holds.
-That covers `/rankings` and nothing else — every engine (trade suggestions,
-the arbitrage finder, angles, waivers, the terminal, the simulator) runs
-server-side off `latest_contract_data` and never saw it. Switching the board
-changed the rankings page and left the trade advice market-priced, with no
-field on any response saying which was which.
+**The lens is WITHDRAWN everywhere.** It was never deleted from the request
+surface, and that is deliberate — read on.
 
-Every league-scoped engine endpoint now accepts `valuation_mode`
-(`"market"` | `"leagueAdjusted"`; body field for POST, `valuationMode` query
-param for GET) and answers from the corresponding board:
+The history matters because the shape is a scar from it. The overlay is for the
+*client* to multiply onto a board it holds, which covered `/rankings` and
+nothing else: every engine (trade suggestions, the arbitrage finder, angles,
+waivers, the terminal, the simulator) runs server-side off
+`latest_contract_data` and never saw it, so switching the board changed the
+rankings page and left the trade advice market-priced with no field saying
+which was which. The repair threaded `valuation_mode` through every
+league-scoped engine endpoint, via one mechanism —
+`server.py::_valuation_scoped_contract` handed the engine a repriced contract,
+so no engine had to know the feature existed.
 
-| endpoint | wired | note |
-|---|---|---|
-| `POST /api/trade/suggestions` | yes | |
-| `POST /api/trade/finder` | yes | our side only — the market anchor stays retail, else the arbitrage gap closes itself |
-| `POST /api/angle/find`, `/api/angle/packages` | yes | same asymmetry |
-| `POST /api/trade/simulate` | yes | |
-| `POST /api/waiver/suggestions` | yes | no UI caller — `/waivers` computes client-side from contract rows, which already carry the lens |
-| `POST /api/waiver/faab-recommend` | yes | a bid is derived from a value |
-| `GET /api/terminal` | yes | applies on top of the cross-league hybrid contract |
-| `POST /api/trade/simulate-mc` | n/a | values arrive in the request body; the client already sends whichever board it holds |
-| `GET /api/draft-capital` | n/a | `compute_scarcity` has no `PICK` key, so picks carry factor 1.0 and the lens is a no-op for the pick board itself. Its `rookieKtcValue` IS a player value and does move under the lens — `/draft` therefore stays market-priced and says so via `ValueBasisNote` rather than being threaded |
+Then #822 evaluated that methodology for promotion to canonical and **rejected
+it** on seven measured defects (current-roster-state input, an ordinal
+log-rank driver, an underived `0.5` reference constant, position-wide scalars,
+no scale renormalisation, no staleness detection, no double-count guard) and on
+the absence of the outcome evidence a replacement would need. Full record:
+`docs/valuation/LEAGUE_AWARE_METHODOLOGY_REJECTION.md`.
 
-Mechanism, in one place: `server.py::_valuation_scoped_contract` fetches the
-league's factors and hands the engine a contract whose `playersArray` rows are
-already repriced (`src/league_intel/overlay.py`). No engine has to know the
-feature exists, because the engines take their input from one field —
-`rankDerivedValue`.
+So today, at every one of those endpoints plus
+`POST /api/rankings/overrides` (closed later, in B9a):
+
+* the field is still **parsed** — `_requested_valuation_mode`;
+* the request is **ignored, never refused**. A stored `leagueAdjusted` in
+  someone's `localStorage` must converge to the canonical answer silently;
+  refusing would turn an obsolete client-side value into a broken page for a
+  user who never chose anything;
+* the response is stamped `valuationMode: "market"` with
+  `valuationNote: "league_adjusted_withdrawn: not_canonical"`, because
+  "this is the market board" and "this field is missing" must not read the same.
+
+`_valuation_scoped_contract` is the single seam where the lens ever reached an
+engine, which is why it is the single place it is closed — pinned by
+`tests/api/test_canonical_value_invariance.py`. `src/league_intel/overlay.py`
+still computes the board, but writes only `experimentalLeagueAdjustedValue` /
+`…Rank` / `…Tier` and is forbidden from touching `CANONICAL_VALUE_FIELDS`.
+
+Rule for new code: **do not re-thread `valuation_mode` into anything.** A
+future validated league-aware methodology re-opens one seam deliberately, and
+renormalising onto the 1–9999 scale is part of what it has to earn.
 
 **The governing invariant, stated carefully.** This section used to read "every
 engine reads exactly one value — `rankDerivedValue`", full stop. That is too

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1403,8 +1403,8 @@ absolute, and `docs/master-site-audit/VALUE_FLOW_MAP.md` §4 splits it:
 | One function computes the board | holds — `_compute_unified_rankings`, bit-reproducible |
 | No frontend ranking engine | holds |
 | Every engine *reads* `rankDerivedValue` | holds |
-| Every engine *serves* `rankDerivedValue` | **fails** |
-| One number per player per session | **fails** |
+| Every engine *serves* `rankDerivedValue` | holds (B9a) |
+| One number per player per session | holds (B9a) |
 
 The invariant to design against is therefore:
 
@@ -1414,14 +1414,40 @@ The invariant to design against is therefore:
 > number.**
 
 Serving a different quantity under the canonical field name is a defect, not an
-alternate opinion. Measured violations exist today and are open findings, not
-intended architecture: `suggestions.py::_serialize_player` writes
-`offense_only_value` into `displayValue` for IDP-free trades (W29-F001 — 19 of
-51 asset legs disagree with the board; Travis Hunter 5,637 on `/trade` vs 4,401
-on `/rankings`, because the offense-only board never saw the two-way boost), and
-the same offense-only value rides through `overlay.adjusted_rows` unscaled while
-the response is still stamped `leagueAdjusted` (W29-F002). Repair those when
-authorized; do not write them up here as though they were the design.
+alternate opinion. **Both measured violations are now fixed** (B9a — W29-F001,
+W29-F002).
+
+The mechanism was a SECOND CANONICAL BOARD. `build_api_data_contract` ran
+`_compute_unified_rankings` a second time with every IDP-scoped source disabled
+and stamped the result on each row as `offenseOnlyRankDerivedValue`; three
+engines then substituted it whenever the trade in front of them happened to
+contain no defender — `suggestions.py` into `displayValue`, `finder.py` into
+`modelValue`, `trade_simulator.py` into the resolved asset value *and* the
+manager's entire untraded roster. The switch was **per trade, not per league**,
+so one player carried two unlabelled numbers in one league on one day.
+
+Measured on the 2026-08-14 contract before removal: 605 rows carried it, 507
+were comparable, and **491 of those disagreed** — up to 21.87%. The
+disagreement was never confined to defenders; **picks moved most** (2026 Pick
+2.06: 3,224 → 2,519), because `idpTradeCalc` is a full-roster calculator and
+dropping it changes the count-aware blend, the Hampel filter, the single-source
+haircut and the pick anchor set for every row.
+
+Removed rather than deprecated — a ready-made second canonical board on every
+row is what let three engines wire it in without anyone deciding to. The
+canonical board is byte-identical after removal (0 values moved, 0 ranks
+changed, `scripts/board_diff.py --expect-no-value-change`), and the contract
+build lost a duplicate pipeline pass (0.62 s → 0.49 s median).
+
+An IDP-free view **filters the asset universe or names its lens; it does not
+reprice the assets.** `suggestions._trade_is_idp_free` survives as exactly that
+— a universe predicate — and its docstring says so. Pinned by
+`tests/api/test_one_canonical_value_per_asset.py`, which asserts the invariant
+(same asset, same value, whatever else is in the trade) plus a structural guard
+that neither engine's asset type can carry a second board again.
+
+W29-F002's overlay half was closed separately by #822: `overlay.adjusted_rows`
+now writes `experimentalLeagueAdjustedValue` and never a canonical field.
 
 The rule this yields for new work: **existing implementation behavior does not
 become canonical architecture merely because it ships.** When code and the

--- a/config/thresholds.json
+++ b/config/thresholds.json
@@ -83,6 +83,30 @@
       "unit": "rows",
       "appliesTo": "display",
       "derivedFrom": "Page-level UX choice: items per /edge premium panel, applied AFTER the ratio gate and the top-250 filter."
+    },
+    "ROS_ELITE_PERCENTILE": {
+      "value": 95,
+      "unit": "percentile",
+      "appliesTo": "rosPercentile (rank of rosValue within the full ROS pool, 100 = best)",
+      "derivedFrom": "Measured 2026-08-14 over the live ROS aggregate (1,031 players with a positive rosValue) and corroborated across all 893 historical aggregates from 2026-04-28 to 2026-08-14. REPLACES the absolute gate rosValue >= 80, which selected 2 of 1,031 players (0.19%) and never more than 3 in any historical aggregate. The 0-100 rosValue is a STRENGTH INDEX, not a percentile: its median is 9.15 and its 99th percentile is 59.41, so a constant written to mean 'elite' sat far above the top 1%. The percentile form states the intended population directly - the top 5% - and cannot drift when the index's distribution moves."
+    },
+    "ROS_STRONG_PERCENTILE": {
+      "value": 75,
+      "unit": "percentile",
+      "appliesTo": "rosPercentile",
+      "derivedFrom": "Measured 2026-08-14 over the live ROS aggregate (1,031 players with a positive rosValue) and corroborated across all 893 historical aggregates from 2026-04-28 to 2026-08-14. REPLACES the absolute gate rosValue >= 60, which selected 9 of 1,031 (0.87%). Its complement is load-bearing and was the clearer defect: 'Injury/bye cover' fires when NOT strong, so it applied to 99.13% of the pool - a label carrying no information. Top 25% is the intended 'strong rest-of-season starter' population."
+    },
+    "ROS_DEPTH_BAND_LOW_PERCENTILE": {
+      "value": 40,
+      "unit": "percentile",
+      "appliesTo": "rosPercentile",
+      "derivedFrom": "Measured 2026-08-14 over the live ROS aggregate (1,031 players with a positive rosValue) and corroborated across all 893 historical aggregates from 2026-04-28 to 2026-08-14. REPLACES the lower edge of the absolute band 30 <= rosValue < 60 ('Depth spike option'). The band's upper edge is ROS_STRONG_PERCENTILE, so the two stay adjacent by construction instead of by two constants that can drift apart."
+    },
+    "ROS_SELLER_PERCENTILE_GAP": {
+      "value": 25,
+      "unit": "percentilePoints",
+      "appliesTo": "rosPercentile - dynastyPercentile",
+      "derivedFrom": "W29-F005. The 'Seller cash-out' predicate was dynastyValue < rosValue * 0.7, comparing a 0-9999 dynasty board value against a 0-100 ROS index. Measured: the right-hand side maxes at 60.8 while the board's minimum priced value is 1,134, so 0 of 1,093 rows could ever satisfy it and the tag had never rendered. The concept - 'the dynasty market has not caught up to current ROS strength' - is a comparison of STANDINGS, so both sides are now percentiles of their own population and the gap is in percentile points. 25 points is one quartile: the player must stand a full quartile better in the ROS pool than on the dynasty board. NOT calibrated against outcomes - no outcome evidence exists for these labels - so this is an intent mapping, and it is recorded as one."
     }
   }
 }

--- a/docs/EXECUTION_PLAN.md
+++ b/docs/EXECUTION_PLAN.md
@@ -59,6 +59,36 @@ This file answers **what work should happen next**. It does not define long-term
 - Architecture record: `docs/master-site-audit/evidence/W18/B6_SCORING_IDENTITY_DESIGN.md`.
 - W18-F003 was NOT touched — it remains B7.
 
+### B7 — realized-points correctness
+
+- **MERGED AND VERIFIED.** PR #820 (`af761fc`). Validated head `0875da5`, run 31738127750.
+- W18-F003 fixed; W18-F004 shipped with it by necessity.
+
+### B8 — privacy / distribution / refresh boundary
+
+- **MERGED.** PR #821 (`053f9e5`), 2026-08-14T03:09:30Z. Validated head `0cc95b9`, run 31764984203.
+- W01-F010 and the W22 family closed on BOTH distribution channels (HTTP and git).
+
+### B9 — canonical player value semantics
+
+- **MERGED.** Two units.
+- **B9a** — `offenseOnlyRankDerivedValue` retired: a second full run of
+  `_compute_unified_rankings` whose output three engines substituted into `displayValue` /
+  `modelValue` per TRADE. 491 of 507 comparable rows disagreed, up to 21.87%. Canonical
+  board byte-identical after removal; contract build 0.62 s → 0.49 s. Closes W29-F001
+  (W29-F002's overlay half closed by #822).
+- **B9a** — the 1–9999 scale is now a contract the validator enforces. The last path that
+  let the rejected league-aware methodology own `rankDerivedValue` published 10,160 on the
+  real factor set and 12,471 at the cap; `apply_valuation_factors` deleted.
+- **B9b** — threshold semantic units. W29-F005 closed: the "Seller cash-out" predicate
+  compared 0–9999 against 0–100 and could not fire for any of 1,093 rows; it now fires for
+  19. Four thresholds registered in `config/thresholds.json` with `unit` + `derivedFrom`.
+  **Partial by design** — four BOARD-RELATIVE constants are classified and registered but
+  not converted, because each changes which assets a recommendation surface offers. See
+  `docs/valuation/THRESHOLD_UNIT_REGISTRY.md`.
+
+---
+
 ---
 
 # 2. NEXT AUTHORIZED FOUNDATION SCOPE

--- a/docs/master-site-audit/B_SERIES_EXECUTION_LEDGER.md
+++ b/docs/master-site-audit/B_SERIES_EXECUTION_LEDGER.md
@@ -19,10 +19,10 @@ working branch for provenance and only the validated GREEN head merges.
 |---|---|---|
 | 0 | **B7.0** — residual B6 evidence closure + preflight | **COMPLETE** (merged in #819) |
 | 1 | B7 — realized-points correctness (RED commit → GREEN head) | **MERGED AND VERIFIED** (#820, `af761fc`) |
-| 2 | B8 — privacy / distribution / refresh boundary | IN PROGRESS |
-| 3 | B9a — overlay ceiling, published formula, one canonical value | not started |
-| 5 | B9b — threshold unit registry | not started |
-| 6 | B10-T1 — scraper KTC dedupe | not started |
+| 2 | B8 — privacy / distribution / refresh boundary | **MERGED** (#821, `053f9e5`) |
+| 3 | B9a — one canonical value + the scale contract | **MERGED** |
+| 5 | B9b — threshold unit registry | **MERGED** (partial — §B9b) |
+| 6 | B10-T1 — scraper KTC dedupe | not started — **premise corrected, see §B10** |
 | 7 | B10-T2 — declare provenance (board byte-identical) | not started |
 | 8 | B10-T3 — family-aware aggregation | not started |
 | 9 | B11 — confidence axes | not started |
@@ -321,7 +321,10 @@ untouched — my refactor respelled its probe string. Signature updated, status 
 
 ---
 
-# B8 — Privacy / distribution / refresh boundary · IN PROGRESS
+# B8 — Privacy / distribution / refresh boundary · **MERGED**
+
+Merged 2026-08-14T03:09:30Z as `053f9e5` (#821). Validated head `0cc95b9`,
+PR Validation run **31764984203** — SUCCESS.
 
 ## Section classification, decided on measured content
 
@@ -473,3 +476,154 @@ methodology · a future properly non-canonical Custom Mix redesign.
 **New standing requirement recorded for B9:** every valid dynasty rookie draft pick **through the
 2029 class** must have a real canonical value, derived from the canonical pick methodology, with
 missing ≠ zero, cross-surface parity, and automated completeness regression. Not yet audited.
+
+---
+
+# B9 — Canonical player value semantics · **MERGED**
+
+Two merge units, both GREEN at merge. Findings closed: `W29-F001`, `W29-F002` (overlay half
+closed earlier by #822), `W29-F005`.
+
+## B9a-1 — one canonical dynasty value per asset
+
+**Root cause.** `build_api_data_contract` ran `_compute_unified_rankings` a **second time**
+with every IDP-scoped source disabled and stamped the result on each row as
+`offenseOnlyRankDerivedValue`. Three engines substituted it whenever the trade in front of
+them contained no defender: `suggestions.py` into `displayValue`, `finder.py` into
+`modelValue`, `trade_simulator.py` into the resolved asset value **and the manager's entire
+untraded roster**.
+
+The switch was **per trade, not per league** (`trade_simulator.py:209`), so one player
+carried two unlabelled numbers in one league on one day.
+
+**Measured before removal** (2026-08-14 contract, 1,093 rows): 605 rows carried it, 507
+comparable, **491 disagreeing**, up to **21.87%**. Picks moved most — 2026 Pick 2.06:
+3,224 → 2,519 — because `idpTradeCalc` is a full-roster calculator, so dropping it changes
+the count-aware blend, the Hampel filter, the single-source haircut and the pick anchor set
+for **every** row. The mechanism was never "exclude IDP calibration from IDP-free trades";
+it was a wholesale second board.
+
+**Correction to the recorded finding.** W29-F001 and `VALUE_FLOW_MAP.md` §4 both attribute
+Travis Hunter's spread to the offense-only board "never seeing the two-way boost". It saw
+it. `_apply_two_way_player_boost` runs on the pre-pass; what degrades is its *input* — the
+alt-position ladder needs ≥3 priced IDP rows, and on an IDP-disabled board there are none,
+so the boost collapses to its single-source `idpTradeCalc` branch. 5,637 is a one-source
+alt-family value; 4,401 is the multi-source blend.
+
+**Repair.** Removed, not deprecated — a ready-made second canonical board on every row is
+what let three engines wire it in without anyone deciding to. An IDP-free view **filters the
+asset universe or names its lens; it does not reprice the assets**.
+`suggestions._trade_is_idp_free` survives as exactly that, a universe predicate, and says so.
+
+**Evidence.** Canonical board **byte-identical** — 0 values moved, 0 ranks changed
+(`board_diff.py --expect-no-value-change`). Contract build **0.62 s → 0.49 s** median: a
+duplicate pipeline pass gone.
+
+## B9a-2 — the scale is a contract, and it is enforced
+
+**Root cause.** #822 ruled the rejected league-aware methodology may not own a canonical
+field, and closed the engine gate. One path was left: `POST /api/rankings/overrides?view=delta`
+with `valuation_mode: "leagueAdjusted"` handed factors to `build_rankings_delta_payload`,
+whose `apply_valuation_factors` multiplied them into `rankDerivedValue`. The ±25% bound is
+on the **factor**, never on the **product**.
+
+| factor | max canonical value on the wire | rows > 9999 |
+|---|---|---|
+| 1.018366 (the real measured set) | 10,160 | 2 |
+| 1.25 (the cap) | 12,471 | 16 |
+
+9,999 is the Hill **asymptote** — numbers the curve defining the scale cannot produce.
+
+**Repair.** Ignored, not refused (the engine gate's convergence rule).
+`apply_valuation_factors` and the `valuation_factors` parameter **deleted**, so there is no
+seam to re-thread. Two consequences, both improvements: asking for the lens no longer
+narrows scope (no 503 on league mismatch), and the response is cacheable again.
+
+**Enforcement.** `methodology.formula` published `scaleMin`/`scaleMax` and nothing verified
+them. `validate_api_data_contract` now checks `rankDerivedValue` **and the `values.*`
+aliases** against `DISPLAY_SCALE_MIN`/`MAX`, imported from `src/canonical/player_valuation.py`
+rather than restated — so the block that publishes the range and the check that enforces it
+read one constant. An **error**, not a warning, because `scripts/validate_api_contract.py`
+gates on `ok`; whole array, not the `[:1000]` prefix, because a ceiling breach lands at the
+top of the board. Verified non-vacuous: injecting 12,471 into one row, or one alias, turns
+the gate red.
+
+## B9b — threshold semantic units
+
+Full classification: `docs/valuation/THRESHOLD_UNIT_REGISTRY.md`.
+
+**The defect class.** A threshold is a number *plus a scale*; drop the scale and the number
+keeps working while its meaning drifts.
+
+**W29-F005, and it was worse than recorded.** The "Seller cash-out" predicate compared a
+0–9999 board value against a 0–100 ROS index (`dynastyValue < rosValue * 0.7`): RHS maxes at
+60.8, the board's floor is 1,134, so **0 of 1,093 rows** could fire and the tag had never
+rendered. Its unit test passed — on `dynasty_value=40`, an input the board cannot produce.
+*A test with no unit discipline validated a predicate with an empty solution set.*
+
+The undocumented half: the same classifier gated "strong"/"elite" on `rosValue >= 60`/`>= 80`
+as if the index were a percentile. Measured across **all 893 historical aggregates
+(2026-04-28 → 2026-08-14)**, that index has median 9.15 and p99 **59.41** — so `>= 60` sat
+above the 99th percentile, selecting 0.87%, and its complement labelled **99.13%** of the
+pool "Injury/bye cover".
+
+**Repair.** Four thresholds registered in `config/thresholds.json` with `unit` +
+`derivedFrom`, converted to percentile units. Measured effect:
+
+| tag | before | after |
+|---|---|---|
+| Seller cash-out | **0** (unreachable) | 19 (1.84%) |
+| Injury/bye cover | 99.13% | 55.87% |
+| Contender upgrade | 2 players | 47 (4.56%) |
+
+Structural, because triplication is what let it survive review three times: `rosPercentile`
+stamped server-side over the **whole** pool (the endpoint truncates to `limit`, so a client
+standing would be a standing within the top half); `canonicalPercentile` stamped on contract
+rows for the same reason; **one** classifier in `frontend/lib/ros-index.js` mirroring
+`src/ros/tags.py`, with the parity test a JS comment had promised as "PR-future" and that was
+never written. All nine tags now have a reachability test.
+
+**Not closed, and specified rather than attempted:** four BOARD-RELATIVE constants
+(`MIN_RELEVANT_VALUE`, `MIN_ACTIONABLE_VALUE`, `MIN_WAIVER_VALUE`, the `>= 7000` contender
+gate) are classified and registered but not converted — each changes which assets a
+recommendation surface offers, which needs its own before/after measurement.
+
+---
+
+# Deferred defect ledger — additions
+
+| id | defect | disposition |
+|---|---|---|
+| — | `inferValueBundle` coerces an unpriced row to **0** (`frontend/lib/dynasty-data.js`). The rationale on the function is sound as far as it goes — it replaced a fallback that put a *composite-scale* number into board-scale sums — and 0 is neutral **in a sum**. It is not neutral in a sort, minimum, average or display, where it asserts "worth nothing". `MISSING IS NEVER ZERO` wants `null`. Blast radius: trade sums, portfolio, movers, team-phase, CSV export. | **must-fix-before-C candidate** — measure, then convert |
+| — | The consolidation search still restricts all-offense give-pairs to offense targets. Its only stated justification was avoiding a value-scale flip, which no longer exists. Removing it widens the recommendation universe — a product decision. | owner decision |
+| — | KTC-native constants duplicated across `src/trade/market_value_adjustment.py` and `src/trade/ktc_va.py` — one concept, two owners. | backlog |
+
+---
+
+# B10 — reconnaissance only, NOT started
+
+Recorded because it **corrects the authorising premise**, which should not be discovered
+twice.
+
+**The "ktc ≈ 1.3 + ktcSfTep ≈ 1.0 → 2.3 vs IDPTC 1.0" double-count does not exist on
+current main.** Measured on `_RANKING_SOURCES`: there is **no `ktc` source key**. There is
+one KTC-family entry, `ktcSfTep`, at weight **1.00**, and **all 21 sources are 1.00** —
+consistent with CLAUDE.md's "all 1.0 by policy". Any B10 plan resting on the 2.3 figure is
+resting on a stale reading.
+
+**The real structure**, and it is still a genuine independence problem:
+
+* `correlationGroup` is **`None` on all 21 sources** — no provider family is declared
+  anywhere, so nothing downstream *can* deduplicate by family.
+* Providers contributing more than one source key: **DLF ×4**, **FantasyPros ×3**,
+  **Flock ×2**, **DraftSharks ×2**.
+* The nested-consensus case the owner ruled on is live and measurable:
+  `fantasyProsSf` (544 players, an expert **consensus**) and `fantasyProsFitzmaurice`
+  (299 players, **one expert inside that panel**) are both `overall_offense`, both weight
+  1.00. Measured: Fitzmaurice is **100% contained** in the consensus board, Pearson
+  **r = 0.9297**, median |rank diff| 12. Declarative provenance, not inferred from the
+  correlation: the source's own display name is "FantasyPros / Pat Fitzmaurice SF-TEP".
+
+Per the owner's ruling, family lineage must be **declarative**, so the correlation above is
+corroboration, not the basis. B10-T2 (declare provenance, board byte-identical) is the next
+unit and has not been started.

--- a/docs/valuation/THRESHOLD_UNIT_REGISTRY.md
+++ b/docs/valuation/THRESHOLD_UNIT_REGISTRY.md
@@ -1,0 +1,154 @@
+# Threshold semantic units — the B9b classification
+
+**Status:** classification record + conversion log
+**Owner of the numbers:** `config/thresholds.json` (loaded by `src/api/thresholds.py`,
+mirrored in `frontend/lib/thresholds.js`, enforced by `tests/api/test_threshold_parity.py`)
+**Companion:** `docs/master-site-audit/B_SERIES_EXECUTION_LEDGER.md` §B9b
+
+---
+
+## 1. The defect class
+
+A threshold is a number *plus a scale*. Drop the scale and the number keeps working
+while its meaning drifts, because the distribution underneath it moves — a refit Hill
+curve, a source added or removed, a deeper pool, a different vendor index.
+
+Two failures, both measured on live data, both invisible to review and to the test suite:
+
+**Cross-scale comparison (W29-F005).** The "Seller cash-out" tag compared a 0–9999
+dynasty board value against a 0–100 ROS strength index:
+
+```
+dynastyValue < rosValue * 0.7
+```
+
+The right-hand side maxes at **60.8**. The board's lowest priced value is **1,134**. The
+ranges do not overlap: **0 of 1,093 rows** could ever satisfy it, and the tag had never
+rendered in production. It existed in three files — two JS copies and one Python — and
+survived review three times.
+
+Its unit test passed. It passed because the fixture supplied `dynasty_value=40`, an input
+the 1–9999 board cannot produce. *A test with no unit discipline validated a predicate with
+an empty solution set.*
+
+**Absolute constants on a non-uniform index.** The same classifier gated "strong" and
+"elite" on `rosValue >= 60` and `>= 80`, written as if the 0–100 index were a percentile.
+It is not. Measured over the live aggregate and **all 893 historical aggregates
+(2026-04-28 → 2026-08-14)**:
+
+| statistic | value |
+|---|---|
+| median `rosValue` | 9.15 |
+| 90th percentile | 26.17 |
+| 99th percentile | 59.41 |
+| maximum | 86.79 |
+
+So `>= 60` sat *above the 99th percentile* and selected 9 of 1,031 players (0.87%);
+`>= 80` selected 2 (0.19%), never more than 3 in any historical aggregate. The complement
+was the clearer damage: "Injury/bye cover" fires when **not** strong, so it labelled
+**99.13%** of the pool — a tag carrying no information.
+
+---
+
+## 2. The classification rule
+
+| class | means | correct unit |
+|---|---|---|
+| **BOARD-RELATIVE** | quality, tier, elite/depth status, relevance, scarcity position, "top X-ish" | rank, percentile, ratio |
+| **VALUE-UNIT** | genuinely additive arithmetic in canonical value units — a gap between two values, a package delta | canonical value units, justified |
+| **FOREIGN SCALE** | a vendor's own scale, never the canonical board | that vendor's unit, named |
+
+A BOARD-RELATIVE concept expressed as an absolute value is the defect. A VALUE-UNIT
+concept expressed as an absolute value is correct and may stay — with its unit declared.
+
+---
+
+## 3. Converted
+
+| constant | was | now | evidence |
+|---|---|---|---|
+| ROS "elite" gate | `rosValue >= 80` | `ROS_ELITE_PERCENTILE = 95` | selected 0.19% of the pool |
+| ROS "strong" gate | `rosValue >= 60` | `ROS_STRONG_PERCENTILE = 75` | selected 0.87%; complement labelled 99.13% |
+| ROS depth band | `30 <= rosValue < 60` | `ROS_DEPTH_BAND_LOW_PERCENTILE = 40` … strong cut | band edges now adjacent by construction |
+| "Seller cash-out" | `dynastyValue < rosValue * 0.7` | `rosPercentile - dynastyPercentile >= 25` | 0 of 1,093 rows could fire; now 19 of 1,031 |
+
+**Measured effect on tag populations** (live pool, 1,031 players):
+
+| tag | before | after |
+|---|---|---|
+| Seller cash-out | **0** (unreachable) | 19 (1.84%) |
+| Injury/bye cover | 99.13% | 55.87% |
+| Contender upgrade | 2 players | 47 (4.56%) |
+| Win-now target | ≤9 possible | 52 (5.04%) |
+
+All nine tags are now reachable and each has a test proving it fires
+(`tests/ros/test_tag_parity.py`).
+
+Two structural changes came with it, because the duplication is what let the defect
+survive:
+
+* **`rosPercentile` is stamped server-side**, over the whole pool.
+  `/api/ros/player-values` truncates to `limit` (500 by default), so a client ranking what
+  it received would be measuring a standing within the top half and calling it a
+  percentile.
+* **`canonicalPercentile` is stamped on contract rows**, for the same reason — a consumer
+  holding one row cannot compute a standing. It is the scale-stable companion to
+  `rankDerivedValue`.
+* **One classifier**, in `frontend/lib/ros-index.js`, mirroring `src/ros/tags.py`, with the
+  parity test that a JS comment had promised as "PR-future" and that was never written.
+
+---
+
+## 4. Classified, registered, not yet converted
+
+These are BOARD-RELATIVE concepts still expressed in canonical value units. Converting each
+changes which assets a recommendation surface offers — a product-visible change that needs
+its own before/after measurement, so each is specified here rather than changed in bulk.
+
+| constant | file | value | concept | conversion target |
+|---|---|---|---|---|
+| `MIN_RELEVANT_VALUE` | `src/trade/suggestions.py:173` | 500 | "worth proposing at all" | board rank / percentile |
+| `MIN_ACTIONABLE_VALUE` | `src/trade/suggestions.py:222` | 2000 | "actionable" quality tier | percentile |
+| `MIN_WAIVER_VALUE` | `src/trade/waiver.py:41` | 500 | wire relevance | percentile |
+| contender gate | `src/trade/suggestions.py:1233` | `display_value >= 7000` | "elite target" | percentile |
+
+## 5. Correctly VALUE-UNIT — retained, with justification
+
+| constant | file | value | why it stays |
+|---|---|---|---|
+| `FAIRNESS_TOLERANCE` | `src/trade/suggestions.py:183` | 769 | a *gap between two canonical values*; subtraction in value units is the operation |
+| near-even gate | `src/trade/suggestions.py:1503` | 500 | same — `abs(give − receive)` |
+| `CONSOLIDATION_MIN_UPGRADE_RATIO` | `suggestions.py:190` | 0.70 | already a ratio, scale-stable |
+| `CONSOLIDATION_MAX_OVERPAY_RATIO` | `suggestions.py:197` | 0.30 | already a ratio |
+
+## 6. FOREIGN SCALE — correctly named, leave alone
+
+| constant | file | scale |
+|---|---|---|
+| `BOARD_TO_COMPOSITE_K = 0.875` | `src/trade/finder.py:58` | the *conversion itself*, and the only place in the repo that names one |
+| `KTC_MAX_PLAYER_VALUE` / `KTC_TOP_REFERENCE` | `src/trade/market_value_adjustment.py` | KTC native 0–10041 |
+| `KTC_MAX_PLAYER_VAL` / `KTC_T_REFERENCE` | `src/trade/ktc_va.py` | KTC native — **duplicated** with the above; one concept, two owners |
+
+## 7. Scales in play
+
+Five, and outside `finder.py` the constants do not say which one they belong to:
+
+1. canonical `rankDerivedValue` — 1–9999 (Hill asymptote)
+2. legacy composite `_finalAdjusted` — ~1.131× the board
+3. KTC native — 0–10041
+4. BDVM trade value — its own 0–10000
+5. ROS `rosValue` — 0–100 strength index, median 9.15
+
+---
+
+## 8. What is NOT closed
+
+* The four BOARD-RELATIVE constants in §4 are registered and specified, not converted.
+* The KTC-native constant pair in §6 is duplicated across two modules.
+* **`inferValueBundle` coerces an unpriced row to `0`** (`frontend/lib/dynasty-data.js`).
+  The rationale on the function is sound as far as it goes — it replaced a fallback that
+  substituted a *composite-scale* number into board-scale sums — and `0` is arithmetically
+  neutral **in a sum**. It is not neutral in a sort, a minimum, an average or a display,
+  where it asserts "this asset is worth nothing". `MISSING IS NEVER ZERO` wants `null`
+  with each consumer deciding. The change is wide (trade sums, portfolio, movers,
+  team-phase, CSV export) and is recorded here rather than attempted unmeasured.

--- a/frontend/components/PlayerPopup.jsx
+++ b/frontend/components/PlayerPopup.jsx
@@ -10,7 +10,7 @@ import { useApp } from "@/components/AppShell";
 import { useLeague } from "@/components/useLeague";
 import { useNews } from "@/components/useNews";
 import { lookupPlayerDigest, lookupPlayerNews } from "@/lib/player-name-match";
-import { buildRosIndex, rosEntryForRow } from "@/lib/ros-index";
+import { buildRosIndex, rosEntryForRow, tagsForPlayer } from "@/lib/ros-index";
 import { buildPlayerMetaIndex } from "@/lib/news-filters";
 import { timeAgo } from "@/lib/news-service";
 import { useTeam } from "@/components/useTeam";
@@ -92,29 +92,6 @@ const _ROS_TAG_TONE = {
 };
 const _VET_AGE = { QB: 32, RB: 26, WR: 29, TE: 30, DL: 30, DE: 30, DT: 30, EDGE: 30, LB: 29, DB: 29, S: 29, CB: 29 };
 
-function _tagsForPlayer({ position, age, rosValue, rosRank, dynastyValue, volatilityFlag }) {
-  const tags = [];
-  if (rosValue == null || rosValue <= 0) return tags;
-  const pos = String(position || "").toUpperCase().split("/")[0];
-  const isIdp = ["DL", "DE", "DT", "EDGE", "LB", "DB", "S", "CB"].includes(pos);
-  const isStrong = rosValue >= 60;
-  const isElite = rosValue >= 80;
-  const isStarterCaliber = rosRank != null && rosRank <= 100;
-  const isTopIdp = isIdp && rosRank != null && rosRank <= 50;
-  const veteran = age != null && _VET_AGE[pos] != null && age >= _VET_AGE[pos];
-  const young = age != null && age <= 24;
-  if (veteran && isStrong) tags.push("Win-now target");
-  if (isElite && isStarterCaliber && !isIdp) tags.push("Contender upgrade");
-  if (veteran && isStrong && dynastyValue != null && dynastyValue < rosValue * 0.7) tags.push("Seller cash-out");
-  if (young && !isStrong) tags.push("Rebuilder hold");
-  if (veteran && isStrong && !isStarterCaliber) tags.push("Avoid unless contending");
-  if (!isStarterCaliber && rosValue >= 30 && rosValue < 60) tags.push("Depth spike option");
-  if (volatilityFlag && isStarterCaliber) tags.push("Best-ball boost");
-  if (isTopIdp) tags.push("IDP contender target");
-  if (!isStrong && !young) tags.push("Injury/bye cover");
-  return tags;
-}
-
 function RosContextSection({ row }) {
   const { settings } = useSettings();
   const enabled = settings?.showRosTags !== false;
@@ -139,13 +116,13 @@ function RosContextSection({ row }) {
       </div>
     );
   }
-  const dynastyValue = row.values?.full ?? row.rankDerivedValue ?? null;
-  const tags = _tagsForPlayer({
+  const tags = tagsForPlayer({
     position: row.pos,
     age: row.age,
     rosValue: ros.rosValue,
+    rosPercentile: ros.rosPercentile,
     rosRank: ros.rosRank,
-    dynastyValue,
+    dynastyPercentile: row.canonicalPercentile ?? null,
     volatilityFlag: ros.volatilityFlag,
   });
   return (

--- a/frontend/components/RosTradeFitPanel.jsx
+++ b/frontend/components/RosTradeFitPanel.jsx
@@ -6,7 +6,7 @@
 // only, gated by ``settings.showRosTradePanel``.
 
 import { useEffect, useState } from "react";
-import { buildRosIndex, rosEntryForRow } from "@/lib/ros-index";
+import { buildRosIndex, rosEntryForRow, tagsForPlayer } from "@/lib/ros-index";
 
 const CACHE_TTL_MS = 30 * 60 * 1000;
 const _cache = { data: null, fetchedAt: 0, inflight: null };
@@ -58,30 +58,6 @@ const LABEL_COLOR = {
 // Pure tag classifier — mirrors src/ros/tags.py::tags_for_player so
 // the trade-calc can label players without a backend round-trip per
 // row.  Stays in sync via the parity test (PR-future).
-function tagsForPlayer({ position, age, rosValue, rosRank, dynastyValue, volatilityFlag }) {
-  const tags = [];
-  if (rosValue == null || rosValue <= 0) return tags;
-  const pos = String(position || "").toUpperCase().split("/")[0];
-  const isIdp = ["DL", "DE", "DT", "EDGE", "LB", "DB", "S", "CB"].includes(pos);
-  const isStrong = rosValue >= 60;
-  const isElite = rosValue >= 80;
-  const isStarterCaliber = rosRank != null && rosRank <= 100;
-  const isTopIdp = isIdp && rosRank != null && rosRank <= 50;
-  const VET_AGE = { QB: 32, RB: 26, WR: 29, TE: 30, DL: 30, DE: 30, DT: 30, EDGE: 30, LB: 29, DB: 29, S: 29, CB: 29 };
-  const veteran = age != null && VET_AGE[pos] != null && age >= VET_AGE[pos];
-  const young = age != null && age <= 24;
-  if (veteran && isStrong) tags.push("Win-now target");
-  if (isElite && isStarterCaliber && !isIdp) tags.push("Contender upgrade");
-  if (veteran && isStrong && dynastyValue != null && dynastyValue < rosValue * 0.7) tags.push("Seller cash-out");
-  if (young && !isStrong) tags.push("Rebuilder hold");
-  if (veteran && isStrong && !isStarterCaliber) tags.push("Avoid unless contending");
-  if (!isStarterCaliber && rosValue >= 30 && rosValue < 60) tags.push("Depth spike option");
-  if (volatilityFlag && isStarterCaliber) tags.push("Best-ball boost");
-  if (isTopIdp) tags.push("IDP contender target");
-  if (!isStrong && !young) tags.push("Injury/bye cover");
-  return tags;
-}
-
 export default function RosTradeFitPanel({ sides, settings }) {
   const [directions, setDirections] = useState({ teams: [] });
   const [valuesByName, setValuesByName] = useState(() => new Map());
@@ -123,8 +99,9 @@ export default function RosTradeFitPanel({ sides, settings }) {
         position: row?.pos,
         age: row?.age,
         rosValue: ros.rosValue,
+        rosPercentile: ros.rosPercentile,
         rosRank: ros.rosRank,
-        dynastyValue: row?.values?.full ?? row?.rankDerivedValue ?? null,
+        dynastyPercentile: row?.canonicalPercentile ?? null,
         volatilityFlag: ros.volatilityFlag,
       });
       return { name, position: row?.pos, age: row?.age, ros, tags };

--- a/frontend/lib/ros-index.js
+++ b/frontend/lib/ros-index.js
@@ -62,6 +62,12 @@
  */
 
 import { normalizePlayerNameKey } from "@/lib/player-name-match";
+import {
+  ROS_ELITE_PERCENTILE,
+  ROS_STRONG_PERCENTILE,
+  ROS_DEPTH_BAND_LOW_PERCENTILE,
+  ROS_SELLER_PERCENTILE_GAP,
+} from "./thresholds";
 
 /**
  * Pick a winner when two ROS rows collapse to one key.
@@ -115,6 +121,9 @@ export function buildRosIndex(players) {
     if (!key) continue;
     const entry = {
       rosValue: p.rosValue,
+      // Standing within the WHOLE ROS pool, stamped by the backend.
+      // Never recomputed here — the response is truncated to `limit`.
+      rosPercentile: p.rosPercentile ?? null,
       rosRank: p.rosRankOverall,
       rosRankPosition: p.rosRankPosition,
       confidence: p.confidence,
@@ -148,4 +157,83 @@ export function rosEntryForRow(index, row) {
     if (hit) return hit;
   }
   return null;
+}
+
+// ── Context tags — the ONE implementation ────────────────────────────
+//
+// `PlayerPopup.jsx` and `RosTradeFitPanel.jsx` each carried a verbatim
+// copy of this classifier, and one of them still carried the comment
+// "Stays in sync via the parity test (PR-future)" — a parity test that
+// was never written. Duplicating it is what let W29-F005 survive review
+// three times (twice here, once in `src/ros/tags.py`).
+//
+// The Python owner is `src/ros/tags.py::tags_for_player`; this mirrors
+// it and `tests/ros/test_tag_parity.py` fails the build when the two
+// disagree. Same mirror+parity mechanism as the ranking-source registry
+// and `frontend/lib/thresholds.js`.
+//
+// Every strength gate is a STANDING within the ROS pool, not a level of
+// the raw 0-100 `rosValue` index. See the B9b note in thresholds.js for
+// what the absolute constants measured before the conversion.
+
+const _IDP_TAG_POSITIONS = new Set(["DL", "DE", "DT", "EDGE", "LB", "DB", "S", "CB"]);
+const _VET_AGE_BY_POS = {
+  QB: 32, RB: 26, WR: 29, TE: 30,
+  DL: 30, DE: 30, DT: 30, EDGE: 30, LB: 29, DB: 29, S: 29, CB: 29,
+};
+
+/**
+ * Context tags for one player.
+ *
+ * `rosPercentile` and `dynastyPercentile` are 0-100 with 100 = best,
+ * each measured within its OWN population. No tags without
+ * `rosPercentile`: every gate is a standing, and a standing cannot be
+ * derived from one player. Returning none is the honest answer.
+ */
+export function tagsForPlayer({
+  position,
+  age,
+  rosValue,
+  rosPercentile,
+  rosRank,
+  dynastyPercentile,
+  volatilityFlag,
+}) {
+  const tags = [];
+  if (rosValue == null || rosValue <= 0) return tags;
+  if (rosPercentile == null) return tags;
+
+  const pos = String(position || "").toUpperCase().split("/")[0];
+  const isIdp = _IDP_TAG_POSITIONS.has(pos);
+  const isStrong = rosPercentile >= ROS_STRONG_PERCENTILE;
+  const isElite = rosPercentile >= ROS_ELITE_PERCENTILE;
+  const isStarterCaliber = rosRank != null && rosRank <= 100;
+  const isTopIdp = isIdp && rosRank != null && rosRank <= 50;
+  const vetAge = _VET_AGE_BY_POS[pos];
+  const veteran = age != null && vetAge != null && age >= vetAge;
+  const young = age != null && age <= 24;
+
+  if (veteran && isStrong) tags.push("Win-now target");
+  if (isElite && isStarterCaliber && !isIdp) tags.push("Contender upgrade");
+  if (
+    veteran &&
+    isStrong &&
+    dynastyPercentile != null &&
+    rosPercentile - dynastyPercentile >= ROS_SELLER_PERCENTILE_GAP
+  ) {
+    tags.push("Seller cash-out");
+  }
+  if (young && !isStrong) tags.push("Rebuilder hold");
+  if (veteran && isStrong && !isStarterCaliber) tags.push("Avoid unless contending");
+  if (
+    !isStarterCaliber &&
+    rosPercentile >= ROS_DEPTH_BAND_LOW_PERCENTILE &&
+    rosPercentile < ROS_STRONG_PERCENTILE
+  ) {
+    tags.push("Depth spike option");
+  }
+  if (volatilityFlag && isStarterCaliber) tags.push("Best-ball boost");
+  if (isTopIdp) tags.push("IDP contender target");
+  if (!isStrong && !young) tags.push("Injury/bye cover");
+  return tags;
 }

--- a/frontend/lib/thresholds.js
+++ b/frontend/lib/thresholds.js
@@ -166,3 +166,26 @@ export const EDGE_PREMIUM_LIMIT = 10;
 // frontend trusts the backend's cap and never imports or
 // re-declares it — this keeps a single source of truth and prevents
 // a parallel ranking engine from sneaking back in.
+
+// ── ROS context tags (B9b) ───────────────────────────────────────────────────
+// These replaced absolute gates on `rosValue`, a 0-100 STRENGTH INDEX that the
+// old constants treated as if it were a percentile. Measured 2026-08-14 over
+// 1,031 players and corroborated across all 893 historical aggregates back to
+// 2026-04-28: the index's median is 9.15 and its 99th percentile is 59.41, so
+// `rosValue >= 80` ("elite") selected 2 players and `>= 60` ("strong") selected
+// 9 — while the complement of "strong" labelled 99.13% of the pool
+// "Injury/bye cover". A percentile states the intended population directly and
+// cannot drift when the index's distribution moves.
+//
+// `rosPercentile` is stamped by the backend over the WHOLE pool. Do not
+// recompute it here: /api/ros/player-values truncates to `limit` (500), so a
+// standing computed from the response is a standing within the top half.
+export const ROS_ELITE_PERCENTILE = 95;
+export const ROS_STRONG_PERCENTILE = 75;
+export const ROS_DEPTH_BAND_LOW_PERCENTILE = 40;
+
+// Percentile POINTS, not a percentile: the gap between a player's ROS standing
+// and their dynasty standing. W29-F005 — the predicate was
+// `dynastyValue < rosValue * 0.7`, comparing a 0-9999 board value against the
+// 0-100 index, so it could not fire for any of the 1,093 rows and never had.
+export const ROS_SELLER_PERCENTILE_GAP = 25;

--- a/server.py
+++ b/server.py
@@ -4217,49 +4217,30 @@ async def post_rankings_overrides(request: Request):
         valuation_mode = str(raw_mode or "").strip()
     want_league_adjusted = valuation_mode == "leagueAdjusted"
 
-    valuation_factors: dict[str, float] | None = None
+    # WITHDRAWN, on this path too (B9a).
+    #
+    # #822 rejected the league-aware methodology for promotion to
+    # canonical and ruled it may no longer own a canonical field.  It
+    # closed the engine gate (``_valuation_scoped_contract``) and moved
+    # ``league_intel.overlay`` onto ``experimentalLeagueAdjusted*``
+    # names — but this path was left composing factors into
+    # ``rankDerivedValue`` itself, via
+    # ``data_contract.apply_valuation_factors``.  The ±25% bound is
+    # applied to the FACTOR and never to the PRODUCT, so the canonical
+    # field left its own declared 1–9999 range: measured on the
+    # 2026-08-14 board, the real factor set published 10,160 and the
+    # factor cap published 12,471, both under the canonical field name.
+    #
+    # Ignored rather than refused, exactly as the engine gate does: a
+    # stored ``leagueAdjusted`` on someone's phone must converge to the
+    # canonical answer silently.  The composition helper is deleted
+    # rather than left unreferenced, so there is no seam to re-thread by
+    # accident; a future *validated* methodology re-opens one seam
+    # deliberately, and renormalising onto the scale is part of what it
+    # would have to earn.
     valuation_note: str | None = None
-    if want_league_adjusted and delta_view:
-        if not sleeper_matches:
-            return JSONResponse(
-                status_code=503,
-                content={
-                    "error": "data_not_ready",
-                    "message": (
-                        f"League-adjusted values need league {league_cfg.key!r}'s "
-                        f"rosters; the server holds {loaded_league or 'none'!r}."
-                    ),
-                    "leagueKey": league_cfg.key,
-                },
-            )
-        try:
-            overlay = await run_in_threadpool(
-                _gameplan.get_league_adjusted_values,
-                league_cfg.key,
-                league_cfg.scoring_profile,
-                latest_contract_data,
-            )
-            raw_factors = overlay.get("factors") if isinstance(overlay, dict) else None
-            valuation_factors = {
-                str(k): float(v)
-                for k, v in (raw_factors or {}).items()
-                if isinstance(v, (int, float))
-            }
-        except _gameplan.GameplanUnavailable as exc:
-            # Scarcity is unmeasurable without a roster snapshot. Serve
-            # the overridden market board and SAY SO rather than
-            # silently presenting it as league-adjusted — the whole
-            # point of this endpoint is that the user can tell which
-            # board they are looking at.
-            valuation_factors = None
-            valuation_note = f"league_adjusted_unavailable: {exc.reason}"
-            log.warning("league-adjusted overlay unavailable for overrides: %s", exc.detail)
-    elif want_league_adjusted and not delta_view:
-        # The full view is a legacy compatibility surface; composing
-        # there would mean maintaining two composition paths for one
-        # behaviour. Refuse explicitly instead of quietly ignoring the
-        # field, which would return a market board labelled as adjusted.
-        valuation_note = "league_adjusted_requires_delta_view"
+    if want_league_adjusted:
+        valuation_note = "league_adjusted_withdrawn: not_canonical"
 
     # Snapshot the shared globals ONCE on the event loop.  The worker
     # thread below must not re-read them mid-build: a concurrent scrape
@@ -4286,7 +4267,6 @@ async def post_rankings_overrides(request: Request):
                 source_overrides=overrides if overrides else None,
                 tep_multiplier=tep_multiplier,
                 tep_native_multiplier=tep_native_multiplier,
-                valuation_factors=valuation_factors,
             )
         else:
             contract_payload = build_api_data_contract(
@@ -4320,7 +4300,9 @@ async def post_rankings_overrides(request: Request):
             # asked for leagueAdjusted and silently got market is the
             # failure mode this whole change exists to remove, so the
             # answer travels with the payload instead of being inferred.
-            meta["valuationMode"] = "leagueAdjusted" if valuation_factors else "market"
+            # Only one board is canonical now, so this is unconditional
+            # rather than derived from whether factors were applied.
+            meta["valuationMode"] = "market"
             if valuation_note:
                 meta["valuationNote"] = valuation_note
                 contract_payload.setdefault("warnings", []).append(valuation_note)
@@ -4337,13 +4319,17 @@ async def post_rankings_overrides(request: Request):
     # ── Response memo ────────────────────────────────────────────────
     # Cache key: everything that can change the response body.  The
     # canonical body JSON covers overrides + tep knobs + any unknown
-    # keys (which produce per-body warnings).  ``valuation_mode``
-    # requests are excluded: their factors come from the gameplan
-    # module whose freshness this cache cannot see.  Entries are
+    # keys (which produce per-body warnings), and it includes
+    # ``valuation_mode``, so a request carrying the withdrawn lens keys
+    # separately from one that does not — which is what the differing
+    # ``valuationNote`` needs.  ``valuation_mode`` requests used to be
+    # excluded because their factors came from the gameplan module whose
+    # freshness this cache cannot see; with the lens withdrawn there are
+    # no factors and nothing unseeable left to exclude.  Entries are
     # versioned on ``latest_data_etag`` (the contract generation) and
     # rebuilt in place when stale; ``_prime_latest_payload`` clears the
     # whole dict on scrape promotion.
-    cacheable = not want_league_adjusted and contract_version is not None
+    cacheable = contract_version is not None
     cache_key = None
     if cacheable:
         canonical_body = json.dumps(body, sort_keys=True, separators=(",", ":"), default=str)

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -9317,42 +9317,31 @@ def build_api_data_contract(
     # the DB-tagged row.
     _strip_mismatched_family_tags(players_array)
 
-    # Pre-pass: compute offense-only values by disabling all IDP-scoped
-    # sources.  The result is stored as ``offenseOnlyRankDerivedValue``
-    # on each row and used by trade evaluation endpoints when none of
-    # the players in a trade are IDP (DL/LB/DB).  The main pass below
-    # then overwrites ``rankDerivedValue`` with the full-source board.
-    # Skipped on delta/override builds since those don't feed the
-    # trade evaluation path.
-    if not source_overrides and not _for_delta:
-        _idp_off_overrides: dict[str, dict[str, Any]] = {
-            src["key"]: {"include": False}
-            for src in _RANKING_SOURCES
-            if src.get("scope") in (SOURCE_SCOPE_OVERALL_IDP, SOURCE_SCOPE_POSITION_IDP)
-        }
-        if _idp_off_overrides:
-            # Use shallow copies of both rows and legacy dicts so the
-            # pre-pass never stamps canonicalConsensusRank /
-            # sourceRankMeta / _canonicalConsensusRank etc. onto the
-            # originals.  The main pass below must see unmodified state.
-            _pa_copy = [dict(r) for r in players_array]
-            _pbn_copy = {
-                k: dict(v) if isinstance(v, dict) else v for k, v in players_by_name.items()
-            }
-            _compute_unified_rankings(
-                _pa_copy,
-                _pbn_copy,
-                csv_index=csv_index,
-                source_overrides=_idp_off_overrides,
-                tep_multiplier=tep_multiplier_effective,
-                tep_native_multiplier=tep_native_multiplier_effective,
-                tep_native_correction=tep_native_correction,
-                tep_multiplier_is_override=(tep_multiplier_source == "override"),
-            )
-            for _orig, _copy in zip(players_array, _pa_copy):
-                _rdv = _copy.get("rankDerivedValue")
-                if isinstance(_rdv, (int, float)) and _rdv > 0:
-                    _orig["offenseOnlyRankDerivedValue"] = int(_rdv)
+    # ONE CANONICAL BOARD.  There used to be a pre-pass here that ran
+    # ``_compute_unified_rankings`` a SECOND time with every IDP-scoped
+    # source disabled and stamped the result as
+    # ``offenseOnlyRankDerivedValue``, which the trade engines then
+    # substituted whenever a trade happened to contain no defender.
+    #
+    # It was a second canonical board: same function, same scale, and on
+    # the 2026-08-14 contract 491 of the 507 comparable rows disagreed
+    # with canonical by up to 21.87%.  The disagreement was not confined
+    # to defenders — PICKS moved most (2026 Pick 2.06: 3,224 → 2,519),
+    # which is what shows the mechanism was never "exclude IDP
+    # calibration from IDP-free trades".  Disabling a source changes the
+    # count-aware blend, the Hampel filter, the single-source haircut and
+    # the pick anchor set for EVERY row, because ``idpTradeCalc`` is a
+    # full-roster calculator that prices offense and picks too.
+    #
+    # Removed rather than deprecated: leaving a ready-made second
+    # canonical board on every row is what let three separate engines
+    # wire it into ``displayValue`` / ``modelValue`` without anyone
+    # deciding to.  An IDP-free view filters the asset universe or names
+    # its lens; it does not reprice the assets.  See W29-F001 / W29-F002
+    # and ``tests/api/test_one_canonical_value_per_asset.py``.
+    #
+    # Also removes a full second run of the ranking pipeline from every
+    # non-delta contract build.
 
     # Compute unified rankings: all sources, all positions, one board.
     # The CSV index lets the ranker stamp a per-row ``sourceAudit``
@@ -9412,18 +9401,6 @@ def build_api_data_contract(
     # delta payload drops the legacy ``players`` dict entirely.
     if not _for_delta:
         _mirror_trust_to_legacy(players_array, players_by_name)
-        # Mirror offenseOnlyRankDerivedValue to the legacy players dict so
-        # the trade finder (which reads from the players dict) can use it.
-        for _row in players_array:
-            _ordv = _row.get("offenseOnlyRankDerivedValue")
-            if not isinstance(_ordv, int):
-                continue
-            _legacy_ref = _row.get("legacyRef")
-            if not _legacy_ref or _legacy_ref not in players_by_name:
-                continue
-            _pdata = players_by_name[_legacy_ref]
-            if isinstance(_pdata, dict):
-                _pdata["_offenseOnlyFinalAdjusted"] = _ordv
 
     data_source = data_source or {}
     generated_at = utc_now_iso()

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -10,10 +10,21 @@ import re
 import statistics
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable
 
 from src.canonical.player_valuation import (
     PERCENTILE_REFERENCE_N as _CANONICAL_PERCENTILE_REFERENCE_N,
+)
+
+#: The canonical value scale, imported rather than restated.
+#: ``DISPLAY_SCALE_MAX`` is the numerator of the Hill family the board is
+#: built from (``V(p) = 9999 / (1 + (p/c)^s)``), i.e. its ASYMPTOTE — so
+#: it is the one owner of "how high a canonical value can go", and both
+#: the published ``methodology.formula`` block and the contract validator
+#: read it from here.  A second literal would be a second scale.
+from src.canonical.player_valuation import (  # noqa: E402  — grouped with its sibling
+    DISPLAY_SCALE_MAX as _CANONICAL_VALUE_MAX,
+    DISPLAY_SCALE_MIN as _CANONICAL_VALUE_MIN,
 )
 from src.data_models.contracts import utc_now_iso
 
@@ -9487,8 +9498,11 @@ def build_api_data_contract(
             ),
             "referenceN": _PERCENTILE_REFERENCE_N,
             "scopeMasters": "see the hillCurves contract block for per-scope (c, s)",
-            "scaleMin": 1,
-            "scaleMax": 9999,
+            # Published from the same constants the validator enforces, so
+            # the contract cannot advertise a range the board is not held
+            # to (B9a).
+            "scaleMin": _CANONICAL_VALUE_MIN,
+            "scaleMax": _CANONICAL_VALUE_MAX,
         },
         "idpTranslation": {
             "description": (
@@ -9712,51 +9726,6 @@ _DELTA_PLAYER_FIELDS: tuple[str, ...] = (
 )
 
 
-def apply_valuation_factors(
-    rows: list[dict[str, Any]],
-    factors: Mapping[str, float] | None,
-    *,
-    anchor_year: int | None = None,
-) -> int:
-    """Multiply ``rankDerivedValue`` by a per-player factor and re-rank.
-
-    Mutates ``rows`` IN PLACE and returns how many rows were re-valued.
-    Callers must therefore own ``rows`` — never hand this
-    ``latest_contract_data``'s list.  ``build_rankings_delta_payload``
-    owns a freshly-built contract, which is why it can.
-
-    This exists so the rankings-override endpoint can serve a board that
-    is BOTH re-weighted and league-adjusted.  The client cannot compose
-    those two: the overlay's ranks are the ranks of
-    ``default_consensus x factor``, while the correct answer is the rank
-    of ``overridden_consensus x factor`` — a board the server had never
-    computed.  Computing it here is the fix that unblocks the
-    combination rather than continuing to refuse it.
-
-    Ranking goes through :func:`compact_ranks_and_tiers`, the one
-    ranker, so an adjusted board is ranked by exactly the same rules as
-    the default one.
-    """
-    if not factors:
-        return 0
-    moved = 0
-    for row in rows:
-        name = str(row.get("displayName") or row.get("canonicalName") or "").strip()
-        factor = factors.get(name)
-        base = row.get("rankDerivedValue")
-        if factor and isinstance(base, (int, float)) and base > 0:
-            row["rankDerivedValue"] = int(round(float(base) * float(factor)))
-            moved += 1
-    if not moved:
-        return 0
-    compact_ranks_and_tiers(
-        rows,
-        anchor_year=anchor_year if anchor_year is not None else current_rookie_draft_year(),
-        copy_rows=False,
-    )
-    return moved
-
-
 def build_rankings_delta_payload(
     raw_payload: dict[str, Any],
     *,
@@ -9764,7 +9733,6 @@ def build_rankings_delta_payload(
     source_overrides: dict[str, dict[str, Any]] | None = None,
     tep_multiplier: float | None = None,
     tep_native_multiplier: float | None = None,
-    valuation_factors: Mapping[str, float] | None = None,
 ) -> dict[str, Any]:
     """Build a compact delta contract for the rankings-override endpoint.
 
@@ -9810,17 +9778,15 @@ def build_rankings_delta_payload(
         _for_delta=True,
     )
 
-    # League-adjusted composition.  Applied AFTER the override pipeline
-    # has produced the re-weighted board, so the factors land on the
-    # user's own consensus values and the re-rank is over that board —
-    # not over the default one.  ``full`` is freshly built and owned by
-    # this call, so mutating its rows is safe.
-    valuation_adjusted_count = 0
-    if valuation_factors:
-        valuation_adjusted_count = apply_valuation_factors(
-            full.get("playersArray") or [],
-            valuation_factors,
-        )
+    # NO league-adjusted composition.  This used to multiply per-player
+    # factors into ``rankDerivedValue`` here so the endpoint could serve
+    # a board that was both re-weighted and league-adjusted.  #822
+    # rejected that methodology for promotion to canonical and ruled it
+    # may not own a canonical field; B9a closed this last path, where the
+    # ±25% bound sat on the FACTOR and never on the PRODUCT, so canonical
+    # values left their declared 1-9999 range (measured: 10,160 on the
+    # real factor set, 12,471 at the cap).  See
+    # ``tests/api/test_canonical_value_scale_contract.py``.
 
     delta_players: list[dict[str, Any]] = []
     active_ids: list[str] = []
@@ -9854,16 +9820,6 @@ def build_rankings_delta_payload(
         "dataSource": full.get("dataSource"),
         "playerCount": full.get("playerCount"),
     }
-    if valuation_factors is not None:
-        # Stamped whether or not anything moved.  "the lens was applied
-        # and moved nothing" and "the lens was never applied" are
-        # different states, and a client that cannot tell them apart
-        # will render one as the other.
-        payload["valuationAdjustment"] = {
-            "applied": True,
-            "adjustedCount": valuation_adjusted_count,
-            "factorCount": len(valuation_factors),
-        }
     warnings = full.get("warnings")
     if warnings:
         payload["warnings"] = list(warnings)
@@ -10162,6 +10118,53 @@ def validate_api_data_contract(payload: dict[str, Any]) -> dict[str, Any]:
             f"outside the range of their own source contributions "
             f"({', '.join(integrity_violations[:6])}"
             f"{', …' if len(integrity_violations) > 6 else ''})"
+        )
+
+    # ── Scale contract (B9a) ──
+    #
+    # ``methodology.formula`` PUBLISHES ``scaleMin: 1`` / ``scaleMax: 9999``,
+    # and the expression it publishes clamps to that range — but nothing
+    # verified the board honoured it.  9,999 is the Hill ASYMPTOTE, so a
+    # canonical value above it is not an unusually good asset; it is a
+    # number the curve that defines the scale cannot produce.
+    #
+    # It was reachable.  ``POST /api/rankings/overrides?view=delta`` with
+    # ``valuation_mode: "leagueAdjusted"`` multiplied a per-position factor
+    # into ``rankDerivedValue`` with the ±25% bound on the FACTOR and never
+    # on the PRODUCT — 10,160 on the real factor set, 12,471 at the cap.
+    # That path is gone; this is what makes its return visible instead of
+    # silent, whatever future code introduces it.
+    #
+    # An ERROR, not a warning, for the same reason blend integrity is one:
+    # ``scripts/validate_api_contract.py`` gates on ``ok`` and ignores
+    # warnings.  Whole array, not the ``[:1000]`` prefix the shape checks
+    # use — the top of the board is exactly where a ceiling breach lands.
+    # The ALIASES are checked too: ``values.*`` are exact copies of the
+    # canonical value, so an alias out of range is the same defect wearing
+    # a different field name.
+    out_of_scale: list[str] = []
+    for i, row in enumerate(players_array):
+        if not isinstance(row, dict):
+            continue
+        label = str(row.get("displayName") or row.get("canonicalName") or f"index {i}")
+        candidates = [("rankDerivedValue", row.get("rankDerivedValue"))]
+        row_values = row.get("values")
+        if isinstance(row_values, dict):
+            candidates.extend(
+                (f"values.{k}", row_values.get(k))
+                for k in ("overall", "finalAdjusted", "displayValue")
+            )
+        for field, value in candidates:
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                continue
+            if not (_CANONICAL_VALUE_MIN <= value <= _CANONICAL_VALUE_MAX):
+                out_of_scale.append(f"{label}.{field}={value}")
+    if out_of_scale:
+        errors.append(
+            f"canonical_value_out_of_scale:{len(out_of_scale)} value(s) outside "
+            f"{_CANONICAL_VALUE_MIN}..{_CANONICAL_VALUE_MAX} "
+            f"({', '.join(out_of_scale[:6])}"
+            f"{', …' if len(out_of_scale) > 6 else ''})"
         )
 
     idp_count = 0

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -8281,6 +8281,20 @@ def _compute_unified_rankings(
         row["canonicalConsensusRank"] = overall_rank
         row["canonicalTierId"] = _tier_id_from_rank(overall_rank)
         row["sourceCount"] = len(source_ranks)
+        # STANDING on the canonical board — 0-100, 100 = best (B9b).
+        #
+        # Published here because this is where the ranked pool exists.
+        # A consumer holding one row cannot compute it, and one holding a
+        # truncated board would compute a standing within the part it
+        # received and call it a percentile.  It is the scale-stable
+        # companion to ``rankDerivedValue``: a value means nothing
+        # without the distribution behind it, which is the defect class
+        # B9b exists to close.
+        row["canonicalPercentile"] = (
+            round(100.0 * (total_ranked - overall_rank) / (total_ranked - 1), 4)
+            if total_ranked > 1
+            else 100.0
+        )
 
         dropped_set = set(row.get("droppedSources") or [])
         effective_source_ranks = {k: v for k, v in source_ranks.items() if k not in dropped_set}
@@ -9677,6 +9691,12 @@ def build_api_data_contract(
 _DELTA_PLAYER_FIELDS: tuple[str, ...] = (
     "canonicalConsensusRank",
     "rankDerivedValue",
+    # Override-sensitive for the same reason the two fields above are:
+    # a standing is a function of the board, and re-weighting sources
+    # re-orders it.  Omitting it would merge an overridden rank and
+    # value onto the DEFAULT board's percentile — a row disagreeing with
+    # itself, which is the defect class B9 closes.
+    "canonicalPercentile",
     "sourceRanks",
     "sourceRankMeta",
     "sourceOriginalRanks",

--- a/src/api/trade_simulator.py
+++ b/src/api/trade_simulator.py
@@ -43,16 +43,17 @@ def _resolve_asset(
     name: str,
     *,
     row_index: dict[str, dict[str, Any]],
-    offense_only: bool = False,
 ) -> dict[str, Any] | None:
     """Resolve a single display name to a summary dict for the
     simulator output.  Matches ``terminal.py``'s rowValue semantics.
 
-    When ``offense_only`` is True and the row carries a pre-computed
-    ``offenseOnlyRankDerivedValue`` (set by the IDP-disabled pipeline
-    pre-pass), that value is used instead of the full-source
-    ``rankDerivedValue``.  This ensures trades involving only offense
-    players and picks aren't influenced by IDP source calibration.
+    One canonical value per asset.  This used to take an
+    ``offense_only`` flag and substitute a second, IDP-disabled board
+    whenever the trade being evaluated contained no defender — so the
+    same player was worth two different numbers in one league on one
+    day, and the substitution reached the manager's entire untraded
+    roster as well as the legs being traded.  See W29-F001 and
+    ``tests/api/test_one_canonical_value_per_asset.py``.
     """
     if not name:
         return None
@@ -60,11 +61,7 @@ def _resolve_asset(
     row = row_index.get(key)
     if not row:
         return None
-    if offense_only:
-        oo = row.get("offenseOnlyRankDerivedValue")
-        value = int(oo) if isinstance(oo, (int, float)) and oo > 0 else int(_row_value(row))
-    else:
-        value = int(_row_value(row))
+    value = int(_row_value(row))
     pos = _normalize_pos(row.get("pos") or row.get("position"))
     age = row.get("age")
     # ``pos`` collapses DL/LB/DB to "IDP" for terminal aggregation;
@@ -182,37 +179,15 @@ def simulate_trade(
         }
         current_players = [str(p) for p in (resolved_team.get("players") or [])]
 
-    # Determine whether any asset in the trade is an IDP player.
-    # When the entire trade is offense + picks, use offense-only values
-    # that exclude IDP source calibration from the blend.
-    # Only applies when at least one asset is being traded — empty
-    # requests must resolve before/after with the same full-board values
-    # as the terminal panel (parity requirement).
-    all_trade_names = [*players_in, *players_out, *picks_in, *picks_out]
-    # Only activate offense-only mode when at least one name resolves to
-    # a known row.  A request where every name is unresolvable (e.g. all
-    # typos) should still return full-board before/after totals that match
-    # the terminal panel, not offense-only baselines.
-    trade_has_resolved = any(
-        row_index.get(n.strip().lower()) is not None for n in all_trade_names if n.strip()
-    )
-    trade_has_idp = trade_has_resolved and any(
-        _normalize_pos(
-            (row_index.get(n.strip().lower()) or {}).get("pos")
-            or (row_index.get(n.strip().lower()) or {}).get("position")
-            or ""
-        )
-        == "IDP"
-        for n in all_trade_names
-        if n.strip()
-    )
-    offense_only = trade_has_resolved and not trade_has_idp
+    # Every asset resolves at its canonical board value, whatever else is
+    # in the trade.  The composition of the question being asked does not
+    # change what the assets are worth (W29-F001).
 
     def _resolve_many(names: list[str]) -> tuple[list[dict[str, Any]], list[str]]:
         resolved: list[dict[str, Any]] = []
         missing: list[str] = []
         for n in names:
-            hit = _resolve_asset(n, row_index=row_index, offense_only=offense_only)
+            hit = _resolve_asset(n, row_index=row_index)
             if hit is None:
                 missing.append(n)
             else:
@@ -222,7 +197,7 @@ def simulate_trade(
     # BEFORE state: the team's current roster + picks, resolved.
     before_assets: list[dict[str, Any]] = []
     for name in current_players:
-        hit = _resolve_asset(name, row_index=row_index, offense_only=offense_only)
+        hit = _resolve_asset(name, row_index=row_index)
         if hit is not None:
             before_assets.append(hit)
     current_picks = (
@@ -231,7 +206,7 @@ def simulate_trade(
         else []
     )
     for pick in current_picks:
-        hit = _resolve_asset(pick, row_index=row_index, offense_only=offense_only)
+        hit = _resolve_asset(pick, row_index=row_index)
         if hit is not None:
             before_assets.append(hit)
 

--- a/src/ros/api.py
+++ b/src/ros/api.py
@@ -126,13 +126,32 @@ async def get_player_values(limit: int = 500) -> JSONResponse:
     if not payload:
         return JSONResponse({"aggregatedAt": None, "players": [], "error": "no_aggregate"})
     players = payload.get("players") or []
+
+    # ``rosPercentile`` is stamped HERE, over the whole pool, because
+    # this is the only place the whole pool exists.  The response is
+    # truncated to ``limit`` (500 by default) immediately below, so a
+    # client that ranked what it received would be measuring a standing
+    # within the top half of the board and calling it a percentile.
+    #
+    # It exists because the ROS context tags gate on STANDING, not on
+    # the raw 0-100 ``rosValue`` index — whose median is 9.15 and whose
+    # 99th percentile is 59.41, so the old ``rosValue >= 60`` "strong"
+    # gate selected 0.87% of the pool and its complement labelled 99.13%
+    # of players "Injury/bye cover" (B9b).
+    from src.ros.tags import ros_percentiles  # noqa: PLC0415 — avoids an import cycle
+
+    percentiles = ros_percentiles([p.get("rosValue") for p in players])
+    stamped = [
+        {**p, "rosPercentile": pct} for p, pct in zip(players, percentiles) if isinstance(p, dict)
+    ]
+
     return JSONResponse(
         {
             "aggregatedAt": payload.get("aggregatedAt"),
             "league": payload.get("league"),
             "playerCount": payload.get("playerCount") or len(players),
             "sourceCount": payload.get("sourceCount"),
-            "players": players[: max(1, min(limit, len(players)))],
+            "players": stamped[: max(1, min(limit, len(stamped)))],
         }
     )
 

--- a/src/ros/tags.py
+++ b/src/ros/tags.py
@@ -22,7 +22,9 @@ trade math, no changes to dynasty values.
 
 from __future__ import annotations
 
+from typing import Sequence
 
+from src.api.thresholds import threshold
 from src.ros.direction import _is_veteran
 
 
@@ -35,8 +37,9 @@ def tags_for_player(
     position: str | None,
     age: int | float | None,
     ros_value: float | None,
+    ros_percentile: float | None = None,
     ros_rank_overall: int | None = None,
-    dynasty_value: float | None = None,
+    dynasty_percentile: float | None = None,
     confidence: float | None = None,
     volatility_flag: bool = False,
 ) -> list[str]:
@@ -44,15 +47,28 @@ def tags_for_player(
 
     No tag fires when ``ros_value`` is None or zero (player isn't
     ranked by any ROS source) — that's a read failure, not a meaningful
-    label.
+    label.  Nor when ``ros_percentile`` is missing: every strength gate
+    below is a STANDING within the ROS pool, and a standing cannot be
+    computed from one player.  Returning no tags is the honest answer;
+    guessing one from the raw index is what this function used to do.
+
+    ``ros_percentile`` and ``dynasty_percentile`` are 0–100 with 100 =
+    best, each measured within its OWN population.
     """
     if ros_value is None or ros_value <= 0:
         return []
+    if ros_percentile is None:
+        return []
+
+    elite_cut = float(threshold("ROS_ELITE_PERCENTILE"))
+    strong_cut = float(threshold("ROS_STRONG_PERCENTILE"))
+    depth_low = float(threshold("ROS_DEPTH_BAND_LOW_PERCENTILE"))
+    seller_gap = float(threshold("ROS_SELLER_PERCENTILE_GAP"))
 
     pos = (position or "").upper().split("/")[0]
     is_idp = pos in _IDP_POSITIONS
-    is_strong = ros_value >= 60.0  # 0-100 normalized scale
-    is_elite = ros_value >= 80.0
+    is_strong = ros_percentile >= strong_cut
+    is_elite = ros_percentile >= elite_cut
     is_starter_caliber = ros_rank_overall is not None and ros_rank_overall <= 100
     is_top_idp = is_idp and ros_rank_overall is not None and ros_rank_overall <= 50
     veteran = _is_veteran(pos, age)
@@ -68,16 +84,27 @@ def tags_for_player(
         tags.append("Win-now target")
     if is_elite and is_starter_caliber and not is_idp:
         tags.append("Contender upgrade")
-    if veteran and is_strong and dynasty_value is not None and dynasty_value < ros_value * 0.7:
+    if (
+        veteran
+        and is_strong
+        and dynasty_percentile is not None
+        and (ros_percentile - dynasty_percentile) >= seller_gap
+    ):
         # The dynasty market hasn't caught up to current ROS strength —
         # an aging vet with strong short-term value but weakening
         # long-term profile.  Sell window before regression.
+        #
+        # BOTH SIDES ARE STANDINGS.  This compared a 0-9999 dynasty board
+        # value against the 0-100 ROS index (``dynasty_value <
+        # ros_value * 0.7``), whose right-hand side maxes at 60.8 while
+        # the board's lowest priced value is 1,134 — so it could not fire
+        # for any of the 1,093 rows, and never had (W29-F005).
         tags.append("Seller cash-out")
     if young and not is_strong:
         tags.append("Rebuilder hold")
     if veteran and is_strong and not is_starter_caliber:
         tags.append("Avoid unless contending")
-    if not is_starter_caliber and ros_value >= 30 and ros_value < 60:
+    if not is_starter_caliber and depth_low <= ros_percentile < strong_cut:
         tags.append("Depth spike option")
     if volatility_flag and is_starter_caliber:
         tags.append("Best-ball boost")
@@ -89,6 +116,32 @@ def tags_for_player(
         tags.append("Injury/bye cover")
 
     return tags
+
+
+def ros_percentiles(values: Sequence[float | None]) -> list[float | None]:
+    """Standing within the ROS pool, 0–100, 100 = best.
+
+    Computed over the WHOLE pool and therefore only on the server:
+    ``/api/ros/player-values`` truncates to ``limit`` (500 by default),
+    so a client that ranked what it received would be measuring a
+    standing within the top half of the board and calling it a
+    percentile.
+
+    Rows without a positive value are not ranked and come back ``None``
+    — "unranked by every ROS source" is not "worst in the league".
+    """
+    ranked = sorted(
+        (i for i, v in enumerate(values) if isinstance(v, (int, float)) and v and v > 0),
+        key=lambda i: -float(values[i]),  # type: ignore[arg-type]
+    )
+    out: list[float | None] = [None] * len(values)
+    n = len(ranked)
+    if n == 1:
+        out[ranked[0]] = 100.0
+        return out
+    for position, idx in enumerate(ranked):
+        out[idx] = round(100.0 * (n - 1 - position) / (n - 1), 4)
+    return out
 
 
 def tag_descriptions() -> dict[str, str]:

--- a/src/trade/finder.py
+++ b/src/trade/finder.py
@@ -167,7 +167,6 @@ class Asset:
     is_pick: bool = False
     source_count: int = 0  # Number of valuation sources
     market_rank: int | None = None  # 1-based rank WITHIN this asset's market
-    offense_only_model_value: int | None = None  # model_value excluding IDP sources
     market_source: str | None = None  # "ktcSfTep" | "ktc" | "idpTradeCalc"
 
     @property
@@ -234,8 +233,6 @@ class TradeCandidate:
         return sorted(seen)
 
     def to_dict(self) -> dict[str, Any]:
-        trade_has_idp = any(a.position in IDP_POSITIONS for a in [*self.give, *self.receive])
-
         def _asset_dict(a: Asset) -> dict[str, Any]:
             d: dict[str, Any] = {
                 "name": a.name,
@@ -245,9 +242,6 @@ class TradeCandidate:
                 "ktcValue": a.ktc_value,
                 "ktcRank": a.ktc_rank,
             }
-            if not trade_has_idp and a.offense_only_model_value is not None:
-                d["modelValue"] = a.offense_only_model_value
-                d["modelValueFull"] = a.model_value
             return d
 
         return {
@@ -475,24 +469,6 @@ def build_asset_pool(
             model = board_values.get(name)
             if model is None or model < 1:
                 continue
-            # Offense-only board value.  ``_offenseOnlyFinalAdjusted`` is
-            # mirrored from ``offenseOnlyRankDerivedValue`` — the output of
-            # the IDP-disabled run of ``_compute_unified_rankings``
-            # (data_contract.py) — so it is on the BOARD scale, the same
-            # scale as ``model`` here.  ``_score_trade`` substitutes one
-            # for the other inside a single subtraction, so sharing a
-            # scale is the correctness requirement, and it is met.
-            #
-            # Corrected 2026-07-29 audit: this branch previously forced
-            # ``oo_raw = None`` on the reasoning that "the board has no
-            # offense-only variant".  It does — measured over 522 assets
-            # carrying both, median ``_offenseOnlyFinalAdjusted /
-            # rankDerivedValue`` = 0.994 (p10 0.893, p90 1.015), i.e. the
-            # same scale.  The composite, by contrast, runs 1.131× the
-            # board.  So the two branches had their scales exactly
-            # backwards: the offense-only feature was dead on the live
-            # path, and the fallback below was the one mixing scales.
-            oo_raw = _int_or_none(pdata.get("_offenseOnlyFinalAdjusted"))
         else:
             # Legacy path: raw scraper composite.
             model = _int_or_none(pdata.get("_finalAdjusted"))
@@ -504,19 +480,6 @@ def build_asset_pool(
                 model = _int_or_none(pdata.get("_composite"))
             if model is None or model < 1:
                 continue
-
-            # No offense-only value on this path.  The only producer of
-            # ``_offenseOnlyFinalAdjusted`` is the contract builder, which
-            # mirrors the BOARD-scale ``offenseOnlyRankDerivedValue`` into
-            # it — while ``model`` here is the COMPOSITE-scale scraper
-            # value, measured at 1.131× the board.  ``_score_trade``
-            # substitutes one for the other inside one subtraction, so
-            # reading it here understated every all-offense give/receive
-            # leg by ~12% whenever a caller passed a contract-built
-            # players dict without the contract itself.  Degrading to
-            # "unavailable" is the honest behaviour on this path — the
-            # rationale that used to sit on the board branch above.
-            oo_raw = None
 
             if source_count == 1:
                 model = int(model * _LEGACY_SINGLE_SOURCE_DISCOUNT)
@@ -571,7 +534,6 @@ def build_asset_pool(
                 market_value=market_value,
                 is_pick=is_pick,
                 source_count=source_count,
-                offense_only_model_value=oo_raw if oo_raw is not None and oo_raw >= 1 else None,
                 market_source=market_source,
             )
         )
@@ -680,14 +642,11 @@ def _score_trade(give: list[Asset], receive: list[Asset]) -> TradeCandidate | No
     # documenting a world the filter had deleted.  Removed rather than
     # left as dead code.
 
-    # Use offense-only model values when neither side has IDP players.
-    # This excludes IDP source calibration from trade scoring so that
-    # an all-offense trade isn't influenced by IDP-relative rankings.
-    trade_has_idp = any(a.position in IDP_POSITIONS for a in [*give, *receive])
-
+    # One canonical value per asset.  ``_mv`` used to substitute a
+    # second, IDP-disabled board whenever neither side held a defender
+    # (W29-F001), so an asset's model value depended on the composition
+    # of the trade it appeared in.
     def _mv(a: Asset) -> int:
-        if not trade_has_idp and a.offense_only_model_value is not None:
-            return a.offense_only_model_value
         return a.model_value
 
     give_model = sum(_mv(a) for a in give)

--- a/src/trade/suggestions.py
+++ b/src/trade/suggestions.py
@@ -285,7 +285,6 @@ class PlayerAsset:
     universe: str = ""
     dispersion_cv: float | None = None
     board_rank: int | None = None  # 1-based rank on OUR blended board
-    offense_only_value: int | None = None  # display_value excluding IDP sources
 
     @property
     def ktc_rank(self) -> int | None:
@@ -646,11 +645,6 @@ def build_asset_pool_from_contract(
                 except (TypeError, ValueError):
                     years_exp = None
 
-        oo_rdv = row.get("offenseOnlyRankDerivedValue")
-        oo_int: int | None = None
-        if isinstance(oo_rdv, (int, float)) and oo_rdv > 0:
-            oo_int = int(oo_rdv)
-
         pool.append(
             PlayerAsset(
                 name=name,
@@ -663,7 +657,6 @@ def build_asset_pool_from_contract(
                 years_exp=years_exp,
                 universe=_universe_from_row(row),
                 dispersion_cv=round(dispersion, 4) if dispersion is not None else None,
-                offense_only_value=oo_int,
             )
         )
     pool.sort(key=lambda x: -x.display_value)
@@ -780,19 +773,17 @@ def analyze_roster(
     )
 
 
-def _eff_val(p: PlayerAsset, offense_only: bool) -> int:
-    """Return the effective value for a player in the context of a trade.
-
-    When ``offense_only`` is True and the player carries a pre-computed
-    offense-only value, that value is returned.  This ensures trades
-    with no IDP players are not influenced by IDP source calibration.
-    """
-    if offense_only and p.offense_only_value is not None:
-        return p.offense_only_value
-    return p.display_value
-
-
 def _trade_is_idp_free(give: list[PlayerAsset], receive: list[PlayerAsset]) -> bool:
+    """Whether a proposed trade contains no IDP asset.
+
+    A UNIVERSE predicate only.  It decides which assets are eligible to
+    be offered — see the consolidation search, which will not offer an
+    IDP target into an all-offense pair.  It must never decide what an
+    asset is WORTH: ``_eff_val`` used to consult it and return a second,
+    IDP-disabled board value instead of ``display_value``, which made
+    one player worth two different numbers in one league on one day
+    (W29-F001).
+    """
     return all(p.position not in _IDP_BASE_POSITIONS for p in [*give, *receive])
 
 
@@ -1053,27 +1044,21 @@ def _generate_sell_high(
 
         for sell in sell_candidates[:3]:
             for need_pos in roster.need_positions:
-                # Pre-compute oo so target filtering and sorting use the same
-                # value scale as the gap calculation below.
-                trade_oo = (
-                    sell.position not in _IDP_BASE_POSITIONS and need_pos not in _IDP_BASE_POSITIONS
-                )
-                sell_ev = _eff_val(sell, trade_oo)
+                sell_ev = sell.display_value
                 targets = [
                     a
                     for a in asset_pool
                     if a.position == need_pos
                     and a.name.lower() not in roster_names_set
-                    and _eff_val(a, trade_oo) >= MIN_RELEVANT_VALUE
-                    and abs(_eff_val(a, trade_oo) - sell_ev) < FAIRNESS_TOLERANCE
+                    and a.display_value >= MIN_RELEVANT_VALUE
+                    and abs(a.display_value - sell_ev) < FAIRNESS_TOLERANCE
                 ]
                 if not targets:
                     continue
-                targets.sort(key=lambda t: abs(_eff_val(t, trade_oo) - sell_ev))
+                targets.sort(key=lambda t: abs(t.display_value - sell_ev))
                 target = targets[0]
-                oo = _trade_is_idp_free([sell], [target])
-                give_val = _eff_val(sell, oo)
-                recv_val = _eff_val(target, oo)
+                give_val = sell.display_value
+                recv_val = target.display_value
                 gap = _va_gap([give_val], [recv_val])
                 suggestions.append(
                     TradeSuggestion(
@@ -1109,9 +1094,8 @@ def _generate_buy_low(
     for need_pos in roster.need_positions:
         # Pre-compute target-side oo from need_pos so candidate gating
         # uses the same value scale as the final gap calculation.
-        pos_oo = need_pos not in _IDP_BASE_POSITIONS
         current = roster.by_position.get(need_pos, [])
-        current_best = _eff_val(current[0], pos_oo) if current else 0
+        current_best = current[0].display_value if current else 0
         target_floor = max(MIN_RELEVANT_VALUE, current_best)
 
         targets = [
@@ -1119,7 +1103,7 @@ def _generate_buy_low(
             for a in asset_pool
             if a.position == need_pos
             and a.name.lower() not in roster_names_set
-            and _eff_val(a, pos_oo) > target_floor
+            and a.display_value > target_floor
         ]
         if not targets:
             continue
@@ -1130,9 +1114,8 @@ def _generate_buy_low(
                 need = DEFAULT_STARTER_NEEDS.get(surplus_pos, 1)
                 tradeable = [p for p in depth[need:] if p.display_value >= MIN_RELEVANT_VALUE]
                 for sell in tradeable[:2]:
-                    oo = _trade_is_idp_free([sell], [target])
-                    give_val = _eff_val(sell, oo)
-                    recv_val = _eff_val(target, oo)
+                    give_val = sell.display_value
+                    recv_val = target.display_value
                     gap = _va_gap([give_val], [recv_val])
                     if abs(gap) < FAIRNESS_TOLERANCE:
                         suggestions.append(
@@ -1194,36 +1177,39 @@ def _generate_consolidation(
                 continue
             tried.add(pair_key)
 
-            # Pre-compute oo from the give side so range filtering and
-            # sorting use the same value scale as the final gap calc.
-            pair_oo = _trade_is_idp_free([p1, p2], [])
-            combined = _eff_val(p1, pair_oo) + _eff_val(p2, pair_oo)
+            # A UNIVERSE restriction, not a value one.  Its original
+            # justification — keeping the target on the same value scale
+            # as the give side — died with the offense-only board: there
+            # is one scale now, so nothing can flip.  It is kept because
+            # dropping it would start offering IDP consolidation targets
+            # for all-offense pairs, which is a recommendation-surface
+            # product decision and not a B9a correctness fix.  Recorded
+            # in the deferred ledger for owner decision.
+            pair_is_offense_only = _trade_is_idp_free([p1, p2], [])
+            combined = p1.display_value + p2.display_value
             min_target = int(combined * CONSOLIDATION_MIN_UPGRADE_RATIO)
             max_target = combined + FAIRNESS_TOLERANCE
-            give_max = max(_eff_val(p1, pair_oo), _eff_val(p2, pair_oo))
+            give_max = max(p1.display_value, p2.display_value)
 
             for prefer_need in [True, False]:
                 targets = [
                     a
                     for a in asset_pool
                     if a.name.lower() not in roster_names_set
-                    and min_target <= _eff_val(a, pair_oo) <= max_target
-                    and _eff_val(a, pair_oo) > give_max
-                    # When the give pair is offense-only, restrict to offense
-                    # targets so pair_oo matches the final oo (no scale flip).
-                    and (not pair_oo or a.position not in _IDP_BASE_POSITIONS)
+                    and min_target <= a.display_value <= max_target
+                    and a.display_value > give_max
+                    and (not pair_is_offense_only or a.position not in _IDP_BASE_POSITIONS)
                     and (not prefer_need or a.position in roster.need_positions)
                 ]
                 if not targets:
                     continue
                 # Pick the closest-value target (smallest gap) rather than
                 # the most expensive one.  This produces fairer packages.
-                targets.sort(key=lambda t: abs(combined - _eff_val(t, pair_oo)))
+                targets.sort(key=lambda t: abs(combined - t.display_value))
                 target = targets[0]
-                oo = _trade_is_idp_free([p1, p2], [target])
-                give_p1, give_p2 = _eff_val(p1, oo), _eff_val(p2, oo)
+                give_p1, give_p2 = p1.display_value, p2.display_value
                 give_total = give_p1 + give_p2
-                recv_total = _eff_val(target, oo)
+                recv_total = target.display_value
                 gap = _va_gap([give_p1, give_p2], [recv_total])
                 pos_note = (
                     f" at a position of need ({target.position})"
@@ -1271,14 +1257,12 @@ def _generate_positional_upgrades(
 
         starters = players[:need]
         # pos is always an offense position in DEFAULT_STARTER_NEEDS; using
-        # pos_oo=True means IDP sweeteners fall back to display_value safely.
-        pos_oo = pos not in _IDP_BASE_POSITIONS
-        depth = [p for p in players[need:] if _eff_val(p, pos_oo) >= MIN_RELEVANT_VALUE]
+        depth = [p for p in players[need:] if p.display_value >= MIN_RELEVANT_VALUE]
         if not starters or not depth:
             continue
 
         weakest_starter = starters[-1]
-        ws_ev = _eff_val(weakest_starter, pos_oo)
+        ws_ev = weakest_starter.display_value
         upgrade_floor = ws_ev + 500
 
         targets = [
@@ -1286,19 +1270,19 @@ def _generate_positional_upgrades(
             for a in asset_pool
             if a.position == pos
             and a.name.lower() not in roster_names_set
-            and _eff_val(a, pos_oo) >= upgrade_floor
+            and a.display_value >= upgrade_floor
         ]
         if not targets:
             continue
 
-        targets.sort(key=lambda t: _eff_val(t, pos_oo))  # closest upgrade first
+        targets.sort(key=lambda t: t.display_value)  # closest upgrade first
         for target in targets[:5]:
-            gap_needed = _eff_val(target, pos_oo) - ws_ev
+            gap_needed = target.display_value - ws_ev
             sweeteners = [
                 p
                 for p in depth
                 if p.name != weakest_starter.name
-                and abs(_eff_val(p, pos_oo) - gap_needed) < FAIRNESS_TOLERANCE
+                and abs(p.display_value - gap_needed) < FAIRNESS_TOLERANCE
             ]
             if not sweeteners:
                 # Widen tolerance for surplus-position sweeteners — these
@@ -1308,19 +1292,18 @@ def _generate_positional_upgrades(
                     sp_depth = roster.by_position.get(sp, [])
                     sp_need = DEFAULT_STARTER_NEEDS.get(sp, 1)
                     for p in sp_depth[sp_need:]:
-                        sp_ev = _eff_val(p, pos_oo)
+                        sp_ev = p.display_value
                         if sp_ev >= MIN_RELEVANT_VALUE and abs(sp_ev - gap_needed) < surplus_tol:
                             sweeteners.append(p)
             if not sweeteners:
                 continue
 
-            sweeteners.sort(key=lambda s: abs(_eff_val(s, pos_oo) - gap_needed))
+            sweeteners.sort(key=lambda s: abs(s.display_value - gap_needed))
             sweetener = sweeteners[0]
-            oo = _trade_is_idp_free([weakest_starter, sweetener], [target])
-            give_ws = _eff_val(weakest_starter, oo)
-            give_sw = _eff_val(sweetener, oo)
+            give_ws = weakest_starter.display_value
+            give_sw = sweetener.display_value
             give_total = give_ws + give_sw
-            recv_total = _eff_val(target, oo)
+            recv_total = target.display_value
             gap = _va_gap([give_ws, give_sw], [recv_total])
 
             if abs(gap) > FAIRNESS_TOLERANCE * 1.5:
@@ -1757,16 +1740,17 @@ def generate_suggestions(
 # ── Serializers ──────────────────────────────────────────────────────
 
 
-def _serialize_player(p: PlayerAsset, *, offense_only: bool = False) -> dict[str, Any]:
-    dv = (
-        p.offense_only_value
-        if offense_only and p.offense_only_value is not None
-        else p.display_value
-    )
+def _serialize_player(p: PlayerAsset) -> dict[str, Any]:
+    """``displayValue`` is the canonical board value, always.
+
+    It used to carry a second, IDP-disabled board whenever the trade
+    contained no defender — two value concepts under one canonical field
+    name, with nothing on the wire saying which was which (W29-F001).
+    """
     result: dict[str, Any] = {
         "name": p.name,
         "position": p.position,
-        "displayValue": dv,
+        "displayValue": p.display_value,
         "team": p.team,
         "rookie": p.rookie,
     }
@@ -1782,11 +1766,10 @@ def _serialize_player(p: PlayerAsset, *, offense_only: bool = False) -> dict[str
 def _serialize_suggestion(
     s: TradeSuggestion, roster: RosterAnalysis | None = None
 ) -> dict[str, Any]:
-    oo = _trade_is_idp_free(s.give, s.receive)
     result: dict[str, Any] = {
         "type": s.type,
-        "give": [_serialize_player(p, offense_only=oo) for p in s.give],
-        "receive": [_serialize_player(p, offense_only=oo) for p in s.receive],
+        "give": [_serialize_player(p) for p in s.give],
+        "receive": [_serialize_player(p) for p in s.receive],
         "giveTotal": s.give_total,
         "receiveTotal": s.receive_total,
         "gap": s.gap,
@@ -1800,7 +1783,7 @@ def _serialize_suggestion(
     result["rankScore"] = rank_score_breakdown(s, roster)
     balancers = s.__dict__.get("balancers", [])
     if balancers:
-        result["suggestedBalancers"] = [_serialize_player(b, offense_only=oo) for b in balancers]
+        result["suggestedBalancers"] = [_serialize_player(b) for b in balancers]
         bal_side = s.__dict__.get("balancer_side", "")
         if bal_side:
             result["balancerSide"] = bal_side

--- a/tests/api/test_canonical_value_scale_contract.py
+++ b/tests/api/test_canonical_value_scale_contract.py
@@ -1,0 +1,211 @@
+"""The canonical value scale is a contract, and it is enforced — B9a.
+
+WHAT A CANONICAL VALUE IS
+─────────────────────────
+``rankDerivedValue`` is a position on the canonical dynasty board.  Its
+range is set by the Hill family the board is built from::
+
+    V(p) = 9999 / (1 + (p/c)^s)
+
+9,999 is the ASYMPTOTE — the value an infinitely good asset would
+approach and never reach.  So the scale's declared range is
+``1 … 9999``, and a published canonical value outside it is not an
+unusually good player; it is a number that the curve which defines the
+scale cannot produce.  Today's board tops out at 9,977.
+
+WHY THIS FILE EXISTS
+────────────────────
+#822 rejected the league-aware methodology for promotion to canonical
+and ruled that it "may no longer own a canonical field".  It closed the
+engine path (``server.py::_valuation_scoped_contract`` ignores a stored
+``leagueAdjusted`` and serves market) and moved
+``league_intel.overlay`` onto ``experimentalLeagueAdjusted*`` names.
+
+One path was left open: ``POST /api/rankings/overrides?view=delta`` with
+``valuation_mode: "leagueAdjusted"`` still built factors and handed them
+to ``build_rankings_delta_payload``, whose ``apply_valuation_factors``
+multiplied them straight into ``rankDerivedValue`` — the canonical field
+— with the ±25% cap applied to the FACTOR and never to the PRODUCT.
+
+Measured on the 2026-08-14 board before the repair:
+
+===================  ==========================  ================
+factor               max canonical value on wire  rows above 9999
+===================  ==========================  ================
+1.018366 (measured)  10,160                       2
+1.25 (the cap)       12,471                      16
+===================  ==========================  ================
+
+Two defects in one expression, and the second is the worse of them: a
+board the product does not offer and the owner did not approve was
+still reachable under the canonical field name.
+
+These tests assert the CONTRACT — canonical values stay inside the scale
+that defines them — rather than the absence of one multiply, so they
+survive any future re-opening of a validated league-aware methodology.
+That methodology would have to renormalise onto the scale, which is one
+of the seven reasons this one was rejected.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+from src.api.data_contract import build_api_data_contract, build_rankings_delta_payload
+
+#: The Hill asymptote.  Not a tunable — it is the numerator of the curve
+#: that defines the scale (``src/canonical/player_valuation.py``).
+CANONICAL_VALUE_MAX = 9999
+CANONICAL_VALUE_MIN = 1
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+
+def _raw_export() -> dict:
+    candidates = sorted((REPO / "exports" / "latest").glob("dynasty_data*.json"), reverse=True)
+    if not candidates:
+        pytest.skip("no export available in this environment")
+    return json.loads(candidates[0].read_text(encoding="utf-8"))
+
+
+def _canonical_values(rows) -> list[tuple[str, int]]:
+    out = []
+    for row in rows:
+        value = row.get("rankDerivedValue")
+        name = row.get("displayName") or row.get("id") or row.get("canonicalName")
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            out.append((str(name), int(value)))
+    return out
+
+
+def _assert_in_range(pairs, *, where: str) -> None:
+    bad = [p for p in pairs if not (CANONICAL_VALUE_MIN <= p[1] <= CANONICAL_VALUE_MAX)]
+    assert not bad, (
+        f"{len(bad)} canonical values outside 1..{CANONICAL_VALUE_MAX} on {where}, "
+        f"e.g. {bad[:5]}"
+    )
+
+
+class TestTheDefaultBoardHonoursItsOwnScale:
+    def test_full_contract(self):
+        contract = build_api_data_contract(_raw_export())
+        pairs = _canonical_values(contract["playersArray"])
+        assert pairs, "no priced rows — the assertion would be vacuous"
+        _assert_in_range(pairs, where="the full contract")
+
+    def test_the_canonical_aliases_agree_with_the_canonical_value(self):
+        """``values.overall`` / ``finalAdjusted`` / ``displayValue`` are
+        exact aliases (#822 measured them equal on all 1,092 rows).  An
+        alias outside the range would be the same defect wearing a
+        different field name."""
+        contract = build_api_data_contract(_raw_export())
+        for row in contract["playersArray"]:
+            values = row.get("values")
+            canonical = row.get("rankDerivedValue")
+            if not isinstance(values, dict) or not isinstance(canonical, (int, float)):
+                continue
+            for alias in ("overall", "finalAdjusted", "displayValue"):
+                seen = values.get(alias)
+                if isinstance(seen, (int, float)) and not isinstance(seen, bool):
+                    assert CANONICAL_VALUE_MIN <= seen <= CANONICAL_VALUE_MAX
+                    assert int(seen) == int(canonical)
+
+
+class TestTheOverrideDeltaCannotPublishAnOutOfScaleCanonicalValue:
+    """The wire shape ``/rankings`` actually consumes."""
+
+    def test_the_plain_override_delta_is_in_range(self):
+        payload = build_rankings_delta_payload(_raw_export())
+        pairs = _canonical_values(payload["rankingsDelta"]["players"])
+        assert pairs
+        _assert_in_range(pairs, where="the override delta")
+
+    def test_the_builder_has_no_seam_for_a_non_canonical_repricing(self):
+        """The regression proper, made structural.
+
+        The breach was not a bad bound — it was that a rejected
+        methodology could reach ``rankDerivedValue`` at all.  A range
+        check alone would have passed the day someone added a factor
+        source that happened to stay under 9,999 while still publishing
+        a board the owner never approved.  So the assertion is that the
+        seam is gone: ``build_rankings_delta_payload`` takes no factor
+        argument, and ``apply_valuation_factors`` no longer exists.
+        """
+        import inspect
+
+        from src.api import data_contract
+
+        params = inspect.signature(build_rankings_delta_payload).parameters
+        assert not [
+            p for p in params if "valuation" in p or "factor" in p
+        ], f"the delta builder still accepts a repricing argument: {sorted(params)}"
+        assert not hasattr(data_contract, "apply_valuation_factors"), (
+            "the canonical-field composition helper is still importable, so a "
+            "caller can reintroduce the breach without touching this module"
+        )
+
+    def test_the_validator_catches_an_out_of_scale_value(self):
+        """The check must not be vacuous.
+
+        ``validate_api_data_contract`` returns ``ok: True`` on the live
+        board, which is what we want and also exactly what a check that
+        never fires would return.  So inject the breach and require the
+        gate to open — ``scripts/validate_api_contract.py`` keys on
+        ``ok``, so this is what turns a ceiling breach into a red CI run
+        rather than a silently published board.
+        """
+        from src.api.data_contract import validate_api_data_contract
+
+        contract = build_api_data_contract(_raw_export())
+        assert validate_api_data_contract(contract)["ok"] is True
+
+        for row in contract["playersArray"]:
+            if isinstance(row.get("rankDerivedValue"), int):
+                row["rankDerivedValue"] = 12471  # the old cap-case value
+                break
+
+        report = validate_api_data_contract(contract)
+        assert report["ok"] is False
+        assert any("canonical_value_out_of_scale" in e for e in report["errors"]), report["errors"]
+
+    def test_the_validator_catches_an_out_of_scale_alias(self):
+        """``values.*`` are exact copies, so they are the same defect."""
+        from src.api.data_contract import validate_api_data_contract
+
+        contract = build_api_data_contract(_raw_export())
+        for row in contract["playersArray"]:
+            values = row.get("values")
+            if isinstance(values, dict) and isinstance(values.get("displayValue"), int):
+                values["displayValue"] = 12471
+                break
+
+        report = validate_api_data_contract(contract)
+        assert report["ok"] is False
+        assert any("canonical_value_out_of_scale" in e for e in report["errors"])
+
+    def test_the_published_scale_is_the_scale_that_is_enforced(self):
+        """A contract that advertises a range it is not held to is worse
+        than one that advertises nothing."""
+        from src.api import data_contract
+
+        formula = build_api_data_contract(_raw_export())["methodology"]["formula"]
+        assert formula["scaleMin"] == data_contract._CANONICAL_VALUE_MIN == CANONICAL_VALUE_MIN
+        assert formula["scaleMax"] == data_contract._CANONICAL_VALUE_MAX == CANONICAL_VALUE_MAX
+
+    def test_the_factor_bound_was_never_the_protection(self):
+        """Documents WHY the bound could not have been the fix.
+
+        ``_clamp(combined, lo, hi)`` bounds the FACTOR.  A factor inside
+        ±25% still carries any base value above 7,999 out of range, and
+        the board's own top row is 9,977 — so on the real board the
+        bound permitted a breach at any factor above ~1.0022.
+        """
+        top_of_board = 9977
+        smallest_breaching_factor = (CANONICAL_VALUE_MAX + 1) / top_of_board
+        assert smallest_breaching_factor < 1.25, (
+            "if the factor cap were tighter than the first breaching factor the "
+            "bound would have been sufficient and this finding would not exist"
+        )

--- a/tests/api/test_league_adjusted_endpoint.py
+++ b/tests/api/test_league_adjusted_endpoint.py
@@ -453,19 +453,26 @@ def test_an_empty_players_array_is_a_clean_noop(league, monkeypatch):  # noqa: F
     assert body["playerCount"] == 0
 
 
-# ── 4. Server-side composition on POST /api/rankings/overrides ───────
+# ── 4. The withdrawn lens on POST /api/rankings/overrides ────────────
 #
-# Custom source weights + the league lens used to be refused. The
-# refusal was correct — the overlay's ranks belong to the un-overridden
-# board — but it meant a user with any custom weight silently lost the
-# lens. The composition now happens server-side.
+# This section used to pin SERVER-SIDE COMPOSITION: custom source
+# weights combined with the league lens, composed on the server because
+# the client cannot (the overlay's ranks belong to the un-overridden
+# board). #822 then rejected the league-aware methodology for promotion
+# to canonical and ruled it may not own a canonical field, closing the
+# engine gate and moving the overlay onto experimental field names.
 #
-# The scope consequence is the subtle part and is what these pin:
-# rankings follow the SCORING PROFILE and are shared across leagues,
-# but scarcity is measured from ONE league's rosters. So asking for the
-# lens narrows a shared response into a league-scoped one, and the
-# endpoint has to start enforcing the stricter rule for that request
-# only.
+# This path was left composing factors straight into
+# ``rankDerivedValue``, with the +/-25% bound on the FACTOR and never on
+# the PRODUCT — so canonical values left their declared 1-9999 range
+# (measured on the 2026-08-14 board: 10,160 on the real factor set,
+# 12,471 at the cap). B9a closed it, and these tests now pin the
+# withdrawal instead of the composition.
+#
+# The scope consequence inverted with it. Asking for the lens used to
+# narrow a scoring-profile-scoped response into a league-scoped one and
+# 503 on a mismatch. With nothing league-scoped left to compute, the
+# request no longer narrows anything, so it no longer 503s.
 
 
 def _raw_payload() -> dict:
@@ -473,10 +480,7 @@ def _raw_payload() -> dict:
 
     ``POST /api/rankings/overrides`` reads ``server.latest_data`` (the
     pre-contract scrape), not ``latest_contract_data`` — it re-runs the
-    whole pipeline rather than patching the built board. The player
-    names must match the league fixture's roster, or the scarcity
-    factors key off nothing and every composition assertion passes
-    vacuously against an empty adjustment.
+    whole pipeline rather than patching the built board.
     """
     players: dict[str, dict] = {}
     for row in _players_array():
@@ -517,13 +521,14 @@ def test_overrides_without_the_lens_stay_scoring_profile_scoped(league, monkeypa
     assert res.json()["meta"]["valuationMode"] == "market"
 
 
-def test_asking_for_the_lens_narrows_the_scope_to_one_league(league, monkeypatch):  # noqa: F811
-    """The same request that succeeds above must 503 once the lens is
-    requested — scarcity from `main`'s rosters is not `side`'s answer.
+def test_asking_for_the_lens_no_longer_narrows_the_scope(league, monkeypatch):  # noqa: F811
+    """Was a 503.
 
-    This is the assertion that makes the composition safe. Without it
-    the endpoint would happily hand league B a board priced by league
-    A's roster shape, which is worse than the refusal it replaced.
+    The 503 existed because scarcity measured from `main`'s rosters is
+    not `side`'s answer, so asking for the lens turned a shareable
+    response into a league-scoped one. Nothing league-scoped is computed
+    any more, so the request is simply ignored and the shared board is
+    served — the same convergence rule the engine gate uses.
     """
     with TestClient(server.app, raise_server_exceptions=True) as c:
         _install_contract(monkeypatch, league_key="main")
@@ -536,35 +541,14 @@ def test_asking_for_the_lens_narrows_the_scope_to_one_league(league, monkeypatch
                 "valuation_mode": "leagueAdjusted",
             },
         )
-    assert res.status_code == 503
-    body = res.json()
-    assert body["error"] == "data_not_ready"
-    assert body["leagueKey"] == "side"
-
-
-def test_the_composed_board_is_stamped_as_league_adjusted(league, monkeypatch):  # noqa: F811
-    with TestClient(server.app, raise_server_exceptions=True) as c:
-        _install_contract(monkeypatch)
-        _install_raw(monkeypatch)
-        res = _post(c, {"ktcSfTep": {"include": False}, "valuation_mode": "leagueAdjusted"})
     assert res.status_code == 200, res.text
-    body = res.json()
-    assert body["meta"]["valuationMode"] == "leagueAdjusted"
-    assert body["valuationAdjustment"]["applied"] is True
-    assert body["valuationAdjustment"]["adjustedCount"] > 0, (
-        "the lens was requested and reported applied but moved nothing — "
-        "either the fixture is starved or the factors never reached the board"
-    )
+    assert res.json()["meta"]["valuationMode"] == "market"
 
 
-def test_a_missing_roster_snapshot_degrades_to_market_and_says_so(
+def test_the_lens_request_is_answered_with_the_canonical_board_and_says_so(
     league,  # noqa: F811
     monkeypatch,
 ):
-    """Without rosters there is no measurable scarcity. Serving the
-    overridden market board is right; presenting it AS league-adjusted
-    is not. The response has to disclose which one the caller got."""
-    monkeypatch.setattr(gameplan, "load_team_strength_snapshot", lambda key=None: None)
     with TestClient(server.app, raise_server_exceptions=True) as c:
         _install_contract(monkeypatch)
         _install_raw(monkeypatch)
@@ -572,13 +556,39 @@ def test_a_missing_roster_snapshot_degrades_to_market_and_says_so(
     assert res.status_code == 200, res.text
     body = res.json()
     assert body["meta"]["valuationMode"] == "market"
-    assert "league_adjusted_unavailable" in body["meta"]["valuationNote"]
-    assert any("league_adjusted_unavailable" in w for w in body.get("warnings") or [])
+    assert body["meta"]["valuationNote"] == "league_adjusted_withdrawn: not_canonical"
+    assert any("league_adjusted_withdrawn" in w for w in body.get("warnings") or [])
+    assert (
+        "valuationAdjustment" not in body
+    ), "the payload still advertises an adjustment block for a withdrawn lens"
 
 
-def test_the_full_view_refuses_the_lens_rather_than_ignoring_it(league, monkeypatch):  # noqa: F811
-    """A silently-dropped field would return a market board labelled as
-    adjusted. Say no instead."""
+def test_the_lens_request_never_reaches_the_roster_snapshot(league, monkeypatch):  # noqa: F811
+    """Withdrawal is structural, not conditional.
+
+    If the handler still consulted the gameplan module it would only be
+    one edit from re-applying what it found — and it would pay a roster
+    load on a request whose answer cannot depend on it.
+    """
+    calls: list = []
+
+    def _boom(*args, **kwargs):
+        calls.append(args)
+        raise AssertionError("the withdrawn lens loaded a roster snapshot")
+
+    monkeypatch.setattr(gameplan, "get_league_adjusted_values", _boom)
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch)
+        _install_raw(monkeypatch)
+        res = _post(c, {"ktcSfTep": {"include": False}, "valuation_mode": "leagueAdjusted"})
+    assert res.status_code == 200, res.text
+    assert not calls
+
+
+def test_the_full_view_answers_the_same_way_as_the_delta_view(league, monkeypatch):  # noqa: F811
+    """The two views used to disagree — delta composed, full refused
+    with ``league_adjusted_requires_delta_view``. With the lens
+    withdrawn there is one answer, so there is one note."""
     with TestClient(server.app, raise_server_exceptions=True) as c:
         _install_contract(monkeypatch)
         _install_raw(monkeypatch)
@@ -590,4 +600,4 @@ def test_the_full_view_refuses_the_lens_rather_than_ignoring_it(league, monkeypa
     assert res.status_code == 200, res.text
     body = res.json()
     assert body["meta"]["valuationMode"] == "market"
-    assert body["meta"]["valuationNote"] == "league_adjusted_requires_delta_view"
+    assert body["meta"]["valuationNote"] == "league_adjusted_withdrawn: not_canonical"

--- a/tests/api/test_one_canonical_value_per_asset.py
+++ b/tests/api/test_one_canonical_value_per_asset.py
@@ -1,0 +1,304 @@
+"""One canonical dynasty value per asset — W29-F001 / W29-F002.
+
+THE INVARIANT
+─────────────
+An asset's canonical value is a property of the ASSET, not of the
+question being asked about it.  Context may change which assets are
+relevant, how they are filtered, ranked, recommended or explained.  It
+may not change what the asset is worth on the canonical board.
+
+WHAT WAS MEASURED (2026-08-14, live contract, 1,093 rows)
+──────────────────────────────────────────────────────────
+``build_api_data_contract`` runs ``_compute_unified_rankings`` a SECOND
+time with every IDP-scoped source disabled, and stamps the result on
+each row as ``offenseOnlyRankDerivedValue``.  That is a second canonical
+board, produced by the canonical function, on the canonical scale:
+
+* 605 rows carry it; 507 are comparable with a priced canonical value;
+* **491 of those 507 disagree** — up to 21.87%;
+* the disagreement is not confined to defenders.  **Picks move most**
+  (2026 Pick 2.06: 3,224 → 2,519).  A draft pick is neither an offensive
+  player nor an IDP player, and its dynasty value cannot depend on
+  which sources a *different* asset class was scored against;
+* Travis Hunter measured 4,758 canonical vs 5,637 offense-only — the
+  spread W29-F001 recorded from the other direction.
+
+The switch is **per trade, not per league**::
+
+    trade_simulator.py:209   offense_only = trade_has_resolved and not trade_has_idp
+    suggestions.py:1789      _serialize_player(p, offense_only=_trade_is_idp_free(...))
+    finder.py:689            if not trade_has_idp and a.offense_only_model_value is not None
+
+So in ONE league, on ONE day, from ONE board, a player is worth one
+number in a trade that happens to contain a defender and a different
+number in a trade that does not — and in the simulator the substitution
+is applied to the team's ENTIRE existing roster, not merely to the legs
+being traded.  Neither number is labelled; both are served under the
+canonical field names ``displayValue`` and ``modelValue``.
+
+That is the definition of a second competing canonical truth, and the
+owner ruling for B9 is that it may not survive.
+
+WHY THESE TESTS ARE SHAPED THIS WAY
+────────────────────────────────────
+They assert the INVARIANT ("the same asset values the same regardless of
+what else is in the trade"), never the absence of a particular field
+name.  A test that merely banned ``offenseOnlyRankDerivedValue`` would
+pass the day someone reintroduced the same second board under another
+name, which is the failure mode this whole finding is an instance of.
+"""
+
+from __future__ import annotations
+
+from src.api import terminal, trade_simulator
+from src.canonical.player_valuation import rank_to_value
+from src.trade import finder, suggestions
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+#
+# The offense-only value is deliberately set FAR from the canonical one
+# (2,500 vs 4,000).  The live spread is up to 21.87%; an exaggerated
+# fixture spread makes a substitution impossible to mistake for rounding
+# and keeps the assertion readable.
+
+
+def _row(name, rank, pos="WR", asset="offense", offense_only=None):
+    row = {
+        "displayName": name,
+        "canonicalName": name,
+        "legacyRef": name,
+        "assetClass": asset,
+        "position": pos,
+        "pos": pos,
+        "canonicalConsensusRank": rank,
+        "rankChange": 0,
+        "rankDerivedValue": int(rank_to_value(rank)),
+        "values": {"full": int(rank_to_value(rank))},
+    }
+    if offense_only is not None:
+        row["offenseOnlyRankDerivedValue"] = int(offense_only)
+    return row
+
+
+def _contract() -> dict:
+    """Two offensive players, one pick, one defender.
+
+    ``Wideout`` and ``Rookie Pick`` both carry an offense-only value that
+    disagrees with canonical.  ``Linebacker`` exists purely so a caller
+    can put an IDP asset into a trade and flip the engines' switch.
+    """
+    wr = _row("Wideout", 20, "WR", offense_only=2500)
+    wr["rankDerivedValue"] = 4000
+    wr["values"]["full"] = 4000
+
+    pick = _row("2026 Pick 2.06", 40, "PICK", asset="pick", offense_only=2519)
+    pick["rankDerivedValue"] = 3224
+    pick["values"]["full"] = 3224
+
+    return {
+        "playersArray": [
+            wr,
+            pick,
+            _row("Quarterback", 5, "QB"),
+            _row("Linebacker", 60, "LB", asset="idp"),
+        ],
+        "sleeper": {
+            "teams": [
+                {
+                    "ownerId": "o1",
+                    "name": "Team Alpha",
+                    "roster_id": 1,
+                    "players": ["Wideout", "Quarterback"],
+                    "picks": [],
+                },
+                {
+                    "ownerId": "o2",
+                    "name": "Team Bravo",
+                    "roster_id": 2,
+                    "players": ["Linebacker"],
+                    "picks": [],
+                },
+            ],
+        },
+    }
+
+
+def _value_of(result: dict, side: str, name: str) -> int:
+    for asset in result[side]:
+        if asset["name"] == name:
+            return asset["value"]
+    raise AssertionError(f"{name!r} not found in {side}: {result[side]}")
+
+
+class TestTheSimulatorValuesAnAssetTheSameWay:
+    """``/api/trade/simulate`` — the per-trade switch, at the boundary."""
+
+    def test_a_player_is_worth_the_same_with_and_without_a_defender_in_the_trade(self):
+        contract = _contract()
+        team = terminal.resolve_team(contract, owner_id="o1", name=None)
+
+        idp_free = trade_simulator.simulate_trade(
+            contract,
+            resolved_team=team,
+            players_in=["Quarterback"],
+            players_out=["Wideout"],
+        )
+        with_idp = trade_simulator.simulate_trade(
+            contract,
+            resolved_team=team,
+            players_in=["Quarterback", "Linebacker"],
+            players_out=["Wideout"],
+        )
+
+        assert _value_of(idp_free, "sending", "Wideout") == _value_of(
+            with_idp, "sending", "Wideout"
+        ), (
+            "Wideout is worth a different number depending on whether an unrelated "
+            "defender is also in the trade — two canonical values for one asset."
+        )
+
+    def test_a_pick_is_worth_the_same_with_and_without_a_defender_in_the_trade(self):
+        """A pick is neither an offensive nor an IDP asset.
+
+        It moved most of all on the live board (2026 Pick 2.06:
+        3,224 → 2,519, −21.87%), which is what shows the mechanism is not
+        "exclude IDP calibration from IDP-free trades" but a wholesale
+        second board.
+        """
+        contract = _contract()
+        team = terminal.resolve_team(contract, owner_id="o1", name=None)
+
+        idp_free = trade_simulator.simulate_trade(
+            contract,
+            resolved_team=team,
+            players_in=["2026 Pick 2.06"],
+            players_out=["Wideout"],
+        )
+        with_idp = trade_simulator.simulate_trade(
+            contract,
+            resolved_team=team,
+            players_in=["2026 Pick 2.06", "Linebacker"],
+            players_out=["Wideout"],
+        )
+
+        assert _value_of(idp_free, "receiving", "2026 Pick 2.06") == _value_of(
+            with_idp, "receiving", "2026 Pick 2.06"
+        )
+
+    def test_the_untraded_roster_is_not_repriced_by_the_trade_being_evaluated(self):
+        """The substitution reached ``before_assets`` — the whole roster.
+
+        Evaluating a trade is a read-only question about a hypothetical.
+        It cannot change what the manager's existing roster is worth.
+        """
+        contract = _contract()
+        team = terminal.resolve_team(contract, owner_id="o1", name=None)
+
+        idp_free = trade_simulator.simulate_trade(
+            contract,
+            resolved_team=team,
+            players_in=["Quarterback"],
+            players_out=[],
+        )
+        with_idp = trade_simulator.simulate_trade(
+            contract,
+            resolved_team=team,
+            players_in=["Linebacker"],
+            players_out=[],
+        )
+
+        assert idp_free["before"]["totalValue"] == with_idp["before"]["totalValue"], (
+            "The team's CURRENT roster is worth a different total depending on "
+            "what is in the hypothetical trade being evaluated."
+        )
+
+
+class TestSuggestionsServeTheCanonicalValue:
+    """``displayValue`` is a canonical field name (W29-F001)."""
+
+    def test_display_value_is_the_board_value_in_an_idp_free_trade(self):
+        player = suggestions.PlayerAsset(
+            name="Wideout",
+            position="WR",
+            display_value=4000,
+            calibrated_value=4000,
+            source_count=4,
+            team="KC",
+            offense_only_value=2500,
+        )
+
+        serialized = suggestions._serialize_player(player, offense_only=True)
+
+        assert serialized["displayValue"] == 4000, (
+            "displayValue carried the offense-only board. Two different value "
+            "concepts under one canonical field name."
+        )
+
+
+class TestTheFinderServesTheCanonicalValue:
+    """``modelValue`` is the finder's canonical field."""
+
+    def test_model_value_is_the_board_value_in_an_idp_free_trade(self):
+        asset = finder.Asset(
+            name="Wideout",
+            position="WR",
+            team="KC",
+            model_value=4000,
+            market_value=4100,
+            offense_only_model_value=2500,
+        )
+        result = finder.TradeCandidate(
+            give=[asset],
+            receive=[],
+            give_model_total=4000,
+            receive_model_total=0,
+            give_ktc_total=4100,
+            receive_ktc_total=0,
+        ).to_dict()
+
+        assert result["give"][0]["modelValue"] == 4000, (
+            "modelValue carried the offense-only board when the trade had no IDP asset."
+        )
+
+
+class TestTheContractPublishesOneCanonicalBoard:
+    """The producer, not just the consumers.
+
+    Leaving the second board on the contract while un-wiring its readers
+    would keep a loaded gun on every row: the next engine to want an
+    "IDP-free view" would find a ready-made second canonical board and
+    wire it straight back in.
+    """
+
+    def test_no_row_carries_a_second_disagreeing_board_value(self):
+        from src.api.data_contract import build_api_data_contract
+
+        import json
+        import pathlib
+
+        export = pathlib.Path("exports/latest")
+        candidates = sorted(export.glob("dynasty_data*.json"), reverse=True)
+        if not candidates:
+            import pytest
+
+            pytest.skip("no export available in this environment")
+
+        raw = json.loads(candidates[0].read_text(encoding="utf-8"))
+        contract = build_api_data_contract(raw)
+
+        disagreeing = []
+        for row in contract["playersArray"]:
+            canonical = row.get("rankDerivedValue")
+            second = row.get("offenseOnlyRankDerivedValue")
+            if not isinstance(canonical, (int, float)) or canonical <= 0:
+                continue
+            if not isinstance(second, (int, float)) or second <= 0:
+                continue
+            if int(second) != int(canonical):
+                disagreeing.append((row.get("displayName"), int(canonical), int(second)))
+
+        assert not disagreeing, (
+            f"{len(disagreeing)} rows carry a second canonical-scale value that "
+            f"disagrees with the canonical board, e.g. {disagreeing[:3]}"
+        )

--- a/tests/api/test_one_canonical_value_per_asset.py
+++ b/tests/api/test_one_canonical_value_per_asset.py
@@ -217,7 +217,7 @@ class TestTheSimulatorValuesAnAssetTheSameWay:
 class TestSuggestionsServeTheCanonicalValue:
     """``displayValue`` is a canonical field name (W29-F001)."""
 
-    def test_display_value_is_the_board_value_in_an_idp_free_trade(self):
+    def test_display_value_is_the_board_value(self):
         player = suggestions.PlayerAsset(
             name="Wideout",
             position="WR",
@@ -225,28 +225,36 @@ class TestSuggestionsServeTheCanonicalValue:
             calibrated_value=4000,
             source_count=4,
             team="KC",
-            offense_only_value=2500,
         )
 
-        serialized = suggestions._serialize_player(player, offense_only=True)
+        assert suggestions._serialize_player(player)["displayValue"] == 4000
 
-        assert serialized["displayValue"] == 4000, (
-            "displayValue carried the offense-only board. Two different value "
-            "concepts under one canonical field name."
-        )
+    def test_the_asset_type_cannot_carry_a_second_board_value(self):
+        """Structural, because the field was the mechanism.
+
+        ``_serialize_player`` no longer takes a mode argument and
+        ``PlayerAsset`` no longer has a slot for a second board, so the
+        substitution cannot be reintroduced by flipping a flag — it would
+        take re-adding the field, which fails here.
+        """
+        import dataclasses
+        import inspect
+
+        fields = {f.name for f in dataclasses.fields(suggestions.PlayerAsset)}
+        assert not [f for f in fields if "offense_only" in f]
+        assert "offense_only" not in inspect.signature(suggestions._serialize_player).parameters
 
 
 class TestTheFinderServesTheCanonicalValue:
     """``modelValue`` is the finder's canonical field."""
 
-    def test_model_value_is_the_board_value_in_an_idp_free_trade(self):
+    def test_model_value_is_the_board_value(self):
         asset = finder.Asset(
             name="Wideout",
             position="WR",
             team="KC",
             model_value=4000,
             market_value=4100,
-            offense_only_model_value=2500,
         )
         result = finder.TradeCandidate(
             give=[asset],
@@ -257,9 +265,17 @@ class TestTheFinderServesTheCanonicalValue:
             receive_ktc_total=0,
         ).to_dict()
 
-        assert result["give"][0]["modelValue"] == 4000, (
-            "modelValue carried the offense-only board when the trade had no IDP asset."
+        assert result["give"][0]["modelValue"] == 4000
+        assert "modelValueFull" not in result["give"][0], (
+            "modelValueFull existed only to carry the canonical value alongside "
+            "the offense-only one that had displaced it."
         )
+
+    def test_the_asset_type_cannot_carry_a_second_board_value(self):
+        import dataclasses
+
+        fields = {f.name for f in dataclasses.fields(finder.Asset)}
+        assert not [f for f in fields if "offense_only" in f]
 
 
 class TestTheContractPublishesOneCanonicalBoard:

--- a/tests/api/test_overrides_response_cache.py
+++ b/tests/api/test_overrides_response_cache.py
@@ -154,15 +154,23 @@ def test_prime_latest_payload_clears_memo(overrides_env):
     assert server._OVERRIDES_RESPONSE_CACHE == {}
 
 
-def test_league_adjusted_requests_bypass_cache(overrides_env, monkeypatch):
+def test_league_adjusted_requests_are_now_memoized_like_any_other(overrides_env, monkeypatch):
+    """Was ``test_league_adjusted_requests_bypass_cache``.
+
+    The bypass existed for a real reason: the lens's factors came from
+    the gameplan module, whose freshness this cache cannot see, so
+    memoizing a response built from them could serve a board keyed to a
+    roster snapshot that had since moved.
+
+    B9a withdrew the lens from this endpoint, so there are no factors
+    and nothing unseeable left to exclude. ``valuation_mode`` is part of
+    the canonical body JSON, so a request carrying it keys separately
+    from one that does not — which is what the differing
+    ``valuationNote`` needs — and both are cacheable.
+    """
     with TestClient(server.app, raise_server_exceptions=True) as c:
         _install_data(monkeypatch)
         calls = _count_builds(monkeypatch)
-        monkeypatch.setattr(
-            server._gameplan,
-            "get_league_adjusted_values",
-            lambda *a, **k: {"factors": {"QB": 1.1}},
-        )
 
         body = {"tep_multiplier": 1.15, "valuation_mode": "leagueAdjusted"}
         r1 = c.post("/api/rankings/overrides?view=delta", json=body)
@@ -170,5 +178,6 @@ def test_league_adjusted_requests_bypass_cache(overrides_env, monkeypatch):
 
     assert r1.status_code == 200, r1.text
     assert r2.status_code == 200, r2.text
-    assert calls["n"] == 2, "leagueAdjusted path must not be memoized"
-    assert not server._OVERRIDES_RESPONSE_CACHE, "no slot may be written for leagueAdjusted"
+    assert r1.content == r2.content
+    assert calls["n"] == 1, "the second identical request rebuilt instead of hitting the memo"
+    assert server._OVERRIDES_RESPONSE_CACHE, "no slot was written"

--- a/tests/api/test_source_overrides.py
+++ b/tests/api/test_source_overrides.py
@@ -1292,132 +1292,51 @@ if __name__ == "__main__":
     unittest.main()
 
 
-class TestValuationFactorComposition(unittest.TestCase):
-    """Server-side composition of source overrides + the league lens.
+class TestTheLeagueLensIsWithdrawnFromThisEndpoint(unittest.TestCase):
+    """Replaces ``TestValuationFactorComposition``.
 
-    The two used to be mutually exclusive, and the reason was sound: the
-    overlay endpoint ranks against the UN-overridden board, so applying
-    its ranks to a re-weighted board gives ranks of
-    ``default_consensus x factor`` when the right answer is the rank of
-    ``overridden_consensus x factor``. The server had never computed the
-    latter. It does now, and these pin that it is the latter.
+    That class pinned SERVER-SIDE COMPOSITION of source overrides with
+    the league-adjusted lens — specifically that factors multiplied the
+    OVERRIDDEN consensus rather than the default one, which is a board
+    the client could not construct for itself.
 
-    The distinction is invisible in a payload's shape — both produce a
-    delta with values, ranks and tiers — so every assertion below is
-    about the arithmetic relationship between them.
+    The arithmetic it pinned was right; the feature was not. #822
+    rejected the league-aware methodology for promotion to canonical and
+    ruled it may not own a canonical field. B9a closed this last path,
+    where the +/-25% bound sat on the FACTOR and never on the PRODUCT, so
+    the canonical field left its declared 1-9999 range: measured on the
+    2026-08-14 board, 10,160 on the real factor set and 12,471 at the
+    cap, both published under ``rankDerivedValue``.
+
+    What survives is the requirement that made composition necessary in
+    the first place: there is ONE board, and the override path serves
+    it.
     """
 
-    def test_factors_multiply_the_overridden_values_not_the_default_ones(self) -> None:
-        """The whole point, expressed as a ratio.
+    def test_the_delta_builder_takes_no_factor_argument(self) -> None:
+        import inspect
 
-        Build the same board twice, once with an override and once
-        without, then apply the same factor to each. If the factors were
-        being applied to the default board, the two adjusted results
-        would be identical; they must not be.
-        """
-        plain = build_rankings_delta_payload(
-            _fixture_raw_payload(),
-            source_overrides={"ktcSfTep": {"include": False}},
-        )
-        plain_vals = {e["id"]: e.get("rankDerivedValue") for e in plain["rankingsDelta"]["players"]}
-        movers = [n for n, v in plain_vals.items() if isinstance(v, int) and v > 0]
-        self.assertTrue(movers, "fixture produced no priced rows to adjust")
-
-        factors = {name: 1.20 for name in movers}
-        adjusted = build_rankings_delta_payload(
-            _fixture_raw_payload(),
-            source_overrides={"ktcSfTep": {"include": False}},
-            valuation_factors=factors,
-        )
-        adj_vals = {
-            e["id"]: e.get("rankDerivedValue") for e in adjusted["rankingsDelta"]["players"]
-        }
-        for name in movers:
-            self.assertEqual(
-                adj_vals[name],
-                int(round(plain_vals[name] * 1.20)),
-                f"{name}: factor was not applied to the OVERRIDDEN value",
-            )
-
-    def test_ranks_are_recomputed_over_the_adjusted_board(self) -> None:
-        """A factor that reorders players must reorder ranks.
-
-        Boosting only the lower-valued half is the test: if ranks were
-        carried over from the pre-adjustment board, the order would be
-        unchanged and this passes vacuously — so it asserts an actual
-        reordering happened.
-        """
-        plain = build_rankings_delta_payload(_fixture_raw_payload())
-        rows = [
-            (e["id"], e.get("rankDerivedValue"), e.get("canonicalConsensusRank"))
-            for e in plain["rankingsDelta"]["players"]
-            if isinstance(e.get("rankDerivedValue"), int)
-            and isinstance(e.get("canonicalConsensusRank"), int)
-        ]
-        rows.sort(key=lambda r: r[2])
-        if len(rows) < 2:
-            self.skipTest("fixture has fewer than two ranked rows")
-
-        # Boost the LAST-ranked row hard enough to pass the first.
-        target = rows[-1][0]
-        top_value = rows[0][1]
-        factor = (top_value * 2.0) / max(rows[-1][1], 1)
-        adjusted = build_rankings_delta_payload(
-            _fixture_raw_payload(),
-            valuation_factors={target: factor},
-        )
-        new_ranks = {
-            e["id"]: e.get("canonicalConsensusRank") for e in adjusted["rankingsDelta"]["players"]
-        }
+        params = inspect.signature(build_rankings_delta_payload).parameters
         self.assertEqual(
-            new_ranks[target], 1, "the boosted row did not take rank 1 — ranks are stale"
+            [p for p in params if "valuation" in p or "factor" in p],
+            [],
+            "the delta builder still accepts a repricing argument",
         )
 
-    def test_ranks_stay_dense_and_contiguous_after_adjustment(self) -> None:
-        plain = build_rankings_delta_payload(_fixture_raw_payload())
-        names = [
-            e["id"]
-            for e in plain["rankingsDelta"]["players"]
-            if isinstance(e.get("rankDerivedValue"), int) and e["rankDerivedValue"] > 0
-        ]
-        adjusted = build_rankings_delta_payload(
-            _fixture_raw_payload(),
-            valuation_factors={n: 1.1 for n in names},
-        )
-        ranks = sorted(
-            e["canonicalConsensusRank"]
-            for e in adjusted["rankingsDelta"]["players"]
-            if isinstance(e.get("canonicalConsensusRank"), int)
-        )
-        self.assertEqual(ranks, list(range(1, len(ranks) + 1)))
+    def test_the_composition_helper_is_gone(self) -> None:
+        from src.api import data_contract
 
-    def test_no_factors_is_byte_identical_to_the_plain_override_path(self) -> None:
-        """The composition must be inert when the lens is off — the
-        default path is the one every user is on."""
-        a = build_rankings_delta_payload(
+        self.assertFalse(
+            hasattr(data_contract, "apply_valuation_factors"),
+            "the canonical-field composition helper is still importable",
+        )
+
+    def test_the_override_delta_still_serves_a_ranked_board(self) -> None:
+        """Withdrawal must not have taken the endpoint's real job with it."""
+        payload = build_rankings_delta_payload(
             _fixture_raw_payload(), source_overrides={"ktcSfTep": {"include": False}}
         )
-        b = build_rankings_delta_payload(
-            _fixture_raw_payload(),
-            source_overrides={"ktcSfTep": {"include": False}},
-            valuation_factors=None,
-        )
-        # Compare the ranking payload rather than the whole envelope —
-        # the envelope carries build timestamps that differ by
-        # microseconds between two calls and say nothing about the
-        # composition path.
-        self.assertEqual(a["rankingsDelta"], b["rankingsDelta"])
-        self.assertEqual(a.get("rankingsOverride"), b.get("rankingsOverride"))
-        self.assertNotIn("valuationAdjustment", a)
-        self.assertNotIn("valuationAdjustment", b)
-
-    def test_an_empty_factor_map_is_reported_as_applied_but_inert(self) -> None:
-        """`applied and moved nothing` and `never applied` are different
-        states. A caller that cannot tell them apart renders one as the
-        other, which is the exact confusion this endpoint removes."""
-        payload = build_rankings_delta_payload(
-            _fixture_raw_payload(), valuation_factors={"Nobody At All": 1.5}
-        )
-        self.assertEqual(payload["valuationAdjustment"]["applied"], True)
-        self.assertEqual(payload["valuationAdjustment"]["adjustedCount"], 0)
-        self.assertEqual(payload["valuationAdjustment"]["factorCount"], 1)
+        players = payload["rankingsDelta"]["players"]
+        self.assertTrue(players)
+        ranked = [p for p in players if p.get("canonicalConsensusRank")]
+        self.assertTrue(ranked, "the override delta returned no ranked rows")

--- a/tests/ros/test_direction_and_tags.py
+++ b/tests/ros/test_direction_and_tags.py
@@ -107,6 +107,27 @@ class TestClassifyTeam(unittest.TestCase):
 
 
 class TestTagsForPlayer(unittest.TestCase):
+    """Converted to percentile units by B9b.
+
+    These cases used to pass ``ros_value`` levels (70, 85, 40) against
+    absolute gates.  Measured over the live ROS aggregate and all 893
+    historical ones, that index has median 9.15 and 99th percentile
+    59.41 — so ``ros_value=70`` is not "a strong player", it is above
+    anything all but a handful of players reach, and the gates it
+    exercised selected 0.87% and 0.19% of the pool.
+
+    The sharpest example was ``test_seller_cash_out_dynasty_lag``, which
+    passed ``dynasty_value=40`` to satisfy ``40 < 70 * 0.7``.  A dynasty
+    board value of 40 cannot occur: the board runs 1–9999 and its lowest
+    priced row is 1,134.  The test constructed an impossible input to
+    make a predicate pass that could not fire for any of the 1,093 real
+    rows (W29-F005), and it did so for as long as the tag existed.  A
+    unit on the fixture would have caught it at zero cost.
+
+    Reachability against realistic inputs now lives in
+    ``tests/ros/test_tag_parity.py``.
+    """
+
     def test_no_ros_value_no_tags(self):
         tags = tags_for_player(
             canonical_name="X",
@@ -120,12 +141,20 @@ class TestTagsForPlayer(unittest.TestCase):
         tags = tags_for_player(canonical_name="X", position="QB", age=25, ros_value=0)
         self.assertEqual(tags, [])
 
+    def test_no_standing_no_tags(self):
+        """A level without a population is not a standing."""
+        tags = tags_for_player(
+            canonical_name="X", position="QB", age=33, ros_value=70, ros_percentile=None
+        )
+        self.assertEqual(tags, [])
+
     def test_win_now_target_for_strong_vet(self):
         tags = tags_for_player(
             canonical_name="Veteran QB",
             position="QB",
             age=33,
             ros_value=70,
+            ros_percentile=90,
         )
         self.assertIn("Win-now target", tags)
 
@@ -135,17 +164,20 @@ class TestTagsForPlayer(unittest.TestCase):
             position="WR",
             age=27,
             ros_value=85,
+            ros_percentile=99,
             ros_rank_overall=10,
         )
         self.assertIn("Contender upgrade", tags)
 
     def test_seller_cash_out_dynasty_lag(self):
+        """Both sides are now standings in their own population."""
         tags = tags_for_player(
             canonical_name="Aging Stud",
             position="WR",
             age=30,
             ros_value=70,
-            dynasty_value=40,  # 40 < 70 * 0.7
+            ros_percentile=95,
+            dynasty_percentile=60,  # a 35-point gap, threshold is 25
         )
         self.assertIn("Seller cash-out", tags)
 
@@ -155,6 +187,7 @@ class TestTagsForPlayer(unittest.TestCase):
             position="WR",
             age=22,
             ros_value=40,
+            ros_percentile=50,
         )
         self.assertIn("Rebuilder hold", tags)
 
@@ -164,6 +197,7 @@ class TestTagsForPlayer(unittest.TestCase):
             position="LB",
             age=27,
             ros_value=80,
+            ros_percentile=98,
             ros_rank_overall=20,
         )
         self.assertIn("IDP contender target", tags)
@@ -172,17 +206,43 @@ class TestTagsForPlayer(unittest.TestCase):
         # Every tag the classifier can emit should have a description.
         all_tags_emitted = set()
         for params in [
-            {"position": "QB", "age": 33, "ros_value": 70},
-            {"position": "WR", "age": 27, "ros_value": 85, "ros_rank_overall": 10},
-            {"position": "WR", "age": 30, "ros_value": 70, "dynasty_value": 40},
-            {"position": "WR", "age": 22, "ros_value": 40},
-            {"position": "LB", "age": 27, "ros_value": 80, "ros_rank_overall": 20},
+            {"position": "QB", "age": 33, "ros_value": 70, "ros_percentile": 90},
+            {
+                "position": "WR",
+                "age": 27,
+                "ros_value": 85,
+                "ros_percentile": 99,
+                "ros_rank_overall": 10,
+            },
+            {
+                "position": "WR",
+                "age": 30,
+                "ros_value": 70,
+                "ros_percentile": 95,
+                "dynasty_percentile": 60,
+            },
+            {"position": "WR", "age": 22, "ros_value": 40, "ros_percentile": 50},
+            {
+                "position": "LB",
+                "age": 27,
+                "ros_value": 80,
+                "ros_percentile": 98,
+                "ros_rank_overall": 20,
+            },
             {
                 "position": "RB",
                 "age": 30,
                 "ros_value": 65,
+                "ros_percentile": 85,
                 "volatility_flag": True,
                 "ros_rank_overall": 50,
+            },
+            {
+                "position": "WR",
+                "age": 28,
+                "ros_value": 20,
+                "ros_percentile": 55,
+                "ros_rank_overall": 400,
             },
         ]:
             tags = tags_for_player(canonical_name="X", **params)
@@ -190,6 +250,9 @@ class TestTagsForPlayer(unittest.TestCase):
         descriptions = tag_descriptions()
         for tag in all_tags_emitted:
             self.assertIn(tag, descriptions, f"missing description for {tag}")
+        # The classifier emits nine tags; a fixture set that exercises
+        # fewer would pass this test while leaving one undescribed.
+        self.assertEqual(len(all_tags_emitted), 9, sorted(all_tags_emitted))
 
 
 if __name__ == "__main__":

--- a/tests/ros/test_tag_parity.py
+++ b/tests/ros/test_tag_parity.py
@@ -1,0 +1,193 @@
+"""The ROS context-tag classifier has one owner and one mirror — B9b.
+
+WHY THIS FILE EXISTS
+────────────────────
+The classifier existed three times: ``src/ros/tags.py::tags_for_player``
+(the nominal owner, with **no production caller**), and verbatim copies
+inside ``PlayerPopup.jsx`` and ``RosTradeFitPanel.jsx`` — which were the
+live path.  One of the JS copies carried the comment *"Stays in sync via
+the parity test (PR-future)"*.  That parity test was never written, and
+triplication is what let W29-F005 survive review three times.
+
+W29-F005: the "Seller cash-out" predicate was
+``dynastyValue < rosValue * 0.7``, comparing a 0–9999 dynasty board
+value against the 0–100 ROS strength index.  The right-hand side maxes
+at 60.8; the board's lowest priced value is 1,134.  The tag could not
+fire for any of 1,093 rows and never had.
+
+This file is the parity test that was promised, plus the reachability
+assertion the finding asked for: *"Add a unit test asserting the tag
+fires on a constructed case, which would have caught this at zero
+cost."*
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+from src.api.thresholds import threshold
+from src.ros.tags import ros_percentiles, tags_for_player
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+MIRROR = REPO / "frontend" / "lib" / "ros-index.js"
+
+
+def _strong() -> float:
+    return float(threshold("ROS_STRONG_PERCENTILE"))
+
+
+class TestEveryTagIsReachable:
+    """A tag that cannot fire is a feature that does not exist.
+
+    Nine tags; nine constructed cases.  This is the assertion that was
+    missing — the shipped predicate had a zero-row solution set and no
+    test noticed for as long as it existed.
+    """
+
+    def _tags(self, **kw):
+        base = dict(
+            canonical_name="Test Player",
+            position="WR",
+            age=30,
+            ros_value=50.0,
+            ros_percentile=99.0,
+            ros_rank_overall=10,
+            dynasty_percentile=50.0,
+            volatility_flag=False,
+        )
+        base.update(kw)
+        return tags_for_player(**base)
+
+    def test_seller_cash_out_fires(self):
+        """The tag W29-F005 proved was unreachable.
+
+        A 30-year-old WR standing at the 99th percentile for
+        rest-of-season and the 50th on the dynasty board: a 49-point gap
+        against a 25-point threshold.
+        """
+        assert "Seller cash-out" in self._tags(ros_percentile=99.0, dynasty_percentile=50.0)
+
+    def test_seller_cash_out_does_not_fire_without_the_gap(self):
+        assert "Seller cash-out" not in self._tags(ros_percentile=99.0, dynasty_percentile=95.0)
+
+    def test_seller_cash_out_needs_a_dynasty_standing(self):
+        """Missing is not zero.
+
+        An unpriced dynasty row must not read as "worth nothing" and
+        therefore maximally underpriced — which is exactly what a
+        ``?? 0`` fallback would produce here.
+        """
+        assert "Seller cash-out" not in self._tags(dynasty_percentile=None)
+
+    def test_win_now_target_fires(self):
+        assert "Win-now target" in self._tags()
+
+    def test_contender_upgrade_fires(self):
+        assert "Contender upgrade" in self._tags(age=24, ros_percentile=99.0)
+
+    def test_rebuilder_hold_fires(self):
+        assert "Rebuilder hold" in self._tags(age=22, ros_percentile=10.0)
+
+    def test_avoid_unless_contending_fires(self):
+        assert "Avoid unless contending" in self._tags(ros_rank_overall=400)
+
+    def test_depth_spike_option_fires(self):
+        low = float(threshold("ROS_DEPTH_BAND_LOW_PERCENTILE"))
+        mid = (low + _strong()) / 2
+        assert "Depth spike option" in self._tags(ros_percentile=mid, ros_rank_overall=400)
+
+    def test_best_ball_boost_fires(self):
+        assert "Best-ball boost" in self._tags(volatility_flag=True)
+
+    def test_idp_contender_target_fires(self):
+        assert "IDP contender target" in self._tags(position="LB", ros_rank_overall=10)
+
+    def test_injury_bye_cover_fires(self):
+        assert "Injury/bye cover" in self._tags(age=30, ros_percentile=10.0)
+
+
+class TestStandingsNotIndexLevels:
+    def test_no_tag_without_a_standing(self):
+        """Every strength gate is a percentile, and a percentile cannot
+        be computed from one player.  Returning nothing is honest;
+        falling back to the raw index is the defect being repaired."""
+        assert (
+            tags_for_player(
+                canonical_name="X",
+                position="WR",
+                age=30,
+                ros_value=86.79,
+                ros_percentile=None,
+            )
+            == []
+        )
+
+    def test_percentiles_rank_the_whole_pool(self):
+        pct = ros_percentiles([10.0, 30.0, 20.0])
+        assert pct[1] == 100.0  # best
+        assert pct[0] == 0.0  # worst
+        assert 0.0 < pct[2] < 100.0
+
+    def test_unranked_rows_are_none_not_zero(self):
+        """ "No ROS source ranked this player" is not "worst in the
+        league" — a 0.0 percentile would make it one."""
+        pct = ros_percentiles([10.0, None, 0, 30.0])
+        assert pct[1] is None
+        assert pct[2] is None
+        assert pct[3] == 100.0
+
+    def test_a_single_ranked_row_does_not_divide_by_zero(self):
+        assert ros_percentiles([42.0]) == [100.0]
+
+
+class TestTheJavaScriptMirrorMatches:
+    """Same mechanism as ``tests/api/test_threshold_parity.py``.
+
+    The mirror cannot be imported from Python, so this asserts the two
+    things that actually drifted historically: the tag vocabulary and
+    the thresholds each gate reads.
+    """
+
+    @pytest.fixture(scope="class")
+    def mirror(self) -> str:
+        if not MIRROR.exists():
+            pytest.skip("frontend mirror not present in this checkout")
+        return MIRROR.read_text(encoding="utf-8")
+
+    def test_the_mirror_emits_exactly_the_same_tags(self, mirror: str):
+        js_tags = set(re.findall(r'tags\.push\("([^"]+)"\)', mirror))
+        py_tags = set(
+            re.findall(
+                r'tags\.append\("([^"]+)"\)',
+                (REPO / "src" / "ros" / "tags.py").read_text(encoding="utf-8"),
+            )
+        )
+        assert (
+            js_tags == py_tags
+        ), f"only in JS: {js_tags - py_tags}; only in Python: {py_tags - js_tags}"
+
+    def test_the_mirror_gates_on_percentiles_not_index_levels(self, mirror: str):
+        block = mirror.split("export function tagsForPlayer", 1)[1]
+        for name in (
+            "ROS_STRONG_PERCENTILE",
+            "ROS_ELITE_PERCENTILE",
+            "ROS_DEPTH_BAND_LOW_PERCENTILE",
+            "ROS_SELLER_PERCENTILE_GAP",
+        ):
+            assert name in block, f"{name} is not read by the JS classifier"
+        assert "rosValue >= 60" not in block
+        assert "rosValue >= 80" not in block
+        assert "rosValue * 0.7" not in block, "the W29-F005 cross-scale predicate is back"
+
+    def test_the_duplicate_classifiers_are_gone(self):
+        for component in ("PlayerPopup.jsx", "RosTradeFitPanel.jsx"):
+            path = REPO / "frontend" / "components" / component
+            if not path.exists():
+                pytest.skip(f"{component} not present")
+            src = path.read_text(encoding="utf-8")
+            assert "function tagsForPlayer(" not in src, f"{component} re-declares the classifier"
+            assert "function _tagsForPlayer(" not in src
+            assert "rosValue * 0.7" not in src

--- a/tests/trade/test_finder_canonical_board.py
+++ b/tests/trade/test_finder_canonical_board.py
@@ -225,37 +225,33 @@ class TestUnpricedCountUsesTheCompositeScale:
         assert (res.get("metadata") or {}).get("assetsUnpricedByBoard") == 1
 
 
-class TestOffenseOnlyValueIsBoardScale:
-    """2026-07-29 audit.  ``_offenseOnlyFinalAdjusted`` is mirrored from
-    ``offenseOnlyRankDerivedValue`` (data_contract.py) — the IDP-disabled
-    run of the SAME pipeline — so it is BOARD-scale, measured at median
-    0.994x ``rankDerivedValue`` over 522 live assets.  The two branches
-    had their scales backwards: the board path discarded it as though the
-    board had no offense-only variant, and the composite path consumed it
-    alongside a 1.131x-scale model value.
+class TestTheOffenseOnlyBoardIsRetired:
+    """B9a / W29-F001.  There is one canonical board.
+
+    This class replaces ``TestOffenseOnlyValueIsBoardScale``, which pinned
+    the SCALE agreement between the blended board and a second,
+    IDP-disabled board that the finder substituted whenever a trade held
+    no defender.  That second board was retired under the owner's B9
+    ruling — one canonical dynasty value per asset — so a test that both
+    boards agree in scale has nothing left to compare.
+
+    What replaces it is the stronger statement: a stale
+    ``_offenseOnlyFinalAdjusted`` key surviving in a cached or
+    hand-built players dict must not resurrect the substitution.  The
+    producer is gone, but old payloads outlive their producers.
     """
 
-    def test_board_path_now_carries_the_offense_only_value(self):
+    def test_a_stale_offense_only_key_does_not_reprice_the_asset(self):
         players = {"Star WR": _player(9000, ktc=9000)}
         players["Star WR"]["_offenseOnlyFinalAdjusted"] = 4100
         board = board_values_from_contract(_contract({"Star WR": 4321}))
         pool = build_asset_pool(players, market_top_n=0, board_values=board)
-        assert [a.offense_only_model_value for a in pool] == [4100]
+        assert [a.model_value for a in pool] == [4321]
 
-    def test_legacy_path_refuses_the_cross_scale_value(self):
-        """On the composite path ``model_value`` is composite-scale, so
-        consuming a board-scale offense-only value inside the same
-        subtraction understated all-offense legs by ~12%.  Degrade to
-        unavailable instead."""
-        players = {"Star WR": _player(9000, ktc=9000)}
-        players["Star WR"]["_offenseOnlyFinalAdjusted"] = 4100
-        pool = build_asset_pool(players, market_top_n=0)
-        assert [a.offense_only_model_value for a in pool] == [None]
-        assert [a.model_value for a in pool] == [9000]
-
-    def test_all_offense_trade_scores_off_the_offense_only_board(self):
-        """End-to-end: with no IDP asset on either side, ``_score_trade``
-        must consume the offense-only values, not the blended ones."""
+    def test_an_all_offense_trade_scores_off_the_canonical_board(self):
+        """The case that used to diverge: two assets tied on the canonical
+        board and separated only by the offense-only one.  They must now
+        score as the tie they are."""
         players = {
             "Mine": _player(6000, ktc=6000),
             "Theirs": _player(6000, ktc=6000),
@@ -264,10 +260,7 @@ class TestOffenseOnlyValueIsBoardScale:
         players["Theirs"]["_offenseOnlyFinalAdjusted"] = 5900
         board = board_values_from_contract(_contract({"Mine": 5200, "Theirs": 5200}))
         pool = {a.name: a for a in build_asset_pool(players, market_top_n=0, board_values=board)}
-        # Blended board values tie; the offense-only board does not.
-        assert pool["Mine"].model_value == pool["Theirs"].model_value
-        assert pool["Mine"].offense_only_model_value == 5000
-        assert pool["Theirs"].offense_only_model_value == 5900
+        assert pool["Mine"].model_value == pool["Theirs"].model_value == 5200
 
 
 class TestBoardDeltaSignIsHonest:


### PR DESCRIPTION
Closes `W29-F001`, `W29-F005`. `W29-F002`'s overlay half was closed by #822; its remaining path is closed here.

Every number below was measured on the tracked 2026-08-14 export before the repair.

---

## B9a-1 — there were two canonical boards

`build_api_data_contract` ran `_compute_unified_rankings` a **second time** with every IDP-scoped source disabled and stamped the result on each row as `offenseOnlyRankDerivedValue`. Three engines substituted it whenever the trade in front of them happened to contain no defender:

| engine | canonical field it overwrote |
|---|---|
| `suggestions.py::_serialize_player` | `displayValue` |
| `finder.py::TradeCandidate.to_dict` | `modelValue` |
| `trade_simulator.py::_resolve_asset` | the asset value **and the manager's entire untraded roster** |

The switch is **per trade, not per league** (`trade_simulator.py:209`), so one player carried two unlabelled numbers in one league on one day.

| measure | value |
|---|---|
| rows carrying the second board | 605 |
| comparable with a priced canonical value | 507 |
| **disagreeing** | **491** |
| largest disagreement | **21.87%** |

**Picks moved most** — 2026 Pick 2.06: 3,224 → 2,519. A pick is neither an offensive nor an IDP asset, which is what shows the mechanism was never "exclude IDP calibration from IDP-free trades". `idpTradeCalc` is a full-roster calculator, so dropping it changes the count-aware blend, the Hampel filter, the single-source haircut and the pick anchor set for **every** row.

**Removed, not deprecated.** A ready-made second canonical board on every row is what let three engines wire it in without anyone deciding to. An IDP-free view **filters the asset universe or names its lens; it does not reprice the assets** — `_trade_is_idp_free` survives as exactly that, a universe predicate, and its docstring says so.

- canonical board **byte-identical**: 0 values moved, 0 ranks changed (`board_diff.py --expect-no-value-change`)
- contract build **0.62 s → 0.49 s** median — a duplicate pipeline pass gone

**Correction to the recorded finding.** W29-F001 and `VALUE_FLOW_MAP.md` §4 attribute Travis Hunter's spread to the offense-only board "never seeing the two-way boost". It saw it. `_apply_two_way_player_boost` runs on the pre-pass; what degrades is its *input* — the alt-position ladder needs ≥3 priced IDP rows, and on an IDP-disabled board there are none, so the boost collapses to its single-source `idpTradeCalc` branch. 5,637 is a one-source alt-family value; 4,401 is the multi-source blend.

## B9a-2 — the 1–9999 scale is a contract, and nothing enforced it

#822 ruled the rejected league-aware methodology may not own a canonical field and closed the engine gate. One path was left: `POST /api/rankings/overrides?view=delta` with `valuation_mode: "leagueAdjusted"` handed factors to `build_rankings_delta_payload`, whose `apply_valuation_factors` multiplied them into `rankDerivedValue`. **The ±25% bound is on the factor, never on the product.**

| factor | max canonical value on the wire | rows > 9999 |
|---|---|---|
| 1.018366 (the real measured set) | **10,160** | 2 |
| 1.25 (the cap) | **12,471** | 16 |

9,999 is the Hill **asymptote** — these are numbers the curve that defines the scale cannot produce.

**Ignored, not refused** (the engine gate's convergence rule: a stored `leagueAdjusted` on someone's phone must return to the canonical answer silently). `apply_valuation_factors` and the `valuation_factors` parameter are **deleted**, so there is no seam to re-thread by accident.

Two consequences, both improvements: asking for the lens **no longer narrows scope** (nothing league-scoped is computed, so no 503 on a league mismatch), and the response is **cacheable** again — the memo excluded it only because gameplan freshness was unseeable.

**Enforcement.** `methodology.formula` published `scaleMin`/`scaleMax` and nothing verified them. `validate_api_data_contract` now checks `rankDerivedValue` **and the `values.*` aliases** against `DISPLAY_SCALE_MIN`/`MAX`, imported from `src/canonical/player_valuation.py` rather than restated — so the block that *publishes* the range and the check that *enforces* it read one constant. An **error**, not a warning, because `scripts/validate_api_contract.py` gates on `ok` and ignores warnings; the **whole array**, not the `[:1000]` prefix, because a ceiling breach lands at the top of the board. Verified non-vacuous: the live board validates `ok`, and injecting 12,471 into one row — or one alias — turns the gate red.

## B9b — a number without a scale is not a threshold

**The recorded half (W29-F005).** "Seller cash-out" compared a 0–9999 board value against a 0–100 ROS strength index: `dynastyValue < rosValue * 0.7`. RHS maxes at 60.8; the board's floor is 1,134. **0 of 1,093 rows** could fire and the tag had never rendered. It lived in three files — two JS copies, one Python — and survived review three times.

Its unit test passed. On `dynasty_value=40` — an input the 1–9999 board cannot produce. *A test with no unit discipline validated a predicate with an empty solution set.*

**The unrecorded half.** The same classifier gated "strong"/"elite" on `rosValue >= 60` / `>= 80`, written as if the index were a percentile. Measured across the live aggregate **and all 893 historical aggregates (2026-04-28 → 2026-08-14)**:

| statistic | `rosValue` |
|---|---|
| median | 9.15 |
| 99th percentile | **59.41** |
| max | 86.79 |

`>= 60` sat *above the 99th percentile* — 9 of 1,031 players. `>= 80` selected 2. The complement was worse: "Injury/bye cover" fires when **not** strong, so it labelled **99.13%** of the pool.

**Repair** — four thresholds in `config/thresholds.json` with `unit` + `derivedFrom`, in percentile units:

| tag | before | after |
|---|---|---|
| Seller cash-out | **0** (unreachable) | 19 (1.84%) |
| Injury/bye cover | 99.13% | 55.87% |
| Contender upgrade | 2 players | 47 (4.56%) |

All nine tags now have a reachability test — the assertion the finding asked for.

**Structural, because triplication is what let it survive:**
- `rosPercentile` stamped **server-side over the whole pool** — `/api/ros/player-values` truncates to `limit` (500), so a client ranking what it received would measure a standing within the top half and call it a percentile
- `canonicalPercentile` stamped on contract rows for the same reason, and included in `_DELTA_PLAYER_FIELDS` because a standing is a function of the board and re-weighting sources re-orders it
- **one** classifier, in `frontend/lib/ros-index.js`, mirroring `src/ros/tags.py`, with the parity test a JS comment had promised as "PR-future" and that was never written

Missing stays missing: `ros_percentiles` returns `None` for unranked rows, and no tag fires without a standing.

**Deliberately not converted.** Four BOARD-RELATIVE constants (`MIN_RELEVANT_VALUE`, `MIN_ACTIONABLE_VALUE`, `MIN_WAIVER_VALUE`, the `>= 7000` contender gate) are classified and registered but left alone — each changes which assets a recommendation surface *offers*, which needs its own before/after measurement. Full classification in `docs/valuation/THRESHOLD_UNIT_REGISTRY.md`.

## Tests replaced rather than deleted

Three suites pinned behaviour this PR removes. Each is rewritten to pin the replacement, and each says what it used to assert and why that assertion no longer has a subject:

- `test_finder_canonical_board.py::TestOffenseOnlyValueIsBoardScale` pinned *scale agreement between the two boards*. With one board there is nothing to compare — replaced by `TestTheOffenseOnlyBoardIsRetired`, which asserts the stronger property: a stale `_offenseOnlyFinalAdjusted` key in a cached payload must not resurrect the substitution.
- `test_league_adjusted_endpoint.py` §4 and `test_source_overrides.py::TestValuationFactorComposition` pinned the composition — now pin the withdrawal, including that the request never reaches a roster snapshot.
- `test_overrides_response_cache.py`'s bypass test pinned the cache exclusion, which existed only because gameplan freshness was unseeable.

## Validation

| gate | result |
|---|---|
| backend, whole repo | **7476 passed / 60 skipped / 0 failed** |
| frontend | **2025 passed / 123 files** |
| board invariance (B9a-1) | 0 values moved, 0 ranks changed |
| `ruff format` + `check` | clean |

## Recorded, not absorbed

`inferValueBundle` coerces an unpriced row to **0** (`frontend/lib/dynasty-data.js`). The rationale on the function is sound as far as it goes — it replaced a fallback that put a *composite-scale* number into board-scale sums — and 0 is neutral **in a sum**. It is not neutral in a sort, a minimum, an average or a display, where it asserts "worth nothing". `MISSING IS NEVER ZERO` wants `null`. The blast radius is wide (trade sums, portfolio, movers, team-phase, CSV export), so it is recorded in the deferred ledger rather than attempted unmeasured.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2EZWDCCbiL2JLvJsARUHg)_