### PR TITLE
A missing -i target is not proof that git cannot authenticate

### DIFF
--- a/.github/workflows/c1a-install-state-backup.yml
+++ b/.github/workflows/c1a-install-state-backup.yml
@@ -1,0 +1,135 @@
+name: C1A install the state-backup line (bounded)
+
+# Installs ONLY the C1A state-backup line, through the deploy account's
+# existing sudo allowlist (systemctl / journalctl / install / chown).
+#
+# It exists because the canonical hardening installer needs a full root shell —
+# measured, that account has no `bash` in its sudoers — and also rewrites the
+# nginx site config, which can silently revert certbot's TLS edits. Installing
+# a backup timer should not cost either of those.
+#
+# The installation logic itself is NOT here: it lives in
+# deploy/backup/install_state_backup.sh, which the full hardening installer
+# also sources. (Its filename is deliberately not spelled here: a tripwire
+# greps these workflow files for it, and a guard a comment can trip is a
+# guard someone eventually weakens to stop the noise.)
+# This workflow is a transport, so the two entry points cannot drift.
+#
+# THIS ONE MUTATES PRODUCTION. It installs units and arms a timer. It is
+# dispatch-only, never scheduled, and every step is scoped to the state-backup
+# line: no nginx, no app units, no certificates.
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_oneshot:
+        description: >-
+          After installing, start riskit-state-backup.service once so the
+          installed path is proven rather than assumed (default true).
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: c1a-install-state-backup
+  cancel-in-progress: false
+
+jobs:
+  install:
+    name: Install and prove the root-owned state-backup line
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Configure production SSH
+        env:
+          DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          install -d -m 700 "$HOME/.ssh"
+          printf '%s\n' "$DEPLOY_SSH_PRIVATE_KEY" | sed 's/\r$//' > "$HOME/.ssh/id_ed25519"
+          printf '%s\n' "$DEPLOY_KNOWN_HOSTS" | sed 's/\r$//' > "$HOME/.ssh/known_hosts"
+          chmod 600 "$HOME/.ssh/id_ed25519"
+          chmod 644 "$HOME/.ssh/known_hosts"
+          ssh-keygen -y -f "$HOME/.ssh/id_ed25519" >/dev/null
+          echo "PORT=${DEPLOY_PORT:-22}" >> "$GITHUB_ENV"
+
+      - name: Install the state-backup line
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          APP_DIR: ${{ vars.PROD_APP_DIR || '/home/dynasty/trade-calculator' }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          # The shipped canonical installer, piped and run as the deploy user.
+          # Its own `priv` helper reaches root through `sudo -n <binary>` only.
+          ssh -i "$HOME/.ssh/id_ed25519" \
+            -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+            -o ConnectTimeout=15 -o ServerAliveInterval=15 \
+            -p "$PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "APP_DIR=$(printf %q "$APP_DIR") bash -s" \
+            < deploy/backup/install_state_backup.sh
+
+      - name: Prove the installed path runs, and where it writes
+        if: ${{ inputs.run_oneshot }}
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          # A manually started oneshot proves the INSTALLED service path
+          # executes. It is not a natural 02:30 firing and must never be
+          # reported as one; the timer's enablement and next elapse are what
+          # prove scheduling is armed, and both are printed here.
+          #
+          # The generation lands under root-owned /var/backups/riskit-state,
+          # which the deploy user cannot list — so the evidence is the writer's
+          # OWN journal lines, which name the effective root, the promoted
+          # generation and the artifact count.
+          ssh -i "$HOME/.ssh/id_ed25519" \
+            -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+            -o ConnectTimeout=15 -o ServerAliveInterval=15 \
+            -p "$PORT" "$DEPLOY_USER@$DEPLOY_HOST" 'bash -s' <<'REMOTE'
+          set -Eeuo pipefail
+          say() { printf '[state-backup-proof] %s\n' "$*"; }
+
+          say "timer state (scheduling armed?)"
+          for p in UnitFileState ActiveState Persistent NextElapseUSecRealtime LastTriggerUSec; do
+            printf '[state-backup-proof]   %-26s %s\n' "$p" \
+              "$(sudo -n systemctl show riskit-state-backup.timer -p "$p" --value || true)"
+          done
+
+          say "service ExecStart (must be the root-owned copy, not the checkout)"
+          sudo -n systemctl show riskit-state-backup.service -p ExecStart --value | sed 's/^/[state-backup-proof]   /'
+
+          say "starting riskit-state-backup.service ONCE (manual, not a 02:30 firing)"
+          sudo -n systemctl start riskit-state-backup.service || true
+
+          for p in Result ExecMainStatus ExecMainExitTimestamp; do
+            printf '[state-backup-proof]   %-26s %s\n' "$p" \
+              "$(sudo -n systemctl show riskit-state-backup.service -p "$p" --value || true)"
+          done
+
+          say "writer journal — names the effective root, generation and artifact count"
+          sudo -n journalctl -u riskit-state-backup.service -n 60 --no-pager 2>&1 \
+            | sed 's/^/[journal] /' || true
+
+          RESULT="$(sudo -n systemctl show riskit-state-backup.service -p Result --value || echo unknown)"
+          STATUS="$(sudo -n systemctl show riskit-state-backup.service -p ExecMainStatus --value || echo 1)"
+          say "Result=${RESULT} ExecMainStatus=${STATUS}"
+          # A oneshot that failed must fail this job. "It ran" is not evidence.
+          [[ "${RESULT}" == "success" && "${STATUS}" == "0" ]]
+          REMOTE

--- a/deploy/playerctx_history_push.sh
+++ b/deploy/playerctx_history_push.sh
@@ -44,29 +44,43 @@ PUSH_RETRY_MAX=3
 log() { printf '[playerctx-history] %s\n' "$*"; }
 err() { printf '[playerctx-history][ERR] %s\n' "$*" >&2; }
 
-export GIT_SSH_COMMAND="ssh -i ${SSH_KEY} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
-
-# The deploy-key check lives HERE, not in install-systemd-service.sh, and
-# that placement is the fix for a measured failure rather than a
-# preference.  The installer gated the whole unit on this file and
-# reported it missing on the 2026-08-05 deploy, installing nothing —
-# but the installer runs as the DEPLOY user, whose sudo is scoped to
-# specific commands, so it can neither `sudo test -f` nor stat another
-# user's ~/.ssh.  This script runs as the app user under
-# `User=__APP_USER__`, which is the only context that can answer the
-# question it is actually asking: can the thing that pushes read the key?
+# THE ABSENCE OF THIS FILE IS NOT PROOF THAT GIT CANNOT AUTHENTICATE, and
+# treating it as proof cost C1-RET-08 every snapshot it ever produced.
 #
-# Exit 0, not 1.  Nothing has been lost or half-done at this point, and a
-# unit that goes red every week is a unit nobody reads.  The backlog is
-# safe because the glob below takes EVERY dated snapshot rather than the
-# newest, so supplying the key later backfills every missed week on the
-# next run.  A stalled retention is meant to surface through
-# `store.history_coverage()`'s missingDays — the same way rank_history
-# reports its own gaps — not through a permanently failing timer.
-if [[ ! -r "${SSH_KEY}" ]]; then
-  log "no readable deploy key at ${SSH_KEY} - snapshots stay on disk, nothing pushed"
-  log "fix: place the key there, or set PLAYERCTX_HISTORY_SSH_KEY in ${LIVE_APP_DIR}/.env"
-  exit 0
+# Measured on production 2026-08-15 (preflight run 31912677700). All three
+# pushers — DLF, IDP Show and this one — run as the SAME user with the SAME
+# HOME, and `${HOME}/.ssh/github_deploy_key` is absent for all three. DLF and
+# IDP Show nonetheless push successfully, because `~/.ssh/config` carries
+#
+#     Host github.com
+#       IdentityFile ~/.ssh/github_push
+#       IdentitiesOnly yes
+#
+# and `-i` accumulates WITH the config's IdentityFile rather than replacing it.
+# The absent `-i` target contributes nothing and `github_push` supplies the
+# identity, so the siblings' `-i` is effectively a no-op. Demonstrated
+# non-mutatingly with `git ls-remote` in that same context: authentication
+# succeeds both with the siblings' exact GIT_SSH_COMMAND and with none at all.
+#
+# This script was the only one of the three that decided, on ssh's behalf and
+# before ssh ran, that a push was impossible — and then exited 0, so the unit
+# went green every week while publishing nothing. Two dated snapshots sat
+# unpushed from 2026-08-05 and 2026-08-11 with the timer reporting success.
+#
+# So: use the key EXPLICITLY when it is there, and otherwise let ssh resolve an
+# identity by its own rules — exactly what the working siblings rely on. What is
+# NOT relaxed is the outcome: a real authentication failure still fails the run,
+# because `git clone`/`git push` failing is still fatal below. The difference is
+# that failure is now reported by the thing that actually tried.
+if [[ -r "${SSH_KEY}" ]]; then
+  export GIT_SSH_COMMAND="ssh -i ${SSH_KEY} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+else
+  log "no readable deploy key at ${SSH_KEY} - falling back to ssh's own identity"
+  log "resolution (~/.ssh/config, agent), which is what the sibling pushers use"
+  log "set PLAYERCTX_HISTORY_SSH_KEY in ${LIVE_APP_DIR}/.env to name one explicitly"
+  # No -i and no IdentitiesOnly here: ssh_config governs. Forcing
+  # IdentitiesOnly with nothing to point at would restrict ssh to an empty set.
+  export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=accept-new"
 fi
 
 SRC_DIR="${LIVE_APP_DIR}/${HISTORY_REL}"

--- a/tests/deploy/test_playerctx_history_push_runs.py
+++ b/tests/deploy/test_playerctx_history_push_runs.py
@@ -161,34 +161,76 @@ def test_nothing_outside_the_history_directory_is_ever_staged(tmp_path):
     ]
 
 
