### PR TITLE
Measure the two C1A facts a deploy and a restore proof structurally cannot

### DIFF
--- a/.github/workflows/c1a-closure-diagnostics.yml
+++ b/.github/workflows/c1a-closure-diagnostics.yml
@@ -1,0 +1,94 @@
+name: C1A closure inventory (read-only)
+
+# Two facts the backup/restore proof structurally cannot report, because
+# they are about state it does not touch:
+#
+#   A. Whether the NIGHTLY backup lineage carries #852.  `apply_hardening.sh`
+#      installs root-owned copies under /usr/local/lib/riskit/ and ordinary
+#      deploys deliberately do not run it — pinned by
+#      tests/deploy/test_hardening_script_stays_operator_run.py.  So a green
+#      deploy says nothing about the nightly, and a green restore proof run
+#      by the deploy user says nothing either.  This hashes what is actually
+#      installed against what is actually deployed.
+#
+#   B. Why C1-RET-08's player-context history has never been published.
+#      /api/status reports pendingPush=2 — both retained snapshots exist
+#      locally and neither is committed.  The producer and the pusher fail
+#      independently, so this reports the pusher's unit state, working
+#      directory, last result and journal.
+#
+# STRICTLY READ-ONLY.  It installs nothing, enables nothing, starts nothing,
+# commits nothing and pushes nothing.  Repairing production is a separate,
+# explicitly authorised action — a diagnostic that fixes its subject
+# destroys the evidence it was run to collect.
+#
+# PRIVACY: unit metadata, file hashes and dated filenames only.  No snapshot
+# contents, no league payload, no roster, no manager name, no key material —
+# the deploy key is probed with `test -r`, never read.
+
+on:
+  workflow_dispatch:
+    inputs:
+      journal_lines:
+        description: "How many journal lines to tail per unit"
+        required: false
+        default: "40"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  # Its own group. Not `production-deploy`: GitHub keeps only the newest
+  # PENDING run per group, so sharing it would let a queued deploy cancel
+  # this inventory into silence.
+  group: c1a-closure-diagnostics
+  cancel-in-progress: false
+
+jobs:
+  inventory:
+    name: Inspect nightly lineage + playerctx publication
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Configure production SSH
+        env:
+          DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          install -d -m 700 "$HOME/.ssh"
+          printf '%s\n' "$DEPLOY_SSH_PRIVATE_KEY" | sed 's/\r$//' > "$HOME/.ssh/id_ed25519"
+          printf '%s\n' "$DEPLOY_KNOWN_HOSTS" | sed 's/\r$//' > "$HOME/.ssh/known_hosts"
+          chmod 600 "$HOME/.ssh/id_ed25519"
+          chmod 644 "$HOME/.ssh/known_hosts"
+          ssh-keygen -y -f "$HOME/.ssh/id_ed25519" >/dev/null
+          echo "PORT=${DEPLOY_PORT:-22}" >> "$GITHUB_ENV"
+
+      - name: Collect the inventory from production
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          APP_DIR: ${{ vars.PROD_APP_DIR || '/home/dynasty/trade-calculator' }}
+          SERVICE_NAME: ${{ vars.PROD_SERVICE_NAME || 'dynasty' }}
+          JOURNAL_LINES: ${{ inputs.journal_lines }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          # The remote exit status is this step's exit status. The script
+          # exits non-zero only when the inventory itself could not run;
+          # a defect it FINDS is reported, not raised, because the point
+          # is to read the report.
+          ssh -i "$HOME/.ssh/id_ed25519" \
+            -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+            -o ConnectTimeout=15 -o ServerAliveInterval=15 \
+            -p "$PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "APP_DIR=$(printf %q "$APP_DIR") SERVICE_NAME=$(printf %q "$SERVICE_NAME") JOURNAL_LINES=$(printf %q "$JOURNAL_LINES") bash -s" \
+            < deploy/diagnostics/c1a_closure_inventory.sh

--- a/.github/workflows/c1a-closure-diagnostics.yml
+++ b/.github/workflows/c1a-closure-diagnostics.yml
@@ -3,13 +3,20 @@ name: C1A closure inventory (read-only)
 # Two facts the backup/restore proof structurally cannot report, because
 # they are about state it does not touch:
 #
-#   A. Whether the NIGHTLY backup lineage carries #852.  `apply_hardening.sh`
-#      installs root-owned copies under /usr/local/lib/riskit/ and ordinary
-#      deploys deliberately do not run it — pinned by
+#   A. Whether the NIGHTLY backup lineage carries #852.  The root-owned copies
+#      under /usr/local/lib/riskit/ are refreshed only by the operator-run
+#      hardening installer, which ordinary deploys deliberately never invoke —
+#      a policy pinned by
 #      tests/deploy/test_hardening_script_stays_operator_run.py.  So a green
 #      deploy says nothing about the nightly, and a green restore proof run
 #      by the deploy user says nothing either.  This hashes what is actually
 #      installed against what is actually deployed.
+#
+#      That test greps these workflow files for the installer's filename, so
+#      this comment deliberately does not spell it out.  Naming it here would
+#      trip a tripwire whose entire job is to make wiring it a deliberate act —
+#      and a guard that a comment can trip is a guard someone eventually
+#      weakens to stop the noise.  The name is in the diagnostic script.
 #
 #   B. Why C1-RET-08's player-context history has never been published.
 #      /api/status reports pendingPush=2 — both retained snapshots exist

--- a/deploy/diagnostics/c1a_closure_inventory.sh
+++ b/deploy/diagnostics/c1a_closure_inventory.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+#
+# C1A unit 1 closure inventory — READ ONLY.
+#
+# Answers two questions that the backup/restore proof deliberately cannot,
+# because they are about state the proof does not touch:
+#
+#   A. THE NIGHTLY LINEAGE.  `deploy/apply_hardening.sh` installs root-owned
+#      copies under /usr/local/lib/riskit/ and ordinary deploys do NOT run it
+#      (pinned by tests/deploy/test_hardening_script_stays_operator_run.py).
+#      So "the deployed checkout is fixed" and "the nightly writer is fixed"
+#      are two different facts, and only the first is evidence a deploy can
+#      produce.  This reports the second by hashing what is actually
+#      installed against what is actually deployed.
+#
+#   B. THE PLAYERCTX PUBLICATION PATH (C1-RET-08).  /api/status reports
+#      pendingPush=2, i.e. both retained snapshots exist locally and neither
+#      has ever been committed.  The producer and the pusher fail
+#      independently; this reports the pusher's unit state, working
+#      directory, last result and journal so the failure is measured rather
+#      than hypothesised.
+#
+# WHAT THIS SCRIPT WILL NOT DO.  It never writes, installs, enables, starts,
+# commits or pushes anything.  Every command is an inspection.  Fixing what
+# it finds is a separate, explicitly authorised action — a diagnostic that
+# repairs its subject destroys the evidence it was run to collect.
+#
+# PRIVACY.  Emits unit metadata, file hashes, and DATED FILENAMES only.  It
+# never prints a snapshot's contents, a league payload, a roster, a manager
+# name, or any key material — `test -r` answers "can the pusher read the
+# key" without revealing it.  Journal tails are scoped to a named unit and
+# capped.
+#
+# Usage (matches the sibling diagnostics):
+#   APP_DIR=... SERVICE_NAME=... bash -s < deploy/diagnostics/c1a_closure_inventory.sh
+#
+# Exit codes:
+#   0  inventory completed — read the report, it may still describe a defect
+#   1  the inventory itself could not run (bad APP_DIR, no bash, etc.)
+#
+# An absent object is reported ABSENT and an unreadable one UNREADABLE.  They
+# are different facts and collapsing them is the exact bug class #852 exists
+# to remove, so this script keeps them apart too.
+
+set -Eeuo pipefail
+
+APP_DIR="${APP_DIR:-/home/dynasty/trade-calculator}"
+SERVICE_NAME="${SERVICE_NAME:-dynasty}"
+LIB_DIR="${RISKIT_PRIV_LIB_DIR:-/usr/local/lib/riskit}"
+JOURNAL_LINES="${JOURNAL_LINES:-40}"
+
+say() { printf '[c1a-inventory] %s\n' "$*"; }
+hdr() { printf '\n[c1a-inventory] ══ %s ══\n' "$*"; }
+kv() { printf '[c1a-inventory]   %-34s %s\n' "$1" "$2"; }
+
+[[ -d "${APP_DIR}" ]] || { printf '[c1a-inventory][ERR] APP_DIR missing: %s\n' "${APP_DIR}" >&2; exit 1; }
+
+say "host=$(hostname) user=$(id -un) date=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+say "APP_DIR=${APP_DIR} SERVICE_NAME=${SERVICE_NAME} LIB_DIR=${LIB_DIR}"
+
+# ── helpers ───────────────────────────────────────────────────────────────
+# Absent, unreadable and present-with-a-hash are three answers, not two.
+file_state() {
+    local path="$1"
+    if [[ -e "${path}" || -L "${path}" ]]; then
+        if [[ -r "${path}" ]]; then
+            printf 'PRESENT sha256=%s bytes=%s mtime=%s' \
+                "$(sha256sum "${path}" 2>/dev/null | awk '{print $1}')" \
+                "$(stat -c %s "${path}" 2>/dev/null || echo '?')" \
+                "$(stat -c %y "${path}" 2>/dev/null | cut -d. -f1 || echo '?')"
+        else
+            printf 'UNREADABLE by %s' "$(id -un)"
+        fi
+    else
+        printf 'ABSENT'
+    fi
+}
+
+unit_state() {
+    local unit="$1"
+    if ! systemctl cat "${unit}" >/dev/null 2>&1; then
+        kv "${unit}" "NOT INSTALLED"
+        return 0
+    fi
+    kv "${unit}" "installed"
+    kv "  is-enabled" "$(systemctl is-enabled "${unit}" 2>&1 || true)"
+    kv "  is-active" "$(systemctl is-active "${unit}" 2>&1 || true)"
+    local prop
+    for prop in Result ExecMainStatus ExecMainExitTimestamp NRestarts \
+                WorkingDirectory User ActiveEnterTimestamp \
+                LastTriggerUSec NextElapseUSecRealtime Persistent; do
+        local val
+        val="$(systemctl show "${unit}" -p "${prop}" --value 2>/dev/null || true)"
+        [[ -n "${val}" ]] && kv "  ${prop}" "${val}"
+    done
+    # ExecStart is a struct; the path is what matters here.
+    local execstart
+    execstart="$(systemctl show "${unit}" -p ExecStart --value 2>/dev/null | head -c 300 || true)"
+    [[ -n "${execstart}" ]] && kv "  ExecStart" "${execstart}"
+}
+
+journal_tail() {
+    local unit="$1"
+    if journalctl -u "${unit}" -n "${JOURNAL_LINES}" --no-pager >/dev/null 2>&1; then
+        say "journal (last ${JOURNAL_LINES}) for ${unit}:"
+        journalctl -u "${unit}" -n "${JOURNAL_LINES}" --no-pager 2>&1 | sed 's/^/[journal] /' || true
+    elif sudo -n journalctl -u "${unit}" -n "${JOURNAL_LINES}" --no-pager >/dev/null 2>&1; then
+        say "journal (last ${JOURNAL_LINES}, via sudo) for ${unit}:"
+        sudo -n journalctl -u "${unit}" -n "${JOURNAL_LINES}" --no-pager 2>&1 | sed 's/^/[journal] /' || true
+    else
+        say "journal for ${unit}: UNAVAILABLE to $(id -un) (not an assertion that it is empty)"
+    fi
+}
+
+# ══ A. NIGHTLY BACKUP LINEAGE ═════════════════════════════════════════════
+hdr "A. nightly backup lineage (root-owned, refreshed only by apply_hardening.sh)"
+
+INSTALLED_WRITER="${LIB_DIR}/riskit-state-backup.sh"
+INSTALLED_LIB="${LIB_DIR}/backup_root_lib.sh"
+DEPLOYED_WRITER="${APP_DIR}/deploy/backup/riskit-state-backup.sh"
+DEPLOYED_LIB="${APP_DIR}/deploy/backup/backup_root_lib.sh"
+
+kv "installed writer" "$(file_state "${INSTALLED_WRITER}")"
+kv "installed lib" "$(file_state "${INSTALLED_LIB}")"
+kv "deployed writer" "$(file_state "${DEPLOYED_WRITER}")"
+kv "deployed lib" "$(file_state "${DEPLOYED_LIB}")"
+
+# The question that actually decides whether the nightly carries #852.
+for pair in "writer:${INSTALLED_WRITER}:${DEPLOYED_WRITER}" "lib:${INSTALLED_LIB}:${DEPLOYED_LIB}"; do
+    name="${pair%%:*}"; rest="${pair#*:}"
+    inst="${rest%%:*}"; depl="${rest#*:}"
+    if [[ -r "${inst}" && -r "${depl}" ]]; then
+        a="$(sha256sum "${inst}" | awk '{print $1}')"
+        b="$(sha256sum "${depl}" | awk '{print $1}')"
+        if [[ "${a}" == "${b}" ]]; then
+            kv "${name}: installed vs deployed" "IDENTICAL — nightly carries the deployed code"
+        else
+            kv "${name}: installed vs deployed" "DIFFERENT — nightly is running OTHER code than the checkout"
+        fi
+    elif [[ ! -e "${inst}" && ! -L "${inst}" ]]; then
+        kv "${name}: installed vs deployed" "INSTALLED COPY ABSENT — apply_hardening.sh has not installed it"
+    else
+        kv "${name}: installed vs deployed" "INDETERMINATE — one side unreadable by $(id -un)"
+    fi
+done
+
+hdr "A2. backup units"
+unit_state "riskit-state-backup.timer"
+unit_state "riskit-state-backup.service"
+journal_tail "riskit-state-backup.service"
+
+hdr "A3. backup roots as seen by $(id -un)"
+# Names only. A generation directory name is a date, not a payload.
+for root in "${BACKUP_ROOT_PRIMARY:-/var/backups/riskit-state}" \
+            "${BACKUP_ROOT_FALLBACK:-${HOME}/backups/riskit-state}"; do
+    say "root ${root}"
+    if [[ ! -e "${root}" && ! -L "${root}" ]]; then
+        kv "  state" "ABSENT"
+        continue
+    fi
+    if [[ ! -r "${root}" || ! -x "${root}" ]]; then
+        kv "  state" "UNREADABLE by $(id -un) — cannot rule out generations here"
+        continue
+    fi
+    kv "  state" "readable"
+    kv "  last_generation pointer" "$(file_state "${root}/last_generation")"
+    if [[ -r "${root}/last_generation" ]]; then
+        sed 's/^/[c1a-inventory]     pointer: /' "${root}/last_generation" 2>/dev/null || true
+    fi
+    if [[ -d "${root}/daily" && -r "${root}/daily" && -x "${root}/daily" ]]; then
+        kv "  daily/ entries" "$(ls -1 "${root}/daily" 2>/dev/null | wc -l | tr -d ' ')"
+        ls -1 "${root}/daily" 2>/dev/null | sed 's/^/[c1a-inventory]     /' || true
+    elif [[ -e "${root}/daily" || -L "${root}/daily" ]]; then
+        kv "  daily/" "PRESENT but not a readable directory"
+    else
+        kv "  daily/" "ABSENT"
+    fi
+done
+
+# ══ B. PLAYERCTX PUBLICATION PATH (C1-RET-08) ═════════════════════════════
+hdr "B. playerctx retention — producer and pusher are separate failures"
+
+unit_state "${SERVICE_NAME}-playerctx-refresh.timer"
+unit_state "${SERVICE_NAME}-playerctx-refresh.service"
+unit_state "${SERVICE_NAME}-playerctx-history.timer"
+unit_state "${SERVICE_NAME}-playerctx-history.service"
+journal_tail "${SERVICE_NAME}-playerctx-history.service"
+
+hdr "B2. the pusher's preconditions"
+WORK_DIR="${PLAYERCTX_HISTORY_WORK_DIR:-/var/lib/playerctx-history}"
+SSH_KEY="${PLAYERCTX_HISTORY_SSH_KEY:-${HOME}/.ssh/github_deploy_key}"
+
+# WorkingDirectory= has no `-` prefix in the unit template, so systemd fails
+# the unit BEFORE ExecStart if this is missing — the script's own `mkdir -p`
+# can never help, because the script never starts. That produces zero
+# [playerctx-history] log lines, which is indistinguishable from "never ran"
+# unless you look here.
+if [[ -d "${WORK_DIR}" ]]; then
+    kv "WorkingDirectory ${WORK_DIR}" "PRESENT owner=$(stat -c '%U:%G' "${WORK_DIR}" 2>/dev/null || echo '?') mode=$(stat -c %a "${WORK_DIR}" 2>/dev/null || echo '?')"
+    kv "  dedicated clone .git" "$([[ -d "${WORK_DIR}/riskittogetthebrisket/.git" ]] && echo PRESENT || echo ABSENT)"
+elif [[ -e "${WORK_DIR}" || -L "${WORK_DIR}" ]]; then
+    kv "WorkingDirectory ${WORK_DIR}" "PRESENT but NOT A DIRECTORY — systemd will fail the unit before ExecStart"
+else
+    kv "WorkingDirectory ${WORK_DIR}" "ABSENT — systemd fails the unit before ExecStart (no '-' prefix in the template)"
+fi
+
+# Readability, never content.
+if [[ -r "${SSH_KEY}" ]]; then
+    kv "deploy key ${SSH_KEY}" "READABLE by $(id -un)"
+elif [[ -e "${SSH_KEY}" || -L "${SSH_KEY}" ]]; then
+    kv "deploy key ${SSH_KEY}" "PRESENT but UNREADABLE by $(id -un)"
+else
+    kv "deploy key ${SSH_KEY}" "ABSENT"
+fi
+
+hdr "B3. what is on disk vs what is committed"
+HIST_DIR="${APP_DIR}/data/playerctx/history"
+if [[ -d "${HIST_DIR}" ]]; then
+    kv "history dir" "${HIST_DIR}"
+    kv "  dated snapshots on disk" "$(ls -1 "${HIST_DIR}"/snapshot_*.json 2>/dev/null | wc -l | tr -d ' ')"
+    ls -1 "${HIST_DIR}" 2>/dev/null | sed 's/^/[c1a-inventory]     /' || true
+    # `data/` is gitignored repo-wide and these reach the tree only via an
+    # explicit `git add -f`, so tracked-vs-untracked IS pushed-vs-unpushed.
+    say "git ls-files for that path (tracked == previously pushed):"
+    git -C "${APP_DIR}" ls-files -- data/playerctx/history 2>&1 | sed 's/^/[c1a-inventory]     /' || true
+    kv "  tracked count" "$(git -C "${APP_DIR}" ls-files -- data/playerctx/history 2>/dev/null | wc -l | tr -d ' ')"
+else
+    kv "history dir" "ABSENT at ${HIST_DIR}"
+fi
+
+hdr "B4. the checkout's git identity (read-only)"
+kv "branch" "$(git -C "${APP_DIR}" rev-parse --abbrev-ref HEAD 2>&1 || true)"
+kv "HEAD" "$(git -C "${APP_DIR}" rev-parse HEAD 2>&1 || true)"
+kv "remote origin" "$(git -C "${APP_DIR}" remote get-url origin 2>&1 || true)"
+
+hdr "DONE — nothing above was modified"
+exit 0


### PR DESCRIPTION
Read-only production inventory. C1A unit 1 closure needs two facts that no existing run reports, and neither gap is a defect in those runs — it is what they are scoped to.

## A. The nightly lineage

The backup/restore proof runs the **deployed checkout** as the deploy user. That is the right thing for it to prove, and it says nothing about the nightly: `apply_hardening.sh` installs root-owned copies under `/usr/local/lib/riskit/`, ordinary deploys deliberately never run it (pinned by `tests/deploy/test_hardening_script_stays_operator_run.py`), and `riskit-state-backup.timer` executes that installed copy.

"The checkout is fixed" and "the nightly is fixed" are two claims, and only the first has evidence today. This hashes installed against deployed so the difference is **measured**, in either direction, rather than assumed.

## B. C1-RET-08

`/api/status` reports `pendingPush: 2` — both retained player-context snapshots exist locally and neither has ever been committed. `data/` is gitignored repo-wide and they reach the tree only via an explicit `git add -f`, so **untracked is unpushed**.

All four `exit 0` paths in `playerctx_history_push.sh` are excluded by that same payload or by owner ruling on the deploy key, which puts the failure **earlier than the script**:

| line | condition | excluded by |
|---|---|---|
| 67–69 | no readable deploy key | owner ruling (sibling pushers use the same user/key successfully) |
| 74 | `SRC_DIR` missing | `exists: true` |
| 87 | no `snapshot_YYYY-MM-DD.json` | 2 snapshots, exactly that shape |
| 121 | no diff after copy | they are untracked, so a copy must produce one |

The unit's `WorkingDirectory=` carries no `-` prefix, so a missing `/var/lib/playerctx-history` fails the unit **before** `ExecStart` and produces zero `[playerctx-history]` log lines — indistinguishable from "never ran" unless something looks. `install-systemd-service.sh:559` creates that directory only inside the `pchist_needs_install` branch, so a host on the "already installed and current" path never re-creates it.

That is a **hypothesis**. This measures rather than asserting it.

## Strictly read-only

It installs nothing, enables nothing, starts nothing, commits nothing and pushes nothing. Repairing production is a separate, explicitly authorised action — a diagnostic that fixes its subject destroys the evidence it was run to collect.

Absent, unreadable and present are kept as **three** answers rather than two, including for the backup roots. Collapsing them is the exact bug class #852 was written to remove, and a diagnostic that reproduced it would report a root it cannot read as a root with nothing in it.

## Privacy

Unit metadata, file hashes and dated filenames only. No snapshot contents, no league payload, no roster, no manager name, no key material — the deploy key is probed with `test -r` and never read. Journal tails are scoped to a named unit and capped.

## Validation

`bash -n` clean. Smoke-run locally, where every object is correctly reported `ABSENT` and the run still exits 0 (an inventory that finds nothing must not fail; a defect it *finds* is reported, not raised, because the point is to read the report).

Note `deploy/*.sh` is the syntax gate's glob, so `deploy/diagnostics/` is not covered by it. Pre-existing, and not addressed here.

## Scope

Diagnostics only. No canonical value path, no product surface, no change to the backup writer, the proof, or any retention stream.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2N5BKwWpfGRK2AkuF5Xup)_