### PR TITLE
Ledger: record the B9 and B10-T2 merges, and the B11 reconnaissance

### DIFF
--- a/docs/EXECUTION_PLAN.md
+++ b/docs/EXECUTION_PLAN.md
@@ -89,6 +89,33 @@ This file answers **what work should happen next**. It does not define long-term
 
 ---
 
+### B10 — source independence / anti-circularity · IN PROGRESS
+
+- **T1 (scraper KTC dedupe) — SATISFIED, nothing to remove.** The authorising premise
+  ("ktc ≈1.3 + ktcSfTep ≈1.0 → ≈2.3 vs IDPTC 1.0") does not describe canonical
+  aggregation: there is no `ktc` entry in `_RANKING_SOURCES`, the KTC family votes
+  canonically once through `ktcSfTep`, and all 21 sources are weight 1.00. The `1.3` is
+  `LEGACY_COMPOSITE_SITE_WEIGHTS` in `Dynasty Scraper.py`, scoped to `_composite`.
+- **T2 (declare provenance) — MERGED.** PR #825 (`e015814`). 19 of 21 sources declared no
+  family, so each counted as independent. **21 source keys → 13 provider families.**
+  FantasyPros votes twice on 299 rows (`fantasyProsFitzmaurice` is one expert 100%
+  contained in the `fantasyProsSf` consensus panel, r = 0.9297), Flock on 70, DLF on 52.
+  Board provably inert: 0 values moved, 0 ranks changed.
+- **T3 (family-aware aggregation) — NOT STARTED.** This is the unit that moves values: it
+  decides how many votes a family gets and re-derives n-sensitive aggregation against the
+  independent family count. Needs an immutable pre-change baseline and the movement
+  envelope check before anything ships.
+
+### B11 — confidence semantics · NOT STARTED
+
+Reconnaissance recorded in the ledger. `_compute_confidence_bucket` reads exactly two
+inputs — source count and percentile spread. Freshness, coverage, independence and
+missingness are not inputs at all. **The monotonicity defect is confirmed and strict:**
+removing `dlfSf` raises the bucket on 26 rows and lowers it on 0. The recorded "192 of 683"
+figure is larger than today's measurement and should not be quoted without re-measuring.
+
+---
+
 ---
 
 # 2. NEXT AUTHORIZED FOUNDATION SCOPE

