### PR TITLE
Stop the crowd-FAAB probe starving behind the deploy queue

### DIFF
--- a/.github/workflows/crowd-faab-diagnostics.yml
+++ b/.github/workflows/crowd-faab-diagnostics.yml
@@ -39,8 +39,30 @@ on:
 permissions:
   contents: read
 
+# Its OWN group, not ``production-deploy``.
+#
+# Copying the deploy group from temporal-ledger-diagnostics.yml looked
+# like the safe choice -- don't probe the box mid-deploy -- but measured
+# in practice it STARVES: every merge enqueues a deploy in that group, so
+# during a merge train this run sat queued with 0 jobs for 17+ minutes
+# and would have waited out four deploys.  A production probe that cannot
+# run when the repository is busy is a probe that reports nothing exactly
+# when the most is changing.
+#
+# Serializing bought nothing here, because section 2 of the probe ALREADY
+# verifies deployment state itself and fails loudly with "stale deploy" if
+# the repaired code is not present.  A mid-deploy read therefore returns
+# an honest answer either way -- old code is reported as a stale deploy,
+# new code as deployed.  The check is in the probe, where it belongs,
+# rather than in a queue that assumes it.
+#
+# NOT changed for fd-diagnostics.yml, scoring-snapshot-diagnostics.yml or
+# temporal-ledger-diagnostics.yml, which share the same group and the same
+# starvation. They have not been verified to self-check deployment state,
+# and for them the serialization may still be load-bearing. Recorded in
+# the audit register rather than changed on assumption.
 concurrency:
-  group: production-deploy
+  group: crowd-faab-diagnostics
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Observability repair, found by using the thing I built an hour ago.

## Measured

The dispatched crowd-FAAB production probe sat with **0 jobs for 17+ minutes** and would have waited out **four** queued deploys. It shares the `production-deploy` concurrency group, which I copied from `temporal-ledger-diagnostics.yml` because *"don't probe the box mid-deploy"* sounded like the safe default.

It is not safe, it is **silent**. Every merge enqueues a deploy in that group, so a production probe becomes unavailable exactly during a merge train — when the most is changing and its answer matters most. That is the same failure shape as the source-health surfaces this audit is already repairing: a signal that is quiet for a structural reason reads identically to a signal that is fine.

## Why serializing bought nothing here

Section 2 of this probe **already verifies deployment state itself** and fails loudly with `stale deploy` when the repaired code is absent:

```
producer consumes the owner           NO (stale deploy)
retired crowd path removed            NO (stale deploy)
```

So a mid-deploy read returns an honest answer either way — old code is reported as a stale deploy, new code as deployed. The check belongs **in the probe**, where it is asserted, rather than in a queue that merely assumes it.

## Deliberately not changed elsewhere

`fd-diagnostics.yml`, `scoring-snapshot-diagnostics.yml` and `temporal-ledger-diagnostics.yml` share the same group and therefore the same starvation — this is a pre-existing repo-wide pattern, not something this PR introduced. They are **not** changed here: I have not verified that they self-check deployment state, and for them the serialization may still be load-bearing. Changing all four on the assumption that they are alike is exactly the move this audit keeps catching.

Recorded for the audit register instead, so the pattern is visible without a speculative edit.

`draftsharks-diagnostic.yml` already has its own group and does not starve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kve8hqgo4v4PeagCHi92ds

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kve8hqgo4v4PeagCHi92ds)_