### PR TITLE
C1A unit 1: fix the backup defect the first real proof run caught

### DIFF
--- a/deploy/backup/riskit-state-backup.sh
+++ b/deploy/backup/riskit-state-backup.sh
@@ -248,17 +248,42 @@ backup_file() {
 # ── Directories (tar.gz, guarded) ────────────────────────────────────
 backup_dir() {
     local src="$1"
-    # Optional archive label.  Needed where basename alone is ambiguous
-    # on restore: data/playerctx/history would land as "history.tar.gz".
-    local name="${2:-}"
-    [[ -n "${name}" ]] || name="$(basename "${src}")"
+    # The MEMBER tar archives is always the real directory name; the
+    # optional second argument only renames the OUTPUT file, for cases
+    # where basename alone is ambiguous on restore (data/playerctx/history
+    # would otherwise land as "history.tar.gz").
+    #
+    # These were conflated when the label was added, and the first real
+    # backup-proof run caught it: tar was asked for a member called
+    # "playerctx_history" inside data/playerctx/, which does not exist, so
+    # the archive failed and — because the run counts that as an error —
+    # the WHOLE nightly generation was discarded.
+    local member
+    member="$(basename "${src}")"
+    local name="${2:-${member}}"
     if [[ ! -d "${src}" ]]; then
         log "skip dir (absent): ${src}"
         return 0
     fi
     local out="${DEST}/dirs/${name}.tar.gz"
-    if ! tar -czf "${out}" -C "$(dirname "${src}")" "${name}"; then
-        warn "tar FAILED: ${src}"
+
+    # GNU tar exits 1 for "file changed as we read it" and 2 for a fatal
+    # error.  They are not the same event and must not be treated alike:
+    # exit 1 means the archive was WRITTEN and one member may be torn,
+    # which for a live directory (data/intel holds a SQLite WAL that the
+    # app writes continuously) is expected and routine.  Failing the run
+    # on it discards every OTHER artifact in the generation — including
+    # the retention stores this backup exists to protect — because one
+    # unrelated directory was busy.  That is a durability defect wearing
+    # the costume of strictness.
+    #
+    # Live SQLite still belongs in backup_sqlite(), which uses the online
+    # backup API and is consistent under WAL; that is exactly why the
+    # retention stores go through it and not through here.
+    local rc=0
+    tar -czf "${out}" -C "$(dirname "${src}")" "${member}" || rc=$?
+    if (( rc >= 2 )); then
+        warn "tar FAILED (rc=${rc}): ${src}"
         ERRORS=$((ERRORS + 1))
         rm -f "${out}"
         return 0
@@ -266,7 +291,11 @@ backup_dir() {
     if ! tar -tzf "${out}" >/dev/null; then
         warn "integrity check FAILED: ${out}"
         ERRORS=$((ERRORS + 1))
+        rm -f "${out}"
         return 0
+    fi
+    if (( rc == 1 )); then
+        warn "tar reported changed file(s) while reading ${src} — archive is intact but a member may be torn"
     fi
     ARTIFACTS=$((ARTIFACTS + 1))
     OK_LIST+="${name} "

--- a/tests/deploy/test_state_backup_dir_archiving.py
+++ b/tests/deploy/test_state_backup_dir_archiving.py
@@ -1,0 +1,149 @@
+"""``backup_dir`` archives the real directory, whatever the label says.
+
+Both cases here were found by the FIRST real production run of the
+backup + restore proof, and both discarded the entire nightly
+generation — every retention artifact included — because of one
+unrelated directory.
+
+The tests run the actual function out of the shipped script rather than
+re-implementing it, so a future edit to the script is what they check.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "deploy" / "backup" / "riskit-state-backup.sh"
+
+pytestmark = pytest.mark.skipif(shutil.which("bash") is None, reason="bash required")
+
+
+def _run_backup_dir(tmp_path: Path, src: Path, label: str = "") -> subprocess.CompletedProcess:
+    """Source the script's helpers and call backup_dir on one directory.
+
+    The script runs its whole backup at import, so the function is
+    extracted by sed rather than sourced wholesale — the point is to
+    exercise the SHIPPED text of ``backup_dir``, not a copy of it.
+    """
+    body = SCRIPT.read_text(encoding="utf-8")
+    start = body.index("backup_dir() {")
+    end = body.index("\n}\n", start) + len("\n}\n")
+    func = body[start:end]
+
+    dest = tmp_path / "dest"
+    (dest / "dirs").mkdir(parents=True)
+    harness = (
+        textwrap.dedent(f"""
+        set -uo pipefail
+        DEST={dest}
+        ERRORS=0
+        ARTIFACTS=0
+        OK_LIST=" "
+        log()  {{ printf '[log] %s\\n' "$*"; }}
+        warn() {{ printf '[warn] %s\\n' "$*"; }}
+    """)
+        + func
+        + f'\nbackup_dir "{src}" "{label}"\n'
+        + ('printf "ARTIFACTS=%s ERRORS=%s\\n" "$ARTIFACTS" "$ERRORS"\n')
+    )
+    return subprocess.run(["bash", "-c", harness], capture_output=True, text=True, timeout=60)
+
+
+def test_a_relabelled_directory_is_still_archived(tmp_path):
+    """THE production defect: the label was used as the tar MEMBER.
+
+    tar was asked for "playerctx_history" inside data/playerctx/, which
+    does not exist — so the archive failed, the run counted an error, and
+    the whole generation (retention stores included) was discarded.
+    """
+    src = tmp_path / "data" / "playerctx" / "history"
+    src.mkdir(parents=True)
+    (src / "snapshot_2026-08-11.json").write_text("{}", encoding="utf-8")
+
+    result = _run_backup_dir(tmp_path, src, "playerctx_history")
+
+    assert "ARTIFACTS=1 ERRORS=0" in result.stdout, result.stdout + result.stderr
+    archive = tmp_path / "dest" / "dirs" / "playerctx_history.tar.gz"
+    assert archive.exists(), "the label must name the OUTPUT file"
+
+    listing = subprocess.run(["tar", "-tzf", str(archive)], capture_output=True, text=True).stdout
+    assert "history/snapshot_2026-08-11.json" in listing, listing
+
+
+def test_an_unlabelled_directory_still_uses_its_basename(tmp_path):
+    src = tmp_path / "data" / "faab"
+    src.mkdir(parents=True)
+    (src / "crowd_history_dynasty_main.json").write_text("{}", encoding="utf-8")
+
+    result = _run_backup_dir(tmp_path, src)
+
+    assert "ARTIFACTS=1 ERRORS=0" in result.stdout, result.stdout + result.stderr
+    assert (tmp_path / "dest" / "dirs" / "faab.tar.gz").exists()
+
+
+def test_a_file_changing_mid_read_warns_but_keeps_the_generation(tmp_path):
+    """GNU tar exits 1 for "file changed as we read it" and 2 for a fatal
+    error; treating them alike discarded every OTHER artifact because one
+    live directory was busy.
+
+    Measured on production: data/intel holds a SQLite WAL the app writes
+    continuously, so this fires routinely.
+    """
+    src = tmp_path / "data" / "intel"
+    src.mkdir(parents=True)
+    big = src / "ledger.sqlite3-wal"
+    big.write_bytes(b"x" * (8 * 1024 * 1024))
+
+    body = SCRIPT.read_text(encoding="utf-8")
+    start = body.index("backup_dir() {")
+    end = body.index("\n}\n", start) + len("\n}\n")
+    func = body[start:end]
+
+    dest = tmp_path / "dest"
+    (dest / "dirs").mkdir(parents=True)
+    # Grow the file while tar reads it — the real race, not a stub.
+    harness = (
+        textwrap.dedent(f"""
+        set -uo pipefail
+        DEST={dest}
+        ERRORS=0
+        ARTIFACTS=0
+        OK_LIST=" "
+        log()  {{ printf '[log] %s\\n' "$*"; }}
+        warn() {{ printf '[warn] %s\\n' "$*"; }}
+        ( for i in $(seq 1 400); do printf 'yyyyyyyy' >> "{big}"; done ) &
+        writer=$!
+    """)
+        + func
+        + f'\nbackup_dir "{src}"\nwait $writer\n'
+        + ('printf "ARTIFACTS=%s ERRORS=%s\\n" "$ARTIFACTS" "$ERRORS"\n')
+    )
+    result = subprocess.run(["bash", "-c", harness], capture_output=True, text=True, timeout=120)
+
+    # Whether the race actually fires is timing-dependent; what must NEVER
+    # happen is an ERROR that discards the generation.
+    assert "ERRORS=0" in result.stdout, result.stdout + result.stderr
+    assert "ARTIFACTS=1" in result.stdout, result.stdout + result.stderr
+
+
+def test_the_retention_artifacts_are_in_the_backup_list():
+    """A retention store that is not in this list is not durable, which
+    is the state C1-RET-01 was in before the tranche."""
+    body = SCRIPT.read_text(encoding="utf-8")
+
+    for expected in (
+        'backup_sqlite "${DATA_DIR}/retention/evidence.sqlite"',
+        'backup_sqlite "${DATA_DIR}/retention/league_events.sqlite"',
+        'backup_sqlite "${DATA_DIR}/board_history.sqlite"',
+        'backup_file   "${DATA_DIR}/rank_history.jsonl"',
+        'backup_dir "${DATA_DIR}/faab"',
+        'backup_dir "${DATA_DIR}/identity"',
+        'backup_dir "${DATA_DIR}/playerctx/history" "playerctx_history"',
+    ):
+        assert expected in body, f"missing from the backup list: {expected}"


### PR DESCRIPTION
The backup + restore proof from #848 ran against production for the first time and **failed — correctly**. It found two defects that were each discarding the **entire nightly generation**, retention artifacts included.

Every SQLite and file artifact had already been written successfully:

```
sqlite ok: data/retention/evidence.sqlite
sqlite ok: data/retention/league_events.sqlite
sqlite ok: data/board_history.sqlite
file   ok: data/rank_history.jsonl
dir    ok: data/faab
dir    ok: data/identity
[state-backup][WARN] run FAILED (2 error(s), 14 artifact(s)) — discarding staging snapshot
```

Fourteen good artifacts thrown away because of two directories.

## 1. Mine: the label was used as the tar *member*

#847 gave `backup_dir` an optional archive label so `data/playerctx/history` would not restore as the ambiguous `history.tar.gz`. That label was then handed to tar **as the member name**, so tar was asked for a directory called `playerctx_history` inside `data/playerctx/`:

```
tar: playerctx_history: Cannot stat: No such file or directory
```

The member is now always the real basename; the label only renames the output file. Reproduced locally against both forms — old fails with the identical message, new archives `history/snapshot_*.json` into `playerctx_history.tar.gz`.

## 2. Pre-existing: a busy directory discarded everything

```
tar: intel/ledger.sqlite3-wal: file changed as we read it
```

GNU tar exits **1** for that and **2** for a fatal error. They are not the same event: exit 1 means the archive *was* written and one member may be torn. `data/intel` holds a SQLite WAL the app writes continuously, so this fires routinely — and failing on it threw away every other artifact in the generation.

**That is a durability defect wearing the costume of strictness**, and it is not introduced by the retention work — it means the nightly generation has been at risk of discard whenever `intel` was being written. Worth knowing separately from C1A.

Exit 1 now warns and keeps the artifact (still integrity-checked with `tar -tzf`); exit ≥2 still fails and removes the partial archive. Live SQLite continues to go through `backup_sqlite()`, which uses the online backup API and is consistent under WAL — precisely why the retention stores use it rather than `backup_dir`.

## Tests

`tests/deploy/test_state_backup_dir_archiving.py` extracts and runs the **shipped** `backup_dir` out of the script rather than reimplementing it, so a future edit to the script is what is checked:

- a relabelled directory is still archived, and the label names only the output
- an unlabelled directory still uses its basename
- a **real** write-while-tarring race warns but does not raise `ERRORS`
- every retention artifact is still in the backup list

## Scope

Still C1A unit 1 — this is the artifact-durability half, and the fix is exactly what the proof mechanism was built to surface. No product behaviour, no valuation path, no new scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2N5BKwWpfGRK2AkuF5Xup

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2N5BKwWpfGRK2AkuF5Xup)_