--- a/docs/master-site-audit/B_SERIES_EXECUTION_LEDGER.md
+++ b/docs/master-site-audit/B_SERIES_EXECUTION_LEDGER.md
@@ -20,12 +20,12 @@ working branch for provenance and only the validated GREEN head merges.
 | 0 | **B7.0** — residual B6 evidence closure + preflight | **COMPLETE** (merged in #819) |
 | 1 | B7 — realized-points correctness (RED commit → GREEN head) | **MERGED AND VERIFIED** (#820, `af761fc`) |
 | 2 | B8 — privacy / distribution / refresh boundary | **MERGED** (#821, `053f9e5`) |
-| 3 | B9a — one canonical value + the scale contract | **MERGED** |
-| 5 | B9b — threshold unit registry | **MERGED** (partial — §B9b) |
-| 6 | B10-T1 — scraper KTC dedupe | not started — **premise corrected, see §B10** |
-| 7 | B10-T2 — declare provenance (board byte-identical) | not started |
-| 8 | B10-T3 — family-aware aggregation | not started |
-| 9 | B11 — confidence axes | not started |
+| 3 | B9a — one canonical value + the scale contract | **MERGED** (#824, `2e0d098`) |
+| 5 | B9b — threshold unit registry | **MERGED** (#824, partial by design — §B9b) |
+| 6 | B10-T1 — scraper KTC dedupe | **SATISFIED, nothing to remove** — §B10-T2 |
+| 7 | B10-T2 — declare provenance (board byte-identical) | **MERGED** (#825, `e015814`) |
+| 8 | B10-T3 — family-aware aggregation | **NOT STARTED** — the unit that moves values |
+| 9 | B11 — confidence axes | **NOT STARTED** — recon recorded, §B11 |
 
 ---
 
@@ -481,6 +481,12 @@ missing ≠ zero, cross-surface parity, and automated completeness regression. N
 
 # B9 — Canonical player value semantics · **MERGED**
 
+PR **#824**, merged 2026-08-14 as `2e0d098`, second parent `f0bb846` — the exact
+CI-validated head (PR Validation run **31787773048**, job 94734341688, SUCCESS).
+Local on that head: backend **7476 passed / 60 skipped / 0 failed**, frontend
+**2025 passed / 123 files**. Main advanced only by automated data refreshes; no source
+overlap.
+
 Two merge units, both GREEN at merge. Findings closed: `W29-F001`, `W29-F002` (overlay half
 closed earlier by #822), `W29-F005`.
 
@@ -627,3 +633,151 @@ resting on a stale reading.
 Per the owner's ruling, family lineage must be **declarative**, so the correlation above is
 corroboration, not the basis. B10-T2 (declare provenance, board byte-identical) is the next
 unit and has not been started.
+
+---
+
+# B10-T2 — Declare provider families · **MERGED**
+
+Declares which sources share a provider. Changes nothing about how they are counted —
+that is T3, and keeping the two apart is what makes each reviewable: a declaration with a
+provably nil board effect is reviewed on whether it is TRUE, an aggregation change on what
+it MOVES.
+
+## What was undeclared
+
+19 of 21 sources declared no `correlation_group`, so `correlation_group_for` defaulted each
+to its own key and every one counted as an independent opinion. Measured on the tracked
+2026-08-14 CSVs:
+
+| provider | boards | rows it votes on more than once |
+|---|---|---|
+| FantasyPros | `fantasyProsSf`, `fantasyProsIdp`, `fantasyProsFitzmaurice` | **299** |
+| Flock Fantasy | `flockFantasySf`, `flockFantasySfRookies` | 70 |
+| DLF | `dlfSf`, `dlfRookieSf`, `dlfIdp`, `dlfRookieIdp` | 52 |
+
+**21 source keys → 13 independent provider families.**
+
+FantasyPros is the owner's nested-consensus ruling made concrete: `fantasyProsSf` is a
+544-player expert **consensus** and `fantasyProsFitzmaurice` is **one expert inside that
+panel** — 299 players, **100% contained**, Pearson **r = 0.9297**, median |rank diff| 12.
+
+Lineage is **declarative**: the source's own `display_name` is "FantasyPros / Pat
+Fitzmaurice SF-TEP". The correlation corroborates and is not the basis, per the rule that
+family ownership must never be inferred from output similarity.
+
+## Inertness
+
+* `board_diff.py --expect-no-value-change`: **0 values moved, 0 ranks changed**
+* **structural** — a test asserts `_compute_unified_rankings`' source contains neither
+  `correlation_group` nor `expand_correlation_groups`, so the blend cannot start consulting
+  families as a side effect of declaring one more provider
+* **live output** — the only consumers are leave-one-out and Consensus Edge, and
+  `consensus_edge` defaults `False` (`src/api/feature_flags.py:296`)
+
+## Correction to the authorising premise — do not re-derive
+
+B10 was scoped around "ktc ≈1.3 + ktcSfTep ≈1.0 → ≈2.3 vs IDPTC 1.0". That does not
+describe canonical aggregation on this tree:
+
+* no `ktc` entry in `_RANKING_SOURCES`; the KTC family votes canonically **once**, through
+  `ktcSfTep`, at weight **1.00**;
+* **all 21 sources are weight 1.00**;
+* the `1.3` is real but is `LEGACY_COMPOSITE_SITE_WEIGHTS` in `Dynasty Scraper.py`, scoped
+  by its own docstring to `_composite` and pick-row blending;
+* `ktc` appears in `canonicalSiteValues` (464 rows, the same rows as `ktcSfTep`) but is not
+  a registered source, so it casts no vote — verified, not taken from the docstring.
+
+**B10-T1 (scraper KTC dedupe) is therefore satisfied for canonical aggregation**: there is
+no canonical KTC double-vote to remove. The `1.3` still shapes `_composite`, which reaches
+users only through the UI's explicit "Raw" value mode and the finder's legacy no-contract
+path — recorded, not absorbed.
+
+## Test changed, not weakened
+
+`test_fair_value.py::test_an_independent_source_expands_to_only_itself` named `dlfSf` as
+its independent example. That **stopped being true** rather than stopped being tested. It
+now names `fantasyCalc`, and a companion test covers the direction that does not fail
+closed: a declared member must expand to the whole family.
+
+## Validation
+
+| gate | result |
+|---|---|
+| board inertness | 0 values moved, 0 ranks changed |
+| backend, whole repo | **7483 passed / 60 skipped / 0 failed** |
+| frontend | **2025 passed / 123 files** |
+| ruff | clean |
+
+---
+
+# B11 — reconnaissance, measured on current main (2026-08-14)
+
+Read-only. Not started as a merge unit.
+
+## The computation, in full
+
+`data_contract._compute_confidence_bucket(source_count, source_rank_spread, percentile_spread)`
+reads **exactly two things**: how many sources ranked the row, and how far apart they are.
+
+```
+source_count >= 2 and percentile_spread <= 0.08  -> high
+source_count >= 2 and percentile_spread <= 0.20  -> medium
+source_count >= 1                                -> low
+otherwise                                        -> none
+```
+
+Not inputs, at all: **freshness**, **coverage**, **independence** (it counts raw source
+keys, so a provider contributing three keys counts as three votes — B10's defect leaking
+into B11), **missingness**, **degraded state**, **staleness**.
+
+## Live distribution (1,093 rows)
+
+| bucket | rows |
+|---|---|
+| low | 441 |
+| none | 305 |
+| medium | 243 |
+| high | 104 |
+
+305 rows carry `none`; **24 of them are PRICED**. A priced row with `none` confidence is
+the "unknown rendered as a confidence level" case — the label is
+`"None — unranked"` on a row that is, in fact, ranked and priced. 18 more carry
+`"None — generic tier suppressed in favor of slot-specific picks"`, which is a *suppression*
+state wearing the same word as *no evidence*.
+
+## The monotonicity defect — CONFIRMED, and it is strict
+
+Rebuilt the whole board with one source disabled and compared buckets row by row:
+
+| source removed | confidence ROSE | fell | unchanged |
+|---|---|---|---|
+| `dlfSf` | **26** | **0** | 1,067 |
+| `fantasyProsSf` | 20 | 9 | 1,064 |
+| `yahooBoone` | 13 | 6 | 1,074 |
+
+`dlfSf` is the pure case: deleting a source **can only help**. Examples — A.J. Brown
+`medium → high`, Cam Ward `medium → high`, Blake Corum `low → medium`, all by *removing*
+evidence.
+
+The mechanism is immediate from the formula: the bucket is decided on the **spread** of the
+sources that remain, so dropping a disagreeing source narrows the spread and promotes the
+row. Nothing in the calculation knows that the evidence base got smaller.
+
+`B.J. Hill` goes `none → low` when `fantasyProsSf` or `yahooBoone` is removed — a row
+gaining a confidence label because a source disappeared.
+
+**Note on the authorising figure.** The prompt records "192 of 683 rows". Today's
+measurement is smaller (26 of 1,093 for the cleanest case). The *direction and mechanism
+are identical and confirmed*; the magnitude is not, and should not be quoted as 192 without
+re-measuring.
+
+## Not yet measured
+
+- The staleness claim ("feeds ~186.9 h old still accounted for 76 of 102 High rows").
+  `dataFreshness` on the built contract did not expose a per-source `stale` map in the shape
+  probed, so the coupling was not tested. Freshness is definitionally not an input to the
+  bucket, so the *structural* claim holds regardless; the row count does not.
+- Which decision engines consume `confidenceBucket` as a gate. The owner ruling requires
+  those to be re-gated deliberately against the new named dimensions, not silently moved by
+  a presentation change.
+- `identityConfidence` / `marketConfidence` — the misleading-name half of the ruling.


### PR DESCRIPTION
Documentation only — two files, no code. Evidence and governance; it authorizes nothing.

## What it records

**B9** (#824, `2e0d098`, second parent `f0bb846` = the CI-validated head, run 31787773048) — the two units, their measurements, and the corrections the pass produced. Including one to a finding's own stated mechanism: W29-F001 attributes Travis Hunter's spread to the offense-only board "never seeing the two-way boost". It **saw** it — `_apply_two_way_player_boost` runs on the pre-pass, and what degrades is its *input*, because the alt-position ladder needs ≥3 priced IDP rows and an IDP-disabled board has none. 5,637 is a single-source alt-family value; 4,401 is the multi-source blend.

**B10-T2** (#825, `e015814`, second parent `80806c0`, run 31789937227) — 21 source keys → 13 provider families, board provably inert.

**B11 reconnaissance** — not started as a unit, recorded so it is not re-derived.

## Two premise corrections, which is most of why this PR exists

**B10's authorising figure does not hold.** The scope was written around "ktc ≈1.3 + ktcSfTep ≈1.0, so KTC-family evidence votes at ≈2.3 against IDPTC's 1.0". Measured: there is no `ktc` entry in `_RANKING_SOURCES`, the KTC family votes canonically **once** through `ktcSfTep`, and all 21 sources are weight **1.00**. The `1.3` is real but is `LEGACY_COMPOSITE_SITE_WEIGHTS` in `Dynasty Scraper.py`, scoped by its own docstring to `_composite`. `ktc` appears in `canonicalSiteValues` (464 rows) but is not a registered source, so it casts no vote — verified rather than taken from the docstring.

Consequence: **B10-T1 has nothing to remove** and is marked satisfied rather than skipped. The real independence defect is the undeclared families, which is what T2 fixed.

**B11's authorising figure is larger than today's measurement.** The recorded defect is "deleting a source increased the confidence bucket on 192 of 683 rows". The mechanism is confirmed and, in the cleanest case, *strict*: removing `dlfSf` raises the bucket on **26 rows and lowers it on 0** — deleting evidence can only help, because the bucket is decided on the spread of whatever sources remain. But 26 ≠ 192, and the ledger says so explicitly rather than carrying the old number forward.

## Deferred additions

| defect | disposition |
|---|---|
| `inferValueBundle` coerces an unpriced row to `0`. Neutral in a **sum** — which is the rationale on the function, and it is sound as far as it goes — but not in a sort, minimum, average or display, where it asserts "worth nothing". `MISSING IS NEVER ZERO` wants `null`. Blast radius: trade sums, portfolio, movers, team-phase, CSV export. | **must-fix-before-C candidate** |
| The consolidation search still restricts all-offense give-pairs to offense targets. Its only stated justification was avoiding a value-scale flip, which no longer exists. | owner decision — removing it widens the recommendation universe |
| KTC-native constants duplicated across `market_value_adjustment.py` and `ktc_va.py` — one concept, two owners. | backlog |

## Status, stated plainly

| unit | status |
|---|---|
| B7.0, B7, B8, #822 | merged |
| B9a, B9b | merged (#824) |
| B10-T1 | satisfied — nothing to remove |
| B10-T2 | merged (#825) |
| **B10-T3** | **not started** — the unit that moves values |
| **B11** | **not started** |
| **completion audit** | **not run** |

**B is not complete.** T3 decides how many votes a family gets and re-derives n-sensitive aggregation against the family count; it needs an immutable pre-change baseline and the movement-envelope check before anything ships.

Verified against the B8 privacy contract: `test_tracked_artifacts_privacy.py` — 12 passed / 4 skipped.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2EZWDCCbiL2JLvJsARUHg)_