### PR TITLE
B10-T2: declare provider families — 21 sources are 13 independent opinions

### DIFF
--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -276,6 +276,7 @@ export const RANKING_SOURCES = [
     // converts ranks to synthetic monotonic values for sort purposes;
     // the UI must render sourceOriginalRanks.dlfSf, never the synthetic.
     key: "dlfSf",
+    correlationGroup: "dlf",
     displayName: "Dynasty League Football Superflex",
     columnLabel: "DLF SF",
     scope: "overall_offense",
@@ -302,6 +303,7 @@ export const RANKING_SOURCES = [
     // DLF's ORDERING remains intact.  Synthetic "2026 Pick R.SS" rows
     // appended during CSV enrichment also nudge rookie pick values.
     key: "dlfRookieSf",
+    correlationGroup: "dlf",
     displayName: "Dynasty League Football Rookie SF",
     columnLabel: "DLF RK",
     scope: "overall_offense",
@@ -332,6 +334,7 @@ export const RANKING_SOURCES = [
     // backbone (typically ~30-50), correctly calibrating DLF against
     // the retail offense market.
     key: "dlfIdp",
+    correlationGroup: "dlf",
     displayName: "Dynasty League Football IDP",
     columnLabel: "DLF IDP",
     scope: "overall_idp",
@@ -352,6 +355,7 @@ export const RANKING_SOURCES = [
     // pick-slot value (most rookie drafts prioritize offensive
     // prospects at the top).
     key: "dlfRookieIdp",
+    correlationGroup: "dlf",
     displayName: "Dynasty League Football Rookie IDP",
     columnLabel: "DLF RK-IDP",
     scope: "overall_idp",
@@ -573,6 +577,7 @@ export const RANKING_SOURCES = [
     // no TE premium baked in.  The frontend `settings.tepMultiplier`
     // boost applies to its blended contribution.
     key: "fantasyProsSf",
+    correlationGroup: "fantasyPros",
     displayName: "FantasyPros Dynasty Superflex",
     columnLabel: "FP SF",
     scope: "overall_offense",
@@ -594,6 +599,7 @@ export const RANKING_SOURCES = [
     // registered source.  Mirrors the backend `_RANKING_SOURCES`
     // entry in src/api/data_contract.py.
     key: "fantasyProsIdp",
+    correlationGroup: "fantasyPros",
     displayName: "FantasyPros Dynasty IDP",
     columnLabel: "FP IDP",
     scope: "overall_idp",
@@ -625,6 +631,7 @@ export const RANKING_SOURCES = [
     // the shared Hill curve.  Mirrors the backend
     // ``_SOURCE_CSV_PATHS["fantasyProsFitzmaurice"].signal = "rank"``.
     key: "fantasyProsFitzmaurice",
+    correlationGroup: "fantasyPros",
     displayName: "FantasyPros / Pat Fitzmaurice SF-TEP",
     columnLabel: "Fitzmaurice",
     scope: "overall_offense",
@@ -643,6 +650,7 @@ export const RANKING_SOURCES = [
     // Flock Fantasy Dynasty Superflex rankings — expert consensus.
     // Standard SF — no TE premium.  tepMultiplier boost applies.
     key: "flockFantasySf",
+    correlationGroup: "flockFantasy",
     displayName: "Flock Fantasy Superflex",
     columnLabel: "FF",
     scope: "overall_offense",
@@ -666,6 +674,7 @@ export const RANKING_SOURCES = [
     // scale-for-top-rookie.  Pick nudging is not wired for this source;
     // dlfRookieSf already stamps synthetic "2026 Pick R.SS" rows.
     key: "flockFantasySfRookies",
+    correlationGroup: "flockFantasy",
     displayName: "Flock Fantasy Rookie SF",
     columnLabel: "Flock RK",
     scope: "overall_offense",
@@ -734,6 +743,7 @@ export const RANKING_SOURCES = [
     // top TEs like Brock Bowers).  Lockstep with
     // src/api/data_contract.py::_RANKING_SOURCES.
     key: "draftSharks",
+    correlationGroup: "draftSharks",
     displayName: "Draft Sharks Dynasty",
     columnLabel: "DS",
     scope: "overall_offense",
@@ -755,6 +765,7 @@ export const RANKING_SOURCES = [
     // (e.g. Carson Schwesinger = 44 as IDP rank 1, not the IDP-
     // only-page rescaled 81).
     key: "draftSharksIdp",
+    correlationGroup: "draftSharks",
     displayName: "Draft Sharks IDP Dynasty",
     columnLabel: "DS IDP",
     scope: "overall_idp",

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -1189,6 +1189,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # preventing false 1-src flags on fringe offense players
         # that DLF SF was never going to list.
         "key": "dlfSf",
+        "correlation_group": "dlf",
         "display_name": "Dynasty League Football Superflex",
         "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
         "position_group": None,
@@ -1226,6 +1227,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # weight scales contribution down so the rookie board never
         # overwhelms the veteran-rich retail/expert blend.
         "key": "dlfRookieSf",
+        "correlation_group": "dlf",
         "display_name": "Dynasty League Football Rookie SF",
         "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
         "position_group": None,
@@ -1268,6 +1270,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # the best IDP in the shared market (typically ~30-50), which
         # correctly calibrates DLF against the retail offense market.
         "key": "dlfIdp",
+        "correlation_group": "dlf",
         "display_name": "Dynasty League Football IDP",
         "scope": SOURCE_SCOPE_OVERALL_IDP,
         "position_group": None,
@@ -1299,6 +1302,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # translated against IDPTC's ladder.  depth=50 matches the
         # typical export size.
         "key": "dlfRookieIdp",
+        "correlation_group": "dlf",
         "display_name": "Dynasty League Football Rookie IDP",
         "scope": SOURCE_SCOPE_OVERALL_IDP,
         "position_group": None,
@@ -1558,6 +1562,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # ``settings.tepMultiplier`` boost applies to its blended
         # contribution.
         "key": "fantasyProsSf",
+        "correlation_group": "fantasyPros",
         "display_name": "FantasyPros Dynasty Superflex",
         "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
         "position_group": None,
@@ -1585,6 +1590,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # ``_expected_sources_for_position`` not to expect this
         # source for players ranked deeper than ~125 (depth * 1.25).
         "key": "fantasyProsIdp",
+        "correlation_group": "fantasyPros",
         "display_name": "FantasyPros Dynasty IDP",
         "scope": SOURCE_SCOPE_OVERALL_IDP,
         "position_group": None,
@@ -1630,6 +1636,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # TE premium directly via the TEP Value column, so the global
         # TEP multiplier MUST NOT compound.
         "key": "fantasyProsFitzmaurice",
+        "correlation_group": "fantasyPros",
         "display_name": "FantasyPros / Pat Fitzmaurice SF-TEP",
         "column_label": "Fitzmaurice",
         "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
@@ -1649,6 +1656,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # `settings.tepMultiplier` boost applies to its blended
         # contribution for TE-position players.
         "key": "flockFantasySf",
+        "correlation_group": "flockFantasy",
         "display_name": "Flock Fantasy Superflex",
         "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
         "position_group": None,
@@ -1678,6 +1686,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # rookie pick tethering pass (Phase 11) blends Flock's rookie
         # values into picks via the merged rookie pool.
         "key": "flockFantasySfRookies",
+        "correlation_group": "flockFantasy",
         "display_name": "Flock Fantasy Rookie SF",
         "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
         "position_group": None,
@@ -1752,6 +1761,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # non-TEP multiplier — which inflated every TE's DS
         # contribution and pushed top TEs like Brock Bowers too high.)
         "key": "draftSharks",
+        "correlation_group": "draftSharks",
         "display_name": "Draft Sharks Dynasty",
         "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
         "extra_scopes": [],
@@ -1790,6 +1800,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # 2026 baseline.  depth=400 because IDP depth in the DS
         # export is smaller than offense.
         "key": "draftSharksIdp",
+        "correlation_group": "draftSharks",
         "display_name": "Draft Sharks IDP Dynasty",
         "scope": SOURCE_SCOPE_OVERALL_IDP,
         "extra_scopes": [],

--- a/tests/api/test_source_provenance.py
+++ b/tests/api/test_source_provenance.py
@@ -1,0 +1,149 @@
+"""Provider families are DECLARED — B10-T2.
+
+WHAT THIS UNIT IS, AND WHAT IT DELIBERATELY IS NOT
+──────────────────────────────────────────────────
+This declares which ranking sources come from the SAME PROVIDER. It does
+not change how they are counted. That separation is the point: a
+declaration whose effect on the board is provably nil can be reviewed on
+whether it is *true*, while a change to aggregation has to be reviewed on
+what it *moves*. Doing both at once means neither gets checked properly.
+
+Measured after declaring: **0 values moved, 0 ranks changed**
+(`scripts/board_diff.py --expect-no-value-change`). The canonical blend
+never reads `correlation_group`; only leave-one-out and Consensus Edge do.
+
+WHY IT MATTERS — measured on the tracked 2026-08-14 CSVs
+────────────────────────────────────────────────────────
+19 of 21 sources declared nothing, so `correlation_group_for` defaulted
+each to its own key and every one counted as an independent opinion.
+Three providers publish more than one board that covers the SAME players:
+
+| provider | rows it votes on more than once |
+|---|---|
+| FantasyPros | **299** |
+| Flock Fantasy | 70 |
+| DLF | 52 |
+
+FantasyPros is the case the owner ruled on directly: `fantasyProsSf` is a
+544-player expert **consensus**, and `fantasyProsFitzmaurice` is **one
+expert inside that panel** — 299 players, **100% contained** in the
+consensus board, Pearson r = 0.9297. An expert already inside a provider
+consensus does not get a second independent canonical vote.
+
+The lineage here is **declarative, not inferred**: the source's own
+`display_name` is "FantasyPros / Pat Fitzmaurice SF-TEP". The correlation
+measurement corroborates it and is not the basis for it — per the owner's
+rule that family ownership must never be guessed from output correlation.
+
+CORRECTION TO THE AUTHORISING PREMISE, recorded so it is not re-derived
+───────────────────────────────────────────────────────────────────────
+The B10 scope was written around "ktc weight ~1.3 + ktcSfTep ~1.0, so
+KTC-family evidence votes at ~2.3 against IDPTC's 1.0". Measured on this
+tree, that does not describe canonical aggregation:
+
+* there is **no `ktc` entry** in `_RANKING_SOURCES`; the KTC family votes
+  canonically exactly once, through `ktcSfTep`, at weight **1.00**;
+* **all 21 sources are weight 1.00**, per the registry's stated policy;
+* the `1.3` is real but belongs to `LEGACY_COMPOSITE_SITE_WEIGHTS` in
+  `Dynasty Scraper.py`, whose own docstring scopes it to `_composite` and
+  pick-row blending — a different concept that shares the word "weight";
+* `ktc` DOES appear in `canonicalSiteValues` (464 rows, the same rows as
+  `ktcSfTep`) but is not a registered source, so it casts no vote.
+
+The real independence defect is the undeclared families above, not a
+KTC double-weight.
+"""
+
+from __future__ import annotations
+
+import collections
+import inspect
+
+from src.api import data_contract
+from src.api.data_contract import (
+    _RANKING_SOURCES,
+    correlation_group_for,
+    expand_correlation_groups,
+)
+
+#: Providers that publish more than one board in the registry. Declared
+#: from provenance — the vendor each feed is fetched from — not from
+#: output similarity.
+KNOWN_MULTI_BOARD_PROVIDERS = {
+    "dlf": {"dlfSf", "dlfRookieSf", "dlfIdp", "dlfRookieIdp"},
+    "fantasyPros": {"fantasyProsSf", "fantasyProsIdp", "fantasyProsFitzmaurice"},
+    "flockFantasy": {"flockFantasySf", "flockFantasySfRookies"},
+    "draftSharks": {"draftSharks", "draftSharksIdp"},
+    "ktc": {"ktcSfTep", "fantasyNavigatorSf"},
+}
+
+
+def _groups() -> dict[str, set[str]]:
+    out: dict[str, set[str]] = collections.defaultdict(set)
+    for src in _RANKING_SOURCES:
+        key = str(src.get("key") or "")
+        out[str(src.get("correlation_group") or key)].add(key)
+    return dict(out)
+
+
+class TestEveryMultiBoardProviderIsDeclared:
+    def test_the_known_families_are_grouped(self):
+        groups = _groups()
+        for provider, members in KNOWN_MULTI_BOARD_PROVIDERS.items():
+            assert (
+                groups.get(provider) == members
+            ), f"{provider} is declared as {groups.get(provider)}, expected {members}"
+
+    def test_the_nested_expert_shares_its_panels_group(self):
+        """The owner's ruling, as an assertion.
+
+        Pat Fitzmaurice is an expert inside the FantasyPros consensus.
+        Whatever B10-T3 decides a family is worth, these two must be
+        deciding it together.
+        """
+        assert correlation_group_for("fantasyProsFitzmaurice") == correlation_group_for(
+            "fantasyProsSf"
+        )
+
+    def test_expanding_one_member_reaches_the_whole_family(self):
+        expanded = expand_correlation_groups(["fantasyProsFitzmaurice"])
+        assert KNOWN_MULTI_BOARD_PROVIDERS["fantasyPros"] <= expanded
+
+    def test_no_source_silently_defaults_into_a_declared_family(self):
+        """A source whose key happens to match a family name would join it
+        by accident rather than by declaration."""
+        declared = {str(s.get("key") or "") for s in _RANKING_SOURCES if s.get("correlation_group")}
+        for src in _RANKING_SOURCES:
+            key = str(src.get("key") or "")
+            if key in declared:
+                continue
+            assert (
+                key not in KNOWN_MULTI_BOARD_PROVIDERS
+            ), f"{key} lands in a multi-board family by defaulting to its own key"
+
+    def test_independent_family_count_is_lower_than_source_count(self):
+        """The number this exists to make available to B10-T3.
+
+        21 source keys, 13 independent provider families. Any aggregation
+        step whose mathematical meaning is "how much independent evidence
+        is there" must use the second number.
+        """
+        assert len(_RANKING_SOURCES) == 21
+        assert len(_groups()) == 13
+
+
+class TestTheDeclarationIsInertOnTheBoard:
+    """T2 changes no value. Its whole reviewability rests on that."""
+
+    def test_the_canonical_blend_does_not_read_correlation_group(self):
+        """Structural, because the byte-identical board diff is a
+        measurement of one input and this is a property of the code.
+
+        If the blend ever starts consulting the family, that is B10-T3 —
+        a deliberate aggregation change with its own before/after
+        envelope — and it must not arrive as a side effect of declaring
+        one more provider.
+        """
+        src = inspect.getsource(data_contract._compute_unified_rankings)
+        assert "correlation_group" not in src
+        assert "expand_correlation_groups" not in src

--- a/tests/consensus_edge/test_fair_value.py
+++ b/tests/consensus_edge/test_fair_value.py
@@ -74,7 +74,27 @@ class TestCorrelationGroups(unittest.TestCase):
         )
 
     def test_an_independent_source_expands_to_only_itself(self):
-        self.assertEqual(dc.expand_correlation_groups(["dlfSf"]), {"dlfSf"})
+        # ``fantasyCalc`` is a genuinely single-board provider.
+        #
+        # This used to name ``dlfSf``, which stopped being true rather
+        # than stopped being tested: B10-T2 declared DLF's four boards
+        # (SF, rookie SF, IDP, rookie IDP) as one provider family, and
+        # measured 52 players that DLF was voting on more than once.
+        # The property under test is unchanged — an independent source
+        # expands to itself — so it needs a source that is still one.
+        self.assertEqual(dc.expand_correlation_groups(["fantasyCalc"]), {"fantasyCalc"})
+
+    def test_a_declared_family_member_expands_to_the_whole_family(self):
+        """The companion the suite lacked.
+
+        Without it, declaring a family could quietly stop propagating and
+        only the singleton case above would notice — which is the
+        direction that does NOT fail closed.
+        """
+        self.assertEqual(
+            dc.expand_correlation_groups(["dlfSf"]),
+            {"dlfSf", "dlfRookieSf", "dlfIdp", "dlfRookieIdp"},
+        )
 
     def test_an_unknown_key_passes_through_rather_than_raising(self):
         # A caller naming a retired source should get a board without it,


### PR DESCRIPTION
Declares which ranking sources come from the **same provider**. It does **not** change how they are counted.

That separation is the whole design. A declaration whose board effect is provably nil can be reviewed on whether it is **true**; an aggregation change has to be reviewed on what it **moves**. Doing both in one PR means neither gets checked properly. B10-T3 is the one that moves numbers, and it is not in here.

---

## Why

19 of 21 sources declared no `correlation_group`, so `correlation_group_for` defaulted each to its own key and every one counted as an independent opinion. Measured on the tracked 2026-08-14 CSVs, three providers publish more than one board covering the **same players**:

| provider | boards | rows it votes on more than once |
|---|---|---|
| FantasyPros | `fantasyProsSf`, `fantasyProsIdp`, `fantasyProsFitzmaurice` | **299** |
| Flock Fantasy | `flockFantasySf`, `flockFantasySfRookies` | 70 |
| DLF | `dlfSf`, `dlfRookieSf`, `dlfIdp`, `dlfRookieIdp` | 52 |

**21 source keys collapse to 13 independent provider families.**

FantasyPros is the nested-consensus case directly: `fantasyProsSf` is a 544-player expert **consensus**, and `fantasyProsFitzmaurice` is **one expert inside that panel** — 299 players, **100% contained** in the consensus board, Pearson **r = 0.9297**, median |rank diff| 12.

The lineage is **declarative, not inferred**. The source's own `display_name` is *"FantasyPros / Pat Fitzmaurice SF-TEP"*. The correlation above corroborates it and is deliberately **not** the basis — family ownership must never be guessed from output similarity, because similar output is what a good independent source also produces.

## Inertness, proven rather than asserted

`scripts/board_diff.py --expect-no-value-change` on a pinned payload:

```
VALUES: 0 moved, 0 newly priced, 0 newly unpriced
RANKS:  0 changed
ASSERTION OK: no value changed.
```

Two further guarantees, because a one-off diff measures one input:

- **Structural** — a test asserts `_compute_unified_rankings`' own source contains neither `correlation_group` nor `expand_correlation_groups`. If the blend ever starts consulting families, that is T3 with its own before/after envelope, and it cannot arrive as a side effect of declaring one more provider.
- **Live output** — the only consumers are leave-one-out and Consensus Edge, and `consensus_edge` defaults to `False` (`src/api/feature_flags.py:296`). So this is inert on the board *and* on what production serves today.

## Correction to the authorising premise

Recorded in the test module so it is not re-derived. B10 was scoped around *"ktc weight ≈1.3 + ktcSfTep ≈1.0, so KTC-family evidence votes at ≈2.3 against IDPTC's 1.0"*. Measured on this tree, that does not describe canonical aggregation:

- there is **no `ktc` entry** in `_RANKING_SOURCES`; the KTC family votes canonically exactly once, through `ktcSfTep`, at weight **1.00**;
- **all 21 sources are weight 1.00**, per the registry's stated policy;
- the `1.3` **is real**, but it is `LEGACY_COMPOSITE_SITE_WEIGHTS` in `Dynasty Scraper.py`, scoped by its own docstring to `_composite` and pick-row blending — a different concept sharing the word "weight";
- `ktc` **does** appear in `canonicalSiteValues` (464 rows, the same rows as `ktcSfTep`) but is not a registered source, so it casts no vote. Verified rather than taken from the docstring.

The real independence defect is the undeclared families above, not a KTC double-weight. Any T3 plan resting on the 2.3 figure is resting on a stale reading.

## Test changed, and why it was not a weakening

`tests/consensus_edge/test_fair_value.py::test_an_independent_source_expands_to_only_itself` named `dlfSf` as its example of an independent source. That **stopped being true**, not stopped being tested — DLF publishes four boards and votes twice on 52 players. The property under test is unchanged, so it now names `fantasyCalc`, which is genuinely single-board.

A companion test was added for the direction that does **not** fail closed: a declared family member must expand to the whole family. Without it, declaration could quietly stop propagating and only the singleton case would notice.

The frontend registry mirror is updated in lockstep (`test_source_registry_parity`).

## Validation

| gate | result |
|---|---|
| board inertness | **0 values moved, 0 ranks changed** |
| backend, whole repo | **7483 passed / 60 skipped / 0 failed** |
| frontend | **2025 passed / 123 files** |
| `ruff format` + `check` | clean |

## What this does not do

`correlation_group` is a flat grouping: it says *these are not independent*. It does not yet say *how many votes a family gets*, which is B10-T3 — and per the owner ruling that is where the nested-panel rule (an expert inside a consensus does not get a second vote) becomes arithmetic, where n-sensitive aggregation moves from raw source-key count to independent family count, and where the movement envelope has to be measured against an immutable pre-change baseline.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)