### PR TITLE
docs: add Best Trade to Send Each Team to canonical backlog

### DIFF
--- a/docs/MASTER_PRODUCT_PLAN.md
+++ b/docs/MASTER_PRODUCT_PLAN.md
@@ -1,7 +1,7 @@
 # Risk It To Get The Brisket — Master Product Plan
 
 **Status:** CANONICAL FRONT DOOR FOR PRODUCT DIRECTION  
-**Owner direction reconciled through:** 2026-08-12  
+**Owner direction reconciled through:** 2026-08-14  
 **Purpose:** Give every future Claude/ChatGPT/Codex session one place to answer: *What are we building? What are we not building? What does each feature mean? What is private vs public? What comes next? Which document wins if records disagree?*
 
 > **Start here for every material product, roadmap, architecture, or implementation-planning task.**
@@ -227,6 +227,7 @@ Required products include:
 - Golden Upgrades as a consumer, not a second engine;
 - Package Builder using the shared package-generation engine;
 - Trade Finder and Trade Suggestions repairs/consolidation;
+- **Best Trade to Send Each Team**: exactly one mutually defensible player-only offer per league opponent, with equal player counts on both sides, a win for the selected team on the canonical calculator, and an even-or-better result for the opponent on at least one fully covered external market calculator (KTC or IDP Trade Calculator); uncovered/missing external assets cannot qualify as approval; rank qualifying offers by our roster benefit/edge, opponent fit and plausibility, external acceptability, and asset quality rather than by maximum calculator exploit; recommendation only, never silent sending;
 - multi-team draft-pick destination correctness;
 - trade equalizer suggestions ranked by **post-active-Value-Adjustment gap**, without double-applying VA;
 - acquisition/holding-period history;

--- a/docs/OWNER_FEATURE_INVENTORY.md
+++ b/docs/OWNER_FEATURE_INVENTORY.md
@@ -15,6 +15,11 @@ player-profile, ticker, TEP, trade-exposure, Dynasty Daddy, X-feed, Game Day, Mo
 Second Opinions and Analyze Trade requirements. Where older wording in this file conflicts with
 §13's explicit owner clarification, the newer §13 decision controls.
 
+**2026-08-14 owner-scope addition:** Trade products now include **2.9 Best Trade to Send Each Team**,
+a private one-best-offer-per-opponent generator with binding player-only, equal-player-count,
+canonical-win-for-us and externally-even-or-better-for-them constraints. The detailed methodology
+lives in `OWNER_PRODUCT_BACKLOG_SPEC.md` §2.3.
+
 ## How to read this
 
 **Classification** is exactly one of:
@@ -84,6 +89,7 @@ build, blocker, backlog item or future feature.
 | 2.6 | **Package Builder** | Build trade packages with return-position constraints applied **during** generation, not as a post-filter | New | No Package Builder component exists in the tree. **OWNER DECISION 2026-08-11: BUILD it as a real user-facing feature.** It must use the SAME canonical package-generation engine as Trade Finder / Trade Suggestions — no second package algorithm. Constraints: QB, RB, WR, TE, DL/EDGE, LB, DB, PICKS, honoured intentionally when several are selected. Must respect selected team, ownership, excluded/untouchable players (1.5), package adjustment (2.2), roster impact (1.3), Team Strength/Weakness (1.1/1.2), pick identity (2.7), missing/unpriced state, and league settings | D8 | 2.2, 2.3, 2.7, 1.5 | **L** | KEEP — NEW BUILD |
 | 2.7 | **Stable draft-pick identity** | A pick keeps season + round + original owner + current owner through the whole pipeline | Existing, lossy | 53 of 216 league picks collapse; original-owner identity discarded before the trade calculator (W08-F005) | C6 | — | **L** | KEEP — EXISTING, REPAIR/COMPLETE |
 | 2.8 | **2028/2029 future-pick valuation** | Price far-future picks instead of dropping them | Existing, partial | `config/weights/pick_year_discount.json` covers near years; unpriced picks are honestly excluded and flagged `isUnpriced` rather than zeroed — the correct posture, but they carry no value | D-tier | 2.7 | **M** | KEEP — EXISTING, REPAIR/COMPLETE |
+| 2.9 | **Best Trade to Send Each Team** | For every other league team, surface exactly one best mutually defensible player-only offer: same number of players each way, no picks, canonical win for the selected team, and opponent even/winning on KTC or IDP Trade Calculator | New | **OWNER DECISION 2026-08-14: BUILD.** No dedicated surface exists. Must consume the same canonical package-generation/trade infrastructure as Finder/Suggestions/Package Builder. An external calculator only qualifies a candidate with whole-package native coverage; missing/unsupported/imputed assets cannot create a fake opponent win/even. Rank qualifying candidates by our roster benefit/edge, opponent roster fit/plausibility, external acceptability and asset quality — not maximum calculator exploit. Exactly one result per opponent; explicitly show no qualifying trade if none satisfies the hard rules. Recommendation only; never silently send | D8 / CE-05 | 2.2, 2.3, 2.4, 1.1, 1.2, 1.3, 1.5, 7.1 | **M–L** | KEEP — NEW BUILD |
 
 ---
 

