### PR TITLE
F-5: the as-of string path now obeys the object path's rule

### DIFF
--- a/src/history/store.py
+++ b/src/history/store.py
@@ -513,7 +513,19 @@ def _reset_setup_cache_for_tests() -> None:
 
 
 def as_of_date(value: date | datetime | str) -> str:
-    """Normalize a caller-supplied date to the ledger's UTC date string."""
+    """Normalize a caller-supplied date to the ledger's UTC date string.
+
+    A string spelling of an instant answers exactly what the equivalent
+    ``datetime`` object answers — the string branch DELEGATES rather than
+    reimplementing, so the two cannot drift.
+
+    F-5: this used to be ``strptime(s, "%Y-%m-%d")`` and nothing else, so
+    an ISO-8601 *datetime* string escaped as a raw
+    ``ValueError: unconverted data remains: T23:00:00``.  That is not this
+    module's error type — a caller cannot catch it with
+    ``except ObservationError`` — and it said nothing about the
+    UTC-awareness rule that actually governs instants here.
+    """
     if isinstance(value, datetime):
         if value.tzinfo is None:
             raise ObservationError(
@@ -522,6 +534,20 @@ def as_of_date(value: date | datetime | str) -> str:
         return value.astimezone(timezone.utc).date().isoformat()
     if isinstance(value, date):
         return value.isoformat()
-    s = str(value)
-    datetime.strptime(s, "%Y-%m-%d")
-    return s
+
+    text = str(value).strip()
+    try:
+        return date.fromisoformat(text).isoformat()
+    except ValueError:
+        pass
+    try:
+        # ``Z`` is valid ISO-8601 but predates fromisoformat's support on
+        # some versions; normalise it rather than depend on the runtime.
+        parsed = datetime.fromisoformat(text[:-1] + "+00:00" if text.endswith("Z") else text)
+    except ValueError:
+        raise ObservationError(
+            f"unparseable as-of date {value!r}; expected YYYY-MM-DD or a UTC-aware ISO-8601 instant"
+        ) from None
+    # Delegate, so a datetime STRING and a datetime OBJECT can never
+    # disagree — including on the naive-instant refusal.
+    return as_of_date(parsed)

--- a/tests/history/test_asof_string_dates.py
+++ b/tests/history/test_asof_string_dates.py
@@ -1,0 +1,69 @@
+"""F-5 — the string path must obey the same rule as the object path.
+
+`store.as_of_date` accepts `date | datetime | str`.  The OBJECT path has
+a clear rule: a tz-aware datetime is converted to its UTC date, and a
+NAIVE datetime is refused with `ObservationError` because "as-of instants
+must be UTC-aware".
+
+The STRING path had no such rule.  It ran `strptime(s, "%Y-%m-%d")`, so an
+ISO-8601 *datetime* string escaped as a raw
+`ValueError: unconverted data remains: T23:00:00` — not the module's own
+error type, and not the module's own policy.  A caller cannot catch that
+with `except ObservationError`, and the message says nothing about the
+UTC-awareness rule that actually governs instants here.
+
+The repair adds no policy.  It makes the string path answer exactly what
+the object path answers for the same instant.
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import date, datetime, timedelta, timezone
+
+from src.history.store import ObservationError, as_of_date
+
+
+class TestPlainDates(unittest.TestCase):
+    def test_a_date_string_passes_through(self):
+        self.assertEqual(as_of_date("2026-08-18"), "2026-08-18")
+
+    def test_a_date_object_passes_through(self):
+        self.assertEqual(as_of_date(date(2026, 8, 18)), "2026-08-18")
+
+
+class TestTheStringPathMatchesTheObjectPath(unittest.TestCase):
+    """Same instant, two spellings, one answer."""
+
+    def test_a_utc_datetime_string_resolves_like_the_object(self):
+        obj = datetime(2026, 8, 18, 23, 0, tzinfo=timezone.utc)
+        self.assertEqual(as_of_date("2026-08-18T23:00:00+00:00"), as_of_date(obj))
+
+    def test_a_zulu_suffix_is_accepted(self):
+        self.assertEqual(as_of_date("2026-08-18T23:00:00Z"), "2026-08-18")
+
+    def test_an_offset_that_crosses_midnight_converts_to_utc(self):
+        """The whole point of normalising to UTC: 2026-08-18 23:00-05:00
+        is 2026-08-19 in UTC, and both spellings must agree."""
+        obj = datetime(2026, 8, 18, 23, 0, tzinfo=timezone(timedelta(hours=-5)))
+        self.assertEqual(
+            as_of_date("2026-08-18T23:00:00-05:00"), obj.astimezone(timezone.utc).date().isoformat()
+        )
+        self.assertEqual(as_of_date("2026-08-18T23:00:00-05:00"), "2026-08-19")
+
+    def test_a_naive_datetime_string_is_refused_the_same_way(self):
+        with self.assertRaises(ObservationError) as ctx:
+            as_of_date("2026-08-18T23:00:00")
+        self.assertIn("UTC-aware", str(ctx.exception))
+
+
+class TestFailuresAreTheModulesOwnType(unittest.TestCase):
+    def test_garbage_raises_observation_error_not_value_error(self):
+        for bad in ("not a date", "2026-13-45", "", "18/08/2026"):
+            with self.subTest(value=bad):
+                with self.assertRaises(ObservationError):
+                    as_of_date(bad)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes audit finding **F-5**.

`store.as_of_date` accepts `date | datetime | str`. The **object** path has a clear rule: a tz-aware datetime converts to its UTC date, and a **naive** one is refused with `ObservationError` because *"as-of instants must be UTC-aware"*.

The **string** path had no such rule. It ran `strptime(s, "%Y-%m-%d")` and nothing else, so an ISO-8601 datetime string escaped as a raw:

```
ValueError: unconverted data remains: T23:00:00
```

Two things wrong with that, beyond cosmetics: it is **not this module's error type**, so a caller cannot catch it with `except ObservationError`; and the message says nothing about the UTC-awareness rule that actually governs instants here.

## The repair adds no policy

The string branch parses a plain `YYYY-MM-DD`, and otherwise parses the instant and **delegates to the datetime branch**. So a datetime *string* and a datetime *object* cannot disagree — including on the naive-instant refusal. Delegation rather than a parallel implementation is the point: the equivalence is structural, not coincidental.

Anything unparseable now raises `ObservationError` naming what was expected, instead of `ValueError`.

## One behaviour worth naming

An offset that crosses midnight now normalises correctly and is pinned:

```
as_of_date("2026-08-18T23:00:00-05:00") == "2026-08-19"
```

which is what the equivalent `datetime` object already answered. Previously this input raised.

## Tests

`tests/history/test_asof_string_dates.py` — RED first (8 failures, including the naive-datetime string raising the wrong type). Covers: plain dates pass through; a UTC datetime string resolves identically to the object; `Z` suffix; the midnight-crossing offset; the naive refusal; and garbage raising the module's own error type.

Full `tests/history/` suite green (51 passed). Ruff check + format clean repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kve8hqgo4v4PeagCHi92ds

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kve8hqgo4v4PeagCHi92ds)_