### PR TITLE
A refusal is an answer: stop the data bridge serving a board off disk (F-14)

### DIFF
--- a/docs/audit/POST_MERGE_C_SERIES_AUDIT_2026-08-18.md
+++ b/docs/audit/POST_MERGE_C_SERIES_AUDIT_2026-08-18.md
@@ -742,7 +742,7 @@ census.
 
 ---
 
-### F-14 · The `/api/dynasty-data` bridge answers 200 off disk when the backend says 401 · CONFIRMED · security / data integrity · **OPEN**
+### F-14 · The `/api/dynasty-data` bridge answers 200 off disk when the backend says 401 · CONFIRMED · security / data integrity · **REPAIRED 2026-08-18**
 
 `frontend/app/api/dynasty-data/route.js` streams the backend response only when
 `res.ok && isJson`. Its own comment states the else branch plainly: *"Non-2xx, or a 200 that
@@ -779,6 +779,33 @@ the code, and nothing tests it.
 This also supersedes the standing **F-3b** diagnosis, which attributed the journey-rankings
 failure to a stack-readiness race. The readiness gate passes; the board never talks to the
 backend at all.
+
+**REPAIRED by removing the fallback, not by validating it.** Measured every candidate
+`loadFromDisk` could reach — `exports/latest/dynasty_data_*.json`, `data/dynasty_data_*.json`
+and `dynasty_data.js` — and **all three are the raw scraper export**: no `contractVersion`, no
+`playersArray`, zero rank stamps. So the path could not serve a usable board on ANY input; it
+only ever converted a diagnosable backend status into an undiagnosable empty board. Validating
+it would have rejected all three candidates, i.e. disabled it while leaving the seam.
+
+The backend's answer now propagates: `401` / `403` / `5xx` verbatim (with `www-authenticate`
+preserved, so a refusal keeps its challenge), a transport failure or header-time abort becomes
+`503` with `reason: backend_unreachable` / `backend_idle_timeout`, and a non-JSON 200 becomes
+`502 backend_non_json`. No client change was needed — `fetchDynastyData` already throws on
+`!res.ok` (`frontend/lib/dynasty-data.js:1587`), so the hook's existing error state surfaces an
+explicit banner where the old path rendered a silent empty board.
+
+`loadFromDisk`, `listCandidates`, `newestFile`, `parseDynastyDataJs` and the `node:fs` import
+are **deleted**, not left dormant — a fallback nobody can reach is a seam somebody re-threads,
+and one of the new assertions reads the file to prove it is gone rather than merely unused.
+
+**RED first, and measured**: 9 of 12 assertions fail against the pre-repair route — every
+auth-propagation case, both transport cases, the non-JSON case and the structural one. The 3
+that pass are the happy paths (streaming, 304 round-trip, cookie + `view`/`leagueKey`
+forwarding), which are deliberately unchanged. Frontend suite: 2055 passed across 127 files.
+Pinned by `frontend/__tests__/dynasty-data-bridge-no-disk-fallback.test.js` (12).
+
+The stale nginx filename in the route's own comment is corrected to
+`deploy/nginx/chaseupside-proxy.conf` at the same time.
 
 ---
 

