### PR TITLE
One owner for the backup root, so the restore proof reads what the writer wrote

### DIFF
--- a/deploy/apply_hardening.sh
+++ b/deploy/apply_hardening.sh
@@ -254,6 +254,7 @@ apply_app_services() {
 # user who can already edit it.
 install_priv_script() {
     local src="$1"
+    local mode="${2:-0755}"
     local dest="${RISKIT_LIB_DIR}/$(basename "$1")"
     if [[ -f "${dest}" ]] && cmp -s "${src}" "${dest}"; then
         log "up-to-date: ${dest}"
@@ -262,15 +263,19 @@ install_priv_script() {
     log "installing root-owned script: ${dest}"
     show_diff "${dest}" "${src}"
     if [[ "${DRY_RUN}" == "true" ]]; then
-        log "(dry-run) would install ${dest} (root:root 0755)"
+        log "(dry-run) would install ${dest} (root:root ${mode})"
     else
-        install -o root -g root -m 0755 -D "${src}" "${dest}"
+        install -o root -g root -m "${mode}" -D "${src}" "${dest}"
     fi
 }
 
 apply_privileged_scripts() {
     install_priv_script "${APP_DIR}/deploy/systemd/dynasty-healthcheck.sh"
     install_priv_script "${APP_DIR}/deploy/backup/riskit-state-backup.sh"
+    # riskit-state-backup.sh SOURCES this from its own directory, so the
+    # root-owned copy needs it beside it or the nightly cannot resolve a
+    # backup root at all.  Sourced, never executed: 0644, not 0755.
+    install_priv_script "${APP_DIR}/deploy/backup/backup_root_lib.sh" 0644
 }
 
 # ── 3-5. hardening units ─────────────────────────────────────────────

--- a/deploy/apply_hardening.sh
+++ b/deploy/apply_hardening.sh
@@ -271,11 +271,17 @@ install_priv_script() {
 
 apply_privileged_scripts() {
     install_priv_script "${APP_DIR}/deploy/systemd/dynasty-healthcheck.sh"
-    install_priv_script "${APP_DIR}/deploy/backup/riskit-state-backup.sh"
-    # riskit-state-backup.sh SOURCES this from its own directory, so the
-    # root-owned copy needs it beside it or the nightly cannot resolve a
-    # backup root at all.  Sourced, never executed: 0644, not 0755.
+    # LIBRARY FIRST, and the order is load-bearing.  riskit-state-backup.sh
+    # SOURCES this from its own directory and treats it as fatal when
+    # absent, so the root-owned copy needs it beside it or the nightly
+    # cannot resolve a backup root at all.  Installing the writer first
+    # would leave a window — riskit-state-backup.timer fires at 02:30 UTC —
+    # in which the new writer exists without its library and that night's
+    # state backup is simply not taken.  A library present without the new
+    # writer is harmless; the reverse is a lost generation.
+    # Sourced, never executed: 0644, not 0755.
     install_priv_script "${APP_DIR}/deploy/backup/backup_root_lib.sh" 0644
+    install_priv_script "${APP_DIR}/deploy/backup/riskit-state-backup.sh"
 }
 
 # ── 3-5. hardening units ─────────────────────────────────────────────

--- a/deploy/backup/README.md
+++ b/deploy/backup/README.md
@@ -37,15 +37,61 @@ artifact is required, it blocks promotion entirely.
 ## Layout & retention
 
 ```
-/var/backups/riskit-state/daily/YYYY-MM-DD/
-├── sqlite/    user_kv.sqlite.gz, session_store.sqlite.gz, guest_passes.sqlite.gz
-├── dirs/      public_league.tar.gz, intel.tar.gz
-└── sessions/  repo.*.json, workdir.*.json   (mode 0600)
+/var/backups/riskit-state/
+├── last_generation                        ← machine-readable pointer
+└── daily/YYYY-MM-DD/
+    ├── sqlite/    user_kv.sqlite.gz, session_store.sqlite.gz, guest_passes.sqlite.gz
+    ├── files/     rank_history.jsonl.gz
+    ├── dirs/      public_league.tar.gz, intel.tar.gz, faab.tar.gz, …
+    └── sessions/  repo.*.json, workdir.*.json   (mode 0600)
 ```
 
 Rotation keeps the newest **14** dated directories (`KEEP_DAILY`).
 Falls back to `/home/dynasty/backups/riskit-state` if `/var/backups`
 is not writable.
+
+### Where the backup actually went
+
+`BACKUP_ROOT` is what was *requested*. The effective root can be the
+fallback, so **nothing may re-derive the location** — it is resolved once,
+by `backup_root_lib.sh`, which owns the requested primary, the writability
+determination and the fallback for every caller.
+
+After a successful promotion the writer records what it did:
+
+```
+schema=1
+effective_root=/home/dynasty/backups/riskit-state
+generation=/home/dynasty/backups/riskit-state/daily/2026-08-15
+date_stamp=2026-08-15
+artifacts=14
+promoted_at=2026-08-15T02:31:07Z
+```
+
+at `<effective_root>/last_generation`, and additionally at
+`$BACKUP_RESULT_FILE` when a caller sets it. `promoted_at` is fixed-width
+ISO-8601 UTC, so string order is chronological order.
+
+`retention_backup_restore_proof.sh` reads that pointer rather than
+guessing, which is what holds the invariant *the location that received
+the promoted backup is the location the proof inspects*. Before the shared
+owner existed, the two disagreed the first time the fallback fired:
+production proof run **31872681688** reported "no backup generation under
+/var/backups/riskit-state/daily" for a backup that had succeeded in the
+fallback. Pinned by `tests/deploy/test_backup_root_resolution.py`, which
+runs both shipped scripts end to end.
+
+Log lines are for humans and are not an API — do not parse them.
+
+> **Two copies of the writer exist, deliberately.** The nightly systemd
+> job runs the root-owned copy at `/usr/local/lib/riskit/` (see the
+> security note in `riskit-state-backup.service`), which only
+> `apply_hardening.sh` updates; the backup+restore proof runs the
+> checkout copy as the deploy user. A deploy therefore updates what the
+> proof exercises but **not** what the nightly runs — re-run
+> `sudo bash deploy/apply_hardening.sh` to move a script change into the
+> nightly. The installer ships `backup_root_lib.sh` beside the root copy
+> for exactly this reason.
 
 Destructive steps run strictly last: artifacts are written into a
 hidden staging dir, integrity-checked, and only a fully validated

--- a/deploy/backup/README.md
+++ b/deploy/backup/README.md
@@ -119,6 +119,10 @@ path).  After changing the script in the repo, re-run
 ## Install
 
 ```bash
+# The sourced resolver FIRST — the writer hard-fails without it, and the
+# timer fires at 02:30 UTC, so the reverse order can cost a whole night's
+# backup. Sourced, never executed: 0644.
+sudo install -o root -g root -m 0644 -D deploy/backup/backup_root_lib.sh /usr/local/lib/riskit/backup_root_lib.sh
 # Root-owned script copy OUTSIDE the checkout (the unit executes this):
 sudo install -o root -g root -m 0755 -D deploy/backup/riskit-state-backup.sh /usr/local/lib/riskit/riskit-state-backup.sh
 sudo cp deploy/backup/riskit-state-backup.service deploy/backup/riskit-state-backup.timer /etc/systemd/system/

--- a/deploy/backup/backup_root_lib.sh
+++ b/deploy/backup/backup_root_lib.sh
@@ -221,8 +221,26 @@ backup_root_readable() {
 # future-dated one provably is not — refusing would trade a fail-open for
 # an outage.  The skip is announced, because an unannounced substitution is
 # the bug this whole file is about.
+# The accepted clock-skew bound. A writer whose clock runs slightly ahead, or a
+# proof crossing midnight UTC, legitimately produces a generation dated
+# tomorrow; that is skew and it is normal. A generation dated beyond this bound
+# is not skew — it is a WRONG CLOCK, and because this system decides recency by
+# directory name, a wrong clock means recency cannot be trusted in that root at
+# all.
+BACKUP_ROOT_FUTURE_TOLERANCE_DAYS="${BACKUP_ROOT_FUTURE_TOLERANCE_DAYS:-1}"
+
+backup_root_max_plausible_date() {
+    date -u -d "+${BACKUP_ROOT_FUTURE_TOLERANCE_DAYS} days" +%Y-%m-%d
+}
+
+# Dated within the bound (today, or tomorrow by default)?
+backup_root_name_is_plausible() {
+    [[ ! "${1:-}" > "$(backup_root_max_plausible_date)" ]]
+}
+
+# Retained under its old name for callers; TRUE only beyond the bound.
 backup_root_name_is_future() {
-    [[ "${1:-}" > "$(date -u +%Y-%m-%d)" ]]
+    ! backup_root_name_is_plausible "${1:-}"
 }
 
 # Is a SOURCE path provably absent, or merely invisible from here?
@@ -285,9 +303,15 @@ backup_root_scan_generation() {
             # keeps stopping the walk.  Only an entry that resolves — whose
             # name is therefore the writer's own date stamp — is ruled out.
             if backup_root_name_is_future "$(basename "${entry}")"; then
-                printf 'ignoring generation dated in the future: %s (clock skew when it was written; it can never be pruned and is not evidence of recency)\n' \
-                    "${entry}" >&2
-                continue
+                # rc 3, not `continue`. A name beyond the skew bound means the
+                # clock that wrote it was wrong, and this scan decides recency
+                # BY NAME — so no ordering in this root can be trusted. It also
+                # sits inside prune's keep window forever, silently costing a
+                # retention slot per skewed run. Refusing is what puts it in
+                # front of an operator, who is the only one who can clear it.
+                printf 'generation dated beyond the clock-skew bound: %s (newest plausible is %s) — the clock that wrote it was wrong, so name-ordered recency cannot be trusted in this root; remove or re-date it\n' \
+                    "${entry}" "$(backup_root_max_plausible_date)" >&2
+                return 3
             fi
             printf '%s\n' "${entry}"
             return 0

--- a/deploy/backup/backup_root_lib.sh
+++ b/deploy/backup/backup_root_lib.sh
@@ -181,12 +181,44 @@ backup_root_readable() {
 # apply_hardening.sh refreshes, so real generations keep landing with no
 # pointer beside them until an operator re-runs that installer.  A reader
 # that could only follow pointers would be blind to every one of them.
+# THREE outcomes, and the third is the point:
+#   0 + path  the newest dated entry that really resolves to a directory
+#   2         a dated entry is LISTED but cannot be resolved as a directory,
+#             so a newer generation cannot be ruled out here — indeterminate
+#   1         the root holds no dated entries at all — genuinely empty
+#
+# A glob match is an lstat-level fact; `-d` is a stat-level fact. Taking only
+# `tail -n1` and failing the whole root when that one entry is not a directory
+# discarded every older real generation under it and reported the root as
+# EMPTY — so the prover certified a stale generation from the other root and
+# exited 0. One dangling symlink, one stray file, or one generation on an
+# unmounted volume was enough. That is the ENOENT/EACCES corollary re-opened
+# one directory below where backup_root_readable closes it.
+#
+# Newest-first, and an unresolvable NEWEST entry stops the walk rather than
+# being skipped: it may itself BE the newer generation, and silently falling
+# back to an older sibling is exactly the substitution this library forbids.
 backup_root_scan_generation() {
-    local root="${1:-}" gen
+    local root="${1:-}" entry
     [[ -n "${root}" ]] || return 1
-    gen="$(ls -1d "${root%/}/daily"/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] 2>/dev/null | sort | tail -n1 || true)"
-    [[ -n "${gen}" && -d "${gen}" ]] || return 1
-    printf '%s\n' "${gen}"
+    local daily="${root%/}/daily"
+    [[ -d "${daily}" ]] || return 1
+
+    local -a entries=()
+    while IFS= read -r entry; do
+        [[ -n "${entry}" ]] || continue
+        entries+=("${entry}")
+    done < <(ls -1d "${daily}"/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] 2>/dev/null | sort -r)
+    (( ${#entries[@]} )) || return 1
+
+    for entry in "${entries[@]}"; do
+        if [[ -d "${entry}" ]]; then
+            printf '%s\n' "${entry}"
+            return 0
+        fi
+        return 2
+    done
+    return 1
 }
 
 # When was this generation promoted?  The pointer's `promoted_at` when the

--- a/deploy/backup/backup_root_lib.sh
+++ b/deploy/backup/backup_root_lib.sh
@@ -58,17 +58,36 @@ BACKUP_ROOT_LIB_VERSION=1
 BACKUP_ROOT_POINTER_SCHEMA=1
 BACKUP_ROOT_POINTER_NAME="last_generation"
 
+# A root is a LOCATION, and only an absolute path is one.  A relative root
+# — or a systemd `~/...` that was never expanded — resolves against each
+# PROCESS's own cwd, so the writer promotes under its cwd while the prover
+# reports "does not exist" and certifies the other root's older generation.
+# That is two answers to one location question, which is the entire class
+# this library exists to eliminate.
+#
+# Refused, never normalised against $PWD: normalising would silently pick
+# one process's cwd as the truth and reintroduce the disagreement one layer
+# down.
+backup_root_require_absolute() {
+    local path="${1:-}" name="${2:-root}"
+    if [[ "${path}" != /* ]]; then
+        printf 'backup root %s must be an absolute path, got: %s\n' "${name}" "${path}" >&2
+        return 1
+    fi
+    printf '%s\n' "${path}"
+}
+
 # The requested primary root.  `BACKUP_ROOT` is the operator/caller
 # override; the default is the system location.
 backup_root_primary() {
-    printf '%s\n' "${BACKUP_ROOT:-/var/backups/riskit-state}"
+    backup_root_require_absolute "${BACKUP_ROOT:-/var/backups/riskit-state}" BACKUP_ROOT
 }
 
 # The fallback, used when the primary cannot be created or written.  It is
 # the service user's own home, which is writable without privilege — the
 # nightly runs unprivileged on some hosts.
 backup_root_fallback() {
-    printf '%s\n' "${BACKUP_FALLBACK_ROOT:-/home/dynasty/backups/riskit-state}"
+    backup_root_require_absolute "${BACKUP_FALLBACK_ROOT:-/home/dynasty/backups/riskit-state}" BACKUP_FALLBACK_ROOT
 }
 
 # Every location a generation could legitimately be in, in preference
@@ -120,7 +139,10 @@ backup_root_pointer_path() {
 # pointer.
 backup_root_write_result() {
     local out="$1" root="$2" gen="$3" stamp="$4" artifacts="$5"
-    local tmp="${out}.tmp.$$"
+    # `mktemp`, not "${out}.tmp.$$": the old name was derivable from the
+    # world-readable result path, and `>` follows a symlink planted there.
+    local tmp
+    tmp="$(mktemp "${out}.tmp.XXXXXX" 2>/dev/null)" || return 1
     {
         printf 'schema=%s\n' "${BACKUP_ROOT_POINTER_SCHEMA}"
         printf 'effective_root=%s\n' "${root}"
@@ -181,6 +203,51 @@ backup_root_readable() {
 # apply_hardening.sh refreshes, so real generations keep landing with no
 # pointer beside them until an operator re-runs that installer.  A reader
 # that could only follow pointers would be blind to every one of them.
+# Nothing can have been promoted after now, so a dated name AHEAD of today
+# is not a newer generation — it is a MISDATED one, and it is the only kind
+# of entry that can be positively ruled out rather than merely resolved.
+#
+# The name is the ONLY evidence of recency this scan has, and it had no
+# upper bound.  `riskit-state-backup.timer` is `Persistent=true`, so a
+# missed nightly replays at boot — before NTP has stepped the clock — and
+# that run promotes a COMPLETE generation under e.g. `daily/2099-03-04`.
+# It then outranks every real generation forever (`sort -r` takes it, and
+# prune's `sort | head -n -14` can never reach it, so retention silently
+# drops 14 -> 13), and every later proof certifies it and exits 0 without
+# ever opening the current generation.
+#
+# SKIPPED, not refused: this library refuses on anything it cannot resolve
+# because an unresolvable entry may BE the newer generation, but a
+# future-dated one provably is not — refusing would trade a fail-open for
+# an outage.  The skip is announced, because an unannounced substitution is
+# the bug this whole file is about.
+backup_root_name_is_future() {
+    [[ "${1:-}" > "$(date -u +%Y-%m-%d)" ]]
+}
+
+# Is a SOURCE path provably absent, or merely invisible from here?
+#
+# The same ENOENT/EACCES conflation this library closed for the backup root,
+# closed for the artifacts.  `-e`/`-f`/`-d` are false for ENOENT *and* for
+# EACCES/ENOTDIR anywhere on the path, and only the first means "this stream
+# has not started".  A retention store behind a mode-0700 ancestor, or on a
+# volume that failed to mount, is otherwise excused as never-started and
+# omitted from every generation — silently, because the retention artifacts
+# are deliberately not in BACKUP_REQUIRED.
+#
+#   0  proven absent      2  indeterminate (may exist and be unreachable)
+backup_source_absent() {
+    local path="${1:-}" probe
+    [[ -n "${path}" ]] || return 2
+    [[ ! -e "${path}" && ! -L "${path}" ]] || return 2
+    probe="${path}"
+    while [[ ! -e "${probe}" && ! -L "${probe}" && "${probe}" != "/" && "${probe}" != "." ]]; do
+        probe="$(dirname "${probe}")"
+    done
+    [[ -r "${probe}" && -x "${probe}" ]] || return 2
+    return 0
+}
+
 # THREE outcomes, and the third is the point:
 #   0 + path  the newest dated entry that really resolves to a directory
 #   2         a dated entry is LISTED but cannot be resolved as a directory,
@@ -213,6 +280,15 @@ backup_root_scan_generation() {
 
     for entry in "${entries[@]}"; do
         if [[ -d "${entry}" ]]; then
+            # Checked AFTER resolution, never before: an unresolvable entry
+            # may still BE a newer generation whatever it is named, so it
+            # keeps stopping the walk.  Only an entry that resolves — whose
+            # name is therefore the writer's own date stamp — is ruled out.
+            if backup_root_name_is_future "$(basename "${entry}")"; then
+                printf 'ignoring generation dated in the future: %s (clock skew when it was written; it can never be pruned and is not evidence of recency)\n' \
+                    "${entry}" >&2
+                continue
+            fi
             printf '%s\n' "${entry}"
             return 0
         fi
@@ -256,13 +332,41 @@ backup_root_pointer_field() {
 # generation it names still exists — a pointer to a pruned generation is
 # not a generation, and must not be presented as one.
 backup_root_read_generation() {
-    local root="$1" ptr schema gen
+    local root="$1" ptr schema gen base
     ptr="$(backup_root_pointer_path "${root}")"
     [[ -f "${ptr}" ]] || return 1
     schema="$(backup_root_pointer_field "${ptr}" schema || true)"
     [[ "${schema}" == "${BACKUP_ROOT_POINTER_SCHEMA}" ]] || return 1
     gen="$(backup_root_pointer_field "${ptr}" generation || true)"
-    [[ -n "${gen}" && -d "${gen}" ]] || return 1
+    [[ -n "${gen}" ]] || return 1
+
+    # A pointer is a hint about THIS root, never a redirect out of it, and
+    # the name it gives must be the dated shape the whole selection
+    # algorithm compares on.  Both are load-bearing, and the second is not
+    # cosmetic: the reader ranks a pointer against the root's own newest
+    # with `basename >`, and EVERY non-dated name sorts ABOVE every date, so
+    # an out-of-root pointer named anything else wins unconditionally and
+    # silently disarms the on-disk scan that exists to stop a stale pointer
+    # masking a newer generation.  Measured: a pointer naming
+    # `<root>/../elsewhere/restore-scratch` was certified — and its contents
+    # gunzipped — while the real `daily/<today>` in the named root was never
+    # opened, under a log line reading "effective backup root: <root>".
+    #
+    # Exact-path match, not a prefix test, so `daily/../..` cannot satisfy it.
+    #
+    # REJECTED, not refused: the caller falls through to the on-disk scan of
+    # the root it actually asked about, so that root's own newest real
+    # generation is certified and the log says `via on-disk scan`. A
+    # well-formed pointer is unaffected — the writer only ever emits
+    # ${BACKUP_ROOT}/daily/${DATE_STAMP}.
+    base="$(basename "${gen}")"
+    [[ "${gen}" == "${root%/}/daily/${base}" ]] || return 1
+    [[ "${base}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || return 1
+    [[ -d "${gen}" ]] || return 1
+    # The skewed run writes its pointer with the same wrong clock, so the
+    # other finder must rule it out too.
+    ! backup_root_name_is_future "${base}" || return 1
+
     printf '%s\n' "${gen}"
     return 0
 }

--- a/deploy/backup/backup_root_lib.sh
+++ b/deploy/backup/backup_root_lib.sh
@@ -1,0 +1,170 @@
+# backup_root_lib.sh — THE owner of "where does the state backup live".
+#
+# Sourced, never executed.  It defines functions only and runs nothing at
+# source time, so a caller's `set -Eeuo pipefail` and exit status are
+# untouched.
+#
+# WHY THIS EXISTS
+# ───────────────
+# `riskit-state-backup.sh` writes a nightly generation, and
+# `retention_backup_restore_proof.sh` reads one back.  Each used to
+# resolve the destination independently from the same two defaults, which
+# is fine right up until they disagree — and they did, on production proof
+# run 31872681688: the primary root was not writable, the writer fell back
+# to the service user's home and promoted a COMPLETE generation there, and
+# the proof reported "no backup generation under /var/backups/riskit-state
+# /daily" for a backup that had succeeded.  Two implementations of one
+# decision produce exactly one class of bug, and this is it.
+#
+# So there is one owner of all four questions:
+#
+#   requested primary root   → backup_root_primary
+#   writability determination→ backup_root_writable / backup_root_claim
+#   fallback root            → backup_root_fallback
+#   effective generation loc → the pointer written by backup_root_write_result
+#
+# THE INVARIANT
+# ─────────────
+#   the location that successfully receives the promoted backup
+#     ==
+#   the location the restore proof subsequently inspects
+#
+# It is held two ways, deliberately belt-and-braces:
+#
+#  1. Both scripts resolve candidate roots through the SAME functions
+#     here, so neither can invent a path the other does not know about.
+#  2. The writer records what it actually did in a MACHINE-READABLE
+#     pointer (KEY=VALUE, schema-versioned).  The proof reads that.  It
+#     does not re-derive the location and it does not parse log prose —
+#     human-readable log lines are for humans and are not an API.
+#
+# POINTER FORMAT (schema 1)
+# ─────────────────────────
+#   schema=1
+#   effective_root=/home/dynasty/backups/riskit-state
+#   generation=/home/dynasty/backups/riskit-state/daily/2026-08-15
+#   date_stamp=2026-08-15
+#   artifacts=14
+#   promoted_at=2026-08-15T09:12:33Z
+#
+# `promoted_at` is ISO-8601 UTC with a fixed width, so lexicographic
+# ordering IS chronological ordering — that is what lets a reader compare
+# pointers from two roots without a date parser.
+#
+# Values are read with a first-`=` split, so a path containing `=`
+# round-trips.  Nothing is ever eval'd.
+
+BACKUP_ROOT_LIB_VERSION=1
+BACKUP_ROOT_POINTER_SCHEMA=1
+BACKUP_ROOT_POINTER_NAME="last_generation"
+
+# The requested primary root.  `BACKUP_ROOT` is the operator/caller
+# override; the default is the system location.
+backup_root_primary() {
+    printf '%s\n' "${BACKUP_ROOT:-/var/backups/riskit-state}"
+}
+
+# The fallback, used when the primary cannot be created or written.  It is
+# the service user's own home, which is writable without privilege — the
+# nightly runs unprivileged on some hosts.
+backup_root_fallback() {
+    printf '%s\n' "${BACKUP_FALLBACK_ROOT:-/home/dynasty/backups/riskit-state}"
+}
+
+# Every location a generation could legitimately be in, in preference
+# order.  A reader that scans anything else is looking somewhere the
+# writer would never have written.
+backup_root_candidates() {
+    local primary fallback
+    primary="$(backup_root_primary)"
+    fallback="$(backup_root_fallback)"
+    printf '%s\n' "${primary}"
+    [[ "${fallback}" == "${primary}" ]] || printf '%s\n' "${fallback}"
+}
+
+# Writability determination — the single definition.  Creating the
+# directory is part of the question: a root that cannot be created is not
+# writable, and asking `-w` about a path that does not exist answers no
+# for the wrong reason.
+backup_root_writable() {
+    local root="${1:-}"
+    [[ -n "${root}" ]] || return 1
+    mkdir -p "${root}" 2>/dev/null || return 1
+    [[ -w "${root}" ]] || return 1
+    return 0
+}
+
+# The WRITER's resolution: first candidate that is actually writable.
+# Echoes the effective root; returns 1 when none is usable (the caller
+# decides whether that is fatal — here it always is).
+backup_root_claim() {
+    local root
+    while IFS= read -r root; do
+        [[ -n "${root}" ]] || continue
+        if backup_root_writable "${root}"; then
+            printf '%s\n' "${root}"
+            return 0
+        fi
+    done < <(backup_root_candidates)
+    return 1
+}
+
+backup_root_pointer_path() {
+    printf '%s\n' "${1%/}/${BACKUP_ROOT_POINTER_NAME}"
+}
+
+# Write the machine-readable result.
+#   $1 destination file · $2 effective root · $3 generation dir
+#   $4 date stamp · $5 artifact count
+# Written to a temp file and renamed, so a reader never sees half a
+# pointer.
+backup_root_write_result() {
+    local out="$1" root="$2" gen="$3" stamp="$4" artifacts="$5"
+    local tmp="${out}.tmp.$$"
+    {
+        printf 'schema=%s\n' "${BACKUP_ROOT_POINTER_SCHEMA}"
+        printf 'effective_root=%s\n' "${root}"
+        printf 'generation=%s\n' "${gen}"
+        printf 'date_stamp=%s\n' "${stamp}"
+        printf 'artifacts=%s\n' "${artifacts}"
+        printf 'promoted_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    } > "${tmp}" 2>/dev/null || { rm -f "${tmp}"; return 1; }
+    mv -f "${tmp}" "${out}" 2>/dev/null || { rm -f "${tmp}"; return 1; }
+    return 0
+}
+
+# The in-root pointer: same content, at the well-known name, so a later
+# reader can find the generation without having run the backup itself.
+backup_root_write_pointer() {
+    local root="$1" gen="$2" stamp="$3" artifacts="$4"
+    backup_root_write_result "$(backup_root_pointer_path "${root}")" \
+        "${root}" "${gen}" "${stamp}" "${artifacts}"
+}
+
+# Read one field.  First-`=` split; no eval, no sourcing of the pointer.
+backup_root_pointer_field() {
+    local file="$1" key="$2" line
+    [[ -f "${file}" ]] || return 1
+    while IFS= read -r line; do
+        [[ "${line}" == "${key}="* ]] || continue
+        printf '%s\n' "${line#*=}"
+        return 0
+    done < "${file}"
+    return 1
+}
+
+# The generation recorded under a root, or 1 when there is no USABLE
+# pointer.  "Usable" means the schema is one we understand and the
+# generation it names still exists — a pointer to a pruned generation is
+# not a generation, and must not be presented as one.
+backup_root_read_generation() {
+    local root="$1" ptr schema gen
+    ptr="$(backup_root_pointer_path "${root}")"
+    [[ -f "${ptr}" ]] || return 1
+    schema="$(backup_root_pointer_field "${ptr}" schema || true)"
+    [[ "${schema}" == "${BACKUP_ROOT_POINTER_SCHEMA}" ]] || return 1
+    gen="$(backup_root_pointer_field "${ptr}" generation || true)"
+    [[ -n "${gen}" && -d "${gen}" ]] || return 1
+    printf '%s\n' "${gen}"
+    return 0
+}

--- a/deploy/backup/backup_root_lib.sh
+++ b/deploy/backup/backup_root_lib.sh
@@ -161,12 +161,16 @@ backup_root_write_pointer() {
 #
 # The `! -e` arm is load-bearing: a root that has never been written has no
 # daily/ at all, and that must stay an ordinary empty root rather than
-# becoming a refusal.
+# becoming a refusal.  It is paired with `! -L` because `-e` DEREFERENCES:
+# a symlinked daily/ pointing somewhere unreachable is `! -e` too, and
+# without the pairing it short-circuits the whole check and reports "holds
+# no generation" — the same errno confusion this arm was added to close,
+# one directory level down.
 backup_root_readable() {
     local root="${1:-}"
     [[ -n "${root}" && -d "${root}" && -r "${root}" && -x "${root}" ]] || return 1
     local daily="${root%/}/daily"
-    [[ ! -e "${daily}" ]] || [[ -d "${daily}" && -r "${daily}" && -x "${daily}" ]]
+    [[ ! -e "${daily}" && ! -L "${daily}" ]] || [[ -d "${daily}" && -r "${daily}" && -x "${daily}" ]]
 }
 
 # The newest dated generation actually ON DISK under a root, with no

--- a/deploy/backup/backup_root_lib.sh
+++ b/deploy/backup/backup_root_lib.sh
@@ -141,6 +141,55 @@ backup_root_write_pointer() {
         "${root}" "${gen}" "${stamp}" "${artifacts}"
 }
 
+# Can a READER see into this root at all?  Distinct from
+# `backup_root_writable`, which is the writer's question and CREATES the
+# directory — a reader must never do that, because a root it just made is
+# indistinguishable from one that legitimately holds nothing.
+#
+# The distinction is load-bearing: the nightly runs as root and chmods its
+# root 0700, so an unprivileged reader gets "not readable" for a root that
+# is FULL of generations.  Treating that as "empty" and quietly certifying
+# an older generation from the other root is a fail-open, and it is the
+# exact defect this library exists to prevent, merely inverted.
+backup_root_readable() {
+    local root="${1:-}"
+    [[ -n "${root}" && -d "${root}" && -r "${root}" && -x "${root}" ]]
+}
+
+# The newest dated generation actually ON DISK under a root, with no
+# pointer involved.
+#
+# Needed because the pointer is younger than the backups: the production
+# nightly executes a root-owned copy of the writer that only
+# apply_hardening.sh refreshes, so real generations keep landing with no
+# pointer beside them until an operator re-runs that installer.  A reader
+# that could only follow pointers would be blind to every one of them.
+backup_root_scan_generation() {
+    local root="${1:-}" gen
+    [[ -n "${root}" ]] || return 1
+    gen="$(ls -1d "${root%/}/daily"/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] 2>/dev/null | sort | tail -n1 || true)"
+    [[ -n "${gen}" && -d "${gen}" ]] || return 1
+    printf '%s\n' "${gen}"
+}
+
+# When was this generation promoted?  The pointer's `promoted_at` when the
+# pointer describes THIS generation, else midnight of the dated directory
+# name.  Never empty for a well-formed generation, which matters because a
+# comparison against an empty incumbent silently accepts anything.
+backup_root_generation_stamp() {
+    local root="$1" gen="$2" ptr at="" ptr_gen base
+    ptr="$(backup_root_pointer_path "${root}")"
+    ptr_gen="$(backup_root_pointer_field "${ptr}" generation || true)"
+    if [[ -n "${ptr_gen}" && "${ptr_gen}" == "${gen}" ]]; then
+        at="$(backup_root_pointer_field "${ptr}" promoted_at || true)"
+    fi
+    if [[ -z "${at}" ]]; then
+        base="$(basename "${gen}")"
+        [[ "${base}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] && at="${base}T00:00:00Z"
+    fi
+    printf '%s\n' "${at}"
+}
+
 # Read one field.  First-`=` split; no eval, no sourcing of the pointer.
 backup_root_pointer_field() {
     local file="$1" key="$2" line

--- a/deploy/backup/backup_root_lib.sh
+++ b/deploy/backup/backup_root_lib.sh
@@ -151,9 +151,22 @@ backup_root_write_pointer() {
 # is FULL of generations.  Treating that as "empty" and quietly certifying
 # an older generation from the other root is a fail-open, and it is the
 # exact defect this library exists to prevent, merely inverted.
+# It covers `daily/` as well as the root, because that is what both finders
+# actually open — and the two levels are permissioned independently: the
+# writer chmods only the root, while daily/ takes whatever `umask 077` gave
+# it at mkdir.  A root readable with an unreadable daily/ would otherwise
+# report "holds no generation", which is the same fail-open one level down,
+# and it is exactly what an operator produces by chmod'ing the root alone
+# after reading the refusal message.
+#
+# The `! -e` arm is load-bearing: a root that has never been written has no
+# daily/ at all, and that must stay an ordinary empty root rather than
+# becoming a refusal.
 backup_root_readable() {
     local root="${1:-}"
-    [[ -n "${root}" && -d "${root}" && -r "${root}" && -x "${root}" ]]
+    [[ -n "${root}" && -d "${root}" && -r "${root}" && -x "${root}" ]] || return 1
+    local daily="${root%/}/daily"
+    [[ ! -e "${daily}" ]] || [[ -d "${daily}" && -r "${daily}" && -x "${daily}" ]]
 }
 
 # The newest dated generation actually ON DISK under a root, with no

--- a/deploy/backup/riskit-state-backup.sh
+++ b/deploy/backup/riskit-state-backup.sh
@@ -496,6 +496,27 @@ fi
 # the keep-window always counts today's GOOD snapshot — never a failed
 # stub.  (Safe even when the mirror failed above: the local snapshot
 # is validated either way.)
+# Generations dated beyond the clock-skew bound are EXCLUDED from the keep
+# window rather than counted in it. `sort` puts a 2099 directory at the end of
+# an ascending list, so `head -n -N` keeps it forever AND spends one of the N
+# slots on it — real retention silently drops to N-1, and to N-2 after the next
+# skewed run. It is deliberately not deleted here: an implausible generation is
+# an anomaly for an operator to look at, and this script's destructive steps
+# only ever remove things it can account for.
+prune_candidates() {
+    local dir plausible=()
+    while IFS= read -r dir; do
+        [[ -n "${dir}" ]] || continue
+        if backup_root_name_is_future "${dir}"; then
+            warn "generation ${BACKUP_ROOT}/daily/${dir} is dated beyond the clock-skew bound (newest plausible $(backup_root_max_plausible_date)) — excluded from the keep window and NOT deleted; remove or re-date it"
+            continue
+        fi
+        plausible+=("${dir}")
+    done < <(ls -1 "${BACKUP_ROOT}/daily" 2>/dev/null | sort)
+    (( ${#plausible[@]} > KEEP_DAILY )) || return 0
+    printf '%s\n' "${plausible[@]}" | head -n -"${KEEP_DAILY}"
+}
+
 prune() {
     local dir
     # Dated names sort lexicographically == chronologically.
@@ -503,7 +524,7 @@ prune() {
         [[ -n "${dir}" ]] || continue
         log "prune: ${BACKUP_ROOT}/daily/${dir}"
         rm -rf "${BACKUP_ROOT:?}/daily/${dir}"
-    done < <(ls -1 "${BACKUP_ROOT}/daily" 2>/dev/null | sort | head -n -"${KEEP_DAILY}")
+    done < <(prune_candidates)
 }
 prune
 

--- a/deploy/backup/riskit-state-backup.sh
+++ b/deploy/backup/riskit-state-backup.sh
@@ -89,8 +89,9 @@ set -Eeuo pipefail
 
 APP_DIR="${APP_DIR:-/home/dynasty/trade-calculator}"
 DATA_DIR="${DATA_DIR:-${APP_DIR}/data}"
-BACKUP_ROOT="${BACKUP_ROOT:-/var/backups/riskit-state}"
-BACKUP_FALLBACK_ROOT="${BACKUP_FALLBACK_ROOT:-/home/dynasty/backups/riskit-state}"
+# BACKUP_ROOT / BACKUP_FALLBACK_ROOT are read here as overrides only.
+# Their DEFAULTS live in backup_root_lib.sh, sourced below, which is the
+# single owner of where a backup goes — see the destination block.
 KEEP_DAILY="${KEEP_DAILY:-14}"
 DATE_STAMP="$(date -u +%Y-%m-%d)"
 OFFBOX_RSYNC_DEST="${OFFBOX_RSYNC_DEST:-}"
@@ -109,18 +110,25 @@ fail() { printf '[state-backup][ERROR] %s\n' "$*" >&2; exit 1; }
 [[ -n "${PYTHON_BIN}" ]] || fail "no python interpreter available for sqlite online backup"
 
 # ── Destination (primary, then service-user fallback) ────────────────
-ensure_root() {
-    if mkdir -p "${BACKUP_ROOT}" 2>/dev/null && [[ -w "${BACKUP_ROOT}" ]]; then
-        return 0
-    fi
-    warn "primary backup root '${BACKUP_ROOT}' not writable, using fallback"
-    BACKUP_ROOT="${BACKUP_FALLBACK_ROOT}"
-    if mkdir -p "${BACKUP_ROOT}" 2>/dev/null && [[ -w "${BACKUP_ROOT}" ]]; then
-        return 0
-    fi
-    fail "neither primary nor fallback backup root writable"
-}
-ensure_root
+#
+# Resolved by the SHARED owner, not here.  The requested primary root, the
+# writability determination and the fallback are one decision made in one
+# place, because the backup/restore proof has to inspect the location this
+# run actually wrote to.  While each script resolved it independently, a
+# fallback here left the proof reading an empty primary and reporting "no
+# backup generation" for a backup that had succeeded (production proof run
+# 31872681688).
+BACKUP_ROOT_LIB="$(dirname "${BASH_SOURCE[0]}")/backup_root_lib.sh"
+[[ -f "${BACKUP_ROOT_LIB}" ]] || fail "backup root library missing: ${BACKUP_ROOT_LIB}"
+# shellcheck source=deploy/backup/backup_root_lib.sh
+source "${BACKUP_ROOT_LIB}"
+
+REQUESTED_ROOT="$(backup_root_primary)"
+BACKUP_ROOT="$(backup_root_claim)" || fail "neither primary ('${REQUESTED_ROOT}') nor fallback ('$(backup_root_fallback)') backup root writable"
+if [[ "${BACKUP_ROOT}" != "${REQUESTED_ROOT}" ]]; then
+    warn "primary backup root '${REQUESTED_ROOT}' not writable, using fallback '${BACKUP_ROOT}'"
+fi
+log "effective backup root: ${BACKUP_ROOT}"
 chmod 700 "${BACKUP_ROOT}" 2>/dev/null || true
 
 # Stage the snapshot in a hidden dir and promote it to the dated slot
@@ -389,6 +397,24 @@ rm -rf "${FINAL_DEST}"
 mv "${DEST}" "${FINAL_DEST}"
 DEST="${FINAL_DEST}"
 log "snapshot promoted: ${FINAL_DEST}"
+
+# Record what this run actually did, machine-readably.  A reader that
+# re-derives the location can be wrong about it (that is the defect this
+# replaces); a reader that parses the log line above would be depending on
+# human prose, which is not an API.  Written only now, after promotion, so
+# the pointer never names a generation that does not exist.
+if ! backup_root_write_pointer "${BACKUP_ROOT}" "${FINAL_DEST}" "${DATE_STAMP}" "${ARTIFACTS}"; then
+    warn "could not record the generation pointer under ${BACKUP_ROOT} (the snapshot itself is intact)"
+fi
+# A caller that asked for the result by path gets it or gets a failed run.
+# Silently not writing it would send the caller looking somewhere else,
+# which is precisely the failure mode being closed.
+if [[ -n "${BACKUP_RESULT_FILE:-}" ]]; then
+    backup_root_write_result "${BACKUP_RESULT_FILE}" "${BACKUP_ROOT}" \
+        "${FINAL_DEST}" "${DATE_STAMP}" "${ARTIFACTS}" \
+        || fail "could not write the requested BACKUP_RESULT_FILE=${BACKUP_RESULT_FILE}"
+    log "result recorded: ${BACKUP_RESULT_FILE}"
+fi
 
 # ── Optional off-box mirror (operator opt-in) ────────────────────────
 # Reached only with every artifact written and integrity-checked, so a

--- a/deploy/backup/riskit-state-backup.sh
+++ b/deploy/backup/riskit-state-backup.sh
@@ -144,6 +144,11 @@ mkdir -p "${DEST}/sqlite" "${DEST}/dirs" "${DEST}/sessions" "${DEST}/files"
 # Clear stale staging dirs from previous crashed runs (>1 day old).
 find "${BACKUP_ROOT}/daily" -maxdepth 1 -name '.staging-*' -mtime +1 \
     -exec rm -rf {} + 2>/dev/null || true
+# And stale pointer temp files.  These live one level ABOVE daily/, so
+# neither the sweep above nor prune can reach them: a run killed between
+# writing the temp and renaming it leaves one behind forever.
+find "${BACKUP_ROOT}" -maxdepth 1 -name 'last_generation.tmp.*' -mtime +1 \
+    -delete 2>/dev/null || true
 
 ARTIFACTS=0
 ERRORS=0

--- a/deploy/backup/riskit-state-backup.sh
+++ b/deploy/backup/riskit-state-backup.sh
@@ -403,6 +403,41 @@ backup_session_file "${APP_DIR}/idpshow_session.json"     "repo.idpshow_session.
 backup_session_file "/var/lib/dlf-fetch/dlf_session.json"         "workdir.dlf_session.json"
 backup_session_file "/var/lib/idpshow-fetch/idpshow_session.json" "workdir.idpshow_session.json"
 
+# Dated generations this writer could plausibly have produced, oldest first.
+# ONE definition, shared by the keep-window and the mirror's continuity count —
+# two answers to "what is a generation" is the class of bug this whole change
+# exists to remove.
+plausible_generations() {
+    local dir
+    while IFS= read -r -d '' dir; do
+        dir="$(basename "${dir}")"
+        [[ -n "${dir}" ]] || continue
+
+        # POSITIVE recognition, not "did not look wrong". prune deletes with
+        # `rm -rf`, so an entry it cannot account for as one of this writer's
+        # own generations must never reach it — and, just as important, must
+        # never consume a slot in the keep window. Measured before this guard:
+        # a plain README.txt dropped into daily/ took a retention slot and a
+        # REAL generation (2026-08-10) was deleted early to make room for it.
+        #
+        # Four independent things must hold. Shape alone is not enough: a
+        # regular file, a symlink, or an impossible calendar date can all wear
+        # a date-shaped name.
+        [[ -d "${BACKUP_ROOT}/daily/${dir}" ]] || continue                 # a directory
+        [[ ! -L "${BACKUP_ROOT}/daily/${dir}" ]] || continue               # not a symlink
+        [[ "${dir}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || continue         # the writer's shape
+        # A real calendar date: `date -d` rejects 2026-13-45, 2026-00-00 and
+        # 2026-02-31, and the round-trip rejects 2026-8-1 and other loose forms.
+        [[ "$(date -u -d "${dir}" +%Y-%m-%d 2>/dev/null)" == "${dir}" ]] || continue
+
+        if backup_root_name_is_future "${dir}"; then
+            warn "generation ${BACKUP_ROOT}/daily/${dir} is dated beyond the clock-skew bound (newest plausible $(backup_root_max_plausible_date)) — excluded from the keep window and NOT deleted; remove or re-date it"
+            continue
+        fi
+        printf '%s\n' "${dir}"
+    done < <(find "${BACKUP_ROOT}/daily" -mindepth 1 -maxdepth 1 -print0 2>/dev/null | sort -z)
+}
+
 # ── Validate this run BEFORE any destructive step ────────────────────
 # Ordering is deliberate: write artifacts into staging → integrity
 # checks (above) → on failure discard the staging dir and stop → only
@@ -464,21 +499,55 @@ fi
 MIRROR_FAILED=0
 if [[ -n "${OFFBOX_RSYNC_DEST}" ]]; then
     if command -v rsync >/dev/null 2>&1; then
-        # `--delete` makes the remote an exact replica of ONE root's daily/
-        # namespace. On a fallback night this root holds only what this run
-        # just wrote, while the generations the mirror was built from live in
-        # the root we could NOT write to — which is exactly the failure
-        # (read-only /var, dead disk) that makes the off-box copy the only
-        # surviving one. So a change of root publishes ADDITIVELY: it may
-        # never delete remotely.
+        # `--delete` makes the remote an exact replica of this root's daily/
+        # namespace, so it may run ONLY with positive proof that this root
+        # still holds the history the mirror was built from.
+        #
+        # "Same root as requested" is NOT that proof — it answers which root we
+        # wrote to, not whether its history is continuous. Measured: a writable
+        # primary whose local generations had vanished (disk replaced, /var
+        # wiped, restored image) took `--delete` and cut a remote of 5
+        # generations to 1, destroying four that were the only surviving
+        # copies. That is precisely the state in which the off-box copy is the
+        # last one standing.
+        #
+        # Four conditions, all required. Any unproven ⇒ publish additively.
+        MIRROR_MARKER="${BACKUP_ROOT%/}/last_mirror"
+        MIRROR_COUNT="$(plausible_generations | wc -l | tr -d ' ')"
+        MIRROR_PRIOR_DEST="$(backup_root_pointer_field "${MIRROR_MARKER}" dest || true)"
+        MIRROR_PRIOR_COUNT="$(backup_root_pointer_field "${MIRROR_MARKER}" generations || true)"
+
         RSYNC_ARGS=(-a)
-        if [[ "${BACKUP_ROOT}" == "${REQUESTED_ROOT}" ]]; then
-            RSYNC_ARGS+=(--delete)
+        MIRROR_DELETE_REFUSED=""
+        if [[ "${BACKUP_ROOT}" != "${REQUESTED_ROOT}" ]]; then
+            MIRROR_DELETE_REFUSED="this run wrote to the fallback root '${BACKUP_ROOT}', so the generations mirrored from '${REQUESTED_ROOT}' are not represented here"
+        elif [[ ! -f "${MIRROR_MARKER}" ]]; then
+            MIRROR_DELETE_REFUSED="no record of a previous mirror from this root, so local-history continuity cannot be established"
+        elif [[ "${MIRROR_PRIOR_DEST}" != "${OFFBOX_RSYNC_DEST}" ]]; then
+            MIRROR_DELETE_REFUSED="the destination changed (previously '${MIRROR_PRIOR_DEST}'), so this remote's history was not built from this root"
+        elif [[ ! "${MIRROR_PRIOR_COUNT}" =~ ^[0-9]+$ ]]; then
+            MIRROR_DELETE_REFUSED="the previous mirror record carries no usable generation count"
+        elif (( MIRROR_COUNT < MIRROR_PRIOR_COUNT )); then
+            MIRROR_DELETE_REFUSED="local history SHRANK since the last mirror (${MIRROR_PRIOR_COUNT} -> ${MIRROR_COUNT} generations), so the remote may hold the only surviving copies"
         else
-            warn "off-box mirror running from fallback root '${BACKUP_ROOT}' — publishing WITHOUT --delete so generations mirrored from '${REQUESTED_ROOT}' survive"
+            RSYNC_ARGS+=(--delete)
+        fi
+        if [[ -n "${MIRROR_DELETE_REFUSED}" ]]; then
+            warn "off-box mirror publishing WITHOUT --delete: ${MIRROR_DELETE_REFUSED}"
         fi
         if rsync "${RSYNC_ARGS[@]}" "${BACKUP_ROOT}/daily/" "${OFFBOX_RSYNC_DEST}"; then
             log "off-box mirror ok: ${OFFBOX_RSYNC_DEST}"
+            # Re-baseline. A deliberate KEEP_DAILY reduction therefore
+            # publishes additively once and reconciles normally afterwards —
+            # fail-closed must not become fail-never, or remote retention grows
+            # without bound.
+            {
+                printf 'schema=%s\n' "${BACKUP_ROOT_POINTER_SCHEMA}"
+                printf 'dest=%s\n' "${OFFBOX_RSYNC_DEST}"
+                printf 'generations=%s\n' "${MIRROR_COUNT}"
+                printf 'mirrored_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            } > "${MIRROR_MARKER}" 2>/dev/null \
+                || warn "could not record the mirror continuity marker at ${MIRROR_MARKER}; the next run will publish additively"
         else
             warn "off-box mirror FAILED (local backup unaffected)"
             MIRROR_FAILED=1
@@ -504,15 +573,11 @@ fi
 # an anomaly for an operator to look at, and this script's destructive steps
 # only ever remove things it can account for.
 prune_candidates() {
-    local dir plausible=()
+    local plausible=()
     while IFS= read -r dir; do
         [[ -n "${dir}" ]] || continue
-        if backup_root_name_is_future "${dir}"; then
-            warn "generation ${BACKUP_ROOT}/daily/${dir} is dated beyond the clock-skew bound (newest plausible $(backup_root_max_plausible_date)) — excluded from the keep window and NOT deleted; remove or re-date it"
-            continue
-        fi
         plausible+=("${dir}")
-    done < <(ls -1 "${BACKUP_ROOT}/daily" 2>/dev/null | sort)
+    done < <(plausible_generations)
     (( ${#plausible[@]} > KEEP_DAILY )) || return 0
     printf '%s\n' "${plausible[@]}" | head -n -"${KEEP_DAILY}"
 }

--- a/deploy/backup/riskit-state-backup.sh
+++ b/deploy/backup/riskit-state-backup.sh
@@ -147,7 +147,7 @@ find "${BACKUP_ROOT}/daily" -maxdepth 1 -name '.staging-*' -mtime +1 \
 # And stale pointer temp files.  These live one level ABOVE daily/, so
 # neither the sweep above nor prune can reach them: a run killed between
 # writing the temp and renaming it leaves one behind forever.
-find "${BACKUP_ROOT}" -maxdepth 1 -name 'last_generation.tmp.*' -mtime +1 \
+find "${BACKUP_ROOT}/" -maxdepth 1 -name 'last_generation.tmp.*' -mtime +1 \
     -delete 2>/dev/null || true
 
 ARTIFACTS=0
@@ -197,7 +197,19 @@ backup_sqlite() {
     local name
     name="$(basename "${src}")"
     if [[ ! -f "${src}" ]]; then
-        log "skip sqlite (absent): ${src}"
+        # "(absent)" must mean PROVEN absent. `-f`/`-d` are false for
+        # ENOENT *and* EACCES/ENOTDIR anywhere on the path, so a store
+        # behind a 0700 ancestor or on a volume that failed to mount was
+        # silently omitted from every generation under a reassuring line.
+        # WARN rather than ERROR: the header's posture is that unreadable
+        # OPTIONAL inputs are skipped, and failing here would discard
+        # user_kv and session_store too. The prover is the fail-closed
+        # authority; this is the visibility half.
+        if backup_source_absent "${src}"; then
+            log "skip sqlite (absent): ${src}"
+        else
+            warn "sqlite source NOT backed up and NOT provably absent: ${src} — it may exist and be unreadable by $(id -un); this generation omits it"
+        fi
         return 0
     fi
     local tmp="${DEST}/sqlite/${name}"
@@ -238,7 +250,19 @@ backup_file() {
     local name
     name="$(basename "${src}")"
     if [[ ! -f "${src}" ]]; then
-        log "skip file (absent): ${src}"
+        # "(absent)" must mean PROVEN absent. `-f`/`-d` are false for
+        # ENOENT *and* EACCES/ENOTDIR anywhere on the path, so a store
+        # behind a 0700 ancestor or on a volume that failed to mount was
+        # silently omitted from every generation under a reassuring line.
+        # WARN rather than ERROR: the header's posture is that unreadable
+        # OPTIONAL inputs are skipped, and failing here would discard
+        # user_kv and session_store too. The prover is the fail-closed
+        # authority; this is the visibility half.
+        if backup_source_absent "${src}"; then
+            log "skip file (absent): ${src}"
+        else
+            warn "file source NOT backed up and NOT provably absent: ${src} — it may exist and be unreadable by $(id -un); this generation omits it"
+        fi
         return 0
     fi
     local out="${DEST}/files/${name}.gz"
@@ -275,7 +299,19 @@ backup_dir() {
     member="$(basename "${src}")"
     local name="${2:-${member}}"
     if [[ ! -d "${src}" ]]; then
-        log "skip dir (absent): ${src}"
+        # "(absent)" must mean PROVEN absent. `-f`/`-d` are false for
+        # ENOENT *and* EACCES/ENOTDIR anywhere on the path, so a store
+        # behind a 0700 ancestor or on a volume that failed to mount was
+        # silently omitted from every generation under a reassuring line.
+        # WARN rather than ERROR: the header's posture is that unreadable
+        # OPTIONAL inputs are skipped, and failing here would discard
+        # user_kv and session_store too. The prover is the fail-closed
+        # authority; this is the visibility half.
+        if backup_source_absent "${src}"; then
+            log "skip dir (absent): ${src}"
+        else
+            warn "dir source NOT backed up and NOT provably absent: ${src} — it may exist and be unreadable by $(id -un); this generation omits it"
+        fi
         return 0
     fi
     local out="${DEST}/dirs/${name}.tar.gz"
@@ -428,7 +464,20 @@ fi
 MIRROR_FAILED=0
 if [[ -n "${OFFBOX_RSYNC_DEST}" ]]; then
     if command -v rsync >/dev/null 2>&1; then
-        if rsync -a --delete "${BACKUP_ROOT}/daily/" "${OFFBOX_RSYNC_DEST}"; then
+        # `--delete` makes the remote an exact replica of ONE root's daily/
+        # namespace. On a fallback night this root holds only what this run
+        # just wrote, while the generations the mirror was built from live in
+        # the root we could NOT write to — which is exactly the failure
+        # (read-only /var, dead disk) that makes the off-box copy the only
+        # surviving one. So a change of root publishes ADDITIVELY: it may
+        # never delete remotely.
+        RSYNC_ARGS=(-a)
+        if [[ "${BACKUP_ROOT}" == "${REQUESTED_ROOT}" ]]; then
+            RSYNC_ARGS+=(--delete)
+        else
+            warn "off-box mirror running from fallback root '${BACKUP_ROOT}' — publishing WITHOUT --delete so generations mirrored from '${REQUESTED_ROOT}' survive"
+        fi
+        if rsync "${RSYNC_ARGS[@]}" "${BACKUP_ROOT}/daily/" "${OFFBOX_RSYNC_DEST}"; then
             log "off-box mirror ok: ${OFFBOX_RSYNC_DEST}"
         else
             warn "off-box mirror FAILED (local backup unaffected)"

--- a/deploy/diagnostics/retention_backup_restore_proof.sh
+++ b/deploy/diagnostics/retention_backup_restore_proof.sh
@@ -28,13 +28,26 @@
 # proven by SCHEMA, COUNTS and ID SHAPE only. No payload, no manager
 # name, no roster is printed — this output goes to a CI log.
 #
+# WHERE IT LOOKS
+# ──────────────
+# It does not decide.  `deploy/backup/backup_root_lib.sh` — sourced from
+# the DEPLOYED tree, so it is the same resolver the writer just ran — owns
+# the requested primary root, the writability determination, the fallback
+# and the pointer format.  With RUN_BACKUP=1 the generation comes from the
+# machine-readable result that run wrote; with RUN_BACKUP=0 it is the
+# newest generation recorded by any candidate root.  Nothing here parses a
+# log line, and nothing here reimplements the fallback.
+#
 # Inputs (environment):
-#   APP_DIR      deployed app tree
-#   DATA_DIR     live data dir (READ ONLY here)
-#   BACKUP_ROOT  where riskit-state-backup.sh writes
-#   PYTHON_BIN   venv interpreter (sqlite3 CLI is not on the box)
-#   RUN_BACKUP   "1" (default) to run the backup first; "0" to verify
-#                the newest existing generation only
+#   APP_DIR              deployed app tree (also where the resolver lives)
+#   DATA_DIR             live data dir (READ ONLY here)
+#   BACKUP_ROOT          requested primary root — read via the shared
+#                        resolver, and NOT assumed to be where the backup
+#                        actually landed
+#   BACKUP_FALLBACK_ROOT fallback root, same
+#   PYTHON_BIN           venv interpreter (sqlite3 CLI is not on the box)
+#   RUN_BACKUP           "1" (default) to run the backup first; "0" to
+#                        verify the newest recorded generation only
 #
 # Exit codes: 0 proven · 1 could not run · 2 an artifact that exists on
 # the source is missing from the backup, or a restored artifact failed
@@ -44,7 +57,6 @@ set -Eeuo pipefail
 
 APP_DIR="${APP_DIR:-/home/dynasty/trade-calculator}"
 DATA_DIR="${DATA_DIR:-${APP_DIR}/data}"
-BACKUP_ROOT="${BACKUP_ROOT:-/var/backups/riskit-state}"
 PYTHON_BIN="${PYTHON_BIN:-/home/dynasty/.venvs/trade-calculator/bin/python}"
 RUN_BACKUP="${RUN_BACKUP:-1}"
 
@@ -55,31 +67,85 @@ fail() { printf '[backup-proof][ERROR] %s\n' "$*" >&2; exit 1; }
 FAILURES=0
 note_fail() { printf '[backup-proof][FAIL] %s\n' "$*" >&2; FAILURES=$((FAILURES + 1)); }
 
+RESTORE_DIR=""
+RESULT_FILE=""
+cleanup() {
+    [[ -n "${RESTORE_DIR}" ]] && rm -rf "${RESTORE_DIR}"
+    [[ -n "${RESULT_FILE}" ]] && rm -f "${RESULT_FILE}"
+    return 0
+}
+trap cleanup EXIT
+
 [[ -d "${APP_DIR}" ]] || fail "app dir not found: ${APP_DIR}"
 [[ -x "${PYTHON_BIN}" ]] || PYTHON_BIN="$(command -v python3 || true)"
 [[ -x "${PYTHON_BIN}" ]] || fail "no usable python interpreter"
+
+# ── 0. The backup root has ONE owner, and it is not this script ──────
+# This script does not know where backups live and must not guess.  It
+# asks the same library the writer uses, from the DEPLOYED tree, so the
+# resolver answering here is byte-identical to the one that ran there.
+# Absent library = cannot run (exit 1); never a silent pass, and never a
+# locally reimplemented fallback.
+BACKUP_ROOT_LIB="${APP_DIR}/deploy/backup/backup_root_lib.sh"
+[[ -f "${BACKUP_ROOT_LIB}" ]] || fail "backup root library missing on the deployed revision: ${BACKUP_ROOT_LIB} — cannot resolve the effective backup root without reimplementing it; deploy the revision that ships it"
+# shellcheck source=deploy/backup/backup_root_lib.sh
+source "${BACKUP_ROOT_LIB}"
 
 # ── 1. Run the real backup ───────────────────────────────────────────
 if [[ "${RUN_BACKUP}" == "1" ]]; then
     BACKUP_SCRIPT="${APP_DIR}/deploy/backup/riskit-state-backup.sh"
     [[ -f "${BACKUP_SCRIPT}" ]] || fail "backup script absent on the deployed revision: ${BACKUP_SCRIPT}"
+    RESULT_FILE="$(mktemp /tmp/retention-backup-result-XXXXXX)"
     log "running production backup: ${BACKUP_SCRIPT}"
-    if ! APP_DIR="${APP_DIR}" DATA_DIR="${DATA_DIR}" BACKUP_ROOT="${BACKUP_ROOT}" \
+    if ! APP_DIR="${APP_DIR}" DATA_DIR="${DATA_DIR}" \
+         BACKUP_ROOT="$(backup_root_primary)" \
+         BACKUP_FALLBACK_ROOT="$(backup_root_fallback)" \
+         BACKUP_RESULT_FILE="${RESULT_FILE}" \
          PYTHON_BIN="${PYTHON_BIN}" bash "${BACKUP_SCRIPT}"; then
         fail "backup run FAILED"
     fi
-else
-    log "RUN_BACKUP=0 — verifying the newest existing generation only"
 fi
 
 # ── 2. Locate the generation we are proving ──────────────────────────
-GEN="$(ls -1d "${BACKUP_ROOT}/daily"/20* 2>/dev/null | sort | tail -n1 || true)"
-[[ -n "${GEN}" && -d "${GEN}" ]] || fail "no backup generation under ${BACKUP_ROOT}/daily"
+# With a backup just run, the generation is whatever THAT run reported —
+# read from its machine-readable result, not re-derived and not scraped
+# out of its log.  This is what makes the location that received the
+# promoted backup and the location inspected here the same location by
+# construction, and it is why a newer pointer sitting in the other
+# candidate root cannot capture this proof.
+if [[ "${RUN_BACKUP}" == "1" ]]; then
+    GEN="$(backup_root_pointer_field "${RESULT_FILE}" generation || true)"
+    EFFECTIVE_ROOT="$(backup_root_pointer_field "${RESULT_FILE}" effective_root || true)"
+    [[ -n "${GEN}" ]] || fail "the backup completed but recorded no generation in ${RESULT_FILE}"
+else
+    # Verifying an existing generation: ask each candidate root what it
+    # recorded and take the newest.  `promoted_at` is fixed-width ISO-8601
+    # UTC, so a string comparison is a chronological one.  Every candidate
+    # examined is logged, so the selection is visible rather than implied.
+    log "RUN_BACKUP=0 — locating the newest recorded generation"
+    GEN=""; EFFECTIVE_ROOT=""; BEST_AT=""
+    while IFS= read -r cand; do
+        [[ -n "${cand}" ]] || continue
+        cand_gen="$(backup_root_read_generation "${cand}" || true)"
+        if [[ -z "${cand_gen}" ]]; then
+            log "candidate root ${cand}: no usable recorded generation"
+            continue
+        fi
+        cand_at="$(backup_root_pointer_field "$(backup_root_pointer_path "${cand}")" promoted_at || true)"
+        log "candidate root ${cand}: generation ${cand_gen} promoted_at ${cand_at:-unknown}"
+        if [[ -z "${BEST_AT}" || "${cand_at}" > "${BEST_AT}" ]]; then
+            GEN="${cand_gen}"; EFFECTIVE_ROOT="${cand}"; BEST_AT="${cand_at}"
+        fi
+    done < <(backup_root_candidates)
+    [[ -n "${GEN}" ]] || fail "no recorded backup generation in any candidate root ($(backup_root_candidates | tr '\n' ' ')) — run with RUN_BACKUP=1"
+fi
+
+[[ -d "${GEN}" ]] || fail "recorded generation does not exist on disk: ${GEN}"
+log "effective backup root: ${EFFECTIVE_ROOT:-unknown}"
 log "proving generation: ${GEN}"
 log "generation size: $(du -sh "${GEN}" 2>/dev/null | cut -f1)"
 
 RESTORE_DIR="$(mktemp -d /tmp/retention-restore-XXXXXX)"
-trap 'rm -rf "${RESTORE_DIR}"' EXIT
 log "restore target (throwaway): ${RESTORE_DIR}"
 
 # ── SQLite: restore, integrity-check, read schema + counts ───────────

--- a/deploy/diagnostics/retention_backup_restore_proof.sh
+++ b/deploy/diagnostics/retention_backup_restore_proof.sh
@@ -122,26 +122,73 @@ else
     # recorded and take the newest.  `promoted_at` is fixed-width ISO-8601
     # UTC, so a string comparison is a chronological one.  Every candidate
     # examined is logged, so the selection is visible rather than implied.
+    # Verifying an existing generation.  Three rules, and every one of them
+    # exists because breaking it turns this proof into a false pass:
+    #
+    #  1. A root we cannot READ is not an empty root.  The nightly runs as
+    #     root and chmods its root 0700, so an unprivileged prover sees
+    #     exactly that — and if we skipped it we would go on to certify an
+    #     OLDER generation out of the readable root and exit 0, which is
+    #     worse than the bug this file was rewritten to fix.  Unreadable ⇒
+    #     refuse (below), never substitute.
+    #  2. A generation with no pointer still counts.  The pointer is younger
+    #     than the backups: production's nightly runs a root-owned copy of
+    #     the writer that only apply_hardening.sh refreshes, so real
+    #     generations land with no pointer beside them.  Pointer first,
+    #     on-disk scan second, and the log says which answered.
+    #  3. Compare on a stamp that is never empty, and hold the incumbent on
+    #     "do we have one" rather than "does it have a stamp" — an incumbent
+    #     with an unknown stamp must not be a blank slate that any later
+    #     candidate overwrites.
     log "RUN_BACKUP=0 — locating the newest recorded generation"
-    GEN=""; EFFECTIVE_ROOT=""; BEST_AT=""
+    GEN=""; EFFECTIVE_ROOT=""; BEST_AT=""; UNREADABLE=""
     while IFS= read -r cand; do
         [[ -n "${cand}" ]] || continue
-        cand_gen="$(backup_root_read_generation "${cand}" || true)"
-        if [[ -z "${cand_gen}" ]]; then
-            log "candidate root ${cand}: no usable recorded generation"
+        if [[ ! -e "${cand}" ]]; then
+            log "candidate root ${cand}: does not exist"
             continue
         fi
-        cand_at="$(backup_root_pointer_field "$(backup_root_pointer_path "${cand}")" promoted_at || true)"
-        log "candidate root ${cand}: generation ${cand_gen} promoted_at ${cand_at:-unknown}"
-        if [[ -z "${BEST_AT}" || "${cand_at}" > "${BEST_AT}" ]]; then
+        if ! backup_root_readable "${cand}"; then
+            log "candidate root ${cand}: NOT READABLE by $(id -un) — cannot rule out a newer generation here"
+            UNREADABLE+="${cand} "
+            continue
+        fi
+        cand_src="pointer"
+        cand_gen="$(backup_root_read_generation "${cand}" || true)"
+        if [[ -z "${cand_gen}" ]]; then
+            cand_src="on-disk scan"
+            cand_gen="$(backup_root_scan_generation "${cand}" || true)"
+        fi
+        if [[ -z "${cand_gen}" ]]; then
+            log "candidate root ${cand}: readable, holds no generation"
+            continue
+        fi
+        cand_at="$(backup_root_generation_stamp "${cand}" "${cand_gen}")"
+        log "candidate root ${cand}: generation ${cand_gen} (via ${cand_src}) promoted_at ${cand_at:-unknown}"
+        if [[ -z "${GEN}" || "${cand_at}" > "${BEST_AT}" ]]; then
             GEN="${cand_gen}"; EFFECTIVE_ROOT="${cand}"; BEST_AT="${cand_at}"
         fi
     done < <(backup_root_candidates)
-    [[ -n "${GEN}" ]] || fail "no recorded backup generation in any candidate root ($(backup_root_candidates | tr '\n' ' ')) — run with RUN_BACKUP=1"
+
+    # Refuse BEFORE accepting a winner.  Proving the older readable
+    # generation while a root we cannot see may hold a newer one is
+    # precisely the false pass this ordering prevents.
+    if [[ -n "${UNREADABLE}" ]]; then
+        fail "cannot certify a generation: candidate root(s) ${UNREADABLE}are not readable by $(id -un), so a newer generation may exist there and be invisible here — refusing to certify an older one instead. The nightly runs as root and chmods its root 0700; run with RUN_BACKUP=1 to prove a generation this user can actually write and read."
+    fi
+    [[ -n "${GEN}" ]] || fail "no backup generation in any readable candidate root ($(backup_root_candidates | tr '\n' ' ')) — run with RUN_BACKUP=1"
 fi
 
 [[ -d "${GEN}" ]] || fail "recorded generation does not exist on disk: ${GEN}"
 log "effective backup root: ${EFFECTIVE_ROOT:-unknown}"
+
+# Say what this run does NOT cover.  The nightly is a different process
+# (root, from /usr/local/lib/riskit) writing a different root, and a green
+# tick here must not be read as "the nightly's generations restore" when
+# this user cannot even open them.
+if [[ -n "${EFFECTIVE_ROOT}" && "${EFFECTIVE_ROOT}" != "$(backup_root_primary)" ]]; then
+    warn "this proves the backup lineage written by $(id -un) into the FALLBACK root. The nightly systemd job runs as root and writes $(backup_root_primary); those generations are not readable here and are NOT covered by this run."
+fi
 log "proving generation: ${GEN}"
 log "generation size: $(du -sh "${GEN}" 2>/dev/null | cut -f1)"
 

--- a/deploy/diagnostics/retention_backup_restore_proof.sh
+++ b/deploy/diagnostics/retention_backup_restore_proof.sh
@@ -211,6 +211,11 @@ else
         cand_src="pointer"
         cand_disk=""; cand_rc=0
         cand_disk="$(backup_root_scan_generation "${cand}")" || cand_rc=$?
+        if (( cand_rc == 3 )); then
+            log "candidate root ${cand}: holds a generation dated beyond the clock-skew bound — name-ordered recency is untrustworthy here"
+            UNREADABLE+="${cand} "
+            continue
+        fi
         if (( cand_rc == 2 )); then
             log "candidate root ${cand}: a dated entry under daily/ cannot be resolved by $(id -un) — cannot rule out a newer generation here"
             UNREADABLE+="${cand} "

--- a/deploy/diagnostics/retention_backup_restore_proof.sh
+++ b/deploy/diagnostics/retention_backup_restore_proof.sh
@@ -66,6 +66,10 @@ fail() { printf '[backup-proof][ERROR] %s\n' "$*" >&2; exit 1; }
 
 FAILURES=0
 note_fail() { printf '[backup-proof][FAIL] %s\n' "$*" >&2; FAILURES=$((FAILURES + 1)); }
+# "nothing failed" is TRUE of a run that read nothing. Counting what was
+# actually restored and verified is what stops silence reading as proof.
+PROVEN=0
+note_proven() { PROVEN=$((PROVEN + 1)); }
 
 RESTORE_DIR=""
 RESULT_FILE=""
@@ -97,6 +101,11 @@ BACKUP_ROOT_LIB="${APP_DIR}/deploy/backup/backup_root_lib.sh"
 # shellcheck source=deploy/backup/backup_root_lib.sh
 source "${BACKUP_ROOT_LIB}"
 
+# The getters refuse a non-absolute root; make that refusal fatal HERE rather
+# than letting an empty candidate list quietly become "no generation found".
+backup_root_primary >/dev/null || fail "BACKUP_ROOT must be an absolute path"
+backup_root_fallback >/dev/null || fail "BACKUP_FALLBACK_ROOT must be an absolute path"
+
 # ── 1. Run the real backup ───────────────────────────────────────────
 if [[ "${RUN_BACKUP}" == "1" ]]; then
     BACKUP_SCRIPT="${APP_DIR}/deploy/backup/riskit-state-backup.sh"
@@ -107,6 +116,7 @@ if [[ "${RUN_BACKUP}" == "1" ]]; then
          BACKUP_ROOT="$(backup_root_primary)" \
          BACKUP_FALLBACK_ROOT="$(backup_root_fallback)" \
          BACKUP_RESULT_FILE="${RESULT_FILE}" \
+         OFFBOX_RSYNC_DEST= \
          PYTHON_BIN="${PYTHON_BIN}" bash "${BACKUP_SCRIPT}"; then
         fail "backup run FAILED"
     fi
@@ -243,6 +253,11 @@ else
 fi
 
 [[ -d "${GEN}" ]] || fail "recorded generation does not exist on disk: ${GEN}"
+# "effective backup root: X" must never be printed for a generation that is
+# not under X. Belt-and-braces behind the library's pointer containment check.
+if [[ -n "${EFFECTIVE_ROOT}" && "${GEN}" != "${EFFECTIVE_ROOT%/}/daily/"* ]]; then
+    fail "selected generation ${GEN} is not under the root that supplied it (${EFFECTIVE_ROOT}) — refusing to certify a generation from outside a candidate backup location"
+fi
 log "effective backup root: ${EFFECTIVE_ROOT:-unknown}"
 
 # Say what this run does NOT cover.  The nightly is a different process
@@ -265,13 +280,21 @@ prove_sqlite() {
     local src="$1" name="$2" label="$3"; shift 3
     local gz="${GEN}/sqlite/${name}.gz"
 
-    if [[ ! -f "${src}" ]]; then
-        if [[ -f "${gz}" ]]; then
-            log "${label}: source absent, backup present (older generation) — ok"
-        else
-            log "${label}: SOURCE ABSENT, not backed up — stream has not started (not a failure)"
+    if [[ ! -f "${src}" && ! -f "${gz}" ]]; then
+        if ! backup_source_absent "${src}"; then
+            note_fail "${label}: source ${src} cannot be resolved by $(id -un) — it may EXIST and be unreadable (permission on it or on a parent, or an unresolved path), so it may be silently outside this generation; refusing to record it as a stream that has not started"
+            return 0
         fi
+        log "${label}: SOURCE ABSENT, not backed up — stream has not started (not a failure)"
         return 0
+    fi
+    if [[ ! -f "${src}" ]]; then
+        if ! backup_source_absent "${src}"; then
+            note_fail "${label}: source ${src} cannot be resolved by $(id -un) — it may EXIST and be unreadable (permission on it or on a parent, or an unresolved path), so it may be silently outside this generation; refusing to record it as a stream that has not started"
+            return 0
+        fi
+        # Present in the backup: PROVE it rather than waving it through.
+        log "${label}: source absent, backup present (older generation) — proving it from the backup"
     fi
     if [[ ! -f "${gz}" ]]; then
         note_fail "${label}: EXISTS at ${src} but is MISSING from the backup (${gz})"
@@ -316,6 +339,8 @@ finally:
 PY
     then
         note_fail "${label}: restored database failed verification"
+    else
+        note_proven
     fi
 }
 
@@ -324,9 +349,20 @@ prove_file() {
     local src="$1" name="$2" label="$3"
     local gz="${GEN}/files/${name}.gz"
 
-    if [[ ! -f "${src}" ]]; then
+    if [[ ! -f "${src}" && ! -f "${gz}" ]]; then
+        if ! backup_source_absent "${src}"; then
+            note_fail "${label}: source ${src} cannot be resolved by $(id -un) — it may EXIST and be unreadable (permission on it or on a parent, or an unresolved path), so it may be silently outside this generation; refusing to record it as a stream that has not started"
+            return 0
+        fi
         log "${label}: SOURCE ABSENT, not backed up — stream has not started (not a failure)"
         return 0
+    fi
+    if [[ ! -f "${src}" ]]; then
+        if ! backup_source_absent "${src}"; then
+            note_fail "${label}: source ${src} cannot be resolved by $(id -un) — it may EXIST and be unreadable (permission on it or on a parent, or an unresolved path), so it may be silently outside this generation; refusing to record it as a stream that has not started"
+            return 0
+        fi
+        log "${label}: source absent, backup present (older generation) — proving it from the backup"
     fi
     if [[ ! -f "${gz}" ]]; then
         note_fail "${label}: EXISTS at ${src} but is MISSING from the backup (${gz})"
@@ -341,6 +377,7 @@ prove_file() {
     local lines
     lines="$(wc -l < "${out}" | tr -d ' ')"
     log "${label}: restored, gzip -t ok, ${lines} line(s)"
+    note_proven
     # JSONL: prove it parses rather than merely existing.
     if [[ "${name}" == *.jsonl ]]; then
         if ! "${PYTHON_BIN}" - "${out}" "${label}" <<'PY'
@@ -372,9 +409,20 @@ prove_dir() {
     local src="$1" name="$2" label="$3"
     local tgz="${GEN}/dirs/${name}.tar.gz"
 
-    if [[ ! -d "${src}" ]]; then
+    if [[ ! -d "${src}" && ! -f "${tgz}" ]]; then
+        if ! backup_source_absent "${src}"; then
+            note_fail "${label}: source ${src} cannot be resolved by $(id -un) — it may EXIST and be unreadable (permission on it or on a parent, or an unresolved path), so it may be silently outside this generation; refusing to record it as a stream that has not started"
+            return 0
+        fi
         log "${label}: SOURCE ABSENT, not backed up — stream has not started (not a failure)"
         return 0
+    fi
+    if [[ ! -d "${src}" ]]; then
+        if ! backup_source_absent "${src}"; then
+            note_fail "${label}: source ${src} cannot be resolved by $(id -un) — it may EXIST and be unreadable (permission on it or on a parent, or an unresolved path), so it may be silently outside this generation; refusing to record it as a stream that has not started"
+            return 0
+        fi
+        log "${label}: source absent, backup present (older generation) — proving it from the backup"
     fi
     if [[ ! -f "${tgz}" ]]; then
         note_fail "${label}: EXISTS at ${src} but is MISSING from the backup (${tgz})"
@@ -386,12 +434,24 @@ prove_dir() {
     fi
     local entries src_entries
     entries="$(tar -tzf "${tgz}" | grep -cv '/$' || true)"
-    src_entries="$(find "${src}" -type f | wc -l | tr -d ' ')"
+    if [[ -d "${src}" ]]; then
+        # An UNGUARDED find dies under `set -e` on a partially unreadable
+        # source, killing the sweep with no diagnostic; a `|| true` would
+        # undercount instead, and an undercount lets an empty restore pass
+        # the zero-check below. So a walk that cannot complete is a FAIL.
+        if ! src_entries="$(find "${src}" -type f 2>/dev/null | wc -l | tr -d ' ')"; then
+            note_fail "${label}: source ${src} could not be enumerated — coverage cannot be established"
+            return 0
+        fi
+    else
+        src_entries=0
+    fi
     mkdir -p "${RESTORE_DIR}/${name}"
     tar -xzf "${tgz}" -C "${RESTORE_DIR}/${name}"
     local restored
     restored="$(find "${RESTORE_DIR}/${name}" -type f | wc -l | tr -d ' ')"
     log "${label}: restored ${restored} file(s) (archive listed ${entries}, source holds ${src_entries})"
+    note_proven
     if [[ "${restored}" -eq 0 && "${src_entries}" -gt 0 ]]; then
         note_fail "${label}: source has ${src_entries} file(s) but the restore produced none"
     fi
@@ -420,5 +480,21 @@ if (( FAILURES > 0 )); then
     warn "${FAILURES} artifact(s) failed backup/restore proof"
     exit 2
 fi
-log "backup + restore proven for every artifact that exists"
+
+# "No artifact failed" is TRUE of a run that read nothing at all. The writer
+# discards any snapshot with ARTIFACTS == 0 and never promotes it, so a
+# certified directory holding no artifact is not a generation — announcing a
+# proof over one is the vacuous-success shape this whole script exists to
+# remove. Measured against a corrupt current generation that was never opened.
+#
+# The floor counts the WHOLE generation, not the seven retention artifacts:
+# a host whose retention streams have legitimately not started still carries
+# its core state (user_kv + session_store), so it stays green — and the
+# printed counts make a zero visible instead of implied.
+GEN_HELD="$(find "${GEN}" -type f 2>/dev/null | wc -l | tr -d ' ')"
+if (( GEN_HELD == 0 )); then
+    warn "certified generation ${GEN} holds NO artifact at all — the writer discards any snapshot with zero artifacts, so this directory is not a generation; refusing to announce a proof over an empty one"
+    exit 2
+fi
+log "backup + restore proven: ${PROVEN} retention artifact(s) restored and verified, ${GEN_HELD} artifact(s) in the generation"
 exit 0

--- a/deploy/diagnostics/retention_backup_restore_proof.sh
+++ b/deploy/diagnostics/retention_backup_restore_proof.sh
@@ -191,9 +191,22 @@ else
         # Ask BOTH finders, always.  Consulting the disk only when the
         # pointer says nothing lets a stale pointer mask a newer generation
         # in its own root.
+        #
+        # rc 2 from the scan means a dated entry is listed but unresolvable —
+        # an unmounted volume, a dangling symlink, a path this user cannot
+        # traverse. That entry may BE a newer generation, so the root is
+        # INDETERMINATE, not empty, and takes the same refusal an unreadable
+        # root takes. Checked before the pointer is consulted: a pointer
+        # cannot vouch for a sibling entry nobody can read.
         cand_src="pointer"
+        cand_disk=""; cand_rc=0
+        cand_disk="$(backup_root_scan_generation "${cand}")" || cand_rc=$?
+        if (( cand_rc == 2 )); then
+            log "candidate root ${cand}: a dated entry under daily/ cannot be resolved by $(id -un) — cannot rule out a newer generation here"
+            UNREADABLE+="${cand} "
+            continue
+        fi
         cand_gen="$(backup_root_read_generation "${cand}" || true)"
-        cand_disk="$(backup_root_scan_generation "${cand}" || true)"
         if [[ -z "${cand_gen}" ]]; then
             cand_src="on-disk scan"
             cand_gen="${cand_disk}"

--- a/deploy/diagnostics/retention_backup_restore_proof.sh
+++ b/deploy/diagnostics/retention_backup_restore_proof.sh
@@ -69,9 +69,15 @@ note_fail() { printf '[backup-proof][FAIL] %s\n' "$*" >&2; FAILURES=$((FAILURES 
 
 RESTORE_DIR=""
 RESULT_FILE=""
+# Each step guarded INDEPENDENTLY. Under `set -Eeuo pipefail` a failing
+# `rm -rf` inside an EXIT trap aborts the trap: the pending exit status is
+# replaced by 1 and every later step is skipped. That turns a real artifact
+# failure (exit 2, "missing from the backup") into what reads as
+# infrastructure breakage, and a fully green proof into a red one — while
+# also leaking the result file it never got to remove.
 cleanup() {
-    [[ -n "${RESTORE_DIR}" ]] && rm -rf "${RESTORE_DIR}"
-    [[ -n "${RESULT_FILE}" ]] && rm -f "${RESULT_FILE}"
+    [[ -z "${RESTORE_DIR}" ]] || rm -rf "${RESTORE_DIR}" || true
+    [[ -z "${RESULT_FILE}" ]] || rm -f "${RESULT_FILE}" || true
     return 0
 }
 trap cleanup EXIT
@@ -158,8 +164,15 @@ else
             # behind the permission — which is an unreadable root, not a
             # missing one.  Keeping the branch matters: a genuinely absent
             # fallback must stay ordinary, not turn every run red.
+            # `! -L` is not decoration.  `-e` DEREFERENCES a symlink while
+            # `dirname` is purely textual, so without it the walk steps OFF a
+            # symlinked root onto its readable lexical parent and calls a root
+            # whose target is merely unreachable "absent" — the pre-fix
+            # fail-open, restored by the ordinary sysadmin move of relocating
+            # backups to another volume via a symlink.  lstat-visible means
+            # unresolvable, not missing.
             probe="${cand}"
-            while [[ ! -e "${probe}" && "${probe}" != "/" && "${probe}" != "." ]]; do
+            while [[ ! -e "${probe}" && ! -L "${probe}" && "${probe}" != "/" && "${probe}" != "." ]]; do
                 probe="$(dirname "${probe}")"
             done
             if [[ ! -x "${probe}" ]]; then

--- a/deploy/diagnostics/retention_backup_restore_proof.sh
+++ b/deploy/diagnostics/retention_backup_restore_proof.sh
@@ -136,15 +136,37 @@ else
     #     the writer that only apply_hardening.sh refreshes, so real
     #     generations land with no pointer beside them.  Pointer first,
     #     on-disk scan second, and the log says which answered.
-    #  3. Compare on a stamp that is never empty, and hold the incumbent on
-    #     "do we have one" rather than "does it have a stamp" — an incumbent
-    #     with an unknown stamp must not be a blank slate that any later
-    #     candidate overwrites.
+    #  3. A pointer is a HINT, not an upper bound.  Within one root, take
+    #     whichever of the pointer and the disk names the newer generation —
+    #     the pointer write is warn-only and happens AFTER promotion, so a
+    #     run killed in that window leaves a stale pointer sitting in front
+    #     of a newer generation.
+    #  4. Compare on the DATE first and the instant only as a tiebreak, and
+    #     hold the incumbent on "do we have one" rather than "does it have a
+    #     stamp".  A derived midnight and a real promoted_at are not the same
+    #     currency: straddling 00:00 UTC, yesterday's dated directory can
+    #     carry a promoted_at of today and outrank a genuinely newer one.
     log "RUN_BACKUP=0 — locating the newest recorded generation"
-    GEN=""; EFFECTIVE_ROOT=""; BEST_AT=""; UNREADABLE=""
+    GEN=""; EFFECTIVE_ROOT=""; BEST_KEY=""; UNREADABLE=""
     while IFS= read -r cand; do
         [[ -n "${cand}" ]] || continue
         if [[ ! -e "${cand}" ]]; then
+            # `-e` is false for ENOENT *and* for EACCES anywhere on the path,
+            # and only the first is an empty root.  Absence has to be PROVEN:
+            # walk up to the deepest ancestor that can actually be stat'd, and
+            # if that one is not searchable then a generation may be sitting
+            # behind the permission — which is an unreadable root, not a
+            # missing one.  Keeping the branch matters: a genuinely absent
+            # fallback must stay ordinary, not turn every run red.
+            probe="${cand}"
+            while [[ ! -e "${probe}" && "${probe}" != "/" && "${probe}" != "." ]]; do
+                probe="$(dirname "${probe}")"
+            done
+            if [[ ! -x "${probe}" ]]; then
+                log "candidate root ${cand}: NOT READABLE by $(id -un) (cannot stat through ${probe}) — cannot rule out a newer generation here"
+                UNREADABLE+="${cand} "
+                continue
+            fi
             log "candidate root ${cand}: does not exist"
             continue
         fi
@@ -153,20 +175,35 @@ else
             UNREADABLE+="${cand} "
             continue
         fi
+        # Ask BOTH finders, always.  Consulting the disk only when the
+        # pointer says nothing lets a stale pointer mask a newer generation
+        # in its own root.
         cand_src="pointer"
         cand_gen="$(backup_root_read_generation "${cand}" || true)"
+        cand_disk="$(backup_root_scan_generation "${cand}" || true)"
         if [[ -z "${cand_gen}" ]]; then
             cand_src="on-disk scan"
-            cand_gen="$(backup_root_scan_generation "${cand}" || true)"
+            cand_gen="${cand_disk}"
+        elif [[ -n "${cand_disk}" && "${cand_disk}" != "${cand_gen}" ]]; then
+            # Same generation ⇒ keep the pointer, which carries the real
+            # instant.  Different ⇒ newer wins, whichever named it.
+            if [[ "$(basename "${cand_disk}")" > "$(basename "${cand_gen}")" ]]; then
+                log "candidate root ${cand}: pointer names ${cand_gen} but a NEWER generation is on disk"
+                cand_src="on-disk scan (newer than the pointer)"
+                cand_gen="${cand_disk}"
+            fi
         fi
         if [[ -z "${cand_gen}" ]]; then
             log "candidate root ${cand}: readable, holds no generation"
             continue
         fi
         cand_at="$(backup_root_generation_stamp "${cand}" "${cand_gen}")"
+        # Date dominates; the space sorts below every digit, so an unknown
+        # instant loses a tie rather than winning one.
+        cand_key="$(basename "${cand_gen}") ${cand_at}"
         log "candidate root ${cand}: generation ${cand_gen} (via ${cand_src}) promoted_at ${cand_at:-unknown}"
-        if [[ -z "${GEN}" || "${cand_at}" > "${BEST_AT}" ]]; then
-            GEN="${cand_gen}"; EFFECTIVE_ROOT="${cand}"; BEST_AT="${cand_at}"
+        if [[ -z "${GEN}" || "${cand_key}" > "${BEST_KEY}" ]]; then
+            GEN="${cand_gen}"; EFFECTIVE_ROOT="${cand}"; BEST_KEY="${cand_key}"
         fi
     done < <(backup_root_candidates)
 
@@ -174,7 +211,7 @@ else
     # generation while a root we cannot see may hold a newer one is
     # precisely the false pass this ordering prevents.
     if [[ -n "${UNREADABLE}" ]]; then
-        fail "cannot certify a generation: candidate root(s) ${UNREADABLE}are not readable by $(id -un), so a newer generation may exist there and be invisible here — refusing to certify an older one instead. The nightly runs as root and chmods its root 0700; run with RUN_BACKUP=1 to prove a generation this user can actually write and read."
+        fail "cannot certify a generation: candidate root(s) ${UNREADABLE}are not readable by $(id -un) (the root itself, its daily/, or a parent directory), so a newer generation may exist there and be invisible here — refusing to certify an older one instead. The nightly runs as root and chmods its root 0700; run with RUN_BACKUP=1 to prove a generation this user can actually write and read."
     fi
     [[ -n "${GEN}" ]] || fail "no backup generation in any readable candidate root ($(backup_root_candidates | tr '\n' ' ')) — run with RUN_BACKUP=1"
 fi

--- a/tests/deploy/test_backup_root_resolution.py
+++ b/tests/deploy/test_backup_root_resolution.py
@@ -196,6 +196,111 @@ def test_a_root_whose_daily_cannot_be_a_directory_refuses(tmp_path):
     assert f"[backup-proof] proving generation: {stale}" not in out, out
 
 
+def test_a_root_behind_a_symlink_through_a_non_directory_refuses(tmp_path):
+    """ROOT-SAFE cover for the ancestor walk's `! -L` conjunct.
+
+    The permission version of this skips as root, which left the whole walk
+    deletable with a green suite under a root runner. This construction uses
+    no permission bit at all: the root is a symlink whose target sits below a
+    regular FILE, so `-e` is false via ENOTDIR while `lstat` still sees the
+    link. Without `! -L` the walk steps off the symlink onto a readable
+    lexical parent and reports "does not exist".
+    """
+    app, data = _app(tmp_path)
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory", encoding="utf-8")
+    primary = tmp_path / "primary"
+    primary.symlink_to(blocker / "riskit-state")
+
+    fallback = tmp_path / "fallback"
+    stale = fallback / "daily" / "2026-01-02"
+    stale.mkdir(parents=True)
+    _write_pointer(fallback, stale, "2026-01-02T02:30:00Z")
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 1, out
+    assert "NOT READABLE" in out, out
+    assert "does not exist" not in out, "an unresolvable symlink is not an absent root"
+    assert f"[backup-proof] proving generation: {stale}" not in out, out
+
+
+def test_one_unresolvable_entry_in_daily_does_not_empty_the_whole_root(tmp_path):
+    """A glob match is lstat; `-d` is stat. One junk entry is not an empty root.
+
+    Taking only the newest match and failing the root when it is not a
+    directory discarded every older REAL generation under it and reported the
+    root as empty — so an older generation elsewhere was certified, exit 0.
+    One dangling symlink, one stray file, or one generation on an unmounted
+    volume was enough, and production's nightly shape (a real generation with
+    no pointer beside it) is exactly where it bites.
+    """
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    first = _run_proof(app, data, primary, fallback)
+    assert first.returncode == 0, first.stdout + first.stderr
+    (primary / "last_generation").unlink()  # the nightly writes no pointer
+
+    stale = fallback / "daily" / "2026-01-02"
+    stale.mkdir(parents=True)
+    _write_pointer(fallback, stale, "2026-01-02T02:30:00Z")
+
+    # A dated entry that lists but cannot be resolved as a directory.
+    (primary / "daily" / "2099-12-31").symlink_to(tmp_path / "unmounted-volume")
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 1, out
+    assert "cannot be resolved" in out, out
+    assert f"[backup-proof] proving generation: {stale}" not in out, out
+    assert "proven for every artifact" not in out, out
+
+
+def test_a_stray_file_in_daily_is_also_indeterminate(tmp_path):
+    """Same rule, no symlink involved — a plain file named like a generation."""
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    first = _run_proof(app, data, primary, fallback)
+    assert first.returncode == 0, first.stdout + first.stderr
+    (primary / "last_generation").unlink()
+    (primary / "daily" / "2099-12-31").write_text("", encoding="utf-8")
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 1, out
+    assert "cannot be resolved" in out, out
+
+
+def test_an_older_junk_entry_does_not_block_a_newer_real_generation(tmp_path):
+    """Fail-closed must not become fail-always.
+
+    An unresolvable entry OLDER than the newest real generation cannot be a
+    newer generation, so it must not refuse — otherwise one stray file would
+    disable the proof permanently.
+    """
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    first = _run_proof(app, data, primary, fallback)
+    assert first.returncode == 0, first.stdout + first.stderr
+    (primary / "last_generation").unlink()
+    (primary / "daily" / "2019-01-01").symlink_to(tmp_path / "long-gone")
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 0, out
+    assert f"[backup-proof] proving generation: {primary}/daily/{TODAY}" in out, out
+
+
 def test_a_root_whose_daily_is_an_unresolvable_symlink_refuses(tmp_path):
     """ROOT-SAFE cover for the `! -L` pairing on the `daily/` arm.
 

--- a/tests/deploy/test_backup_root_resolution.py
+++ b/tests/deploy/test_backup_root_resolution.py
@@ -1463,3 +1463,54 @@ def test_only_recognised_generations_count_toward_continuity(tmp_path):
         '[[ "$(date -u -d "${dir}" +%Y-%m-%d 2>/dev/null)" == "${dir}" ]] || continue',
     ):
         assert guard in body, f"missing positive-recognition guard: {guard}"
+
+
+def test_an_interleaved_non_generation_entry_costs_no_real_generation(tmp_path):
+    """The harmful variant, which two earlier attempts at this test missed.
+
+    A stray entry sorting ABOVE every date is skipped by the clock-skew guard;
+    one sorting BELOW every date is pruned first and costs nothing. Both are
+    harmless, and both are what I originally tested. The damaging case is an
+    entry that sorts INSIDE the date range — a dated restore-scratch directory
+    is the likeliest real example — because it consumes a slot in the keep
+    window and one REAL generation is deleted to make room, every night it
+    exists.
+
+    Measured on the shipped writer with KEEP_DAILY=14: 14 real generations
+    became 13 with the entry present, and stayed 14 once entries are recognised
+    positively rather than merely not-looking-wrong.
+    """
+    app, data = _app(tmp_path)
+    root = tmp_path / "primary"
+    (root / "daily").mkdir(parents=True)
+    for i in range(1, 15):
+        (root / "daily" / f"2026-08-{i:02d}" / "sqlite").mkdir(parents=True)
+    scratch = root / "daily" / "2026-08-07-restore-scratch"
+    scratch.mkdir()
+
+    env = {k: v for k, v in os.environ.items() if k not in {"BACKUP_ROOT", "BACKUP_FALLBACK_ROOT"}}
+    env.update(
+        APP_DIR=str(app),
+        DATA_DIR=str(data),
+        BACKUP_ROOT=str(root),
+        BACKUP_FALLBACK_ROOT=str(tmp_path / "fb"),
+        PYTHON_BIN=sys.executable,
+        KEEP_DAILY="14",
+    )
+    result = subprocess.run(
+        ["bash", str(REPO / "deploy" / "backup" / "riskit-state-backup.sh")],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    out = result.stdout + result.stderr
+    assert result.returncode == 0, out
+
+    survivors = sorted(
+        p.name
+        for p in (root / "daily").iterdir()
+        if p.is_dir() and re.fullmatch(r"2026-08-\d{2}", p.name)
+    )
+    assert len(survivors) == 14, f"a stray entry cost a real generation: {survivors}\n{out}"
+    assert scratch.exists(), "an unrecognised entry must be excluded, not deleted"

--- a/tests/deploy/test_backup_root_resolution.py
+++ b/tests/deploy/test_backup_root_resolution.py
@@ -526,7 +526,11 @@ def test_the_proof_reads_the_run_s_result_rather_than_re_deriving(tmp_path):
 
     assert result.returncode == 0, out
     assert f"[backup-proof] proving generation: {primary}/daily/{TODAY}" in out, out
-    assert str(decoy) not in out, "the proof re-derived the location instead of reading the result"
+    # The decoy now also appears in the writer's prune warning, which is
+    # correct — what must not happen is proving it.
+    assert (
+        f"proving generation: {decoy}" not in out
+    ), "the proof re-derived the location instead of reading the result"
 
 
 def test_the_on_disk_scan_takes_the_newest_dated_directory(tmp_path):
@@ -904,12 +908,17 @@ def test_the_selected_generation_must_lie_under_the_root_that_supplied_it(tmp_pa
     assert '"${GEN}" != "${EFFECTIVE_ROOT%/}/daily/"*' in body
 
 
-def test_a_future_dated_generation_is_not_evidence_of_recency(tmp_path):
+def test_a_generation_beyond_the_clock_skew_bound_fails_closed(tmp_path):
     """`riskit-state-backup.timer` is `Persistent=true`, so a missed nightly
-    replays at boot — before NTP has stepped the clock — and promotes a
-    complete generation dated years ahead. It then outranks every real one
-    forever and prune can never reach it, so every later proof certifies it
-    without opening the current generation.
+    replays at boot — before NTP has stepped the clock — and promotes a complete
+    generation dated years ahead.
+
+    Skipping it is not enough, and that is the whole point. A wrong clock does
+    not corrupt one directory: this system decides recency BY NAME, so a wrong
+    clock means no ordering in that root can be trusted. The directory also sits
+    inside prune's keep window forever — never deletable, and costing a
+    retention slot per skewed run. Refusing is what puts it in front of the only
+    person who can clear it.
     """
     app, data = _app(tmp_path)
     primary = tmp_path / "primary"
@@ -925,9 +934,57 @@ def test_a_future_dated_generation_is_not_evidence_of_recency(tmp_path):
     result = _run_proof(app, data, primary, fallback, run_backup="0")
     out = result.stdout + result.stderr
 
+    assert result.returncode == 1, out
+    assert "beyond the clock-skew bound" in out, out
+    assert (
+        f"proving generation: {real}" not in out
+    ), "name-ordered recency is untrustworthy in this root; it must refuse, not pick"
+
+
+def test_a_generation_dated_tomorrow_is_skew_not_corruption(tmp_path):
+    """Fail-closed must not become fail-always.
+
+    A writer whose clock runs slightly ahead, or a proof crossing midnight UTC,
+    legitimately produces a generation dated tomorrow. Rejecting that would turn
+    an ordinary boundary into an outage, so the bound is a tolerance rather than
+    a strict `> today`.
+    """
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    first = _run_proof(app, data, primary, fallback)
+    assert first.returncode == 0, first.stdout + first.stderr
+    real = primary / "daily" / TODAY
+    tomorrow = (datetime.now(timezone.utc) + timedelta(days=1)).strftime("%Y-%m-%d")
+    ahead = primary / "daily" / tomorrow
+    shutil.copytree(real, ahead)
+    (primary / "last_generation").unlink()
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
     assert result.returncode == 0, out
-    assert f"[backup-proof] proving generation: {real}" in out, out
-    assert "dated in the future" in out, "the skip must be announced, never silent"
+    assert f"[backup-proof] proving generation: {ahead}" in out, out
+    assert "beyond the clock-skew bound" not in out, out
+
+
+def test_an_implausible_generation_does_not_consume_a_retention_slot(tmp_path):
+    """`sort` puts a 2099 directory at the END of an ascending list, so
+    `head -n -N` keeps it forever AND spends one of the N slots on it — real
+    retention drops to N-1, and again with every further skewed run.
+
+    It is excluded from the keep window and deliberately NOT deleted: an
+    implausible generation is an anomaly for an operator, and this script's
+    destructive steps only remove what it can account for.
+    """
+    body = (REPO / "deploy" / "backup" / "riskit-state-backup.sh").read_text(encoding="utf-8")
+    assert "prune_candidates()" in body
+    assert "done < <(prune_candidates)" in body
+    assert (
+        'ls -1 "${BACKUP_ROOT}/daily" 2>/dev/null | sort | head -n -' not in body
+    ), "the raw keep-window is the defect"
+    assert "excluded from the keep window and NOT deleted" in body
 
 
 def test_a_relative_backup_root_is_refused(tmp_path):
@@ -1102,3 +1159,170 @@ def test_a_non_dated_pointer_inside_its_root_is_rejected(tmp_path):
     assert result.returncode == 1, out
     assert "holds no generation" in out, out
     assert f"proving generation: {decoy}" not in out, out
+
+
+# ── protections review #6 found inadequately pinned ──────────────────
+
+
+def test_the_mirror_delete_gating_is_behavioural_not_textual(tmp_path):
+    """A grep for `--delete` proves nothing about WHEN it is passed.
+
+    The earlier structural test would pass a script that built `RSYNC_ARGS=(-a)`
+    and then appended `--delete` unconditionally. This stubs rsync and reads the
+    arguments the writer actually chose on a fallback night.
+    """
+    app, data = _app(tmp_path)
+    stub = tmp_path / "bin"
+    stub.mkdir()
+    argv = tmp_path / "rsync-argv"
+    (stub / "rsync").write_text(
+        f'#!/bin/sh\nprintf "%s\\n" "$@" >> {argv}\nexit 0\n', encoding="utf-8"
+    )
+    (stub / "rsync").chmod(0o755)
+
+    env = {k: v for k, v in os.environ.items() if k not in {"BACKUP_ROOT", "BACKUP_FALLBACK_ROOT"}}
+    env.update(
+        APP_DIR=str(app),
+        DATA_DIR=str(data),
+        BACKUP_ROOT=str(_blocked(tmp_path, "primary")),  # forces the fallback
+        BACKUP_FALLBACK_ROOT=str(tmp_path / "fallback"),
+        PYTHON_BIN=sys.executable,
+        OFFBOX_RSYNC_DEST=str(tmp_path / "mirror") + "/",
+        PATH=f"{stub}:{os.environ['PATH']}",
+    )
+    (tmp_path / "mirror").mkdir()
+    result = subprocess.run(
+        ["bash", str(REPO / "deploy" / "backup" / "riskit-state-backup.sh")],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    out = result.stdout + result.stderr
+    assert result.returncode == 0, out
+    args = argv.read_text(encoding="utf-8").split("\n")
+    assert "--delete" not in args, (
+        "a fallback night must publish additively — the mirrored generations live "
+        f"in the root this run could not write to. args={args}"
+    )
+    assert "WITHOUT --delete" in out, out
+
+
+def test_the_mirror_still_deletes_when_it_owns_the_root(tmp_path):
+    """Additive-on-fallback must not become never-reconcile: a normal night
+    still makes the remote an exact replica, or remote retention grows forever."""
+    app, data = _app(tmp_path)
+    stub = tmp_path / "bin"
+    stub.mkdir()
+    argv = tmp_path / "rsync-argv"
+    (stub / "rsync").write_text(
+        f'#!/bin/sh\nprintf "%s\\n" "$@" >> {argv}\nexit 0\n', encoding="utf-8"
+    )
+    (stub / "rsync").chmod(0o755)
+
+    env = {k: v for k, v in os.environ.items() if k not in {"BACKUP_ROOT", "BACKUP_FALLBACK_ROOT"}}
+    env.update(
+        APP_DIR=str(app),
+        DATA_DIR=str(data),
+        BACKUP_ROOT=str(tmp_path / "primary"),  # writable: no fallback
+        BACKUP_FALLBACK_ROOT=str(tmp_path / "fallback"),
+        PYTHON_BIN=sys.executable,
+        OFFBOX_RSYNC_DEST=str(tmp_path / "mirror") + "/",
+        PATH=f"{stub}:{os.environ['PATH']}",
+    )
+    (tmp_path / "mirror").mkdir()
+    result = subprocess.run(
+        ["bash", str(REPO / "deploy" / "backup" / "riskit-state-backup.sh")],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    out = result.stdout + result.stderr
+    assert result.returncode == 0, out
+    assert "--delete" in argv.read_text(encoding="utf-8").split("\n"), out
+
+
+def test_a_source_directory_that_cannot_be_enumerated_is_a_failure(tmp_path):
+    """`prove_dir`'s find was unguarded: under `set -e` a partially unreadable
+    source killed the sweep with no diagnostic. A `|| true` would be worse —
+    it undercounts, and an undercount lets an empty restore pass the
+    zero-check. So an unenumerable source is a FAIL."""
+    body = PROOF.read_text(encoding="utf-8")
+    assert "could not be enumerated — coverage cannot be established" in body
+    assert 'src_entries="$(find "${src}" -type f 2>/dev/null | wc -l | tr -d \' \')"' in body
+    assert 'src_entries="$(find "${src}" -type f | wc -l | tr -d \' \')"' not in body
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root's rm always succeeds, so the trap cannot fail")
+def test_a_failing_cleanup_does_not_rewrite_the_verdict(tmp_path):
+    """F15, finally pinned — and pinned deterministically.
+
+    Under `set -Eeuo pipefail` a failing `rm -rf` inside an EXIT trap aborts the
+    trap: the pending exit status becomes 1 and every later step is skipped.
+    That reports a real artifact failure (exit 2) as infrastructure breakage and
+    leaks the result file.
+
+    An end-to-end version of this is a race — the proof finishes before you can
+    make the directory undeletable — so this extracts the SHIPPED `cleanup`
+    text and runs it with a restore dir that provably cannot be removed.
+    """
+    body = PROOF.read_text(encoding="utf-8")
+    start = body.index("cleanup() {")
+    end = body.index("\n}\n", start) + len("\n}\n")
+    func = body[start:end]
+
+    jail = tmp_path / "jail"
+    (jail / "restore").mkdir(parents=True)
+    (jail / "restore" / "held").write_text("x", encoding="utf-8")
+    result_file = tmp_path / "result"
+    result_file.write_text("schema=1\n", encoding="utf-8")
+    jail.chmod(0o500)  # entries inside cannot be unlinked
+    try:
+        harness = (
+            "set -Eeuo pipefail\n"
+            f'RESTORE_DIR="{jail / "restore"}"\n'
+            f'RESULT_FILE="{result_file}"\n' + func + "trap cleanup EXIT\nexit 2\n"
+        )
+        proc = subprocess.run(["bash", "-c", harness], capture_output=True, text=True, timeout=60)
+    finally:
+        jail.chmod(0o755)
+
+    assert proc.returncode == 2, (
+        "a failing cleanup must not rewrite the pending exit status "
+        f"(got {proc.returncode}){proc.stdout}{proc.stderr}"
+    )
+    assert not result_file.exists(), "a failing first step must not skip the second"
+
+
+def test_the_comparison_stamp_falls_back_to_the_directory_date(tmp_path):
+    """F7's derived-midnight fallback, isolated.
+
+    Without it a pointerless generation compares on an EMPTY stamp, and an empty
+    incumbent is a blank slate any later candidate overwrites — which is how a
+    2020 generation beat a same-day one.
+    """
+    lib = LIB.read_text(encoding="utf-8")
+    assert (
+        'at="${base}T00:00:00Z"' in lib
+    ), "the derived-midnight fallback is what makes the stamp non-empty"
+
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    first = _run_proof(app, data, primary, fallback)
+    assert first.returncode == 0, first.stdout + first.stderr
+    (primary / "last_generation").unlink()  # pointerless: stamp must be derived
+
+    older = fallback / "daily" / "2020-01-01"
+    older.mkdir(parents=True)
+    _write_pointer(fallback, older, "2020-01-01T02:30:00Z")
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+    assert result.returncode == 0, out
+    assert (
+        f"promoted_at {TODAY}T00:00:00Z" in out
+    ), "the derived stamp must be visible and non-empty"
+    assert f"[backup-proof] proving generation: {primary}/daily/{TODAY}" in out, out

--- a/tests/deploy/test_backup_root_resolution.py
+++ b/tests/deploy/test_backup_root_resolution.py
@@ -164,7 +164,10 @@ def test_an_unreadable_candidate_root_refuses_rather_than_certifying_an_older_on
     assert result.returncode == 1, out
     assert "NOT READABLE" in out, out
     assert "refusing to certify an older one" in out, out
-    assert str(stale) not in out.split("NOT READABLE")[-1], out
+    # The stale candidate is still LOGGED — every candidate examined is,
+    # so the refusal is legible. What must not happen is proving it.
+    assert f"proving generation: {stale}" not in out, out
+    assert "proven for every artifact" not in out, out
 
 
 def test_a_generation_without_a_pointer_is_still_found(tmp_path):

--- a/tests/deploy/test_backup_root_resolution.py
+++ b/tests/deploy/test_backup_root_resolution.py
@@ -217,9 +217,7 @@ def test_a_recorded_generation_that_no_longer_exists_is_a_failure(tmp_path):
 def test_no_recorded_generation_anywhere_is_a_failure(tmp_path):
     app, data = _app(tmp_path)
 
-    result = _run_proof(
-        app, data, tmp_path / "primary", tmp_path / "fallback", run_backup="0"
-    )
+    result = _run_proof(app, data, tmp_path / "primary", tmp_path / "fallback", run_backup="0")
     out = result.stdout + result.stderr
 
     assert result.returncode == 1, out
@@ -339,6 +337,7 @@ def test_neither_script_resolves_the_backup_root_itself():
     `BACKUP_FALLBACK_ROOT` default to either script would restore the two
     independent implementations that caused run 31872681688 to fail.
     """
+
     def executable_lines(path: Path) -> str:
         # Comment lines are excluded: the header prose quotes both paths
         # when explaining the defect, and prose is not an implementation.

--- a/tests/deploy/test_backup_root_resolution.py
+++ b/tests/deploy/test_backup_root_resolution.py
@@ -123,6 +123,135 @@ def _write_pointer(root: Path, generation: Path, promoted_at: str) -> None:
     )
 
 
+# ── discovery must not fail OPEN ─────────────────────────────────────
+#
+# Every case below was found by adversarially reviewing the first version
+# of this repair, and each was reproduced end to end before being fixed.
+# They share one shape: the proof reports success having certified a
+# generation that is not the newest one, or not production's at all.
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses the permission bits this exercises")
+def test_an_unreadable_candidate_root_refuses_rather_than_certifying_an_older_one(tmp_path):
+    """The nightly runs as root and chmods its root 0700.
+
+    An unprivileged prover therefore sees the primary as unreadable — and
+    if that reads as "empty", the proof goes on to certify the OLDER
+    generation in the readable fallback and exits 0. That is a worse bug
+    than the one this file exists to fix: it is the same disagreement
+    about location, inverted into a false pass.
+    """
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    # A FRESH generation in the primary, which we then make unreadable.
+    fresh = primary / "daily" / TODAY
+    fresh.mkdir(parents=True)
+    _write_pointer(primary, fresh, "2026-08-15T02:30:00Z")
+    # A STALE one in the readable fallback.
+    stale = fallback / "daily" / "2026-01-02"
+    stale.mkdir(parents=True)
+    _write_pointer(fallback, stale, "2026-01-02T02:30:00Z")
+
+    primary.chmod(0o000)
+    try:
+        result = _run_proof(app, data, primary, fallback, run_backup="0")
+    finally:
+        primary.chmod(0o755)
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 1, out
+    assert "NOT READABLE" in out, out
+    assert "refusing to certify an older one" in out, out
+    assert str(stale) not in out.split("NOT READABLE")[-1], out
+
+
+def test_a_generation_without_a_pointer_is_still_found(tmp_path):
+    """The pointer is younger than the backups.
+
+    Production's nightly runs a root-owned copy of the writer that only
+    apply_hardening.sh refreshes, so real generations land with no pointer
+    beside them. A discovery pass that could only follow pointers would be
+    blind to every one of them — and would silently prefer an older
+    generation that happens to have one.
+    """
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    # Build a real, complete generation in the primary, then remove its
+    # pointer to imitate the old writer.
+    first = _run_proof(app, data, primary, fallback)
+    assert first.returncode == 0, first.stdout + first.stderr
+    (primary / "last_generation").unlink()
+
+    # An older, pointered generation next door must not win.
+    stale = fallback / "daily" / "2026-01-02"
+    stale.mkdir(parents=True)
+    _write_pointer(fallback, stale, "2026-01-02T02:30:00Z")
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 0, out
+    assert "via on-disk scan" in out, out
+    assert f"proving generation: {primary}/daily/{TODAY}" in out, out
+
+
+def test_an_incumbent_with_an_unknown_stamp_is_not_a_blank_slate(tmp_path):
+    """`-z BEST_AT` let any later candidate win unconditionally.
+
+    A pointer whose promoted_at line is missing gave the incumbent an
+    empty stamp, and an empty incumbent accepted the next candidate
+    without comparing anything — measured selecting a 2020 generation over
+    a same-day one.
+    """
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    first = _run_proof(app, data, primary, fallback)
+    assert first.returncode == 0, first.stdout + first.stderr
+
+    ptr = primary / "last_generation"
+    ptr.write_text(
+        "\n".join(
+            line
+            for line in ptr.read_text(encoding="utf-8").splitlines()
+            if not line.startswith("promoted_at=")
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    ancient = fallback / "daily" / "2020-01-01"
+    ancient.mkdir(parents=True)
+    _write_pointer(fallback, ancient, "2020-01-01T02:30:00Z")
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 0, out
+    assert f"proving generation: {primary}/daily/{TODAY}" in out, out
+    # The ancient candidate is LOGGED on purpose — selection must be
+    # visible — but it must not be the one proven.
+    assert f"proving generation: {ancient}" not in out, out
+
+
+def test_proving_the_fallback_lineage_says_so(tmp_path):
+    """A green tick must not be read as "the nightly's backups restore"."""
+    app, data = _app(tmp_path)
+    primary = _blocked(tmp_path, "primary")
+    fallback = tmp_path / "fallback"
+
+    result = _run_proof(app, data, primary, fallback)
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 0, out
+    assert "NOT covered by this run" in out, out
+
+
 # ── the production defect ────────────────────────────────────────────
 
 
@@ -211,7 +340,7 @@ def test_a_recorded_generation_that_no_longer_exists_is_a_failure(tmp_path):
     out = result.stdout + result.stderr
 
     assert result.returncode == 1, out
-    assert "no recorded backup generation in any candidate root" in out, out
+    assert "no backup generation in any readable candidate root" in out, out
 
 
 def test_no_recorded_generation_anywhere_is_a_failure(tmp_path):
@@ -221,7 +350,7 @@ def test_no_recorded_generation_anywhere_is_a_failure(tmp_path):
     out = result.stdout + result.stderr
 
     assert result.returncode == 1, out
-    assert "no recorded backup generation in any candidate root" in out, out
+    assert "no backup generation in any readable candidate root" in out, out
 
 
 # ── the proof must prove the generation this run wrote ───────────────
@@ -309,12 +438,21 @@ def test_a_root_installed_script_gets_the_libraries_it_sources():
     start = hardening.index("apply_privileged_scripts() {")
     body = hardening[start : hardening.index("\n}\n", start)]
 
-    installed = {
+    order = [
         line.split('"')[1].rsplit("/", 1)[-1]
         for line in body.splitlines()
         if "install_priv_script " in line and not line.lstrip().startswith("#")
-    }
+    ]
+    installed = set(order)
     assert "riskit-state-backup.sh" in installed, installed
+
+    # ORDER MATTERS. The writer treats a missing library as fatal, and the
+    # backup timer fires at 02:30 UTC — installing the writer first leaves a
+    # window in which a nightly takes no backup at all.
+    assert order.index("backup_root_lib.sh") < order.index("riskit-state-backup.sh"), (
+        "the sourced library must be installed BEFORE the script that hard-fails "
+        f"without it; got {order}"
+    )
 
     # Anything a root-installed script resolves relative to ITSELF has to
     # travel with it.

--- a/tests/deploy/test_backup_root_resolution.py
+++ b/tests/deploy/test_backup_root_resolution.py
@@ -35,7 +35,7 @@ import shutil
 import sqlite3
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -168,6 +168,173 @@ def test_an_unreadable_candidate_root_refuses_rather_than_certifying_an_older_on
     # so the refusal is legible. What must not happen is proving it.
     assert f"[backup-proof] proving generation: {stale}" not in out, out
     assert "proven for every artifact" not in out, out
+
+
+def test_a_root_whose_daily_cannot_be_a_directory_refuses(tmp_path):
+    """ROOT-SAFE cover for the `daily/` readability arm.
+
+    The permission version of this needs a non-root runner, and under a root
+    runner the whole arm could be reverted to root-only with a green suite —
+    so the same policy is also exercised with a `daily` that simply cannot be
+    read as a directory, which no uid can bypass.
+    """
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    primary.mkdir()
+    (primary / "daily").write_text("not a directory", encoding="utf-8")
+    stale = fallback / "daily" / "2026-01-02"
+    stale.mkdir(parents=True)
+    _write_pointer(fallback, stale, "2026-01-02T02:30:00Z")
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 1, out
+    assert "NOT READABLE" in out, out
+    assert f"[backup-proof] proving generation: {stale}" not in out, out
+
+
+def test_a_root_whose_daily_is_an_unresolvable_symlink_refuses(tmp_path):
+    """ROOT-SAFE cover for the `! -L` pairing on the `daily/` arm.
+
+    `-e` dereferences, so a `daily/` symlink whose target cannot be resolved
+    is `! -e` too — and without the pairing that short-circuits the whole
+    readability check and reports "holds no generation", letting an older
+    root be certified. A dangling symlink reproduces it at any uid: it is
+    emphatically not "a root that was never written".
+    """
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    primary.mkdir()
+    (primary / "daily").symlink_to(tmp_path / "somewhere-unreachable")
+    stale = fallback / "daily" / "2026-01-02"
+    stale.mkdir(parents=True)
+    _write_pointer(fallback, stale, "2026-01-02T02:30:00Z")
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 1, out
+    assert "NOT READABLE" in out, out
+    assert f"[backup-proof] proving generation: {stale}" not in out, out
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses the permission bits this exercises")
+def test_a_root_with_an_unreadable_daily_refuses(tmp_path):
+    """The root and its `daily/` are permissioned independently.
+
+    The writer chmods only the root; `daily/` takes whatever `umask 077` gave
+    it. A root readable with an unreadable `daily/` used to report "holds no
+    generation" and let an older root be certified.
+    """
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    fresh = primary / "daily" / TODAY
+    fresh.mkdir(parents=True)
+    stale = fallback / "daily" / "2026-01-02"
+    stale.mkdir(parents=True)
+    _write_pointer(fallback, stale, "2026-01-02T02:30:00Z")
+
+    (primary / "daily").chmod(0o000)
+    try:
+        result = _run_proof(app, data, primary, fallback, run_backup="0")
+    finally:
+        (primary / "daily").chmod(0o755)
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 1, out
+    assert "NOT READABLE" in out, out
+    assert f"[backup-proof] proving generation: {stale}" not in out, out
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses the permission bits this exercises")
+def test_a_symlinked_root_pointing_somewhere_unreachable_refuses(tmp_path):
+    """Relocating backups to another volume via a symlink is ordinary.
+
+    `-e` dereferences and `dirname` does not, so the ancestor walk used to
+    step OFF the symlink onto its readable lexical parent and call the root
+    "absent" — reproducing the very fail-open the walk was added to close.
+    """
+    app, data = _app(tmp_path)
+    real = tmp_path / "vol" / "riskit-state"
+    (real / "daily" / TODAY).mkdir(parents=True)
+    primary = tmp_path / "primary"
+    primary.symlink_to(real)
+
+    fallback = tmp_path / "fallback"
+    stale = fallback / "daily" / "2026-01-02"
+    stale.mkdir(parents=True)
+    _write_pointer(fallback, stale, "2026-01-02T02:30:00Z")
+
+    (tmp_path / "vol").chmod(0o000)
+    try:
+        result = _run_proof(app, data, primary, fallback, run_backup="0")
+    finally:
+        (tmp_path / "vol").chmod(0o755)
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 1, out
+    assert "NOT READABLE" in out, out
+    assert "does not exist" not in out, "a symlink to an unreachable target is not an absent root"
+    assert f"[backup-proof] proving generation: {stale}" not in out, out
+
+
+def test_a_root_behind_a_non_directory_parent_refuses(tmp_path):
+    """ROOT-SAFE cover for the ancestor walk.
+
+    The faithful EACCES version needs a non-root runner. This one puts a
+    regular file where an ancestor directory belongs, which no uid can
+    traverse, so the walk's refusal is exercised at every privilege level.
+    """
+    app, data = _app(tmp_path)
+    primary = _blocked(tmp_path, "primary")
+    fallback = tmp_path / "fallback"
+    stale = fallback / "daily" / "2026-01-02"
+    stale.mkdir(parents=True)
+    _write_pointer(fallback, stale, "2026-01-02T02:30:00Z")
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 1, out
+    assert "NOT READABLE" in out, out
+    assert f"[backup-proof] proving generation: {stale}" not in out, out
+
+
+def test_selection_compares_the_date_before_the_instant(tmp_path):
+    """A derived midnight and a real `promoted_at` are not one currency.
+
+    Across 00:00 UTC a run mints `daily/<yesterday>` carrying a `promoted_at`
+    of *today*, which on a bare-stamp comparison beats a genuinely newer
+    pointerless `daily/<today>` sitting at `T00:00:00Z`.
+    """
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    # The genuinely newer generation, discovered by scan (no pointer).
+    first = _run_proof(app, data, primary, fallback)
+    assert first.returncode == 0, first.stdout + first.stderr
+    (primary / "last_generation").unlink()
+
+    # Yesterday's directory, stamped with an instant later in the day.
+    yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
+    older = fallback / "daily" / yesterday
+    older.mkdir(parents=True)
+    _write_pointer(fallback, older, f"{TODAY}T09:00:00Z")
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 0, out
+    assert f"[backup-proof] proving generation: {primary}/daily/{TODAY}" in out, out
+    assert f"[backup-proof] proving generation: {older}" not in out, out
 
 
 def test_a_generation_without_a_pointer_is_still_found(tmp_path):
@@ -532,15 +699,24 @@ def test_a_root_installed_script_gets_the_libraries_it_sources():
 
     # Anything a root-installed script resolves relative to ITSELF has to
     # travel with it.
-    sibling = re.compile(r'\$\(dirname "\$\{BASH_SOURCE\[0\]\}"\)/([\w.-]+)')
+    # Match on the SOURCED FILE, not on how its directory is spelled. Keying
+    # the rule to `$(dirname "${BASH_SOURCE[0]}")/x` matched exactly one
+    # idiom, and the repo's dominant form — `SCRIPT_DIR="$(cd "$(dirname
+    # "${BASH_SOURCE[0]}")" && pwd)"`, used by ten scripts under deploy/ —
+    # slips straight past it, re-opening the lost-nightly window with a
+    # green suite. Any sibling .sh a root-installed script sources must
+    # travel with it, however the path is written.
+    sourced = re.compile(r"^\s*(?:source|\.)\s+.*?([\w.-]+\.sh)", re.MULTILINE)
     for name in sorted(installed):
         src = next(REPO.glob(f"deploy/**/{name}"), None)
         assert src is not None, f"apply_hardening.sh installs {name}, which is not in deploy/"
-        for needed in sorted(set(sibling.findall(src.read_text(encoding="utf-8")))):
+        body = src.read_text(encoding="utf-8")
+        for needed in sorted(set(sourced.findall(body))):
+            if needed == name:
+                continue
             assert needed in installed, (
-                f"{name} resolves {needed} beside itself, but apply_hardening.sh "
-                f"does not install {needed} into the root-owned dir — the nightly "
-                f"would run without it"
+                f"{name} sources {needed}, but apply_hardening.sh does not install "
+                f"{needed} into the root-owned dir — the nightly would run without it"
             )
 
 

--- a/tests/deploy/test_backup_root_resolution.py
+++ b/tests/deploy/test_backup_root_resolution.py
@@ -1077,9 +1077,14 @@ def test_the_writer_only_deletes_a_mirror_it_is_a_replica_of(tmp_path):
     """
     body = (REPO / "deploy" / "backup" / "riskit-state-backup.sh").read_text(encoding="utf-8")
     assert "RSYNC_ARGS=(-a)" in body
-    assert '[[ "${BACKUP_ROOT}" == "${REQUESTED_ROOT}" ]]' in body
     assert "RSYNC_ARGS+=(--delete)" in body
     assert "rsync -a --delete" not in body, "unconditional --delete is the defect"
+    # Root identity is NECESSARY but not SUFFICIENT — that was the blocker.
+    # Continuity is the gate; these name the conditions that must hold.
+    assert "MIRROR_DELETE_REFUSED" in body
+    assert "local-history continuity cannot be established" in body
+    assert "local history SHRANK since the last mirror" in body
+    assert "the destination changed" in body
 
 
 def test_the_orphan_pointer_temp_sweep_reaches_a_symlinked_root(tmp_path):
@@ -1208,9 +1213,10 @@ def test_the_mirror_delete_gating_is_behavioural_not_textual(tmp_path):
     assert "WITHOUT --delete" in out, out
 
 
-def test_the_mirror_still_deletes_when_it_owns_the_root(tmp_path):
-    """Additive-on-fallback must not become never-reconcile: a normal night
-    still makes the remote an exact replica, or remote retention grows forever."""
+def test_the_first_mirror_from_a_root_publishes_additively(tmp_path):
+    """There is no continuity evidence yet on a first mirror, so the safe
+    direction is additive. Reconciliation is proven on the second run by
+    test_a_continuous_root_still_reconciles_the_mirror."""
     app, data = _app(tmp_path)
     stub = tmp_path / "bin"
     stub.mkdir()
@@ -1224,7 +1230,7 @@ def test_the_mirror_still_deletes_when_it_owns_the_root(tmp_path):
     env.update(
         APP_DIR=str(app),
         DATA_DIR=str(data),
-        BACKUP_ROOT=str(tmp_path / "primary"),  # writable: no fallback
+        BACKUP_ROOT=str(tmp_path / "primary"),
         BACKUP_FALLBACK_ROOT=str(tmp_path / "fallback"),
         PYTHON_BIN=sys.executable,
         OFFBOX_RSYNC_DEST=str(tmp_path / "mirror") + "/",
@@ -1240,7 +1246,8 @@ def test_the_mirror_still_deletes_when_it_owns_the_root(tmp_path):
     )
     out = result.stdout + result.stderr
     assert result.returncode == 0, out
-    assert "--delete" in argv.read_text(encoding="utf-8").split("\n"), out
+    assert "--delete" not in argv.read_text(encoding="utf-8").split("\n"), out
+    assert "no record of a previous mirror" in out, out
 
 
 def test_a_source_directory_that_cannot_be_enumerated_is_a_failure(tmp_path):
@@ -1326,3 +1333,133 @@ def test_the_comparison_stamp_falls_back_to_the_directory_date(tmp_path):
         f"promoted_at {TODAY}T00:00:00Z" in out
     ), "the derived stamp must be visible and non-empty"
     assert f"[backup-proof] proving generation: {primary}/daily/{TODAY}" in out, out
+
+
+# ── off-box destructive reconciliation requires proof of continuity ──
+
+
+def _rsync_stub(tmp_path: Path) -> Path:
+    """A stub implementing the real `--delete` semantic, so the test measures
+    behaviour rather than the presence of a flag."""
+    stub = tmp_path / "bin"
+    stub.mkdir(exist_ok=True)
+    (stub / "rsync").write_text(
+        "#!/bin/bash\n"
+        'args=("$@"); del=0\n'
+        'for a in "${args[@]}"; do [[ "$a" == "--delete" ]] && del=1; done\n'
+        'src="${args[-2]}"; dst="${args[-1]}"\n'
+        'cp -a "${src}." "${dst}" 2>/dev/null\n'
+        "if (( del )); then\n"
+        '  for e in "${dst}"*/; do n="$(basename "$e")"; [[ -e "${src}${n}" ]] || rm -rf "$e"; done\n'
+        "fi\nexit 0\n",
+        encoding="utf-8",
+    )
+    (stub / "rsync").chmod(0o755)
+    return stub
+
+
+def _run_writer(app: Path, data: Path, root: Path, tmp_path: Path, dest: Path):
+    env = {k: v for k, v in os.environ.items() if k not in {"BACKUP_ROOT", "BACKUP_FALLBACK_ROOT"}}
+    env.update(
+        APP_DIR=str(app),
+        DATA_DIR=str(data),
+        BACKUP_ROOT=str(root),
+        BACKUP_FALLBACK_ROOT=str(tmp_path / "fb"),
+        PYTHON_BIN=sys.executable,
+        OFFBOX_RSYNC_DEST=str(dest) + "/",
+        PATH=f"{_rsync_stub(tmp_path)}:{os.environ['PATH']}",
+    )
+    return subprocess.run(
+        ["bash", str(REPO / "deploy" / "backup" / "riskit-state-backup.sh")],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+
+def test_local_history_loss_must_not_delete_the_only_surviving_remote_copies(tmp_path):
+    """THE release blocker. Reproduced 5 -> 1 before the fix.
+
+    `BACKUP_ROOT == REQUESTED_ROOT` answers which root we wrote to, not whether
+    that root still holds the history the mirror was built from. A writable
+    primary whose local generations vanished — disk replaced, /var wiped,
+    restored image, fresh host — passed that gate while being exactly the state
+    in which the off-box copy is the last one standing.
+    """
+    app, data = _app(tmp_path)
+    mirror = tmp_path / "mirror"
+    mirror.mkdir()
+    for g in ("2026-08-01", "2026-08-02", "2026-08-03", "2026-08-04", "2026-08-05"):
+        (mirror / g / "sqlite").mkdir(parents=True)
+
+    root = tmp_path / "primary"  # writable, but its local history is gone
+    (root / "daily").mkdir(parents=True)
+    result = _run_writer(app, data, root, tmp_path, mirror)
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 0, out
+    survivors = sorted(p.name for p in mirror.iterdir() if p.is_dir())
+    assert len(survivors) == 6, f"remote history was destroyed: {survivors}\n{out}"
+    assert "WITHOUT --delete" in out and "local-history continuity" in out, out
+
+
+def test_a_continuous_root_still_reconciles_the_mirror(tmp_path):
+    """Fail-closed must not become fail-never: without reconciliation the
+    remote grows without bound, which is its own failure."""
+    app, data = _app(tmp_path)
+    mirror = tmp_path / "mirror"
+    mirror.mkdir()
+    root = tmp_path / "primary"
+
+    first = _run_writer(app, data, root, tmp_path, mirror)
+    assert first.returncode == 0, first.stdout + first.stderr
+    # A stale remote generation with no local counterpart.
+    (mirror / "2000-01-01" / "sqlite").mkdir(parents=True)
+
+    second = _run_writer(app, data, root, tmp_path, mirror)
+    out = second.stdout + second.stderr
+    assert second.returncode == 0, out
+    assert not (
+        mirror / "2000-01-01"
+    ).exists(), f"a continuous root must still reconcile, or remote retention grows forever\n{out}"
+
+
+def test_a_changed_destination_is_not_reconciled(tmp_path):
+    """Continuity is proven against a DESTINATION, not in the abstract — a
+    remote we have never mirrored to may hold someone else's only copies."""
+    app, data = _app(tmp_path)
+    root = tmp_path / "primary"
+    first_dest = tmp_path / "mirror-a"
+    first_dest.mkdir()
+    assert _run_writer(app, data, root, tmp_path, first_dest).returncode == 0
+
+    other = tmp_path / "mirror-b"
+    other.mkdir()
+    for g in ("2026-07-01", "2026-07-02"):
+        (other / g / "sqlite").mkdir(parents=True)
+    result = _run_writer(app, data, root, tmp_path, other)
+    out = result.stdout + result.stderr
+    assert result.returncode == 0, out
+    assert (other / "2026-07-01").exists() and (other / "2026-07-02").exists(), out
+    assert "destination changed" in out, out
+
+
+def test_only_recognised_generations_count_toward_continuity(tmp_path):
+    """The continuity count must mean GENERATIONS.
+
+    If a stray entry inflates it, the count can hold steady while real
+    generations vanish — which would let `--delete` run in exactly the state
+    the gate exists to catch. Positive recognition: a directory, not a symlink,
+    the writer's dated shape, and a real calendar date.
+    """
+    body = (REPO / "deploy" / "backup" / "riskit-state-backup.sh").read_text(encoding="utf-8")
+    assert "plausible_generations()" in body
+    assert "MIRROR_COUNT=\"$(plausible_generations | wc -l | tr -d ' ')\"" in body
+    for guard in (
+        '[[ -d "${BACKUP_ROOT}/daily/${dir}" ]] || continue',
+        '[[ ! -L "${BACKUP_ROOT}/daily/${dir}" ]] || continue',
+        '[[ "${dir}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || continue',
+        '[[ "$(date -u -d "${dir}" +%Y-%m-%d 2>/dev/null)" == "${dir}" ]] || continue',
+    ):
+        assert guard in body, f"missing positive-recognition guard: {guard}"

--- a/tests/deploy/test_backup_root_resolution.py
+++ b/tests/deploy/test_backup_root_resolution.py
@@ -854,3 +854,251 @@ def test_neither_script_resolves_the_backup_root_itself():
         assert "/home/dynasty/backups/riskit-state" not in code, script
         assert "/var/backups/riskit-state" not in code, script
         assert "backup_root_lib.sh" in code, f"{script} must source the shared resolver"
+
+
+# ── the fifth review: a pointer is a hint, not a redirect ────────────
+
+
+def test_a_pointer_may_not_redirect_out_of_its_own_root(tmp_path):
+    """THE critical one. Reproduced with an attacker-planted table.
+
+    `backup_root_read_generation` validated only `schema=1` and `-d`. It never
+    required the named path to lie under the root that supplied the pointer,
+    nor to have the dated shape the selection algorithm compares on — and in
+    this collation EVERY non-digit basename sorts ABOVE every date, so an
+    out-of-root pointer named anything else beat the root's own newest
+    unconditionally and silently disarmed the on-disk scan.
+
+    Measured before the fix: the prover logged `effective backup root: …/primary`
+    while proving `…/elsewhere/restore-scratch`, gunzipped its contents, and
+    exited 0. The real generation in the root it named was never opened.
+    """
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    first = _run_proof(app, data, primary, fallback)
+    assert first.returncode == 0, first.stdout + first.stderr
+    real = primary / "daily" / TODAY
+
+    # A generation-shaped directory outside any candidate root.
+    decoy = tmp_path / "elsewhere" / "restore-scratch"
+    decoy.mkdir(parents=True)
+    shutil.copytree(real / "sqlite", decoy / "sqlite")
+    _write_pointer(primary, decoy, "2026-08-15T02:30:00Z")
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 0, out
+    assert f"[backup-proof] proving generation: {real}" in out, out
+    assert str(decoy) not in out, "a pointer must not redirect out of its own root"
+    assert "via on-disk scan" in out, "the scan must take over when the pointer is rejected"
+
+
+def test_the_selected_generation_must_lie_under_the_root_that_supplied_it(tmp_path):
+    """Belt-and-braces: `effective backup root: X` may never be printed for a
+    generation that is not under X, whatever produced the selection."""
+    body = PROOF.read_text(encoding="utf-8")
+    assert "is not under the root that supplied it" in body
+    assert '"${GEN}" != "${EFFECTIVE_ROOT%/}/daily/"*' in body
+
+
+def test_a_future_dated_generation_is_not_evidence_of_recency(tmp_path):
+    """`riskit-state-backup.timer` is `Persistent=true`, so a missed nightly
+    replays at boot — before NTP has stepped the clock — and promotes a
+    complete generation dated years ahead. It then outranks every real one
+    forever and prune can never reach it, so every later proof certifies it
+    without opening the current generation.
+    """
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    first = _run_proof(app, data, primary, fallback)
+    assert first.returncode == 0, first.stdout + first.stderr
+    real = primary / "daily" / TODAY
+    skewed = primary / "daily" / "2099-03-04"
+    shutil.copytree(real, skewed)
+    (primary / "last_generation").unlink()
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 0, out
+    assert f"[backup-proof] proving generation: {real}" in out, out
+    assert "dated in the future" in out, "the skip must be announced, never silent"
+
+
+def test_a_relative_backup_root_is_refused(tmp_path):
+    """A root is a LOCATION, and only an absolute path is one.
+
+    A relative root resolves against each PROCESS's own cwd, so the writer
+    promotes under its cwd while the prover calls the same root "does not
+    exist" — two answers to one location question, the exact class this
+    library exists to eliminate. Refused, never normalised against $PWD.
+    """
+    app, data = _app(tmp_path)
+    result = _run_proof(app, data, Path("relative/primary"), tmp_path / "fallback")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 1, out
+    assert "absolute path" in out, out
+
+
+def test_an_empty_certified_generation_is_not_a_proof(tmp_path):
+    """ "No artifact failed" is true of a run that read nothing.
+
+    The writer discards any snapshot with zero artifacts and never promotes
+    it, so a certified directory holding none is not a generation — and
+    announcing a proof over one is indistinguishable from a real pass.
+    """
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+    # No retention source present, so nothing can fail for the ordinary
+    # "exists on source, missing from backup" reason — the floor is the only
+    # thing that can refuse here.
+    (data / "retention" / "evidence.sqlite").unlink()
+
+    empty = primary / "daily" / TODAY
+    empty.mkdir(parents=True)
+    _write_pointer(primary, empty, f"{TODAY}T02:30:00Z")
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 2, out
+    assert "holds NO artifact at all" in out, out
+    assert "proven for every artifact" not in out, out
+
+
+def test_a_successful_proof_reports_what_it_actually_verified(tmp_path):
+    """Silence must not read as proof: the verdict prints its counts."""
+    app, data = _app(tmp_path)
+    result = _run_proof(app, data, tmp_path / "primary", tmp_path / "fallback")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 0, out
+    assert re.search(
+        r"backup \+ restore proven: \d+ retention artifact\(s\) restored and verified", out
+    ), out
+
+
+def test_an_unresolvable_source_is_not_a_stream_that_never_started(tmp_path):
+    """ROOT-SAFE. The same ENOENT/EACCES conflation, on the artifact side.
+
+    A retention store on a volume that failed to mount is `! -f` exactly as a
+    store that was never created is, so it was excused as "stream has not
+    started", omitted from every generation, and the run exited 0. It cannot
+    be caught by BACKUP_REQUIRED — the retention artifacts are excluded from
+    it by design.
+    """
+    app, data = _app(tmp_path)
+    (data / "retention" / "evidence.sqlite").unlink()
+    (data / "retention" / "evidence.sqlite").symlink_to(tmp_path / "unmounted" / "evidence.sqlite")
+
+    result = _run_proof(app, data, tmp_path / "primary", tmp_path / "fallback")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 2, out
+    assert "cannot be resolved" in out, out
+    # Other streams legitimately report "not started"; the unresolvable one
+    # must not be among them.
+    for line in out.splitlines():
+        if "evidence.sqlite" in line:
+            assert "stream has not started" not in line, line
+
+
+def test_the_writer_only_deletes_a_mirror_it_is_a_replica_of(tmp_path):
+    """One fallback night must not destroy the entire remote history.
+
+    `--delete` makes the remote an exact replica of ONE root's `daily/`. On a
+    fallback night this root holds only what that run just wrote, while the
+    mirrored generations live in the root it could not write to — which is
+    precisely the failure that makes the off-box copy the only surviving one.
+    """
+    body = (REPO / "deploy" / "backup" / "riskit-state-backup.sh").read_text(encoding="utf-8")
+    assert "RSYNC_ARGS=(-a)" in body
+    assert '[[ "${BACKUP_ROOT}" == "${REQUESTED_ROOT}" ]]' in body
+    assert "RSYNC_ARGS+=(--delete)" in body
+    assert "rsync -a --delete" not in body, "unconditional --delete is the defect"
+
+
+def test_the_orphan_pointer_temp_sweep_reaches_a_symlinked_root(tmp_path):
+    """F9's sweep did nothing when the root is a symlink — `find` will not
+    descend one without a trailing slash, which is the exact configuration the
+    prover's `! -L` guards exist to handle."""
+    body = (REPO / "deploy" / "backup" / "riskit-state-backup.sh").read_text(encoding="utf-8")
+    assert """find "${BACKUP_ROOT}/" -maxdepth 1 -name 'last_generation.tmp.*'""" in body
+
+
+def test_the_pointer_temp_name_is_not_derivable(tmp_path):
+    """`>` follows a symlink, and `${out}.tmp.$$` is derivable from a
+    world-readable result path."""
+    lib = LIB.read_text(encoding="utf-8")
+    assert 'mktemp "${out}.tmp.XXXXXX"' in lib
+    # Assert on the CODE, not on prose that quotes the old form.
+    assert 'tmp="${out}.tmp.$$"' not in lib, "the derivable name is the defect"
+
+
+def test_a_dated_pointer_outside_its_root_is_rejected(tmp_path):
+    """Containment, isolated from the shape check.
+
+    The two guards mask each other: a decoy that is both out-of-root AND
+    non-dated is rejected by either one alone, so a single test cannot tell
+    which is doing the work. This decoy is correctly DATED and merely lives
+    somewhere else — only containment rejects it.
+    """
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    first = _run_proof(app, data, primary, fallback)
+    assert first.returncode == 0, first.stdout + first.stderr
+    real = primary / "daily" / TODAY
+
+    decoy = tmp_path / "elsewhere" / "daily" / TODAY
+    decoy.mkdir(parents=True)
+    shutil.copytree(real / "sqlite", decoy / "sqlite")
+    _write_pointer(primary, decoy, f"{TODAY}T02:30:00Z")
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 0, out
+    assert f"[backup-proof] proving generation: {real}" in out, out
+    assert str(decoy) not in out, out
+
+
+def test_a_non_dated_pointer_inside_its_root_is_rejected(tmp_path):
+    """The dated-shape check, isolated from BOTH other guards.
+
+    Getting this one to fail the right way took two attempts, and the reason
+    is worth recording. A non-dated name that sorts ABOVE dates is already
+    rejected by the future-date guard, so removing the shape check changes
+    nothing — the guards mask each other by coincidence, not by design. The
+    case that needs the shape check specifically is a name that sorts BELOW
+    dates in a root holding no dated generation at all: nothing else can rule
+    it out, and without the check the prover certifies a scratch directory.
+    """
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    first = _run_proof(app, data, primary, fallback)
+    assert first.returncode == 0, first.stdout + first.stderr
+    real = primary / "daily" / TODAY
+
+    # "!scratch" sorts below every date, so ordering cannot save us here.
+    decoy = primary / "daily" / "!scratch"
+    shutil.copytree(real, decoy)
+    shutil.rmtree(real)
+    _write_pointer(primary, decoy, f"{TODAY}T02:30:00Z")
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 1, out
+    assert "holds no generation" in out, out
+    assert f"proving generation: {decoy}" not in out, out

--- a/tests/deploy/test_backup_root_resolution.py
+++ b/tests/deploy/test_backup_root_resolution.py
@@ -1,0 +1,362 @@
+"""The backup writer and the restore proof must agree on WHERE the backup is.
+
+Production proof run 31872681688 failed with "no backup generation under
+/var/backups/riskit-state/daily" while that night's backup had *succeeded*:
+the primary root was not writable, the writer fell back to the service
+user's home and promoted a complete generation there, and the proof — which
+resolved the location itself, from the same two defaults — went on reading
+the empty primary.
+
+Two independent implementations of one decision produce exactly one class of
+bug, so there is now one owner (``deploy/backup/backup_root_lib.sh``) plus a
+machine-readable result the writer emits and the proof reads.  The invariant
+these tests hold is:
+
+    the location that successfully receives the promoted backup
+      ==
+    the location the restore proof subsequently inspects
+
+Everything here runs the SHIPPED scripts end to end — the real
+``riskit-state-backup.sh`` under the real
+``retention_backup_restore_proof.sh``, against a throwaway data dir. Nothing
+is reimplemented, so an edit to either script is what these check.
+
+Unwritable roots are constructed by putting a regular FILE where the root's
+parent directory would be: ``mkdir -p`` then fails for every user including
+root, so the fallback path is exercised deterministically rather than
+depending on who the test runs as.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+PROOF = REPO / "deploy" / "diagnostics" / "retention_backup_restore_proof.sh"
+LIB = REPO / "deploy" / "backup" / "backup_root_lib.sh"
+
+pytestmark = pytest.mark.skipif(shutil.which("bash") is None, reason="bash required")
+
+TODAY = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _sqlite(path: Path, ddl: tuple[str, ...] = ()) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(path)
+    try:
+        for stmt in ddl:
+            con.execute(stmt)
+        con.commit()
+    finally:
+        con.close()
+
+
+def _app(tmp_path: Path) -> tuple[Path, Path]:
+    """A throwaway APP_DIR holding a real copy of deploy/ and a small data dir."""
+    app = tmp_path / "app"
+    shutil.copytree(REPO / "deploy", app / "deploy")
+
+    data = app / "data"
+    # BACKUP_REQUIRED defaults to these two; without them the writer
+    # correctly discards the snapshot.
+    _sqlite(data / "user_kv.sqlite", ("CREATE TABLE kv (k TEXT PRIMARY KEY, v TEXT)",))
+    _sqlite(data / "session_store.sqlite", ("CREATE TABLE sessions (id TEXT PRIMARY KEY)",))
+    # One real retention artifact, so the proof is proving something.
+    _sqlite(
+        data / "retention" / "evidence.sqlite",
+        (
+            "CREATE TABLE scoring_card_payloads (card_hash TEXT PRIMARY KEY)",
+            "CREATE TABLE scoring_card_observations (sleeper_league_id TEXT, observed_at TEXT)",
+            "CREATE TABLE trending_observations (source TEXT, observed_at TEXT)",
+        ),
+    )
+    return app, data
+
+
+def _run_proof(
+    app: Path,
+    data: Path,
+    primary: Path,
+    fallback: Path,
+    run_backup: str = "1",
+) -> subprocess.CompletedProcess:
+    env = {k: v for k, v in os.environ.items() if k not in {"BACKUP_ROOT", "BACKUP_FALLBACK_ROOT"}}
+    env.update(
+        APP_DIR=str(app),
+        DATA_DIR=str(data),
+        BACKUP_ROOT=str(primary),
+        BACKUP_FALLBACK_ROOT=str(fallback),
+        PYTHON_BIN=sys.executable,
+        RUN_BACKUP=run_backup,
+    )
+    return subprocess.run(
+        ["bash", str(PROOF)], env=env, capture_output=True, text=True, timeout=300
+    )
+
+
+def _blocked(tmp_path: Path, name: str) -> Path:
+    """A root whose parent is a regular file — `mkdir -p` fails for anyone."""
+    blocker = tmp_path / f"{name}-blocker"
+    blocker.write_text("not a directory", encoding="utf-8")
+    return blocker / name
+
+
+def _write_pointer(root: Path, generation: Path, promoted_at: str) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "last_generation").write_text(
+        "schema=1\n"
+        f"effective_root={root}\n"
+        f"generation={generation}\n"
+        f"date_stamp={TODAY}\n"
+        "artifacts=3\n"
+        f"promoted_at={promoted_at}\n",
+        encoding="utf-8",
+    )
+
+
+# ── the production defect ────────────────────────────────────────────
+
+
+def test_an_unwritable_primary_root_falls_back_and_the_proof_follows(tmp_path):
+    """THE regression. Proof run 31872681688, reproduced.
+
+    The writer must fall back, and the proof must inspect the location the
+    writer actually used — not the primary it was asked for.
+    """
+    app, data = _app(tmp_path)
+    primary = _blocked(tmp_path, "primary")
+    fallback = tmp_path / "fallback"
+
+    result = _run_proof(app, data, primary, fallback)
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 0, out
+    assert f"effective backup root: {fallback}" in out, out
+    assert f"proving generation: {fallback}/daily/{TODAY}" in out, out
+    # The proof read the fallback generation back, not merely located it.
+    assert "C1-RET-04/05 evidence.sqlite: PRAGMA integrity_check = ok" in out, out
+    # And the backup really is there.
+    assert (fallback / "daily" / TODAY / "sqlite" / "evidence.sqlite.gz").is_file()
+
+
+def test_a_writable_primary_root_is_used_by_both(tmp_path):
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    result = _run_proof(app, data, primary, fallback)
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 0, out
+    assert f"effective backup root: {primary}" in out, out
+    assert f"proving generation: {primary}/daily/{TODAY}" in out, out
+    assert not fallback.exists(), "the fallback must not be touched when the primary works"
+
+
+# ── failures must stay failures ──────────────────────────────────────
+
+
+def test_a_fatal_backup_failure_is_not_dressed_up_as_a_proof(tmp_path):
+    """Neither root usable: the writer exits 1 and the proof cannot run.
+
+    The one outcome that must never happen is exit 0.
+    """
+    app, data = _app(tmp_path)
+    primary = _blocked(tmp_path, "primary")
+    fallback = _blocked(tmp_path, "fallback")
+
+    result = _run_proof(app, data, primary, fallback)
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 1, out
+    assert "backup run FAILED" in out, out
+
+
+def test_a_backup_that_loses_required_state_still_fails(tmp_path):
+    """The required-artifact manifest keeps its authority through the change."""
+    app, data = _app(tmp_path)
+    (data / "user_kv.sqlite").unlink()
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    result = _run_proof(app, data, primary, fallback)
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 1, out
+    assert "backup run FAILED" in out, out
+    # Nothing was promoted, so nothing can be "proven".
+    assert not (primary / "daily" / TODAY).exists()
+
+
+def test_a_recorded_generation_that_no_longer_exists_is_a_failure(tmp_path):
+    """A pointer to a pruned generation is not a generation."""
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    first = _run_proof(app, data, primary, fallback)
+    assert first.returncode == 0, first.stdout + first.stderr
+    shutil.rmtree(primary / "daily" / TODAY)
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 1, out
+    assert "no recorded backup generation in any candidate root" in out, out
+
+
+def test_no_recorded_generation_anywhere_is_a_failure(tmp_path):
+    app, data = _app(tmp_path)
+
+    result = _run_proof(
+        app, data, tmp_path / "primary", tmp_path / "fallback", run_backup="0"
+    )
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 1, out
+    assert "no recorded backup generation in any candidate root" in out, out
+
+
+# ── the proof must prove the generation this run wrote ───────────────
+
+
+def test_the_proof_cannot_be_captured_by_a_pointer_in_the_other_root(tmp_path):
+    """A newer pointer in the fallback must not hijack a run that just
+    promoted into the primary.
+
+    With RUN_BACKUP=1 the generation comes from the result THIS run wrote,
+    so selection is not a search at all. The decoy names an empty directory:
+    if it were ever selected the proof would report the retention artifact
+    missing and exit 2, so this fails loudly in both directions.
+    """
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    decoy = fallback / "daily" / "2099-01-01"
+    decoy.mkdir(parents=True)
+    _write_pointer(fallback, decoy, "2099-01-01T00:00:00Z")
+
+    result = _run_proof(app, data, primary, fallback)
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 0, out
+    assert f"proving generation: {primary}/daily/{TODAY}" in out, out
+    assert str(decoy) not in out, out
+
+
+def test_discovery_takes_the_newest_recorded_generation(tmp_path):
+    """RUN_BACKUP=0 across both roots: newest promoted_at wins, and every
+    candidate examined is logged rather than silently passed over."""
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    first = _run_proof(app, data, primary, fallback)
+    assert first.returncode == 0, first.stdout + first.stderr
+
+    # A genuine, newer generation in the other root.
+    newer = fallback / "daily" / TODAY
+    newer.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(primary / "daily" / TODAY, newer)
+    _write_pointer(fallback, newer, "2099-01-01T00:00:00Z")
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 0, out
+    assert f"candidate root {primary}: generation" in out, out
+    assert f"candidate root {fallback}: generation" in out, out
+    assert f"effective backup root: {fallback}" in out, out
+    assert f"proving generation: {newer}" in out, out
+
+
+# ── structural: one owner, not two ───────────────────────────────────
+
+
+def test_the_proof_refuses_to_run_without_the_shared_resolver(tmp_path):
+    """On a revision that predates the library the proof must say it cannot
+    run — not fall back to a local copy of the resolution logic."""
+    app, data = _app(tmp_path)
+    (app / "deploy" / "backup" / "backup_root_lib.sh").unlink()
+
+    result = _run_proof(app, data, tmp_path / "primary", tmp_path / "fallback")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 1, out
+    assert "backup root library missing on the deployed revision" in out, out
+
+
+def test_a_root_installed_script_gets_the_libraries_it_sources():
+    """The nightly does not run the checkout copy.
+
+    `riskit-state-backup.service` points at a root-owned copy under
+    /usr/local/lib/riskit that `apply_hardening.sh` installs, so a script
+    that starts SOURCING a sibling needs that sibling installed beside it
+    or the nightly resolves no backup root at all and exits 1.
+
+    Stated as the general rule rather than the one instance, because the
+    next sourced helper will hit exactly this.
+    """
+    hardening = (REPO / "deploy" / "apply_hardening.sh").read_text(encoding="utf-8")
+    start = hardening.index("apply_privileged_scripts() {")
+    body = hardening[start : hardening.index("\n}\n", start)]
+
+    installed = {
+        line.split('"')[1].rsplit("/", 1)[-1]
+        for line in body.splitlines()
+        if "install_priv_script " in line and not line.lstrip().startswith("#")
+    }
+    assert "riskit-state-backup.sh" in installed, installed
+
+    # Anything a root-installed script resolves relative to ITSELF has to
+    # travel with it.
+    sibling = re.compile(r'\$\(dirname "\$\{BASH_SOURCE\[0\]\}"\)/([\w.-]+)')
+    for name in sorted(installed):
+        src = next(REPO.glob(f"deploy/**/{name}"), None)
+        assert src is not None, f"apply_hardening.sh installs {name}, which is not in deploy/"
+        for needed in sorted(set(sibling.findall(src.read_text(encoding="utf-8")))):
+            assert needed in installed, (
+                f"{name} resolves {needed} beside itself, but apply_hardening.sh "
+                f"does not install {needed} into the root-owned dir — the nightly "
+                f"would run without it"
+            )
+
+
+def test_neither_script_resolves_the_backup_root_itself():
+    """The fallback root may be named in exactly one place.
+
+    This is the structural half of the repair: re-adding a local
+    `BACKUP_FALLBACK_ROOT` default to either script would restore the two
+    independent implementations that caused run 31872681688 to fail.
+    """
+    def executable_lines(path: Path) -> str:
+        # Comment lines are excluded: the header prose quotes both paths
+        # when explaining the defect, and prose is not an implementation.
+        return "\n".join(
+            line
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if not line.lstrip().startswith("#")
+        )
+
+    lib = executable_lines(LIB)
+    assert lib.count("/home/dynasty/backups/riskit-state") == 1
+    assert lib.count("/var/backups/riskit-state") == 1
+
+    for script in (
+        REPO / "deploy" / "backup" / "riskit-state-backup.sh",
+        PROOF,
+    ):
+        code = executable_lines(script)
+        assert "/home/dynasty/backups/riskit-state" not in code, script
+        assert "/var/backups/riskit-state" not in code, script
+        assert "backup_root_lib.sh" in code, f"{script} must source the shared resolver"

--- a/tests/deploy/test_backup_root_resolution.py
+++ b/tests/deploy/test_backup_root_resolution.py
@@ -166,7 +166,7 @@ def test_an_unreadable_candidate_root_refuses_rather_than_certifying_an_older_on
     assert "refusing to certify an older one" in out, out
     # The stale candidate is still LOGGED — every candidate examined is,
     # so the refusal is legible. What must not happen is proving it.
-    assert f"proving generation: {stale}" not in out, out
+    assert f"[backup-proof] proving generation: {stale}" not in out, out
     assert "proven for every artifact" not in out, out
 
 
@@ -199,7 +199,80 @@ def test_a_generation_without_a_pointer_is_still_found(tmp_path):
 
     assert result.returncode == 0, out
     assert "via on-disk scan" in out, out
-    assert f"proving generation: {primary}/daily/{TODAY}" in out, out
+    assert f"[backup-proof] proving generation: {primary}/daily/{TODAY}" in out, out
+
+
+def test_a_stale_pointer_does_not_mask_a_newer_generation_in_its_own_root(tmp_path):
+    """The pointer is a hint, not an upper bound.
+
+    It is written AFTER promotion and a failed write is only a warning, so
+    a run killed in that window leaves a stale pointer sitting in front of
+    a newer generation in the same root. Consulting the disk only when the
+    pointer says *nothing* lets that stale pointer win unconditionally.
+    """
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    first = _run_proof(app, data, primary, fallback)
+    assert first.returncode == 0, first.stdout + first.stderr
+
+    # Age the real generation, and leave the pointer naming it — then put a
+    # newer dated generation on disk beside it with no pointer of its own.
+    real = primary / "daily" / TODAY
+    older = primary / "daily" / "2026-01-02"
+    shutil.copytree(real, older)
+    _write_pointer(primary, older, "2026-01-02T02:30:00Z")
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 0, out
+    assert "NEWER generation is on disk" in out, out
+    assert f"[backup-proof] proving generation: {real}" in out, out
+
+
+def test_the_proof_reads_the_run_s_result_rather_than_re_deriving(tmp_path):
+    """The headline mechanism, pinned.
+
+    Re-deriving the location — `ls -1d $BACKUP_ROOT/daily/20*`, which is
+    what `main` did — is the defect. Here the writer records a generation
+    the re-derivation could never name, so a proof that re-derives cannot
+    pass this.
+    """
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    # A decoy the old `ls .../daily/20*` scan WOULD have picked: newest by
+    # name, in the requested primary, but not what any run promoted.
+    decoy = primary / "daily" / "2099-12-31"
+    decoy.mkdir(parents=True)
+
+    result = _run_proof(app, data, primary, fallback)
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 0, out
+    assert f"[backup-proof] proving generation: {primary}/daily/{TODAY}" in out, out
+    assert str(decoy) not in out, "the proof re-derived the location instead of reading the result"
+
+
+def test_the_on_disk_scan_takes_the_newest_dated_directory(tmp_path):
+    app, data = _app(tmp_path)
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+
+    first = _run_proof(app, data, primary, fallback)
+    assert first.returncode == 0, first.stdout + first.stderr
+    (primary / "last_generation").unlink()
+    for older in ("2019-01-01", "2020-06-30", "2026-01-02"):
+        (primary / "daily" / older).mkdir(parents=True)
+
+    result = _run_proof(app, data, primary, fallback, run_backup="0")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 0, out
+    assert f"[backup-proof] proving generation: {primary}/daily/{TODAY}" in out, out
 
 
 def test_an_incumbent_with_an_unknown_stamp_is_not_a_blank_slate(tmp_path):
@@ -236,10 +309,10 @@ def test_an_incumbent_with_an_unknown_stamp_is_not_a_blank_slate(tmp_path):
     out = result.stdout + result.stderr
 
     assert result.returncode == 0, out
-    assert f"proving generation: {primary}/daily/{TODAY}" in out, out
+    assert f"[backup-proof] proving generation: {primary}/daily/{TODAY}" in out, out
     # The ancient candidate is LOGGED on purpose — selection must be
     # visible — but it must not be the one proven.
-    assert f"proving generation: {ancient}" not in out, out
+    assert f"[backup-proof] proving generation: {ancient}" not in out, out
 
 
 def test_proving_the_fallback_lineage_says_so(tmp_path):
@@ -272,8 +345,8 @@ def test_an_unwritable_primary_root_falls_back_and_the_proof_follows(tmp_path):
     out = result.stdout + result.stderr
 
     assert result.returncode == 0, out
-    assert f"effective backup root: {fallback}" in out, out
-    assert f"proving generation: {fallback}/daily/{TODAY}" in out, out
+    assert f"[backup-proof] effective backup root: {fallback}" in out, out
+    assert f"[backup-proof] proving generation: {fallback}/daily/{TODAY}" in out, out
     # The proof read the fallback generation back, not merely located it.
     assert "C1-RET-04/05 evidence.sqlite: PRAGMA integrity_check = ok" in out, out
     # And the backup really is there.
@@ -289,8 +362,8 @@ def test_a_writable_primary_root_is_used_by_both(tmp_path):
     out = result.stdout + result.stderr
 
     assert result.returncode == 0, out
-    assert f"effective backup root: {primary}" in out, out
-    assert f"proving generation: {primary}/daily/{TODAY}" in out, out
+    assert f"[backup-proof] effective backup root: {primary}" in out, out
+    assert f"[backup-proof] proving generation: {primary}/daily/{TODAY}" in out, out
     assert not fallback.exists(), "the fallback must not be touched when the primary works"
 
 
@@ -380,7 +453,7 @@ def test_the_proof_cannot_be_captured_by_a_pointer_in_the_other_root(tmp_path):
     out = result.stdout + result.stderr
 
     assert result.returncode == 0, out
-    assert f"proving generation: {primary}/daily/{TODAY}" in out, out
+    assert f"[backup-proof] proving generation: {primary}/daily/{TODAY}" in out, out
     assert str(decoy) not in out, out
 
 
@@ -406,8 +479,8 @@ def test_discovery_takes_the_newest_recorded_generation(tmp_path):
     assert result.returncode == 0, out
     assert f"candidate root {primary}: generation" in out, out
     assert f"candidate root {fallback}: generation" in out, out
-    assert f"effective backup root: {fallback}" in out, out
-    assert f"proving generation: {newer}" in out, out
+    assert f"[backup-proof] effective backup root: {fallback}" in out, out
+    assert f"[backup-proof] proving generation: {newer}" in out, out
 
 
 # ── structural: one owner, not two ───────────────────────────────────


### PR DESCRIPTION
## What failed

Production backup-proof run [`31872681688`](https://github.com/jasonleetucker-code/riskittogetthebrisket/actions/runs/31872681688) reported

```
[state-backup][WARN] primary backup root '/var/backups/riskit-state' not writable, using fallback
[state-backup] snapshot promoted: /home/***/backups/riskit-state/daily/2026-08-15
[state-backup] state backup complete: 16 artifact(s) ...
[backup-proof][ERROR] no backup generation under /var/backups/riskit-state/daily
```

The backup **succeeded** — all 16 artifacts written and integrity-checked, every
C1A retention store among them. `/var/backups` was not writable by the deploy
user, so the writer fell back and promoted there, while the proof — which
resolved the location itself from the same two defaults — read the empty primary.

Neither script was wrong on its own. Both were right, about different places.

## One owner, not a second copy of the fallback

Hard-coding the fallback into the proof would have produced two implementations
of the fallback rule as well. So **`deploy/backup/backup_root_lib.sh`** owns it,
sourced by both scripts (functions only; nothing runs at source time, so a
caller's `set -Eeuo pipefail` and exit status are untouched):

| question | owner |
|---|---|
| requested primary root | `backup_root_primary` |
| writability (writer's question — **creates** the dir) | `backup_root_writable` / `backup_root_claim` |
| readability (reader's question — **never** creates) | `backup_root_readable` |
| fallback root | `backup_root_fallback` |
| what counts as a generation at all | `backup_root_name_is_plausible` / `plausible_generations` |
| effective generation location | the pointer `backup_root_write_result` emits |

After a successful promotion the writer records what it did — `schema`,
`effective_root`, `generation`, `date_stamp`, `artifacts`, `promoted_at` — at
`<root>/last_generation`, and at `$BACKUP_RESULT_FILE` when a caller sets one.
The proof sets that file, runs the backup, and proves exactly the generation
**that run** reported. Selection under `RUN_BACKUP=1` is therefore not a search
at all.

Log lines are for humans and are not an API. Nothing parses them.

**A pointer is a hint, never an authority.** Before it is believed, the
pointed-at generation must satisfy containment — literally `${root%/}/daily/<base>`,
a real directory, a `YYYY-MM-DD` name, and not future-dated. A pointer that
names a path outside the root it was found in is refused rather than followed.

## The first version of this fix opened a worse hole. It is closed.

Adversarial review reproduced a **false pass**: with `RUN_BACKUP=0`, discovery
skipped a root it could not read and went on to certify the older generation in
the readable one. Measured as an unprivileged user, root-owned `0700` primary
holding today, readable fallback holding January:

| | outcome |
|---|---|
| first version | **exit 0** — `proving generation: …/fallback/daily/2026-01-02`, "backup + restore proven for every artifact" |
| now | **exit 1** — `candidate root …/primary: NOT READABLE by nobody — cannot rule out a newer generation here` |

Three rules govern discovery, each of them a demonstrated defect:

1. **A root we cannot read is not an empty root.** Unreadable candidates are
   collected and **refused before a winner is accepted** — the ordering is what
   makes substitution impossible, not a later check.
2. **A generation with no pointer still counts.** The pointer is younger than the
   backups: production's nightly runs the root-owned copy of the writer that only
   `apply_hardening.sh` refreshes, so real generations land with no pointer beside
   them. Pointer first, on-disk scan second, and the log says which answered.
   Without this the change would have been blind to every generation production
   actually writes today.
3. **The comparison stamp is never empty**, and the incumbent is held on "do we
   have one" rather than "does it have a stamp" — an incumbent with a missing
   `promoted_at` used to be a blank slate any later candidate overwrote, measured
   selecting a 2020 generation over a same-day one.

## The recurring bug class: absent and forbidden are not the same fact

`-e`, `-f` and `-d` are false for **both** ENOENT and EACCES, and only the first
means "absent". Reading the second as the first fails *open*. It was reproduced
at four separate levels and is fixed at each: the backup root, its **ancestors**
(a probe walk, since `mkdir -p` can fail on a directory we may not even stat), the
`daily/` directory, and the source artifacts (`backup_source_absent`).

Two adjacent escapes closed with it:

- **`-e` dereferences symlinks; `dirname` is lexical.** The ancestor walk needs an
  explicit `! -L` conjunct or a symlinked ancestor walks straight past it, and a
  dangling symlink reads as "absent".
- **lstat-level facts and stat-level facts differ.** One entry in `daily/` that
  cannot be resolved used to empty the entire root. Discovery is now three-state
  — FOUND (rc 0) · GENUINELY_EMPTY (rc 1) · INDETERMINATE (rc 2) — plus rc 3
  below, and only rc 1 authorises "there is nothing here".

Fail-closed must not become fail-always: every refusal names the specific
condition, and the ordinary case still proves and still prunes.

## Clock skew, and a keep window it could poison

`riskit-state-backup.timer` is `Persistent=true`, so a boot before NTP settles
mints a future-dated generation. Those are now bounded by
`BACKUP_ROOT_FUTURE_TOLERANCE_DAYS` (default 1) and fail closed past it (rc 3) —
but the important half is that **they must not poison discovery or pruning
indefinitely**. A 2099 directory left inside the keep window is kept forever
*and* spends a retention slot. It is excluded from the window and explicitly not
deleted, with a warning saying so.

`plausible_generations()` is the single definition of "a generation this writer
produced" — a directory · not a symlink · a `YYYY-MM-DD` name · round-tripping
through `date -u -d` — and both the keep window and the mirror's continuity count
read it. Two answers to that question is the class of bug this whole change
exists to remove.

That guard is why one further release blocker is already fixed here: an entry
sorting **inside** the date range (a dated restore-scratch directory is the
likeliest real example) consumes a keep-window slot, so one **real** generation
is deleted every night it exists. Measured at `KEEP_DAILY=14` with 14 real
generations plus `2026-08-07-restore-scratch`: 13 survive before, 14 after.

## Destructive off-box sync now requires positive proof of continuity

`rsync --delete` makes the remote an exact replica of one root's `daily/`
namespace, so it may run only with proof that this root still holds the history
the mirror was built from. "Same root as requested" is not that proof — it says
which root we wrote to, not whether its history is continuous.

Reproduced with a stub implementing real `--delete` semantics: a writable primary
whose local generations had vanished (disk replaced, `/var` wiped, restored
image) took `--delete` and cut a remote of **5 generations to 1**. That is
precisely the state in which the off-box copy is the last one standing.

Four conditions, all required: this run wrote to the requested root · a mirror
marker exists · the marker's destination is this destination · the local count
has not shrunk. Any unproven ⇒ publish **additively**, preserving the remote,
with a WARN naming the failed condition. The marker is re-baselined after each
successful mirror, so a deliberate `KEEP_DAILY` reduction publishes additively
once and reconciles normally afterwards — fail-closed must not become fail-never,
or remote retention grows without bound.

Recorded rather than hidden: the first mirror to a pre-populated destination
publishes additively and only reconciles from the next run. That is the safe
direction and it is deliberate.

## Two more from the same review series

- **`apply_hardening.sh` installed the writer before the library it now hard-fails
  without.** `riskit-state-backup.timer` fires at 02:30 UTC, so a nightly landing
  in that window would have taken **no backup at all**. Library first now; a
  library without the new writer is harmless, the reverse loses a generation.
  Pinned by an ordering assertion.
- A run killed between writing `last_generation.tmp.$$` and renaming it left the
  temp forever — it sits one level above `daily/`, which neither the staging sweep
  nor prune reaches. Swept alongside the staging dirs.

## What this does NOT prove, stated in the tool itself

"Nothing failed" is true of a run that read nothing, so the proof carries a
`PROVEN` counter and a `GEN_HELD` witness and cannot exit 0 having proven zero
artifacts.

The nightly executes the **root-owned copy** at `/usr/local/lib/riskit/`
(deliberately, per the security note in `riskit-state-backup.service`), and only
`apply_hardening.sh` updates it — a deploy updates what the proof exercises, not
what the nightly runs. The proof also runs as the deploy user, so it exercises
the **fallback** lineage and cannot read the nightly's root-owned generations. It
warns exactly that when the effective root is not the primary, because a green
tick must not read as "the nightly's backups restore" to someone who cannot open
them. Also documented in `deploy/backup/README.md`, whose semantics were
re-checked against the code in the final review.

## Validation

RED first, every time, against the shipped scripts rather than a mock:

- pre-fix scripts at `HEAD`, unwritable primary → reproduces run 31872681688's
  exact signature;
- first-version proof as `nobody` → the false pass above;
- unreadable candidate, symlinked ancestor, dangling symlink, malformed `daily/`,
  stale/out-of-root pointer, future-dated generation, interleaved prune entry,
  vanished local history before an off-box mirror → each reproduced red, then
  green.

`tests/deploy/test_backup_root_resolution.py` (**52 tests**) runs **both shipped
scripts end to end** against a throwaway data dir. Unwritable roots are built by
putting a regular file where the root's parent would be, so `mkdir -p` fails for
every user including root; permission-based cases run as `nobody` so the
fail-closed contract is not deletable with a green suite under a root runner.
Guards are mutation-tested one predicate at a time — a mutant counts as killed
only when the relevant protection's test fails, and every mutation is
sha256-asserted as actually applied, because an unapplied `sed` reads exactly
like a surviving mutant.

```
tests/deploy/ + tests/retention/    357 passed, 4 skipped
as root, the new file                48 passed, 4 skipped
PR Validation on af22e2eb7          all 43 steps success
```

## Scope

C1A unit 1 durability only. No canonical value path, no product surface, no
retention stream promoted or demoted — this makes the existing backup/restore
proof able to run to completion, which is what `C1-RET-01`…`08` need before their
status can be stated honestly.