### PR TITLE
Piped over stdin is a different execution mode, and it was the only one that mattered

### DIFF
--- a/deploy/backup/install_state_backup.sh
+++ b/deploy/backup/install_state_backup.sh
@@ -133,7 +133,17 @@ state_backup_enable() {
 # ── standalone entry point ────────────────────────────────────────────────
 # Sourced by apply_hardening.sh (which calls the functions itself, in its own
 # sequence); executed directly for the bounded install.
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+#
+# `${BASH_SOURCE[0]:-$0}`, not `${BASH_SOURCE[0]}`. When bash reads a script
+# from STDIN — `ssh host bash -s < script`, which is how every workflow in this
+# repo delivers one to production — BASH_SOURCE is EMPTY, and `set -u` makes
+# referencing element 0 fatal. The first production run died here, before any
+# privileged call, having installed nothing.
+#
+# Defaulting to $0 gives the right answer in all three modes: piped (unset ->
+# $0 -> equal -> run), executed by path (equal -> run), sourced (the file path
+# vs the parent's name -> not equal -> define only).
+if [[ "${BASH_SOURCE[0]:-$0}" == "${0}" ]]; then
     APP_DIR="${APP_DIR:-/home/dynasty/trade-calculator}"
     RISKIT_LIB_DIR="${RISKIT_LIB_DIR:-/usr/local/lib/riskit}"
 

--- a/tests/deploy/test_state_backup_installer.py
+++ b/tests/deploy/test_state_backup_installer.py
@@ -264,6 +264,79 @@ def test_rerunning_is_idempotent(tmp_path):
     assert "up-to-date" in proc.stdout
 
 
+def test_it_runs_when_piped_over_stdin_the_way_the_workflow_delivers_it(tmp_path):
+    """`ssh host bash -s < script` is how EVERY workflow in this repo delivers a
+    script to production, and it is a different execution mode from `bash path`.
+
+    Piped, bash leaves BASH_SOURCE empty, so the standalone-entry guard's
+    `${BASH_SOURCE[0]}` was an unbound variable under `set -u`. The first
+    production run of the bounded installer died there — before any privileged
+    call, having installed nothing.
+
+    Every other test in this file invokes the script BY PATH, which is why they
+    were all green while the only invocation that matters was broken. This one
+    constructs the real mode.
+    """
+    app = _app_dir(tmp_path)
+    bindir, log = _stub_bin(tmp_path)
+    env = dict(os.environ)
+    env.update(
+        {
+            "PATH": f"{bindir}:{env['PATH']}",
+            "CMD_LOG": str(log),
+            "APP_DIR": str(app),
+            "RISKIT_LIB_DIR": str(tmp_path / "lib"),
+            "STATE_BACKUP_UNIT_DIR": str(tmp_path / "units"),
+        }
+    )
+    with INSTALLER.open("rb") as script:
+        proc = subprocess.run(
+            ["bash", "-s"],
+            stdin=script,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    assert proc.returncode == 0, proc.stderr
+    assert "unbound variable" not in proc.stderr
+    # It must actually DO the work, not merely survive: a guard that silently
+    # decides "I am being sourced" would also exit 0 and install nothing.
+    assert (tmp_path / "lib" / "backup_root_lib.sh").is_file()
+    assert (tmp_path / "units" / "riskit-state-backup.timer").is_file()
+
+
+def test_sourcing_defines_without_installing(tmp_path):
+    """The other side of the same guard: apply_hardening.sh sources this file
+    and drives the functions itself, so sourcing must install nothing."""
+    app = _app_dir(tmp_path)
+    bindir, log = _stub_bin(tmp_path)
+    env = dict(os.environ)
+    env.update(
+        {
+            "PATH": f"{bindir}:{env['PATH']}",
+            "CMD_LOG": str(log),
+            "APP_DIR": str(app),
+            "RISKIT_LIB_DIR": str(tmp_path / "lib"),
+            "STATE_BACKUP_UNIT_DIR": str(tmp_path / "units"),
+        }
+    )
+    proc = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'set -Eeuo pipefail; source "{INSTALLER}"; type -t state_backup_install_scripts',
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "function"
+    assert not _log_lines(log), f"sourcing must not install anything; ran: {_log_lines(log)}"
+
+
 # ── one owner, structurally ───────────────────────────────────────────────
 
 


### PR DESCRIPTION
The first production run of the bounded installer ([`31915017070`](https://github.com/jasonleetucker-code/riskittogetthebrisket/actions/runs/31915017070)) died at

```
bash: line 136: BASH_SOURCE[0]: unbound variable
```

before any privileged call, having installed nothing.

## The bug

`ssh host bash -s < script` is how **every** workflow in this repo delivers a script to production. In that mode bash leaves `BASH_SOURCE` empty, so `${BASH_SOURCE[0]}` in the standalone-entry guard is an unbound variable under `set -u`.

`${BASH_SOURCE[0]:-$0}` gives the right answer in all three modes:

| mode | `BASH_SOURCE[0]` | result |
|---|---|---|
| piped (`bash -s <`) | unset → `$0` | equal → **run** |
| executed by path | the path | equal → **run** |
| sourced | the file path vs parent's `$0` | not equal → **define only** |

## Why it shipped green — the part worth recording

Every test in the file invoked the script **by path**. Twelve passing tests covered the mode production never uses, and none covered the mode it always uses.

That is the same mistake as asserting on a script's own banner instead of its command log, and as testing a prune case the guard happens to survive: **the test constructed a condition that was not the real one, and read identically to one that worked.**

## Now pinned on both sides

- **piped over stdin** — must install, not merely survive. A guard that silently decided "I am being sourced" would also exit 0 having done nothing, so the test asserts the files actually land.
- **sourced** — must define the functions and install nothing (this is how `apply_hardening.sh` uses it).

Mutation-tested by restoring the unguarded expansion (sha256-asserted as applied): the stdin test dies, and returns on restore.

## Production state

**Unchanged by the failed run.** It aborted before the first `priv` call — nothing installed, enabled or started.

```
tests/deploy/   270 passed, 4 skipped
```

ruff clean.

## Scope

One-line fix to the installer plus its missing coverage. No canonical value path, no product surface, no retention stream.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2N5BKwWpfGRK2AkuF5Xup)_