### PR TITLE
B10-T3b: one vote per provider family

### DIFF
--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -2339,6 +2339,75 @@ def get_ranking_source_keys() -> list[str]:
 #         KeepTradeCut as a data source).
 
 
+#: Registry position of each source key, which IS the declared
+#: precedence inside a correlation group.  It already encodes the right
+#: heads without a second list to keep in step: ``ktcSfTep`` is
+#: registered before ``fantasyNavigatorSf`` (the board before the
+#: republisher), ``fantasyProsSf`` before ``fantasyProsFitzmaurice``
+#: (the consensus panel before the expert inside it), and every vendor's
+#: main board before its rookie-specialty board.
+def _source_precedence(key: str) -> int:
+    for i, src in enumerate(_RANKING_SOURCES):
+        if str(src.get("key") or "") == key:
+            return i
+    return len(_RANKING_SOURCES)
+
+
+def collapse_to_independent_families(
+    pairs: "list[tuple[str, float, bool]]",
+) -> "tuple[list[tuple[str, float, bool]], dict[str, str]]":
+    """One vote per provider family — a SELECTION, never an average.
+
+    ``pairs`` is ``(source_key, value, is_anchor_source)`` for the
+    sources that survived Hampel on one row.  Returns the surviving
+    pairs plus ``{superseded_key: winning_key}`` for provenance.
+
+    WHY SELECTION AND NOT AVERAGING
+    --------------------------------
+    A correlation group is a binary assertion: *these are not
+    independent votes*.  Averaging a family's members quietly re-admits
+    the derived one at 50% — which for ``fantasyProsFitzmaurice`` inside
+    the ``fantasyProsSf`` consensus is exactly the nested-consensus
+    prohibition, and for ``fantasyNavigatorSf`` inside ``ktc`` re-admits
+    a republication of the anchor at half weight.  Averaging also
+    manufactures a number no source published.
+
+    Part of the intra-family spread is our own encoding artifact rather
+    than two opinions: ``ktcSfTep`` votes value-direct
+    (``raw / site_max x 9999``) while ``fantasyNavigatorSf`` votes
+    rank -> percentile -> Hill, so averaging them averages an encoding
+    difference into the board's anchor.
+
+    If a family member genuinely carries independent signal, the repair
+    is to UNDECLARE the group, not to half-count it.
+
+    Precedence is registry order (``_source_precedence``), and only
+    among members actually present on this row — so an IDP row where
+    ``dlfSf`` is out of scope is decided by ``dlfIdp``, and a rookie row
+    carrying both the main and rookie board is decided by the main one,
+    matching the vendor's current opinion rather than a pre-draft
+    artifact.
+    """
+    best: dict[str, tuple[int, tuple[str, float, bool]]] = {}
+    for key, value, is_anchor in pairs:
+        group = correlation_group_for(key)
+        rank = _source_precedence(key)
+        current = best.get(group)
+        if current is None or rank < current[0]:
+            best[group] = (rank, (key, value, is_anchor))
+
+    winners = {group: entry for group, (_r, entry) in best.items()}
+    winning_keys = {entry[0] for entry in winners.values()}
+    superseded = {
+        key: winners[correlation_group_for(key)][0]
+        for key, _v, _a in pairs
+        if key not in winning_keys
+    }
+    # Preserve the caller's ordering; only membership changes.
+    kept = [pair for pair in pairs if pair[0] in winning_keys]
+    return kept, superseded
+
+
 def correlation_group_for(key: str) -> str:
     """Return the correlation-group id for ``key``.
 
@@ -7957,6 +8026,46 @@ def _compute_unified_rankings(
                     meta = row_source_meta[row_idx].get(sk, {})
                     meta["hampelDropped"] = True
         players_array[row_idx]["droppedSources"] = list(hampel_dropped_keys)
+
+        # ── One vote per provider family (B10-T3b) ──
+        #
+        # Runs AFTER Hampel deliberately: Hampel's verdicts are about
+        # whether a source got THIS player wrong, and it should judge
+        # the raw observation set.  Collapsing first would change
+        # rejection decisions about unrelated sources.
+        #
+        # A SELECTION, never an average — see
+        # ``collapse_to_independent_families``.  ``_source_precedence``
+        # is registry order, which already declares the heads.
+        surviving = [(k, v, a) for k, v, a in all_value_pairs if k not in set(hampel_dropped_keys)]
+        family_kept, family_superseded = collapse_to_independent_families(surviving)
+        if family_superseded:
+            kept_keys = {k for k, _v, _a in family_kept}
+            all_values = [v for k, v, _a in family_kept]
+            cross_market_values = [v for k, v, a in family_kept if a]
+            subgroup_values = [v for k, v, a in family_kept if not a]
+            all_weights = [blend_weight_by_source.get(k, 1.0) for k, _v, _a in family_kept]
+            cross_market_weights = [
+                blend_weight_by_source.get(k, 1.0) for k, _v, a in family_kept if a
+            ]
+            subgroup_weights = [
+                blend_weight_by_source.get(k, 1.0) for k, _v, a in family_kept if not a
+            ]
+            for sk, winner in family_superseded.items():
+                meta = row_source_meta[row_idx].get(sk, {})
+                # The observation is kept and still readable — it did not
+                # vote, which is a different statement from it not existing.
+                meta["contributedToBlend"] = False
+                meta["supersededBy"] = winner
+            del kept_keys
+
+        # Three counts, named for what they each mean.  ``sourceCount``
+        # (stamped elsewhere) stays the raw matched-key count, because it
+        # answers a COVERAGE question — "did the scrape reach this row".
+        # These two answer independence questions and must not be
+        # conflated with it.
+        players_array[row_idx]["effectiveSourceCount"] = len(surviving)
+        players_array[row_idx]["independentSourceCount"] = len(family_kept)
 
         # Coverage diagnostic (2026-04-20 override): soft-fallback
         # values used to be injected into the blend as "just past the

--- a/tests/api/test_family_aware_aggregation.py
+++ b/tests/api/test_family_aware_aggregation.py
@@ -1,0 +1,179 @@
+"""One vote per provider family — B10-T3b.
+
+WHAT CHANGED
+────────────
+B10-T2 declared which sources share a provider. It changed no value:
+the blend still counted every source key as an independent opinion. This
+is the unit that acts on the declaration.
+
+After Hampel and before the blend, each correlation group is collapsed to
+**one** value: the one published by its highest-precedence member present
+on that row. A SELECTION, never an average.
+
+WHY SELECTION, NOT AVERAGING
+─────────────────────────────
+A correlation group is a binary assertion — *these are not independent
+votes*. Averaging a family's members quietly re-admits the derived one at
+50%, which for ``fantasyProsFitzmaurice`` inside the ``fantasyProsSf``
+consensus panel is precisely the nested-consensus prohibition, and for
+``fantasyNavigatorSf`` inside ``ktc`` re-admits a republication of the
+board's own anchor at half weight. It also manufactures a number no
+source published.
+
+Part of the intra-family spread is our own encoding artifact rather than
+two opinions: ``ktcSfTep`` votes value-direct (``raw / site_max × 9999``)
+while ``fantasyNavigatorSf`` votes rank → percentile → Hill.
+
+If a family member genuinely carries independent signal, the repair is to
+UNDECLARE the group — not to half-count it.
+
+PRECEDENCE IS DECLARED, NOT INVENTED
+─────────────────────────────────────
+It is registry order, which already encodes the right heads: the board
+before its republisher (``ktcSfTep`` → ``fantasyNavigatorSf``), the
+consensus panel before the expert inside it (``fantasyProsSf`` →
+``fantasyProsFitzmaurice``), and every vendor's main board before its
+rookie-specialty board.
+
+MEASURED on the pinned 2026-08-14 payload
+──────────────────────────────────────────
+455 values moved · p50 0.9% · p90 2.7% · max 14.8%
+top-100 membership churn ZERO; top-200 three in, three out
+direction 258 up / 197 down (balanced — no systematic re-pricing)
+offense 375/406 moved, picks 66/103, IDP only 14/298 (max 0.9%)
+priced count unchanged at 812, so the five newly-unpriced rows are a
+swap at the rank-800 boundary rather than a loss.
+"""
+
+from __future__ import annotations
+
+from src.api.data_contract import (
+    _RANKING_SOURCES,
+    _source_precedence,
+    collapse_to_independent_families,
+    correlation_group_for,
+)
+
+
+class TestOneVotePerFamily:
+    def test_a_family_contributes_exactly_one_value(self):
+        pairs = [
+            ("ktcSfTep", 9000.0, True),
+            ("fantasyNavigatorSf", 7000.0, False),
+            ("fantasyCalc", 8000.0, False),
+        ]
+        kept, superseded = collapse_to_independent_families(pairs)
+
+        assert [k for k, _v, _a in kept] == ["ktcSfTep", "fantasyCalc"]
+        assert superseded == {"fantasyNavigatorSf": "ktcSfTep"}
+
+    def test_the_head_keeps_its_own_published_value(self):
+        """Not the mean of 9000 and 7000 — a number nobody published."""
+        kept, _ = collapse_to_independent_families(
+            [("ktcSfTep", 9000.0, True), ("fantasyNavigatorSf", 7000.0, False)]
+        )
+        assert [v for _k, v, _a in kept] == [9000.0]
+
+    def test_the_nested_expert_does_not_outvote_its_panel(self):
+        """The owner ruling, as arithmetic.
+
+        An expert inside a consensus panel does not get a second vote,
+        and does not get half of one either.
+        """
+        kept, superseded = collapse_to_independent_families(
+            [
+                ("fantasyProsSf", 6000.0, False),
+                ("fantasyProsFitzmaurice", 4000.0, False),
+            ]
+        )
+        assert [v for _k, v, _a in kept] == [6000.0]
+        assert superseded == {"fantasyProsFitzmaurice": "fantasyProsSf"}
+
+    def test_precedence_only_ranks_members_present_on_the_row(self):
+        """An IDP row where the vendor's offense board is out of scope is
+        decided by the board that actually covered the player."""
+        kept, superseded = collapse_to_independent_families(
+            [("dlfIdp", 5000.0, False), ("dlfRookieIdp", 4000.0, False)]
+        )
+        assert [k for k, _v, _a in kept] == ["dlfIdp"]
+        assert superseded == {"dlfRookieIdp": "dlfIdp"}
+
+    def test_a_main_board_outranks_the_same_vendors_rookie_board(self):
+        """Once a rookie is promoted onto the main board, the rookie
+        board is a pre-draft artifact, not the vendor's current view."""
+        kept, _ = collapse_to_independent_families(
+            [("dlfRookieSf", 4000.0, False), ("dlfSf", 5000.0, False)]
+        )
+        assert [k for k, _v, _a in kept] == ["dlfSf"]
+
+    def test_independent_sources_are_untouched(self):
+        pairs = [
+            ("fantasyCalc", 8000.0, False),
+            ("otcffbSf", 7500.0, False),
+            ("yahooBoone", 7200.0, False),
+        ]
+        kept, superseded = collapse_to_independent_families(pairs)
+        assert kept == pairs
+        assert superseded == {}
+
+    def test_the_anchor_flag_travels_with_the_surviving_member(self):
+        """The family casts one vote, into whichever partition its own
+        member belongs to — the flag is not inherited from a loser."""
+        kept, _ = collapse_to_independent_families(
+            [("draftSharks", 5000.0, True), ("draftSharksIdp", 4000.0, False)]
+        )
+        assert kept == [("draftSharks", 5000.0, True)]
+
+    def test_ordering_is_preserved(self):
+        """Only membership changes. The blend's count-aware ladder picks
+        rungs by index, so a reordering here would be a silent second
+        change riding along with this one."""
+        pairs = [
+            ("fantasyCalc", 8000.0, False),
+            ("ktcSfTep", 9000.0, True),
+            ("fantasyNavigatorSf", 7000.0, False),
+            ("otcffbSf", 7500.0, False),
+        ]
+        kept, _ = collapse_to_independent_families(pairs)
+        assert [k for k, _v, _a in kept] == ["fantasyCalc", "ktcSfTep", "otcffbSf"]
+
+    def test_an_empty_row_collapses_to_nothing(self):
+        assert collapse_to_independent_families([]) == ([], {})
+
+
+class TestPrecedenceIsDeclaredByTheRegistry:
+    """No second list to drift.
+
+    If a future edit reorders the registry so a republisher precedes the
+    board it republishes, that is a real change in which opinion the
+    board hears — and it fails here rather than shipping quietly.
+    """
+
+    HEADS = {
+        "ktc": "ktcSfTep",
+        "fantasyPros": "fantasyProsSf",
+        "dlf": "dlfSf",
+        "flockFantasy": "flockFantasySf",
+        "draftSharks": "draftSharks",
+    }
+
+    def test_each_declared_family_has_the_intended_head(self):
+        for group, expected in self.HEADS.items():
+            members = [
+                str(s.get("key"))
+                for s in _RANKING_SOURCES
+                if correlation_group_for(str(s.get("key"))) == group
+            ]
+            assert members, f"{group} has no members"
+            head = min(members, key=_source_precedence)
+            assert head == expected, f"{group} head is {head}, expected {expected}"
+
+    def test_precedence_is_total_over_the_registry(self):
+        keys = [str(s.get("key")) for s in _RANKING_SOURCES]
+        ranks = [_source_precedence(k) for k in keys]
+        assert len(set(ranks)) == len(keys), "two sources share a precedence"
+
+    def test_an_unregistered_key_sorts_last_rather_than_raising(self):
+        """A retired source naming itself in cached data must not win a
+        family by accident, and must not crash a board build."""
+        assert _source_precedence("retiredSource") == len(_RANKING_SOURCES)

