### PR TITLE
Settle the auth question, and give the state-backup line one owner the deploy account can run

### DIFF
--- a/.github/workflows/c1a-closure-preflight.yml
+++ b/.github/workflows/c1a-closure-preflight.yml
@@ -65,6 +65,7 @@ jobs:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           APP_DIR: ${{ vars.PROD_APP_DIR || '/home/dynasty/trade-calculator' }}
+          SERVICE_NAME: ${{ vars.PROD_SERVICE_NAME || 'dynasty' }}
         shell: bash
         run: |
           set -Eeuo pipefail
@@ -73,5 +74,5 @@ jobs:
             -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
             -o ConnectTimeout=15 -o ServerAliveInterval=15 \
             -p "$PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
-            "APP_DIR=$(printf %q "$APP_DIR") bash -s" \
+            "APP_DIR=$(printf %q "$APP_DIR") SERVICE_NAME=$(printf %q "$SERVICE_NAME") bash -s" \
             < deploy/diagnostics/c1a_closure_preflight.sh

--- a/deploy/apply_hardening.sh
+++ b/deploy/apply_hardening.sh
@@ -252,6 +252,15 @@ apply_app_services() {
 # installed here: it runs unprivileged (User=dynasty) from the
 # checkout, which is fine because it has no more privilege than the
 # user who can already edit it.
+# THE canonical state-backup installation lives in its own file so that the
+# deploy account can run it WITHOUT a root shell — measured 2026-08-15, this
+# host's NOPASSWD sudo covers systemctl/journalctl/install/chown and not bash,
+# so `sudo bash apply_hardening.sh` cannot run here at all. Sourced rather than
+# re-implemented: two copies of "which files, in which order, with which modes"
+# drift, and drift here means a writer installed without its library.
+# shellcheck source=deploy/backup/install_state_backup.sh
+source "${APP_DIR}/deploy/backup/install_state_backup.sh"
+
 install_priv_script() {
     local src="$1"
     local mode="${2:-0755}"
@@ -271,17 +280,14 @@ install_priv_script() {
 
 apply_privileged_scripts() {
     install_priv_script "${APP_DIR}/deploy/systemd/dynasty-healthcheck.sh"
-    # LIBRARY FIRST, and the order is load-bearing.  riskit-state-backup.sh
-    # SOURCES this from its own directory and treats it as fatal when
-    # absent, so the root-owned copy needs it beside it or the nightly
-    # cannot resolve a backup root at all.  Installing the writer first
-    # would leave a window — riskit-state-backup.timer fires at 02:30 UTC —
-    # in which the new writer exists without its library and that night's
-    # state backup is simply not taken.  A library present without the new
-    # writer is harmless; the reverse is a lost generation.
-    # Sourced, never executed: 0644, not 0755.
-    install_priv_script "${APP_DIR}/deploy/backup/backup_root_lib.sh" 0644
-    install_priv_script "${APP_DIR}/deploy/backup/riskit-state-backup.sh"
+    # The state-backup pair — library first, modes, destinations — is owned by
+    # deploy/backup/install_state_backup.sh and called, not copied. That file
+    # documents why the ordering is load-bearing.
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log "(dry-run) would install the state-backup library + writer into ${RISKIT_LIB_DIR}"
+    else
+        state_backup_install_scripts "${APP_DIR}" "${RISKIT_LIB_DIR}"
+    fi
 }
 
 # ── 3-5. hardening units ─────────────────────────────────────────────
@@ -290,10 +296,13 @@ apply_hardening_units() {
                  "/etc/systemd/system/dynasty-healthcheck.service" yes
     install_unit "${APP_DIR}/deploy/systemd/dynasty-healthcheck.timer" \
                  "/etc/systemd/system/dynasty-healthcheck.timer"
-    install_unit "${APP_DIR}/deploy/backup/riskit-state-backup.service" \
-                 "/etc/systemd/system/riskit-state-backup.service" yes
-    install_unit "${APP_DIR}/deploy/backup/riskit-state-backup.timer" \
-                 "/etc/systemd/system/riskit-state-backup.timer"
+    # Same owner as above — see deploy/backup/install_state_backup.sh.
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log "(dry-run) would install ${STATE_BACKUP_SERVICE} + ${STATE_BACKUP_TIMER}"
+    else
+        state_backup_install_units "${APP_DIR}" "${RISKIT_LIB_DIR}"
+        CHANGED_UNITS=true
+    fi
     install_unit "${APP_DIR}/deploy/monitoring/riskit-uptime.service" \
                  "/etc/systemd/system/riskit-uptime.service" yes
     install_unit "${APP_DIR}/deploy/monitoring/riskit-uptime.timer" \
@@ -316,7 +325,7 @@ if [[ "${DRY_RUN}" != "true" && "${CHANGED_UNITS}" == "true" ]]; then
     log "systemd daemon-reload done"
 fi
 enable_timer dynasty-healthcheck.timer
-enable_timer riskit-state-backup.timer
+enable_timer "${STATE_BACKUP_TIMER}"
 enable_timer riskit-uptime.timer
 
 # ── Verification checklist ───────────────────────────────────────────

--- a/deploy/backup/install_state_backup.sh
+++ b/deploy/backup/install_state_backup.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# THE canonical installer for the C1A state-backup line.
+#
+# Installs exactly four things and nothing else:
+#
+#   /usr/local/lib/riskit/backup_root_lib.sh        root:root 0644  (sourced)
+#   /usr/local/lib/riskit/riskit-state-backup.sh    root:root 0755  (executed)
+#   /etc/systemd/system/riskit-state-backup.service
+#   /etc/systemd/system/riskit-state-backup.timer
+#
+# WHY THIS FILE EXISTS.  The same four steps used to live inside
+# `apply_hardening.sh`, which also rewrites the nginx site config, re-renders
+# the backend and frontend units, and reloads nginx — and which requires a full
+# root shell to run.  Measured on production 2026-08-15, the deploy account's
+# NOPASSWD sudo covers `systemctl`, `journalctl`, `install` and `chown` and NOT
+# `bash`, so that installer cannot run at all from the deployment privilege
+# model.  Installing a backup timer therefore demanded a human root session and
+# an nginx rewrite it had no business performing — and nginx is exactly the step
+# that can silently revert certbot's TLS edits.
+#
+# So the four steps moved HERE, and `apply_hardening.sh` now calls this file
+# rather than carrying its own copy.  ONE implementation, two entry points:
+#
+#   * full hardening      — apply_hardening.sh sources this and calls the same
+#                           functions, in the same order, at the same point;
+#   * bounded install     — `bash install_state_backup.sh`, runnable by the
+#                           deploy account using only install/chown/systemctl.
+#
+# The point is not that duplication is untidy.  It is that two copies of
+# "which files, in which order, with which modes" WILL drift, and the failure
+# mode of drift here is a nightly that runs the wrong writer, or a writer
+# installed without its library — a silently lost generation.
+#
+# PRIVILEGE.  Every privileged operation goes through `priv`, which runs the
+# command directly when already root and via `sudo -n` otherwise.  That is what
+# lets one implementation serve both entry points: as root inside
+# apply_hardening.sh, and as the deploy user through the existing allowlist.
+#
+# WHAT IT DELIBERATELY DOES NOT DO: nginx, backend/frontend units, healthcheck,
+# uptime, certificates, or anything else in the hardening script.  Those remain
+# apply_hardening.sh's business.
+
+set -Eeuo pipefail
+
+STATE_BACKUP_SERVICE="riskit-state-backup.service"
+STATE_BACKUP_TIMER="riskit-state-backup.timer"
+STATE_BACKUP_UNIT_DIR="${STATE_BACKUP_UNIT_DIR:-/etc/systemd/system}"
+
+_sb_log() { printf '[state-backup-install] %s\n' "$*"; }
+_sb_err() { printf '[state-backup-install][ERR] %s\n' "$*" >&2; }
+
+# Run a command as root. Direct when already root, `sudo -n` otherwise.
+# Never `sudo bash` — the whole point is to stay inside an allowlist that
+# grants specific binaries rather than a shell.
+priv() {
+    if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+        "$@"
+    else
+        sudo -n "$@"
+    fi
+}
+
+# Install one root-owned file. Idempotent: an identical destination is left
+# alone so a re-run is not a rewrite.
+_sb_install_file() {
+    local src="$1" dest="$2" mode="$3"
+    if [[ ! -r "${src}" ]]; then
+        _sb_err "source missing or unreadable: ${src}"
+        return 1
+    fi
+    if [[ -f "${dest}" ]] && cmp -s "${src}" "${dest}"; then
+        _sb_log "up-to-date: ${dest}"
+        return 0
+    fi
+    _sb_log "installing ${dest} (root:root ${mode})"
+    priv install -o root -g root -m "${mode}" -D "${src}" "${dest}"
+}
+
+# ── the four steps ────────────────────────────────────────────────────────
+
+# LIBRARY FIRST, and the order is load-bearing rather than stylistic.
+# riskit-state-backup.sh SOURCES backup_root_lib.sh from its own directory and
+# treats it as fatal when absent, so the root-owned copy needs the library
+# beside it or the nightly cannot resolve a backup root at all. Installing the
+# writer first leaves a window — the timer fires at 02:30 UTC — in which the
+# new writer exists without its library and that night's backup is simply not
+# taken. A library without the new writer is harmless; the reverse loses a
+# generation.
+#
+# Sourced, never executed: 0644, not 0755.
+state_backup_install_scripts() {
+    local app_dir="$1" lib_dir="$2"
+    _sb_install_file "${app_dir}/deploy/backup/backup_root_lib.sh" \
+                     "${lib_dir}/backup_root_lib.sh" 0644
+    _sb_install_file "${app_dir}/deploy/backup/riskit-state-backup.sh" \
+                     "${lib_dir}/riskit-state-backup.sh" 0755
+}
+
+# The service is RENDERED (checkout path and lib dir rewritten for non-default
+# installs); the timer is copied verbatim because it names neither. Rendering
+# happens unprivileged into a temp file, so only the final copy needs root.
+state_backup_install_units() {
+    local app_dir="$1" lib_dir="$2"
+    local staged
+    staged="$(mktemp)"
+    sed -e "s|/home/dynasty/trade-calculator|${app_dir}|g" \
+        -e "s|/usr/local/lib/riskit|${lib_dir}|g" \
+        "${app_dir}/deploy/backup/${STATE_BACKUP_SERVICE}" > "${staged}"
+    if [[ -f "${STATE_BACKUP_UNIT_DIR}/${STATE_BACKUP_SERVICE}" ]] \
+        && cmp -s "${staged}" "${STATE_BACKUP_UNIT_DIR}/${STATE_BACKUP_SERVICE}"; then
+        _sb_log "up-to-date: ${STATE_BACKUP_UNIT_DIR}/${STATE_BACKUP_SERVICE}"
+    else
+        _sb_log "installing ${STATE_BACKUP_UNIT_DIR}/${STATE_BACKUP_SERVICE}"
+        priv install -m 0644 -D "${staged}" "${STATE_BACKUP_UNIT_DIR}/${STATE_BACKUP_SERVICE}"
+    fi
+    rm -f "${staged}"
+
+    _sb_install_file "${app_dir}/deploy/backup/${STATE_BACKUP_TIMER}" \
+                     "${STATE_BACKUP_UNIT_DIR}/${STATE_BACKUP_TIMER}" 0644
+}
+
+# Re-read the unit files, then arm the timer. `daemon-reload` before `enable`
+# is not optional: systemd serves a cached copy otherwise, so a freshly written
+# unit can be enabled while the running manager still holds the old one.
+state_backup_enable() {
+    _sb_log "systemctl daemon-reload"
+    priv systemctl daemon-reload
+    _sb_log "systemctl enable --now ${STATE_BACKUP_TIMER}"
+    priv systemctl enable --now "${STATE_BACKUP_TIMER}"
+}
+
+# ── standalone entry point ────────────────────────────────────────────────
+# Sourced by apply_hardening.sh (which calls the functions itself, in its own
+# sequence); executed directly for the bounded install.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    APP_DIR="${APP_DIR:-/home/dynasty/trade-calculator}"
+    RISKIT_LIB_DIR="${RISKIT_LIB_DIR:-/usr/local/lib/riskit}"
+
+    [[ -d "${APP_DIR}" ]] || { _sb_err "APP_DIR missing: ${APP_DIR}"; exit 1; }
+
+    _sb_log "host=$(hostname) user=$(id -un) date=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    _sb_log "APP_DIR=${APP_DIR} RISKIT_LIB_DIR=${RISKIT_LIB_DIR}"
+    _sb_log "state-backup line ONLY — no nginx, no app units, no certificates"
+
+    state_backup_install_scripts "${APP_DIR}" "${RISKIT_LIB_DIR}"
+    state_backup_install_units "${APP_DIR}" "${RISKIT_LIB_DIR}"
+    state_backup_enable
+
+    _sb_log "done"
+fi

--- a/deploy/diagnostics/c1a_closure_preflight.sh
+++ b/deploy/diagnostics/c1a_closure_preflight.sh
@@ -144,5 +144,115 @@ else
     kv "apply_hardening.sh" "ABSENT or unreadable at ${HARDEN}"
 fi
 
+# ── C. the sibling auth question, settled ────────────────────────────────
+hdr "C. do the pushers share an auth context?"
+#
+# Three candidate explanations for "siblings push, playerctx does not", and
+# they call for three different repairs, so guessing is not an option:
+#
+#   A. the siblings run as a DIFFERENT user with a different HOME, so their
+#      nominal key path resolves somewhere else and exists there;
+#   B. the siblings run in the SAME context and simply let ssh resolve an
+#      identity by its normal rules, while playerctx refuses before ssh runs;
+#   C. some other mechanism entirely.
+#
+# PRIVACY: unit metadata, usernames, home directories and FILE NAMES only.
+# The one place a value is printed is a variable whose NAME ends in _SSH_KEY,
+# because that value is a path and the repair has to name it. No key is read.
+
+unit_identity() {
+    local unit="$1"
+    if ! systemctl cat "${unit}" >/dev/null 2>&1; then
+        kv "${unit}" "NOT INSTALLED"
+        return 0
+    fi
+    kv "${unit}" "installed"
+    local prop val
+    for prop in User Group WorkingDirectory EnvironmentFiles; do
+        val="$(systemctl show "${unit}" -p "${prop}" --value 2>/dev/null || true)"
+        if [[ -n "${val}" ]]; then
+            kv "  ${prop}" "${val}"
+        fi
+    done
+    # Environment= can carry secrets, so only *_SSH_KEY names are echoed and
+    # everything else is counted rather than shown.
+    local envblock other
+    envblock="$(systemctl show "${unit}" -p Environment --value 2>/dev/null || true)"
+    if [[ -n "${envblock}" ]]; then
+        other=0
+        for tok in ${envblock}; do
+            case "${tok}" in
+                *_SSH_KEY=*) kv "  Environment" "${tok}" ;;
+                *) other=$(( other + 1 )) ;;
+            esac
+        done
+        kv "  Environment (other vars)" "${other} present, values withheld"
+    else
+        kv "  Environment" "none set inline"
+    fi
+    # Effective HOME for the unit's User, from passwd — not a secret.
+    local u home
+    u="$(systemctl show "${unit}" -p User --value 2>/dev/null || true)"
+    [[ -n "${u}" ]] || u="$(id -un)"
+    home="$(getent passwd "${u}" 2>/dev/null | cut -d: -f6 || true)"
+    kv "  effective HOME" "${home:-<unresolvable>}"
+    if [[ -n "${home}" ]]; then
+        if [[ -r "${home}/.ssh/github_deploy_key" ]]; then
+            kv "  <HOME>/.ssh/github_deploy_key" "READABLE by $(id -un)"
+        elif [[ -e "${home}/.ssh/github_deploy_key" ]]; then
+            kv "  <HOME>/.ssh/github_deploy_key" "present, not readable by $(id -un)"
+        else
+            kv "  <HOME>/.ssh/github_deploy_key" "ABSENT"
+        fi
+    fi
+    return 0
+}
+
+for u in dlf-fetch idpshow-fetch playerctx-history; do
+    unit_identity "${SERVICE_NAME:-dynasty}-${u}.service"
+done
+
+hdr "C2. what ssh would resolve for this account (names and paths only)"
+kv "~/.ssh exists" "$([[ -d "${HOME}/.ssh" ]] && echo yes || echo no)"
+if [[ -d "${HOME}/.ssh" && -r "${HOME}/.ssh" ]]; then
+    say "~/.ssh entries (names only, no contents):"
+    ls -1 "${HOME}/.ssh" 2>/dev/null | sed 's/^/[c1a-preflight]     /' || true
+fi
+if [[ -r "${HOME}/.ssh/config" ]]; then
+    say "~/.ssh/config Host + IdentityFile lines (paths, never key material):"
+    grep -iE '^[[:space:]]*(host|identityfile|identitiesonly)[[:space:]]' "${HOME}/.ssh/config" 2>/dev/null \
+        | sed 's/^/[c1a-preflight]     /' || true
+else
+    kv "~/.ssh/config" "absent or unreadable"
+fi
+if ssh-add -l >/dev/null 2>&1; then
+    kv "ssh-agent" "reachable, $(ssh-add -l 2>/dev/null | wc -l | tr -d ' ') identity(ies) loaded"
+else
+    kv "ssh-agent" "not reachable from this session"
+fi
+
+hdr "C3. NON-MUTATING auth demonstration — the RED/GREEN for RET-08"
+# `git ls-remote` reads. It never writes a ref, so this cannot publish
+# anything by accident, and it answers the only question that matters:
+# does authentication succeed in THIS context despite the nominal -i target
+# being absent?
+cd "${APP_DIR}" 2>/dev/null || true
+MISSING_KEY="${HOME}/.ssh/github_deploy_key"
+
+say "probe 1 — exactly what the SIBLING pushers export, with the absent key:"
+if GIT_SSH_COMMAND="ssh -i ${MISSING_KEY} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -o BatchMode=yes" \
+     git ls-remote --heads origin main >/dev/null 2>&1; then
+    kv "  result" "AUTH SUCCEEDS despite the absent -i target"
+else
+    kv "  result" "AUTH FAILS — the absent -i target is fatal here"
+fi
+
+say "probe 2 — ambient resolution, no GIT_SSH_COMMAND at all:"
+if git ls-remote --heads origin main >/dev/null 2>&1; then
+    kv "  result" "AUTH SUCCEEDS"
+else
+    kv "  result" "AUTH FAILS"
+fi
+
 hdr "DONE — nothing above was modified"
 exit 0

--- a/tests/deploy/test_backup_root_resolution.py
+++ b/tests/deploy/test_backup_root_resolution.py
@@ -779,22 +779,33 @@ def test_a_root_installed_script_gets_the_libraries_it_sources():
     """The nightly does not run the checkout copy.
 
     `riskit-state-backup.service` points at a root-owned copy under
-    /usr/local/lib/riskit that `apply_hardening.sh` installs, so a script
-    that starts SOURCING a sibling needs that sibling installed beside it
-    or the nightly resolves no backup root at all and exits 1.
+    /usr/local/lib/riskit, so a script that starts SOURCING a sibling needs
+    that sibling installed beside it or the nightly resolves no backup root at
+    all and exits 1.
 
     Stated as the general rule rather than the one instance, because the
     next sourced helper will hit exactly this.
+
+    FOLLOWS THE INVARIANT TO ITS OWNER. The two installs used to sit in
+    `apply_hardening.sh::apply_privileged_scripts`; they now live in
+    `deploy/backup/install_state_backup.sh`, which that script sources, so the
+    deploy account can install the backup line without the root shell its
+    sudoers does not grant. The rule did not change, only where it is written.
+    `tests/deploy/test_state_backup_installer.py` pins the same ordering
+    BEHAVIOURALLY — by running the shipped installer and reading back the
+    command log — which is the stronger proof; this stays as the textual guard
+    so a future edit that reorders the calls is caught at the source too.
     """
-    hardening = (REPO / "deploy" / "apply_hardening.sh").read_text(encoding="utf-8")
-    start = hardening.index("apply_privileged_scripts() {")
-    body = hardening[start : hardening.index("\n}\n", start)]
+    installer = (REPO / "deploy" / "backup" / "install_state_backup.sh").read_text(encoding="utf-8")
+    start = installer.index("state_backup_install_scripts() {")
+    body = installer[start : installer.index("\n}\n", start)]
 
     order = [
         line.split('"')[1].rsplit("/", 1)[-1]
         for line in body.splitlines()
-        if "install_priv_script " in line and not line.lstrip().startswith("#")
+        if "_sb_install_file " in line or "backup/" in line
     ]
+    order = [n for n in order if n.endswith(".sh")]
     installed = set(order)
     assert "riskit-state-backup.sh" in installed, installed
 

--- a/tests/deploy/test_state_backup_installer.py
+++ b/tests/deploy/test_state_backup_installer.py
@@ -1,0 +1,294 @@
+"""The C1A state-backup line installs under the deployment privilege model.
+
+Measured on production 2026-08-15 (preflight run 31910753511), the deploy
+account's NOPASSWD sudo is exactly::
+
+    /usr/bin/systemctl /bin/systemctl /usr/bin/journalctl /bin/journalctl
+    /usr/bin/install   /bin/install   /usr/bin/chown      /bin/chown
+
+No ``bash``.  ``apply_hardening.sh`` requires a full root shell, so it cannot
+run there at all — which meant installing a backup timer demanded a human root
+session AND an nginx rewrite it had no business performing, nginx being the one
+step that can silently revert certbot's TLS edits.
+
+``deploy/backup/install_state_backup.sh`` is the repair: the same four steps,
+callable through that allowlist.  These tests run the SHIPPED script against
+stub ``sudo``/``install``/``systemctl`` that record an ordered command log, so
+what is asserted is what the file actually does rather than what it says.
+
+The stub sudo enforces the production allowlist, which is what makes the first
+test a reproduction rather than an assertion.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+INSTALLER = REPO / "deploy" / "backup" / "install_state_backup.sh"
+HARDENING = REPO / "deploy" / "apply_hardening.sh"
+
+# Exactly what production permits, measured — not a plausible-looking subset.
+PROD_SUDO_ALLOWLIST = ("systemctl", "journalctl", "install", "chown")
+
+
+def _stub_bin(tmp_path: Path) -> tuple[Path, Path]:
+    """A PATH of stubs that log their invocation, plus the log they write to."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    log = tmp_path / "cmd.log"
+
+    # sudo enforces the production allowlist and refuses everything else, so a
+    # script that reaches for a root shell FAILS here exactly as it does on the
+    # box.
+    (bindir / "sudo").write_text(
+        "#!/usr/bin/env bash\n"
+        'args=(); for a in "$@"; do [[ "$a" == "-n" ]] || args+=("$a"); done\n'
+        'cmd="$(basename "${args[0]}")"\n'
+        f'case "$cmd" in {"|".join(PROD_SUDO_ALLOWLIST)}) ;; *)\n'
+        '  echo "sudo: a password is required" >&2; exit 1 ;; esac\n'
+        'exec "${args[@]}"\n'
+    )
+    for name in ("install", "systemctl", "chown"):
+        (bindir / name).write_text(
+            "#!/usr/bin/env bash\n"
+            f'printf "%s %s\\n" "{name}" "$*" >> "$CMD_LOG"\n'
+            # `install` must really create the file so idempotence is testable.
+            f'if [[ "{name}" == "install" ]]; then\n'
+            '  src=""; dest=""; prev=""\n'
+            '  for a in "$@"; do\n'
+            '    case "$a" in -*) ;; *) if [[ -f "$a" ]]; then src="$a"; else dest="$a"; fi ;; esac\n'
+            '    prev="$a"\n'
+            "  done\n"
+            '  if [[ -n "$src" && -n "$dest" ]]; then mkdir -p "$(dirname "$dest")"; cp "$src" "$dest"; fi\n'
+            "fi\n"
+            "exit 0\n"
+        )
+    for f in bindir.iterdir():
+        f.chmod(0o755)
+    return bindir, log
+
+
+def _app_dir(tmp_path: Path) -> Path:
+    """A minimal checkout carrying only what the installer reads."""
+    app = tmp_path / "app"
+    (app / "deploy" / "backup").mkdir(parents=True)
+    for name in (
+        "backup_root_lib.sh",
+        "riskit-state-backup.sh",
+        "riskit-state-backup.service",
+        "riskit-state-backup.timer",
+    ):
+        shutil.copy(REPO / "deploy" / "backup" / name, app / "deploy" / "backup" / name)
+    return app
+
+
+def _run(tmp_path: Path, app: Path, bindir: Path, log: Path) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.update(
+        {
+            "PATH": f"{bindir}:{env['PATH']}",
+            "CMD_LOG": str(log),
+            "APP_DIR": str(app),
+            "RISKIT_LIB_DIR": str(tmp_path / "lib"),
+            "STATE_BACKUP_UNIT_DIR": str(tmp_path / "units"),
+        }
+    )
+    return subprocess.run(
+        ["bash", str(INSTALLER)], env=env, capture_output=True, text=True, timeout=120
+    )
+
+
+def _log_lines(log: Path) -> list[str]:
+    return [ln for ln in log.read_text().splitlines() if ln.strip()] if log.exists() else []
+
+
+# ── the reproduction ──────────────────────────────────────────────────────
+
+
+def test_full_hardening_installer_cannot_run_under_the_production_allowlist(tmp_path):
+    """RED: `sudo bash apply_hardening.sh` is refused by production's sudoers.
+
+    This is the whole reason the bounded path exists. If this ever starts
+    passing, the allowlist has been widened to include a root shell and the
+    justification for a separate entry point should be revisited — the test
+    would then be reporting a real change in the privilege model.
+    """
+    bindir, log = _stub_bin(tmp_path)
+    env = dict(os.environ)
+    env.update({"PATH": f"{bindir}:{env['PATH']}", "CMD_LOG": str(log)})
+    proc = subprocess.run(
+        ["sudo", "-n", "bash", str(HARDENING), "--dry-run"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode != 0
+    assert "password is required" in proc.stderr
+
+
+def test_bounded_installer_runs_under_the_same_allowlist(tmp_path):
+    """GREEN: the bounded path completes using only allowlisted binaries."""
+    app = _app_dir(tmp_path)
+    bindir, log = _stub_bin(tmp_path)
+    proc = _run(tmp_path, app, bindir, log)
+    assert proc.returncode == 0, proc.stderr
+    for line in _log_lines(log):
+        assert line.split()[0] in PROD_SUDO_ALLOWLIST, f"used a non-allowlisted binary: {line}"
+
+
+# ── the four steps, in order and with the right modes ─────────────────────
+
+
+def test_library_is_installed_before_the_writer(tmp_path):
+    """Ordering is load-bearing: the writer sources the library and dies without it.
+
+    Writer-first leaves a window in which the 02:30 timer can fire against a
+    writer whose library is absent — a silently lost generation. A library
+    without the writer is harmless.
+    """
+    app = _app_dir(tmp_path)
+    bindir, log = _stub_bin(tmp_path)
+    assert _run(tmp_path, app, bindir, log).returncode == 0
+    installs = [ln for ln in _log_lines(log) if ln.startswith("install ")]
+    lib_at = next(i for i, ln in enumerate(installs) if "backup_root_lib.sh" in ln)
+    writer_at = next(i for i, ln in enumerate(installs) if "riskit-state-backup.sh" in ln)
+    assert lib_at < writer_at, "writer installed before its library:\n" + "\n".join(installs)
+
+
+def test_ownership_and_modes(tmp_path):
+    app = _app_dir(tmp_path)
+    bindir, log = _stub_bin(tmp_path)
+    assert _run(tmp_path, app, bindir, log).returncode == 0
+    installs = [ln for ln in _log_lines(log) if ln.startswith("install ")]
+    lib = next(ln for ln in installs if "backup_root_lib.sh" in ln)
+    writer = next(ln for ln in installs if "riskit-state-backup.sh" in ln)
+    # Sourced, never executed -> 0644. Executed -> 0755.
+    assert "-o root -g root -m 0644" in lib, lib
+    assert "-o root -g root -m 0755" in writer, writer
+
+
+def test_units_are_installed_and_the_service_is_rendered(tmp_path):
+    app = _app_dir(tmp_path)
+    bindir, log = _stub_bin(tmp_path)
+    assert _run(tmp_path, app, bindir, log).returncode == 0
+    units = tmp_path / "units"
+    service = units / "riskit-state-backup.service"
+    timer = units / "riskit-state-backup.timer"
+    assert service.is_file() and timer.is_file()
+    # The timer is copied verbatim; it names neither path.
+    assert (
+        timer.read_text() == (app / "deploy" / "backup" / "riskit-state-backup.timer").read_text()
+    )
+    # The service is rendered onto this install's directories.
+    assert str(tmp_path / "lib") in service.read_text()
+
+
+def test_execstart_points_at_the_root_owned_copy_not_the_checkout(tmp_path):
+    """The nightly must run the root-owned copy, never the deploy-user-writable
+    checkout. A checkout ExecStart would mean anyone who can edit the checkout
+    can choose what runs as root every night."""
+    app = _app_dir(tmp_path)
+    bindir, log = _stub_bin(tmp_path)
+    assert _run(tmp_path, app, bindir, log).returncode == 0
+    service = (tmp_path / "units" / "riskit-state-backup.service").read_text()
+    exec_lines = [ln for ln in service.splitlines() if ln.startswith("ExecStart=")]
+    assert exec_lines, service
+    for ln in exec_lines:
+        assert str(tmp_path / "lib") in ln, ln
+        assert str(app) not in ln, f"ExecStart points into the checkout: {ln}"
+
+
+def test_daemon_reload_precedes_enable_and_the_timer_is_armed(tmp_path):
+    """systemd serves a cached unit otherwise, so enabling a freshly written
+    unit without reloading arms the OLD one."""
+    app = _app_dir(tmp_path)
+    bindir, log = _stub_bin(tmp_path)
+    assert _run(tmp_path, app, bindir, log).returncode == 0
+    sysctl = [ln for ln in _log_lines(log) if ln.startswith("systemctl ")]
+    reload_at = next(i for i, ln in enumerate(sysctl) if "daemon-reload" in ln)
+    enable_at = next(i for i, ln in enumerate(sysctl) if "enable --now" in ln)
+    assert reload_at < enable_at, sysctl
+    assert "riskit-state-backup.timer" in sysctl[enable_at]
+
+
+def test_state_backup_only_touches_nothing_else(tmp_path):
+    """No nginx, no app units, no certificates, no healthcheck, no uptime."""
+    app = _app_dir(tmp_path)
+    bindir, log = _stub_bin(tmp_path)
+    proc = _run(tmp_path, app, bindir, log)
+    assert proc.returncode == 0
+    # The COMMAND LOG, not stdout. The script's own banner says "no nginx, no
+    # app units, no certificates", and scanning that would let a script pass
+    # this test by claiming innocence. What it RAN is the evidence.
+    executed = "\n".join(_log_lines(log))
+    for forbidden in (
+        "nginx",
+        "sites-available",
+        "sites-enabled",
+        "letsencrypt",
+        "certbot",
+        "dynasty-frontend",
+        "dynasty-healthcheck",
+        "riskit-uptime",
+    ):
+        assert forbidden not in executed, f"bounded install touched {forbidden}"
+    # And only the four intended destinations were written.
+    written = sorted(p.name for p in (tmp_path / "lib").iterdir()) + sorted(
+        p.name for p in (tmp_path / "units").iterdir()
+    )
+    assert written == [
+        "backup_root_lib.sh",
+        "riskit-state-backup.sh",
+        "riskit-state-backup.service",
+        "riskit-state-backup.timer",
+    ], written
+
+
+def test_rerunning_is_idempotent(tmp_path):
+    """A second run must not rewrite identical files — re-running an installer
+    is how an operator checks state, and it should not churn root-owned files."""
+    app = _app_dir(tmp_path)
+    bindir, log = _stub_bin(tmp_path)
+    assert _run(tmp_path, app, bindir, log).returncode == 0
+    log.write_text("")
+    proc = _run(tmp_path, app, bindir, log)
+    assert proc.returncode == 0
+    assert not [ln for ln in _log_lines(log) if ln.startswith("install ")], _log_lines(log)
+    assert "up-to-date" in proc.stdout
+
+
+# ── one owner, structurally ───────────────────────────────────────────────
+
+
+def test_apply_hardening_delegates_instead_of_carrying_its_own_copy(tmp_path):
+    """Two copies of "which files, in which order, with which modes" drift, and
+    drift here installs a writer without its library."""
+    text = HARDENING.read_text()
+    assert "install_state_backup.sh" in text, "apply_hardening.sh no longer sources the owner"
+    assert "state_backup_install_scripts" in text
+    assert "state_backup_install_units" in text
+    # The install calls themselves must be gone, not merely supplemented.
+    assert 'install_priv_script "${APP_DIR}/deploy/backup/backup_root_lib.sh"' not in text
+    assert 'install_priv_script "${APP_DIR}/deploy/backup/riskit-state-backup.sh"' not in text
+    assert '"/etc/systemd/system/riskit-state-backup.service"' not in text
+    assert '"/etc/systemd/system/riskit-state-backup.timer"' not in text
+
+
+@pytest.mark.parametrize("name", ["backup_root_lib.sh", "riskit-state-backup.sh"])
+def test_installed_sources_are_the_canonical_checkout_copies(tmp_path, name):
+    """What lands under the lib dir must be byte-identical to the checkout, so
+    a hash comparison on production is a meaningful check rather than a
+    coincidence."""
+    app = _app_dir(tmp_path)
+    bindir, log = _stub_bin(tmp_path)
+    assert _run(tmp_path, app, bindir, log).returncode == 0
+    assert (tmp_path / "lib" / name).read_bytes() == (
+        REPO / "deploy" / "backup" / name
+    ).read_bytes()


### PR DESCRIPTION
Two bounded pieces of the C1A closure. Neither starts C implementation.

---

# 1. Settle which auth context the pushers share (read-only)

Three candidate explanations survive for *"DLF and IDP Show push from the box, playerctx does not"*, and they call for three different repairs, so choosing one by reasoning is exactly the mistake this series keeps making:

| | explanation | repair it would imply |
|---|---|---|
| **A** | siblings run as a **different user** whose HOME holds the key | credential boundary — stop and report |
| **B** | **same context**; siblings let ssh resolve an identity normally, playerctx refuses before ssh runs | code defect in playerctx's guard |
| **C** | something else | depends |

**Section C** reports each unit's `User` / `Group` / `WorkingDirectory` / `EnvironmentFiles` and the effective `HOME` from `passwd` — separating A from B directly.

**Section C3** decides the repair: `git ls-remote` twice in the app user's own context, once exporting exactly what the siblings export (including the absent `-i` target) and once with no `GIT_SSH_COMMAND`. `ls-remote` **reads**; it cannot publish by accident. If auth succeeds with the absent key, playerctx's guard is refusing a push that would have worked.

**Privacy:** only variables whose *name* ends in `_SSH_KEY` have values printed (they are paths, and the repair must name one); every other variable is counted, never shown; `~/.ssh` is listed by name; `~/.ssh/config` contributes only `Host`/`IdentityFile`/`IdentitiesOnly` lines. No key is read.

---

# 2. One owner for the state-backup line, runnable without a root shell

Installing a nightly backup timer required a human root session **and** an nginx rewrite. Neither was necessary.

Measured on production (preflight run `31910753511`), the deploy account's NOPASSWD sudo is exactly `systemctl` / `journalctl` / `install` / `chown` — **no `bash`**. So `sudo bash apply_hardening.sh` cannot run there at all, not even `--dry-run`. The four steps that install the C1A state-backup line were trapped inside a monolithic installer that also rewrites the nginx site config and re-renders the backend and frontend units — and nginx is the step that can silently revert certbot's TLS edits, which is *why* that script is deliberately operator-run. The cost of installing a backup timer was a root shell plus the one operation with real blast radius.

`deploy/backup/install_state_backup.sh` now **owns** those four steps and `apply_hardening.sh` **sources** it. Every privileged action goes through `priv`, which runs the command directly when already root and via `sudo -n` otherwise — one implementation, two entry points. Never `sudo bash`: the point is to stay inside an allowlist that grants binaries rather than a shell.

**Extracted, not copied**, and that is load-bearing. Two copies of "which files, in which order, with which modes" drift, and drift here installs a writer without the library it hard-fails without — a nightly that takes no backup and says nothing. Even the timer name is a shared constant.

## Validation — RED against the real constraint

With a stub `sudo` enforcing production's measured allowlist:

```
sudo -n bash apply_hardening.sh --dry-run   → refused, "password is required"   (RED)
bash install_state_backup.sh                → completes, allowlisted binaries only (GREEN)
```

The tests run the **shipped** script and read back an ordered command log, so what is asserted is what it does. Also pinned: library-before-writer ordering, `root:root` `0644`/`0755`, rendered service vs verbatim timer, ExecStart rooted at the lib dir and **not** the checkout, `daemon-reload` before `enable --now`, idempotence, byte-identical installed sources, and no nginx/certbot/app-unit/healthcheck/uptime operation.

Two honest notes:

- One test originally scanned **stdout**, and the script's own banner says "no nginx, no app units, no certificates" — so it passed by reading the script's claim of innocence. It now scans the command log.
- This broke `test_a_root_installed_script_gets_the_libraries_it_sources`, #852's ordering guard, which parsed `apply_privileged_scripts()` for the two installs I had just moved. **Re-pointed at the new owner rather than deleted** — the rule did not change, only where it is written. Mutation-tested by flipping the two installs (sha256-asserted as applied): both the new behavioural guard and the re-pointed textual one die, and both return on restore.

```
tests/deploy/test_state_backup_installer.py   12 passed
tests/deploy/                                 266 passed, 4 skipped
tests/retention/                              103 passed
```

ruff check + format clean; `bash -n` clean on both scripts.

## Scope

Diagnostics plus a bounded operational repair. No canonical value path, no product surface, no change to the backup writer's or restore proof's behaviour, no retention stream promoted or demoted. `apply_hardening.sh`'s full hardening behaviour is preserved.