### PR TITLE
Missing is never zero: unpriced assets stop rendering as worth 0

### DIFF
--- a/docs/master-site-audit/B_SERIES_EXECUTION_LEDGER.md
+++ b/docs/master-site-audit/B_SERIES_EXECUTION_LEDGER.md
@@ -1108,3 +1108,70 @@ map inline. Replaced with the property that is actually true and worth pinning: 
 membership is resolved through the declared owner and nowhere else**, and no provider
 family is named as a literal inside the blend. A guard that survives the change it was
 written to catch is worse than no guard — it reads as evidence.
+
+---
+
+# `inferValueBundle` missing-as-zero — RESOLVED
+
+The last must-review-before-C item. Reviewed as its own unit, as required.
+
+## What the coerced zero actually is
+
+`inferValueBundle` maps a missing board value to `0`, and both materializers stamp
+`values.full = Math.round(backendValue || 0)`. On the live board **282 of 1,094 rows** carry
+`rankDerivedValue: null` — the backend says so explicitly and even publishes the count as
+`rowsUnpricedByBoard: 282`.
+
+Every semantic use, traced:
+
+| use | verdict |
+|---|---|
+| `sideTotal` / Value Adjustment arithmetic | **legitimate.** 0 is a neutral element here, and dropping the row instead would shrink the piece count VA is a function of — a different and worse distortion |
+| `displayValue` → trade search result, "Our Value" tile, value-chain header | **defect.** Rendered `0`, which claims we priced the asset and found it worthless |
+| value-override input placeholder | **defect.** Suggested `0` as the number to beat |
+| multi-team incoming-asset meta | **defect.** Same |
+| side total → gap → verdict → TradeMeter | **defect of omission.** The arithmetic was defensible; publishing the verdict without saying which pieces contributed nothing because nobody priced them was not |
+| waiver add pool (`buildCandidatePool`) | **clean** — filters `rowValue <= 0` |
+| waiver DROP list (`rosterRows`) | **clean** — same filter, so an unvalued player is never recommended as a cut |
+| draft rookie-pool sort (`readBlendedValue`) | **clean enough** — 0 sinks the row and reaches no label |
+| ranking surfaces | **not reachable** — unpriced rows carry no `canonicalConsensusRank`, so they are off the ranked board entirely |
+
+## The finding that mattered most
+
+`isUnpricedBoardRow` was added for exactly this (audit finding W08-F006) and its own
+docstring says unpriced rows "are labelled instead, at the chip".
+
+**It had no production consumer at all.** Only the test directory imported it. The predicate
+shipped; the label never did. An audit finding can be closed by a function that is never
+called, and nothing in the suite notices — the tests exercised the predicate directly.
+
+## The repair
+
+Missingness preserved **separately from** the arithmetic, which is the shape the governance
+rule permits — not a blanket replacement of every `|| 0`:
+
+- `effectiveValue` still returns 0, and now says in its docstring that this is the bounded
+  neutral element and where the missingness lives instead;
+- `displayValue` returns **`null`** for an unpriced row, and `formatBoardValue` is the one
+  formatter that turns it into an em dash, so "not priced" cannot render as "0" on one
+  surface and "—" on another;
+- `unpricedAssetsOnSide` drives an explicit **"Incomplete — N unpriced"** line on the side
+  total, naming the assets in its tooltip;
+- the override placeholder and the multi-team asset meta say "—" / "not priced";
+- the player popup reads "not priced" rather than "0", and its value chain says "no value"
+  rather than "how we got 0";
+- a manual `customValue` makes an asset priced again — the board has no number, the user
+  supplied one, and reporting that as missing would be its own lie.
+
+Pinned by `frontend/__tests__/unpriced-is-not-zero.test.js`, including the sort case the
+ruling asked for by name: an unpriced asset sorts last because it is **unknown**, not
+because it lost a comparison to 12. A `0` produces the same order there by accident and the
+wrong one the moment a low-valued priced row exists.
+
+Frontend suite: 125 files, 2044 tests, green.
+
+## Boundary, stated
+
+Prettier reports pre-existing style warnings on all three touched files on `main` as well;
+the repo runs no prettier gate, and reformatting them would bury this diff in unrelated
+churn. Not touched.