--- a/tests/consensus_edge/test_fair_value.py
+++ b/tests/consensus_edge/test_fair_value.py
@@ -119,38 +119,131 @@ class TestCorrelationGroups(unittest.TestCase):
             )
 
 
-class TestCorrelationMetadataIsInert(unittest.TestCase):
-    """The default board must not move because we added metadata.
+class TestCorrelationMetadataDrivesTheBlendExactly(unittest.TestCase):
+    """Was ``TestCorrelationMetadataIsInert``.
 
-    Correlation grouping exists for one caller.  If declaring it changed
-    the live board by even one value, that would be a silent repricing of
-    every user's rankings — the exact thing the repo's "preserve working
-    behavior" rule forbids.
+    That class asserted the default board must NOT move because we added
+    correlation metadata — true while grouping existed only for
+    leave-one-out and Consensus Edge, and it is what made B10-T2's
+    declaration safely reviewable.
+
+    B10-T3b deliberately ends that. The declaration now drives the blend:
+    each family casts one vote, published by its highest-precedence
+    member. "The board does not move" is no longer the property to
+    protect.
+
+    What replaces it is stricter — the board must move by EXACTLY the
+    family collapse and nothing else. Two propagation routes are
+    legitimate and are stated rather than excluded silently:
+
+    * **Picks inherit.** Current-year slot picks are tethered to the
+      merged rookie pool (Phase 5.2b), so a pick moves when the rookies
+      move even though its own source list has no duplicated family.
+      Measured: 66 of the 71 non-local changes are picks, every one of
+      them single-source on ``idpTradeCalc``.
+    * **The rank-800 boundary.** ``OVERALL_RANK_LIMIT`` truncates value
+      as well as rank, so a row can cross into or out of pricing. Those
+      rows have no *before* source list to classify. Measured: the other
+      5, and each one's post-change source list does carry a duplicated
+      family (Jam Miller holds ``ktcSfTep`` + ``fantasyNavigatorSf`` and
+      both Flock boards).
+
+    Anything outside those two is a side effect riding along with the
+    intended change, which is what the inertness test was really for.
     """
 
-    @_needs_payload
-    def test_declaring_a_correlation_group_does_not_change_the_default_board(self):
-        def fingerprint(contract):
-            return [
-                (r.get("displayName"), r.get("rankDerivedValue"), r.get("canonicalConsensusRank"))
-                for r in (contract.get("playersArray") or [])
-            ]
-
-        with_groups = fingerprint(dc.build_api_data_contract(_RAW))
-
-        stripped = []
+    @staticmethod
+    def _stripped_registry():
+        out = []
         for src in dc._RANKING_SOURCES:
             copy = dict(src)
             copy.pop("correlation_group", None)
-            stripped.append(copy)
+            out.append(copy)
+        return out
 
-        with mock.patch.object(dc, "_RANKING_SOURCES", stripped):
-            without_groups = fingerprint(dc.build_api_data_contract(_RAW))
+    @_needs_payload
+    def test_declaring_families_moves_the_board(self):
+        """If this passes trivially, T3b is not wired in at all."""
+
+        def values(contract):
+            return {
+                r.get("displayName"): r.get("rankDerivedValue")
+                for r in (contract.get("playersArray") or [])
+            }
+
+        with_groups = values(dc.build_api_data_contract(_RAW))
+        with mock.patch.object(dc, "_RANKING_SOURCES", self._stripped_registry()):
+            without_groups = values(dc.build_api_data_contract(_RAW))
+
+        changed = [
+            n for n, v in with_groups.items() if n in without_groups and without_groups[n] != v
+        ]
+        self.assertTrue(changed, "declaring families changed nothing")
+
+    @_needs_payload
+    def test_every_changed_player_had_a_family_voting_twice(self):
+        """Players only — picks inherit, see the class docstring."""
+
+        def rows(contract):
+            return {r.get("displayName"): r for r in (contract.get("playersArray") or [])}
+
+        after = rows(dc.build_api_data_contract(_RAW))
+        with mock.patch.object(dc, "_RANKING_SOURCES", self._stripped_registry()):
+            before = rows(dc.build_api_data_contract(_RAW))
+
+        offenders = []
+        for name, arow in after.items():
+            brow = before.get(name)
+            if brow is None:
+                continue
+            bv, av = brow.get("rankDerivedValue"), arow.get("rankDerivedValue")
+            if bv == av:
+                continue
+            if not isinstance(bv, int) or not isinstance(av, int):
+                # A PRICING-STATE change, not a value move: OVERALL_RANK_LIMIT
+                # truncates value as well as rank, so a row crosses in or out
+                # of pricing when the rows ABOVE it reorder. Its own sources
+                # need not have changed at all. Counted separately below.
+                continue
+            if (arow.get("assetClass") or "") == "pick":
+                continue  # tethered to the rookie pool
+            keys = set(brow.get("sourceRanks") or {}) | set(arow.get("sourceRanks") or {})
+            groups = [dc.correlation_group_for(k) for k in keys]
+            if len(set(groups)) == len(groups):
+                offenders.append((name, sorted(keys)))
 
         self.assertEqual(
-            with_groups,
-            without_groups,
-            "correlation-group metadata changed the default board; it must be inert there",
+            offenders,
+            [],
+            "player rows moved with no duplicated provider family — the collapse "
+            "is doing something beyond removing duplicate family votes",
+        )
+
+    @_needs_payload
+    def test_the_rank_limit_boundary_swaps_rather_than_loses_rows(self):
+        """Rows crossing OVERALL_RANK_LIMIT must balance.
+
+        A net loss would mean the collapse is dropping coverage rather
+        than reordering it — the reduced evidence base pushing rows off
+        the board instead of merely re-ranking them.
+        """
+
+        def priced(contract):
+            return {
+                r.get("displayName")
+                for r in (contract.get("playersArray") or [])
+                if isinstance(r.get("rankDerivedValue"), int)
+            }
+
+        after = priced(dc.build_api_data_contract(_RAW))
+        with mock.patch.object(dc, "_RANKING_SOURCES", self._stripped_registry()):
+            before = priced(dc.build_api_data_contract(_RAW))
+
+        self.assertEqual(
+            len(after),
+            len(before),
+            f"priced count changed: {len(before)} -> {len(after)} "
+            f"(entered {sorted(after - before)}, left {sorted(before - after)})",
         )
 
 


### PR DESCRIPTION
B10-T2 declared which sources share a provider and changed no value. This is the unit that acts on the declaration: after Hampel and before the blend, each correlation group collapses to **one** value — the one published by its highest-precedence member present on that row.

---

## A selection, never an average

A correlation group is a **binary assertion**: *these are not independent votes*. Averaging a family's members quietly re-admits the derived one at 50% — which for `fantasyProsFitzmaurice` inside the `fantasyProsSf` consensus panel is precisely the nested-consensus prohibition, and for `fantasyNavigatorSf` inside `ktc` re-admits a republication of the board's own anchor at half weight. It is also the arbitrary half-vote the owner ruling forbids.

Two further reasons averaging is the wrong reducer here:

- It **manufactures a number no source published**.
- Part of the intra-family spread is our own **encoding artifact** rather than two opinions: `ktcSfTep` votes value-direct (`raw / site_max × 9999`) while `fantasyNavigatorSf` votes rank → percentile → Hill. Averaging them averages an encoding difference into the board's anchor.

If a family member genuinely carries independent signal, the repair is to **undeclare the group** — not to half-count it.

## Precedence is declared, not invented

It is **registry order**, which already encodes the right heads: the board before its republisher (`ktcSfTep` → `fantasyNavigatorSf`), the consensus panel before the expert inside it (`fantasyProsSf` → `fantasyProsFitzmaurice`), and every vendor's main board before its rookie-specialty board. No second list to drift.

Precedence ranks only members **present on that row**, so an IDP row where `dlfSf` is out of scope is decided by `dlfIdp`, and a rookie row carrying both boards is decided by the main one — the vendor's current opinion rather than a pre-draft artifact.

## Ordering: after Hampel, deliberately

Hampel judges whether a source got **this player** wrong, so it should see the raw observation set. Collapsing first would change rejection verdicts about unrelated sources.

## Three counts, each named for what it means

| field | question it answers |
|---|---|
| `sourceCount` (unchanged) | **coverage** — did the scrape reach this row |
| `effectiveSourceCount` | post-Hampel survivors |
| `independentSourceCount` | post-collapse family count — **the** independence number |

Superseded observations are kept and readable, stamped `contributedToBlend: false` + `supersededBy`. They did not vote, which is a different statement from not existing.

## Measured, on a payload pinned against the 2-hourly refresh

| criterion | authorised envelope | measured |
|---|---|---|
| rows moved | hundreds | **455** — p50 0.9%, p90 2.7% |
| max movement | ~29% | **14.8%** (design predicted 14.5%) |
| top-200 churn | limited | **3 in / 3 out** — top-100 **zero** |
| asset-class corruption | none | **258 up / 197 down**; IDP only 14/298, max 0.9% |

Offense carries 375/406 and picks 66/103, which is where the `ktc` and `fantasyPros` overlaps live. **IDP being almost untouched is the tell that the mechanism is right** — the only IDP family overlap is `dlfIdp`/`dlfRookieIdp` on 16 rows, so a correct implementation should leave IDP alone.

Priced count is **812 before and after**, so the five newly-unpriced rows are a swap at the rank-800 boundary, not a loss.

## The characterization test, and two wrong turns worth keeping

`TestCorrelationMetadataIsInert` asserted the board must **not** move when correlation metadata is declared. True while grouping served only leave-one-out and Consensus Edge — and it is what made T2 safely reviewable. T3b deliberately ends it, so it is replaced by the stricter property: the board must move by **exactly** the family collapse and nothing else.

Writing that surfaced two legitimate propagation routes, both verified rather than assumed:

- **Picks inherit.** Current-year slot picks are tethered to the merged rookie pool (Phase 5.2b), so a pick moves when the rookies move even though its own source list has no duplicated family. **66 of the 71** non-local changes are picks, every one single-source on `idpTradeCalc`.
- **The rank-800 boundary.** `OVERALL_RANK_LIMIT` truncates value as well as rank, so a row crosses into or out of pricing when the rows *above* it reorder. That is a pricing-state change, not a value move. The other **5** (Jam Miller, Jaydn Ott, Will Levis, B.J. Hill, Jonathan Allen).

My first two attempts at the test were wrong in instructive ways, and both are now encoded: reading the *before* capture's source list misses rows that were unpriced then, and treating `None → value` as a value move misclassifies a boundary crossing as unexplained movement.

Three assertions now stand: the collapse **moves** the board (a trivially-passing version would mean it is not wired in), every changed **player** had a family voting twice, and the boundary **swaps rather than loses** rows.

## Validation

| gate | result |
|---|---|
| backend, whole repo | **7502 passed / 60 skipped / 0 failed** |
| family-aggregation + fair-value + provenance suites | **44 passed** |
| `ruff format` + `check` | clean |
| board movement | inside the authorised envelope on every criterion |

## What remains in B

**B11** (confidence semantics) and the bounded **completion audit**. B is not complete.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2EZWDCCbiL2JLvJsARUHg)_