### PR TITLE
A timer has no ExecStart, and set -e turned that into a truncated report

### DIFF
--- a/deploy/diagnostics/c1a_closure_inventory.sh
+++ b/deploy/diagnostics/c1a_closure_inventory.sh
@@ -85,18 +85,28 @@ unit_state() {
     kv "${unit}" "installed"
     kv "  is-enabled" "$(systemctl is-enabled "${unit}" 2>&1 || true)"
     kv "  is-active" "$(systemctl is-active "${unit}" 2>&1 || true)"
-    local prop
+    local prop val
     for prop in Result ExecMainStatus ExecMainExitTimestamp NRestarts \
                 WorkingDirectory User ActiveEnterTimestamp \
                 LastTriggerUSec NextElapseUSecRealtime Persistent; do
-        local val
         val="$(systemctl show "${unit}" -p "${prop}" --value 2>/dev/null || true)"
-        [[ -n "${val}" ]] && kv "  ${prop}" "${val}"
+        if [[ -n "${val}" ]]; then
+            kv "  ${prop}" "${val}"
+        fi
     done
     # ExecStart is a struct; the path is what matters here.
+    #
+    # `if`, not `[[ … ]] && kv …`.  A TIMER has no ExecStart, so the && chain
+    # returns 1, that becomes this function's exit status, and `set -e` kills
+    # the whole inventory mid-report — which is what happened on the first
+    # production run: section A completed, the first installed TIMER aborted it.
+    # The units in section A had escaped it only by returning early.
     local execstart
     execstart="$(systemctl show "${unit}" -p ExecStart --value 2>/dev/null | head -c 300 || true)"
-    [[ -n "${execstart}" ]] && kv "  ExecStart" "${execstart}"
+    if [[ -n "${execstart}" ]]; then
+        kv "  ExecStart" "${execstart}"
+    fi
+    return 0
 }
 
 journal_tail() {
@@ -145,6 +155,17 @@ for pair in "writer:${INSTALLED_WRITER}:${DEPLOYED_WRITER}" "lib:${INSTALLED_LIB
 done
 
 hdr "A2. backup units"
+# Corroborate a NOT-INSTALLED verdict against the unit REGISTRY before
+# believing it. Probing one hard-coded name and reporting absence would turn a
+# rename into "there is no nightly backup", which is a far more alarming claim
+# than the evidence would support.
+say "unit files whose name mentions riskit/backup:"
+if systemctl list-unit-files --no-pager --no-legend 2>/dev/null \
+    | grep -Ei 'riskit|backup' | sed 's/^/[c1a-inventory]     /'; then
+    :
+else
+    kv "  registry match" "NONE — no installed unit file mentions riskit or backup"
+fi
 unit_state "riskit-state-backup.timer"
 unit_state "riskit-state-backup.service"
 journal_tail "riskit-state-backup.service"


### PR DESCRIPTION
Follow-up to #856. The first production run of the closure inventory (run [`31907979486`](https://github.com/jasonleetucker-code/riskittogetthebrisket/actions/runs/31907979486)) exited 1 partway through section B — after printing the player-context *refresh* timer's properties and before anything about the *pusher*, which is the part it exists to measure.

## The bug

`[[ -n "${execstart}" ]] && kv …` was the last statement in `unit_state`. A **timer** has no `ExecStart`, so the `&&` chain returns 1, that becomes the function's exit status, and `set -Eeuo pipefail` killed the run.

Section A survived only because both units it inspects are `NOT INSTALLED` and returned early — so the bug was invisible until the first *installed* timer, which is the first thing section B touches.

Worth naming because the failure mode is the one this tranche is about: **a diagnostic that stops early still prints a plausible-looking report**, and the absence of section B reads like section B having nothing to say.

## Reproduced, then fixed

Against a stub `systemctl` that behaves like a real installed timer — exists, `enabled`, `active`, empty `ExecStart`:

```
pre-fix   exit 1
fixed     exit 0
```

Same condition both times; the stub is the thing that makes it a test rather than an assertion.

## Second change: corroborate a NOT-INSTALLED verdict

Section A2 now lists the unit **registry** before probing two hard-coded names.

This matters because of what the first run actually found: `riskit-state-backup.timer` and `.service` both report `NOT INSTALLED`, and `/usr/local/lib/riskit/` holds neither the writer nor the library. That is a claim that **there is no root-owned nightly backup on this host at all** — a much larger statement than one negative name lookup can support, since a rename would produce the identical output. So the run now prints the evidence that distinguishes the two.

## Scope

Diagnostics only, still strictly read-only. No canonical value path, no product surface, no change to the backup writer, the restore proof, or any retention stream.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2N5BKwWpfGRK2AkuF5Xup)_