### PR TITLE
F-1: constrain the derived-year surface so 2029 picks cannot invert

### DIFF
--- a/config/weights/pick_year_discount.json
+++ b/config/weights/pick_year_discount.json
@@ -6,7 +6,7 @@
   "derivedYearModel": {
     "family": "measured_vendor_year_step_v1",
     "classification": "PRIOR",
-    "classificationNote": "measured-anchored: each cell is the median same-day cross-sectional 1-out->2-out ratio (2028/2027 while current=2026) over both vendor pick markets and every archive date; applying it one further year out (2-out->3-out) is an extrapolation no market evidence can test today, so the family stays PRIOR, never MEASURED/VALIDATED",
+    "classificationNote": "measured-anchored: each cell is the median same-day cross-sectional 1-out->2-out ratio (2028/2027 while current=2026) over both vendor pick markets and every archive date; applying it one further year out (2-out->3-out) is an extrapolation no market evidence can test today, so the family stays PRIOR, never MEASURED/VALIDATED. The surface is additionally CONSTRAINED at load time — see monotonicityConstraint — which does not make it measured.",
     "stepByTierRound": {
       "early.1": 0.7138,
       "early.2": 0.8174,

--- a/docs/audit/POST_MERGE_C_SERIES_AUDIT_2026-08-18.md
+++ b/docs/audit/POST_MERGE_C_SERIES_AUDIT_2026-08-18.md
@@ -28,7 +28,7 @@ Two conventions are load-bearing:
 
 ## 1. Findings
 
-### F-1 · 2029 pick tier ordering is inverted on the live board · CONFIRMED · data integrity
+### F-1 · 2029 pick tier ordering is inverted on the live board · CONFIRMED · data integrity · **REPAIRED 2026-08-18**
 
 An earlier pick must be worth more than a later one. On the 2026-08-17 contract it is not,
 for every round of 2029:
@@ -100,6 +100,70 @@ under a freeze. Both were considered and declined.
 **Recommendation.** First authorized unit after the audit: constrain the derived-year surface
 to preserve tier and round ordering, declare the constraint as part of the `PRIOR` family, and
 measure its effect on all 18 cells before and after.
+
+**REPAIRED 2026-08-18** — owner authorised the repair and chose the isotonic method.
+
+*What was done.* Within a round, the year step is projected onto the **non-increasing cone** by
+isotonic regression (pool-adjacent-violators), at config load, in
+`data_contract._project_tier_steps_monotone`. The measured surface is preserved untouched under
+`yearStepByTierRoundMeasured` — the evidence is not overwritten by the model built from it — and
+the constraint is declared in `config/weights/pick_year_discount.json` under
+`derivedYearModel.monotonicityConstraint`, classification **PRIOR** with the rest of the family.
+
+*Why this and not a value-space projection or an output clamp.* It acts on the derivation
+**surface**, so nothing clamps downstream of the blend. And because a **constant ratio applied to
+a strictly ordered template year yields a strictly ordered derived year**, pooling can never
+produce a TIE in value space — ordering holds **by construction**, for every source and every
+template, with no epsilon. A least-squares projection in *value* space would instead sit exactly
+**on** the ordering boundary and produce ties, which is why it was rejected.
+
+*Effect on the surface* — 11 of 12 cells changed; `late.4` already complied:
+
+| round | measured (early / mid / late) | projected |
+|---|---|---|
+| 1 | 0.7138 / 0.8078 / 0.8339 | 0.7852 / 0.7852 / 0.7852 |
+| 2 | 0.8174 / 0.8662 / 0.8760 | 0.8532 / 0.8532 / 0.8532 |
+| 3 | 0.8328 / 0.8399 / 0.8954 | 0.8560 / 0.8560 / 0.8560 |
+| 4 | 0.8633 / 0.8938 / 0.7726 | 0.8786 / 0.8786 / **0.7726** |
+
+*Effect on the board* — **18 of 18 complete tier cells now satisfy Early > Mid > Late; violations
+0.** The denominator is 18, not the 24 an earlier count in this session reported: 2026 rows exist
+but are slot-based rather than complete tier triples, so they were never eligible cells. The
+register's original "6 of 18" was correct.
+
+*Board diff, pinned input, code varied only:*
+
+```
+VALUES: 20 moved, 0 newly priced, 0 newly unpriced   |pct| p50=1.7% p90=5.9% max=10.0%
+RANKS:  130 changed        canonicalTierId: 499 flipped
+```
+
+Classified per §25:
+
+* **EXPECTED REPAIR MOVEMENT** — the 20 value moves. Every one is a 2029 tier row, which is
+  exactly the population the constraint targets. Largest: `2029 Early 1st` 3593 → 3952 (+10.0%),
+  `2029 Late 1st` 3446 → 3243 (−5.9%). No 2027 or 2028 row moved; no player moved.
+* **INCIDENTAL BUT EXPLAINED** — the 130 rank changes (115 on non-pick rows, 88% of them ±1: the
+  ordinal reshuffle as 2029 rows pass other rows) and the 499 `canonicalTierId` flips. Mechanism
+  verified rather than assumed: the board **lost two tiers** (136 → 134) because the repair
+  changed the gap structure the tier cutter reads, and tier ids are **dense ordinals**, so every
+  row below the shallowest affected boundary renumbers by 1–2. The shallowest flipped tier is
+  **21**, and all **113 rows in tiers 1–20 are unchanged**. Tier membership semantics are intact;
+  only the ordinal label shifted.
+* **UNEXPECTED** — none.
+
+*Enforcement, mutation-proven.* `validate_api_data_contract`'s pick census gained a
+`pick_tier_ordering:*` **ERROR** (the gate keys on `ok` and ignores warnings), and
+`tests/picks/test_future_tier_ordering.py` asserts the invariant on both the surface (deterministic)
+and a contract built from an archive fixture (all-of-them, never a count — §3d). Bypassing the
+projection reproduces **6** census errors; projecting the wrong direction reproduces **3**. Both
+also fail the tests; clean restore is green.
+
+*Known characteristic, named rather than smoothed.* The projection constrains ordering; it does
+not denoise. `late.4` (0.7726) survives unpooled and carries the surface's largest cross-provider
+disagreement (**0.086**, 3–8× every other cell), so 2029 R4–R6 show a wide Mid → Late step
+(e.g. R4: 1436 / 1396 / 980). That is the measured value preserved, not an artifact of the
+constraint. Recalibrating it is a separate evidence question, not this repair's.
 
 ### F-2 · The E2E board diagnostic reports a false root cause · CONFIRMED · observability · REPAIRED (#893)
 

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -4814,6 +4814,81 @@ from src.identity.picks import (  # noqa: E402
 _PICK_YEAR_DISCOUNT_CACHE: dict[str, Any] | None = None
 
 
+_TIER_ORDER: tuple[str, ...] = ("early", "mid", "late")
+
+
+def _pava_non_increasing(values: list[float]) -> list[float]:
+    """Pool-adjacent-violators projection onto the non-increasing cone.
+
+    The least-squares closest non-increasing sequence, equal weights.
+    Standard isotonic regression; pooling replaces a violating run with
+    its mean.
+    """
+    blocks: list[list[float]] = []  # [sum, count]
+    for value in values:
+        blocks.append([float(value), 1.0])
+        while len(blocks) > 1 and (blocks[-2][0] / blocks[-2][1]) < (blocks[-1][0] / blocks[-1][1]):
+            total, count = blocks.pop()
+            blocks[-1][0] += total
+            blocks[-1][1] += count
+    out: list[float] = []
+    for total, count in blocks:
+        out.extend([total / count] * int(count))
+    return out
+
+
+def _project_tier_steps_monotone(cells: dict[str, float]) -> dict[str, float]:
+    """Constrain the year-step surface so it cannot invert tier ordering.
+
+    **F-1.** Each ``<tier>.<round>`` cell is an independently measured
+    same-day vendor ratio, and the ratios RISE with tier — a late pick
+    decays less year-over-year than an early one.  That compresses the
+    Early-Late spread, and nothing stopped the compression before it
+    CROSSED.  On 2029 it crossed in six of six rounds: ``2029 Mid 1st``
+    priced 3676 against ``2029 Early 1st`` at 3593, so the trade
+    calculator booked a gain for downgrading, and ``/rankings`` published
+    the mid first ABOVE the early first.
+
+    Within a round the step is projected onto the non-increasing cone by
+    isotonic regression.  Two properties make this the constraint rather
+    than a patch:
+
+    * it acts on the DERIVATION SURFACE, not on output values — no clamp
+      sits downstream of the blend;
+    * a constant ratio applied to a strictly ordered template year yields
+      a strictly ordered derived year, so pooling can never produce a
+      TIE in value space.  Ordering is preserved **by construction**, for
+      every source and every template, with no epsilon.
+
+    Cells that already comply are returned unchanged, so the projection
+    is the identity wherever the measured surface is already consistent.
+
+    Classification stays **PRIOR** with the rest of
+    ``derivedYearModel``: the 2-out->3-out extrapolation was already
+    untestable on current evidence, and constraining it does not make it
+    measured.  The unprojected surface is preserved under
+    ``yearStepByTierRoundMeasured`` so the evidence is not overwritten by
+    the model built from it.
+    """
+    if not cells:
+        return {}
+    rounds: set[int] = set()
+    for key in cells:
+        tier, _, rnd = str(key).partition(".")
+        if tier in _TIER_ORDER and rnd.isdigit():
+            rounds.add(int(rnd))
+
+    projected = dict(cells)
+    for rnd in sorted(rounds):
+        keys = [f"{tier}.{rnd}" for tier in _TIER_ORDER]
+        if not all(k in cells for k in keys):
+            continue  # a partial round is left exactly as measured
+        fitted = _pava_non_increasing([float(cells[k]) for k in keys])
+        for key, value in zip(keys, fitted):
+            projected[key] = round(value, 6)
+    return projected
+
+
 def _load_pick_year_discount() -> dict[str, Any]:
     """Load and cache the canonical future-pick derivation config.
 
@@ -4894,6 +4969,15 @@ def _load_pick_year_discount() -> dict[str, Any]:
         # Stick with the built-in defaults — never block the build on
         # a missing/malformed pick-derivation config.
         pass
+
+    # F-1: the measured surface is EVIDENCE and is kept; what the
+    # derivation consumes is that surface projected onto the cone where
+    # it cannot invert tier ordering.  Keeping both means a future
+    # recalibration compares against what was measured, not against what
+    # was constrained.
+    measured = dict(cfg["yearStepByTierRound"])
+    cfg["yearStepByTierRoundMeasured"] = measured
+    cfg["yearStepByTierRound"] = _project_tier_steps_monotone(measured)
 
     _PICK_YEAR_DISCOUNT_CACHE = cfg
     return cfg
@@ -11833,6 +11917,41 @@ def validate_api_data_contract(payload: dict[str, Any]) -> dict[str, Any]:
                             errors.append(f"pick_completeness_census:{nm}:missing_or_unpriced")
                         elif not isinstance(row.get("pickValueProvenance"), dict):
                             errors.append(f"pick_completeness_census:{nm}:no_provenance")
+
+                    # F-1: an EARLIER pick must be worth MORE than a later
+                    # one.  The census above proves every cell is finite,
+                    # priced and provenanced — it said nothing about ORDER,
+                    # and for six of eighteen cells the order was wrong:
+                    # ``2029 Mid 1st`` published 3676 against ``2029 Early
+                    # 1st`` at 3593, so the trade calculator booked a gain
+                    # for downgrading and /rankings ranked the mid first
+                    # ABOVE the early first.  A finite, provenanced,
+                    # correctly-scaled, wrongly-ordered board passed every
+                    # other check in this function.
+                    tier_values = []
+                    for tier_name in ("Early", "Mid", "Late"):
+                        tier_row = pick_rows_by_name.get(
+                            f"{census_year} {tier_name} {_round_suffix(census_round)}"
+                        )
+                        tv = (
+                            tier_row.get("rankDerivedValue") if isinstance(tier_row, dict) else None
+                        )
+                        tier_values.append(
+                            float(tv)
+                            if isinstance(tv, (int, float))
+                            and not isinstance(tv, bool)
+                            and math.isfinite(float(tv))
+                            else None
+                        )
+                    if all(v is not None for v in tier_values) and not (
+                        tier_values[0] > tier_values[1] > tier_values[2]
+                    ):
+                        errors.append(
+                            "pick_tier_ordering:"
+                            f"{census_year}:r{census_round}:"
+                            f"early={tier_values[0]:.0f},mid={tier_values[1]:.0f},"
+                            f"late={tier_values[2]:.0f}"
+                        )
 
     # ── Top-50 per-source coverage floors ───────────────────────────────
     # Sort each asset class (offense / idp) by values.overall desc and

--- a/tests/picks/test_future_tier_ordering.py
+++ b/tests/picks/test_future_tier_ordering.py
@@ -1,0 +1,136 @@
+"""F-1 — an earlier pick must be worth more than a later one.
+
+The derived-year surface (`derivedYearModel.stepByTierRound`) carries an
+independent measured ratio per (tier, round) cell.  The ratios RISE with
+tier — late picks decay less year-over-year than early ones — which
+compresses the Early–Late spread.  Nothing constrained that compression
+to stop before it CROSSES, and on 2029 it does:
+
+    2029 R1: Early=3593  Mid=3676  Late=3446    <- Mid > Early
+
+Six of the twenty-four (year, round) tier cells were inverted, all of
+them 2029, the only fully derived year.  The trade calculator therefore
+booked a GAIN for downgrading a 2029 early first to a mid first, and
+`/rankings` published `2029 Mid 1st` at #117 above `2029 Early 1st` at
+#123.  The pick census checked finiteness, not-zero-as-missing and
+provenance — never order.
+
+The repair constrains the SURFACE, not the output: within a round the
+year step may not increase from Early to Late, enforced by isotonic
+projection (pool-adjacent-violators).  Because a constant ratio applied
+to a strictly ordered template year yields a strictly ordered derived
+year, ordering is preserved BY CONSTRUCTION, for every source, with no
+epsilon and no output clamp.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+
+TIERS = ("early", "mid", "late")
+_TIER_ROW = re.compile(r"^(\d{4})\s+(Early|Mid|Late)\s+(\d)(?:st|nd|rd|th)$")
+
+
+class TestTheStepSurfaceCannotInvertOrdering(unittest.TestCase):
+    """Deterministic — reads the config owner, not a board."""
+
+    def _surface(self):
+        from src.api.data_contract import _load_pick_year_discount, _year_step_for
+
+        cfg = _load_pick_year_discount()
+        rounds = sorted(
+            {int(k.split(".")[1]) for k in (cfg.get("yearStepByTierRound") or {}) if "." in k}
+        )
+        return {r: [_year_step_for(t, r, cfg) for t in TIERS] for r in rounds}
+
+    def test_the_step_never_increases_from_early_to_late(self):
+        """The invariant that makes ordering structural.
+
+        A ratio that rises with tier compresses the spread; if it rises
+        by more than the spread, the order crosses.  Requiring the ratio
+        to be non-increasing removes the possibility for ANY correctly
+        ordered template year, without needing to know its values.
+        """
+        offenders = {
+            rnd: dict(zip(TIERS, steps))
+            for rnd, steps in self._surface().items()
+            if not (steps[0] >= steps[1] >= steps[2])
+        }
+        self.assertEqual(
+            offenders,
+            {},
+            "year-step rises with tier in these rounds, so a correctly ordered "
+            "template year can cross when it is applied",
+        )
+
+    def test_every_step_is_a_usable_ratio(self):
+        for rnd, steps in self._surface().items():
+            for tier, step in zip(TIERS, steps):
+                with self.subTest(round=rnd, tier=tier):
+                    self.assertGreater(step, 0.05)
+                    self.assertLessEqual(step, 1.0)
+
+    def test_a_constant_ratio_preserves_a_strict_ordering(self):
+        """Why non-increasing is sufficient, stated as a test rather than
+        as a comment: equal ratios cannot reorder a strictly ordered
+        template, so pooling never produces a tie in VALUE space."""
+        template = {"early": 5034.0, "mid": 4551.0, "late": 4133.0}
+        for rnd, steps in self._surface().items():
+            derived = [template[t] * s for t, s in zip(TIERS, steps)]
+            with self.subTest(round=rnd):
+                self.assertTrue(
+                    derived[0] > derived[1] > derived[2],
+                    f"round {rnd}: {dict(zip(TIERS, derived))}",
+                )
+
+
+class TestTheBoardItselfIsOrdered(unittest.TestCase):
+    """The invariant on a real contract.
+
+    Asserts ALL-OF-THEM rather than a count or a floor, so it stays a
+    statement about our code rather than about which sources answered
+    (`docs/ops/STABILIZATION_2026-08-16.md` §3d).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        from tests.archive_fixtures import newest_complete_raw_payload
+
+        raw, name = newest_complete_raw_payload()
+        if not raw:
+            raise unittest.SkipTest("no complete archived scrape available")
+        from src.api.data_contract import build_api_data_contract
+
+        cls.archive = name
+        cls.rows = build_api_data_contract(raw).get("playersArray") or []
+
+    def _cells(self):
+        cells: dict[tuple[int, int], dict[str, float]] = {}
+        for row in self.rows:
+            m = _TIER_ROW.match(str(row.get("displayName") or "").strip())
+            if not m:
+                continue
+            value = row.get("rankDerivedValue")
+            if isinstance(value, (int, float)):
+                cells.setdefault((int(m.group(1)), int(m.group(3))), {})[m.group(2).lower()] = (
+                    float(value)
+                )
+        return cells
+
+    def test_every_tier_cell_is_ordered_early_over_mid_over_late(self):
+        violations = {
+            f"{year} R{rnd}": tiers
+            for (year, rnd), tiers in sorted(self._cells().items())
+            if len(tiers) == 3 and not (tiers["early"] > tiers["mid"] > tiers["late"])
+        }
+        self.assertEqual(violations, {}, f"tier ordering violated on {self.archive}: {violations}")
+
+    def test_the_cells_exist_at_all(self):
+        """A guard that passes because it found nothing to check is not a
+        guard — this is what makes the assertion above non-vacuous."""
+        self.assertTrue(self._cells(), "no future pick tier rows on the board")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes audit finding **F-1**, the post-merge audit's hard gate. Owner authorised the repair and selected the isotonic method.

## The defect

An earlier pick must be worth more than a later one. For **6 of the 18** (year, round) tier cells it was not, and all six were **2029** — the only fully derived year:

```
2029 R1: Early=3593  Mid=3676  Late=3446      2029 R4: Early=1412 Mid=1421 Late=980
2029 R2: Early=2590  Mid=2596  Late=2440      2029 R5: Early=1312 Mid=1320 Late=910
2029 R3: Early=1811  Mid=1758  Late=1794      2029 R6: Early=1202 Mid=1209 Late=834
```

So the trade calculator booked a **gain for downgrading** a 2029 early first to a mid first, and `/rankings` published `2029 Mid 1st` at **#117** above `2029 Early 1st` at **#123**.

The pick census checked finiteness, not-zero-as-missing and provenance — **never order**. A finite, provenanced, correctly-scaled, wrongly-ordered board passed every other check in the validator.

## Mechanism

`derivedYearModel.stepByTierRound` carries an independently measured ratio per cell, and the ratios **rise** with tier — a late pick decays less year-over-year than an early one. That compresses the Early–Late spread, and nothing stopped the compression before it **crossed**. At R1 the ratio rose 13.2% (0.7138 → 0.8078) against a template spread of only 10.6%.

## Repair

Within a round the step is projected onto the **non-increasing cone** by isotonic regression (pool-adjacent-violators), at config load.

Two properties make this the constraint rather than a patch:

- it acts on the derivation **surface**, so nothing clamps downstream of the blend;
- **a constant ratio applied to a strictly ordered template year yields a strictly ordered derived year**, so pooling can never produce a tie in value space. Ordering holds **by construction**, for every source and every template, with no epsilon.

A least-squares projection in *value* space was rejected for exactly that reason: its optimum sits **on** the ordering boundary and produces ties.

The measured surface is preserved untouched under `yearStepByTierRoundMeasured` — evidence is not overwritten by the model built from it — and the constraint is declared in the config as part of the **PRIOR** family. Constraining an untestable extrapolation does not make it measured.

| round | measured (early / mid / late) | projected |
|---|---|---|
| 1 | 0.7138 / 0.8078 / 0.8339 | 0.7852 / 0.7852 / 0.7852 |
| 2 | 0.8174 / 0.8662 / 0.8760 | 0.8532 / 0.8532 / 0.8532 |
| 3 | 0.8328 / 0.8399 / 0.8954 | 0.8560 / 0.8560 / 0.8560 |
| 4 | 0.8633 / 0.8938 / 0.7726 | 0.8786 / 0.8786 / **0.7726** |

11 of 12 cells changed; `late.4` already complied, and the projection is the identity wherever the surface was already consistent.

## Measured

**18 of 18** complete tier cells now satisfy Early > Mid > Late; violations **0**. (The denominator is 18, not 24 — 2026 rows are slot-based, not complete tier triples, so they were never eligible cells.)

Board diff, pinned input, code varied only:

```
VALUES: 20 moved, 0 newly priced, 0 newly unpriced   |pct| p50=1.7% p90=5.9% max=10.0%
RANKS:  130 changed        canonicalTierId: 499 flipped
```

- **EXPECTED REPAIR MOVEMENT** — the 20 value moves. Every one is a 2029 tier row, exactly the targeted population. Largest: `2029 Early 1st` 3593 → 3952 (+10.0%), `2029 Late 1st` 3446 → 3243 (−5.9%). **No 2027 or 2028 row moved, and no player moved.**
- **INCIDENTAL BUT EXPLAINED** — the 130 rank changes (115 on non-pick rows, 88% of them ±1) and the 499 tier-id flips. Mechanism **verified rather than assumed**: the board lost two tiers (136 → 134) because the repair changed the gap structure the tier cutter reads, and tier ids are dense ordinals, so rows below the shallowest affected boundary renumber by 1–2. That boundary is tier **21**, and all **113 rows in tiers 1–20 are unchanged**. Tier membership semantics are intact; only the ordinal label shifted.
- **UNEXPECTED** — none.

## Enforcement, mutation-proven

`validate_api_data_contract`'s pick census gained a `pick_tier_ordering:*` **ERROR** (the CI gate keys on `ok` and ignores warnings — same posture as the blend-integrity scan). `tests/picks/test_future_tier_ordering.py` asserts the invariant on the surface deterministically and on a contract built from an archive fixture as **all-of-them rather than a count** (§3d).

Bypassing the projection reproduces **6** census errors; projecting the wrong direction reproduces **3**. Both also fail the tests. Clean restore is green.

## Known characteristic, named rather than smoothed

The projection constrains ordering; it does not denoise. `late.4` (0.7726) survives unpooled and carries the surface's largest cross-provider disagreement (**0.086**, 3–8× every other cell), so 2029 R4–R6 show a wide Mid → Late step (R4: 1436 / 1396 / 980). That is the measured value preserved, not an artifact of the constraint. Recalibrating it is a separate evidence question, not this repair's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kve8hqgo4v4PeagCHi92ds

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kve8hqgo4v4PeagCHi92ds)_