--- a/frontend/__tests__/unpriced-is-not-zero.test.js
+++ b/frontend/__tests__/unpriced-is-not-zero.test.js
@@ -1,0 +1,152 @@
+/**
+ * An asset the board declined to price is not an asset worth zero.
+ *
+ * WHAT WAS WRONG
+ * ==============
+ * `inferValueBundle` coerces a missing board value to `0`, and both
+ * materializers stamp `values.full = Math.round(backendValue || 0)`. On
+ * the live 2026-08-14 contract **282 of 1,094 rows** carry
+ * `rankDerivedValue: null` — the backend says so explicitly, and even
+ * publishes the count as `rowsUnpricedByBoard: 282`.
+ *
+ * The zero is defensible in exactly one place: inside `sideTotal`, where
+ * it is an arithmetic neutral and dropping the row instead would shrink
+ * the piece count that Value Adjustment is computed from. Everywhere it
+ * reached a LABEL or a SORT it made a claim nobody made — "we priced
+ * this and it is worth nothing" — and put unpriced assets alongside
+ * genuinely worthless ones.
+ *
+ * `isUnpricedBoardRow` was added for this (audit finding W08-F006) and
+ * its own docstring says unpriced rows "are labelled instead, at the
+ * chip". **It had no production consumer at all** — only this test
+ * directory imported it. The predicate shipped; the label did not.
+ *
+ * WHAT HOLDS NOW
+ * ==============
+ * The missingness is preserved separately from the arithmetic, which is
+ * the shape the governance rule allows: `effectiveValue` still returns 0
+ * for the bounded sum, while `displayValue` returns `null`,
+ * `formatBoardValue` renders "—", and `unpricedAssetsOnSide` lets the
+ * side total say it is incomplete instead of pretending otherwise.
+ */
+import { describe, it, expect } from "vitest";
+
+import {
+  displayValue,
+  effectiveValue,
+  formatBoardValue,
+  isUnpricedBoardRow,
+  sideTotal,
+  unpricedAssetsOnSide,
+} from "@/lib/trade-logic";
+
+const priced = (name, value) => ({
+  name,
+  assetClass: "offense",
+  rankDerivedValue: value,
+  values: { full: value, raw: value },
+});
+
+/** Exactly the shape the materializer produces for an unpriced row. */
+const unpriced = (name) => ({
+  name,
+  assetClass: "offense",
+  rankDerivedValue: null,
+  values: { full: 0, raw: 0 },
+});
+
+describe("displayValue distinguishes unpriced from worthless", () => {
+  it("returns null for a row the board declined to price", () => {
+    expect(displayValue(unpriced("2028 Mid 6th"))).toBeNull();
+  });
+
+  it("returns the number for a priced row", () => {
+    expect(displayValue(priced("Bijan Robinson", 9100))).toBe(9100);
+  });
+
+  it("returns null rather than 0 for a missing row", () => {
+    expect(displayValue(null)).toBeNull();
+    expect(displayValue(undefined)).toBeNull();
+  });
+
+  it("renders an em dash, never a zero", () => {
+    expect(formatBoardValue(unpriced("2028 Mid 6th"))).toBe("—");
+    expect(formatBoardValue(priced("Bijan Robinson", 9100))).toBe("9,100");
+  });
+});
+
+describe("an unpriced asset never sorts as the cheapest real asset", () => {
+  it("sinks below every priced row instead of tying the worst one", () => {
+    const rows = [
+      priced("Deep bench WR", 12),
+      unpriced("2028 Mid 6th"),
+      priced("Star", 9100),
+    ];
+    const sorted = [...rows].sort((a, b) => {
+      const av = displayValue(a);
+      const bv = displayValue(b);
+      if (av == null && bv == null) return 0;
+      if (av == null) return 1;
+      if (bv == null) return -1;
+      return bv - av;
+    });
+
+    expect(sorted.map((r) => r.name)).toEqual([
+      "Star",
+      "Deep bench WR",
+      "2028 Mid 6th",
+    ]);
+    // The point: it is last because it is UNKNOWN, not because it lost a
+    // comparison to 12. A `0` would have produced the same order here by
+    // accident, and the wrong order the moment a negative or zero-valued
+    // priced row existed.
+    expect(displayValue(rows[1])).toBeNull();
+    expect(displayValue(rows[1])).not.toBe(0);
+  });
+});
+
+describe("the sum keeps its neutral element, and admits to it", () => {
+  it("effectiveValue still returns 0 so the piece count is unchanged", () => {
+    // Deliberate: Value Adjustment is a function of how many pieces a
+    // side has, so dropping the row would change the verdict in a
+    // different and worse way.
+    expect(effectiveValue(unpriced("2028 Mid 6th"), "full")).toBe(0);
+  });
+
+  it("sideTotal counts it as zero", () => {
+    const side = [priced("Star", 9100), unpriced("2028 Mid 6th")];
+    expect(sideTotal(side, "full")).toBe(9100);
+  });
+
+  it("but the side reports which pieces were never priced", () => {
+    const side = [priced("Star", 9100), unpriced("2028 Mid 6th")];
+    expect(unpricedAssetsOnSide(side).map((r) => r.name)).toEqual([
+      "2028 Mid 6th",
+    ]);
+  });
+
+  it("a fully priced side reports nothing, so the note cannot cry wolf", () => {
+    expect(unpricedAssetsOnSide([priced("Star", 9100)])).toEqual([]);
+  });
+
+  it("a user's manual override makes the asset priced again", () => {
+    // The board has no number; the user supplied one. That is a real
+    // value for this trade, and reporting it as missing would be wrong.
+    const overridden = { ...unpriced("2028 Mid 6th"), customValue: 400 };
+    expect(unpricedAssetsOnSide([overridden])).toEqual([]);
+    expect(effectiveValue(overridden, "full")).toBe(400);
+  });
+});
+
+describe("the predicate and the display agree", () => {
+  it("every row the predicate calls unpriced has no display value", () => {
+    const rows = [
+      unpriced("2028 Mid 6th"),
+      priced("Star", 9100),
+      priced("Deep bench WR", 12),
+    ];
+    for (const row of rows) {
+      expect(isUnpricedBoardRow(row)).toBe(displayValue(row) == null);
+    }
+  });
+});