--- a/frontend/__tests__/dynasty-data-bridge-no-disk-fallback.test.js
+++ b/frontend/__tests__/dynasty-data-bridge-no-disk-fallback.test.js
@@ -1,0 +1,209 @@
+/**
+ * The data bridge must never answer a refusal with a board.
+ *
+ * AUDIT FINDING F-14 (2026-08-18)
+ * ───────────────────────────────
+ * `frontend/app/api/dynasty-data/route.js` is THE base-contract fetch for the
+ * whole app — `frontend/lib/dynasty-data.js` sets
+ * `DEFAULT_DATA_URL = "/api/dynasty-data"`. It used to fall back to a disk
+ * snapshot on ANY non-2xx, on a non-JSON 200, or on a 4-second header stall,
+ * and return it as an unconditional **HTTP 200**.
+ *
+ * TWO DEFECTS, AND THE FIRST IS THE SERIOUS ONE
+ *
+ * (a) A REFUSAL WAS CONVERTED INTO A GRANT. `401` is non-2xx, so an
+ *     unauthenticated caller received the board off disk under 200.
+ *     `frontend/middleware.js`'s matcher is
+ *     `"/((?!_next/static|_next/image|api/|.*\\.[\\w]+$).*)"` — it EXCLUDES
+ *     `api/` by design, because the backend's own `/api/*` gate is meant to be
+ *     the authority. The fallback overrode the only gate there was.
+ *     Measured against a live stack: unauthenticated request → 200 with
+ *     635,170 bytes while the backend answered 401, byte-identical to the disk
+ *     file. The CI artifact for run 32120428479 shows ten
+ *     `GET /api/data?view=array HTTP/1.1 401 Unauthorized`.
+ *
+ * (b) IT COULD NOT SERVE A BOARD ANYWAY. Every candidate the loader reached —
+ *     `exports/latest/dynasty_data_*.json`, `data/dynasty_data_*.json`, and
+ *     `dynasty_data.js` — is the RAW SCRAPER EXPORT. Measured 2026-08-18: all
+ *     three carry no `contractVersion`, no `playersArray` and ZERO rank
+ *     stamps, which is exactly what `buildRows`' fail-fast rejects. So the
+ *     "resilience" path turned a diagnosable backend status into an
+ *     undiagnosable empty board under a status code that said all was well.
+ *
+ * SCOPE, STATED HONESTLY
+ * Production is not affected: `deploy/nginx/chaseupside-proxy.conf` and
+ * `deploy/nginx/riskittogetthebrisket.org.conf` both route `location /api/`
+ * to the backend, so this file is never reached there. Dev, the E2E stack and
+ * any Next-fronted deployment are — the same asymmetry
+ * `bridge-routes-forward-cookies.test.js` was written for, and for the same
+ * reason: production being fine is what lets a defect here stay invisible.
+ * The protection is a deployment convention, not a property of the code, and
+ * nothing tested it. That is what this file is.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { GET } from "../app/api/dynasty-data/route.js";
+
+const ROUTE_PATH = path.join(process.cwd(), "app", "api", "dynasty-data", "route.js");
+
+function request(url = "http://localhost:3000/api/dynasty-data", headers = {}) {
+  return new Request(url, { headers });
+}
+
+function backendResponse(status, body, headers = {}) {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+describe("dynasty-data bridge", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── (a) the refusal half ────────────────────────────────────────────
+
+  it.each([401, 403])("propagates a %s instead of answering with a board", async (status) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => backendResponse(status, JSON.stringify({ detail: "nope" }))),
+    );
+    const res = await GET(request());
+    expect(res.status).toBe(status);
+    const text = await res.text();
+    // Whatever it returns, it must not be a board.
+    expect(text).not.toMatch(/"players"/);
+    expect(text.length).toBeLessThan(10_000);
+  });
+
+  it("does not launder a 401 into a 200 for an anonymous caller", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => backendResponse(401, '{"detail":"unauthenticated"}')));
+    const res = await GET(request());
+    expect(res.status).not.toBe(200);
+  });
+
+  it("forwards the challenge header on a 401 so the caller can act on it", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        backendResponse(401, "{}", { "www-authenticate": 'Cookie realm="dynasty"' }),
+      ),
+    );
+    const res = await GET(request());
+    expect(res.headers.get("www-authenticate")).toBe('Cookie realm="dynasty"');
+  });
+
+  it("propagates a 5xx rather than substituting a payload", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => backendResponse(503, '{"detail":"not ready"}')));
+    const res = await GET(request());
+    expect(res.status).toBe(503);
+  });
+
+  // ── (b) the "not the contract" half ─────────────────────────────────
+
+  it("reports a transport failure as a failure, never a 200", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      }),
+    );
+    const res = await GET(request());
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.reason).toBe("backend_unreachable");
+  });
+
+  it("reports a header-time abort as a failure, never a 200", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        const err = new Error("aborted");
+        err.name = "AbortError";
+        throw err;
+      }),
+    );
+    const res = await GET(request());
+    expect(res.status).toBe(503);
+    expect((await res.json()).reason).toBe("backend_idle_timeout");
+  });
+
+  it("treats a non-JSON 200 as a bad gateway, not as a cue to invent one", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("<html>gateway</html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      })),
+    );
+    const res = await GET(request());
+    expect(res.status).toBe(502);
+    expect((await res.json()).reason).toBe("backend_non_json");
+  });
+
+  // ── the happy paths must still work ─────────────────────────────────
+
+  it("streams a healthy contract through unchanged", async () => {
+    const payload = JSON.stringify({ contractVersion: "2026-03-10.v2", playersArray: [] });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => backendResponse(200, payload, { etag: 'W/"abc"' })),
+    );
+    const res = await GET(request());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("etag")).toBe('W/"abc"');
+    expect(JSON.parse(await res.text()).contractVersion).toBe("2026-03-10.v2");
+  });
+
+  it("round-trips a 304 with no body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 304, headers: { etag: 'W/"abc"' } })),
+    );
+    const res = await GET(request("http://localhost:3000/api/dynasty-data", {
+      "if-none-match": 'W/"abc"',
+    }));
+    expect(res.status).toBe(304);
+  });
+
+  it("still forwards the session cookie and view/leagueKey params", async () => {
+    const spy = vi.fn(async () => backendResponse(200, "{}"));
+    vi.stubGlobal("fetch", spy);
+    await GET(
+      request("http://localhost:3000/api/dynasty-data?view=array&leagueKey=dynasty_new", {
+        cookie: "jason_session=abc",
+      }),
+    );
+    const [url, init] = spy.mock.calls[0];
+    expect(url).toContain("view=array");
+    expect(url).toContain("leagueKey=dynasty_new");
+    expect(init.headers.Cookie).toBe("jason_session=abc");
+  });
+
+  // ── structural: the seam must be GONE, not merely unused ────────────
+  //
+  // Read the file, because a dormant loader is a seam somebody re-threads.
+  // These assertions are what stop the fallback coming back as "resilience".
+
+  it("has no disk-snapshot loader left in the file", async () => {
+    const src = fs.readFileSync(ROUTE_PATH, "utf8");
+    const code = src
+      .split("\n")
+      .filter((l) => !l.trim().startsWith("//") && !l.trim().startsWith("*"))
+      .join("\n");
+    for (const seam of ["loadFromDisk", "listCandidates", "newestFile", "parseDynastyDataJs"]) {
+      expect(code, `${seam} must not survive as a dormant seam`).not.toContain(seam);
+    }
+    expect(code, "the route must not read the filesystem at all").not.toMatch(
+      /require\(["']node:fs["']\)|from ["']node:fs["']/,
+    );
+  });
+});

--- a/frontend/app/api/dynasty-data/route.js
+++ b/frontend/app/api/dynasty-data/route.js
@@ -1,6 +1,4 @@
 import { NextResponse } from "next/server";
-import fs from "node:fs";
-import path from "node:path";
 
 // Backend origin (scheme + host) resolved once at module load.  We
 // build the ``/api/data`` URL per-request so the caller's view /
@@ -17,12 +15,48 @@ const BACKEND_ORIGIN = (() => {
 
 // NOTE ON DEPLOYMENT SCOPE: in production, nginx routes every ``/api/*``
 // request (including ``/api/dynasty-data``) straight to the Python
-// backend — see ``deploy/nginx/chaseupside.com.conf`` — where
-// ``server.py::get_dynasty_data_alias`` already honors the caller's
-// ``view``/``leagueKey``.  This Next route only handles the dev flow
-// (no nginx in front) and any Next-fronted deployment.  The improvements
-// here (param forwarding, stream-through, idle-abort) bring that dev
-// path in line with production; they are NOT a production data-path fix.
+// backend — see ``deploy/nginx/chaseupside-proxy.conf`` (the shared
+// location snippet) and ``deploy/nginx/riskittogetthebrisket.org.conf``,
+// where ``server.py::get_dynasty_data_alias`` already honors the
+// caller's ``view``/``leagueKey``.  This Next route only handles the dev
+// flow (no nginx in front), the E2E stack, and any Next-fronted
+// deployment.
+//
+// That asymmetry is exactly what let audit finding F-14 hide, and it is
+// the same asymmetry documented in
+// ``frontend/__tests__/bridge-routes-forward-cookies.test.js``:
+// production is fine, so a defect here is quietly invisible.
+
+// THE DISK FALLBACK IS GONE (audit F-14, 2026-08-18).
+//
+// This route used to answer ``NextResponse.json(loadFromDisk())`` — an
+// unconditional **HTTP 200** — whenever the backend returned any non-2xx
+// status, a non-JSON 200, or stalled at header time.  Two defects, and
+// the first is the serious one:
+//
+//  (a) A REFUSAL WAS CONVERTED INTO A GRANT.  ``401`` is non-2xx, so an
+//      unauthenticated caller received the board off disk under 200.
+//      ``frontend/middleware.js``'s matcher excludes ``api/`` by design —
+//      the backend's own ``/api/*`` gate is meant to be the authority —
+//      so the fallback overrode the only gate there was.  Measured
+//      against a live stack: unauthenticated request → 200 / 635,170
+//      bytes while the backend answered 401, byte-identical to the disk
+//      file.
+//
+//  (b) IT COULD NOT SERVE A BOARD ANYWAY.  Every candidate the loader
+//      could reach — ``exports/latest/dynasty_data_*.json``,
+//      ``data/dynasty_data_*.json`` and ``dynasty_data.js`` — is the RAW
+//      SCRAPER EXPORT: measured 2026-08-18, all three carry no
+//      ``contractVersion``, no ``playersArray`` and ZERO rank stamps,
+//      which is precisely what ``buildRows``' fail-fast rejects.  So the
+//      "resilience" path turned a diagnosable backend status into an
+//      undiagnosable empty board, under a status code that said
+//      everything was fine.
+//
+// The backend's answer is now propagated verbatim, and a genuine
+// transport failure is reported AS a failure.  MISSING IS NEVER ZERO,
+// at the HTTP layer: "here is the board" and "I could not get the
+// board" must not share a status code.
 
 // Idle (per-chunk) timeout: abort if the backend stalls for this long
 // without sending data, at header time OR mid-body.  Using an inactivity
@@ -36,13 +70,18 @@ const BACKEND_IDLE_TIMEOUT_MS = 4000;
 // on the way out.
 const PASS_THROUGH_HEADERS = ["content-type", "cache-control", "etag", "vary"];
 
+// Headers that must survive on an ERROR response too, or the caller
+// cannot act on it.  ``www-authenticate`` is the one that matters: a 401
+// without it is a refusal with no stated challenge.
+const PASS_THROUGH_ERROR_HEADERS = ["content-type", "www-authenticate"];
+
 function backendDataUrl(reqUrl) {
   const incoming = new URL(reqUrl);
   const target = new URL(`${BACKEND_ORIGIN}/api/data`);
   // Forward the params that actually change the payload the backend
   // serves.  ``view`` is the big one — mobile / slow-network callers
-  // ask for the compact (~90% smaller) view, which the previous proxy
-  // silently dropped by always requesting the default.
+  // ask for the compact view, which the previous proxy silently dropped
+  // by always requesting the default.
   for (const key of ["view", "leagueKey"]) {
     const val = incoming.searchParams.get(key);
     if (val) target.searchParams.set(key, val);
@@ -52,11 +91,11 @@ function backendDataUrl(reqUrl) {
 }
 
 // Fetch the backend response with an idle timeout that covers ONLY the
-// header phase.  A header-time stall aborts and returns null so the
-// caller falls back to disk.  Once headers arrive the timer is cleared;
-// the body phase gets its own per-read idle timeout (see
-// ``streamWithUpstreamIdleAbort``) so header latency doesn't eat into
-// the first body chunk's budget.
+// header phase.  A header-time stall aborts and returns null; the caller
+// then reports a transport failure rather than inventing a body.  Once
+// headers arrive the timer is cleared; the body phase gets its own
+// per-read idle timeout (see ``streamWithUpstreamIdleAbort``) so header
+// latency doesn't eat into the first body chunk's budget.
 async function fetchFromBackendApi(request, backendUrl) {
   const ctl = new AbortController();
   const headerTimer = setTimeout(() => ctl.abort(), BACKEND_IDLE_TIMEOUT_MS);
@@ -75,9 +114,9 @@ async function fetchFromBackendApi(request, backendUrl) {
     });
     clearTimeout(headerTimer);
     return { res, ctl };
-  } catch {
+  } catch (err) {
     clearTimeout(headerTimer);
-    return null;
+    return { res: null, ctl, error: err };
   }
 }
 
@@ -127,72 +166,11 @@ function streamWithUpstreamIdleAbort(res, ctl) {
   });
 }
 
-function parseDynastyDataJs(jsText) {
-  if (!jsText) return null;
-  const match = jsText.match(/window\.DYNASTY_DATA\s*=\s*(\{[\s\S]*\})\s*;?/);
-  if (!match) return null;
-  try {
-    return JSON.parse(match[1]);
-  } catch {
-    return null;
-  }
-}
-
-function listCandidates(baseDir) {
-  const checks = [
-    path.join(baseDir, "exports", "latest"),
-    path.join(baseDir, "data"),
-    baseDir,
-  ];
-
-  const candidates = [];
-  for (const dir of checks) {
-    if (!fs.existsSync(dir)) continue;
-    const files = fs.readdirSync(dir)
-      .filter((f) => /^dynasty_data_\d{4}-\d{2}-\d{2}\.json$/i.test(f))
-      .map((f) => path.join(dir, f));
-    candidates.push(...files);
-  }
-
-  return candidates;
-}
-
-function newestFile(files) {
-  if (!files.length) return null;
-  return files
-    .map((f) => ({ f, m: fs.statSync(f).mtimeMs }))
-    .sort((a, b) => b.m - a.m)[0]?.f || null;
-}
-
-// Disk fallback — used only when the backend is unreachable / errored.
-// Returns the RAW contract object; the client normalizes both the raw
-// contract and the legacy ``{ ok, source, data }`` wrapper.
-function loadFromDisk() {
-  const repoRoot = path.resolve(process.cwd(), "..");
-
-  const jsonFile = newestFile(listCandidates(repoRoot));
-  if (jsonFile && fs.existsSync(jsonFile)) {
-    return JSON.parse(fs.readFileSync(jsonFile, "utf8"));
-  }
-
-  const jsCandidates = [
-    path.join(repoRoot, "exports", "latest", "dynasty_data.js"),
-    path.join(repoRoot, "dynasty_data.js"),
-    path.join(repoRoot, "data", "dynasty_data.js"),
-  ];
-  for (const jsFile of jsCandidates) {
-    if (!fs.existsSync(jsFile)) continue;
-    const parsed = parseDynastyDataJs(fs.readFileSync(jsFile, "utf8"));
-    if (parsed) return parsed;
-  }
-  return null;
-}
-
 // Copy the response headers we forward downstream (content-type,
 // cache-control, etag, vary — never content-encoding; see note above).
-function passThroughHeaders(res) {
+function passThroughHeaders(res, names = PASS_THROUGH_HEADERS) {
   const headers = new Headers();
-  for (const h of PASS_THROUGH_HEADERS) {
+  for (const h of names) {
     const v = res.headers.get(h);
     if (v) headers.set(h, v);
   }
@@ -202,63 +180,75 @@ function passThroughHeaders(res) {
 export async function GET(request) {
   try {
     const backendUrl = backendDataUrl(request.url);
-    const backend = await fetchFromBackendApi(request, backendUrl);
+    const { res, ctl, error } = await fetchFromBackendApi(request, backendUrl);
 
-    // Happy path: stream the backend response straight through without
-    // buffering / re-serializing the multi-MB contract, preserving its
-    // Cache-Control + ETag so the browser can revalidate.
-    if (backend) {
-      const { res, ctl } = backend;
-
-      // Conditional hit — no body to stream.
-      if (res.status === 304) {
-        return new NextResponse(null, { status: 304, headers: passThroughHeaders(res) });
-      }
-
-      // A 200 is only streamable if it's actually the JSON contract.  We
-      // can't validate the full body without buffering (that would defeat
-      // streaming), but we can reject a non-JSON 200 — an HTML gateway
-      // page, an error interstitial, a scalar — up front so the client
-      // gets the disk snapshot instead of a body it can't parse.
-      const contentType = res.headers.get("content-type") || "";
-      const isJson = /\bapplication\/json\b/i.test(contentType);
-      if (res.ok && isJson) {
-        if (!res.body) {
-          return new NextResponse(null, { status: res.status, headers: passThroughHeaders(res) });
-        }
-        // Stream the body with a per-read (upstream-only) idle timeout.
-        return new NextResponse(streamWithUpstreamIdleAbort(res, ctl), {
-          status: res.status,
-          headers: passThroughHeaders(res),
-        });
-      }
-      // Non-2xx, or a 200 that isn't JSON — fall through to disk.
+    // Transport failure or a header-time stall.  We have no answer, and
+    // saying so is the answer — never a 200 with a substitute body.
+    if (!res) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "backend unreachable or stalled",
+          reason: error?.name === "AbortError" ? "backend_idle_timeout" : "backend_unreachable",
+          timeoutMs: BACKEND_IDLE_TIMEOUT_MS,
+        },
+        { status: 503, headers: { "Cache-Control": "no-store" } },
+      );
     }
 
-    // Backend unreachable / errored / served a non-contract response —
-    // fall back to a disk snapshot.  (Once streaming has started we can
-    // no longer fall back; a mid-stream stall aborts and surfaces as a
-    // fetch error.)  Release the unconsumed backend response, if any.
-    if (backend) {
+    // Conditional hit — no body to stream.
+    if (res.status === 304) {
+      return new NextResponse(null, { status: 304, headers: passThroughHeaders(res) });
+    }
+
+    const contentType = res.headers.get("content-type") || "";
+    const isJson = /\bapplication\/json\b/i.test(contentType);
+
+    if (res.ok && isJson) {
+      if (!res.body) {
+        return new NextResponse(null, { status: res.status, headers: passThroughHeaders(res) });
+      }
+      // Stream the body with a per-read (upstream-only) idle timeout.
+      return new NextResponse(streamWithUpstreamIdleAbort(res, ctl), {
+        status: res.status,
+        headers: passThroughHeaders(res),
+      });
+    }
+
+    // A 200 that is not JSON — an HTML gateway page, an error
+    // interstitial, a scalar.  The upstream answered, but not with the
+    // contract, and that is a BAD GATEWAY, not a cue to invent one.
+    if (res.ok) {
       try {
-        backend.ctl.abort();
+        ctl.abort();
       } catch {
         /* already aborted */
       }
