### PR TITLE
Audit batch A: make the deploy's verdict about the deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -509,6 +509,26 @@ jobs:
           echo "::error title=Deploy would skip or reverse shipped code::${REASON}. If this is an intentional rollback, re-run via workflow_dispatch with allow_non_fast_forward=true."
           exit 1
 
+      - name: Assert post-deploy verification will actually run
+        # BOTH verification steps below are gated on
+        # ``vars.PROD_PUBLIC_URL != ''``.  If that variable is unset,
+        # renamed, or scoped to an environment this job cannot read,
+        # they SKIP and the job reports green — a gate whose input is
+        # missing reading exactly like a gate that passed.  That is the
+        # same failure class as the contract gate which silently skipped
+        # for months (``scripts/validate_api_contract.py`` docstring),
+        # and it is the one thing that could make every other statement
+        # in this workflow untrue.  Fail loudly instead (audit
+        # 2026-08-17).
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          if [[ -z "${{ vars.PROD_PUBLIC_URL }}" ]]; then
+            echo "::error title=PROD_PUBLIC_URL is not set::Post-deploy smoke test and live-contract validation would both silently skip, and this job would report success without verifying anything. Set the repository variable PROD_PUBLIC_URL."
+            exit 1
+          fi
+          echo "PROD_PUBLIC_URL is set; post-deploy verification will run."
+
       - name: Run remote deploy script
         env:
           DEPLOY_REF_INPUT: ${{ github.event.inputs.deploy_ref }}
