### PR TITLE
Second Opinions: the comparison basis is explicit and owned

### DIFF
--- a/docs/trade/SECOND_OPINIONS_TODO.md
+++ b/docs/trade/SECOND_OPINIONS_TODO.md
@@ -1,3 +1,84 @@
 # Second Opinions Aggregate TODO
 
 Add a quick per-independent-vendor trade verdict summary above the detailed source breakdown. Native source coverage must be distinguished from canonical-value imputation; do not count imputed rows as independent external votes. See `TRADE_DECISION_SYNTHESIS_PLAN_2026-08-11.md`.
+
+---
+
+## Scale contract — RESOLVED (Second Opinions Scale Audit, 2026-08-14)
+
+**The basis is owned by `frontend/lib/second-opinions.js` and nothing else may set it.**
+
+Every number entering a vendor's package array carries a declared basis, and only
+compatible bases may be summed:
+
+| basis | what it is |
+|---|---|
+| `CANONICAL_1_9999` | Chase Upside's `rankDerivedValue` |
+| `NORMALIZED_VENDOR_1_9999` | a vendor signal after canonical normalization (`valueContribution`) |
+| `KTC_NATIVE` | KTC's own published value — the basis V13 VA was calibrated on |
+| `MISSING` | no comparable number exists; **never a quantity, never zero** |
+
+`CANONICAL` and `NORMALIZED_VENDOR` are compatible. `KTC_NATIVE` is its own island.
+
+### The defect that was fixed
+
+The uncovered-asset fallback was `effectiveValue(row, valueMode)` — and `valueMode` is
+the Trade Calculator's **display** toggle. Flipping it to "Raw" swapped the fallback onto
+the legacy scraper composite while every vendor number beside it stayed canonical, then
+fed the mixture to a **nonlinear** Value Adjustment.
+
+Numeric range equality is not unit compatibility. Measured on the 2026-08-14 board,
+`rawComposite / canonical` over 805 rows: median 1.063, p10 0.915, p90 1.262, **min 0.266,
+max 2.082**. Both are "roughly 0–9999"; substituting one for the other is wrong by up to a
+factor of two on one row.
+
+`TradeSourceBreakdown` now takes **no `valueMode` at all**.
+
+### Non-KTC vendors — canonical imputation is valid
+
+Proven per source on the live board: all 21 registered sources' `valueContribution` lands
+inside 1–9999, with median ratio to canonical between **0.874 and 1.196**. It is the same
+comparison space, so filling an uncovered asset with `rankDerivedValue` is unit-correct.
+
+`rawSourceValues` exists only for `ktcSfTep`, and no `canonicalSites` entry on the live
+board exceeds 9999 — but both remain excluded by construction rather than by luck.
+
+### KTC — imputation REFUSED, coverage reported instead
+
+KTC's covered assets use KTC-native values because V13 VA was calibrated on them. Direct
+canonical substitution was measured over the 385 players carrying both:
+
+| region | n | median KTC-native / canonical |
+|---|---|---|
+| top (≥7000) | 28 | 0.947 |
+| middle (3000–7000) | 103 | 1.027 |
+| tail (<3000) | 254 | 1.142 |
+| overall | 385 | 1.091 (min 0.400, max 1.491) |
+
+Not identity, and **not a constant** — it drifts monotonically with board depth, so the
+error's *direction* depends on where the player sits. Inside a nonlinear VA whose
+suppression thresholds compare raw differences, that is not a rounding concern.
+
+So an asset KTC does not cover makes KTC's opinion **incomplete**. We do not manufacture
+KTC's view of a player it never published. A calibrated canonical → KTC-native crosswalk
+may be defensible later; it would have to be derived, monotonic, tested and honest about
+extrapolation, and inventing a multiplier to get there is explicitly out of bounds.
+
+### Missing is not zero
+
+An asset with neither vendor coverage nor a canonical value is **unresolved**. It does not
+contribute `0` to the side array, and the vendor row renders **Incomplete** with no winner
+and no margin rather than publishing a verdict built on a silent zero. This applies in
+strict mode too: turning imputation off reports uncovered pieces as unresolved, where it
+previously zero-filled them.
+
+### Two kinds of weight
+
+An imputed canonical value may complete the package **arithmetic**. It does not become an
+independent external **opinion**. `nativeCounts`, `imputedCounts` and `unresolvedCounts`
+are carried per side so the future aggregate can count native coverage only — the standing
+ruling at the top of this file.
+
+Pinned by `frontend/__tests__/components/second-opinions-scale.test.jsx` (8 tests:
+raw-mode isolation, canonical fallback, no `rawComposite` leak, no foreign-native leak,
+KTC incompleteness, missing-value handling, strict mode, multi-team).

--- a/frontend/__tests__/components/second-opinions-scale.test.jsx
+++ b/frontend/__tests__/components/second-opinions-scale.test.jsx
@@ -40,7 +40,7 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, act } from "@testing-library/react";
 
 import TradeSourceBreakdown from "@/components/trade/TradeSourceBreakdown";
 