-def test_a_missing_key_exits_clean_and_pushes_nothing(tmp_path):
-    """Exit 0, not 1 — a unit that goes red weekly is one nobody reads,
-    and nothing is half-done at that point."""
+def test_a_missing_key_no_longer_aborts_the_push(tmp_path):
+    """The absence of the nominal -i target is NOT proof that git cannot
+    authenticate, and treating it as proof cost C1-RET-08 every snapshot it
+    ever produced.
+
+    Measured on production 2026-08-15 (preflight run 31912677700): all three
+    pushers run as the same user with the same HOME, ``github_deploy_key`` is
+    absent for all three, and DLF and IDP Show push anyway because
+    ``~/.ssh/config`` supplies ``IdentityFile ~/.ssh/github_push``. ``-i``
+    accumulates WITH that rather than replacing it, so the siblings' ``-i`` is
+    a no-op. This script alone decided on ssh's behalf, before ssh ran, that a
+    push was impossible — and exited 0, so the timer went green weekly while
+    publishing nothing.
+
+    The old test asserted that keyless meant "pushes nothing". That was the
+    defect, written down as the contract.
+    """
     origin = _make_origin(tmp_path)
     live = _make_live_dir(tmp_path, ["2026-08-11"])
 
     proc = _run(tmp_path, live, origin, key=None)
     assert proc.returncode == 0, proc.stderr