-    }
-    const parsed = loadFromDisk();
-    if (parsed) {
-      return NextResponse.json(parsed);
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "backend returned a non-JSON 200",
+          reason: "backend_non_json",
+          contentType,
+        },
+        { status: 502, headers: { "Cache-Control": "no-store" } },
+      );
     }
 
-    return NextResponse.json(
-      { ok: false, error: "No dynasty_data_YYYY-MM-DD.json or dynasty_data.js found." },
-      { status: 404 },
-    );
+    // Any other non-2xx — 401, 403, 404, 5xx — is the BACKEND'S ANSWER
+    // and it is propagated.  A refusal is an answer, not a failure: the
+    // backend's ``/api/*`` gate is the only authority here (Next's
+    // middleware matcher deliberately excludes ``api/``), so converting
+    // its 401 into anything else is an authentication bypass.
+    const body = await res.text().catch(() => "");
+    return new NextResponse(body || null, {
+      status: res.status,
+      headers: passThroughHeaders(res, PASS_THROUGH_ERROR_HEADERS),
+    });
   } catch (err) {
     return NextResponse.json(
-      { ok: false, error: err?.message || "Unknown server error" },
-      { status: 500 },
+      { ok: false, error: err?.message || "Unknown server error", reason: "bridge_exception" },
+      { status: 500, headers: { "Cache-Control": "no-store" } },
     );
   }
 }