@@ -62,7 +62,13 @@ vi.mock("@/lib/dynasty-data", async (importOriginal) => {
  * so a substitution of one for the other cannot be mistaken for
  * rounding.
  */
-function asset({ name, canonical, rawComposite, covers = {}, ktcNative = null }) {
+function asset({
+  name,
+  canonical,
+  rawComposite,
+  covers = {},
+  ktcNative = null,
+}) {
   const sourceRankMeta = {};
   for (const [key, valueContribution] of Object.entries(covers)) {
     sourceRankMeta[key] = { valueContribution };
@@ -79,18 +85,34 @@ function asset({ name, canonical, rawComposite, covers = {}, ktcNative = null })
   };
 }
 
-function renderPanel(sides, valueMode) {
+/**
+ * Render and return the table CELLS.
+ *
+ * Cell-by-cell rather than a regex over `textContent`: adjacent cells
+ * concatenate ("9000" + "3000" -> "90003000") and a whole-text regex
+ * then reads a number that was never displayed.
+ *
+ * `valueMode` is still passed to prove the component IGNORES it — the
+ * prop is gone from the signature, and a stray one must not resurrect
+ * the old behaviour.
+ */
+function renderCells(sides, valueMode) {
   const { container, unmount } = render(
     <TradeSourceBreakdown sides={sides} settings={{}} valueMode={valueMode} />,
   );
+  const cells = Array.from(container.querySelectorAll("td")).map((td) =>
+    (td.textContent || "").trim(),
+  );
   const text = container.textContent || "";
   unmount();
-  return text;
+  return { cells, text };
 }
 
-/** Every number the table rendered, so a total can be compared. */
-function numbersIn(text) {
-  return (text.match(/[\d,]+/g) || []).map((s) => Number(s.replace(/,/g, "")));
+/** Numeric cell contents, e.g. "9,000" -> 9000. */
+function numbersIn(cells) {
+  return cells
+    .filter((c) => /^[\d,]+$/.test(c) && c !== "")
+    .map((c) => Number(c.replace(/,/g, "")));
 }
 
 describe("Second Opinions does not inherit the display value mode", () => {
@@ -100,16 +122,31 @@ describe("Second Opinions does not inherit the display value mode", () => {
     {
       label: "A",
       assets: [
-        asset({ name: "Covered", canonical: 5000, rawComposite: 5900, covers: { dlfSf: 5000 } }),
+        asset({
+          name: "Covered",
+          canonical: 5000,
+          rawComposite: 5900,
+          covers: { dlfSf: 5000 },
+        }),
         asset({ name: "Uncovered", canonical: 4000, rawComposite: 4800 }),
       ],
     },
-    { label: "B", assets: [asset({ name: "Other", canonical: 3000, rawComposite: 3600, covers: { dlfSf: 3000 } })] },
+    {
+      label: "B",
+      assets: [
+        asset({
+          name: "Other",
+          canonical: 3000,
+          rawComposite: 3600,
+          covers: { dlfSf: 3000 },
+        }),
+      ],
+    },
   ];
 
   it("renders the same arithmetic under full and raw", () => {
-    const full = numbersIn(renderPanel(sides, "full"));
-    const raw = numbersIn(renderPanel(sides, "raw"));
+    const full = renderCells(sides, "full").cells;
+    const raw = renderCells(sides, "raw").cells;
 
     expect(raw).toEqual(full);
   });
@@ -117,15 +154,14 @@ describe("Second Opinions does not inherit the display value mode", () => {
   it("imputes the canonical value, not the legacy composite", () => {
     // Uncovered asset: canonical 4000, rawComposite 4800. The DLF row's
     // side-A total must be 5000 + 4000 = 9000, never 5000 + 4800 = 9800.
-    const text = renderPanel(sides, "full");
-    const seen = numbersIn(text);
+    const seen = numbersIn(renderCells(sides, "full").cells);
 
     expect(seen).toContain(9000);
     expect(seen).not.toContain(9800);
   });
 
   it("still imputes the canonical value when the display mode is raw", () => {
-    const seen = numbersIn(renderPanel(sides, "raw"));
+    const seen = numbersIn(renderCells(sides, "raw").cells);
 
     expect(seen).toContain(9000);
     expect(seen).not.toContain(9800);
@@ -141,17 +177,220 @@ describe("Second Opinions does not treat a missing value as zero", () => {
       {
         label: "A",
         assets: [
-          asset({ name: "Priced", canonical: 5000, rawComposite: 5900, covers: { dlfSf: 5000 } }),
-          { name: "Unpriced", displayName: "Unpriced", values: {}, sourceRankMeta: {}, rawSourceValues: {}, canonicalSites: {} },
+          asset({
+            name: "Priced",
+            canonical: 5000,
+            rawComposite: 5900,
+            covers: { dlfSf: 5000 },
+          }),
+          {
+            name: "Unpriced",
+            displayName: "Unpriced",
+            values: {},
+            sourceRankMeta: {},
+            rawSourceValues: {},
+            canonicalSites: {},
+          },
         ],
       },
-      { label: "B", assets: [asset({ name: "Other", canonical: 3000, rawComposite: 3600, covers: { dlfSf: 3000 } })] },
+      {
+        label: "B",
+        assets: [
+          asset({
+            name: "Other",
+            canonical: 3000,
+            rawComposite: 3600,
+            covers: { dlfSf: 3000 },
+          }),
+        ],
+      },
     ];
 
-    const text = renderPanel(sides, "full");
+    const { text } = renderCells(sides, "full");
 
     // 5000 + 0 = 5000 would be the defect: an unpriced asset silently
     // contributing nothing while the row still claims a full verdict.
     expect(text).toMatch(/incomplete|partial|unresolved/i);
+  });
+});
+
+describe("KTC is not imputed into, because its basis is not ours", () => {
+  /**
+   * KTC's covered assets use KTC-NATIVE values on purpose: the V13 VA
+   * formula and its raw-difference suppression thresholds were
+   * calibrated against them.
+   *
+   * Dropping a canonical value into that array would only be valid if
+   * the two were interchangeable. Measured over the 385 players
+   * carrying both on the 2026-08-14 board:
+   *
+   *   KTC native / canonical   median 1.091  min 0.400  max 1.491
+   *     top (>=7000)           median 0.947
+   *     middle (3000-7000)     median 1.027
+   *     tail (<3000)           median 1.142
+   *
+   * Not identity, and not a constant — it drifts with board depth, so
+   * the error's DIRECTION depends on where the player sits. Inside a
+   * nonlinear VA that compares raw differences, that is not rounding.
+   *
+   * So an asset KTC does not cover makes KTC's opinion INCOMPLETE. We
+   * do not manufacture KTC's view of a player it never published.
+   */
+  it("reports incomplete rather than substituting our canonical value", () => {
+    const sides = [
+      {
+        label: "A",
+        assets: [
+          asset({
+            name: "KTC has this",
+            canonical: 5000,
+            rawComposite: 5900,
+            ktcNative: 5200,
+          }),
+          asset({
+            name: "KTC lacks this",
+            canonical: 4000,
+            rawComposite: 4800,
+          }),
+        ],
+      },
+      {
+        label: "B",
+        assets: [
+          asset({
+            name: "Other",
+            canonical: 3000,
+            rawComposite: 3600,
+            ktcNative: 3100,
+          }),
+        ],
+      },
+    ];
+
+    const { cells, text } = renderCells(sides, "full");
+    const seen = numbersIn(cells);
+
+    expect(text).toMatch(/incomplete/i);
+    // 5200 + 4000 would be canonical imputed into a KTC-native array.
+    expect(seen).not.toContain(9200);
+  });
+});
+
+describe("Foreign vendor-native scales never reach package math", () => {
+  it("uses the normalized contribution, not the vendor's own published number", () => {
+    // A source publishing 72 on its own 0-100 scale while its
+    // normalized contribution is 5600. Summing 72 with canonical-scale
+    // numbers would be the same defect class as rawComposite.
+    const row = asset({
+      name: "Scaled",
+      canonical: 5600,
+      rawComposite: 6100,
+      covers: { dlfSf: 5600 },
+    });
+    row.sourceNativeValues = { dlfSf: 72 };
+    row.canonicalSites = { dlfSf: 100072 }; // synthetic rank encoding
+
+    const sides = [
+      { label: "A", assets: [row] },
+      {
+        label: "B",
+        assets: [
+          asset({
+            name: "Other",
+            canonical: 3000,
+            rawComposite: 3600,
+            covers: { dlfSf: 3000 },
+          }),
+        ],
+      },
+    ];
+
+    const seen = numbersIn(renderCells(sides, "full").cells);
+
+    expect(seen).toContain(5600);
+    expect(seen).not.toContain(72);
+    expect(seen).not.toContain(100072);
+  });
+});
+
+describe("Strict mode keeps its meaning", () => {
+  it("uncovered pieces are unresolved, not zero-valued", () => {
+    const sides = [
+      {
+        label: "A",
+        assets: [
+          asset({
+            name: "Covered",
+            canonical: 5000,
+            rawComposite: 5900,
+            covers: { dlfSf: 5000 },
+          }),
+          asset({ name: "Uncovered", canonical: 4000, rawComposite: 4800 }),
+        ],
+      },
+      {
+        label: "B",
+        assets: [
+          asset({
+            name: "Other",
+            canonical: 3000,
+            rawComposite: 3600,
+            covers: { dlfSf: 3000 },
+          }),
+        ],
+      },
+    ];
+
+    const { container, unmount } = render(
+      <TradeSourceBreakdown sides={sides} settings={{}} />,
+    );
+    const toggle = container.querySelector('input[type="checkbox"]');
+    act(() => {
+      toggle.click();
+    });
+    const text = container.textContent || "";
+    unmount();
+
+    // With imputation off the vendor covers only part of the trade, so
+    // the honest report is incomplete — not a 5,000-vs-3,000 verdict
+    // built on an asset silently priced at nothing.
+    expect(text).toMatch(/incomplete/i);
+  });
+});
+
+describe("Multi-team trades hold the same unit invariants", () => {
+  it("three sides render identically under full and raw", () => {
+    const sides = [
+      {
+        label: "A",
+        assets: [
+          asset({
+            name: "A1",
+            canonical: 5000,
+            rawComposite: 5900,
+            covers: { dlfSf: 5000 },
+          }),
+        ],
+      },
+      {
+        label: "B",
+        assets: [asset({ name: "B1", canonical: 4000, rawComposite: 4800 })],
+      },
+      {
+        label: "C",
+        assets: [
+          asset({
+            name: "C1",
+            canonical: 3000,
+            rawComposite: 3600,
+            covers: { dlfSf: 3000 },
+          }),
+        ],
+      },
+    ];
+
+    expect(renderCells(sides, "raw").cells).toEqual(
+      renderCells(sides, "full").cells,
+    );
   });
 });

--- a/frontend/__tests__/components/second-opinions-scale.test.jsx
+++ b/frontend/__tests__/components/second-opinions-scale.test.jsx
@@ -1,0 +1,157 @@
+/**
+ * Second Opinions — every number entering package math has a declared,
+ * compatible unit.
+ *
+ * WHAT THE PANEL DOES
+ * -------------------
+ * `TradeSourceBreakdown` re-answers "is this trade fair?" once per
+ * vendor. A vendor's covered assets use
+ * `sourceRankMeta[key].valueContribution` — the source's signal after
+ * canonical normalization. When a vendor does not cover an asset, the
+ * "Fill uncovered pieces with our value" toggle substitutes a Chase
+ * Upside value so the vendor can still produce a complete opinion.
+ *
+ * That product behaviour is wanted. The mathematics is only valid if
+ * the substituted number is in a unit system compatible with the
+ * vendor values it is summed with, before Value Adjustment runs.
+ *
+ * NUMERIC RANGE EQUALITY IS NOT UNIT COMPATIBILITY. Measured on the
+ * tracked 2026-08-14 board:
+ *
+ *   rawComposite / canonical   n=805   median 1.063
+ *                                      p10 0.915  p90 1.262
+ *                                      min 0.266  max 2.082
+ *
+ * Both live in "roughly 0-9999", and substituting one for the other is
+ * wrong by up to a factor of two on a single row.
+ *
+ * THE DEFECT
+ * ----------
+ * The fallback was `effectiveValue(row, valueMode, settings)`, and
+ * `effectiveValue` returns `row.values[valueMode]`. `valueMode` is the
+ * Trade Calculator's DISPLAY toggle, passed straight in from
+ * `/trade/page.jsx`. So flipping a diagnostic control from "Our value"
+ * to "Raw" silently changed the unit system underneath Second
+ * Opinions' arithmetic: `values.raw` is the legacy scraper composite,
+ * summed alongside canonical-scale vendor contributions and fed into a
+ * NONLINEAR Value Adjustment.
+ *
+ * A user's display selection may not change the math basis.
+ */
+import { describe, it, expect, vi } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import TradeSourceBreakdown from "@/components/trade/TradeSourceBreakdown";
+
+vi.mock("@/lib/dynasty-data", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    RANKING_SOURCES: [
+      { key: "dlfSf", displayName: "DLF SF", columnLabel: "DLF" },
+      { key: "ktcSfTep", displayName: "KTC TE++", columnLabel: "KTC" },
+    ],
+    SOURCE_VENDOR_LABELS: {},
+    vendorForSource: (key) => key,
+  };
+});
+
+/**
+ * One asset. `canonical` and `rawComposite` are deliberately far apart
+ * so a substitution of one for the other cannot be mistaken for
+ * rounding.
+ */
+function asset({ name, canonical, rawComposite, covers = {}, ktcNative = null }) {
+  const sourceRankMeta = {};
+  for (const [key, valueContribution] of Object.entries(covers)) {
+    sourceRankMeta[key] = { valueContribution };
+  }
+  return {
+    name,
+    displayName: name,
+    canonicalName: name,
+    rankDerivedValue: canonical,
+    values: { full: canonical, raw: rawComposite },
+    sourceRankMeta,
+    rawSourceValues: ktcNative == null ? {} : { ktcSfTep: ktcNative },
+    canonicalSites: {},
+  };
+}
+
+function renderPanel(sides, valueMode) {
+  const { container, unmount } = render(
+    <TradeSourceBreakdown sides={sides} settings={{}} valueMode={valueMode} />,
+  );
+  const text = container.textContent || "";
+  unmount();
+  return text;
+}
+
+/** Every number the table rendered, so a total can be compared. */
+function numbersIn(text) {
+  return (text.match(/[\d,]+/g) || []).map((s) => Number(s.replace(/,/g, "")));
+}
+
+describe("Second Opinions does not inherit the display value mode", () => {
+  // DLF covers one asset and not the other, so the uncovered one goes
+  // through the fallback — which is the whole subject.
+  const sides = [
+    {
+      label: "A",
+      assets: [
+        asset({ name: "Covered", canonical: 5000, rawComposite: 5900, covers: { dlfSf: 5000 } }),
+        asset({ name: "Uncovered", canonical: 4000, rawComposite: 4800 }),
+      ],
+    },
+    { label: "B", assets: [asset({ name: "Other", canonical: 3000, rawComposite: 3600, covers: { dlfSf: 3000 } })] },
+  ];
+
+  it("renders the same arithmetic under full and raw", () => {
+    const full = numbersIn(renderPanel(sides, "full"));
+    const raw = numbersIn(renderPanel(sides, "raw"));
+
+    expect(raw).toEqual(full);
+  });
+
+  it("imputes the canonical value, not the legacy composite", () => {
+    // Uncovered asset: canonical 4000, rawComposite 4800. The DLF row's
+    // side-A total must be 5000 + 4000 = 9000, never 5000 + 4800 = 9800.
+    const text = renderPanel(sides, "full");
+    const seen = numbersIn(text);
+
+    expect(seen).toContain(9000);
+    expect(seen).not.toContain(9800);
+  });
+
+  it("still imputes the canonical value when the display mode is raw", () => {
+    const seen = numbersIn(renderPanel(sides, "raw"));
+
+    expect(seen).toContain(9000);
+    expect(seen).not.toContain(9800);
+  });
+});
+
+describe("Second Opinions does not treat a missing value as zero", () => {
+  it("an asset with no canonical value is not summed as a zero-value piece", () => {
+    // No vendor coverage AND no canonical value: the honest answer is
+    // that this vendor's opinion of the trade is incomplete, not that
+    // the asset is worthless.
+    const sides = [
+      {
+        label: "A",
+        assets: [
+          asset({ name: "Priced", canonical: 5000, rawComposite: 5900, covers: { dlfSf: 5000 } }),
+          { name: "Unpriced", displayName: "Unpriced", values: {}, sourceRankMeta: {}, rawSourceValues: {}, canonicalSites: {} },
+        ],
+      },
+      { label: "B", assets: [asset({ name: "Other", canonical: 3000, rawComposite: 3600, covers: { dlfSf: 3000 } })] },
+    ];
+
+    const text = renderPanel(sides, "full");
+
+    // 5000 + 0 = 5000 would be the defect: an unpriced asset silently
+    // contributing nothing while the row still claims a full verdict.
+    expect(text).toMatch(/incomplete|partial|unresolved/i);
+  });
+});

--- a/frontend/app/trade/page.jsx
+++ b/frontend/app/trade/page.jsx
@@ -1997,11 +1997,9 @@ export default function TradePage() {
             defaultCollapsed
             mountCollapsedChildren={false}
           >
-          <TradeSourceBreakdown
-            sides={sides}
-            settings={settings}
-            valueMode={valueMode}
-          />
+          {/* No valueMode: Second Opinions owns its own comparison
+              basis and must not inherit a display toggle. */}
+          <TradeSourceBreakdown sides={sides} settings={settings} />
           <RosTradeFitPanel sides={sides} settings={settings} />
           <BdvmTradePanel sides={sides} leagueKey={selectedLeagueKey} />
 

--- a/frontend/components/trade/TradeSourceBreakdown.jsx
+++ b/frontend/components/trade/TradeSourceBreakdown.jsx
@@ -34,26 +34,28 @@ import {
   SOURCE_VENDOR_LABELS,
   vendorForSource,
 } from "@/lib/dynasty-data";
-import {
-  effectiveValue,
-  valueAdjustmentFromSideArrays,
-} from "@/lib/trade-logic";
+import { valueAdjustmentFromSideArrays } from "@/lib/trade-logic";
+import { resolveVendorAssetValue, summariseSide } from "@/lib/second-opinions";
 
 const KTC_RAW_NATIVE_VENDORS = new Set(["ktcSfTep"]);
 
-export default function TradeSourceBreakdown({
-  sides,
-  settings,
-  valueMode = "full",
-}) {
-  // When ON (default), pieces uncovered by a vendor's sub-boards
-  // are imputed with our blended canonical value via
-  // ``effectiveValue`` — the same value the main fairness bar
-  // uses.  Lets every vendor render a complete opinion on the
-  // trade so side totals are directly comparable.  Imputed cells
-  // get an italic style + dotted underline + tooltip explaining
-  // the substitution.  Power-user mode (toggle OFF) shows raw
-  // vendor coverage with zero-fill, the previous behavior.
+// NOTE: this component deliberately takes NO ``valueMode``.
+//
+// It used to, and passed it to ``effectiveValue`` for the
+// uncovered-asset fallback — so flipping the Trade Calculator's
+// display toggle to "Raw" swapped the fallback onto the legacy scraper
+// composite while every vendor number beside it stayed canonical.
+// Measured: rawComposite/canonical runs 0.266-2.082 across 805 rows.
+// A user's diagnostic selection may not change the unit system the
+// arithmetic runs in, so the basis is owned by
+// ``lib/second-opinions.js`` and nothing here can override it.
+export default function TradeSourceBreakdown({ sides, settings }) {
+  // When ON (default), pieces a vendor does not cover are filled with
+  // our CANONICAL value — explicitly, via ``resolveVendorAssetValue``,
+  // never through a display mode.  Imputed cells get an italic style +
+  // dotted underline + tooltip.  Toggle OFF for strict "what does this
+  // vendor literally say" mode, which now reports the uncovered pieces
+  // as unresolved rather than summing them as zeros.
   const [imputeUncovered, setImputeUncovered] = useState(true);
 
   const rows = useMemo(() => {
@@ -92,97 +94,37 @@ export default function TradeSourceBreakdown({
         // case where only one sub-board covers a given player.
         const mainSubs = subs.filter((s) => !s.needsRookieTranslation);
         const rookieSubs = subs.filter((s) => s.needsRookieTranslation);
-        // Per-source value resolution.
-        //
-        // For KTC's TE++ board, the V13 Value Adjustment formula and
-        // its empirical suppression thresholds (V13_SUPPRESS_RAW_DIFF,
-        // V13_SUPPRESS_SAME_SIDE_RAW_DIFF) were calibrated against
-        // KTC's raw 0-9999 piece values.  Feeding the formula the
-        // canonical Hill-blended ``valueContribution`` instead would
-        // mis-fire VA — sometimes suppressing a real VA, sometimes
-        // inventing one — and the per-source KTC row would disagree
-        // with what keeptradecut.com displays for the same trade.
-        //
-        // Read the raw scrape from ``row.rawSourceValues.ktcSfTep``
-        // so TE rows feed the V13 formula the actual KTC TE++ value
-        // straight from keeptradecut.com.  Post PR #406 the canonical
-        // ``canonicalSites.ktcSfTep`` stamp matches the raw scrape
-        // (KTC is in ``_TE_BLANKET_KTC_EXEMPT_KEYS`` and the scraper-
-        // side ×1.15 has been removed), so the two paths agree — the
-        // canonical fallback stays in place for legacy fixtures and
-        // as a defense against any future canonical-pipeline drift.
-        //
-        // For every other vendor we keep the Hill-normalized
-        // ``valueContribution``: rank-signal sources DO carry their
-        // vendor-native number in ``sourceNativeValues`` (FC crowd
-        // value, OTC 0-100, ...), but those live on per-vendor scales
-        // that would break this component's cross-vendor 0-9999
-        // ratios — natives are display/tooltip data, not math inputs.
-        // The ``canonicalSites`` slot for these sources is a synthetic
-        // 100,000+ rank-encoded number, equally unusable here.
+        // Per-asset value resolution lives in ``lib/second-opinions.js``,
+        // which returns a BASIS with every number and refuses to return a
+        // quantity it cannot justify.  KTC is the one vendor whose covered
+        // assets use its own native values (V13 VA was calibrated on
+        // them), and it is therefore the one vendor we will not impute
+        // into — canonical and KTC-native are not interchangeable
+        // (median ratio 1.091, drifting 0.947 at the top of the board to
+        // 1.142 in the tail, range 0.400-1.491).
         const useRawNative = KTC_RAW_NATIVE_VENDORS.has(vendor);
-        const sourceValueForRow = (row, sub) => {
-          if (useRawNative) {
-            const raw = Number(row.rawSourceValues?.[sub.key]);
-            if (Number.isFinite(raw) && raw > 0) return raw;
-            const native = Number(row.canonicalSites?.[sub.key]);
-            if (Number.isFinite(native) && native > 0) return native;
-          }
-          const vc = Number(row.sourceRankMeta?.[sub.key]?.valueContribution);
-          return Number.isFinite(vc) && vc > 0 ? vc : 0;
-        };
-        const averageCovered = (row, sourceList) => {
-          let sum = 0;
-          let covered = 0;
-          for (const sub of sourceList) {
-            const v = sourceValueForRow(row, sub);
-            if (v > 0) {
-              sum += v;
-              covered += 1;
-            }
-          }
-          return covered > 0 ? sum / covered : 0;
-        };
-        // Per-piece value resolution.  Both players and picks go
-        // through ``averageCovered`` which returns 0 for any sub-
-        // board that doesn't rank this piece.  When the vendor
-        // genuinely doesn't cover a piece (e.g. DLF on draft picks,
-        // KTC pre-V13 on IDP) the imputeUncovered toggle decides:
-        //   ON  → fall back to our blended value via effectiveValue
-        //          (the same value the main fairness bar uses), so
-        //          every vendor produces a complete opinion the
-        //          user can compare across rows.
-        //   OFF → contribute 0, the strict "what does this vendor
-        //          literally say?" mode for power-user diagnostics.
-        // Imputed pieces are tracked in ``imputedFlags`` so the UI
-        // can italicize + underline the cells that include
-        // imputation.
-        const fallbackForRow = (row) =>
-          imputeUncovered
-            ? Math.max(0, Number(effectiveValue(row, valueMode, settings)) || 0)
-            : 0;
-        const sideValuesAndFlags = assetsBySide.map((assets) =>
-          assets.map((row) => {
-            const mainAvg = averageCovered(row, mainSubs);
-            if (mainAvg > 0) return { value: mainAvg, imputed: false };
-            const rookieAvg = averageCovered(row, rookieSubs);
-            if (rookieAvg > 0) return { value: rookieAvg, imputed: false };
-            const fb = fallbackForRow(row);
-            return { value: fb, imputed: fb > 0 };
-          }),
+        const sideSummaries = assetsBySide.map((assets) =>
+          summariseSide(
+            assets.map((row) =>
+              resolveVendorAssetValue({
+                row,
+                mainSubs,
+                rookieSubs,
+                useKtcNative: useRawNative,
+                impute: imputeUncovered,
+              }),
+            ),
+          ),
         );
-        const sideValues = sideValuesAndFlags.map((side) =>
-          side.map((p) => p.value),
-        );
-        const imputedCounts = sideValuesAndFlags.map(
-          (side) => side.filter((p) => p.imputed).length,
-        );
+        const sideValues = sideSummaries.map((s) => s.values);
+        const imputedCounts = sideSummaries.map((s) => s.imputed);
+        const nativeCounts = sideSummaries.map((s) => s.native);
+        const unresolvedCounts = sideSummaries.map((s) => s.unresolved);
+        const incomplete = sideSummaries.some((s) => s.incomplete);
         const rawTotals = sideValues.map((vs) =>
           vs.reduce((sum, v) => sum + v, 0),
         );
-        const coverage = sideValues.map(
-          (vs) => vs.filter((v) => v > 0).length,
-        );
+        const coverage = nativeCounts.map((n, i) => n + imputedCounts[i]);
         // Skip vendors that touch zero pieces across the whole trade
         // (this can still happen when imputation is OFF and the
         // vendor covers nothing — keep the empty-rows diagnostic
@@ -205,8 +147,7 @@ export default function TradeSourceBreakdown({
           .reduce((max, v) => Math.max(max, v), 0);
         const rawMargin = adjustedTotals[winnerIdx] - runnerUp;
         const winnerTotal = adjustedTotals[winnerIdx];
-        const marginPct =
-          winnerTotal > 0 ? (rawMargin / winnerTotal) * 100 : 0;
+        const marginPct = winnerTotal > 0 ? (rawMargin / winnerTotal) * 100 : 0;
         const tied = rawMargin < 1;
 
         // Display label: use SOURCE_VENDOR_LABELS for multi-board
@@ -233,6 +174,9 @@ export default function TradeSourceBreakdown({
           adjustedTotals,
           coverage,
           imputedCounts,
+          nativeCounts,
+          unresolvedCounts,
+          incomplete,
           winnerIdx: tied ? null : winnerIdx,
           winnerLabel: tied ? "Even" : sides[winnerIdx]?.label || "?",
           marginPct,
@@ -242,7 +186,7 @@ export default function TradeSourceBreakdown({
     // ``settings`` is kept in the dep list for memo invalidation
     // when source weights / overrides change downstream.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sides, settings, valueMode, imputeUncovered]);
+  }, [sides, settings, imputeUncovered]);
 
   // Empty-rows diagnostic — historically this branch returned null,
   // which made it impossible to distinguish "card not rendering at
@@ -270,8 +214,8 @@ export default function TradeSourceBreakdown({
             style={{ fontSize: "0.72rem" }}
           >
             VA-adjusted totals on the 0-9999 value scale, summed per vendor.
-            Sub-boards (e.g. DLF SF + DLF RK) roll up into one row; margin
-            shows winner's edge as a percent.
+            Sub-boards (e.g. DLF SF + DLF RK) roll up into one row; margin shows
+            winner's edge as a percent.
           </span>
         </span>
         <label
@@ -399,21 +343,21 @@ export default function TradeSourceBreakdown({
                               : "var(--cyan)",
                     }}
                   >
-                    {row.winnerIdx === null
-                      ? "Even"
-                      : `Side ${row.winnerLabel}`}
+                    {row.incomplete
+                      ? "Incomplete"
+                      : row.winnerIdx === null
+                        ? "Even"
+                        : `Side ${row.winnerLabel}`}
                   </td>
                   <td
                     style={{
                       textAlign: "right",
                       fontFamily: "var(--mono)",
                       color:
-                        row.winnerIdx === null
-                          ? "var(--muted)"
-                          : "var(--text)",
+                        row.winnerIdx === null ? "var(--muted)" : "var(--text)",
                     }}
                   >
-                    {row.winnerIdx === null
+                    {row.incomplete || row.winnerIdx === null
                       ? "—"
                       : `${row.marginPct.toFixed(1)}%`}
                   </td>

--- a/frontend/lib/second-opinions.js
+++ b/frontend/lib/second-opinions.js
@@ -1,0 +1,246 @@
+/**
+ * Second Opinions — the value basis, made explicit.
+ *
+ * WHY THIS MODULE EXISTS
+ * ----------------------
+ * `TradeSourceBreakdown` sums a vendor's per-asset values and feeds the
+ * arrays to a NONLINEAR Value Adjustment. That is only meaningful if
+ * every number in one array is in the same unit system.
+ *
+ * It was not. The uncovered-asset fallback read
+ * `effectiveValue(row, valueMode)`, i.e. `row.values[valueMode]`, and
+ * `valueMode` is the Trade Calculator's DISPLAY toggle. Flipping a
+ * diagnostic control to "Raw" swapped the fallback to the legacy
+ * scraper composite while the vendor's own numbers stayed canonical.
+ *
+ * NUMERIC RANGE EQUALITY IS NOT UNIT COMPATIBILITY. Measured on the
+ * tracked 2026-08-14 board:
+ *
+ *   rawComposite / canonical    n=805   median 1.063
+ *                                       p10 0.915   p90 1.262
+ *                                       min 0.266   max 2.082
+ *
+ * Both are "roughly 0-9999"; substituting one for the other is wrong by
+ * up to a factor of two on one row.
+ *
+ * So the resolver returns a BASIS with every number, and the caller may
+ * only sum values that share one. A comment cannot fail a build; a
+ * basis mismatch here can.
+ *
+ * WHY KTC IS DIFFERENT, AND WHY WE DO NOT IMPUTE INTO IT
+ * ------------------------------------------------------
+ * KTC's covered assets deliberately use KTC-NATIVE values, because the
+ * V13 Value Adjustment formula and its empirical suppression thresholds
+ * were calibrated against them. Dropping a canonical value into that
+ * array would only be valid if canonical and KTC-native were
+ * interchangeable. Measured over the 385 players carrying both:
+ *
+ *   KTC native / canonical      median 1.091   min 0.400   max 1.491
+ *     top of board (>=7000)     median 0.947   (n=28)
+ *     middle (3000-7000)        median 1.027   (n=103)
+ *     tail (<3000)              median 1.142   (n=254)
+ *
+ * The relationship is not identity and not a constant — it drifts
+ * monotonically with board depth, so the error's DIRECTION depends on
+ * where the player sits. Inside a nonlinear VA whose suppression
+ * thresholds compare raw differences, that is not a rounding concern.
+ *
+ * A calibrated canonical -> KTC-native crosswalk might be defensible
+ * later, but it would need to be derived, monotonic, tested and honest
+ * about extrapolation — and the owner ruling forbids inventing a
+ * multiplier to get there. Until that exists, an asset KTC does not
+ * cover makes KTC's opinion INCOMPLETE. We do not fabricate KTC's view
+ * of a player it never published.
+ */
+
+/** The unit systems a Second Opinions number can be in. */
+export const VALUE_BASIS = {
+  /** Chase Upside's canonical board value (`rankDerivedValue`), 1-9999. */
+  CANONICAL: "CANONICAL_1_9999",
+  /** A vendor signal after canonical normalization (`valueContribution`). */
+  NORMALIZED_VENDOR: "NORMALIZED_VENDOR_1_9999",
+  /** KTC's own published value, the basis V13 VA was calibrated on. */
+  KTC_NATIVE: "KTC_NATIVE",
+  /** No comparable number exists. Never a quantity — never zero. */
+  MISSING: "MISSING",
+};
+
+/**
+ * Bases that may be summed together inside one vendor's package array.
+ *
+ * `CANONICAL` and `NORMALIZED_VENDOR` are both the canonical 1-9999
+ * comparison space — verified per source on the live board: all 21
+ * registered sources' `valueContribution` lands inside 1-9999 with
+ * median ratio to canonical between 0.874 and 1.196.
+ *
+ * `KTC_NATIVE` is its own island by construction, which is the point.
+ */
+const COMPATIBLE = {
+  [VALUE_BASIS.CANONICAL]: new Set([
+    VALUE_BASIS.CANONICAL,
+    VALUE_BASIS.NORMALIZED_VENDOR,
+  ]),
+  [VALUE_BASIS.NORMALIZED_VENDOR]: new Set([
+    VALUE_BASIS.CANONICAL,
+    VALUE_BASIS.NORMALIZED_VENDOR,
+  ]),
+  [VALUE_BASIS.KTC_NATIVE]: new Set([VALUE_BASIS.KTC_NATIVE]),
+  [VALUE_BASIS.MISSING]: new Set(),
+};
+
+export function basesAreCompatible(a, b) {
+  return Boolean(COMPATIBLE[a]?.has(b));
+}
+
+function positive(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/**
+ * Chase Upside's canonical value for a row, or null.
+ *
+ * Reads `values.full` — which the materializer sets from
+ * `rankDerivedValue` — and falls back to the stamp itself. Deliberately
+ * NOT `effectiveValue`, which takes a display mode, and NOT
+ * `displayValue`, which returns 0 for an unpriced row. Here the
+ * difference between "worth nothing" and "not priced" is the whole
+ * point, so this returns null and the caller reports it.
+ */
+export function canonicalValueOf(row) {
+  if (!row) return null;
+  const override = positive(row.customValue);
+  if (override) return override;
+  return positive(row.values?.full) ?? positive(row.rankDerivedValue);
+}
+
+/**
+ * The value one vendor contributes for one asset.
+ *
+ * Returns `{value, basis, imputed, unresolved}`. `value` is null
+ * whenever `basis` is MISSING — a caller cannot accidentally add it.
+ *
+ * @param {object}  row          board row
+ * @param {object[]} mainSubs    the vendor's main sub-boards
+ * @param {object[]} rookieSubs  the vendor's rookie sub-boards
+ * @param {boolean} useKtcNative true for the KTC vendor only
+ * @param {boolean} impute       "fill uncovered pieces with our value"
+ */
+export function resolveVendorAssetValue({
+  row,
+  mainSubs = [],
+  rookieSubs = [],
+  useKtcNative = false,
+  impute = true,
+}) {
+  const covered = (subs) => {
+    let sum = 0;
+    let n = 0;
+    for (const sub of subs) {
+      const v = useKtcNative
+        ? (positive(row?.rawSourceValues?.[sub.key]) ??
+          positive(row?.canonicalSites?.[sub.key]))
+        : positive(row?.sourceRankMeta?.[sub.key]?.valueContribution);
+      if (v) {
+        sum += v;
+        n += 1;
+      }
+    }
+    return n > 0 ? sum / n : null;
+  };
+
+  const basis = useKtcNative
+    ? VALUE_BASIS.KTC_NATIVE
+    : VALUE_BASIS.NORMALIZED_VENDOR;
+
+  // Main boards win over rookie-specialty boards: once a rookie is
+  // promoted onto the main board, the rookie board is a pre-draft
+  // artifact rather than the vendor's current opinion.
+  const main = covered(mainSubs);
+  if (main) return { value: main, basis, imputed: false, unresolved: false };
+  const rookie = covered(rookieSubs);
+  if (rookie)
+    return { value: rookie, basis, imputed: false, unresolved: false };
+
+  if (!impute) {
+    // Strict mode: report what the vendor literally says. That is an
+    // absence, not a zero — the caller decides how to present a vendor
+    // that covers only part of the trade.
+    return {
+      value: null,
+      basis: VALUE_BASIS.MISSING,
+      imputed: false,
+      unresolved: true,
+    };
+  }
+
+  if (useKtcNative) {
+    // See the module docstring: canonical is not interchangeable with
+    // KTC-native (median 1.091, drifting 0.947 -> 1.142 across board
+    // depth, range 0.400-1.491). Imputing here would manufacture a KTC
+    // opinion on a player KTC never published, inside a nonlinear VA.
+    return {
+      value: null,
+      basis: VALUE_BASIS.MISSING,
+      imputed: false,
+      unresolved: true,
+    };
+  }
+
+  const canonical = canonicalValueOf(row);
+  if (!canonical) {
+    // The vendor does not cover it and neither do we. Missing is not
+    // zero; the vendor's opinion of this trade is incomplete.
+    return {
+      value: null,
+      basis: VALUE_BASIS.MISSING,
+      imputed: false,
+      unresolved: true,
+    };
+  }
+  return {
+    value: canonical,
+    basis: VALUE_BASIS.CANONICAL,
+    imputed: true,
+    unresolved: false,
+  };
+}
+
+/**
+ * Fold per-asset resolutions into one side.
+ *
+ * Any unresolved asset makes the side incomplete. The values that DID
+ * resolve are still returned so a caller can show partial evidence —
+ * but `incomplete` is what stops a partial sum being published as a
+ * verdict.
+ */
+export function summariseSide(resolutions) {
+  const values = [];
+  let imputed = 0;
+  let native = 0;
+  let unresolved = 0;
+  let mixedBasis = false;
+  let basis = null;
+
+  for (const r of resolutions) {
+    if (r.unresolved || r.value == null) {
+      unresolved += 1;
+      continue;
+    }
+    if (basis === null) basis = r.basis;
+    else if (!basesAreCompatible(basis, r.basis)) mixedBasis = true;
+    values.push(r.value);
+    if (r.imputed) imputed += 1;
+    else native += 1;
+  }
+
+  return {
+    values,
+    basis,
+    imputed,
+    native,
+    unresolved,
+    mixedBasis,
+    incomplete: unresolved > 0 || mixedBasis,
+  };
+}


### PR DESCRIPTION
Bounded correctness audit of Second Opinions' input units. **Defect found: YES — two, in the same resolver.**

---

## Defect 1 — a display toggle changed the math basis

`TradeSourceBreakdown` sums a vendor's per-asset values and feeds the arrays to a **nonlinear** Value Adjustment. Covered assets use `sourceRankMeta[key].valueContribution`. Uncovered assets went through:

```js
effectiveValue(row, valueMode, settings)   // → row.values[valueMode]
```

`valueMode` is the Trade Calculator's **display** control, passed straight in from `/trade/page.jsx`. Flipping it from "Our value" to "Raw" swapped the fallback onto the legacy scraper composite while every vendor number beside it stayed canonical.

**Numeric range equality is not unit compatibility.** Measured on the tracked 2026-08-14 board:

| `rawComposite / canonical` | n=805 |
|---|---|
| median | 1.063 |
| p10 / p90 | 0.915 / 1.262 |
| **min / max** | **0.266 / 2.082** |

Both are "roughly 0–9999". Substituting one for the other is wrong by up to a **factor of two** on a single row.

`TradeSourceBreakdown` now takes **no `valueMode` at all**.

## Defect 2 — missing became zero

An asset with neither vendor coverage nor a canonical value contributed literal `0`, and the row still published a confident verdict. Rendered before the fix:

```
DLF   5,000   3,000   Side A   40.0%
```

The unpriced asset silently priced at nothing. It is now **unresolved**, and the row renders **Incomplete** with no winner and no margin. Strict mode too: turning imputation off reports uncovered pieces as unresolved rather than zero-filling them.

## Non-KTC imputation — VALID, proven not assumed

All 21 registered sources' `valueContribution` lands inside 1–9999, with median ratio to canonical between **0.874 and 1.196** — the same comparison space. So filling an uncovered asset with `rankDerivedValue` is unit-correct.

`rawSourceValues` exists only for `ktcSfTep`, and no `canonicalSites` entry on the live board exceeds 9999 — but both stay excluded **by construction** rather than by luck.

## KTC imputation — REFUSED

KTC's covered assets use KTC-native values because V13 VA was calibrated on them. Direct canonical substitution, measured over the 385 players carrying both:

| region | n | median native / canonical |
|---|---|---|
| top (≥7000) | 28 | 0.947 |
| middle (3000–7000) | 103 | 1.027 |
| tail (<3000) | 254 | 1.142 |
| **overall** | **385** | **1.091** (min 0.400, max 1.491) |

Not identity, and **not a constant** — it drifts monotonically with board depth, so the error's *direction* depends on where the player sits. Inside a nonlinear VA whose suppression thresholds compare raw differences, that is not a rounding concern.

So an asset KTC does not cover makes KTC's opinion **incomplete**. We do not manufacture KTC's view of a player it never published. A calibrated canonical → KTC-native crosswalk may be defensible later — it would have to be derived, monotonic, tested and honest about extrapolation, and inventing a multiplier to get there is out of bounds.

## The basis is explicit in code

`frontend/lib/second-opinions.js` owns it:

| basis | what it is |
|---|---|
| `CANONICAL_1_9999` | `rankDerivedValue` |
| `NORMALIZED_VENDOR_1_9999` | a vendor signal after canonical normalization |
| `KTC_NATIVE` | KTC's own published value |
| `MISSING` | no comparable number — **never a quantity, never zero** |

`CANONICAL` and `NORMALIZED_VENDOR` are compatible; `KTC_NATIVE` is its own island. `MISSING` carries `value: null`, so a caller **cannot add it by accident**. A comment cannot fail a build; this can.

## Two kinds of weight, kept separate

An imputed canonical value may complete the package **arithmetic**. It does not become an independent external **opinion**. `nativeCounts` / `imputedCounts` / `unresolvedCounts` are carried per side so the future aggregate can count native coverage only — the standing ruling in `SECOND_OPINIONS_TODO.md`.

## Validation

| gate | result |
|---|---|
| new Second Opinions tests | **8 passed** — raw-mode isolation, canonical fallback, no `rawComposite` leak, no foreign-native leak, KTC incompleteness, missing-value, strict mode, multi-team |
| frontend, whole suite | **2033 passed / 124 files** |
| backend, whole repo | **7488 passed / 60 skipped / 0 failed** |

## Scope

Value Adjustment itself is untouched. This is input-unit correctness and missing-asset semantics only.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)