-    assert "no readable deploy key" in proc.stdout + proc.stderr
-    assert not any("playerctx/history" in f for f in _committed_files(origin))
+    # It says what it is doing rather than going quiet.
+    assert "falling back to ssh" in proc.stdout + proc.stderr
+    # And it PUBLISHES, which is the whole point.
+    assert "data/playerctx/history/snapshot_2026-08-11.json" in _committed_files(origin)
 
 
-def test_the_backlog_survives_a_keyless_run(tmp_path):
-    """The claim exit-0 rests on, end to end: a keyless week loses
-    nothing, and the next run with a key backfills it."""
+def test_an_explicit_readable_key_is_still_used_explicitly(tmp_path):
+    """Unchanged behaviour where a key IS configured: it is passed as -i with
+    IdentitiesOnly, so naming a key still pins the identity."""
+    origin = _make_origin(tmp_path)
+    live = _make_live_dir(tmp_path, ["2026-08-11"])
+    key = tmp_path / "key"
+    key.write_text("k", encoding="utf-8")
+
+    proc = _run(tmp_path, live, origin, key=key)
+    assert proc.returncode == 0, proc.stderr
+    assert "falling back to ssh" not in proc.stdout + proc.stderr
+    assert "data/playerctx/history/snapshot_2026-08-11.json" in _committed_files(origin)
+
+
+def test_the_whole_backlog_publishes_on_one_keyless_run(tmp_path):
+    """Every dated snapshot, not just the newest — the backlog claim now has to
+    hold on the run itself rather than on a later run that has a key."""
     origin = _make_origin(tmp_path)
     live = _make_live_dir(tmp_path, ["2026-08-11", "2026-08-18"])
 
     assert _run(tmp_path, live, origin, key=None).returncode == 0
-    assert not any("playerctx/history" in f for f in _committed_files(origin))
-
-    key = tmp_path / "key"
-    key.write_text("k", encoding="utf-8")
-    assert _run(tmp_path, live, origin, key=key).returncode == 0
 
     files = _committed_files(origin)
     assert "data/playerctx/history/snapshot_2026-08-11.json" in files
     assert "data/playerctx/history/snapshot_2026-08-18.json" in files
+
+
+def test_a_real_authentication_failure_is_still_a_failure(tmp_path):
+    """Relaxing the pre-flight guard must NOT relax the outcome. An
+    unreachable remote has to fail the run loudly — the failure this repair
+    removes is the one that reported success while publishing nothing, not
+    every failure.
+    """
+    origin = tmp_path / "does-not-exist.git"
+    live = _make_live_dir(tmp_path, ["2026-08-11"])
+
+    proc = _run(tmp_path, live, origin, key=None)
+    assert proc.returncode != 0, (
+        "an unreachable remote must fail the unit; got exit 0 with stdout:\n" + proc.stdout
+    )
+    # And it must not have claimed to publish.
+    assert "pushed on attempt" not in proc.stdout
 
 
 def test_no_snapshots_exits_clean(tmp_path):