--- a/docs/OWNER_PRODUCT_BACKLOG_SPEC.md
+++ b/docs/OWNER_PRODUCT_BACKLOG_SPEC.md
@@ -1,7 +1,7 @@
 # Risk It To Get The Brisket — Owner Product Backlog Specification
 
 **Status:** AUTHORITATIVE PRODUCT-SPEC COMPANION TO `docs/OWNER_FEATURE_INVENTORY.md`  
-**Owner direction captured through:** 2026-08-12  
+**Owner direction captured through:** 2026-08-14  
 **Purpose:** Preserve not merely *what* the owner wants built, but *what the feature is supposed to mean*, its methodology, canonical dependencies, public/private posture, non-scope, missing-data behavior, validation requirements, and already-resolved owner decisions.
 
 > `OWNER_FEATURE_INVENTORY.md` remains the scope/status inventory. This document is the detailed implementation intent. A one-line inventory entry must never be treated as permission to invent methodology that is specified here.
@@ -137,6 +137,59 @@ Cost basis is **informational**. Do not penalize a rational sale merely because 
 **KEEP — NEW BUILD.** Must use the same canonical package-generation engine as Trade Finder, Trade Suggestions and Golden Upgrades.
 
 Return-position filters/constraints are applied *during generation*, not as a post-filter. Support QB/RB/WR/TE/DL-EDGE/LB/DB/PICKS and intentional multi-selection. Respect ownership, selected team, untouchables/exclusions, unpriced state, pick identity, league settings and roster impact.
+
+## 2.3 Best Trade to Send Each Team
+
+**KEEP — NEW BUILD. PRIVATE DECISION INTELLIGENCE.** For every other team in the selected league, generate and display **exactly one best trade to send that opponent**.
+
+This is a specialized consumer of the same canonical package-generation, valuation, roster-impact and external-market comparison infrastructure used elsewhere. It must **not** create a second trade finder, second value model or page-local package algorithm.
+
+### Hard qualification rules
+
+A candidate trade qualifies only when **all** of the following are true:
+
+1. **Players only.** No draft picks may appear on either side.
+2. **Equal player counts.** The number of players sent must equal the number received: 1-for-1, 2-for-2, 3-for-3, etc. No unequal-count consolidation packages qualify for this feature.
+3. **Canonical win for us.** From the selected user's/team's perspective, the site's canonical trade calculator/decision economics must grade the trade as a win. A merely even or losing canonical result does not qualify.
+4. **Externally defensible for them.** The opponent must grade **even or better** on at least one approved external market calculator: **KeepTradeCut (KTC)** or **IDP Trade Calculator**.
+5. **Whole-package native coverage.** An external calculator counts only when it can meaningfully/native-value every asset in the proposed package. Missing, unsupported, imputed-through-our-own-values, or partially covered assets may not be treated as an external win/even result.
+6. **One result per opponent.** Return the single highest-ranked qualifying trade for each other team. If no candidate satisfies the hard rules with adequate data/coverage, explicitly show **No qualifying trade found** rather than weakening the constraints or fabricating approval.
+
+### What “best” means
+
+Do **not** simply maximize the discrepancy between our calculator and an external calculator. Among qualifying candidates, rank for a strong, plausible, mutually defensible offer using a transparent multi-factor objective that includes:
+
+- improvement to our real roster after the trade: Team Strength, starting-lineup impact, weakness fixed/created, replacement/displacement and asset quality;
+- magnitude/confidence of our canonical edge;
+- opponent roster fit: whether the incoming players address their actual needs and come from positions where we can reasonably deal;
+- opponent external-market acceptability: how comfortably KTC or IDP Trade Calculator says they are even/winning, with source and margin shown;
+- plausibility / trade shape, avoiding absurd calculator-only exploits;
+- dynasty asset quality, liquidity and tier preservation when otherwise close;
+- untouchable/excluded-player controls and other explicit owner overlays.
+
+The feature should prefer **the best trade we would actually want to send and they could rationally accept**, not the mathematically largest exploit.
+
+### UX / explanation
+
+For each opponent show at minimum:
+
+- opponent/team;
+- players we send;
+- players we receive;
+- canonical result for us and margin;
+- which external calculator qualifies the opponent, their result/margin there, and coverage status;
+- concise **Why this helps us** explanation;
+- concise **Why they may accept** explanation based on their roster and the qualifying external market view;
+- key roster-impact facts where material;
+- confidence/coverage and any important caveat.
+
+The league view should make it easy to scan all opponents and may sort by **Best Opportunity**, but must still preserve one result per opponent.
+
+### Recommendation vs execution
+
+This feature recommends/drafts an offer only. It must never silently send trades. Any future send action must go through the canonical league-action gateway with explicit user confirmation.
+
+**Method status:** OWNER-DECIDED PRODUCT REQUIREMENT; EXACT RANKING WEIGHTS REQUIRE VALIDATION AGAINST PLAUSIBILITY/ROSTER-IMPACT EXAMPLES BEFORE PRODUCTION.
 
 ---
 
