### PR TITLE
Audit batch G: a regression test required private intelligence to be public

### DIFF
--- a/tests/e2e/specs/public-league.spec.js
+++ b/tests/e2e/specs/public-league.spec.js
@@ -62,7 +62,11 @@ const TABS = [
  * docs/e2e-assertion-audit.md rather than papered over by broadening a
  * listener whose meaning would then be ambiguous.
  */
-async function visitLeague(page, path = "/league", { waitForText = null } = {}) {
+async function visitLeague(
+  page,
+  path = "/league",
+  { waitForText = null } = {},
+) {
   const privateHits = [];
   page.on("request", (req) => {
     const url = req.url();
@@ -90,7 +94,9 @@ async function visitLeague(page, path = "/league", { waitForText = null } = {}) 
 }
 
 test.describe("public /league page", () => {
-  test("renders league page, switches tabs, and never touches private endpoints", async ({ page }) => {
+  test("renders league page, switches tabs, and never touches private endpoints", async ({
+    page,
+  }) => {
     // Walking 12 tabs and waiting for each to actually render its own
     // content does not fit the default 90s budget — the old version fit
     // only because it slept 150ms and asserted nothing about rendering.
@@ -160,7 +166,9 @@ test.describe("public /league page", () => {
         await mobileSelect.selectOption({ label });
         continue;
       }
-      const btn = page.getByRole("button", { name: label, exact: true }).first();
+      const btn = page
+        .getByRole("button", { name: label, exact: true })
+        .first();
       if ((await btn.count()) === 0) {
         missingTabs.push(label);
         continue;
@@ -176,14 +184,22 @@ test.describe("public /league page", () => {
     // The walk must leave the page functional, not crashed.
     await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible();
 
-    expect(privateHits, `private endpoints were touched: ${privateHits.join(", ")}`).toHaveLength(0);
+    expect(
+      privateHits,
+      `private endpoints were touched: ${privateHits.join(", ")}`,
+    ).toHaveLength(0);
   });
 
-  test("deep links via ?tab= query param land on the right tab", async ({ page }) => {
+  test("deep links via ?tab= query param land on the right tab", async ({
+    page,
+  }) => {
     await visitLeague(page, "/league?tab=awards", { waitForText: "award" });
   });
 
-  test("franchise deep link via ?owner= opens the selected franchise", async ({ page, request }) => {
+  test("franchise deep link via ?owner= opens the selected franchise", async ({
+    page,
+    request,
+  }) => {
     const res = await request.get("/api/public/league");
     const body = await res.json();
     const ownerId = body?.league?.managers?.[0]?.ownerId;
@@ -196,25 +212,35 @@ test.describe("public /league page", () => {
     );
   });
 
-  test("dedicated /league/franchise/[owner] route renders", async ({ page, request }) => {
+  test("dedicated /league/franchise/[owner] route renders", async ({
+    page,
+    request,
+  }) => {
     const res = await request.get("/api/public/league");
     const body = await res.json();
     const ownerId = body?.league?.managers?.[0]?.ownerId;
     expect(ownerId).toBeTruthy();
 
-    await page.goto(pageUrl(`/league/franchise/${encodeURIComponent(ownerId)}`), {
-      waitUntil: "domcontentloaded",
-    });
+    await page.goto(
+      pageUrl(`/league/franchise/${encodeURIComponent(ownerId)}`),
+      {
+        waitUntil: "domcontentloaded",
+      },
+    );
     await page.waitForFunction(
-      () => document.body.innerText.includes("Cumulative")
-        && document.body.innerText.includes("Season results"),
+      () =>
+        document.body.innerText.includes("Cumulative") &&
+        document.body.innerText.includes("Season results"),
       null,
       { timeout: 45_000 },
     );
     await expect(page.getByText("← League home").first()).toBeVisible();
   });
 
-  test("dedicated /league/rivalry/[pair] route renders when pair exists", async ({ page, request }) => {
+  test("dedicated /league/rivalry/[pair] route renders when pair exists", async ({
+    page,
+    request,
+  }) => {
     const res = await request.get("/api/public/league/rivalries");
     const body = await res.json();
     const rivalries = body?.data?.rivalries || [];
@@ -229,17 +255,22 @@ test.describe("public /league page", () => {
     ).toBeGreaterThan(0);
     const [a, b] = rivalries[0].ownerIds;
     const slug = `${encodeURIComponent(a)}-vs-${encodeURIComponent(b)}`;
-    await page.goto(pageUrl(`/league/rivalry/${slug}`), { waitUntil: "domcontentloaded" });
+    await page.goto(pageUrl(`/league/rivalry/${slug}`), {
+      waitUntil: "domcontentloaded",
+    });
     await page.waitForFunction(
-      () => document.body.innerText.includes("Head-to-head")
-        && document.body.innerText.includes("Memorable meetings"),
+      () =>
+        document.body.innerText.includes("Head-to-head") &&
+        document.body.innerText.includes("Memorable meetings"),
       null,
       { timeout: 45_000 },
     );
   });
 
   test("archives filter narrows the result set", async ({ page }) => {
-    await visitLeague(page, "/league?tab=archives", { waitForText: "Public archives" });
+    await visitLeague(page, "/league?tab=archives", {
+      waitForText: "Public archives",
+    });
 
     // The test's NAME promised narrowing; the body only counted rows
     // once and asserted `> 0`, so it passed with a filter that did
@@ -260,8 +291,12 @@ test.describe("public /league page", () => {
     // stale count and the later comparison was against the wrong
     // number. That is how this test reported 190 (the unfiltered
     // trades total) while claiming to measure matchups.
-    const matchupsBtn = page.getByRole("button", { name: /^Matchups \(\d+\)$/ });
-    const declared = Number((await matchupsBtn.innerText()).match(/\((\d+)\)/)[1]);
+    const matchupsBtn = page.getByRole("button", {
+      name: /^Matchups \(\d+\)$/,
+    });
+    const declared = Number(
+      (await matchupsBtn.innerText()).match(/\((\d+)\)/)[1],
+    );
 
     // Click INSIDE the poll, because the first one can land before
     // React has attached its handlers and is then simply lost.
@@ -305,7 +340,10 @@ test.describe("public /league page", () => {
 
     // Season filter is the narrowing control.  Pick the first specific
     // season offered and require a strictly smaller set than "all".
-    const seasonSelect = page.locator("select").filter({ hasText: /\d{4}/ }).first();
+    const seasonSelect = page
+      .locator("select")
+      .filter({ hasText: /\d{4}/ })
+      .first();
     const hasSeasonFilter = await seasonSelect.count();
     if (hasSeasonFilter) {
       const options = await seasonSelect.locator("option").allInnerTexts();
@@ -349,7 +387,10 @@ test.describe("public /league page", () => {
       // No season control in this build — then the section-type
       // buttons are the only filter, so prove THOSE narrow: a
       // different archive type must yield a different row count.
-      await page.getByRole("button", { name: /Trades/i }).first().click();
+      await page
+        .getByRole("button", { name: /Trades/i })
+        .first()
+        .click();
       await expect
         .poll(() => rows.count(), {
           message: "switching archive type should change the row set",
@@ -359,7 +400,9 @@ test.describe("public /league page", () => {
     }
   });
 
-  test("public contract payload never includes private field names", async ({ request }) => {
+  test("public contract payload never includes private field names", async ({
+    request,
+  }) => {
     const res = await request.get("/api/public/league");
     expect(res.status()).toBe(200);
     const body = await res.text();
@@ -374,11 +417,16 @@ test.describe("public /league page", () => {
       '"rankderivedvalue":',
       '"arbitragescore":',
     ]) {
-      expect(lower, `banned field ${banned} leaked into public contract`).not.toContain(banned);
+      expect(
+        lower,
+        `banned field ${banned} leaked into public contract`,
+      ).not.toContain(banned);
     }
   });
 
-  test("/league page has an OG title (server-rendered metadata)", async ({ request }) => {
+  test("/league page has an OG title (server-rendered metadata)", async ({
+    request,
+  }) => {
     const res = await request.get(pageUrl("/league"));
     expect(res.status()).toBe(200);
     const html = await res.text();
@@ -386,7 +434,9 @@ test.describe("public /league page", () => {
     expect(html).toMatch(/<meta property="og:description"/i);
   });
 
-  test("/league?tab=overview SSRs with overview content (no loading flash)", async ({ request }) => {
+  test("/league?tab=overview SSRs with overview content (no loading flash)", async ({
+    request,
+  }) => {
     // Server-rendered /league?tab=overview hits the overview content
     // directly — HTML should contain the overview headlines, not the
     // fallback "Loading" text.
@@ -395,15 +445,22 @@ test.describe("public /league page", () => {
     expect(html).toMatch(/At a glance|Defending champion|Featured rivalry/);
   });
 
-  test("/draft-capital redirects into the folded /league tab", async ({ request }) => {
-    const res = await request.get(pageUrl("/draft-capital"), { maxRedirects: 0 });
+  test("/draft-capital redirects into the folded /league tab", async ({
+    request,
+  }) => {
+    const res = await request.get(pageUrl("/draft-capital"), {
+      maxRedirects: 0,
+    });
     expect(res.status()).toBeGreaterThanOrEqual(300);
     expect(res.status()).toBeLessThan(400);
     const location = res.headers().location || "";
     expect(location).toMatch(/\/league\?tab=draft-capital/);
   });
 
-  test("per-matchup recap route is reachable with real data", async ({ page, request }) => {
+  test("per-matchup recap route is reachable with real data", async ({
+    page,
+    request,
+  }) => {
     const matchupsRes = await request.get("/api/public/league/matchups");
     expect(matchupsRes.status()).toBe(200);
     const body = await matchupsRes.json();
@@ -417,13 +474,20 @@ test.describe("public /league page", () => {
     ).toBeGreaterThan(0);
     const first = matchups[0];
     await page.goto(
-      pageUrl(`/league/weekly/${encodeURIComponent(first.season)}/${encodeURIComponent(first.week)}/${encodeURIComponent(first.matchupId)}`),
+      pageUrl(
+        `/league/weekly/${encodeURIComponent(first.season)}/${encodeURIComponent(first.week)}/${encodeURIComponent(first.matchupId)}`,
+      ),
       { waitUntil: "domcontentloaded" },
     );
-    await expect(page.getByText("Game summary").first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("Game summary").first()).toBeVisible({
+      timeout: 15_000,
+    });
   });
 
-  test("player-journey route is reachable with real data", async ({ page, request }) => {
+  test("player-journey route is reachable with real data", async ({
+    page,
+    request,
+  }) => {
     const playersRes = await request.get("/api/public/league/players");
     expect(playersRes.status()).toBe(200);
     const players = (await playersRes.json()).players || [];
@@ -444,7 +508,9 @@ test.describe("public /league page", () => {
     await page.goto(pageUrl(`/league/player/${encodeURIComponent(pid)}`), {
       waitUntil: "domcontentloaded",
     });
-    await expect(page.getByText("Impact by manager").first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("Impact by manager").first()).toBeVisible({
+      timeout: 15_000,
+    });
   });
 
   test("CSV export endpoint serves text/csv", async ({ request }) => {
@@ -453,7 +519,9 @@ test.describe("public /league page", () => {
     expect(res.headers()["content-type"]).toMatch(/text\/csv/);
   });
 
-  test("metrics endpoint exposes snapshot cache counters", async ({ request }) => {
+  test("metrics endpoint exposes snapshot cache counters", async ({
+    request,
+  }) => {
     const res = await request.get("/api/public/league/metrics");
     expect(res.status()).toBe(200);
     const body = await res.json();
@@ -486,33 +554,45 @@ test.describe("public /league page", () => {
     }
   });
 
-  test("faabAnalytics lazy section returns documented shape (Phase B5)", async ({
-    request,
-  }) => {
-    // FAAB analytics is a lazy section — only addressable through
-    // /api/public/league/{section}.  Powers the /waivers FAAB
-    // recommender's calibration step.  Shape regression here =
-    // recommender shape regression on next user click.
-    const res = await request.get("/api/public/league/faabAnalytics");
-    expect(res.status()).toBe(200);
-    const json = await res.json();
-    const data = json.data || json.body || json;
-    for (const k of [
-      "leagueBudget",
-      "leagueAvgWinningBid",
-      "leagueMedianWinningBid",
-      "totalBidsAnalyzed",
-      "positionBids",
-      "tierBids",
-      "teamAggression",
-      "recentWins",
-      "playerHistory",
-    ]) {
-      expect(data, `faabAnalytics missing ${k}`).toHaveProperty(k);
-    }
-    expect(typeof data.leagueBudget).toBe("number");
-    expect(Array.isArray(data.recentWins)).toBeTruthy();
-    expect(typeof data.positionBids).toBe("object");
-    expect(typeof data.tierBids).toBe("object");
-  });
+  // ── the private-intelligence boundary, from the anonymous door ────────
+  //
+  // This block used to assert that `faabAnalytics` answered an anonymous
+  // GET with **200** and the full recommender payload.  It does not, and
+  // must not: B8 classified it as one of three
+  // `PRIVATE_INTELLIGENCE_SECTIONS` (with `rosTeamStrength` and
+  // `rosTradeDeadline`), and `_public_section_access_error` refuses it
+  // without a session.  The 401 is the feature.
+  //
+  // A stale assertion here is not a harmless red: the obvious way to make
+  // it pass is to reopen the section, which would delete the privacy
+  // boundary to satisfy a test.  So the boundary is what gets pinned, and
+  // the shape assertions the old test carried moved to
+  // `signed-in-smoke.spec.js`, where a session makes them reachable — the
+  // coverage is relocated, not dropped.
+  for (const section of [
+    "faabAnalytics",
+    "rosTeamStrength",
+    "rosTradeDeadline",
+  ]) {
+    test(`${section} refuses an anonymous caller (B8 private intelligence)`, async ({
+      request,
+    }) => {
+      const res = await request.get(`/api/public/league/${section}`);
+      expect(res.status(), `${section} must require a session`).toBe(401);
+      const json = await res.json();
+      expect(json.error).toBe("auth_required");
+      expect(json.section).toBe(section);
+      // "requires a session" and "no such section" must not read the same.
+      expect(JSON.stringify(json)).not.toContain("availableSections");
+    });
+
+    test(`${section} refuses the .csv door too`, async ({ request }) => {
+      // One predicate, every representation.  The CSV route serves the
+      // same payload through a different door, and a boundary enforced on
+      // one door is not a boundary — the gate's own docstring says so.
+      const res = await request.get(`/api/public/league/${section}.csv`);
+      expect(res.status(), `${section}.csv must require a session`).toBe(401);
+      expect((await res.text()).toLowerCase()).not.toContain("leaguebudget");
+    });
+  }
 });

--- a/tests/e2e/specs/signed-in-smoke.spec.js
+++ b/tests/e2e/specs/signed-in-smoke.spec.js
@@ -34,7 +34,6 @@ const {
   desktopOnly,
 } = require("../helpers/journey");
 
-
 // ── Assertion policy for this file ─────────────────────────────────
 // Every test below previously asserted `body).toContainText(/Word/i)`
 // where `Word` also appears in the persistent shell nav ("Trade",
@@ -60,9 +59,14 @@ test.describe("signed-in: basic navigation + UI render", () => {
   // mobile-smoke.spec.js, per the convention in helpers/journey.js.
   test.beforeEach(async ({}, testInfo) => desktopOnly(test, testInfo));
 
-  test("home dashboard renders the war-room surface with a real team list", async ({ authedPage }) => {
+  test("home dashboard renders the war-room surface with a real team list", async ({
+    authedPage,
+  }) => {
     const { teamNames } = await contractFixture(authedPage);
-    expect(teamNames.length, "contract must carry Sleeper teams").toBeGreaterThan(0);
+    expect(
+      teamNames.length,
+      "contract must carry Sleeper teams",
+    ).toBeGreaterThan(0);
 
     await authedPage.goto(pageUrl("/"));
 
@@ -108,7 +112,10 @@ test.describe("signed-in: basic navigation + UI render", () => {
     // Scoped to the team menu, and to ONE of them, for both reasons above:
     // an unscoped [role="option"] counts the league menu's entries too, and a
     // streaming duplicate would double the count.
-    const options = authedPage.locator(".team-switcher-menu").first().locator('[role="option"]');
+    const options = authedPage
+      .locator(".team-switcher-menu")
+      .first()
+      .locator('[role="option"]');
     await expect
       .poll(() => options.count(), {
         message: `team switcher should offer all ${teamNames.length} contract teams`,
@@ -116,13 +123,19 @@ test.describe("signed-in: basic navigation + UI render", () => {
       })
       .toBe(teamNames.length);
 
-    const offered = (await options.allInnerTexts()).map((t) => t.split("\n")[0].trim());
+    const offered = (await options.allInnerTexts()).map((t) =>
+      t.split("\n")[0].trim(),
+    );
     for (const name of teamNames) {
-      expect(offered, `team "${name}" missing from the switcher`).toContain(name);
+      expect(offered, `team "${name}" missing from the switcher`).toContain(
+        name,
+      );
     }
   });
 
-  test("trade builder renders its own page body, not just the nav link", async ({ authedPage }) => {
+  test("trade builder renders its own page body, not just the nav link", async ({
+    authedPage,
+  }) => {
     await authedPage.goto(pageUrl("/trade"));
     await expect(pageHeading(authedPage, titleFor("/trade"))).toBeVisible({
       timeout: 60_000,
@@ -138,7 +151,9 @@ test.describe("signed-in: basic navigation + UI render", () => {
     ).toBeVisible();
   });
 
-  test("rosters page power-ranks every team in the contract", async ({ authedPage }) => {
+  test("rosters page power-ranks every team in the contract", async ({
+    authedPage,
+  }) => {
     const { teamNames } = await contractFixture(authedPage);
     expect(teamNames.length).toBeGreaterThan(0);
 
@@ -151,7 +166,9 @@ test.describe("signed-in: basic navigation + UI render", () => {
     // ones.  A blank table, a partial roster load, or a rename in the
     // pipeline all fail here; "the word Roster is on the page" — the
     // assertion this replaced — catches none of them.
-    const teamCells = authedPage.locator(".table-wrap table tbody tr td:nth-child(2)");
+    const teamCells = authedPage.locator(
+      ".table-wrap table tbody tr td:nth-child(2)",
+    );
     await expect
       .poll(() => teamCells.count(), {
         message: `rosters table should render one row per contract team (${teamNames.length})`,
@@ -163,13 +180,16 @@ test.describe("signed-in: basic navigation + UI render", () => {
       t.split("\n")[0].trim(),
     );
     for (const name of teamNames) {
-      expect(rendered, `team "${name}" missing from the roster power rankings`).toContain(
-        name,
-      );
+      expect(
+        rendered,
+        `team "${name}" missing from the roster power rankings`,
+      ).toContain(name);
     }
   });
 
-  test("settings page lists the real ranking-source registry", async ({ authedPage }) => {
+  test("settings page lists the real ranking-source registry", async ({
+    authedPage,
+  }) => {
     // Authoritative count from the backend registry.
     const regRes = await authedPage.request.get("/api/rankings/sources");
     expect(regRes.status()).toBe(200);
@@ -200,7 +220,6 @@ test.describe("signed-in: basic navigation + UI render", () => {
   });
 });
 
-
 test.describe("signed-in: API round-trips that public smoke can't hit", () => {
   test("/api/data returns 200 with a players block", async ({ authedPage }) => {
     const res = await authedPage.request.get("/api/data?view=delta");
@@ -228,10 +247,14 @@ test.describe("signed-in: API round-trips that public smoke can't hit", () => {
   // the contract is an exact value, so assert that. Both ends of the
   // clamp are checked because they are separate `max`/`min` terms
   // (server.py:3556) and only one of them was covered before.
-  test("rank-history clamps days to [1, MAX_SNAPSHOTS]", async ({ authedPage }) => {
+  test("rank-history clamps days to [1, MAX_SNAPSHOTS]", async ({
+    authedPage,
+  }) => {
     const MAX_SNAPSHOTS = 365 * 3; // src/api/rank_history.py:85
 
-    const high = await authedPage.request.get("/api/data/rank-history?days=9999");
+    const high = await authedPage.request.get(
+      "/api/data/rank-history?days=9999",
+    );
     expect(high.status()).toBe(200);
     const highBody = await high.json();
     expect(highBody.days).toBe(MAX_SNAPSHOTS);
@@ -242,20 +265,26 @@ test.describe("signed-in: API round-trips that public smoke can't hit", () => {
     expect((await low.json()).days).toBe(1);
 
     // A non-numeric value falls back to the default rather than 500ing.
-    const junk = await authedPage.request.get("/api/data/rank-history?days=abc");
+    const junk = await authedPage.request.get(
+      "/api/data/rank-history?days=abc",
+    );
     expect(junk.status()).toBe(200);
     const junkDays = (await junk.json()).days;
     expect(junkDays).toBeGreaterThanOrEqual(1);
     expect(junkDays).toBeLessThanOrEqual(MAX_SNAPSHOTS);
   });
 
-  test("/api/terminal returns 200 (or 503 data_not_ready) for default league", async ({ authedPage }) => {
+  test("/api/terminal returns 200 (or 503 data_not_ready) for default league", async ({
+    authedPage,
+  }) => {
     const res = await authedPage.request.get("/api/terminal");
     // 200 = happy; 503 data_not_ready is acceptable when no live contract.
     expect([200, 503]).toContain(res.status());
   });
 
-  test("/api/trade/simulate-mc returns 503 feature_disabled by default", async ({ authedPage }) => {
+  test("/api/trade/simulate-mc returns 503 feature_disabled by default", async ({
+    authedPage,
+  }) => {
     // MC flag defaults OFF — endpoint returns 503 feature_disabled.
     const res = await authedPage.request.post("/api/trade/simulate-mc", {
       data: { sideA: [], sideB: [] },
@@ -275,9 +304,48 @@ test.describe("signed-in: API round-trips that public smoke can't hit", () => {
   });
 });
 
+test.describe("signed-in: private-intelligence sections", () => {
+  // Relocated from `public-league.spec.js`, which asserted this payload
+  // was readable ANONYMOUSLY with a 200.  It is not — B8 made
+  // `faabAnalytics` one of three `PRIVATE_INTELLIGENCE_SECTIONS`, and the
+  // anonymous 401 is pinned there now.  The shape still matters for the
+  // reason the original comment gave (it powers the /waivers FAAB
+  // recommender's calibration step, so a shape regression here is a
+  // recommender regression on the next user click), so it is tested from
+  // the door that is actually allowed to see it.
+  test("faabAnalytics returns the documented shape to a session", async ({
+    authedPage,
+  }) => {
+    const res = await authedPage.request.get(
+      "/api/public/league/faabAnalytics",
+    );
+    expect(res.status(), "a session must be able to read it").toBe(200);
+    const json = await res.json();
+    const data = json.data || json.body || json;
+    for (const k of [
+      "leagueBudget",
+      "leagueAvgWinningBid",
+      "leagueMedianWinningBid",
+      "totalBidsAnalyzed",
+      "positionBids",
+      "tierBids",
+      "teamAggression",
+      "recentWins",
+      "playerHistory",
+    ]) {
+      expect(data, `faabAnalytics missing ${k}`).toHaveProperty(k);
+    }
+    expect(typeof data.leagueBudget).toBe("number");
+    expect(Array.isArray(data.recentWins)).toBeTruthy();
+    expect(typeof data.positionBids).toBe("object");
+    expect(typeof data.tierBids).toBe("object");
+  });
+});
 
 test.describe("signed-in: admin endpoints are gated", () => {
-  test("/api/admin/nfl-data/flush returns ok for allowed user", async ({ authedPage }) => {
+  test("/api/admin/nfl-data/flush returns ok for allowed user", async ({
+    authedPage,
+  }) => {
     const res = await authedPage.request.post("/api/admin/nfl-data/flush");
     // If the test user is in the admin allowlist: 200.
     // If not: 403.  Either proves the gate works — we just pin that


### PR DESCRIPTION
The E2E suite asserted that `GET /api/public/league/faabAnalytics` answers an **anonymous**
caller with `200` and the full FAAB recommender payload.

It answers **401**, and it must: B8 classified `faabAnalytics` as one of three
`PRIVATE_INTELLIGENCE_SECTIONS` (with `rosTeamStrength` and `rosTradeDeadline`), and
`_public_section_access_error` refuses all three without a session. The test encoded the
pre-B8 contract and had been failing on both projects.

## Why this is more than a red-to-green edit

The obvious way to make that assertion pass is to reopen the section. A stale test would then
have **deleted a privacy boundary in order to satisfy itself** — the same shape as *"existing
implementation behavior does not become canonical architecture merely because it ships"*,
running in the other direction.

So the **boundary** is what gets pinned:

- all three private sections, not just the one that happened to be tested;
- **through both doors.** The `.csv` route serves the same payload through a different door and
  shares the predicate. The gate's own docstring says *"a boundary enforced on one door is not
  a boundary"* — and nothing tested the second one;
- the refusal is asserted to be **distinguishable from "no such section"**: `401 auth_required`
  carrying the section name, with no `availableSections` list.

## The shape coverage is relocated, not dropped

The original comment's reasoning still holds — `faabAnalytics` powers the `/waivers` FAAB
recommender's calibration step, so a shape regression there is a recommender regression on the
next user click. It was also the *only* coverage of that payload anywhere in the suite.

The same nine keys and four type checks now run in `signed-in-smoke.spec.js` against
`authedPage` — the door that is allowed to see them.

## Verification, and the state of the E2E job

Verified locally against a booted stack: **7 passed** (3 sections × 2 doors, plus the relocated
signed-in shape test). The filtered run prints the suite's coverage-floor banner, which is
expected for a `-g` selection and not a result.

**The `Boot stack + run journeys` job is red, and it was red before this branch existed.** The
E2E workflow has failed on **every scheduled run on `main` for seven consecutive days**
(2026-08-11 through 2026-08-17), plus the open dependabot PR. Its last success was 2026-08-10,
on `claude/bridge-timeout-root-cause` — the branch of the still-open PR that diagnosed the root
cause.

That root cause was re-measured during this audit and is recorded as a separate finding: after
a restart whose scrape has not yet succeeded, `/api/data` serves the **raw** snapshot with HTTP
200 — `playersArray=0`, zero rank stamps, `contractVersion: null` — so `buildRows` fail-fasts by
design and the board renders empty. Measured against the backend directly, with no Next in the
path, which corrects that PR's attribution to the bridge. It is the deterministic cause of the
two board-rendering failures in the suite; a third (Streaks) passed on re-run and is a flake.

This PR neither causes nor fixes that. It is noted here so the red job is not mistaken for a
regression introduced by these specs.