--- a/tests/deploy/test_playerctx_history_timer_is_wired.py
+++ b/tests/deploy/test_playerctx_history_timer_is_wired.py
@@ -150,11 +150,19 @@ def test_the_installer_does_not_gate_the_unit_on_a_key_it_cannot_read():
         None,
     )
     assert guard is not None, "the key check must run as the service user"
-    block = lines[guard : guard + 8]
+    # AND IT MUST NOT ABORT. This assertion used to require `exit 0` inside the
+    # guard block — the defect written down as the contract. Measured on
+    # production 2026-08-15 (preflight 31912677700): all three pushers share a
+    # user and HOME, github_deploy_key is absent for all three, and the two that
+    # DO publish authenticate via ~/.ssh/config's IdentityFile, because `-i`
+    # accumulates with it rather than replacing it. Exiting on a missing -i
+    # target meant this unit reported success weekly while publishing nothing.
+    block = lines[guard : guard + 12]
     end = next((i for i, ln in enumerate(block) if ln.strip() == "fi"), len(block))
-    assert any(
-        ln.strip() == "exit 0" for ln in block[:end]
-    ), "a missing key must not make the weekly unit go red — nothing is lost yet"
+    assert not any(ln.strip() == "exit 0" for ln in block[:end]), (
+        "a missing -i target is not proof that git cannot authenticate; the "
+        "guard must select ssh's own identity resolution, not abort the push"
+    )
 
 
 def test_a_missing_key_does_not_lose_the_backlog():


### PR DESCRIPTION
C1-RET-08 has published nothing since it was built. The cause was this script deciding **on ssh's behalf, before ssh ran**, that a push was impossible — then exiting 0, so the weekly timer reported success while two dated snapshots sat unpushed from 2026-08-05 and 2026-08-11.

## The measurement

Production preflight run [`31912677700`](https://github.com/jasonleetucker-code/riskittogetthebrisket/actions/runs/31912677700):

| | DLF | IDP Show | playerctx |
|---|---|---|---|
| `User` / `Group` / effective `HOME` | same | same | same |
| `<HOME>/.ssh/github_deploy_key` | **ABSENT** | **ABSENT** | **ABSENT** |
| `*_SSH_KEY` override configured | no | no | no |
| publishes? | **yes** | **yes** | no |

```
~/.ssh/config:  Host github.com
                  IdentityFile ~/.ssh/github_push
                  IdentitiesOnly yes
```

`-i` **accumulates** with the config's `IdentityFile` rather than replacing it. The absent `-i` target contributes nothing, `github_push` supplies the identity, and the siblings' `-i` is effectively a no-op.

Demonstrated non-mutatingly with `git ls-remote` in that same context — **auth succeeds** both with the siblings' exact `GIT_SSH_COMMAND` and with none at all. That is case **B**: a code defect, not a credential boundary. No key was copied and no new credential location invented.

## The repair

The guard now **selects** rather than aborts:

- explicit readable key → still passed as `-i` with `IdentitiesOnly`, unchanged;
- otherwise → warn, and let ssh resolve an identity by its own rules, which is what the working siblings already rely on.

No `-i` and no `IdentitiesOnly` in the fallback: forcing `IdentitiesOnly` with nothing to point at restricts ssh to an empty set.

**What is not relaxed is the outcome.** A real authentication failure still fails the run — pinned by a new test that points the script at an unreachable remote and requires a non-zero exit *and* the absence of any "pushed on attempt" claim. The failure this removes is the one that reported success while publishing nothing.

## Two tests asserted the defect as the contract

`test_a_missing_key_exits_clean_and_pushes_nothing` and the `exit 0` assertion in `test_the_installer_does_not_gate_the_unit_on_a_key_it_cannot_read` both encoded the old behaviour. **Rewritten rather than deleted**, each carrying why.

Mutation-tested by restoring the old guard (sha256-asserted as applied): **three tests die**, including the auth-failure one, and all return on restore.

## Also: the bounded install workflow (Part 4 transport)

Pipes the canonical installer to production and starts the state-backup service **once**. That oneshot proves the installed path executes — it is **not** a natural 02:30 firing, and the workflow says so where it prints the timer's next elapse. The generation lands under root-owned `/var/backups/riskit-state`, which the deploy user cannot list, so the evidence is the writer's own journal lines naming the effective root and artifact count. A non-success `Result` fails the job, because "it ran" is not evidence.

```
tests/deploy/ + tests/retention/   371 passed, 4 skipped
```

ruff check + format clean; `bash -n` clean.

## Scope

C1A closure only. No canonical value path, no product surface, no retention stream promoted or demoted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2N5BKwWpfGRK2AkuF5Xup)_