### PR TITLE
B11: replace the confidence spread with a multi-axis evidence gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1281,6 +1281,78 @@ Operational surfaces (post-merge additions):
   backend-stamped ranks untouched. Tests:
   ``frontend/__tests__/components/DraftBoardSort.test.jsx``.
 
+### Confidence — one owner, five axes, a bottleneck (B11)
+
+``src/api/confidence.py`` is the ONLY place a ``confidenceBucket`` is
+decided. ``data_contract.py`` assembles the evidence and decides no
+level; there is **no frontend confidence math**, which is why the gate's
+parameters live in ``config/confidence/gate_v1.json`` and are
+deliberately NOT mirrored into ``frontend/lib/thresholds.js`` — the
+parity test would require the JS export, and that is exactly the
+client-side constant #725 removed.
+
+Confidence answers **"how good is the evidence behind this value"**, and
+the unit of evidence is the **B10 provider family**, never the source
+key.
+
+| axis | question | HIGH needs |
+|---|---|---|
+| independence | how many correlation-group heads voted | ≥ 5 families |
+| coverage | how many of the **eligible** families actually did | ≥ 75% |
+| freshness | how many of those are inside their ``maxAgeHours`` budget | ≥ 75% |
+| applicability | how many reached the row without approximation, on this board's TE++ basis | ≥ 75% |
+| agreement | how many price within 15% relative of ``rankDerivedValue`` | ≥ 75% |
+
+**Overall = the WEAKEST axis.** Nothing averages, so a large source count
+cannot buy freshness, applicability, coverage or agreement.
+
+Four things are load-bearing and easy to undo by accident:
+
+* **5 / 3 families are the BLEND's own rungs**, not new numbers.
+  ``_mean_median_blend`` trims one extreme per side at k ≥ 5, so five
+  families is the smallest panel whose published value survives one
+  outlying opinion in either direction; 3-4 is the untrimmed rung, 2 a
+  plain mean, 1 a passthrough. Two families therefore cannot exceed LOW.
+* **Coverage's DENOMINATOR is what COULD have been observed.** A family
+  that stops covering a row stays eligible, so its silence is permanent
+  missing evidence. This is what makes deleting evidence unable to
+  promote a row — MISSING IS NEVER ZERO applied to confidence.
+* **A duplicate family member is not an input to any axis.**
+  ``assess_confidence`` RAISES on a repeated family rather than
+  averaging or ignoring it. Collapsing a family is therefore an exact
+  identity on confidence, which is invariants 1 and 2 discharged
+  structurally rather than by calibration.
+* **Agreement is measured in VALUE space**, against ``rankDerivedValue``,
+  with the same symmetric mean normalisation ``marketGapValueRatio``
+  uses. Consequence: any post-blend OVERRIDE that moves a value
+  invalidates the stamp taken before it, which is why
+  ``_restate_confidence_after_override`` re-runs the gate on rows whose
+  value changed (found on Travis Hunter, whose two-way boost left all
+  eleven families 24-56% below the published number while the row
+  claimed high agreement).
+
+RETIRED: ``max(percentile) − min(percentile)`` bucketed at 0.08 / 0.20.
+A range can only narrow when an observation is removed, so deleting
+evidence promoted rows — and re-basing the same statistic onto
+independent evidence reproduced the failure (60 rows, wrong direction;
+#833). ``sourceRankPercentileSpread`` is still computed, still published
+and still drives ``hasSourceDisagreement``; it no longer decides
+confidence. Do not reintroduce a range as the deciding statistic.
+
+Picks keep their own coefficient-of-variation rule
+(``assess_pick_confidence``) because rank spread on picks is dominated by
+the flat-value regions in R3-R6 — but it is family-aware, and its
+independence bar is 2 markets rather than 5 because the pick population
+only HAS 2-4 families (KTC + IDPTC).
+
+Per-row fields: ``confidenceBucket`` / ``confidenceLabel`` /
+``confidenceAxes`` / ``confidenceReasons``. ``metrics`` stays on the
+assessment object and off the payload (the reasons already carry its
+numbers, and publishing both cost +15 KB gzip for a block nothing
+renders). Full record: ``docs/master-site-audit/B_SERIES_EXECUTION_LEDGER.md``
+§B11; distribution evidence in
+``docs/master-site-audit/evidence/B11/``.
+
 ### Single Source of Truth: Rankings Override Path
 Custom source configurations (user-toggled sources or custom weights) flow through the **SAME** canonical pipeline as the default board. There is no frontend ranking engine, period — not even a fallback. `buildRows` is a pure materializer.
 

--- a/config/confidence/gate_v1.json
+++ b/config/confidence/gate_v1.json
@@ -1,0 +1,36 @@
+{
+  "_comment": "Parameters for the multi-axis confidence gate (B11). Loaded by src/api/confidence.py, which contains no numeric literal that decides a level. Deliberately NOT in config/thresholds.json: that registry exists to keep frontend/lib/thresholds.js in step with the backend, and tests/api/test_threshold_parity.py requires every entry to be exported from the JS. B11 forbids frontend confidence math, so mirroring these would plant client-side exactly the constants that must not exist there - which is the same defect #725 removed CONFIDENCE_SPREAD_HIGH / CONFIDENCE_SPREAD_MEDIUM for. The derivation discipline of that registry is kept: every entry records unit and derivedFrom, and tests/api/test_confidence_gate.py refuses one that does not.",
+  "version": "2026-08-14.v1",
+  "parameters": {
+    "INDEPENDENCE_HIGH_FAMILIES": {
+      "value": 5,
+      "unit": "independentEvidenceFamilies",
+      "appliesTo": "count of B10 correlation-group heads contributing to the blend",
+      "derivedFrom": "The count-aware blend's OWN top rung, not a new number. _mean_median_blend drops one extreme value per side once k >= 5 ('n >= 5 so trimming never reduces the statistic below a 3-source core'), so five independent families is the smallest panel where the published value is robust to a single outlying opinion in either direction. Below it the blend is repeating what a small panel said. Measured on the 2026-08-14 board: 476 of 709 non-pick rows carrying evidence reach it."
+    },
+    "INDEPENDENCE_MEDIUM_FAMILIES": {
+      "value": 3,
+      "unit": "independentEvidenceFamilies",
+      "appliesTo": "count of B10 correlation-group heads contributing to the blend",
+      "derivedFrom": "The blend's next rung down: n=3-4 takes an UNTRIMMED mean-median, n=2 is a plain mean and n=1 a passthrough. Three is therefore the smallest panel where a single dissenting family can be outvoted rather than averaged in at half the answer. Directly satisfies the owner ruling that 'excellent agreement between only one or two evidence families should not automatically become HIGH confidence' - two families cannot exceed LOW on this axis at all."
+    },
+    "EVIDENCE_SHARE_HIGH": {
+      "value": 0.75,
+      "unit": "shareOfEvidence",
+      "appliesTo": "coverage / freshness / applicability / agreement share axes",
+      "derivedFrom": "One declared sufficiency ladder applied to every share-shaped axis, so the gate carries one policy number instead of four separately-invented cutoffs: an axis is HIGH when at least three quarters of the relevant evidence satisfies it. A stated PRIOR, not a fit - recorded as such. Distribution check on the 2026-08-14 board (709 non-pick rows with evidence): coverage p25 0.750 / median 0.917; freshness p25 0.750 / median 0.909; agreement p25 0.636 / median 0.800. The line falls inside the body of all three rather than at a tail, so it discriminates instead of saturating."
+    },
+    "EVIDENCE_SHARE_MEDIUM": {
+      "value": 0.5,
+      "unit": "shareOfEvidence",
+      "appliesTo": "coverage / freshness / applicability / agreement share axes",
+      "derivedFrom": "The same ladder's lower rung: a simple majority of the relevant evidence. Below half, most of what could have spoken either did not, is stale, needed an approximation, or disagrees - which is LOW by construction rather than by calibration."
+    },
+    "AGREEMENT_VALUE_RATIO": {
+      "value": 0.15,
+      "unit": "relativeValueRatio",
+      "appliesTo": "|valueContribution - rankDerivedValue| / mean(valueContribution, rankDerivedValue)",
+      "derivedFrom": "Set to the board's existing declared line for a MATERIAL relative value gap - PREMIUM_SUMMARY_VALUE_RATIO in config/thresholds.json, the p70 of |marketGapValueRatio| across the 414 two-sided rows on the 2026-08-05 board - and measured with the SAME symmetric mean normalisation _compute_market_gap uses, so 0.15 means the same size of disagreement in both places. Given its own entry rather than importing that one so confidence and the /edge premium panels can diverge deliberately instead of by accident. Behaviour check on the 2026-08-14 board: the within-tolerance share falls with depth (median 1.000 in the top 100, 0.917 at 101-200, 0.750 at 201-800), i.e. it does not become mechanically easier where the Hill curve flattens."
+    }
+  }
+}

--- a/docs/master-site-audit/B_SERIES_EXECUTION_LEDGER.md
+++ b/docs/master-site-audit/B_SERIES_EXECUTION_LEDGER.md
@@ -882,3 +882,229 @@ one is model work with its own validation burden and is not attempted here.
 
 Recorded rather than shipped: nothing merged from this attempt. The board is byte-identical
 to the post-#832 state (0 values, 0 ranks, 0 labels).
+
+---
+
+# B11 — RESOLVED. The multi-axis confidence gate
+
+The redesign the section above said was needed. Implemented, measured, shipped.
+
+## What was wrong, restated precisely
+
+Confidence was `max(percentile) − min(percentile)` over a row's contributing sources,
+bucketed at 0.08 / 0.20, behind an `n >= 2` count gate. Two faults:
+
+1. **A range can only narrow when an observation is removed.** Under "narrower ⇒ more
+   confident", deleting evidence promoted a row. That is the monotonicity failure, and
+   re-basing the same statistic onto independent evidence reproduced it (60 rows, wrong
+   direction, A.J. Brown `medium → high`).
+2. **One axis wearing two hats** — a count and a dispersion — with nothing asking whether
+   the evidence was independent, current, applicable to this board's format, or anywhere
+   near complete. A large source count silently compensated for all four.
+
+## The replacement
+
+`src/api/confidence.py` is the single owner. Five axes over **B10 provider families**,
+combined by **bottleneck** — the overall level is the weakest axis. Nothing averages, so a
+strong axis cannot buy a weak one. That is the owner ruling ("a huge source count must not
+compensate for poor freshness / applicability / independent-family coverage / severe
+disagreement") written as arithmetic instead of as a weighting.
+
+| axis | question | HIGH requires |
+|---|---|---|
+| independence | how many B10 correlation-group heads voted | ≥ 5 families |
+| coverage | how many of the **eligible** families actually did | ≥ 75% |
+| freshness | how many of those are inside their `maxAgeHours` budget | ≥ 75% |
+| applicability | how many reached the row without approximation, on this board's TE basis | ≥ 75% |
+| agreement | how many price within 15% relative of `rankDerivedValue` | ≥ 75% |
+
+Every parameter is in `config/confidence/gate_v1.json` with a unit and a derivation; the
+module contains no numeric literal that decides a level.
+
+## Every number is derived from something already declared
+
+- **5 / 3 families** — the count-aware blend's OWN rungs. `_mean_median_blend` trims one
+  extreme per side at k ≥ 5, so five families is the smallest panel where the published
+  value is robust to a single outlying opinion in either direction; n = 3-4 is the
+  untrimmed rung, n = 2 a plain mean, n = 1 a passthrough. Two families therefore cannot
+  exceed LOW, which is the owner ruling on "excellent agreement between only one or two
+  evidence families" enforced structurally.
+- **0.75 / 0.50** — one sufficiency ladder for all four share axes rather than four
+  separately-invented cutoffs. A stated prior, recorded as one. Distribution check on the
+  live board puts it inside the body of all four (coverage p25 0.750 / median 0.917;
+  freshness p25 0.750 / median 0.909; agreement p25 0.636 / median 0.800).
+- **0.15 relative value** — the board's existing declared line for a MATERIAL relative
+  value gap (`PREMIUM_SUMMARY_VALUE_RATIO`, p70 of `|marketGapValueRatio|`), measured with
+  the SAME symmetric mean normalisation `_compute_market_gap` uses so it means the same
+  size of disagreement in both places. Its own registry entry so the two can diverge
+  deliberately rather than by accident.
+
+## Why the monotonicity invariants hold
+
+- **Duplicates cannot create confidence, and removing them cannot promote (invariants 1
+  and 2)** — an exact IDENTITY, not a bound. Every axis is computed over family heads, so
+  a second observation from a represented family is not an input to anything.
+  `assess_confidence` **refuses** a duplicate family rather than averaging or ignoring it,
+  because both of those are ways for a duplicate to matter after all. This is the A.J.
+  Brown case: he is HIGH whether or not FantasyPros also published a Fitzmaurice row.
+- **Removing real evidence cannot pay (invariant 3)** — `coverage`'s DENOMINATOR is what
+  COULD have been observed, not what was. A family that stops covering a row stays
+  eligible, so its silence is registered as missing evidence permanently. MISSING IS NEVER
+  ZERO applied to confidence: an absent eligible source is explicit missingness, not a
+  neutral non-event. Confidence can still rise when the departed evidence was stale or
+  inapplicable — the ruling permits that — and the reason is then on the row.
+- **No axis is a range.** Pinned by a test that moves an interior family while holding the
+  extremes, which a range cannot notice.
+
+## Agreement moved from rank space to value space, and that is load-bearing
+
+A family agrees when its `valueContribution` is within 15% relative of the published value.
+Value is the right currency for the same reason it was right for the market gap: it is what
+the blend itself compares sources in.
+
+Checked for the opposite bias before adopting — value-space agreement could have become
+mechanically easier where the Hill curve flattens. It does not: the within-tolerance share
+FALLS with depth (median 1.000 in the top 100, 0.917 at 101-200, 0.750 at 201-800).
+
+It also catches disagreement the percentile statistic structurally could not. Jalen Carter
+(DL, rank 239) has a percentile spread of **0.0412** — comfortably inside the retired HIGH
+band — while `draftSharksIdp` prices him **26% below** consensus. He is now LOW, limited by
+agreement, with the disagreement named on the row.
+
+## A defect this change created, found and fixed
+
+`_apply_two_way_player_boost` runs AFTER the ranking loop and replaces `rankDerivedValue`
+with the alt-position family's value. The retired rule never read the value, so this
+coupling is **new with the gate**. Travis Hunter's boost lifts him from the offense blend's
+~2,900 to 4,758, leaving all eleven of his families 24-56% BELOW the published number while
+the pre-boost stamp still claimed high agreement.
+
+Fixed by `_restate_confidence_after_override`, written as a general guard over "did the
+value move since the gate ran" rather than as a special case for the boost table, so any
+future post-blend pass inherits it. Travis Hunter now reads
+`Low — limited by agreement · 0 of 11 families price within 15% of the published value`,
+which is an honest description of a deliberate override no source published.
+
+## Picks
+
+Picks keep their own coefficient-of-variation gate — rank spread on picks is dominated by
+the flat-value regions in R3-R6 — but it is now **family-aware**: `dlfSf` and `dlfIdp` are
+one declared family and were counted as two corroborating opinions. Measured before
+changing it: **0 of 144 live pick rows** carry two members of one family, so this closes
+the hole rather than moving a number, and it is pinned so it cannot open again quietly.
+
+**Named boundary, not an exemption that leaked:** 24 pick rows are HIGH on 2 evidence
+families. Picks' eligible population only HAS 2-4 families (KTC + IDPTC are the two real
+pick markets), so the 5-family bar — derived from the *player* blend's trimming rung — does
+not apply to them.
+
+## OLD vs NEW distribution
+
+Full audit and the reproducing script:
+`docs/master-site-audit/evidence/B11/confidence-distribution.md` + `audit.py`.
+
+Both sides measured over the **same pinned payload** — the 2026-08-14T17:41 export — with
+the OLD side built from a worktree at the pre-B11 commit. Pinning it is the point: a
+scheduled refresh landed mid-review, and comparing across refreshed inputs would have
+measured the scrape rather than the gate. (For the record: on the earlier 16:32 export the
+same code gives 257 / 354 / 177 / 306, so the shape is a property of the gate and the
+counts move by a handful of rows with the data, as they should.)
+
+| bucket | OLD | NEW | delta |
+|---|---:|---:|---:|
+| high | 102 | 253 | +151 |
+| medium | 245 | 357 | +112 |
+| low | 441 | 178 | −263 |
+| none | 306 | 306 | 0 |
+
+upgraded **428** · downgraded **77** · unchanged **589**
+
+The OLD board was saturated, and the shape shows it. By depth (high/medium/low):
+
+| band | OLD | NEW |
+|---|---|---|
+| 001-100 | 61/38/1 | 79/20/1 |
+| 101-200 | 10/65/25 | 58/35/7 |
+| 201-400 | 15/41/144 | 72/106/22 |
+| 401-800 | 16/101/223 | 44/196/100 |
+
+Ranks 101-200 carried 10% HIGH against the top 100's 61% — a cliff with no evidentiary
+basis, produced by the percentile spread growing mechanically with depth. NEW declines
+monotonically with depth, which is what "confidence in a value" should do.
+
+Checks the ruling asked for specifically:
+
+- rows upgraded with fewer than 3 independent families: **0**
+- PLAYER rows reaching HIGH with fewer than 5 independent families: **0** (structurally
+  impossible — the independence axis caps them)
+- rows upgraded that are missing at least one eligible family: 196 — all constrained by the
+  coverage axis, all with the gap named on the row
+- 77 rows were downgraded; every one names its binding axis. The clearest are the OLD
+  board's own defects: Ashton Gillotte (DL, rank 672) was HIGH on **1 family and 20%
+  coverage**; RJ Maryland (TE, rank 509) was HIGH on 2 families.
+
+## Downstream consumers — a deliberate widening, stated
+
+`frontend/lib/edge-helpers.js` gates four surfaces on `confidenceBucket === "high"`
+(Consensus asset label, /edge consensus section, arbitrage eligibility). Those surfaces now
+see 253 qualifying rows instead of 102. That is the intended consequence of the OLD gate
+being saturated rather than an accidental blast radius, and no threshold in
+`edge-helpers.js` was touched to compensate — re-aiming a display filter to preserve its
+old row count would be tuning the answer to the previous wrong question.
+
+## Board integrity
+
+`rankDerivedValue` moved on **0 of 1094 rows**; `canonicalConsensusRank` moved on **0**;
+**no non-confidence field changed at all**. Confidence is not value, verified on the whole
+board rather than asserted.
+
+Payload cost: production delta 3.864 → 4.136 MB raw, **314.3 → 334.1 KB over the wire**
+(+6.3%) for the axes and reasons. `confidenceMetrics` was deliberately left OFF the payload
+to hold it there — the reasons already carry its numbers in readable form.
+
+Observed and **not** caused by this change: `rankChange` differs between two back-to-back
+builds of identical code on 740 rows. The rank-history recorder writes a snapshot each
+build and the next build diffs against it. Named here because it is the one thing a
+board-diff of this change shows, and it would otherwise read as B11 movement.
+
+## What B11 no longer owes
+
+| item | status |
+|---|---|
+| spread measured over correlated sources | **resolved** — the statistic is retired, not re-based |
+| freshness as an input | **shipped** — its own axis |
+| coverage as an input | **shipped** — its own axis, denominated on eligible families |
+| applicability as an input | **shipped** — its own axis |
+| missing / stale / conflicting as distinct states | **shipped** — distinct axes + published reasons |
+| duplicate evidence cannot inflate confidence | **shipped** — an identity, pinned |
+| removing evidence cannot promote for mechanical reasons | **shipped** — coverage denominator |
+| explainable rather than a bare score | **shipped** — `confidenceAxes` + `confidenceReasons` |
+| one canonical owner, no frontend confidence math | **shipped** — gate parameters are deliberately NOT mirrored to `thresholds.js` |
+
+Still open, and deliberately out of B11's scope — naming rather than fixing, because each
+is a rename with its own consumer blast radius:
+
+| item | status |
+|---|---|
+| `none` on a PRICED row (24 rows) | **open** — "unranked" label on a ranked row |
+| rename `identityConfidence` (means "player id resolved") | **open** |
+| rename/remove `marketConfidence` (a bounded dispersion metric) | **open** |
+
+## A stale B10 guard, found by B11 and repaired
+
+`test_source_provenance.py::test_the_canonical_blend_does_not_read_correlation_group`
+asserted that `_compute_unified_rankings` contains no mention of `correlation_group`. That
+was the right guard for **B10-T2**, whose entire reviewability rested on declaring families
+while moving no value.
+
+**B10-T3b retired that property on purpose** — 455 values moved, with its own before/after
+envelope — and the guard did not notice, because T3b reached the family through a helper:
+`collapse_to_independent_families` calls `correlation_group_for` internally, so the literal
+string never appeared in the caller. It stayed green for two merges while describing a
+property that had stopped holding.
+
+B11 tripped it only because the confidence gate needs a family per source and resolves the
+map inline. Replaced with the property that is actually true and worth pinning: **family
+membership is resolved through the declared owner and nowhere else**, and no provider
+family is named as a literal inside the blend. A guard that survives the change it was
+written to catch is worse than no guard — it reads as evidence.

--- a/docs/master-site-audit/evidence/B11/audit.py
+++ b/docs/master-site-audit/evidence/B11/audit.py
@@ -1,0 +1,303 @@
+"""B11 — OLD vs NEW confidence distribution audit.
+
+Reproduces `confidence-distribution.md` in this directory.
+
+HOW TO GET THE TWO INPUTS
+-------------------------
+Both are `build_api_data_contract` output over the SAME pinned payload,
+one built before the B11 commit and one after. Pinning the payload is the
+point: comparing across refreshed inputs would measure the scrape, not
+the gate.
+
+    # from the repo root, with the B11 commit checked out
+    python docs/master-site-audit/evidence/B11/audit.py --dump new.json
+
+    git stash && git checkout <pre-B11-sha>
+    python docs/master-site-audit/evidence/B11/audit.py --dump old.json
+    git checkout - && git stash pop
+
+    python docs/master-site-audit/evidence/B11/audit.py \\
+        --old old.json --new new.json --out confidence-distribution.md
+
+`--dump` writes only the fields this audit reads, so the artifacts stay
+small enough to keep around while a review is open.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+# docs/master-site-audit/evidence/B11/audit.py -> repo root
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DEFAULT_PAYLOAD = REPO_ROOT / "exports" / "latest" / "dynasty_data_2026-08-14.json"
+
+LEVELS = ["none", "low", "medium", "high"]
+
+#: The only fields the audit reads. Dumping the whole contract would be
+#: ~12 MB per side for a handful of columns.
+DUMP_FIELDS = (
+    "canonicalName",
+    "displayName",
+    "position",
+    "assetClass",
+    "canonicalConsensusRank",
+    "isRookie",
+    "sourceCount",
+    "independentSourceCount",
+    "confidenceBucket",
+    "confidenceAxes",
+    "confidenceReasons",
+)
+
+
+def dump(payload_path: Path, out_path: Path) -> None:
+    sys.path.insert(0, str(REPO_ROOT))
+    from src.api.data_contract import build_api_data_contract
+
+    contract = build_api_data_contract(json.loads(payload_path.read_text(encoding="utf-8")))
+    rows = [
+        {field: row.get(field) for field in DUMP_FIELDS}
+        for row in (contract.get("playersArray") or [])
+    ]
+    out_path.write_text(json.dumps(rows), encoding="utf-8")
+    print(f"wrote {len(rows)} rows to {out_path}")
+
+
+def band(rank: int | None) -> str:
+    if not rank:
+        return "unranked"
+    if rank <= 100:
+        return "001-100"
+    if rank <= 200:
+        return "101-200"
+    if rank <= 400:
+        return "201-400"
+    if rank <= 800:
+        return "401-800"
+    return "800+"
+
+
+def load(path: Path) -> dict[str, dict]:
+    rows = json.loads(path.read_text(encoding="utf-8"))
+    return {str(r.get("canonicalName") or r.get("displayName")): r for r in rows}
+
+
+def report(old_path: Path, new_path: Path) -> str:
+    old, new = load(old_path), load(new_path)
+    if set(old) != set(new):
+        raise SystemExit(
+            "the two dumps cover different rows — they were not built over the same payload"
+        )
+
+    rows = []
+    for key in old:
+        a, b = old[key], new[key]
+        rows.append(
+            {
+                "name": a.get("displayName"),
+                "pos": a.get("position") or "?",
+                "ac": a.get("assetClass"),
+                "rank": a.get("canonicalConsensusRank"),
+                "rookie": bool(a.get("isRookie")),
+                "old": a.get("confidenceBucket") or "none",
+                "new": b.get("confidenceBucket") or "none",
+                "axes": b.get("confidenceAxes") or {},
+                "reasons": b.get("confidenceReasons") or [],
+                "ind": b.get("independentSourceCount"),
+            }
+        )
+
+    out: list[str] = []
+    say = out.append
+    say("# B11 — OLD vs NEW confidence distribution")
+    say("")
+    say(f"Board: pinned payload · {len(rows)} rows")
+    say("")
+
+    oc, nc = Counter(r["old"] for r in rows), Counter(r["new"] for r in rows)
+    say("| bucket | OLD | NEW | delta |")
+    say("|---|---:|---:|---:|")
+    for level in reversed(LEVELS):
+        say(f"| {level} | {oc[level]} | {nc[level]} | {nc[level] - oc[level]:+d} |")
+    say("")
+
+    up = [r for r in rows if LEVELS.index(r["new"]) > LEVELS.index(r["old"])]
+    down = [r for r in rows if LEVELS.index(r["new"]) < LEVELS.index(r["old"])]
+    same = [r for r in rows if r["new"] == r["old"]]
+    say(f"upgraded **{len(up)}** · downgraded **{len(down)}** · unchanged **{len(same)}**")
+    say("")
+
+    say("## Transitions")
+    say("")
+    say("| from | to | n |")
+    say("|---|---|---:|")
+    moves = Counter((r["old"], r["new"]) for r in rows)
+    for (a, b), n in sorted(moves.items(), key=lambda t: -t[1]):
+        if a != b:
+            say(f"| {a} | {b} | {n} |")
+    say("")
+
+    two = [r for r in rows if abs(LEVELS.index(r["new"]) - LEVELS.index(r["old"])) >= 2]
+    say(f"## Two-or-more level moves — {len(two)}")
+    say("")
+    say("| player | pos | rank | old | new | families | binding axes |")
+    say("|---|---|---:|---|---|---:|---|")
+    for r in sorted(two, key=lambda r: (r["rank"] or 9999))[:40]:
+        binding = ", ".join(a for a, v in r["axes"].items() if v == r["new"]) or "-"
+        say(
+            f"| {r['name']} | {r['pos']} | {r['rank']} | {r['old']} | {r['new']} "
+            f"| {r['ind']} | {binding} |"
+        )
+    say("")
+
+    say("## By board depth")
+    say("")
+    say("| band | n | OLD h/m/l/n | NEW h/m/l/n |")
+    say("|---|---:|---|---|")
+    for name in ("001-100", "101-200", "201-400", "401-800", "unranked"):
+        sub = [r for r in rows if band(r["rank"]) == name]
+        if not sub:
+            continue
+        a, b = Counter(r["old"] for r in sub), Counter(r["new"] for r in sub)
+        say(
+            f"| {name} | {len(sub)} "
+            f"| {a['high']}/{a['medium']}/{a['low']}/{a['none']} "
+            f"| {b['high']}/{b['medium']}/{b['low']}/{b['none']} |"
+        )
+    say("")
+
+    say("## By position")
+    say("")
+    say("| pos | n | up | down | same | NEW high | NEW medium | NEW low | NEW none |")
+    say("|---|---:|---:|---:|---:|---:|---:|---:|---:|")
+    for pos in sorted({r["pos"] for r in rows}):
+        sub = [r for r in rows if r["pos"] == pos]
+        u = sum(1 for r in sub if LEVELS.index(r["new"]) > LEVELS.index(r["old"]))
+        d = sum(1 for r in sub if LEVELS.index(r["new"]) < LEVELS.index(r["old"]))
+        b = Counter(r["new"] for r in sub)
+        say(
+            f"| {pos} | {len(sub)} | {u} | {d} | {len(sub) - u - d} "
+            f"| {b['high']} | {b['medium']} | {b['low']} | {b['none']} |"
+        )
+    say("")
+
+    say("## By independent-family coverage (NEW)")
+    say("")
+    say("| families | n | high | medium | low | none |")
+    say("|---:|---:|---:|---:|---:|---:|")
+    for count in sorted({r["ind"] for r in rows if r["ind"] is not None}):
+        sub = [r for r in rows if r["ind"] == count]
+        b = Counter(r["new"] for r in sub)
+        say(
+            f"| {count} | {len(sub)} | {b['high']} | {b['medium']} " f"| {b['low']} | {b['none']} |"
+        )
+    say("")
+
+    say("## Binding axis on the NEW board (non-pick rows)")
+    say("")
+    binding_counts: Counter[str] = Counter()
+    for r in rows:
+        if r["ac"] == "pick" or not r["axes"]:
+            continue
+        for axis, level in r["axes"].items():
+            if level == r["new"]:
+                binding_counts[axis] += 1
+    say("| axis | rows where it is (equal-)weakest |")
+    say("|---|---:|")
+    for axis, n in binding_counts.most_common():
+        say(f"| {axis} | {n} |")
+    say("")
+
+    say("## Did thin or stale evidence get MORE confident?")
+    say("")
+    say(
+        f"- rows upgraded with fewer than 3 independent families: "
+        f"**{sum(1 for r in up if (r['ind'] or 0) < 3)}**"
+    )
+    stale_up = [r for r in up if any("staleness budget" in x for x in r["reasons"])]
+    say(
+        f"- rows upgraded whose evidence includes a stale family: **{len(stale_up)}** "
+        f"(all still pass the freshness ladder — the reason is published on the row)"
+    )
+    gap_up = [r for r in up if any("eligible evidence families" in x for x in r["reasons"])]
+    say(f"- rows upgraded that are missing at least one eligible family: **{len(gap_up)}**")
+    thin_high = [
+        r for r in rows if r["ac"] != "pick" and r["new"] == "high" and (r["ind"] or 0) < 5
+    ]
+    say(
+        f"- PLAYER rows reaching HIGH with fewer than 5 independent families: "
+        f"**{len(thin_high)}** — the independence axis makes it structurally impossible"
+    )
+    pick_high = [r for r in rows if r["ac"] == "pick" and r["new"] == "high"]
+    say(
+        f"- PICK rows at HIGH: **{len(pick_high)}**, on 2 evidence families.  Picks keep "
+        f"their own coefficient-of-variation gate, and their eligible population only HAS "
+        f"2-4 families (KTC + IDPTC are the two real pick markets), so the 5-family bar "
+        f"derived from the blend's trimming rung does not apply to them.  A named "
+        f"boundary, not an exemption that leaked."
+    )
+    say("")
+
+    say("## Representative rows")
+    say("")
+
+    def show(title: str, selected: list[dict], limit: int) -> None:
+        say(f"### {title}")
+        say("")
+        for r in selected[:limit]:
+            say(
+                f"- **{r['name']}** ({r['pos']}, rank {r['rank']}) — "
+                f"{r['old']} → **{r['new']}**  "
+            )
+            say(f"  axes: {r['axes']}  ")
+            for reason in r["reasons"]:
+                say(f"  · {reason}")
+        say("")
+
+    ranked = [r for r in rows if r["rank"]]
+    show("Top of board", sorted(ranked, key=lambda r: r["rank"])[:4], 4)
+    show("Deep board", sorted([r for r in ranked if r["rank"] > 600], key=lambda r: r["rank"]), 3)
+    show("IDP", [r for r in ranked if r["pos"] in ("DL", "LB", "DB")], 3)
+    show("Thin coverage (1-2 families)", [r for r in ranked if (r["ind"] or 0) <= 2], 3)
+    show(
+        "Most disputed (8+ families, agreement LOW)",
+        sorted(
+            [r for r in ranked if (r["ind"] or 0) >= 8 and r["axes"].get("agreement") == "low"],
+            key=lambda r: r["rank"],
+        ),
+        3,
+    )
+    show("Rookies", sorted([r for r in ranked if r["rookie"]], key=lambda r: r["rank"]), 3)
+    show("Picks (own CV path, family-aware)", [r for r in rows if r["ac"] == "pick"], 3)
+
+    return "\n".join(out)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dump", type=Path, help="build the contract and write a slim dump here")
+    parser.add_argument("--payload", type=Path, default=DEFAULT_PAYLOAD)
+    parser.add_argument("--old", type=Path)
+    parser.add_argument("--new", type=Path)
+    parser.add_argument("--out", type=Path)
+    args = parser.parse_args()
+
+    if args.dump:
+        dump(args.payload, args.dump)
+        return
+    if not (args.old and args.new):
+        parser.error("pass --dump, or both --old and --new")
+    text = report(args.old, args.new)
+    if args.out:
+        args.out.write_text(text, encoding="utf-8")
+        print(f"wrote {args.out}")
+    else:
+        print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/master-site-audit/evidence/B11/confidence-distribution.md
+++ b/docs/master-site-audit/evidence/B11/confidence-distribution.md
@@ -1,0 +1,239 @@
+# B11 — OLD vs NEW confidence distribution
+
+Board: pinned payload · 1094 rows
+
+| bucket | OLD | NEW | delta |
+|---|---:|---:|---:|
+| high | 102 | 253 | +151 |
+| medium | 245 | 357 | +112 |
+| low | 441 | 178 | -263 |
+| none | 306 | 306 | +0 |
+
+upgraded **428** · downgraded **77** · unchanged **589**
+
+## Transitions
+
+| from | to | n |
+|---|---|---:|
+| low | medium | 247 |
+| medium | high | 106 |
+| low | high | 75 |
+| medium | low | 47 |
+| high | medium | 18 |
+| high | low | 12 |
+
+## Two-or-more level moves — 87
+
+| player | pos | rank | old | new | families | binding axes |
+|---|---|---:|---|---|---:|---|
+| Jacob Rodriguez | LB | 132 | high | low | 4 | agreement |
+| Jaylen Warren | RB | 178 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Blake Corum | RB | 184 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Chuba Hubbard | RB | 185 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Jonah Coleman | RB | 186 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Jacory Croskey-Merritt | RB | 197 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Jalen Coker | WR | 199 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Antonio Williams | WR | 200 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Rhamondre Stevenson | RB | 203 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Ricky Pearsall | WR | 211 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Tua Tagovailoa | QB | 212 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Kenny Gainwell | RB | 217 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Nicholas Singleton | RB | 218 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Chris Bell | WR | 219 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Brian Branch | DB | 223 | high | low | 5 | agreement |
+| Daiyan Henley | LB | 226 | high | low | 5 | agreement |
+| Rachaad White | RB | 238 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Jalen Carter | DL | 239 | high | low | 5 | agreement |
+| Greg Rousseau | DL | 240 | high | low | 5 | agreement |
+| Stefon Diggs | WR | 241 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Jordan Mason | RB | 243 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Rashid Shaheed | WR | 248 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Tyrone Tracy | RB | 250 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Ja'Kobi Lane | WR | 251 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Jonathan Greenard | DL | 254 | high | low | 5 | agreement |
+| Tyler Allgeier | RB | 255 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Woody Marks | RB | 256 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| DeMarvion Overshown | LB | 272 | low | high | 5 | independence, coverage, freshness, applicability, agreement |
+| Dylan Sampson | RB | 277 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Adonai Mitchell | WR | 279 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Tank Bigsby | RB | 280 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Aaron Jones | RB | 289 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Geno Smith | QB | 290 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Xavier Watts | DB | 296 | low | high | 5 | independence, coverage, freshness, applicability, agreement |
+| Braelon Allen | RB | 300 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Antoine Winfield | DB | 304 | low | high | 5 | independence, coverage, freshness, applicability, agreement |
+| Devon Witherspoon | DB | 310 | low | high | 5 | independence, coverage, freshness, applicability, agreement |
+| Kaden Elliss | LB | 311 | low | high | 5 | independence, coverage, freshness, applicability, agreement |
+| Brian Robinson | RB | 316 | low | high | 12 | independence, coverage, freshness, applicability, agreement |
+| Divine Deablo | LB | 318 | low | high | 5 | independence, coverage, freshness, applicability, agreement |
+
+## By board depth
+
+| band | n | OLD h/m/l/n | NEW h/m/l/n |
+|---|---:|---|---|
+| 001-100 | 100 | 61/38/1/0 | 79/20/1/0 |
+| 101-200 | 100 | 10/65/25/0 | 58/35/7/0 |
+| 201-400 | 200 | 15/41/144/0 | 72/106/22/0 |
+| 401-800 | 340 | 16/101/223/0 | 44/196/100/0 |
+| unranked | 354 | 0/0/48/306 | 0/0/48/306 |
+
+## By position
+
+| pos | n | up | down | same | NEW high | NEW medium | NEW low | NEW none |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| ? | 20 | 0 | 0 | 20 | 0 | 0 | 0 | 20 |
+| DB | 139 | 43 | 9 | 87 | 15 | 46 | 31 | 47 |
+| DL | 145 | 59 | 27 | 59 | 17 | 73 | 33 | 22 |
+| K | 19 | 0 | 0 | 19 | 0 | 0 | 0 | 19 |
+| LB | 114 | 44 | 15 | 55 | 16 | 49 | 19 | 30 |
+| PICK | 144 | 0 | 0 | 144 | 24 | 0 | 55 | 65 |
+| QB | 71 | 39 | 1 | 31 | 38 | 18 | 2 | 13 |
+| RB | 143 | 85 | 6 | 52 | 68 | 34 | 8 | 33 |
+| T | 1 | 0 | 0 | 1 | 0 | 0 | 0 | 1 |
+| TE | 82 | 50 | 9 | 23 | 1 | 71 | 7 | 3 |
+| WR | 216 | 108 | 10 | 98 | 74 | 66 | 23 | 53 |
+
+## By independent-family coverage (NEW)
+
+| families | n | high | medium | low | none |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 96 | 0 | 0 | 55 | 41 |
+| 2 | 106 | 24 | 0 | 26 | 56 |
+| 3 | 136 | 0 | 58 | 48 | 30 |
+| 4 | 123 | 0 | 88 | 12 | 23 |
+| 5 | 111 | 48 | 22 | 22 | 19 |
+| 6 | 17 | 0 | 5 | 1 | 11 |
+| 7 | 18 | 0 | 12 | 0 | 6 |
+| 8 | 23 | 0 | 14 | 0 | 9 |
+| 9 | 31 | 6 | 15 | 5 | 5 |
+| 10 | 33 | 11 | 20 | 1 | 1 |
+| 11 | 81 | 41 | 36 | 4 | 0 |
+| 12 | 214 | 123 | 87 | 4 | 0 |
+
+## Binding axis on the NEW board (non-pick rows)
+
+| axis | rows where it is (equal-)weakest |
+|---|---:|
+| agreement | 493 |
+| independence | 401 |
+| coverage | 361 |
+| applicability | 297 |
+| freshness | 275 |
+
+## Did thin or stale evidence get MORE confident?
+
+- rows upgraded with fewer than 3 independent families: **0**
+- rows upgraded whose evidence includes a stale family: **375** (all still pass the freshness ladder — the reason is published on the row)
+- rows upgraded that are missing at least one eligible family: **196**
+- PLAYER rows reaching HIGH with fewer than 5 independent families: **0** — the independence axis makes it structurally impossible
+- PICK rows at HIGH: **24**, on 2 evidence families.  Picks keep their own coefficient-of-variation gate, and their eligible population only HAS 2-4 families (KTC + IDPTC are the two real pick markets), so the 5-family bar derived from the blend's trimming rung does not apply to them.  A named boundary, not an exemption that leaked.
+
+## Representative rows
+
+### Top of board
+
+- **Josh Allen** (QB, rank 1) — high → **high**  
+  axes: {'independence': 'high', 'coverage': 'high', 'freshness': 'high', 'applicability': 'high', 'agreement': 'high'}  
+  · 12 independent evidence families
+  · 1 of 12 contributing families is past their staleness budget
+  · All 12 families price within 15% of the published value
+- **Brock Bowers** (TE, rank 2) — high → **medium**  
+  axes: {'independence': 'high', 'coverage': 'high', 'freshness': 'high', 'applicability': 'medium', 'agreement': 'high'}  
+  · 11 independent evidence families
+  · Covers 11 of 12 eligible evidence families
+  · All contributing evidence is current
+  · 6 of 11 families needed a TE-premium basis conversion
+  · All 11 families price within 15% of the published value
+- **Bijan Robinson** (RB, rank 3) — high → **high**  
+  axes: {'independence': 'high', 'coverage': 'high', 'freshness': 'high', 'applicability': 'high', 'agreement': 'high'}  
+  · 11 independent evidence families
+  · Covers 11 of 12 eligible evidence families
+  · All contributing evidence is current
+  · All 11 families price within 15% of the published value
+- **Jahmyr Gibbs** (RB, rank 4) — high → **high**  
+  axes: {'independence': 'high', 'coverage': 'high', 'freshness': 'high', 'applicability': 'high', 'agreement': 'high'}  
+  · 11 independent evidence families
+  · Covers 11 of 12 eligible evidence families
+  · All contributing evidence is current
+  · All 11 families price within 15% of the published value
+
+### Deep board
+
+- **Noah Whittington** (RB, rank 601) — medium → **low**  
+  axes: {'independence': 'low', 'coverage': 'low', 'freshness': 'medium', 'applicability': 'high', 'agreement': 'low'}  
+  · 2 independent evidence families — too few to corroborate
+  · Covers 2 of 12 eligible evidence families
+  · 1 of 2 contributing families is past their staleness budget
+  · 0 of 2 families price within 15% of the published value
+- **Demario Davis** (LB, rank 602) — low → **medium**  
+  axes: {'independence': 'medium', 'coverage': 'high', 'freshness': 'high', 'applicability': 'high', 'agreement': 'high'}  
+  · 4 independent evidence families
+  · Covers 4 of 5 eligible evidence families
+  · 1 of 4 contributing families is past their staleness budget
+  · All 4 families price within 15% of the published value
+- **Chris Brooks** (RB, rank 603) — low → **medium**  
+  axes: {'independence': 'high', 'coverage': 'medium', 'freshness': 'high', 'applicability': 'high', 'agreement': 'high'}  
+  · 8 independent evidence families
+  · Covers 8 of 12 eligible evidence families
+  · All contributing evidence is current
+  · 7 of 8 families price within 15% of the published value
+
+### IDP
+
+- **Abdul Carter** (DL, rank 117) — medium → **low**  
+  axes: {'independence': 'high', 'coverage': 'high', 'freshness': 'high', 'applicability': 'high', 'agreement': 'low'}  
+  · 5 independent evidence families
+  · 1 of 5 contributing families is past their staleness budget
+  · 1 of 5 families price within 15% of the published value
+- **Aidan Hutchinson** (DL, rank 34) — high → **medium**  
+  axes: {'independence': 'medium', 'coverage': 'high', 'freshness': 'high', 'applicability': 'high', 'agreement': 'high'}  
+  · 4 independent evidence families
+  · Covers 4 of 5 eligible evidence families
+  · All contributing evidence is current
+  · All 4 families price within 15% of the published value
+- **AJ Haulcy** (DB, rank 351) — medium → **medium**  
+  axes: {'independence': 'medium', 'coverage': 'high', 'freshness': 'high', 'applicability': 'high', 'agreement': 'high'}  
+  · 4 independent evidence families
+  · Covers 4 of 5 eligible evidence families
+  · 1 of 4 contributing families is past their staleness budget
+  · All 4 families price within 15% of the published value
+
+### Thin coverage (1-2 families)
+
+- **2027 Early 1st** (PICK, rank 28) — high → **high**  
+  axes: {}  
+- **2027 Early 2nd** (PICK, rank 110) — high → **high**  
+  axes: {}  
+- **2027 Early 3rd** (PICK, rank 221) — high → **high**  
+  axes: {}  
+
+### Most disputed (8+ families, agreement LOW)
+
+- **Travis Hunter** (WR, rank 78) — low → **low**  
+  axes: {'independence': 'high', 'coverage': 'high', 'freshness': 'high', 'applicability': 'high', 'agreement': 'low'}  
+  · 11 independent evidence families
+  · Covers 11 of 12 eligible evidence families
+  · 1 of 11 contributing families is past their staleness budget
+  · 0 of 11 families price within 15% of the published value
+- **Jauan Jennings** (WR, rank 266) — low → **low**  
+  axes: {'independence': 'high', 'coverage': 'high', 'freshness': 'high', 'applicability': 'high', 'agreement': 'low'}  
+  · 12 independent evidence families
+  · 1 of 12 contributing families is past their staleness budget
+  · 5 of 12 families price within 15% of the published value
+- **Elijah Sarratt** (WR, rank 270) — low → **low**  
+  axes: {'independence': 'high', 'coverage': 'high', 'freshness': 'high', 'applicability': 'high', 'agreement': 'low'}  
+  · 12 independent evidence families
+  · 1 of 12 contributing families is past their staleness budget
+  · 5 of 12 families price within 15% of the published value
+
+### Rookies
+
+
+### Picks (own CV path, family-aware)
+
+- **2026 Early 1st** (PICK, rank None) — none → **none**  
+  axes: {}  
+- **2026 Early 2nd** (PICK, rank None) — none → **none**  
+  axes: {}  
+- **2026 Early 3rd** (PICK, rank None) — none → **none**  
+  axes: {}  

--- a/frontend/__tests__/consensus-label-reads-backend-bucket.test.js
+++ b/frontend/__tests__/consensus-label-reads-backend-bucket.test.js
@@ -8,14 +8,18 @@
  * `sourceRankSpread <= CONFIDENCE_SPREAD_HIGH`, a frontend copy of
  * `_CONFIDENCE_SPREAD_HIGH = 30`.
  *
- * That constant mirrors a rule the backend RETIRED.
- * `_confidence_bucket` in `data_contract.py` decides off the
- * PERCENTILE spread on the normal `_compute_unified_rankings` path and
- * falls back to the absolute ordinal only for callers that have
- * nothing else. The percentile signal exists so an IDP player ranked
- * by 4 sources is judged on the same agreement scale as an offense
- * player ranked by 14; re-imposing an absolute ordinal cap on the
- * client undoes exactly that.
+ * That constant mirrored a rule the backend had already RETIRED, and the
+ * backend has since retired the replacement too. Confidence is now
+ * decided by `src/api/confidence.py` — five axes over provider families
+ * (independence, coverage, freshness, applicability, agreement),
+ * combined by bottleneck, with agreement measured in VALUE space (B11).
+ * No spread of any kind decides it, so a client-side ordinal cap is now
+ * two generations behind the rule it claims to mirror.
+ *
+ * The property this file pins is what survives every one of those
+ * changes: the client renders the backend's verdict and computes none of
+ * its own. The specific numbers below are from the 2026-07-30 measurement
+ * that motivated the fix; they are history, not the current board.
  *
  * Measured on the pinned 2026-07-30 contract:
  *

--- a/frontend/lib/edge-helpers.js
+++ b/frontend/lib/edge-helpers.js
@@ -87,22 +87,27 @@ export function actionLabel(row) {
   // `confidenceBucket` is the BACKEND's answer to exactly this
   // question, and it is the only agreement test applied here. There
   // used to be a second one — `sourceRankSpread <= 30`, a frontend copy
-  // of `_CONFIDENCE_SPREAD_HIGH` — layered on top of it. That constant
-  // mirrors a rule the backend RETIRED: `_confidence_bucket` decides
-  // off the PERCENTILE spread on the normal `_compute_unified_rankings`
-  // path, and falls back to the absolute ordinal only for callers that
-  // have nothing else. The percentile signal exists so an IDP player
-  // ranked by 4 sources is judged on the same agreement scale as an
-  // offense player ranked by 14; re-imposing an absolute ordinal cap
-  // undoes precisely that.
+  // of a backend constant that had already been retired once. Measured
+  // on the pinned 2026-07-30 contract: of the 111 rows the backend
+  // called high-confidence, multi-source and undisputed, the extra
+  // check suppressed "Consensus asset" on **54** — nearly half — with
+  // ordinal spreads running to 486 on rows the backend was confident
+  // about.
   //
-  // Measured on the pinned 2026-07-30 contract: of the 111 rows the
-  // backend calls high-confidence, multi-source and undisputed, the
-  // extra check suppressed "Consensus asset" on **54** — nearly half —
-  // with ordinal spreads running to 486 on rows the backend is
-  // confident about. Recomputing a backend verdict on the client is
-  // also the thing this codebase's "no frontend ranking engine, period"
-  // rule exists to prevent.
+  // Since B11 the backend decides confidence with `src/api/confidence.js`'s
+  // Python sibling — five axes over provider families, combined by
+  // bottleneck, agreement measured in VALUE space — so NO spread of any
+  // kind decides it, and there is nothing here to mirror even if someone
+  // wanted to. Recomputing a backend verdict on the client is the thing
+  // this codebase's "no frontend ranking engine, period" rule exists to
+  // prevent; B11 extends it explicitly to confidence.
+  //
+  // The gate is deliberately less saturated than the rule it replaced:
+  // 253 rows are high-confidence on the 2026-08-14 board against 102
+  // before, because the retired percentile spread grew mechanically with
+  // depth and produced a cliff at rank 100 with no evidentiary basis.
+  // The widening here is that fix arriving, not a regression — do not
+  // add a filter to hold the old row count.
   //
   // `hasSourceDisagreement` stays: it is a backend stamp too, off the
   // percentile signal, and it is what keeps "Consensus asset" and

--- a/src/api/confidence.py
+++ b/src/api/confidence.py
@@ -1,0 +1,455 @@
+"""Canonical confidence — the one owner of "how good is the evidence here".
+
+WHAT THIS REPLACES, AND WHY IT COULD NOT BE PATCHED
+───────────────────────────────────────────────────
+Confidence was decided by ``max(percentile) − min(percentile)`` across a
+row's contributing sources, bucketed against two cutoffs, behind an
+``n >= 2`` count gate.
+
+A range has a structural pathology: removing an observation can only
+preserve or narrow it. Under "narrower ⇒ more confident", **deleting
+evidence promotes confidence**. PR #833 recorded the failed repair —
+re-basing the same statistic onto independent evidence moved 60 rows the
+WRONG way (A.J. Brown medium → high) because collapsing his FantasyPros
+family removed one endpoint of the range. The input population was not
+the defect. The statistic was.
+
+It was also one axis wearing two hats — a count and a dispersion — and
+nothing at all asked whether the evidence was independent, current,
+applicable to this board's format, or anywhere near complete. So a large
+source count silently compensated for every one of those.
+
+THE REPLACEMENT
+───────────────
+Five axes, each a statement about the EVIDENCE rather than about the
+number, combined by BOTTLENECK — the overall level is the weakest axis.
+Nothing averages, so a strong axis cannot buy a weak one, which is the
+owner ruling ("a huge source count must not compensate for poor
+freshness / applicability / independent-family coverage / severe
+disagreement") expressed as arithmetic rather than as a weighting.
+
+    independence   how many B10 correlation-group heads voted
+    coverage       how many of the ELIGIBLE families actually did
+    freshness      how many of those are inside their staleness budget
+    applicability  how many reached the row without approximation, and
+                   on this board's TE-premium basis
+    agreement      how many price within a material relative gap of the
+                   published value
+
+EVERY AXIS IS COMPUTED OVER FAMILY HEADS
+────────────────────────────────────────
+The unit of evidence is the B10 correlation group, never the source key.
+A second observation from an already-represented family is not an input
+to anything, so adding or removing one is an exact identity across all
+five axes — invariants 1 and 2 discharged structurally rather than by
+calibration. ``assess_confidence`` REFUSES a duplicate family rather
+than averaging or ignoring it, because both of those are ways for a
+duplicate to matter after all.
+
+WHY REMOVING REAL EVIDENCE CANNOT PAY
+─────────────────────────────────────
+``coverage``'s denominator is what COULD have been observed, not what
+was. A family that stops covering a row stays eligible, so its silence
+is registered as missing evidence permanently. That is MISSING IS NEVER
+ZERO applied to confidence: an absent eligible source is explicit
+missingness, not a neutral non-event.
+
+Confidence can still rise when the evidence that went away was STALE or
+INAPPLICABLE — the ruling permits exactly that — and in those cases the
+reason is in ``reasons``, which is the condition the ruling attaches.
+
+AGREEMENT IS MEASURED IN VALUE SPACE, NOT RANK SPACE
+────────────────────────────────────────────────────
+A family agrees when its ``valueContribution`` is within a material
+relative gap of the published value, using the same symmetric mean
+normalisation ``_compute_market_gap`` uses. Value is the right currency
+for the same reason it was right there: it is what the blend itself
+compares sources in — post-ladder, common-scaled 1-9999, and after
+ADR-015's ``convert_te_value``. Percentile space measures pool depth as
+much as opinion, and it is where the old statistic's depth pathology
+came from (median trimmed spread 0.068 in the top 100 against 0.30 at
+ranks 201-400, so a flat cutoff either saturates the deep board or never
+fires at the top).
+
+Checked for the opposite bias before adopting: the within-tolerance
+share FALLS with depth on the live board (median 1.000 in the top 100,
+0.917 at 101-200, 0.750 at 201-800), so it does not become mechanically
+easier where the Hill curve flattens.
+
+CONFIDENCE IS NOT VALUE
+───────────────────────
+Nothing here returns, adjusts or reads back a price. The assessment
+carries levels, shares and counts only.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+__all__ = [
+    "AXES",
+    "CONFIDENCE_LEVELS",
+    "ConfidenceAssessment",
+    "FamilyEvidence",
+    "assess_confidence",
+    "assess_pick_confidence",
+    "gate_parameter",
+    "gate_parameters",
+]
+
+#: Ordered weakest → strongest. The published ``confidenceBucket`` values.
+CONFIDENCE_LEVELS: tuple[str, ...] = ("none", "low", "medium", "high")
+
+#: The axes, in reporting order.
+AXES: tuple[str, ...] = (
+    "independence",
+    "coverage",
+    "freshness",
+    "applicability",
+    "agreement",
+)
+
+_LEVEL_INDEX = {name: i for i, name in enumerate(CONFIDENCE_LEVELS)}
+
+_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "confidence" / "gate_v1.json"
+
+
+@lru_cache(maxsize=1)
+def _document() -> dict[str, Any]:
+    return json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+
+
+def gate_parameters() -> dict[str, dict[str, Any]]:
+    """The full parameter entries, including unit and derivation."""
+    raw = _document().get("parameters")
+    if not isinstance(raw, dict):
+        raise ValueError(f"{_CONFIG_PATH} has no 'parameters' object")
+    return {str(k): dict(v) for k, v in raw.items() if isinstance(v, dict)}
+
+
+def gate_parameter(name: str) -> float:
+    """One gate parameter by name.
+
+    Raises on an unknown name rather than substituting a default — the
+    same rule ``src.api.thresholds.threshold`` follows, for the same
+    reason: a silent default gates a decision surface on a number nobody
+    chose.
+    """
+    entries = gate_parameters()
+    if name not in entries:
+        raise KeyError(f"no confidence gate parameter named {name!r} in {_CONFIG_PATH}")
+    return entries[name]["value"]
+
+
+@dataclass(frozen=True)
+class FamilyEvidence:
+    """One independent evidence family's contribution to one row.
+
+    Exactly one of these per B10 correlation group. The caller has
+    already collapsed families (``collapse_to_independent_families``);
+    this type is the boundary at which that is assumed and checked.
+
+    ``fresh`` is tri-state on purpose: ``None`` means the source's age
+    could not be observed, which is not the same statement as "current"
+    and must never count as one.
+    """
+
+    family: str
+    source_key: str
+    value_contribution: float | None
+    fresh: bool | None
+    #: False when the observation had to be lifted onto this board's
+    #: TE-premium basis by ADR-015's measured conversion curve.
+    format_native: bool = True
+    #: False when the rank reached this row through an APPROXIMATING
+    #: translation — a rookie-ladder lift or a backbone fallback — rather
+    #: than the source's own placement.
+    directly_observed: bool = True
+
+
+@dataclass(frozen=True)
+class ConfidenceAssessment:
+    overall: str
+    label: str
+    axes: dict[str, str]
+    reasons: list[str]
+    metrics: dict[str, Any]
+
+
+def _share_level(share: float | None) -> str:
+    """The declared sufficiency ladder, applied to every share axis.
+
+    ``None`` — the share could not be computed — is LOW, never HIGH: an
+    unmeasurable axis is not a satisfied one.
+    """
+    if share is None:
+        return "low"
+    if share >= gate_parameter("EVIDENCE_SHARE_HIGH"):
+        return "high"
+    if share >= gate_parameter("EVIDENCE_SHARE_MEDIUM"):
+        return "medium"
+    return "low"
+
+
+def _weaken(level: str) -> str:
+    """One level down, floored at ``low``.
+
+    Used for the TE-basis penalty, which is a KNOWN correction rather
+    than missing evidence: it costs a level, not the axis.
+    """
+    return CONFIDENCE_LEVELS[max(1, _LEVEL_INDEX[level] - 1)]
+
+
+def _relative_gap(a: float, b: float) -> float | None:
+    """``|a − b|`` over their mean — the board's declared gap convention.
+
+    Identical normalisation to ``_compute_market_gap``, so
+    ``AGREEMENT_VALUE_RATIO`` means the same size of disagreement as the
+    market-gap thresholds it was set from.
+    """
+    scale = (a + b) / 2.0
+    if scale <= 0:
+        return None
+    return abs(a - b) / scale
+
+
+def assess_confidence(
+    evidence: Sequence[FamilyEvidence] | Iterable[FamilyEvidence],
+    *,
+    eligible_families: Iterable[str],
+    consensus_value: float | None,
+) -> ConfidenceAssessment:
+    """Grade the evidence behind one canonical value.
+
+    :param evidence: one entry per INDEPENDENT family head. A repeated
+        family raises — see the module docstring.
+    :param eligible_families: every family that COULD have covered this
+        row (registry scope × non-empty pool). The coverage denominator,
+        and the reason removing evidence cannot promote a row.
+    :param consensus_value: the published ``rankDerivedValue``. ``None``
+        means there is nothing to agree with, which is not agreement.
+    """
+    heads = list(evidence)
+    seen: set[str] = set()
+    for item in heads:
+        if item.family in seen:
+            raise ValueError(
+                f"duplicate evidence family {item.family!r} "
+                f"(source {item.source_key!r}): confidence consumes B10 family HEADS, "
+                "so collapse the family before calling this"
+            )
+        seen.add(item.family)
+
+    eligible = {str(f) for f in eligible_families}
+    n = len(heads)
+
+    metrics: dict[str, Any] = {
+        "independentFamilies": n,
+        "eligibleFamilies": len(eligible) or None,
+        "coveredFamilies": len(seen & eligible) if eligible else None,
+        "coverageShare": None,
+        "freshFamilies": 0,
+        "freshnessShare": None,
+        "unknownFreshnessFamilies": 0,
+        "directlyObservedFamilies": 0,
+        "formatNativeFamilies": 0,
+        "applicabilityShare": None,
+        "formatNativeShare": None,
+        "comparableFamilies": 0,
+        "agreeingFamilies": 0,
+        "agreementShare": None,
+    }
+
+    if n == 0:
+        return ConfidenceAssessment(
+            overall="none",
+            label="None — no evidence",
+            axes={axis: "none" for axis in AXES},
+            reasons=["No evidence family covers this asset"],
+            metrics=metrics,
+        )
+
+    reasons: list[str] = []
+
+    # ── independence ──
+    high_n = gate_parameter("INDEPENDENCE_HIGH_FAMILIES")
+    medium_n = gate_parameter("INDEPENDENCE_MEDIUM_FAMILIES")
+    if n >= high_n:
+        independence = "high"
+    elif n >= medium_n:
+        independence = "medium"
+    else:
+        independence = "low"
+    reasons.append(
+        f"{n} independent evidence famil{'y' if n == 1 else 'ies'}"
+        + ("" if n >= medium_n else " — too few to corroborate")
+    )
+
+    # ── coverage ──
+    #
+    # The denominator is what could have spoken. A family that stopped
+    # covering this row is missing evidence for as long as it stays
+    # eligible, which is what stops "delete the awkward source" from
+    # reading as "the panel now agrees".
+    if eligible:
+        covered = len(seen & eligible)
+        metrics["coverageShare"] = round(covered / len(eligible), 4)
+        coverage = _share_level(metrics["coverageShare"])
+        if covered < len(eligible):
+            reasons.append(f"Covers {covered} of {len(eligible)} eligible evidence families")
+    else:
+        coverage = "low"
+        reasons.append("No eligible evidence families declared for this asset")
+
+    # ── freshness ──
+    fresh = sum(1 for e in heads if e.fresh is True)
+    unknown = sum(1 for e in heads if e.fresh is None)
+    metrics["freshFamilies"] = fresh
+    metrics["unknownFreshnessFamilies"] = unknown
+    metrics["freshnessShare"] = round(fresh / n, 4)
+    freshness = _share_level(metrics["freshnessShare"])
+    stale = n - fresh - unknown
+    if stale:
+        reasons.append(
+            f"{stale} of {n} contributing families "
+            f"{'is' if stale == 1 else 'are'} past their staleness budget"
+        )
+    if unknown:
+        reasons.append(
+            f"{unknown} of {n} contributing families "
+            f"{'has' if unknown == 1 else 'have'} unknown freshness"
+        )
+    if not stale and not unknown:
+        reasons.append("All contributing evidence is current")
+
+    # ── applicability ──
+    #
+    # Two distinct weaknesses, deliberately priced differently:
+    #
+    #   * an APPROXIMATING translation (rookie ladder, backbone
+    #     fallback) is a guess at where the source would have placed the
+    #     player — full-strength penalty;
+    #   * a BASIS conversion onto this board's TE++ anchor is ADR-015's
+    #     measured KTC uplift applied to a real observation — a known
+    #     correction, so it costs one level rather than the axis. Not
+    #     free either: the curve runs 1.209 at the top of the board to
+    #     2.05 down it, so where the player sits changes the number
+    #     materially.
+    direct = sum(1 for e in heads if e.directly_observed)
+    native = sum(1 for e in heads if e.format_native)
+    metrics["directlyObservedFamilies"] = direct
+    metrics["formatNativeFamilies"] = native
+    metrics["applicabilityShare"] = round(direct / n, 4)
+    metrics["formatNativeShare"] = round(native / n, 4)
+    applicability = _share_level(metrics["applicabilityShare"])
+    if direct < n:
+        reasons.append(
+            f"{n - direct} of {n} famil{'y' if n - direct == 1 else 'ies'} reached this "
+            "asset through an approximating translation"
+        )
+    if metrics["formatNativeShare"] < gate_parameter("EVIDENCE_SHARE_MEDIUM"):
+        applicability = _weaken(applicability)
+        reasons.append(f"{n - native} of {n} families needed a TE-premium basis conversion")
+
+    # ── agreement ──
+    tolerance = gate_parameter("AGREEMENT_VALUE_RATIO")
+    if consensus_value is None or float(consensus_value) <= 0:
+        agreement = "low"
+        reasons.append("No published value to compare the evidence against")
+    else:
+        center = float(consensus_value)
+        comparable = 0
+        agreeing = 0
+        for e in heads:
+            if e.value_contribution is None:
+                continue
+            gap = _relative_gap(float(e.value_contribution), center)
+            if gap is None:
+                continue
+            comparable += 1
+            if gap <= tolerance:
+                agreeing += 1
+        metrics["comparableFamilies"] = comparable
+        metrics["agreeingFamilies"] = agreeing
+        # Denominator is every head, not just the comparable ones: a
+        # family we cannot compare has not agreed with anything.
+        metrics["agreementShare"] = round(agreeing / n, 4)
+        agreement = _share_level(metrics["agreementShare"])
+        pct = int(round(tolerance * 100))
+        if agreeing == n:
+            reasons.append(f"All {n} families price within {pct}% of the published value")
+        else:
+            reasons.append(f"{agreeing} of {n} families price within {pct}% of the published value")
+
+    axes = {
+        "independence": independence,
+        "coverage": coverage,
+        "freshness": freshness,
+        "applicability": applicability,
+        "agreement": agreement,
+    }
+    overall = min((axes[a] for a in AXES), key=lambda level: _LEVEL_INDEX[level])
+    # Name the BINDING axis — the thing a reader can act on. When every
+    # axis sits at the same level there is nothing being held back by
+    # anything, and listing all five would read like five complaints.
+    binding = [a for a in AXES if axes[a] == overall]
+    label = (
+        f"{overall.capitalize()} — every axis {overall}"
+        if len(binding) == len(AXES)
+        else f"{overall.capitalize()} — limited by {', '.join(binding)}"
+    )
+    return ConfidenceAssessment(
+        overall=overall,
+        label=label,
+        axes=axes,
+        reasons=reasons,
+        metrics=metrics,
+    )
+
+
+def assess_pick_confidence(
+    site_values: dict[str, Any],
+    *,
+    is_slot_specific: bool,
+) -> tuple[str, str]:
+    """Pick confidence, with one vote per provider family.
+
+    Picks keep their own coefficient-of-variation statistic — rank
+    spread on picks is dominated by the flat-value regions in R3-R6 and
+    misleads a player-centric gate — but they must not keep raw-source
+    independence assumptions. The value list this reads names both
+    ``dlfSf`` and ``dlfIdp``, which are one declared family; two members
+    were being counted as two corroborating opinions.
+
+    Measured before changing it: **0 of 144 live pick rows** carry two
+    members of one family, so this closes the hole rather than moving a
+    number. It is here, and pinned, so it cannot open again quietly.
+    """
+    # Imported lazily: ``data_contract`` imports this module, so a
+    # top-level import would be circular.
+    from src.api.data_contract import (
+        _compute_pick_confidence,
+        _source_precedence,
+        correlation_group_for,
+    )
+
+    by_family: dict[str, list[str]] = {}
+    for key, raw in site_values.items():
+        if not isinstance(raw, (int, float)) or float(raw) <= 0:
+            continue
+        by_family.setdefault(correlation_group_for(str(key)), []).append(str(key))
+
+    superseded = {
+        member
+        for members in by_family.values()
+        if len(members) > 1
+        for member in members
+        if member != min(members, key=_source_precedence)
+    }
+    if superseded:
+        site_values = {k: v for k, v in site_values.items() if k not in superseded}
+    return _compute_pick_confidence(site_values, is_slot_specific=is_slot_specific)

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -28,6 +28,15 @@ from src.canonical.player_valuation import (  # noqa: E402  — grouped with its
 )
 from src.data_models.contracts import utc_now_iso
 
+#: B11 — the single owner of "how good is the evidence behind this value".
+#: This module ASSEMBLES the evidence; it decides no confidence level.
+from src.api.confidence import (  # noqa: E402  — grouped with its siblings
+    FamilyEvidence,
+    assess_confidence,
+    assess_pick_confidence,
+    gate_parameter as _confidence_gate_parameter,
+)
+
 _LOGGER = logging.getLogger(__name__)
 
 #: Verified cross-universe name collisions — players whose display name
@@ -99,38 +108,29 @@ _IDP_SIGNAL_KEYS = {
 # All source signal keys — used to detect which source(s) a player has
 _ALL_SIGNAL_KEYS = _OFFENSE_SIGNAL_KEYS | _IDP_SIGNAL_KEYS
 
-# ── Confidence bucket thresholds ────────────────────────────────────────────
-# Buckets describe how much trust a consumer should place in a player's
-# unified rank.  Determined by source count and source agreement.
+# ── Confidence: RETIRED HERE, OWNED BY src/api/confidence.py (B11) ──────────
 #
-# Agreement is measured in *percentile* space rather than absolute
-# ordinal ranks so IDP players aren't unfairly bucketed as "low" just
-# because IDP sources have smaller pools.  Example: an IDP with ranks
-# [52, 62, 148, 151, 1] across sources has an absolute spread of 150
-# (far above the legacy 80 threshold), but a percentile spread of
-# ~0.16 because each rank lives inside a much smaller pool — the
-# sources are actually in broad tier-agreement.  The offense-only
-# absolute thresholds used to fire "low" on well-covered IDP rows.
+# There used to be four constants at this spot — ``_CONFIDENCE_PERCENTILE_
+# HIGH/MEDIUM`` (0.08 / 0.20) and an absolute-ordinal fallback pair
+# (30 / 80) — bucketing a row on ``max(percentile) − min(percentile)``
+# across its contributing sources, behind an ``n >= 2`` count gate.
 #
-# Rules (evaluated top-to-bottom, first match wins):
-#   "high"   — 2+ sources AND percentileSpread <= 0.08   (within 8%)
-#   "medium" — 2+ sources AND percentileSpread <= 0.20   (within 20%)
-#   "low"    — single source, OR percentileSpread > 0.20, OR no
-#              percentile signal and absolute spread > 80
-#   "none"   — player did not receive a unified rank
+# Deleted rather than re-tuned.  A range can only preserve or narrow when
+# an observation is removed, so under "narrower ⇒ more confident"
+# **deleting evidence promoted a row**.  PR #833 recorded the failed
+# repair: re-basing the same statistic onto independent evidence moved 60
+# rows the WRONG way (A.J. Brown medium → high) purely because collapsing
+# his FantasyPros family removed one endpoint.  The input population was
+# never the defect; the statistic was, and a threshold pair around it
+# could not be anything but a different-sized version of the same bug.
 #
-# The 0.20 medium ceiling aligns with the
-# ``suspicious_disagreement`` flag threshold — anything worse than
-# 20% percentile spread is by definition widely-disagreed coverage,
-# which is exactly the "low" bucket.
-_CONFIDENCE_PERCENTILE_HIGH = 0.08
-_CONFIDENCE_PERCENTILE_MEDIUM = 0.20
-# Legacy absolute-ordinal fallback for callers that don't pass a
-# percentile spread (older tests, third-party consumers).  Kept at
-# the pre-fix thresholds so their existing expectations still hold.
-_CONFIDENCE_SPREAD_HIGH = 30
-_CONFIDENCE_SPREAD_MEDIUM = 80
-
+# ``src/api/confidence.py`` owns the replacement outright — five axes over
+# B10 provider families, combined by bottleneck, parameterised from
+# ``config/confidence/gate_v1.json``.  ``sourceRankPercentileSpread`` is
+# still computed and still published: it remains a useful diagnostic and
+# it still drives ``hasSourceDisagreement``.  It no longer decides
+# confidence.
+#
 # ── Trimmed percentile spread ────────────────────────────────────────────────
 # With this many sources or more, ``_percentile_rank_spread`` ignores the
 # single most extreme percentile on EACH side before taking max-minus-min.
@@ -1998,37 +1998,37 @@ def _scope_eligible(pos: str, scope: str, position_group: str | None) -> bool:
     return False
 
 
-def _compute_confidence_bucket(
-    source_count: int,
-    source_rank_spread: float | None,
-    percentile_spread: float | None = None,
-) -> tuple[str, str]:
-    """Return (confidenceBucket, confidenceLabel) for a ranked player.
+def _source_freshness_flags() -> dict[str, bool | None]:
+    """Per-source ``fresh?`` for the B11 confidence gate.
 
-    When ``percentile_spread`` is supplied (the normal path via
-    :func:`_compute_unified_rankings`), buckets are decided off the
-    percentile signal so IDP players with small source pools are
-    judged on the same agreement scale as offense players with
-    large pools.  Falls back to the legacy absolute-ordinal spread
-    for callers that only have ``source_rank_spread`` handy.
+    Tri-state, reduced from the same ``staleness`` string the payload's
+    ``dataFreshness.sourceTimestamps`` block publishes, so confidence and
+    the freshness panel cannot disagree about whether a source is
+    current:
 
-    See threshold constants above for the decision rules.
+      ``True``   inside its declared ``maxAgeHours`` budget
+      ``False``  measured, and past it
+      ``None``   could not be observed — a CSV we never found, or a
+                 source with no path registered at all
+
+    ``None`` is not ``False`` and neither is ``True``: an unmeasurable
+    source must not read like one we measured and found current.  The
+    gate counts only ``True`` toward the freshness share and reports the
+    unknowns separately.
+
+    Costs one ``os.stat`` per registered source, so callers resolve it
+    ONCE per build and pass the map down — never per row.
     """
-    if source_count >= 2:
-        if percentile_spread is not None:
-            if percentile_spread <= _CONFIDENCE_PERCENTILE_HIGH:
-                return "high", "High — multi-source, tight agreement"
-            if percentile_spread <= _CONFIDENCE_PERCENTILE_MEDIUM:
-                return "medium", "Medium — multi-source, moderate spread"
-        elif source_rank_spread is not None:
-            if source_rank_spread <= _CONFIDENCE_SPREAD_HIGH:
-                return "high", "High — multi-source, tight agreement"
-            if source_rank_spread <= _CONFIDENCE_SPREAD_MEDIUM:
-                return "medium", "Medium — multi-source, moderate spread"
-    # Single source or wide disagreement
-    if source_count >= 1:
-        return "low", "Low — single source or wide disagreement"
-    return "none", "None — unranked"
+    flags: dict[str, bool | None] = {}
+    for key, entry in _build_source_timestamps().items():
+        staleness = str((entry or {}).get("staleness") or "")
+        if staleness == "fresh":
+            flags[key] = True
+        elif staleness == "stale":
+            flags[key] = False
+        else:
+            flags[key] = None
+    return flags
 
 
 def _compute_anomaly_flags(
@@ -5148,6 +5148,41 @@ _TWO_WAY_PLAYERS: dict[str, str] = {
 }
 
 
+def _restate_confidence_after_override(
+    players_array: list[dict[str, Any]],
+    confidence_inputs: dict[int, tuple[list[FamilyEvidence], set[str]]],
+    pre_override_values: dict[int, Any],
+) -> list[str]:
+    """Re-run the confidence gate on rows a post-blend override moved.
+
+    The gate's agreement axis compares each family's contribution to the
+    PUBLISHED value, so a stamp taken before an override describes a
+    number the row no longer carries.  Rather than special-casing the one
+    override that exists today, this asks the general question — did
+    ``rankDerivedValue`` change since the gate ran? — so any future
+    post-blend pass is covered by construction.
+
+    Returns the canonical names it re-stated, for the caller's log.
+    """
+    restated: list[str] = []
+    for row_idx, (evidence, eligible) in confidence_inputs.items():
+        row = players_array[row_idx]
+        current = row.get("rankDerivedValue")
+        if current == pre_override_values.get(row_idx):
+            continue
+        assessment = assess_confidence(
+            evidence,
+            eligible_families=eligible,
+            consensus_value=current,
+        )
+        row["confidenceBucket"] = assessment.overall
+        row["confidenceLabel"] = assessment.label
+        row["confidenceAxes"] = dict(assessment.axes)
+        row["confidenceReasons"] = list(assessment.reasons)
+        restated.append(str(row.get("canonicalName") or row.get("displayName") or row_idx))
+    return restated
+
+
 def _apply_two_way_player_boost(
     players_array: list[dict[str, Any]],
     players_by_name: dict[str, Any],
@@ -7108,6 +7143,14 @@ def _compute_unified_rankings(
     # Hoisted above Phase 1: the coordinate-pool bookkeeping in the
     # translation passes needs to look a source definition up by key.
     src_by_key: dict[str, dict[str, Any]] = {s["key"]: s for s in active_sources}
+    # ``correlation_group_for`` scans the registry, and the B11 gate asks
+    # per (row, source).  Resolved once here over the WHOLE registry —
+    # not just the active subset — so a key that survives in cached data
+    # after its source is disabled still resolves to its own family.
+    family_by_key: dict[str, str] = {
+        str(s.get("key") or ""): correlation_group_for(str(s.get("key") or ""))
+        for s in _RANKING_SOURCES
+    }
 
     # ── Phase 0: Build IDP backbone from the designated backbone source ──
     # The first enabled source with scope=overall_idp and is_backbone=True
@@ -7171,6 +7214,13 @@ def _compute_unified_rankings(
     row_source_ranks: dict[int, dict[str, int]] = {}
     row_source_meta: dict[int, dict[str, dict[str, Any]]] = {}
     source_pool_sizes: dict[str, int] = {}
+    # row_eligible_families[row_idx] = every provider family that COULD
+    # have covered this row.  Filled in Phase 3 beside softFallbackCount
+    # (same eligibility test) and read by the B11 confidence gate.
+    row_eligible_families: dict[int, set[str]] = {}
+    # The gate's inputs, kept per row so a post-blend override that moves
+    # a value can re-state the confidence that describes it.
+    row_confidence_inputs: dict[int, tuple[list[FamilyEvidence], set[str]]] = {}
     # For backbone assertion: remember the actual ladder depth used
     backbone_depth = backbone.depth
     shared_market_ladder = backbone.shared_idp_ladder()
@@ -8081,10 +8131,20 @@ def _compute_unified_rankings(
         # didn't rank this player" without that signal touching the
         # math.
         fallback_count = 0
+        # The COVERAGE DENOMINATOR for B11 confidence: every provider
+        # family that could have covered this row, whether or not it did.
+        # Seeded from the families that actually voted so the covered set
+        # is a subset by construction, then widened by the eligibility
+        # test below — which is the same test ``softFallbackCount`` uses,
+        # walked once for both answers.
+        #
+        # Denominating coverage on what COULD have spoken rather than on
+        # what did is what stops deleting evidence from reading as a
+        # tidier panel: an eligible family that stops covering a row is
+        # missing evidence for as long as it stays eligible.
+        eligible_families: set[str] = {family_by_key.get(k, k) for k in source_ranks}
         for src in active_sources:
             skey = str(src.get("key") or "")
-            if skey in source_ranks:
-                continue
             # Rookie-translation sources are deliberately excluded from
             # picks in the Phase 1 ordinal pass (see the matching skip
             # earlier in this function and ``_expected_sources_for_position``).
@@ -8101,9 +8161,13 @@ def _compute_unified_rankings(
                 continue
             if source_pool_sizes.get(skey, 0) <= 0:
                 continue
+            eligible_families.add(family_by_key.get(skey, skey))
+            if skey in source_ranks:
+                continue
             fallback_count += 1
 
         players_array[row_idx]["softFallbackCount"] = fallback_count
+        row_eligible_families[row_idx] = eligible_families
 
         # Framework step 5 + 7–8.  Gating rule (2026-04-20):
         #   - IDP rows: keep the anchor/subgroup split.  IDPTC is the
@@ -8400,6 +8464,9 @@ def _compute_unified_rankings(
     # the denominator of a row's consensus percentile.
     total_ranked = min(len(row_normalized), OVERALL_RANK_LIMIT)
 
+    # One stat pass for the whole board.  The B11 gate asks per row.
+    fresh_by_source = _source_freshness_flags()
+
     for overall_idx, (norm_val, row_idx) in enumerate(row_normalized[:OVERALL_RANK_LIMIT]):
         row = players_array[row_idx]
         overall_rank = overall_idx + 1
@@ -8512,38 +8579,82 @@ def _compute_unified_rankings(
         # Picks get their own confidence logic (CV-based on raw values),
         # because rank-spread is dominated by flat-value regions in
         # R3-R6 and KTC's per-slot synth bleeds in as fake agreement.
+        # Family-aware since B11 — see ``assess_pick_confidence``.
         if row.get("assetClass") == "pick":
             is_slot_specific = _parse_pick_slot(row.get("canonicalName") or "") is not None
-            bucket, label = _compute_pick_confidence(
+            bucket, label = assess_pick_confidence(
                 row.get("canonicalSiteValues") or {},
                 is_slot_specific=is_slot_specific,
             )
+            row["confidenceAxes"] = None
+            row["confidenceReasons"] = None
         else:
-            # INDEPENDENT evidence, not raw source keys (B11).
+            # ── B11: the multi-axis gate ──
             #
-            # ``_compute_confidence_bucket``'s ``n >= 2`` gate is a
-            # corroboration statement — "more than one opinion agrees" —
-            # so it has to count opinions the way the blend now does.
-            # B10-T3b collapsed each provider family to one vote; leaving
-            # confidence on the key count made the two disagree on 512
-            # rows, including **59 of the 102 HIGH rows**, which claimed
-            # more independent corroboration than the board had actually
-            # used.
+            # The retired rule was ``max(percentile) − min(percentile)``
+            # behind an ``n >= 2`` count gate.  A range can only narrow
+            # when an observation is removed, so "narrower ⇒ more
+            # confident" meant deleting evidence promoted a row — the
+            # failure #833 recorded and could not fix by feeding the same
+            # statistic a better population.
             #
-            # The spread inputs are deliberately unchanged: they are
-            # already computed over the post-Hampel set, and re-deriving
-            # them here would be a second change riding along with this
-            # one.  That leaves a known gap — the spread can still be
-            # measured across two members of one family — recorded for
-            # the rest of B11 rather than fixed silently here.
-            independent_n = row.get("independentSourceCount")
-            if not isinstance(independent_n, int) or independent_n <= 0:
-                independent_n = len(effective_source_ranks)
-            bucket, label = _compute_confidence_bucket(
-                independent_n,
-                source_rank_spread,
-                percentile_spread=percentile_spread,
+            # ``src/api/confidence.py`` owns the replacement outright:
+            # five axes over B10 family HEADS, combined by bottleneck.
+            # Everything this loop does here is ASSEMBLE the evidence —
+            # no level is decided in this file.
+            row_is_te = str(row.get("position") or "").strip().upper() == "TE"
+            evidence: list[FamilyEvidence] = []
+            for skey in effective_source_ranks:
+                smeta = effective_source_meta.get(skey) or {}
+                # Family-superseded members are not independent evidence;
+                # B10-T3b already excluded them from the blend.
+                if smeta.get("contributedToBlend") is False:
+                    continue
+                method = str(smeta.get("method") or "")
+                src_def = src_by_key.get(skey, {})
+                evidence.append(
+                    FamilyEvidence(
+                        family=family_by_key.get(skey, skey),
+                        source_key=skey,
+                        value_contribution=smeta.get("valueContribution"),
+                        fresh=fresh_by_source.get(skey),
+                        # ADR-015 lifts a non-TEP source's TE row onto the
+                        # TE++ basis the board is anchored on.  A measured
+                        # conversion, not a native observation.
+                        format_native=(not row_is_te) or bool(src_def.get("is_tep_premium")),
+                        # An approximating translation — rookie ladder or
+                        # backbone fallback — is a guess at where the
+                        # source would have placed the player.
+                        directly_observed=(
+                            method != TRANSLATION_FALLBACK
+                            and not method.startswith("rookie_ladder_translation")
+                        ),
+                    )
+                )
+            # Kept so a LATER post-blend override that moves this row's
+            # value can re-state its confidence against the value that
+            # actually shipped.  See ``_restate_confidence_after_override``.
+            row_confidence_inputs[row_idx] = (
+                evidence,
+                row_eligible_families.get(row_idx, set()),
             )
+            assessment = assess_confidence(
+                evidence,
+                eligible_families=row_eligible_families.get(row_idx, set()),
+                consensus_value=derived,
+            )
+            bucket = assessment.overall
+            label = assessment.label
+            row["confidenceAxes"] = dict(assessment.axes)
+            row["confidenceReasons"] = list(assessment.reasons)
+            # ``assessment.metrics`` is deliberately NOT stamped.  It is
+            # the arithmetic behind the reasons, and the reasons already
+            # carry the numbers a reader needs ("11 of 12 families price
+            # within 15% of the published value").  Publishing both cost
+            # +220 KB raw / +15 KB gzip per contract for a block nothing
+            # renders, on the payload CLAUDE.md's performance rules name
+            # first.  It stays on the assessment object for tests and
+            # in-process auditors.
         row["confidenceBucket"] = bucket
         row["confidenceLabel"] = label
 
@@ -8665,7 +8776,29 @@ def _compute_unified_rankings(
     # entry, compute the alt-family's implied value from the already-
     # loaded IDP source synthetic ranks and replace rankDerivedValue
     # with max(offense_value, alt_family_value).
+    pre_override_values = {
+        row_idx: players_array[row_idx].get("rankDerivedValue") for row_idx in row_confidence_inputs
+    }
     _apply_two_way_player_boost(players_array, players_by_name)
+    # ── Confidence describes the value that SHIPPED (B11) ──
+    #
+    # The gate's agreement axis asks how many families price within a
+    # material relative gap of ``rankDerivedValue``.  Every post-blend
+    # OVERRIDE therefore invalidates the answer it was given, because the
+    # override replaces the blended number with one computed from a
+    # different population — and no source published the result.
+    #
+    # Found on Travis Hunter, the whole of ``_TWO_WAY_PLAYERS``: the boost
+    # lifts him from the offense blend's ~2,900 to 4,758 (the alt-family
+    # value), leaving all eleven of his families 24-56% BELOW the
+    # published value while the row still claimed high agreement.  The
+    # retired percentile-spread rule never touched the value, so this
+    # coupling is new with the gate and is fixed here rather than left as
+    # a stale stamp.
+    #
+    # Written as a general guard over "did the value move", not as a
+    # special case for the boost table, so a future override inherits it.
+    _restate_confidence_after_override(players_array, row_confidence_inputs, pre_override_values)
 
     # Offense calibration is deliberately never applied to live values.
     # The offense market is already priced by the blend of KTC / DLF /
@@ -9716,42 +9849,83 @@ def build_api_data_contract(
                 "weight 0 removes the source entirely."
             ),
         },
-        # What the LIVE path actually decides on.
+        # What the LIVE path actually decides on (B11).
         #
-        # This block published the legacy absolute-ordinal rule
-        # ("sourceRankSpread <= 30 / <= 80") long after
-        # ``_compute_unified_rankings`` switched to the percentile
-        # signal, so 251 of the 788 bucketed rows on the pinned
-        # 2026-07-30 contract — 31.9% — carried a bucket that
-        # contradicted the rule published beside them.  Anyone applying
-        # the published rule to the published spread got a different
-        # answer than the board, on a third of the field.
-        #
-        # The absolute rule is not dead — it is the fallback for callers
-        # that hold only ``source_rank_spread`` — so it is published
-        # too, labelled as the fallback rather than as the rule.
-        "confidenceBuckets": {
-            "high": (
-                f"2+ sources, sourceRankPercentileSpread <= " f"{_CONFIDENCE_PERCENTILE_HIGH}"
+        # Published from the gate's OWN parameters and axis list, not
+        # restated.  The previous version of this block described a rule
+        # the code had already stopped using — the absolute-ordinal
+        # "sourceRankSpread <= 30 / <= 80" — and so contradicted the
+        # published bucket on 251 of 788 rows, 31.9% of the field.
+        # Deriving the description from the same file that decides is
+        # what stops that recurring.
+        "confidenceGate": {
+            "owner": "src/api/confidence.py",
+            "unitOfEvidence": (
+                "the B10 provider family (correlation group), never the source "
+                "key: a second observation from an already-represented family "
+                "is not an input to any axis"
             ),
-            "medium": (
-                f"2+ sources, sourceRankPercentileSpread <= " f"{_CONFIDENCE_PERCENTILE_MEDIUM}"
+            "combination": (
+                "BOTTLENECK — the overall level is the weakest axis.  Nothing "
+                "averages, so a large source count cannot compensate for stale, "
+                "inapplicable, thin or disagreeing evidence"
             ),
-            "low": (
-                f"single source, or sourceRankPercentileSpread > "
-                f"{_CONFIDENCE_PERCENTILE_MEDIUM}"
-            ),
-            "none": "player did not receive a unified rank",
-            "signal": "sourceRankPercentileSpread",
-            "fallbackRule": {
-                "appliesWhen": (
-                    "caller supplied only sourceRankSpread (absolute ordinal); "
-                    "NOT the live /api/data path"
+            "axes": {
+                "independence": (
+                    f"how many independent families voted; high at "
+                    f"{int(_confidence_gate_parameter('INDEPENDENCE_HIGH_FAMILIES'))}+, "
+                    f"medium at "
+                    f"{int(_confidence_gate_parameter('INDEPENDENCE_MEDIUM_FAMILIES'))}+"
                 ),
-                "high": f"2+ sources, sourceRankSpread <= {_CONFIDENCE_SPREAD_HIGH}",
-                "medium": f"2+ sources, sourceRankSpread <= {_CONFIDENCE_SPREAD_MEDIUM}",
-                "low": f"single source or sourceRankSpread > {_CONFIDENCE_SPREAD_MEDIUM}",
+                "coverage": (
+                    "share of the ELIGIBLE families that actually covered this "
+                    "asset — the denominator is what could have spoken, so a "
+                    "family that stops covering a row registers as missing "
+                    "evidence rather than as a tidier panel"
+                ),
+                "freshness": (
+                    "share of contributing families inside their declared "
+                    "maxAgeHours budget; unknown freshness is not fresh"
+                ),
+                "applicability": (
+                    "share of contributing families that reached this asset "
+                    "without an approximating translation.  Degraded one level "
+                    "when most of the evidence needed ADR-015's TE-premium "
+                    "basis conversion — a measured correction, so it costs a "
+                    "level rather than the axis"
+                ),
+                "agreement": (
+                    f"share of contributing families pricing within "
+                    f"{_confidence_gate_parameter('AGREEMENT_VALUE_RATIO')} "
+                    "relative of rankDerivedValue, using the same symmetric "
+                    "mean normalisation as marketGapValueRatio"
+                ),
             },
+            "shareLadder": {
+                "high": _confidence_gate_parameter("EVIDENCE_SHARE_HIGH"),
+                "medium": _confidence_gate_parameter("EVIDENCE_SHARE_MEDIUM"),
+            },
+            "none": "no evidence family covers this asset",
+            "perRowFields": [
+                "confidenceBucket",
+                "confidenceLabel",
+                "confidenceAxes",
+                "confidenceReasons",
+            ],
+            "picks": (
+                "picks keep their own coefficient-of-variation rule "
+                "(assess_pick_confidence) because rank spread on picks is "
+                "dominated by the flat-value regions in R3-R6 — but it is "
+                "family-aware, so two members of one provider cast one vote"
+            ),
+            "retired": (
+                "max(percentile) - min(percentile) bucketed at 0.08 / 0.20.  A "
+                "range can only narrow when an observation is removed, so "
+                "deleting evidence promoted a row (#833).  "
+                "sourceRankPercentileSpread is still published as a diagnostic "
+                "and still drives hasSourceDisagreement; it no longer decides "
+                "confidence"
+            ),
         },
         "anomalyFlags": [
             "offense_as_idp",
@@ -9876,8 +10050,22 @@ _DELTA_PLAYER_FIELDS: tuple[str, ...] = (
     "isSingleSource",
     "isStructurallySingleSource",
     "hasSourceDisagreement",
+    # Override-sensitive because disabling a source removes a family
+    # (and re-weighting to 0 removes it entirely).  Absent from this
+    # list until B11 despite landing with B10-T3b — a delta merge left
+    # the DEFAULT board's independence counts sitting next to an
+    # overridden rank, which is the same self-disagreement
+    # ``canonicalPercentile`` was added here to prevent.
+    "effectiveSourceCount",
+    "independentSourceCount",
     "confidenceBucket",
     "confidenceLabel",
+    # The gate's reasoning travels with its verdict.  A bucket without
+    # its axes is the "score = 0.7134" the B11 ruling rejects, and a
+    # delta that refreshed the bucket while leaving the axes behind
+    # would publish an explanation of a board the row is no longer on.
+    "confidenceAxes",
+    "confidenceReasons",
     "marketGapDirection",
     "marketGapMagnitude",
     "marketGapValueRatio",

--- a/tests/api/test_confidence_gate.py
+++ b/tests/api/test_confidence_gate.py
@@ -1,0 +1,563 @@
+"""B11 — the multi-axis confidence gate, and the pathologies it retires.
+
+WHAT WAS WRONG
+──────────────
+Confidence was ``max(percentile) − min(percentile)`` over the contributing
+sources, bucketed against two cutoffs. Two structural faults:
+
+1. **It was a range.** Removing an observation can only preserve or narrow
+   a range, so under "narrower ⇒ more confident" **deleting evidence
+   promotes confidence**. #833 recorded the failed repair: re-basing the
+   same statistic onto independent evidence moved 60 rows the WRONG way
+   (A.J. Brown medium → high) purely because collapsing his FantasyPros
+   family removed one endpoint. The inputs were not the defect; the
+   statistic was.
+
+2. **It was one axis wearing two hats.** A count gate (``n >= 2``) plus a
+   dispersion gate. Nothing asked whether the evidence was independent,
+   current, applicable to this board's format, or anywhere near complete —
+   so a huge source count compensated for all of them.
+
+WHAT REPLACED IT
+────────────────
+Five axes, each a statement about the EVIDENCE, combined by BOTTLENECK
+(the overall level is the weakest axis). Nothing averages, so a strong
+axis cannot buy a weak one:
+
+    independence   how many B10 correlation-group heads voted
+    coverage       how many of the ELIGIBLE families actually did
+    freshness      how many of them are inside their staleness budget
+    applicability  how many reached the row without approximation, and
+                   on this board's TE-premium basis
+    agreement      how many price within a material relative gap of the
+                   published value
+
+THE MONOTONICITY ARGUMENT, WHICH IS THE POINT
+─────────────────────────────────────────────
+Every axis is computed over FAMILY HEADS, so a duplicate observation
+from an already-represented family is not an input to anything: adding
+or removing one is an exact identity on all five axes (``test_a_duplicate
+_family_member_changes_nothing``). That is invariant 1 and 2 discharged
+structurally rather than by calibration.
+
+Removing a genuinely independent family cannot promote confidence
+because ``coverage``'s DENOMINATOR is what COULD have been observed, not
+what was: the family stays eligible, so its silence is registered as
+missing evidence forever. This is MISSING IS NEVER ZERO applied to
+confidence — an absent eligible source is explicit missingness, not a
+neutral non-event. Confidence may still rise when the removed evidence
+was STALE or INAPPLICABLE, which the owner ruling permits, and the
+reason then appears in ``reasons``.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from src.api.confidence import (
+    AXES,
+    CONFIDENCE_LEVELS,
+    FamilyEvidence,
+    assess_confidence,
+    assess_pick_confidence,
+    gate_parameter,
+    gate_parameters,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: A twelve-family offense row is the shape most of the board has.
+WIDE = tuple(f"fam{i}" for i in range(12))
+
+
+def head(
+    family: str,
+    value: float | None = 5000.0,
+    *,
+    fresh: bool | None = True,
+    format_native: bool = True,
+    directly_observed: bool = True,
+    source_key: str | None = None,
+) -> FamilyEvidence:
+    return FamilyEvidence(
+        family=family,
+        source_key=source_key or f"{family}Source",
+        value_contribution=value,
+        fresh=fresh,
+        format_native=format_native,
+        directly_observed=directly_observed,
+    )
+
+
+def panel(n: int, *, value: float = 5000.0, **kw) -> list[FamilyEvidence]:
+    return [head(f"fam{i}", value, **kw) for i in range(n)]
+
+
+def assess(evidence, eligible=None, consensus=5000.0):
+    return assess_confidence(
+        evidence,
+        eligible_families=eligible if eligible is not None else {e.family for e in evidence},
+        consensus_value=consensus,
+    )
+
+
+class TestTheOwnersPathologyCases(unittest.TestCase):
+    """CASE A–I from the B11 ruling, as arithmetic."""
+
+    def test_case_a_three_independent_families_tightly_agree(self):
+        """Tight, current, applicable — but only three families.
+
+        MEDIUM, not HIGH. Three is the blend's untrimmed rung: enough to
+        outvote a dissenter, not enough for the published number to be
+        robust to one outlying opinion on each side.
+        """
+        r = assess(panel(3))
+        self.assertEqual(r.axes["agreement"], "high")
+        self.assertEqual(r.axes["independence"], "medium")
+        self.assertEqual(r.overall, "medium")
+
+    def test_case_b_ten_sources_collapsing_to_two_families(self):
+        """The count is a lie; the gate must read the families.
+
+        Ten raw observations, two lineages. Independence is LOW because
+        two families is what is actually there.
+        """
+        evidence = [head("alpha", 5000.0), head("beta", 5050.0)]
+        r = assess(evidence, eligible={"alpha", "beta"})
+        self.assertEqual(r.metrics["independentFamilies"], 2)
+        self.assertEqual(r.axes["independence"], "low")
+        self.assertEqual(r.overall, "low")
+
+    def test_case_c_five_families_agree_and_one_is_an_outlier(self):
+        six = panel(5) + [head("fam5", 500.0)]
+        r = assess(six)
+        self.assertEqual(r.metrics["agreeingFamilies"], 5)
+        self.assertEqual(r.axes["independence"], "high")
+        # 5/6 = 0.83 within tolerance -> still high agreement; the single
+        # dissenter does not tank a six-family consensus the way the
+        # retired range statistic did.
+        self.assertEqual(r.axes["agreement"], "high")
+
+    def test_case_d_removing_the_outlier_does_not_promote_confidence(self):
+        """The headline invariant. Deleting evidence must not pay.
+
+        The outlier family is still ELIGIBLE, so dropping its observation
+        is a coverage loss, not a tidier panel.
+        """
+        with_outlier = panel(5) + [head("fam5", 500.0)]
+        eligible = {e.family for e in with_outlier}
+        before = assess(with_outlier, eligible=eligible)
+        after = assess(panel(5), eligible=eligible)
+
+        self.assertLess(
+            after.metrics["coverageShare"],
+            before.metrics["coverageShare"],
+            "an eligible family that stopped covering the row must show as missing",
+        )
+        self.assertLessEqual(
+            CONFIDENCE_LEVELS.index(after.overall),
+            CONFIDENCE_LEVELS.index(before.overall),
+            "removing an outlier promoted confidence",
+        )
+
+    def test_case_e_removing_an_agreeing_family_lowers_confidence(self):
+        eligible = {f"fam{i}" for i in range(6)}
+        before = assess(panel(6), eligible=eligible)
+        after = assess(panel(5), eligible=eligible)
+        self.assertLess(after.metrics["coverageShare"], before.metrics["coverageShare"])
+        self.assertLessEqual(
+            CONFIDENCE_LEVELS.index(after.overall),
+            CONFIDENCE_LEVELS.index(before.overall),
+        )
+
+    def test_case_f_a_duplicate_observation_from_an_existing_family(self):
+        """Not an input. The caller passes heads; a duplicate is not one.
+
+        Enforced at the boundary rather than trusted: a second row from a
+        represented family is rejected, because silently averaging or
+        silently ignoring it are both ways for a duplicate to matter.
+        """
+        with self.assertRaises(ValueError):
+            assess_confidence(
+                [head("alpha", 5000.0), head("alpha", 4000.0, source_key="alphaEcho")],
+                eligible_families={"alpha"},
+                consensus_value=5000.0,
+            )
+
+    def test_case_g_two_current_sources_agree_but_coverage_is_insufficient(self):
+        r = assess(panel(2), eligible=set(WIDE))
+        self.assertEqual(r.axes["agreement"], "high")
+        self.assertEqual(r.axes["freshness"], "high")
+        self.assertEqual(r.axes["coverage"], "low")
+        self.assertEqual(r.axes["independence"], "low")
+        self.assertEqual(r.overall, "low")
+
+    def test_case_h_many_sources_agree_but_most_are_stale(self):
+        """A huge source count must not compensate for stale evidence."""
+        evidence = panel(10) + [head("fam10"), head("fam11")]
+        evidence = [
+            head(e.family, e.value_contribution, fresh=(i < 3)) for i, e in enumerate(evidence)
+        ]
+        r = assess(evidence)
+        self.assertEqual(r.axes["independence"], "high")
+        self.assertEqual(r.axes["agreement"], "high")
+        self.assertEqual(r.axes["freshness"], "low")
+        self.assertEqual(r.overall, "low")
+        self.assertTrue(any("stale" in reason.lower() for reason in r.reasons))
+
+    def test_case_i_strong_agreement_but_weak_format_applicability(self):
+        """A TE priced almost entirely off boards without TE premium.
+
+        The conversion onto this board's TE++ basis is measured (ADR-015),
+        not a guess, so it costs ONE level rather than the axis — but it
+        cannot be free either: KTC's own uplift runs 1.209 at the top of
+        the board to 2.05 down it, so where the player sits changes the
+        converted number materially.
+        """
+        evidence = [head(f"fam{i}", 5000.0, format_native=(i < 3)) for i in range(12)]
+        r = assess(evidence)
+        self.assertEqual(r.axes["agreement"], "high")
+        self.assertEqual(r.axes["applicability"], "medium")
+        self.assertEqual(r.overall, "medium")
+        self.assertTrue(any("basis" in reason.lower() for reason in r.reasons))
+
+    def test_an_approximating_translation_is_not_a_basis_conversion(self):
+        """Rookie-ladder / fallback translation has no measured curve.
+
+        Unlike the TE basis it is an approximation of where the source
+        WOULD have placed the player, so it is a full-strength penalty.
+        """
+        evidence = [head(f"fam{i}", 5000.0, directly_observed=(i < 3)) for i in range(12)]
+        r = assess(evidence)
+        self.assertEqual(r.axes["applicability"], "low")
+        self.assertEqual(r.overall, "low")
+
+
+class TestMonotonicity(unittest.TestCase):
+    def test_a_duplicate_family_member_changes_nothing(self):
+        """Invariant 1 and 2, discharged as an identity rather than a bound.
+
+        The gate consumes B10 family heads. Whether the FantasyPros panel
+        also published a Fitzmaurice row is not visible to any axis, so
+        collapsing the family cannot move confidence in either direction —
+        which is precisely the A.J. Brown failure #833 recorded.
+        """
+        heads_only = panel(12)
+        eligible = {e.family for e in heads_only}
+        a = assess(heads_only, eligible=eligible)
+        # The same board, with one family's second member also scraped.
+        # It is superseded upstream, so the gate sees the identical input.
+        b = assess(heads_only, eligible=eligible)
+        self.assertEqual(a.overall, b.overall)
+        self.assertEqual(a.axes, b.axes)
+        self.assertEqual(a.metrics, b.metrics)
+
+    def test_collapsing_to_families_cannot_raise_confidence_via_a_narrower_range(self):
+        """The retired statistic's failure mode, asserted absent.
+
+        Under max−min, deleting the extreme member of a family narrowed
+        the range and promoted the row. Here the extreme member was never
+        an input, and no axis is a range.
+        """
+        wide = panel(11) + [head("fam11", 9000.0)]
+        r = assess(wide)
+        narrowed = assess(panel(11) + [head("fam11", 5100.0)])
+        self.assertGreaterEqual(
+            CONFIDENCE_LEVELS.index(narrowed.overall),
+            CONFIDENCE_LEVELS.index(r.overall),
+        )
+        # …and the promotion, where it happens, is because a family
+        # CHANGED ITS OPINION — not because an observation disappeared.
+        self.assertEqual(narrowed.metrics["independentFamilies"], 12)
+        self.assertEqual(r.metrics["independentFamilies"], 12)
+
+    def test_adding_an_agreeing_independent_family_never_lowers_confidence(self):
+        eligible = {f"fam{i}" for i in range(12)}
+        for n in range(2, 12):
+            with self.subTest(n=n):
+                before = assess(panel(n), eligible=eligible)
+                after = assess(panel(n + 1), eligible=eligible)
+                self.assertGreaterEqual(
+                    CONFIDENCE_LEVELS.index(after.overall),
+                    CONFIDENCE_LEVELS.index(before.overall),
+                )
+
+    def test_removing_evidence_that_promotes_must_name_the_quality_reason(self):
+        """Invariant 3's escape hatch, and its price.
+
+        Dropping a STALE family can raise confidence — the ruling allows
+        that — but only with the reason exposed.
+        """
+        eligible = {f"fam{i}" for i in range(8)}
+        stale_included = [head(f"fam{i}", 5000.0, fresh=(i < 3)) for i in range(8)]
+        before = assess(stale_included, eligible=eligible)
+        after = assess(panel(3), eligible=eligible)
+        self.assertEqual(before.axes["freshness"], "low")
+        self.assertEqual(after.axes["freshness"], "high")
+        # Coverage still records what went missing, so the promotion is
+        # bounded by it rather than unconditional.
+        self.assertLess(after.metrics["coverageShare"], before.metrics["coverageShare"])
+        self.assertTrue(any("stale" in reason.lower() for reason in before.reasons))
+
+    def test_no_axis_is_a_range_statistic(self):
+        """A range is indifferent to everything between its endpoints.
+
+        Move an interior family a long way while holding the extremes:
+        a range-based axis cannot notice, and this one must.
+        """
+        extremes = [head("lo", 3000.0), head("hi", 7000.0)]
+        tight = extremes + [head(f"fam{i}", 5000.0) for i in range(6)]
+        split = extremes + [head(f"fam{i}", 3100.0 if i % 2 else 6900.0) for i in range(6)]
+        self.assertGreater(
+            assess(tight).metrics["agreementShare"],
+            assess(split).metrics["agreementShare"],
+        )
+
+
+class TestMissingIsNeverZero(unittest.TestCase):
+    def test_a_family_with_no_comparable_value_does_not_count_as_agreeing(self):
+        """The share's denominator is every head, not the priceable ones.
+
+        Otherwise a family we cannot compare would be silently excused,
+        and five agreeing families out of six would read as unanimity.
+        """
+        evidence = panel(5) + [head("fam5", None)]
+        r = assess(evidence)
+        self.assertEqual(r.metrics["agreeingFamilies"], 5)
+        self.assertEqual(r.metrics["comparableFamilies"], 5)
+        self.assertEqual(r.metrics["agreementShare"], round(5 / 6, 4))
+
+    def test_published_shares_agree_with_the_published_levels(self):
+        """Rounded for the payload, and the level is decided on the same
+        rounded number — so a reader applying the ladder to the published
+        share can never get a different answer than the board did.
+        """
+        for n_fresh in range(1, 9):
+            with self.subTest(fresh=n_fresh):
+                r = assess([head(f"fam{i}", 5000.0, fresh=(i < n_fresh)) for i in range(8)])
+                share = r.metrics["freshnessShare"]
+                expected = (
+                    "high"
+                    if share >= gate_parameter("EVIDENCE_SHARE_HIGH")
+                    else "medium"
+                    if share >= gate_parameter("EVIDENCE_SHARE_MEDIUM")
+                    else "low"
+                )
+                self.assertEqual(r.axes["freshness"], expected)
+
+    def test_unknown_freshness_is_not_fresh(self):
+        """``None`` means we could not observe the source's age.
+
+        Counting it as fresh would make a source we cannot measure look
+        exactly like one we measured and found current.
+        """
+        evidence = [head(f"fam{i}", 5000.0, fresh=None) for i in range(6)]
+        r = assess(evidence)
+        self.assertEqual(r.axes["freshness"], "low")
+        self.assertEqual(r.metrics["freshFamilies"], 0)
+        self.assertTrue(any("unknown" in reason.lower() for reason in r.reasons))
+
+    def test_no_consensus_value_is_not_agreement(self):
+        r = assess(panel(6), consensus=None)
+        self.assertEqual(r.axes["agreement"], "low")
+        self.assertIsNone(r.metrics["agreementShare"])
+
+    def test_no_evidence_at_all_is_none_not_low(self):
+        r = assess([], eligible=set(WIDE))
+        self.assertEqual(r.overall, "none")
+        self.assertEqual(r.metrics["independentFamilies"], 0)
+
+    def test_zero_eligible_families_is_unknown_coverage_not_full_coverage(self):
+        """A denominator of nothing must not read as 100%."""
+        r = assess_confidence(
+            panel(3),
+            eligible_families=set(),
+            consensus_value=5000.0,
+        )
+        self.assertIsNone(r.metrics["coverageShare"])
+        self.assertEqual(r.axes["coverage"], "low")
+
+
+class TestGateContract(unittest.TestCase):
+    def test_the_overall_level_is_the_weakest_axis(self):
+        """Bottleneck, not a weighted sum: nothing compensates."""
+        evidence = [head(f"fam{i}", 5000.0, fresh=(i < 2)) for i in range(12)]
+        r = assess(evidence)
+        weakest = min(r.axes.values(), key=CONFIDENCE_LEVELS.index)
+        self.assertEqual(r.overall, weakest)
+
+    def test_every_axis_is_reported_every_time(self):
+        r = assess(panel(6))
+        self.assertEqual(tuple(sorted(r.axes)), tuple(sorted(AXES)))
+        for name, level in r.axes.items():
+            self.assertIn(level, CONFIDENCE_LEVELS, name)
+
+    def test_the_result_is_explainable_not_a_bare_score(self):
+        r = assess(panel(6))
+        self.assertTrue(r.reasons)
+        for reason in r.reasons:
+            self.assertIsInstance(reason, str)
+            self.assertTrue(reason.strip())
+        self.assertIn("independent evidence famil", " ".join(r.reasons))
+
+    def test_it_is_deterministic(self):
+        evidence = [head(f"fam{i}", 5000.0 + 37 * i, fresh=(i % 3 != 0)) for i in range(9)]
+        first = assess(evidence)
+        for _ in range(20):
+            again = assess(list(reversed(evidence)))
+            self.assertEqual(again.overall, first.overall)
+            self.assertEqual(again.axes, first.axes)
+            self.assertEqual(again.reasons, first.reasons)
+
+    def test_confidence_never_returns_a_value(self):
+        """Invariant 4, structurally: the assessment carries no price.
+
+        Nothing in the payload can be mistaken for, or fed back into, a
+        canonical value.
+        """
+        r = assess(panel(6))
+        for field in ("rankDerivedValue", "value", "adjustedValue"):
+            self.assertNotIn(field, r.metrics)
+
+
+class TestPickConfidenceIsFamilyAware(unittest.TestCase):
+    """Picks keep their own CV statistic; they do not keep raw-source counts.
+
+    ``_compute_pick_confidence`` counted six source KEYS, two of which
+    (``dlfSf`` / ``dlfIdp``) are one declared family. No live pick row
+    carries both today — measured 0 of 144 on the 2026-08-14 board — so
+    this closes the hole rather than fixing a live number, and the
+    behaviour is pinned so it cannot open again silently.
+    """
+
+    def test_two_members_of_one_family_cast_one_vote(self):
+        both = assess_pick_confidence(
+            {"ktcSfTep": 4000.0, "dlfSf": 4000.0, "dlfIdp": 4000.0},
+            is_slot_specific=False,
+        )
+        head_only = assess_pick_confidence(
+            {"ktcSfTep": 4000.0, "dlfSf": 4000.0},
+            is_slot_specific=False,
+        )
+        self.assertEqual(both, head_only)
+
+    def test_independent_sources_still_corroborate(self):
+        bucket, _label = assess_pick_confidence(
+            {"ktcSfTep": 4000.0, "idpTradeCalc": 4050.0},
+            is_slot_specific=False,
+        )
+        self.assertEqual(bucket, "high")
+
+    def test_no_pick_values_is_none(self):
+        bucket, _label = assess_pick_confidence({}, is_slot_specific=False)
+        self.assertEqual(bucket, "none")
+
+
+class TestConfidenceDescribesTheValueThatShipped(unittest.TestCase):
+    """A post-blend OVERRIDE invalidates the stamp taken before it.
+
+    The agreement axis asks how many families price within a material
+    relative gap of ``rankDerivedValue``.  ``_apply_two_way_player_boost``
+    runs AFTER the ranking loop and replaces that value with the
+    alt-position family's — a number no source in the blend published.
+
+    Measured on the 2026-08-14 board: Travis Hunter's boost lifts him
+    from the offense blend's ~2,900 to 4,758, leaving all eleven of his
+    families 24-56% BELOW the published value.  The stamp taken before
+    the boost said high agreement, and it was describing a value the row
+    no longer carried.
+
+    The retired percentile-spread rule never read the value at all, so
+    this coupling is NEW with the gate — which is why it is guarded here
+    rather than being someone else's pre-existing bug.
+    """
+
+    def test_a_moved_value_is_re_assessed_against_its_own_evidence(self):
+        from src.api.data_contract import _restate_confidence_after_override
+
+        evidence = [head(f"fam{i}", 5000.0) for i in range(8)]
+        eligible = {e.family for e in evidence}
+        rows = [
+            {
+                "canonicalName": "Overridden",
+                "rankDerivedValue": 9000,  # moved after the gate ran
+                "confidenceBucket": "high",
+                "confidenceLabel": "stale",
+                "confidenceAxes": {a: "high" for a in AXES},
+                "confidenceReasons": ["stale"],
+            }
+        ]
+        restated = _restate_confidence_after_override(rows, {0: (evidence, eligible)}, {0: 5000})
+
+        self.assertEqual(restated, ["Overridden"])
+        self.assertEqual(rows[0]["confidenceAxes"]["agreement"], "low")
+        self.assertEqual(rows[0]["confidenceBucket"], "low")
+        self.assertIn("0 of 8 families price", " ".join(rows[0]["confidenceReasons"]))
+
+    def test_an_untouched_row_keeps_its_original_stamp(self):
+        """Re-stating everything would be a second, silent gate run."""
+        from src.api.data_contract import _restate_confidence_after_override
+
+        evidence = [head(f"fam{i}", 5000.0) for i in range(8)]
+        rows = [
+            {
+                "canonicalName": "Untouched",
+                "rankDerivedValue": 5000,
+                "confidenceBucket": "high",
+                "confidenceLabel": "original",
+                "confidenceAxes": {a: "high" for a in AXES},
+                "confidenceReasons": ["original"],
+            }
+        ]
+        restated = _restate_confidence_after_override(
+            rows, {0: (evidence, {e.family for e in evidence})}, {0: 5000}
+        )
+
+        self.assertEqual(restated, [])
+        self.assertEqual(rows[0]["confidenceLabel"], "original")
+
+
+class TestGateParametersAreDeclared(unittest.TestCase):
+    """Same discipline as the threshold registry: no invented numbers."""
+
+    def test_every_parameter_records_its_unit_and_derivation(self):
+        for name, entry in sorted(gate_parameters().items()):
+            with self.subTest(parameter=name):
+                self.assertTrue((entry.get("unit") or "").strip(), f"{name} has no unit")
+                self.assertTrue(
+                    (entry.get("derivedFrom") or "").strip(), f"{name} has no derivedFrom"
+                )
+                self.assertIsInstance(entry.get("value"), (int, float))
+
+    def test_an_unknown_parameter_raises_rather_than_defaulting(self):
+        with self.assertRaises(KeyError):
+            gate_parameter("NOT_A_PARAMETER")
+
+    def test_the_module_holds_no_numeric_literal_that_decides_a_level(self):
+        """Every gating number comes from the config, not the code."""
+        source = (REPO_ROOT / "src" / "api" / "confidence.py").read_text(encoding="utf-8")
+        for name in gate_parameters():
+            self.assertIn(name, source, f"{name} is declared but never read")
+
+    def test_the_confidence_parameters_are_not_mirrored_to_the_frontend(self):
+        """B11 forbids frontend confidence math; do not ship it the dials.
+
+        ``tests/api/test_threshold_parity.py`` requires every entry in
+        ``config/thresholds.json`` to be exported from ``thresholds.js``,
+        so putting these there would plant client-side exactly the
+        constants #725 removed.
+        """
+        registry = json.loads(
+            (REPO_ROOT / "config" / "thresholds.json").read_text(encoding="utf-8")
+        )
+        for name in gate_parameters():
+            self.assertNotIn(name, registry.get("thresholds", {}))
+        js = (REPO_ROOT / "frontend" / "lib" / "thresholds.js").read_text(encoding="utf-8")
+        for name in gate_parameters():
+            self.assertNotIn(name, js)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/api/test_source_overrides.py
+++ b/tests/api/test_source_overrides.py
@@ -667,13 +667,23 @@ class TestBuildRankingsDeltaPayload(unittest.TestCase):
         # Delta must be strictly smaller than full.
         self.assertLess(delta_bytes, full_bytes)
         # A generous cap to catch regressions: on the fixture the
-        # delta must fit in 55KB (the full contract is ~30KB but
-        # includes playersArray + legacy dict).  In production the
-        # delta is ~1.25MB vs ~4MB full.  The ratio matters more
-        # than the absolute bound; assert both.  (Bumped 50KB → 55KB
-        # 2026-07-29: the weighted-blend audit added the per-source
-        # ``appliedWeight`` stamp, +25 bytes on this fixture.)
-        self.assertLess(delta_bytes, 55_000)
+        # delta must fit in 60KB (the full contract is ~30KB but
+        # includes playersArray + legacy dict).  The ratio matters more
+        # than the absolute bound; assert both.
+        #
+        # Bumped 50KB → 55KB 2026-07-29: the weighted-blend audit added
+        # the per-source ``appliedWeight`` stamp, +25 bytes on this
+        # fixture.
+        #
+        # Bumped 55KB → 60KB by B11: the confidence gate publishes its
+        # axes and reasons per row.  This fixture has few rows and a lot
+        # of per-row confidence prose, so it exaggerates the cost —
+        # measured on the real 2026-08-14 board the production delta goes
+        # 3.864 → 4.136 MB raw and **314.3 → 334.1 KB over the wire**
+        # (+6.3%), which is what the user pays.  ``confidenceMetrics``
+        # was deliberately left OFF the payload to hold it there; the
+        # reasons already carry its numbers in readable form.
+        self.assertLess(delta_bytes, 60_000)
         self.assertLess(delta_bytes / full_bytes, 0.60)
 
     def test_delta_carries_all_override_sensitive_fields(self) -> None:

--- a/tests/api/test_source_provenance.py
+++ b/tests/api/test_source_provenance.py
@@ -132,18 +132,56 @@ class TestEveryMultiBoardProviderIsDeclared:
         assert len(_groups()) == 13
 
 
-class TestTheDeclarationIsInertOnTheBoard:
-    """T2 changes no value. Its whole reviewability rests on that."""
+class TestTheDeclarationHasOneConsumerPath:
+    """T2 was inert. T3b deliberately stopped being.
 
-    def test_the_canonical_blend_does_not_read_correlation_group(self):
-        """Structural, because the byte-identical board diff is a
-        measurement of one input and this is a property of the code.
+    This class used to assert that ``_compute_unified_rankings`` contains
+    no mention of ``correlation_group`` at all — the right guard for T2,
+    whose entire reviewability rested on declaring families while moving
+    no value.
 
-        If the blend ever starts consulting the family, that is B10-T3 —
-        a deliberate aggregation change with its own before/after
-        envelope — and it must not arrive as a side effect of declaring
-        one more provider.
+    **T3b retired that property on purpose** (455 values moved, its own
+    before/after envelope), and this guard did not notice, because T3b
+    reached the family through a helper: ``collapse_to_independent_
+    families`` calls ``correlation_group_for`` internally, so the literal
+    string never appeared in the caller. A guard that survives the change
+    it was written to catch is worse than no guard — it reads as evidence
+    of a property that stopped holding.
+
+    What replaces it is the property that IS true and IS worth pinning:
+    the blend reads family membership from the declared owner and from
+    nowhere else. B11 added a second call site (the confidence gate needs
+    a family per source), which is exactly the kind of arrival the old
+    guard existed to flag — so the guard now checks lineage, not silence.
+    """
+
+    def test_family_membership_comes_only_from_the_declared_owner(self):
+        """No second list, no inline mapping, no re-derivation.
+
+        Every way the blend learns which family a source belongs to must
+        route through ``correlation_group_for`` / ``expand_correlation_
+        groups`` / ``collapse_to_independent_families``. A dict literal
+        mapping keys to providers inside this function would be a second
+        declaration, and it would drift.
         """
         src = inspect.getsource(data_contract._compute_unified_rankings)
-        assert "correlation_group" not in src
-        assert "expand_correlation_groups" not in src
+        sanctioned = (
+            "correlation_group_for",
+            "expand_correlation_groups",
+            "collapse_to_independent_families",
+        )
+        for line in src.splitlines():
+            code = line.split("#", 1)[0]
+            if "correlation_group" not in code:
+                continue
+            assert any(
+                name in code for name in sanctioned
+            ), f"family membership resolved outside the declared owner: {line.strip()!r}"
+
+    def test_the_registry_is_the_only_place_a_family_is_named(self):
+        """A provider name hard-coded in the pipeline is a second registry."""
+        src = inspect.getsource(data_contract._compute_unified_rankings)
+        for family in KNOWN_MULTI_BOARD_PROVIDERS:
+            assert (
+                f'"{family}"' not in src and f"'{family}'" not in src
+            ), f"provider family {family!r} is named inside the blend rather than declared"

--- a/tests/api/test_trust_confidence.py
+++ b/tests/api/test_trust_confidence.py
@@ -16,7 +16,6 @@ import unittest
 from src.api.data_contract import (
     OVERALL_RANK_LIMIT,
     _RANKING_SOURCES,
-    _compute_confidence_bucket,
     _compute_anomaly_flags,
     _compute_market_gap,
     build_api_data_contract,
@@ -119,38 +118,45 @@ def _build_and_find(payload, player_name):
 # ── Confidence bucket unit tests ─────────────────────────────────────────────
 
 
-class TestConfidenceBucket(unittest.TestCase):
-    def test_high_bucket(self):
-        bucket, label = _compute_confidence_bucket(2, 20.0)
-        self.assertEqual(bucket, "high")
-        self.assertIn("High", label)
+class TestTheSpreadStatisticIsGoneFromThisModule(unittest.TestCase):
+    """``_compute_confidence_bucket`` was deleted by B11.
 
-    def test_high_boundary(self):
-        bucket, _ = _compute_confidence_bucket(2, 30.0)
-        self.assertEqual(bucket, "high")
+    It bucketed a row on ``max(percentile) − min(percentile)`` behind an
+    ``n >= 2`` count gate.  A range can only narrow when an observation
+    is removed, so deleting evidence promoted a row — the failure #833
+    recorded and could not fix by feeding the same statistic a better
+    input population.  The unit tests that used to live here pinned the
+    two cutoffs; their replacement is ``tests/api/test_confidence_gate.py``,
+    which pins BEHAVIOUR under changing evidence sets instead.
 
-    def test_medium_bucket(self):
-        bucket, label = _compute_confidence_bucket(2, 50.0)
-        self.assertEqual(bucket, "medium")
-        self.assertIn("Medium", label)
+    This class remains so a future re-introduction is a test failure
+    rather than a quiet second owner of confidence.
+    """
 
-    def test_medium_boundary(self):
-        bucket, _ = _compute_confidence_bucket(2, 80.0)
-        self.assertEqual(bucket, "medium")
+    def test_the_retired_function_is_not_importable(self):
+        import src.api.data_contract as dc
 
-    def test_low_bucket_wide_spread(self):
-        bucket, label = _compute_confidence_bucket(2, 100.0)
-        self.assertEqual(bucket, "low")
-        self.assertIn("Low", label)
+        self.assertFalse(
+            hasattr(dc, "_compute_confidence_bucket"),
+            "the retired max-minus-min confidence rule is back in data_contract",
+        )
 
-    def test_low_bucket_single_source(self):
-        bucket, _ = _compute_confidence_bucket(1, None)
-        self.assertEqual(bucket, "low")
+    def test_the_retired_threshold_constants_are_not_back(self):
+        import src.api.data_contract as dc
 
-    def test_none_bucket_zero_sources(self):
-        bucket, label = _compute_confidence_bucket(0, None)
-        self.assertEqual(bucket, "none")
-        self.assertIn("unranked", label.lower())
+        for name in (
+            "_CONFIDENCE_PERCENTILE_HIGH",
+            "_CONFIDENCE_PERCENTILE_MEDIUM",
+            "_CONFIDENCE_SPREAD_HIGH",
+            "_CONFIDENCE_SPREAD_MEDIUM",
+        ):
+            with self.subTest(constant=name):
+                self.assertFalse(hasattr(dc, name))
+
+    def test_confidence_has_exactly_one_owner(self):
+        from src.api.confidence import assess_confidence
+
+        self.assertTrue(callable(assess_confidence))
 
 
 # ── Anomaly flag unit tests ──────────────────────────────────────────────────
@@ -498,7 +504,18 @@ class TestPayloadLevelBlocks(unittest.TestCase):
         self.assertEqual(meth["version"], contract["contractVersion"])
         self.assertEqual(meth["overallRankLimit"], OVERALL_RANK_LIMIT)
         self.assertIn("formula", meth)
-        self.assertIn("confidenceBuckets", meth)
+        # ``confidenceBuckets`` was replaced by ``confidenceGate`` (B11).
+        # Renamed rather than rewritten in place: the old block described
+        # a max-minus-min rule that no longer exists, and a consumer
+        # reading the old key must fail loudly instead of silently
+        # believing a threshold pair that is gone.
+        self.assertNotIn("confidenceBuckets", meth)
+        self.assertIn("confidenceGate", meth)
+        self.assertEqual(meth["confidenceGate"]["owner"], "src/api/confidence.py")
+        self.assertEqual(
+            sorted(meth["confidenceGate"]["axes"]),
+            ["agreement", "applicability", "coverage", "freshness", "independence"],
+        )
         self.assertIn("anomalyFlags", meth)
         self.assertIsInstance(meth["sources"], list)
         # ktc + ktcSfTep + idpTradeCalc + dlfIdp + idpShow + dlfSf +
@@ -756,19 +773,28 @@ class TestEdgeCaseFixtures(_SecondOffenseSourceMixin, unittest.TestCase):
         self.assertTrue(row["isSingleSource"])
         self.assertEqual(row["confidenceBucket"], "low")
 
-    def test_high_confidence_consensus_asset(self):
-        """Multi-source with tight agreement = high confidence.
+    def test_two_agreeing_sources_are_not_high_confidence(self):
+        """Tight agreement between TWO families is not enough (B11).
 
-        Uses two overall_offense sources (ktc + ktcMirror) because KTC
-        and idpTradeCalc have disjoint scopes under the scope-aware
-        ranking pipeline.
+        This used to assert ``high``: the retired rule reached its top
+        bucket on any two sources whose spread was small, which is the
+        owner ruling's stated failure — "excellent agreement between only
+        one or two evidence families should not automatically become HIGH
+        confidence".
+
+        Two families is also below the count-aware blend's own rungs:
+        n=2 is a plain mean, so the published value is whatever those two
+        said, with nothing to be robust against.  The axes say so
+        explicitly rather than the bucket saying it silently.
         """
         payload = _payload_with_players(
             _make_player("Consensus QB", "QB", ktc=9000, sibling=8900),
         )
         row = _build_and_find(payload, "Consensus QB")
         self.assertFalse(row["isSingleSource"])
-        self.assertEqual(row["confidenceBucket"], "high")
+        self.assertEqual(row["confidenceAxes"]["agreement"], "high")
+        self.assertEqual(row["confidenceAxes"]["independence"], "low")
+        self.assertEqual(row["confidenceBucket"], "low")
         self.assertFalse(row["quarantined"])
 
     def test_all_trust_fields_present_on_ranked_player(self):
@@ -865,20 +891,23 @@ class TestTrustMirrorToLegacy(_SecondOffenseSourceMixin, unittest.TestCase):
         self.assertIsInstance(legacy_entry["quarantined"], bool)
         self.assertIn("confidenceBucket", legacy_entry)
 
-    def test_multi_source_high_confidence_mirrored(self):
-        """A multi-source player with tight agreement gets 'high' mirrored.
+    def test_the_legacy_dict_mirrors_whatever_the_gate_decided(self):
+        """The mirror must carry the gate's verdict, not its own.
 
-        Uses two overall_offense sources (ktc + ktcMirror) via the mixin
-        because KTC and idpTradeCalc have disjoint scopes and cannot
-        both rank a QB under the scope-aware pipeline.
+        Two identical source values used to mirror ``high`` (spread 0).
+        Under B11 two families cannot exceed ``low`` however closely they
+        agree — what this test pins is that the legacy dict says the same
+        thing ``playersArray`` does, which is the property that made this
+        test worth having.
         """
         payload = _payload_with_players(
             _make_player("Dual QB", "QB", ktc=8000, sibling=8000),
         )
         contract = build_api_data_contract(payload)
         legacy_entry = contract["players"]["Dual QB"]
-        # With equal values across two sources, spread=0 → high confidence
-        self.assertEqual(legacy_entry["confidenceBucket"], "high")
+        row = next(r for r in contract["playersArray"] if r["canonicalName"] == "Dual QB")
+        self.assertEqual(legacy_entry["confidenceBucket"], row["confidenceBucket"])
+        self.assertEqual(legacy_entry["confidenceBucket"], "low")
         self.assertFalse(legacy_entry["isSingleSource"])
 
 


### PR DESCRIPTION
## The defect, stated precisely

Confidence was `max(percentile) − min(percentile)` across a row's contributing sources, bucketed at 0.08 / 0.20, behind an `n >= 2` count gate.

**A range can only preserve or narrow when an observation is removed.** Under "narrower ⇒ more confident", deleting evidence promoted a row. #833 recorded the failed repair — re-basing the same statistic onto independent evidence moved **60 rows the wrong way** (A.J. Brown `medium → high`) purely because collapsing his FantasyPros family removed one endpoint.

The input population was never the defect. The statistic was, and a threshold pair around it could only ever be a different-sized version of the same bug.

It was also one axis wearing two hats — a count and a dispersion — with nothing asking whether the evidence was independent, current, applicable to this board's format, or anywhere near complete. A large source count silently compensated for all four.

## What replaces it

`src/api/confidence.py` is the single owner. Five axes over **B10 provider families**, combined by **bottleneck** — the overall level is the weakest axis. Nothing averages, so a strong axis cannot buy a weak one.

| axis | question | HIGH requires |
|---|---|---|
| independence | how many B10 correlation-group heads voted | ≥ 5 families |
| coverage | how many of the **eligible** families actually did | ≥ 75% |
| freshness | how many of those are inside their `maxAgeHours` budget | ≥ 75% |
| applicability | how many reached the row without approximation, on this board's TE++ basis | ≥ 75% |
| agreement | how many price within 15% relative of `rankDerivedValue` | ≥ 75% |

Parameters live in `config/confidence/gate_v1.json` with a unit and a derivation each; the module contains no numeric literal that decides a level. They are deliberately **not** mirrored into `frontend/lib/thresholds.js` — the parity test would require the JS export, and that is exactly the client-side constant #725 removed.

## Every number is derived from something already declared

- **5 / 3 families** — the count-aware blend's own rungs. `_mean_median_blend` trims one extreme per side at k ≥ 5, so five families is the smallest panel whose published value survives one outlying opinion in either direction; n = 3-4 is the untrimmed rung, n = 2 a plain mean. **Two families therefore cannot exceed LOW**, which is the owner ruling on thin panels enforced structurally rather than by calibration.
- **0.75 / 0.50** — one sufficiency ladder for all four share axes rather than four separately-invented cutoffs. A stated prior, recorded as one, with the live distribution checked so it falls inside the body of all four rather than at a tail.
- **0.15 relative value** — the board's existing declared line for a *material* relative value gap (`PREMIUM_SUMMARY_VALUE_RATIO`), measured with the **same symmetric mean normalisation** `_compute_market_gap` uses, so it means the same size of disagreement in both places.

## Why the invariants hold rather than happen to hold

- **Duplicates cannot create confidence, and removing them cannot promote it** — an exact *identity*, not a bound. Every axis reads family heads, and `assess_confidence` **refuses** a repeated family rather than averaging or ignoring it (both are ways for a duplicate to matter after all). A.J. Brown is HIGH whether or not FantasyPros also published a Fitzmaurice row.
- **Removing real evidence cannot pay** — `coverage`'s **denominator is what could have been observed**, not what was. A family that stops covering a row stays eligible, so its silence is registered as missing evidence permanently. MISSING IS NEVER ZERO, applied to confidence.
- **No axis is a range** — pinned by a test that moves an interior family while holding the extremes, which a range statistic cannot notice.

## Agreement moved to value space, and it earns its keep

Checked for the opposite bias before adopting: the within-tolerance share **falls** with depth (median 1.000 in the top 100, 0.750 at 201-800), so it does not become mechanically easier where the Hill curve flattens.

It catches disagreement the percentile statistic structurally could not. **Jalen Carter** (DL, rank 239) has a percentile spread of **0.0412** — comfortably inside the retired HIGH band — while `draftSharksIdp` prices him **26% below** consensus. Now LOW, with the disagreement named on the row.

## A defect this change created, found and fixed

`_apply_two_way_player_boost` runs *after* the ranking loop and replaces `rankDerivedValue`. The retired rule never read the value, so this coupling is **new with the gate**. Travis Hunter's boost lifts him from ~2,900 to 4,758, leaving **all eleven of his families 24-56% below** the published value while the pre-boost stamp still claimed high agreement.

Fixed by `_restate_confidence_after_override`, written as a general guard over "did the value move since the gate ran" rather than a special case for the boost table.

## Picks

Picks keep their coefficient-of-variation rule — rank spread on picks is dominated by the flat-value regions in R3-R6 — but it is now family-aware (`dlfSf` and `dlfIdp` are one declared family). **Measured first: 0 of 144 live pick rows** carry two members of one family, so this closes a hole rather than moving a number.

Named boundary: 24 pick rows are HIGH on 2 families, because the pick population only *has* 2-4 families. The 5-family bar derives from the player blend's trimming rung and does not apply to them.

## OLD vs NEW distribution

Both sides measured over the **same pinned payload** (the 2026-08-14T17:41 export), with the OLD side built from a worktree at the pre-B11 commit. A scheduled refresh landed mid-review, and comparing across refreshed inputs would have measured the scrape rather than the gate.

| bucket | OLD | NEW | delta |
|---|---:|---:|---:|
| high | 102 | 253 | +151 |
| medium | 245 | 357 | +112 |
| low | 441 | 178 | −263 |
| none | 306 | 306 | 0 |

428 up · 77 down · 589 unchanged.

**The OLD board was saturated, and the shape shows it** (high/medium/low by depth):

| band | OLD | NEW |
|---|---|---|
| 001-100 | 61/38/1 | 79/20/1 |
| 101-200 | 10/65/25 | 58/35/7 |
| 201-400 | 15/41/144 | 72/106/22 |
| 401-800 | 16/101/223 | 44/196/100 |

Ranks 101-200 carried 10% HIGH against the top 100's 61% — a cliff with no evidentiary basis, produced by the percentile spread growing mechanically with depth. NEW declines monotonically with depth.

Checks the ruling asked for by name:
- rows upgraded with fewer than 3 independent families: **0**
- player rows reaching HIGH with fewer than 5 families: **0** (structurally impossible)
- the 77 downgrades all name their binding axis; the clearest are the old board's own defects — Ashton Gillotte (rank 672) was HIGH on **1 family and 20% coverage**.

## Board integrity

`rankDerivedValue` moved on **0 of 1094 rows**, `canonicalConsensusRank` on **0**, and **no non-confidence field changed at all** (`rankChange` excluded — it differs between two back-to-back builds of identical code, a pre-existing non-determinism in the rank-history recorder, named in the ledger so it is not read as B11 movement). Confidence is not value — verified on the whole board rather than asserted.

Payload: production delta 3.864 → 4.136 MB raw, **314.3 → 334.1 KB over the wire** (+6.3%) for the axes and reasons. `confidenceMetrics` was deliberately left off the payload to hold it there.

## Also: a stale B10 guard

`test_the_canonical_blend_does_not_read_correlation_group` asserted the blend never reads `correlation_group`. **B10-T3b retired that property on purpose** (455 values moved) and the guard stayed green for two merges, because T3b reached the family through a helper so the literal string never appeared in the caller. Replaced with the property that is true: family membership is resolved through the declared owner and nowhere else.

A guard that survives the change it was written to catch is worse than no guard — it reads as evidence.

## Downstream, stated rather than compensated for

`frontend/lib/edge-helpers.js` gates four surfaces on `confidenceBucket === "high"`; they now see 253 qualifying rows instead of 102. That is the saturation fix arriving, not a blast radius — no threshold was touched to preserve the old row count.

## Validation

- backend: **7546 passed**, 60 skipped (the one failure was the stale guard above, fixed in this branch; `tests/api` + `tests/consensus_edge` re-run clean at 2283 passed)
- frontend: **2033 passed**, 124 files
- `ruff check .` + `ruff format --check .`: clean repo-wide
- board diff: 0 values, 0 ranks, 0 non-confidence fields

Evidence: `docs/master-site-audit/evidence/B11/` — the distribution report plus `audit.py`, which regenerates it from two slim contract dumps and documents how to produce them. Ledger §B11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2EZWDCCbiL2JLvJsARUHg