@@ -517,7 +570,6 @@ Do not create awards such as “Comeback Player” unless the data truly measure
 Create a canonical Award Ledger preserving season, award key, winner, top-five finalists, VORP/metric, franchise credit, methodology version, scoring-config fingerprint, input coverage and finalized timestamp.
 
 For the inaugural system, backfill 2024/2025 with the approved 2026 methodology. Future methodology changes should be explicit/versioned rather than accidental consequences of changing a helper function.
-
 ## 10.11 Coverage gates
 
 Awards require sufficient player scoring, starter attribution, position resolution and week coverage. Missing historical scoring must not silently become zero. If a season lacks defensible coverage, mark the award unavailable/insufficient rather than fabricating a winner.

--- a/docs/trade/ROSTER_CAPACITY_FORCED_DROP_TRADE_ANALYSIS_ADDENDUM_2026-08-14.md
+++ b/docs/trade/ROSTER_CAPACITY_FORCED_DROP_TRADE_ANALYSIS_ADDENDUM_2026-08-14.md
@@ -1,0 +1,42 @@
+# Roster Capacity / Forced-Drop Trade Analysis Addendum — 2026-08-14
+
+**Owner-approved superseding/additive trade-generation requirement. Tracking: #843.**
+
+When **Use Team Context = ON** (default; #842), Trade Calculator, Analyze Trade (#792), Trade Finder / Best Trade to Send Each Team (#841), and later Trade Desk workflows must evaluate the team's **actual final legal roster**, including open spots, existing over-limit status, and any forced cleanup caused by the trade.
+
+## Canonical sequence
+
+`before roster → apply trade → calculate capacity / overage → determine required legal cleanup → apply lowest-cost legal cleanup → rerun canonical roster intelligence → evaluate final post-cleanup result`
+
+A required cut is a real consequence of the trade. The system must not pretend every incoming player survives when the roster has no room.
+
+## Required capacity facts
+
+For both sides, derive active roster limit/count, open spots, current overage, net player-count change, post-package count, required cleanup count, final post-cleanup count, and whether the trade resolves/improves/worsens an existing overage. Use taxi/IR only when actual rules and player eligibility make the move legal. Picks normally do not consume an immediate active-roster spot.
+
+## Forced-drop cost
+
+Use canonical dropability / roster utility to choose the lowest-cost legal cleanup path rather than simply dropping the lowest raw-value player. Show likely cut candidates and values for explainability, but rank/analyze on the true final post-cleanup roster impact.
+
+## Generated-trade behavior
+
+The `<=1` player-count topology remains unchanged, but roster capacity affects mutual-benefit ranking.
+
+- A team with an open spot can absorb a 1-for-2 cleanly.
+- A full team receiving the extra player must be evaluated with the resulting forced cut.
+- A team already over the limit may rationally prefer a 2-for-1 consolidation because it reduces or resolves its overage.
+- A package that looks favorable before cleanup may be downgraded or rejected if the forced cut destroys the advantage.
+
+Capacity applies to **both teams** and does not override protection / LOCK / EXCLUDE or other hard package constraints.
+
+## Analyze Trade behavior
+
+With Team Context ON, roster-capacity / forced-drop impact is part of canonical roster marginal impact. Recompute Team Strength/Weakness, #839 Meaningful Roster Core, #838 Age-Value/Young Core, and season probabilities from the final post-cleanup roster when material.
+
+## Team Context OFF
+
+Asset-Only mode excludes roster-capacity/forced-drop effects from verdict and generated ranking. If capacity is displayed for convenience, label it as not included in Asset-Only analysis.
+
+## Completion condition
+
+A trade tool is not considered fully roster-aware if it cannot distinguish clean absorption, forced cuts, existing over-limit improvement, and over-limit worsening.

--- a/docs/trade/TRADE_CONTEXT_AND_TOPOLOGY_SUPERSESSION_2026-08-14.md
+++ b/docs/trade/TRADE_CONTEXT_AND_TOPOLOGY_SUPERSESSION_2026-08-14.md
@@ -1,0 +1,113 @@
+# Trade Finder / Analyze Trade — Team Context Mode + Player-Count Topology Supersession
+
+**Owner decision:** 2026-08-14  
+**Tracking:** #841, #842, #792, #840  
+**Status:** APPROVED PRODUCT REQUIREMENT; SUPERSEDES OLDER CONTRADICTORY TRADE-GENERATION RULES
+
+## 1. Player-count topology
+
+The older exact-equal-player-count requirement is withdrawn.
+
+For generated Trade Finder / Best Trade to Send Each Team packages:
+
+`abs(players_side_a - players_side_b) <= 1`
+
+Allowed examples:
+- 1-for-1
+- 2-for-1 / 1-for-2
+- 3-for-2 / 2-for-3
+
+Disallowed examples:
+- 3-for-1 / 1-for-3
+- 4-for-2 / 2-for-4
+- any package where the number of **players** differs by more than one
+
+Draft picks do not count as players for this topology rule. A package like `2 players + 1 pick for 1 player` is topology-valid; `3 players for 1 player + 1 pick` is not.
+
+This rule broadens the search space; it does not require uneven packages. Prefer whichever qualifying topology is strongest and most mutually defensible.
+
+## 2. Draft picks remain allowed
+
+The prior no-picks rule remains withdrawn under #841. Picks may appear on either side when they improve the package under the active analysis mode. They are not filler and must use canonical identity/value, real ownership, and honest external-market coverage.
+
+## 3. Shared `Use Team Context` control
+
+Trade evaluation and generation use one shared mode contract from #842.
+
+Default: **ON**.
+
+### ON — Team Context
+
+Use real selected-team/opponent context where available and valid:
+- roster ownership;
+- Team Strength / Team Weakness;
+- #839 Meaningful Roster Core;
+- #838 Age-Value / Young Core;
+- #840 PUSH / HOLD / RETOOL / REBUILD posture;
+- playoff / bye / championship probability and post-trade counterfactuals;
+- season timing / trade deadline;
+- current/future pick ownership, value and Pick Forecast;
+- positional need, surplus, depth, promotion/displacement;
+- approved user/team constraints.
+
+Trade Finder must optimize mutual benefit for both teams. Posture-aware pick direction is active in this mode.
+
+### OFF — Asset-Only
+
+Evaluate/generate without team-specific roster or competitive context influencing the verdict/ranking.
+
+May still use:
+- canonical league-format-aware player/pick value;
+- package / Value Adjustment math;
+- external-market corroboration/disagreement;
+- asset-level uncertainty;
+- player age as an intrinsic descriptor;
+- pick year/round/slot/value;
+- real trade comps / liquidity where valid;
+- source confidence/coverage;
+- hard user constraints.
+
+Must not use in the verdict/ranking:
+- selected-team roster fit or positional needs;
+- Team Strength / Weakness changes;
+- #838 team Age-Value / Young Core changes;
+- playoff / bye / championship odds;
+- #840 competitive posture;
+- own-pick strategic/tanking effects;
+- season-window strategy;
+- opponent posture.
+
+OFF does **not** mean standard-format values. The selected league's TEP/Superflex/IDP/scoring/roster configuration may still affect canonical asset valuation. It removes team-specific context only.
+
+## 4. Analyze Trade
+
+#792 must expose the same mode:
+- ON = complete team-aware MAKE / LEAN MAKE / TOO CLOSE / LEAN PASS / PASS decision;
+- OFF = clearly labeled **Asset-Only Analysis** using only asset/package/market/uncertainty evidence.
+
+If team-context panels are visible while OFF, they must be marked `not included in this verdict`.
+
+Never silently fall back from ON to OFF because team context is missing. Missing team-context dimensions must degrade explicitly.
+
+## 5. Trade Finder / Best Trade to Send Each Team
+
+#841 consumes this mode:
+- ON = posture-aware mutual-benefit generation, including picks based on team objectives;
+- OFF = asset/package/market-based generation without contender/rebuilder or roster-fit reasoning.
+
+The player-count-difference rule applies in both modes.
+
+## 6. Validation
+
+Required fixtures:
+- 1v1, 2v1, 1v2, 3v2, 2v3 accepted when otherwise qualifying;
+- 3v1 and 1v3 rejected even when picks are present;
+- picks do not affect the player-count topology calculation;
+- same trade can legitimately differ ON vs OFF only because team-context dimensions are included/excluded;
+- OFF verdict/generation cannot consume #840, playoff odds, Team Strength/Weakness, or team-level age/value outputs;
+- ON with missing context degrades honestly rather than switching modes;
+- desktop/mobile parity and reproducible share-link state when mode affects verdict.
+
+## 7. Reconciliation rule
+
+Newest owner instruction wins. Any older planning language requiring `players only`, `no draft picks`, or `same number of players each direction` must be treated as superseded. Any trade-analysis document that assumes team context is mandatory with no user control must be reconciled to #842.

--- a/docs/trade/TRADE_FINDER_POSTURE_AWARE_PICKS_ADDENDUM_2026-08-14.md
+++ b/docs/trade/TRADE_FINDER_POSTURE_AWARE_PICKS_ADDENDUM_2026-08-14.md
@@ -1,0 +1,116 @@
+# Trade Finder — Posture-Aware Draft Picks Addendum
+
+**Owner decision date:** 2026-08-14  
+**Tracking:** #841  
+**Supersedes:** the earlier blanket `players only / no draft picks` rule for Trade Finder / Best Trade to Send Each Team generation  
+**Depends on:** #840 Competitive Posture, #839 Meaningful Roster Core, #838 Roster Age-Value / Young Core, canonical Team Strength/Weakness, Playoff Predictor, canonical pick values / Pick Forecast
+
+## Binding owner decision
+
+Draft picks are valid generated-trade assets when their inclusion makes a proposed trade more mutually beneficial given **both teams' actual strategic position**.
+
+The generator must not treat picks as generic equalizer filler. It should use them because dynasty teams can rationally value current production and future capital differently depending on championship probability, playoff probability, season timing, roster window, positional needs, age/value construction, and future-pick ownership.
+
+## Required strategic behavior
+
+### PUSH contender vs RETOOL / REBUILD opponent
+
+Explore packages where the contender sends future draft capital and/or younger liquid value in exchange for current production that:
+
+- fills a real Team Weakness;
+- improves the canonical Meaningful Roster Core;
+- materially improves Make Playoffs / Bye / Championship probability where supported;
+- is worth the future-value cost.
+
+The rebuilding/retooling side must receive enough future value, youth, liquidity, or pick capital for the package to improve its own window rather than merely subsidizing the contender.
+
+### RETOOL / REBUILD selected team vs PUSH opponent
+
+Explore packages where the selected team sends present-oriented production that the contender can genuinely use and receives:
+
+- owned draft picks;
+- younger liquid assets;
+- future-value improvement;
+- legitimate improvement to its own pick outlook only when it actually owns the relevant pick and league draft-order rules support that conclusion.
+
+The contender should receive a meaningful current-season benefit, not merely a player with a recognizable name.
+
+### HOLD / same-posture matchups
+
+Picks remain legal but are not mandatory. Add them only when they improve the actual package or solve a real two-team objective mismatch.
+
+## Best Trade to Send Each Team
+
+The prior `no draft picks` constraint is withdrawn.
+
+The feature should still return exactly one strongest qualifying offer per opponent when one exists.
+
+The prior equal-count constraint now means **equal number of players each direction**. Picks are not players and may appear additionally on either side when the posture-aware generator finds that appropriate.
+
+Examples:
+
+- 1 player + 2027 1st for 1 player is allowed.
+- 2 players for 2 players + 2028 2nd is allowed.
+- 1 player for 2 players remains disallowed under the equal-player-count rule unless the owner later changes that separate constraint.
+
+Do not force a pick into a player-only trade that is already the strongest mutually defensible offer.
+
+## Pick construction rules
+
+1. Use canonical pick identity and canonical pick value.
+2. Offer only picks actually owned by the team unless the surface explicitly supports hypothetical generic picks.
+3. Prefer exact known pick identity/slot when known; otherwise use the canonical future-pick representation and projected slot distribution.
+4. Do not assume every first is interchangeable. Year, round, original franchise, projected slot/range, and uncertainty matter.
+5. Do not use a pick merely to make raw totals line up.
+6. Quantify pick-value change against what each side is giving up.
+7. If the team does not own its own pick, worsening that team's outlook is not a draft-capital benefit to that team.
+8. Respect the league's actual draft-order mechanics, including Max PF / record / consolation rules.
+9. Never recommend illegal lineup manipulation or intentional lineup violations.
+
+## Two-team mutual-utility objective
+
+Generated candidates should be evaluated for both teams with a shared canonical package generator. Relevant dimensions include:
+
+- canonical package/equity value;
+- package / consolidation methodology where approved;
+- Team Strength and Team Weakness before/after;
+- #839 Meaningful Roster Core promotions/displacements;
+- #838 age/value and Young Core before/after;
+- Make Playoffs / Bye / Championship probability change;
+- future draft capital and Pick Forecast change;
+- #840 Competitive Posture fit for each side;
+- external market corroboration/coverage where valid;
+- owner protections, untouchables, LOCK and EXCLUDE constraints;
+- plausibility / asset quality / liquidity.
+
+Do not double-count descendants of the same canonical value evidence and do not rank by the largest calculator exploit.
+
+## External calculator coverage
+
+Pick-inclusive packages complicate the earlier external qualification rule. Preserve honesty:
+
+- use only native external coverage as an independent vote;
+- canonical imputation cannot manufacture external corroboration;
+- if KTC or IDP Trade Calculator cannot natively evaluate the full pick-inclusive package, mark that source incomplete;
+- before shipping, define a valid qualification path for pick-inclusive generated packages rather than silently pretending an unsupported source approved the trade.
+
+## Analyzer integration
+
+Every generated package should be eligible for the same canonical Analyze Trade contract (#792), including before/after roster construction, age/value, playoff/championship odds, pick capital, and Competitive Posture explanation.
+
+A generated package is not good merely because the selected side 'wins the calculator.' The intended end state is a deal the selected manager should want **and** the opponent has a rational reason to accept based on its own situation.
+
+## Acceptance examples
+
+- PUSH team offers a future 1st to a REBUILD team for a veteran who materially changes championship odds: valid candidate.
+- REBUILD team asks a PUSH team for picks in exchange for useful current production: valid candidate.
+- PUSH team pays a 1st for a veteran who changes championship odds only trivially: should rank poorly / fail strategic-fit threshold.
+- REBUILD team that does not own its own 1st is not credited with 'improving its pick' by getting worse.
+- Player-only offer remains preferred when it is the best mutual trade.
+- Pick is never inserted solely as cosmetic filler.
+
+## Sequencing
+
+This is approved C-series scope. Establish the shared canonical foundations first, then integrate posture-aware pick generation into Trade Finder / Best Trade to Send Each Team and validate the same packages through Analyze Trade.
+
+This addendum is binding where older trade-generation records still say `no draft picks`; those older statements are superseded.

--- a/docs/trade/TRADE_GENERATION_PREFERENCES_AND_REFINEMENT_SPEC.md
+++ b/docs/trade/TRADE_GENERATION_PREFERENCES_AND_REFINEMENT_SPEC.md
@@ -1,0 +1,188 @@
+# Trade Generation Preferences & Package Refinement
+
+**Status:** OWNER-APPROVED PRODUCT REQUIREMENT  
+**Owner direction captured:** 2026-08-14  
+**Scope:** Private/authenticated generated-trade recommendations only  
+**Canonical relationship:** Extends the shared Untouchable / excluded-player control, shared package-generation engine, Trade Finder/Suggestions, Package Builder, Golden Upgrades, Best Trade to Send Each Team, equalizers/counters, Trade Desk recommendations, and future generated-trade surfaces. It does not create another value model or package engine.
+
+---
+
+## 1. Goal
+
+Generated trade recommendations should respect what the selected user is actually willing to trade and should let the user refine a proposed package without manually rebuilding it.
+
+There are **two different classes of constraint** and they must remain separate:
+
+1. **Persistent personal trade protection** — durable user + fantasy-league preferences such as an individual untouchable player or an NFL-team-wide outgoing protection.
+2. **Temporary package refinement** — LOCK and EXCLUDE/X controls applied to the currently generated trade context and preserved until the user clears them.
+
+Neither class changes canonical player values, external market values, Team Strength, or another user's recommendations.
+
+---
+
+## 2. Persistent personal trade protection
+
+### 2.1 Scope and storage
+
+Persistent protection is scoped to the authenticated **user + selected fantasy league**. It is not a global player flag and must never be hard-coded into canonical player data.
+
+Support at least:
+
+- individual-player untouchable/protected rules; and
+- NFL-team outgoing protection.
+
+### 2.2 Owner-specific Minnesota preference
+
+For Jason's configured league preference, **Minnesota Vikings (MIN) players are protected from appearing on the OUTGOING side of automatically generated trade packages**.
+
+This is a personal recommendation constraint, not a valuation rule:
+
+- MIN players may still appear as INCOMING acquisition targets;
+- MIN players retain their ordinary canonical value;
+- KTC/IDP/market values are unchanged;
+- other users without this preference may receive outgoing MIN recommendations;
+- manual Trade Calculator what-if analysis remains free-form.
+
+NFL-team protection follows canonical current NFL-team identity dynamically. A player who joins MIN becomes protected by the team rule; a player who leaves MIN stops being protected by that team rule unless an individual untouchable rule still applies.
+
+### 2.3 Consumers
+
+Every automatically generated trade surface must consume the same canonical outgoing-constraint owner during candidate generation, including at minimum:
+
+- Trade Finder / arbitrage;
+- Trade Suggestions;
+- Golden Upgrades;
+- Package Builder;
+- Best Trade to Send Each Team;
+- trade equalizers / counteroffer suggestions;
+- Trade Desk recommendations; and
+- future AI/generated trade-recommendation surfaces.
+
+Do not implement page-local copies or post-filter protected players after ranking.
+
+---
+
+## 3. Generated-package LOCK and EXCLUDE/X
+
+Every generated trade package should expose two separate controls for **outgoing players**.
+
+### 3.1 LOCK
+
+LOCK means:
+
+> Keep this outgoing player in the next regenerated package for this current target/opponent/refinement context.
+
+When the user locks Player A and regenerates, every candidate considered for the replacement result must include Player A on the outgoing side.
+
+### 3.2 EXCLUDE / X
+
+EXCLUDE/X means:
+
+> Do not use this outgoing player in the next regenerated package for this current target/opponent/refinement context.
+
+When the user excludes Player B and regenerates, Player B must not appear on the outgoing side of the replacement result.
+
+### 3.3 Interaction rules
+
+- LOCK and EXCLUDE are mutually exclusive for the same player.
+- Selecting one for a player clears the opposite temporary state for that player.
+- Multiple locks and exclusions may be active simultaneously where the parent feature can satisfy them.
+- Clicking LOCK or EXCLUDE should immediately rerun the shared canonical package generator; a separate manual refresh may also preserve and rerun the same constraints.
+- Active refinement state survives package regeneration and ordinary UI/data refreshes until the user explicitly clears/resets it.
+- Provide a clear **Reset/Clear refinements** action and visible state for every active lock/exclusion.
+- A temporary EXCLUDE/X does **not** silently become a permanent untouchable. The UI may separately offer an explicit action to promote it to persistent protection.
+- Persistent protection outranks temporary refinement. A protected outgoing player cannot be forced into generated recommendations merely by a temporary LOCK unless the user intentionally changes/removes the persistent protection.
+
+---
+
+## 4. Parent-feature constraints remain hard
+
+LOCK/EXCLUDE refines the feasible candidate set. It never weakens the parent feature's qualification rules.
+
+For **Best Trade to Send Each Team**, a regenerated candidate still must satisfy all of its hard requirements:
+
+- players only;
+- equal player counts each direction;
+- canonical win for the selected team;
+- opponent even/win on at least one approved external calculator (KTC or IDP Trade Calculator);
+- whole-package native external coverage;
+- one best qualifying result per opponent.
+
+If active locks/exclusions make those conditions impossible, return an explicit state such as:
+
+**No qualifying trade found under current constraints.**
+
+Never solve the conflict by silently:
+
+- dropping a lock;
+- reintroducing an excluded/protected player;
+- adding a draft pick;
+- changing required package count;
+- accepting a canonical loss/even result when a win is required; or
+- treating missing external coverage as approval.
+
+The same fail-closed principle applies to hard requirements on other generated-trade surfaces.
+
+---
+
+## 5. UX contract
+
+Each outgoing player in a generated package should expose accessible controls for:
+
+- **LOCK** — visually indicates the player is required for regeneration;
+- **EXCLUDE / X** — visually indicates the player is forbidden for regeneration.
+
+Icons may be used, but each control needs an unambiguous text/tooltip and screen-reader label. State must not rely on color alone.
+
+Regeneration should be immediate enough to feel like refining a proposal, not restarting the workflow. Preserve the selected opponent/target and all compatible active constraints.
+
+Manual Trade Calculator entry is intentionally different: the user may manually inspect any trade, including a protected player, because manual analysis is not an automated recommendation.
+
+---
+
+## 6. Canonical implementation rule
+
+Apply persistent protections and temporary LOCK/EXCLUDE constraints **during shared candidate generation, before package scoring/ranking**.
+
+Conceptually:
+
+1. resolve selected user + league;
+2. resolve persistent outgoing protections;
+3. resolve active temporary locks/exclusions for the current refinement context;
+4. reject contradictory/forbidden state;
+5. generate only feasible packages satisfying those constraints;
+6. apply the parent feature's hard qualification rules;
+7. rank the remaining qualifying packages with the canonical objective;
+8. return the best result or an honest no-result state.
+
+Do not generate everything first and hide forbidden packages afterward. That wastes work and can return the wrong 'best' result.
+
+---
+
+## 7. Validation / acceptance
+
+At minimum prove:
+
+1. a locked outgoing player survives regeneration;
+2. an excluded outgoing player disappears and remains excluded on subsequent regeneration;
+3. LOCK and EXCLUDE cannot be active simultaneously for the same player;
+4. multiple locks/exclusions are honored together when feasible;
+5. impossible constraints return an honest no-result state without weakening parent rules;
+6. Reset/Clear removes temporary refinement state;
+7. persistent individual protection applies across every generated-trade surface;
+8. Jason's MIN team protection applies only to his configured user+league context;
+9. MIN players are blocked outgoing but remain valid incoming targets;
+10. a different user without MIN protection can receive outgoing MIN recommendations;
+11. a player joining/leaving MIN updates team-rule protection through canonical NFL-team identity;
+12. manual Trade Calculator analysis can still include protected players;
+13. canonical player values and external market values are unchanged by preference state;
+14. every generated-trade surface consumes the same canonical constraint owner rather than a page-local implementation;
+15. future trade execution remains separate, requires explicit confirmation, and cannot silently bypass persistent protection.
+
+---
+
+## 8. Method status
+
+**FINAL / OWNER-DECIDED PRODUCT BEHAVIOR:** persistent-vs-temporary distinction, outgoing-only MIN preference, LOCK semantics, EXCLUDE semantics, shared-generator application, fail-closed no-result behavior, and recommendation/execution separation.
+
+**IMPLEMENTATION DETAIL TO VALIDATE:** exact persistence/storage schema, refinement-context identifier, UI placement/iconography, and performance strategy. Those choices may not change the owner-decided semantics above.


### PR DESCRIPTION
Records the owner's 2026-08-14 trade-generation additions in the canonical planning hierarchy.

## Best Trade to Send Each Team — current owner rules

**Superseding owner decisions 2026-08-14:**
- earlier `players only; no draft picks` rule is withdrawn; see #841;
- earlier exact-equal-player-count rule is softened to **no more than a one-player difference between sides**;
- trade evaluation/generation gets a shared **Use Team Context** toggle that defaults **ON**; see #842.

Current hard/primary rules:
- exactly one recommended trade per opponent
- **draft picks are allowed** when they improve the package under the active analysis mode
- do not force picks into a package when the best deal is player-only
- player counts may differ by at most one: `abs(players_A - players_B) <= 1`
- examples allowed: 1-for-1, 2-for-1, 1-for-2, 3-for-2, 2-for-3
- examples disallowed: 3-for-1, 1-for-3, 4-for-2
- picks do **not** count as players for this topology rule
- selected team must win on the canonical calculator / canonical decision methodology required by the parent feature
- opponent must remain genuinely defensible under the approved external-market / mutual-utility qualification path; missing or unsupported external coverage cannot be converted into fake corroboration
- rank for mutual defensibility and actual benefit rather than maximum calculator exploit
- recommendation only; no silent trade sending

## `Use Team Context` mode

### ON — default
Consume the selected team and opponent's real team context, including #840 Competitive Posture, #839 Meaningful Roster Core, #838 Age-Value / Young Core, Team Strength/Weakness, playoff/championship probability effects, actual pick ownership/value/forecast, season timing, positional need and roster fit.

The generator should exploit legitimate differences in team goals:
- PUSH contender vs RETOOL/REBUILD opponent: explore the contender paying picks/future value for current production that materially improves playoff/championship odds while improving the opponent's future value/window.
- RETOOL/REBUILD selected team vs PUSH opponent: explore the selected team sending present-oriented production and receiving picks/young liquid value while giving the contender a meaningful current-season improvement.
- HOLD/similar-posture matchups: picks remain allowed only when they materially improve the package; never use them as meaningless filler.

### OFF — Asset-Only
Generate/rank packages without team-specific roster fit, Team Strength/Weakness, team Age-Value changes, playoff/title odds, #840 posture, own-pick strategic effects, season-window logic, or opponent team strategy.

Asset-Only still uses the league-format-aware canonical value basis plus valid package/VA math, external-market evidence, asset uncertainty, age as an intrinsic asset characteristic, pick value, liquidity/comps and hard user constraints. Picks remain allowed, but as package assets rather than because one team is contending and the other rebuilding.

The control defaults ON, must be obvious in the UI, and must not silently fall back to OFF when context is missing. See #842.

## Personal trade-preference / refinement contract
- never hard-code Minnesota or any favorite team into canonical player data/value logic
- persistent user+league outgoing protection can cover an NFL team (Jason: MIN) or individual players
- every automatically generated trade surface must consume the same canonical constraint owner
- on a displayed generated package, each outgoing player gets two refinement actions: LOCK and EXCLUDE (X)
- LOCK means that player must remain in the next regenerated package for that target/opponent; EXCLUDE means that player cannot appear in the regenerated outgoing package
- regeneration is immediate and must preserve the active lock/exclude state; if the constraints make the parent feature's hard rules impossible, show no qualifying trade rather than silently dropping/violating a constraint
- persistent untouchables/team protection remain distinct from temporary package-refinement exclusions
- manual Trade Calculator what-if analysis remains free-form; generated recommendations obey preferences
- future execution/send flows require explicit confirmation and must respect persistent protections unless the user intentionally changes them

Binding detailed specs in this PR include `docs/trade/TRADE_GENERATION_PREFERENCES_AND_REFINEMENT_SPEC.md` plus the later owner-supersession addendum for posture-aware picks / topology / team-context mode.

**Required reconciliation:** `docs/MASTER_PRODUCT_PLAN.md`, `docs/OWNER_FEATURE_INVENTORY.md`, `docs/OWNER_PRODUCT_BACKLOG_SPEC.md`, the dedicated trade-generation specs, and the C-series zero-loss ledger must all reflect #841/#842 so no active record retains `no draft picks`, exact-equal-player-count, or always-team-context assumptions as current policy.

The parallel owner master discussion ledger on PR #816 must carry the same supersessions. This records approved scope without changing current implementation sequencing/authorization.