### PR DESCRIPTION
`frontend/app/api/dynasty-data/route.js` is **the** base-contract fetch for the whole app — `frontend/lib/dynasty-data.js` sets `DEFAULT_DATA_URL = "/api/dynasty-data"`. It fell back to a disk snapshot on **any** non-2xx, on a non-JSON 200, or on a 4-second header stall, and returned it as an unconditional **HTTP 200**.

## Two defects, and the first is the serious one

**(a) A refusal was converted into a grant.** `401` is non-2xx, so an unauthenticated caller received the board off disk under 200. `frontend/middleware.js`'s matcher is `"/((?!_next/static|_next/image|api/|.*\\.[\\w]+$).*)"` — it **excludes `api/` by design**, because the backend's own `/api/*` gate is meant to be the authority. The fallback overrode the only gate there was.

Measured against a live stack: unauthenticated request → **200 / 635,170 bytes** while the backend answered **401**, byte-identical to the disk file. The CI artifact for run 32120428479 shows ten `GET /api/data?view=array HTTP/1.1 401 Unauthorized`.

**(b) It could not serve a board anyway.** I measured every candidate `loadFromDisk` could reach — `exports/latest/dynasty_data_*.json`, `data/dynasty_data_*.json` and `dynasty_data.js` — and **all three are the raw scraper export**: no `contractVersion`, no `playersArray`, zero rank stamps. That is precisely what `buildRows`' fail-fast rejects. So the "resilience" path only ever turned a diagnosable backend status into an *undiagnosable empty board*, under a status code that said everything was fine. MISSING IS NEVER ZERO, at the HTTP layer.