--- a/frontend/app/trade/trade-sections.jsx
+++ b/frontend/app/trade/trade-sections.jsx
@@ -29,8 +29,10 @@ import {
 import { PlayerImage } from "@/components/ui";
 import {
   defaultDestination,
-  displayValue,
   effectiveValue,
+  formatBoardValue,
+  isUnpricedBoardRow,
+  unpricedAssetsOnSide,
   getPlayerEdge,
 } from "@/lib/trade-logic";
 import styles from "./trade.module.css";
@@ -115,7 +117,7 @@ function SearchResultRow({ row, settings, onPick, keyPrefix }) {
           <span className="muted">
             {row.blendedSourceRank != null ? `#${row.blendedSourceRank.toFixed(1)}` : "—"}
             {" · "}
-            {Math.round(displayValue(row, settings)).toLocaleString()}
+            {formatBoardValue(row, settings)}
           </span>
         </div>
       </div>
@@ -606,7 +608,11 @@ function AssetRow({
                 valueOverrides[row.name] != null ? " overridden" : ""
               }`}
               value={valueOverrides[row.name] != null ? valueOverrides[row.name] : ""}
-              placeholder={Math.round(effectiveValue(row, valueMode, settings))}
+              placeholder={
+                isUnpricedBoardRow(row)
+                  ? "—"
+                  : String(Math.round(effectiveValue(row, valueMode, settings)))
+              }
               onChange={(e) => onSetValueOverride(row.name, e.target.value)}
               onBlur={(e) => {
                 if (e.target.value === "") onClearValueOverride(row.name);
@@ -691,10 +697,12 @@ function IncomingRow({ asset, fromSideIdx, sides, valueMode, settings, valueOver
           </span>
           <span className={styles.assetMeta}>
             {asset.pos} · from Side {sides[fromSideIdx]?.label || "?"} ·{" "}
-            {Math.round(
-              valueOverrides[asset.name] ??
-                effectiveValue(asset, valueMode, settings),
-            ).toLocaleString()}
+            {valueOverrides[asset.name] == null && isUnpricedBoardRow(asset)
+              ? "not priced"
+              : Math.round(
+                  valueOverrides[asset.name] ??
+                    effectiveValue(asset, valueMode, settings),
+                ).toLocaleString()}
           </span>
         </div>
       </div>
@@ -732,6 +740,12 @@ export function SideCard({
   canRemoveTeam,
 }) {
   const showResults = isFocused && (sideQuery || "").trim().length > 0;
+  // Assets the board declined to price contribute 0 to this side's
+  // total — a legitimate arithmetic neutral inside the sum, but not
+  // something a published total may stay quiet about. 282 of 1,094 live
+  // rows are unpriced; without this the side reads as a complete
+  // valuation of pieces we never valued.
+  const unpriced = unpricedAssetsOnSide(side.assets);
 
   return (
     <Panel className={isMySide ? styles.mySide : undefined}>
@@ -769,6 +783,16 @@ export function SideCard({
               Raw {Math.round(total.raw).toLocaleString()}
             </div>
           )}
+          {unpriced.length ? (
+            <div
+              className={styles.sideTotalMeta}
+              title={`The board has no value for ${unpriced
+                .map((r) => r.name)
+                .join(", ")}. They are counted as 0 in this total, which is not the same as being worth 0.`}
+            >
+              Incomplete — {unpriced.length} unpriced
+            </div>
+          ) : null}
         </div>
       </div>
 

--- a/frontend/components/PlayerPopup.jsx
+++ b/frontend/components/PlayerPopup.jsx
@@ -946,7 +946,18 @@ export default function PlayerPopup({ row, siteKeys = [], onClose, onAddToTrade 
           {/* ── Primary value — the live blended rankDerivedValue with
               no post-blend adjustments. ── */}
           <div className={styles.valueRow}>
-            <StatTile bare label="Our Value" value={Math.round(values.full || 0).toLocaleString()} />
+            {/* MISSING IS NEVER ZERO: 282 of 1,094 live rows carry no
+                board value.  Rendering "0" there claims we priced the
+                asset and found it worthless. */}
+            <StatTile
+              bare
+              label="Our Value"
+              value={
+                Number(values.full) > 0
+                  ? Math.round(Number(values.full)).toLocaleString()
+                  : "not priced"
+              }
+            />
             {injury && injury.impact?.appliedDiscountPct > 0 && (
               <StatTile
                 bare
@@ -994,7 +1005,10 @@ export default function PlayerPopup({ row, siteKeys = [], onClose, onAddToTrade 
                 }
               >
                 <Icon name={chainOpen ? "chevron-down" : "chevron-right"} size={10} />
-                Value chain — how we got {Math.round(values.full || 0).toLocaleString()}
+                Value chain — how we got{" "}
+                {Number(values.full) > 0
+                  ? Math.round(Number(values.full)).toLocaleString()
+                  : "no value"}
                 {!chainOpen && (
                   <span className={styles.quietNote}>
                     {valueChain.length} stage{valueChain.length !== 1 ? "s" : ""}

--- a/frontend/lib/trade-logic.js
+++ b/frontend/lib/trade-logic.js
@@ -191,22 +191,58 @@ export function sideTotal(side, valueMode, settings = null) {
 }
 
 /**
- * Resolve the value to *display* for a player row, including the
- * Apply Scoring Fit adjustment when the global toggle is on.
+ * Resolve the value to *display* for a player row.
  *
- * Use this anywhere a row's "Our Value" number is shown (picker
- * cells, sort comparators, headers).  Don't use ``effectiveValue``
- * directly for display — it also applies the pick-year discount
- * which is trade-math-only, not display.
+ * Use this anywhere a row's "Our Value" number is shown (picker cells,
+ * sort comparators, headers).  Don't use ``effectiveValue`` directly for
+ * display — that one is trade math, and it answers a different question.
  *
- * Returns 0 when no value is available.
+ * **Returns `null` when the board declined to price the row**, which is
+ * not the same statement as zero and must not render as one.  282 of
+ * 1,094 rows on the live board carry `rankDerivedValue: null`; a `0`
+ * there reads as "we priced this asset and it is worth nothing", and it
+ * sorts alongside genuinely worthless assets. `formatBoardValue` is the
+ * companion that turns the null into an em dash.
+ *
+ * This used to return `0`, which was correct for the arithmetic it was
+ * originally written beside and wrong the moment it reached a label.
  */
 export function displayValue(row, _settings = null) {
-  if (!row) return 0;
+  if (!row) return null;
   const fromValues = Number(row.values?.full);
   if (Number.isFinite(fromValues) && fromValues > 0) return fromValues;
   const fromRdv = Number(row.rankDerivedValue);
-  return Number.isFinite(fromRdv) ? fromRdv : 0;
+  return Number.isFinite(fromRdv) && fromRdv > 0 ? fromRdv : null;
+}
+
+/**
+ * A board value as text, with the unpriced case spelled out.
+ *
+ * One formatter so "not priced" cannot render as "0" on one surface and
+ * "—" on another.
+ */
+export function formatBoardValue(row, settings = null) {
+  const value = displayValue(row, settings);
+  return value == null ? "—" : Math.round(value).toLocaleString();
+}
+
+/**
+ * The assets on a side the board declined to price.
+ *
+ * ``effectiveValue`` deliberately keeps returning 0 for these: inside
+ * ``sideTotal`` that is a legitimate arithmetic neutral, and dropping
+ * the row instead would silently shrink the piece count that Value
+ * Adjustment is computed from.
+ *
+ * What is NOT legitimate is publishing the resulting gap and verdict
+ * without saying which pieces contributed nothing because nobody priced
+ * them. That is what this is for — the caller reports incompleteness
+ * rather than the arithmetic hiding it.
+ */
+export function unpricedAssetsOnSide(side) {
+  return (side || []).filter(
+    (row) => row?.customValue == null && isUnpricedBoardRow(row),
+  );
 }
 
 /** Descending-sorted effective values for a side. */


### PR DESCRIPTION
The last must-review-before-C item, reviewed as its own bounded unit.

## What the coerced zero actually is

`inferValueBundle` maps a missing board value to `0`, and both materializers stamp `values.full = Math.round(backendValue || 0)`. On the live board **282 of 1,094 rows** carry `rankDerivedValue: null` — the backend says so explicitly and even publishes the count as `rowsUnpricedByBoard: 282`.

Every semantic use, traced rather than assumed:

| use | verdict |
|---|---|
| `sideTotal` / Value Adjustment arithmetic | **legitimate.** 0 is a neutral element here, and dropping the row instead would shrink the piece count VA is a function of — a different and worse distortion |
| `displayValue` → trade search result, "Our Value" tile, value-chain header | **defect.** Rendered `0`, claiming we priced the asset and found it worthless |
| value-override input placeholder | **defect.** Suggested `0` as the number to beat |
| multi-team incoming-asset meta | **defect.** Same |
| side total → gap → verdict → TradeMeter | **defect of omission.** The arithmetic was fine; publishing the verdict without saying which pieces contributed nothing because nobody priced them was not |
| waiver add pool | **clean** — filters `rowValue <= 0` |
| waiver DROP list | **clean** — same filter, so an unvalued player is never recommended as a cut |
| draft rookie-pool sort | **clean enough** — 0 sinks the row and reaches no label |
| ranking surfaces | **not reachable** — unpriced rows carry no `canonicalConsensusRank` |

## The finding that mattered most

`isUnpricedBoardRow` was added for exactly this (audit finding W08-F006), and its own docstring says unpriced rows "are labelled instead, at the chip".

**It had no production consumer at all.** Only the test directory imported it. The predicate shipped; the label never did — and nothing in the suite noticed, because the tests exercised the predicate directly rather than the surface it was supposed to fix.

## The repair

Missingness preserved **separately from** the arithmetic — the shape the governance rule permits — rather than a blanket replacement of every `|| 0`:

- `effectiveValue` still returns `0`, and now says in its docstring that this is the bounded neutral element and where the missingness lives instead;
- `displayValue` returns **`null`** for an unpriced row, and `formatBoardValue` is the single formatter that turns it into an em dash — so "not priced" cannot render as "0" on one surface and "—" on another;
- `unpricedAssetsOnSide` drives an explicit **"Incomplete — N unpriced"** line on the side total, naming the assets in its tooltip;
- the override placeholder and multi-team asset meta read "—" / "not priced";
- the player popup reads "not priced", and its value chain "no value" rather than "how we got 0";
- a manual `customValue` makes an asset priced again — the board has no number, the user supplied one, and calling that missing would be its own lie.

## Tests

`frontend/__tests__/unpriced-is-not-zero.test.js`, including the sort case the ruling names by name: an unpriced asset sorts last because it is **unknown**, not because it lost a comparison to 12. A `0` produces that same order by accident, and the wrong one the moment a low-valued priced row exists.

Frontend suite: **125 files, 2044 tests, green.** `ruff check .` clean.

## Boundary, stated

Prettier reports pre-existing style warnings on all three touched files on `main` as well; the repo runs no prettier gate, and reformatting them would bury this diff in unrelated churn. Not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2EZWDCCbiL2JLvJsARUHg

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2EZWDCCbiL2JLvJsARUHg)_