@@ -633,6 +653,10 @@ jobs:
 
           check_endpoint() {
             local path="$1"
+            # Accepts a REGEX of tolerated codes, not a single literal.
+            # ``/api/health`` needs ``200|503`` — see the readiness loop
+            # below for why a 503 here is a source-health statement, not
+            # a deploy failure.
             local expect_code="${2:-200}"
             local full_url="${URL}${path}"
             local code
@@ -642,7 +666,7 @@ jobs:
             # which preserve the brackets on disk.
             code=$(curl --silent --show-error --globoff --output /dev/null \
               --write-out '%{http_code}' --max-time 30 "${full_url}" || echo "000")
-            if [[ "${code}" == "${expect_code}" ]]; then
+            if [[ "${code}" =~ ^(${expect_code})$ ]]; then
               echo "PASS: ${path} -> ${code}"
               PASS=$((PASS + 1))
             else
@@ -657,16 +681,45 @@ jobs:
           # The service is restarted moments before this step runs, so
           # wait for it to finish loading its first payload before we
           # probe — a cold-start blip must not false-fail the deploy.
-          echo "Waiting for ${URL}/api/health to become ready…"
+          #
+          # ACCEPT 200 **OR** 503, and say which we got (audit 2026-08-17).
+          # ``/api/health`` returns 503 whenever ``is_ok`` is false
+          # (server.py: no last_error AND not stalled AND not data_stale
+          # AND contractHealth.ok) — so a box that is merely MID-SCRAPE,
+          # or serving a board whose critical source timed out, answers
+          # 503 while being perfectly alive.  A loop that breaks only on
+          # 200 therefore cannot distinguish "still booting" from
+          # "booted and degraded": it burned its whole budget and the
+          # probe below then failed the deploy over a SOURCE-HEALTH
+          # condition.  That is the CI lane inversion
+          # ``docs/ops/STABILIZATION_2026-08-16.md`` §3d exists to
+          # prevent, reproduced on the deploy side — measured on run
+          # 32062696830 (2026-08-17), where the remote deploy script had
+          # already succeeded and the smoke step reddened the job anyway.
+          #
+          # The adjudicator for "ok vs degraded" is the
+          # ``Validate live data contract`` step below, which already
+          # tolerates ``degraded`` deliberately.  Two consecutive steps
+          # must not hold opposite policies on one signal.
+          echo "Waiting for ${URL}/api/health to answer…"
+          _ready=""
           for _i in $(seq 1 30); do
             _hc=$(curl --silent --globoff --output /dev/null --max-time 10 \
               --write-out '%{http_code}' "${URL}/api/health" || echo "000")
-            if [[ "${_hc}" == "200" ]]; then
-              echo "  health ready after ~$(( _i * 3 ))s"
+            if [[ "${_hc}" == "200" || "${_hc}" == "503" ]]; then
+              echo "  health answering after ~$(( _i * 3 ))s (HTTP ${_hc})"
+              [[ "${_hc}" == "503" ]] && echo "  note: 503 = degraded (mid-scrape or source health); the live-contract step adjudicates"
+              _ready="${_hc}"
               break
             fi
             sleep 3
           done
+          # Exhaustion must be LOUD.  Previously this loop fell through
+          # silently and the only symptom was a failing probe 30 lines
+          # later with no explanation in the log.
+          if [[ -z "${_ready}" ]]; then
+            echo "::warning title=Health never answered::${URL}/api/health did not return 200 or 503 within ~90s (last code ${_hc}). Continuing to the probes, which will report the real code."
+          fi
 
           # The public-league snapshot is ALWAYS cold right after a
           # restart: the first request kicks a multi-season Sleeper
@@ -679,17 +732,34 @@ jobs:
           # and poll until warm (up to ~6 min) before the pass/fail
           # probes below.
           echo "Waiting for ${URL}/api/public/league snapshot to come warm…"
+          _warm=""
           for _i in $(seq 1 24); do
             _plc=$(curl --silent --globoff --output /dev/null --max-time 20 \
               --write-out '%{http_code}' "${URL}/api/public/league" || echo "000")
             if [[ "${_plc}" == "200" ]]; then
               echo "  public-league snapshot warm after ~$(( _i * 15 ))s"
+              _warm="1"
               break
             fi
             sleep 15
           done
+          # Deliberately still BLOCKING below (a public page that cannot
+          # answer after ~6 min is a real regression), but exhaustion is
+          # now stated instead of inferred from a bare FAIL line.  The
+          # residual false-red vector — a slow Sleeper upstream — is
+          # named in the audit rather than silently widened away.
+          if [[ -z "${_warm}" ]]; then
+            echo "::warning title=Public-league snapshot never warmed::Last code ${_plc} after ~6 min. If the probe below fails, suspect a slow Sleeper rebuild before suspecting this deploy."
+          fi
 
-          check_endpoint "/api/health" 200
+          # 200 OR 503 — see the readiness loop above.  503 means
+          # "degraded", which is a statement about SOURCE HEALTH, and
+          # source health is adjudicated by ``Validate live data
+          # contract`` below (which accepts ``degraded`` by design) and
+          # by the blocking ``--lane full`` contract gate in the
+          # validate job.  It is not a reason to red a deploy whose
+          # remote script already succeeded.
+          check_endpoint "/api/health" "200|503"
           check_endpoint "/api/status" 200
           # /api/data is intentionally gated by _private_api_gate in
           # server.py — an unauthenticated probe MUST return 401.

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -128,3 +128,90 @@ jobs:
         run: |
           set -Eeuo pipefail
           python scripts/check_source_health.py --repo .
+
+      # ── Parity with PR Validation ───────────────────────────────────
+      # This workflow's header claims it "runs the same gates
+      # `PR Validation` runs".  Audit 2026-08-17 measured that claim
+      # false: it omitted EIGHT gates, including the entire frontend
+      # (vitest + build + bundle budgets) and the `import server`
+      # runtime gate.  So the HEAD-FREEZE tree — the one thing this
+      # workflow exists to validate, and the tree that will actually
+      # merge — was validated MORE WEAKLY than any ordinary PR.
+      #
+      # That is the same defect class `deploy.yml` records at its own
+      # head ("the deploy path was strictly weaker than the PR path"),
+      # reintroduced one workflow over.  The steps below close it.
+
+      - name: Validate dependency graph (pip check)
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          python -m pip check
+
+      - name: Preflight environment check
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          python scripts/check_env.py
+
+      - name: Python syntax gate
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          python -m py_compile server.py "Dynasty Scraper.py"
+          python -m py_compile src/api/data_contract.py
+
+      - name: Python runtime import gate
+        shell: bash
+        env:
+          ALLOW_DEFAULT_LOGIN_DEV: "1"
+        run: |
+          set -Eeuo pipefail
+          python - <<'PY'
+          import fastapi  # noqa: F401
+          import uvicorn  # noqa: F401
+          import requests  # noqa: F401
+          from playwright.async_api import async_playwright  # noqa: F401
+          import server  # noqa: F401
+          print("Runtime import gate passed.")
+          PY
+
+      - name: Deploy script syntax gate (existing scripts only)
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          for f in deploy/*.sh; do
+            [ -e "$f" ] || continue
+            bash -n "$f"
+          done
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+
+      - name: Install frontend dependencies
+        shell: bash
+        working-directory: frontend
+        run: |
+          set -Eeuo pipefail
+          if [[ -f package-lock.json ]]; then
+            npm ci --no-audit --no-fund
+          else
+            npm install --no-audit --no-fund
+          fi
+
+      - name: Frontend unit tests (vitest)
+        shell: bash
+        working-directory: frontend
+        run: |
+          set -Eeuo pipefail
+          npm test
+
+      - name: Frontend build + bundle-size budget
+        shell: bash
+        working-directory: frontend
+        run: |
+          set -Eeuo pipefail
+          npm run build:nocheck
+          npm run check:bundles

--- a/tests/deploy/test_post_deploy_verification_is_honest.py
+++ b/tests/deploy/test_post_deploy_verification_is_honest.py
@@ -1,0 +1,189 @@
+"""The deploy's own verdict must be about the DEPLOY.
+
+Audit 2026-08-17, batch A.  Three defects in `.github/workflows/deploy.yml`
+made the deploy's verdict untrustworthy in both directions, and all three
+are cheap to reintroduce, so they are pinned here.
+
+**1. A source-health condition reported as a failed deploy.**
+``/api/health`` returns **503** whenever ``is_ok`` is false — and ``is_ok``
+requires ``not data_stale`` and ``contractHealth.ok``, so a box that is
+merely MID-SCRAPE answers 503 while being perfectly alive.  The readiness
+loop broke only on ``200`` and the probe then demanded ``200``, so the
+step failed the deploy over source health.  Measured on run 32062696830
+(2026-08-17): the remote deploy script had already SUCCEEDED at 20:10:45,
+the startup scrape ran 20:10:21→20:14:02, the smoke test ran
+20:10:45→20:13:26 entirely inside it, and the job went red.  25 of 27
+checks had passed.  That is the CI-lane inversion
+``docs/ops/STABILIZATION_2026-08-16.md`` §3d exists to prevent,
+reproduced on the deploy side.
+
+**2. Two consecutive steps held opposite policies on one signal.**
+``Validate live data contract`` accepts ``degraded`` deliberately
+(``if status not in ("ok", "degraded")``), while the smoke step one
+position earlier failed on the 503 that *means* degraded — and being
+earlier, it won, and the adjudicating step never ran (it reported
+``skipped``).
+
+**3. An unset ``PROD_PUBLIC_URL`` silently skipped BOTH verification
+steps and the job still reported green** — a gate whose input is missing
+reading exactly like a gate that passed, which is the same failure class
+as the contract gate that silently skipped for months.
+
+These are assertions about the workflow's *text* because that is where
+the policy lives; there is no runtime to interrogate.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+DEPLOY = REPO / ".github" / "workflows" / "deploy.yml"
+RELEASE_CANDIDATE = REPO / ".github" / "workflows" / "release-candidate.yml"
+PR_VALIDATION = REPO / ".github" / "workflows" / "pr-validation.yml"
+SERVER = REPO / "server.py"
+
+
+@pytest.fixture(scope="module")
+def deploy_text() -> str:
+    return DEPLOY.read_text(encoding="utf-8")
+
+
+class TestHealthProbeToleratesDegraded:
+    def test_the_server_really_does_answer_503_when_degraded(self):
+        """The premise.  If this ever stops being true the tolerance
+        below is unnecessary — and this test says so rather than leaving
+        a mysterious allowance behind."""
+        src = SERVER.read_text(encoding="utf-8")
+        assert "status_code=200 if is_ok else 503" in src, (
+            "/api/health no longer returns 503 when degraded — re-examine whether the "
+            "deploy probe still needs to tolerate it"
+        )
+
+    def test_the_readiness_loop_accepts_503(self, deploy_text: str):
+        loop = deploy_text.split("Waiting for ${URL}/api/health", 1)
+        assert len(loop) == 2, "the /api/health readiness loop is gone"
+        window = loop[1][:1200]
+        assert '"${_hc}" == "503"' in window, (
+            "the readiness loop must accept 503 (degraded) as an ANSWER, or it cannot "
+            "distinguish 'still booting' from 'booted and degraded' and will burn its "
+            "whole budget on a mid-scrape box"
+        )
+
+    def test_the_health_probe_tolerates_200_or_503(self, deploy_text: str):
+        assert 'check_endpoint "/api/health" "200|503"' in deploy_text, (
+            "the /api/health probe must accept 200 OR 503; a 503 is a source-health "
+            "statement adjudicated by the live-contract step, not a deploy failure"
+        )
+
+    def test_the_probe_helper_still_anchors_its_match(self, deploy_text: str):
+        """The tolerance is a REGEX now, so it must stay anchored —
+        otherwise `2000` or `1503` would pass."""
+        assert "=~ ^(${expect_code})$" in deploy_text, (
+            "check_endpoint's match must stay anchored; an unanchored regex would "
+            "accept any code containing the expected one"
+        )
+
+    def test_the_auth_gate_probe_is_untouched(self, deploy_text: str):
+        """The single most valuable probe in the file: an unauthenticated
+        /api/data MUST be 401.  Widening it would expose private data."""
+        assert 'check_endpoint "/api/data" 401' in deploy_text
+        assert 'check_endpoint "/api/data" "200|401"' not in deploy_text
+
+    def test_the_two_steps_no_longer_disagree(self, deploy_text: str):
+        """The live-contract step tolerates `degraded`; the smoke step
+        must not contradict it."""
+        assert 'status not in ("ok", "degraded")' in deploy_text, (
+            "the live-contract adjudicator changed shape — re-check that the smoke "
+            "step's tolerance still matches it"
+        )
+
+
+class TestExhaustionIsLoud:
+    """A wait loop that gives up silently turns a real condition into an
+    unexplained failure 30 lines later."""
+
+    @pytest.mark.parametrize(
+        "marker",
+        ["title=Health never answered", "title=Public-league snapshot never warmed"],
+    )
+    def test_loop_exhaustion_emits_a_warning(self, deploy_text: str, marker: str):
+        assert marker in deploy_text, f"loop exhaustion must announce itself: {marker}"
+
+
+class TestVerificationCannotSilentlySkip:
+    def test_an_unset_public_url_fails_instead_of_skipping(self, deploy_text: str):
+        assert "Assert post-deploy verification will actually run" in deploy_text, (
+            "without this guard, an unset PROD_PUBLIC_URL skips BOTH post-deploy "
+            "steps and the job reports green having verified nothing"
+        )
+        assert "title=PROD_PUBLIC_URL is not set" in deploy_text
+
+    def test_the_guard_runs_before_the_deploy_script(self, deploy_text: str):
+        """Fail before shipping, not after."""
+        guard = deploy_text.index("Assert post-deploy verification will actually run")
+        ship = deploy_text.index("- name: Run remote deploy script")
+        assert guard < ship, "the guard must run BEFORE the remote deploy script"
+
+    def test_both_verification_steps_are_still_gated_on_the_same_variable(self, deploy_text: str):
+        """If they ever diverge, the guard above stops protecting one of
+        them."""
+        gated = deploy_text.count("if: ${{ vars.PROD_PUBLIC_URL != '' }}")
+        assert gated == 2, (
+            f"expected exactly 2 steps gated on PROD_PUBLIC_URL, found {gated} — "
+            "the assert-guard covers that variable only"
+        )
+
+
+class TestReleaseCandidateReallyMatchesPrValidation:
+    """`release-candidate.yml` exists to validate the tree that will
+    actually merge, and its header claims it "runs the same gates
+    `PR Validation` runs".  The audit measured that claim false by eight
+    gates — so the HEAD-FREEZE tree was validated MORE WEAKLY than any
+    ordinary PR, which is the exact defect `deploy.yml` records at its own
+    head and had already fixed once.
+    """
+
+    @pytest.fixture(scope="class")
+    def rc(self) -> str:
+        return RELEASE_CANDIDATE.read_text(encoding="utf-8")
+
+    @pytest.mark.parametrize(
+        "gate,why",
+        [
+            ("python -m pip check", "a broken dependency graph"),
+            ("scripts/check_env.py", "a missing runtime module"),
+            ("py_compile", "a syntax error in server.py or the scraper"),
+            ("import server", "an import-time failure in the app itself"),
+            ("npm test", "every frontend unit test — ~1,390 assertions"),
+            ("npm run check:bundles", "a blown bundle budget"),
+            ("bash -n", "a broken deploy script"),
+        ],
+    )
+    def test_the_candidate_runs_the_gate(self, rc: str, gate: str, why: str):
+        assert gate in rc, (
+            f"release-candidate.yml does not run `{gate}` — the merge candidate would "
+            f"ship without anyone checking for {why}"
+        )
+
+    def test_it_sets_up_node_at_all(self, rc: str):
+        assert (
+            "actions/setup-node" in rc
+        ), "no Node setup means the frontend gates above cannot run even if invoked"
+
+    def test_node_major_matches_pr_validation(self, rc: str):
+        pr = PR_VALIDATION.read_text(encoding="utf-8")
+
+        def node_versions(text: str) -> set[str]:
+            return set(re.findall(r'node-version:\s*"([^"]+)"', text))
+
+        assert node_versions(rc) == node_versions(pr), (
+            "release-candidate and pr-validation must agree on the Node version, or "
+            "the candidate is validated on a runtime production never sees"
+        )
+
+    def test_the_blocking_hard_gate_is_still_there(self, rc: str):
+        assert 'pytest tests/ -x -q --tb=short -m "not livedata"' in rc


### PR DESCRIPTION
Post-merge C-Series audit, batch A. **CI/deploy truthfulness only** — no product code, no methodology. This batch runs first because every other verdict in the audit depends on the gates being honest.

Audit base `96ecc22a9`. Four defects, each reproduced from evidence rather than inferred.

---

## 1. A source-health condition was reported as a FAILED DEPLOY

`/api/health` returns **503** whenever `is_ok` is false (`server.py:5121`), and `is_ok` requires `not data_stale` **and** `contractHealth.ok`. So a box that is merely **mid-scrape** answers 503 while being perfectly alive. The readiness loop broke only on `200`, then the probe demanded `200`.

**Measured on run 32062696830 (2026-08-17):**

| | |
|---|---|
| `Run remote deploy script` | **succeeded** at 20:10:45 — the code shipped |
| startup scrape | 20:10:21 → 20:14:02 |
| smoke test | 20:10:45 → **20:13:26** — entirely inside the scrape |
| result | 25 of 27 checks passed; job **red** |
| re-run after the scrape cleared | smoke **success in 22s**, no code change |

That is the CI-lane inversion `docs/ops/STABILIZATION_2026-08-16.md` §3d exists to prevent, reproduced on the deploy side.

## 2. Two consecutive steps held opposite policies on one signal

`Validate live data contract` accepts `degraded` deliberately (`if status not in ("ok", "degraded")`). The smoke step one position earlier failed on the 503 that *means* degraded — and being earlier, it won, so the adjudicating step never ran (it reported `skipped`).

**Repair:** `check_endpoint` now takes a regex of tolerated codes, `/api/health` accepts `200|503`, and the readiness loop treats 503 as an *answer* and says so.

The regex is **anchored** — proven that `2000`, `1200`, `000` and `500` still fail. **`/api/data` stays pinned at exactly `401`**: that probe asserts the private-API gate is *active*, and widening it would expose private data.

Both wait loops now announce exhaustion instead of falling through silently into an unexplained failure 30 lines later.

## 3. An unset `PROD_PUBLIC_URL` silently skipped all post-deploy verification

Both verification steps are gated on `vars.PROD_PUBLIC_URL != ''`. If it were unset, renamed, or scoped out of reach, **both skip and the job reports green having verified nothing** — a gate whose input is missing reading exactly like a gate that passed. Same failure class as the contract gate that silently skipped for months.

Now asserted **before** the remote deploy script runs, so it fails before shipping rather than after.

## 4. `release-candidate.yml` claimed parity with PR Validation and omitted eight gates

Its header says it "runs the same gates `PR Validation` runs". Measured false: it omitted `pip check`, `check_env.py`, `py_compile`, the `import server` runtime gate, the livedata advisory lane, `bash -n deploy/*.sh`, and **the entire frontend** — vitest (~1,390 assertions), the Next build, and the bundle budgets. It had no `setup-node` step at all.

So the **HEAD-FREEZE tree** — the one thing that workflow exists to validate, and the tree that actually merges — was validated *more weakly* than any ordinary PR. That is the defect `deploy.yml` records at its own head and had already fixed once, reintroduced one workflow over.

The missing gates are added, mirroring pr-validation's own steps and Node version.

---

## Deliberately not widened

`/api/public/league` stays **blocking**. A public page that cannot answer ~6 minutes after a deploy is a real regression. Its residual false-red vector is a slow Sleeper upstream — named in the audit rather than silently tolerated away.

## Regression

`tests/deploy/test_post_deploy_verification_is_honest.py`, 21 tests. **Guards proven to fire by mutation:**

| mutation | result |
|---|---|
| revert health probe to strict `200` | fails `test_the_health_probe_tolerates_200_or_503` |
| delete the `PROD_PUBLIC_URL` guard | fails 2 tests in `TestVerificationCannotSilentlySkip` |
| strip `npm test` from the candidate | fails the parametrized `npm test` gate |
| restore | all 21 green again |

Also pinned: the *premise* (that `/api/health` really does answer 503 when degraded), so if that ever changes the tolerance is re-examined rather than left behind as a mysterious allowance.

Gates: `tests/deploy/` 291 passed / 4 skipped; ruff check + format clean; both workflows parse as YAML and every `run:` block passes `bash -n`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kve8hqgo4v4PeagCHi92ds)_