## That measurement decided the repair

Validating the fallback would have rejected all three candidates — disabling it while leaving the seam in place. So the fallback is **removed** and the backend's answer propagates:

| condition | before | after |
|---|---|---|
| backend `401` / `403` | 200 + board off disk | status propagated, `www-authenticate` preserved |
| backend `5xx` | 200 + board off disk | status propagated |
| transport failure | 200 + board off disk | `503` `reason: backend_unreachable` |
| header-time stall (4s) | 200 + board off disk | `503` `reason: backend_idle_timeout` |
| non-JSON `200` | 200 + board off disk | `502` `reason: backend_non_json` |
| healthy contract / `304` | unchanged | unchanged |

`loadFromDisk`, `listCandidates`, `newestFile`, `parseDynastyDataJs` and the `node:fs` import are **deleted**, not left dormant — a fallback nobody can reach is a seam somebody re-threads. One assertion reads the file to prove it is *gone* rather than merely unused.

**No client change was needed.** `fetchDynastyData` already throws on `!res.ok` (`frontend/lib/dynasty-data.js:1587`), so the hook's existing error state surfaces an explicit banner where the old path rendered a silent empty board.

## Scope, stated honestly

**Production is unaffected.** I verified `location /api/ { proxy_pass … backend; }` in both `deploy/nginx/chaseupside-proxy.conf` and `deploy/nginx/riskittogetthebrisket.org.conf`, so this file is never reached there. Dev, the E2E stack and any Next-fronted deployment are — the same asymmetry `frontend/__tests__/bridge-routes-forward-cookies.test.js` was written for, and for the same reason: production being fine is what lets a defect here stay invisible. The protection was a deployment convention, not a property of the code, and nothing tested it. That is what the new module is.

The route's comment also cited the wrong nginx file; it now names the shared `chaseupside-proxy.conf` snippet where the block actually lives.

## Verification

- **RED first, measured**: **9 of 12 assertions fail** against the pre-repair route — every auth-propagation case, both transport cases, the non-JSON case, and the structural one. The 3 that pass are the happy paths (streaming, 304 round-trip, cookie + `view`/`leagueKey` forwarding), deliberately unchanged.
- Frontend suite: **2055 passed across 127 files**. Bundle budgets all under. Planning-integrity and coercion gates clean.
- New: `frontend/__tests__/dynasty-data-bridge-no-disk-fallback.test.js` (12). All stubbed — no live stack, no network.

## Supersedes F-3b

The standing F-3b diagnosis attributed the journey-rankings failure to a stack-readiness race. The readiness gate passes; the board never talks to the backend at all. The audit register is updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kve8hqgo4v4PeagCHi92ds

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kve8hqgo4v4PeagCHi92ds)_