### PR TITLE
C1A unit 1: the backup + restore proof the checkpoint requires

### DIFF
--- a/.github/workflows/retention-backup-proof.yml
+++ b/.github/workflows/retention-backup-proof.yml
@@ -1,0 +1,94 @@
+name: Retention backup + restore proof
+
+# C1A unit 1 requires BOTH halves, and neither could be asserted before:
+# `riskit-state-backup.sh` verifies what it writes, but nothing ever read
+# a generation back. A backup nobody has restored is a hypothesis, and
+# log text saying a backup command ran is not evidence the artifact is
+# in it.
+#
+# This runs the REAL production backup, then restores the retained
+# artifacts into a throwaway directory and verifies them —
+# PRAGMA integrity_check on each SQLite copy, schema and row counts,
+# archive listings, JSONL parse.
+#
+# The rule that makes it meaningful: an artifact that EXISTS on the
+# source and is ABSENT from the backup FAILS the run; an artifact whose
+# stream has legitimately not started is reported and does not. So a
+# not-yet-provisioned stream cannot make this red, and a provisioned one
+# cannot be quietly left out of the backup.
+#
+# It NEVER touches live state: restore goes to mktemp, no path under
+# DATA_DIR is written, and the backend is not stopped.
+#
+# PRIVACY: `league_events.sqlite` holds our own leagues' real trades and
+# is proven by schema, counts and schema_version only. No payload,
+# manager name or roster reaches this log.
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_backup:
+        description: >-
+          Run the production backup before verifying (default true).
+          Set false to verify the newest existing generation only.
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  # Its own group. Not `production-deploy`: GitHub keeps only the newest
+  # PENDING run per group, so sharing it would let a queued deploy cancel
+  # this proof into silence — the same failure the retention watchdog
+  # was corrected for.
+  group: retention-backup-proof
+  cancel-in-progress: false
+
+jobs:
+  prove:
+    name: Backup, restore, verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Configure production SSH
+        env:
+          DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          install -d -m 700 "$HOME/.ssh"
+          printf '%s\n' "$DEPLOY_SSH_PRIVATE_KEY" | sed 's/\r$//' > "$HOME/.ssh/id_ed25519"
+          printf '%s\n' "$DEPLOY_KNOWN_HOSTS" | sed 's/\r$//' > "$HOME/.ssh/known_hosts"
+          chmod 600 "$HOME/.ssh/id_ed25519"
+          chmod 644 "$HOME/.ssh/known_hosts"
+          ssh-keygen -y -f "$HOME/.ssh/id_ed25519" >/dev/null
+          echo "PORT=${DEPLOY_PORT:-22}" >> "$GITHUB_ENV"
+
+      - name: Run backup and prove restore on production
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          APP_DIR: ${{ vars.PROD_APP_DIR || '/home/dynasty/trade-calculator' }}
+          PYTHON_BIN: ${{ vars.PROD_PYTHON_BIN || '/home/dynasty/.venvs/trade-calculator/bin/python' }}
+          RUN_BACKUP: ${{ inputs.run_backup == false && '0' || '1' }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          # The remote exit status is this step's exit status — no
+          # `|| true`, no masking pipe. A proof that reports success
+          # while asserting nothing is the failure being repaired.
+          ssh -i "$HOME/.ssh/id_ed25519" \
+            -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+            -o ConnectTimeout=15 -o ServerAliveInterval=15 \
+            -p "$PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "APP_DIR=$(printf %q "$APP_DIR") PYTHON_BIN=$(printf %q "$PYTHON_BIN") RUN_BACKUP=$(printf %q "$RUN_BACKUP") bash -s" \
+            < deploy/diagnostics/retention_backup_restore_proof.sh

--- a/deploy/diagnostics/retention_backup_restore_proof.sh
+++ b/deploy/diagnostics/retention_backup_restore_proof.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+#
+# retention_backup_restore_proof.sh — run the real production backup,
+# then RESTORE the retained artifacts into a throwaway directory and
+# verify them.
+#
+# C1A unit 1 requires backup AND restore proof, and this exists because
+# neither could be asserted before: `riskit-state-backup.sh` verifies
+# what it writes, but nothing ever read a generation back, and a backup
+# nobody has restored is a hypothesis.  Log text saying a backup command
+# ran is not evidence the artifact is in it.
+#
+# WHAT IT PROVES, AND WHAT IT REFUSES TO CLAIM
+# ─────────────────────────────────────────────
+# For each retained artifact the rule is the same and it is the point of
+# the script: **an artifact that exists on the source and is ABSENT from
+# the backup is a FAILURE; an artifact that does not exist yet is
+# reported and is not.**  A retention stream that has legitimately not
+# started cannot make this red, and a stream that HAS started cannot be
+# quietly left out of the backup.
+#
+# Restore goes to a temp directory. It NEVER touches live state — no
+# path under $DATA_DIR is written, and the backend is not stopped.
+#
+# PRIVACY
+# ───────
+# `league_events.sqlite` holds our own leagues' real trades. It is
+# proven by SCHEMA, COUNTS and ID SHAPE only. No payload, no manager
+# name, no roster is printed — this output goes to a CI log.
+#
+# Inputs (environment):
+#   APP_DIR      deployed app tree
+#   DATA_DIR     live data dir (READ ONLY here)
+#   BACKUP_ROOT  where riskit-state-backup.sh writes
+#   PYTHON_BIN   venv interpreter (sqlite3 CLI is not on the box)
+#   RUN_BACKUP   "1" (default) to run the backup first; "0" to verify
+#                the newest existing generation only
+#
+# Exit codes: 0 proven · 1 could not run · 2 an artifact that exists on
+# the source is missing from the backup, or a restored artifact failed
+# verification.
+
+set -Eeuo pipefail
+
+APP_DIR="${APP_DIR:-/home/dynasty/trade-calculator}"
+DATA_DIR="${DATA_DIR:-${APP_DIR}/data}"
+BACKUP_ROOT="${BACKUP_ROOT:-/var/backups/riskit-state}"
+PYTHON_BIN="${PYTHON_BIN:-/home/dynasty/.venvs/trade-calculator/bin/python}"
+RUN_BACKUP="${RUN_BACKUP:-1}"
+
+log()  { printf '[backup-proof] %s\n' "$*"; }
+warn() { printf '[backup-proof][WARN] %s\n' "$*" >&2; }
+fail() { printf '[backup-proof][ERROR] %s\n' "$*" >&2; exit 1; }
+
+FAILURES=0
+note_fail() { printf '[backup-proof][FAIL] %s\n' "$*" >&2; FAILURES=$((FAILURES + 1)); }
+
+[[ -d "${APP_DIR}" ]] || fail "app dir not found: ${APP_DIR}"
+[[ -x "${PYTHON_BIN}" ]] || PYTHON_BIN="$(command -v python3 || true)"
+[[ -x "${PYTHON_BIN}" ]] || fail "no usable python interpreter"
+
+# ── 1. Run the real backup ───────────────────────────────────────────
+if [[ "${RUN_BACKUP}" == "1" ]]; then
+    BACKUP_SCRIPT="${APP_DIR}/deploy/backup/riskit-state-backup.sh"
+    [[ -f "${BACKUP_SCRIPT}" ]] || fail "backup script absent on the deployed revision: ${BACKUP_SCRIPT}"
+    log "running production backup: ${BACKUP_SCRIPT}"
+    if ! APP_DIR="${APP_DIR}" DATA_DIR="${DATA_DIR}" BACKUP_ROOT="${BACKUP_ROOT}" \
+         PYTHON_BIN="${PYTHON_BIN}" bash "${BACKUP_SCRIPT}"; then
+        fail "backup run FAILED"
+    fi
+else
+    log "RUN_BACKUP=0 — verifying the newest existing generation only"
+fi
+
+# ── 2. Locate the generation we are proving ──────────────────────────
+GEN="$(ls -1d "${BACKUP_ROOT}/daily"/20* 2>/dev/null | sort | tail -n1 || true)"
+[[ -n "${GEN}" && -d "${GEN}" ]] || fail "no backup generation under ${BACKUP_ROOT}/daily"
+log "proving generation: ${GEN}"
+log "generation size: $(du -sh "${GEN}" 2>/dev/null | cut -f1)"
+
+RESTORE_DIR="$(mktemp -d /tmp/retention-restore-XXXXXX)"
+trap 'rm -rf "${RESTORE_DIR}"' EXIT
+log "restore target (throwaway): ${RESTORE_DIR}"
+
+# ── SQLite: restore, integrity-check, read schema + counts ───────────
+# $1 source path under DATA_DIR · $2 basename in the backup · $3 label
+# $4.. tables whose row counts to report
+prove_sqlite() {
+    local src="$1" name="$2" label="$3"; shift 3
+    local gz="${GEN}/sqlite/${name}.gz"
+
+    if [[ ! -f "${src}" ]]; then
+        if [[ -f "${gz}" ]]; then
+            log "${label}: source absent, backup present (older generation) — ok"
+        else
+            log "${label}: SOURCE ABSENT, not backed up — stream has not started (not a failure)"
+        fi
+        return 0
+    fi
+    if [[ ! -f "${gz}" ]]; then
+        note_fail "${label}: EXISTS at ${src} but is MISSING from the backup (${gz})"
+        return 0
+    fi
+
+    local out="${RESTORE_DIR}/${name}"
+    if ! gunzip -c "${gz}" > "${out}"; then
+        note_fail "${label}: gunzip failed"
+        return 0
+    fi
+    log "${label}: restored $(stat -c%s "${out}" 2>/dev/null || echo '?') bytes from $(stat -c%s "${gz}" 2>/dev/null || echo '?') compressed"
+
+    if ! "${PYTHON_BIN}" - "${out}" "${label}" "$@" <<'PY'
+import sqlite3, sys
+path, label = sys.argv[1], sys.argv[2]
+tables = sys.argv[3:]
+con = sqlite3.connect(path)
+try:
+    rows = [str(r[0]) for r in con.execute("PRAGMA integrity_check")]
+    if rows != ["ok"]:
+        print(f"[backup-proof][FAIL] {label}: integrity_check -> {rows}", file=sys.stderr)
+        sys.exit(1)
+    print(f"[backup-proof] {label}: PRAGMA integrity_check = ok")
+    present = {r[0] for r in con.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'")}
+    print(f"[backup-proof] {label}: schema tables = {sorted(present)}")
+    try:
+        ver = con.execute("SELECT value FROM meta WHERE key='schema_version'").fetchone()
+        print(f"[backup-proof] {label}: schema_version = {ver[0] if ver else 'absent'}")
+    except sqlite3.Error:
+        pass
+    missing = [t for t in tables if t not in present]
+    if missing:
+        print(f"[backup-proof][FAIL] {label}: expected table(s) missing: {missing}", file=sys.stderr)
+        sys.exit(1)
+    for t in tables:
+        n = con.execute(f"SELECT COUNT(*) FROM {t}").fetchone()[0]
+        print(f"[backup-proof] {label}: {t} rows = {n}")
+finally:
+    con.close()
+PY
+    then
+        note_fail "${label}: restored database failed verification"
+    fi
+}
+
+# ── Plain file (gzipped) ─────────────────────────────────────────────
+prove_file() {
+    local src="$1" name="$2" label="$3"
+    local gz="${GEN}/files/${name}.gz"
+
+    if [[ ! -f "${src}" ]]; then
+        log "${label}: SOURCE ABSENT, not backed up — stream has not started (not a failure)"
+        return 0
+    fi
+    if [[ ! -f "${gz}" ]]; then
+        note_fail "${label}: EXISTS at ${src} but is MISSING from the backup (${gz})"
+        return 0
+    fi
+    if ! gzip -t "${gz}"; then
+        note_fail "${label}: gzip integrity check failed"
+        return 0
+    fi
+    local out="${RESTORE_DIR}/${name}"
+    gunzip -c "${gz}" > "${out}"
+    local lines
+    lines="$(wc -l < "${out}" | tr -d ' ')"
+    log "${label}: restored, gzip -t ok, ${lines} line(s)"
+    # JSONL: prove it parses rather than merely existing.
+    if [[ "${name}" == *.jsonl ]]; then
+        if ! "${PYTHON_BIN}" - "${out}" "${label}" <<'PY'
+import json, sys
+path, label = sys.argv[1], sys.argv[2]
+good = bad = 0
+with open(path, encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            json.loads(line); good += 1
+        except ValueError:
+            bad += 1
+print(f"[backup-proof] {label}: {good} parseable record(s), {bad} unparseable")
+# A trailing torn line is tolerable (append-only log); wholesale
+# corruption is not.
+sys.exit(1 if bad > 1 else 0)
+PY
+        then
+            note_fail "${label}: restored JSONL did not parse"
+        fi
+    fi
+}
+
+# ── Directory (tar.gz) ───────────────────────────────────────────────
+prove_dir() {
+    local src="$1" name="$2" label="$3"
+    local tgz="${GEN}/dirs/${name}.tar.gz"
+
+    if [[ ! -d "${src}" ]]; then
+        log "${label}: SOURCE ABSENT, not backed up — stream has not started (not a failure)"
+        return 0
+    fi
+    if [[ ! -f "${tgz}" ]]; then
+        note_fail "${label}: EXISTS at ${src} but is MISSING from the backup (${tgz})"
+        return 0
+    fi
+    if ! tar -tzf "${tgz}" >/dev/null; then
+        note_fail "${label}: tar integrity check failed"
+        return 0
+    fi
+    local entries src_entries
+    entries="$(tar -tzf "${tgz}" | grep -cv '/$' || true)"
+    src_entries="$(find "${src}" -type f | wc -l | tr -d ' ')"
+    mkdir -p "${RESTORE_DIR}/${name}"
+    tar -xzf "${tgz}" -C "${RESTORE_DIR}/${name}"
+    local restored
+    restored="$(find "${RESTORE_DIR}/${name}" -type f | wc -l | tr -d ' ')"
+    log "${label}: restored ${restored} file(s) (archive listed ${entries}, source holds ${src_entries})"
+    if [[ "${restored}" -eq 0 && "${src_entries}" -gt 0 ]]; then
+        note_fail "${label}: source has ${src_entries} file(s) but the restore produced none"
+    fi
+}
+
+log "── retention artifacts ──────────────────────────────────────────"
+
+prove_sqlite "${DATA_DIR}/retention/evidence.sqlite" "evidence.sqlite" \
+    "C1-RET-04/05 evidence.sqlite" scoring_card_observations scoring_card_payloads trending_observations
+
+# PRIVATE. Schema + counts only; the loop above prints no payload column.
+prove_sqlite "${DATA_DIR}/retention/league_events.sqlite" "league_events.sqlite" \
+    "C1-RET-06 league_events.sqlite (PRIVATE)" league_transactions
+
+prove_sqlite "${DATA_DIR}/board_history.sqlite" "board_history.sqlite" \
+    "C1-RET-02 board_history.sqlite" board_history
+
+prove_file "${DATA_DIR}/rank_history.jsonl" "rank_history.jsonl" "C1-RET-03 rank_history.jsonl"
+
+prove_dir "${DATA_DIR}/faab"              "faab"              "C1-RET-01 faab/"
+prove_dir "${DATA_DIR}/identity"          "identity"          "C1-RET-07 identity/"
+prove_dir "${DATA_DIR}/playerctx/history" "playerctx_history" "C1-RET-08 playerctx history/"
+
+log "─────────────────────────────────────────────────────────────────"
+if (( FAILURES > 0 )); then
+    warn "${FAILURES} artifact(s) failed backup/restore proof"
+    exit 2
+fi
+log "backup + restore proven for every artifact that exists"
+exit 0


### PR DESCRIPTION
Still C1A unit 1. #847 landed the retention substrate and its backup coverage; the production checkpoint additionally requires **backup AND restore proven**, and no dispatchable mechanism existed to do it.

`riskit-state-backup.sh` verifies what it *writes* (`gzip -t`, `tar -tzf`, `PRAGMA integrity_check`, and it discards a partial snapshot rather than promoting it). But **nothing has ever read a generation back**, and a backup nobody has restored is a hypothesis. Log text saying a backup command ran is not evidence the artifact is in it.

## What it does

Runs the **real** production backup, then restores each retained artifact into a `mktemp` directory and verifies it:

| artifact kind | proof |
|---|---|
| SQLite | `PRAGMA integrity_check` on the restored copy, schema tables present, `schema_version`, row counts per expected table |
| JSONL | `gzip -t`, restore, line count, per-record JSON parse (one torn trailing line tolerated — it is an append-only log; wholesale corruption is not) |
| directories | `tar -tzf`, extract, restored-file count compared against the source |

## The rule that makes it a proof

> An artifact that **exists on the source** and is **absent from the backup** fails the run (exit 2). An artifact whose stream has legitimately **not started** is reported and does not.

Both halves matter. A stream nobody has provisioned yet cannot make this permanently red — that is how a check stops being read. And a stream that *is* running cannot be quietly left out of the backup, which is exactly the state `C1-RET-01` was in before #847: a working accumulator absent from a backup script whose own header claimed to cover "all irreplaceable production state".

## Safety

- **Never touches live state.** Restore goes to `mktemp`; nothing under `DATA_DIR` is written; the backend is not stopped.
- **Privacy.** `league_events.sqlite` holds our own leagues' real trades. It is proven by **schema, counts and `schema_version` only** — no payload, manager name or roster reaches the CI log.
- **Its own concurrency group**, not `production-deploy`: GitHub keeps only the newest *pending* run per group, so sharing it would let a queued deploy cancel the proof into silence — the same failure the retention watchdog was corrected for in #847.
- The remote exit status is the step's exit status. No `|| true`, no masking pipe.

## Scope

Two new files, no existing file changed, no code path touched. Nothing beyond C1A unit 1: this is the evidence half of the tranche already authorized, not new product scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2N5BKwWpfGRK2AkuF5Xup

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2N5BKwWpfGRK2AkuF5Xup)_