### PR TITLE
Repair inherited 2029 pick-completeness failure without fabricating market evidence

### DIFF
--- a/src/api/confidence.py
+++ b/src/api/confidence.py
@@ -134,6 +134,14 @@ CONFIDENCE_BASES: tuple[str, ...] = (
     "evidence_gate",  # the five-axis bottleneck ran
     "pick_dispersion",  # the pick coefficient-of-variation rule ran
     "derived_round_step",  # value derived from the same year's nearest priced round
+    # Value derived from the nearest priced EARLIER future year's board
+    # value for the same tier+round (``derivedYearModel``).  Distinct
+    # from ``derived_round_step``: that one steps ACROSS ROUNDS within
+    # one year, this one steps ACROSS YEARS within one round.  A row
+    # reaching the board through the far-future source injection
+    # blends normally and is ``evidence_gate``; this basis marks the
+    # rows the blend could not price at all.
+    "derived_year_step",
     "derived_rookie_tether",  # value inherited from the rookie at this slot
     "derived_tier_values",  # value derived from tier values (generic grade)
     "unpriced",  # no canonical value exists for this row

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -7292,11 +7292,25 @@ def _complete_future_pick_values(
 
     Runs after the rookie tether and before the draft-day projections,
     so it sees final values for everything the blend and the tether
-    priced.  Three derivations, strict priority (direct evidence always
+    priced.  Four derivations, strict priority (direct evidence always
     outranks a derivation — a row that already carries a finite value is
     never touched):
 
-    1. **Round-step** (``derivedRoundModel``, classification PRIOR) —
+    1. **Year-step** (``derivedYearModel``, classification PRIOR) —
+       a future-year tier row the blend could not price derives from
+       the nearest priced EARLIER future year's canonical board value
+       for the same tier+round: ``value(Y) = value(Y-gap) ×
+       yearStep(tier, round) ** gap``.  Same model and same measured
+       per-cell steps as the injection-time derivation in
+       ``_inject_far_future_pick_sources``; what differs is the basis
+       quantity (the published board value rather than the template
+       year's raw per-source values), which is what makes the horizon
+       guarantee independent of which vendor keys survived in the raw
+       scrape.  Its DOMAIN is the config's own measured surface — the
+       rounds ``derivedYearModel`` publishes cells for — so rounds no
+       year cell covers fall to the round-step rung below.
+
+    2. **Round-step** (``derivedRoundModel``, classification PRIOR) —
        future-year tier rows in rounds no vendor prices (5-6; both pick
        markets stop at round 4) derive from the same year+tier's nearest
        priced lower round: ``value(R) = value(R-1) × roundStep(R)``.
@@ -7305,7 +7319,7 @@ def _complete_future_pick_values(
        the assumption that the current class's tail structure carries to
        future classes is named in the config.
 
-    2. **Uniform-tier EV** (``genericGradeModel``, classification
+    3. **Uniform-tier EV** (``genericGradeModel``, classification
        PRIOR) — a rank-less generic-grade row (``"2027 Round 1"``) per
        future year × round, valued at the unweighted mean of the
        year+round's three tier values.  This is the board row for
@@ -7315,7 +7329,7 @@ def _complete_future_pick_values(
        untouched, and C1-U7 replaces the uniform assumption with real
        owned-pick distributions.
 
-    3. **Provenance** — every pick row gets ``pickValueProvenance``
+    4. **Provenance** — every pick row gets ``pickValueProvenance``
        naming which evidence class produced its number:
        ``direct_market_blend`` / ``rookie_pool_tether`` /
        ``derived_year_step`` / ``derived_round_step`` /
@@ -7354,7 +7368,106 @@ def _complete_future_pick_values(
     future_years = range(current_year + 1, current_year + horizon + 1)
     derived: dict[str, int] = {}
 
-    # ── 1. Round-step completion for unpriced future tier rows ──
+    # ── 1. Year-step completion for unpriced future tier rows ──
+    #
+    # The horizon guarantee must not depend on WHICH vendor keys
+    # happened to survive in the raw scrape JSON.
+    # ``_inject_far_future_pick_sources`` seeds the synthetic far-future
+    # rows by cloning the template year's entry out of
+    # ``players_by_name`` — the raw scraper payload — and that
+    # population is strictly poorer than the one the canonical board
+    # uses for the very same template year: ``ktcSfTep``'s pick values
+    # (all 36 vendor pick rows) reach a row through the CSV enrichment,
+    # and the CSVs correctly carry no far-future year with which to
+    # enrich a synthetic row.  A synthetic row can therefore only ever
+    # vote on the in-JSON sources, and when those thin out it is left
+    # with NO voting source at all.
+    #
+    # Measured on the 2026-08-18T17:11Z refresh: the scrape's in-JSON
+    # ``idpTradeCalc`` pick values collapsed to the round-1 tiers while
+    # BOTH vendor CSVs stayed complete (36 ``ktcSfTep`` + 84
+    # ``idpTradeCalc`` pick rows, every 2028 tier through round 4).
+    # Every 2029 row in rounds 2-6 blended to ``None`` and the census
+    # below failed 20 cells on a board whose evidence was intact.
+    #
+    # So completion carries its own year-step rung, anchored on the
+    # CANONICAL BOARD value of the nearest priced earlier future year:
+    # the same ``derivedYearModel`` family and the same measured
+    # per-(tier, round) step compounded across the gap, applied to the
+    # number the board actually published rather than to whichever raw
+    # keys survived.  Direct evidence still outranks it absolutely — a
+    # row already carrying a finite value is never touched — so this is
+    # inert on a healthy board.  Nothing here is keyed to a particular
+    # year; the horizon self-rolls with ``current_year``.
+    year_step_rounds: set[int] = set()
+    for _cell in cfg.get("yearStepByTierRound") or {}:
+        _, _, _cell_round = str(_cell).partition(".")
+        if _cell_round.isdigit():
+            year_step_rounds.add(int(_cell_round))
+    for _cell in cfg.get("yearStepByRound") or {}:
+        if str(_cell).isdigit():
+            year_step_rounds.add(int(_cell))
+    for year in future_years:
+        for tier in ("Early", "Mid", "Late"):
+            for rnd in sorted(year_step_rounds):
+                name = f"{year} {tier} {_round_suffix(rnd)}"
+                row = by_name.get(name)
+                if row is None or _finite_value(row) is not None:
+                    continue
+                # Nearest priced EARLIER **future** year.  Never the
+                # current draft year: its rows are rookie-pool-tethered
+                # slot picks (a different quantity), and vendor-priced
+                # years take no year discount at all (T-3/C-2).
+                basis_name: str | None = None
+                basis_year: int | None = None
+                basis_value: float | None = None
+                for cand_year in range(year - 1, current_year, -1):
+                    cand_name = f"{cand_year} {tier} {_round_suffix(rnd)}"
+                    cand_value = _finite_value(by_name.get(cand_name))
+                    if cand_value is not None:
+                        basis_name, basis_year, basis_value = cand_name, cand_year, cand_value
+                        break
+                if basis_value is None or basis_year is None:
+                    # No future evidence to step from.  The row stays
+                    # unpriced and is reported ``unavailable`` below —
+                    # never 0, never a fabricated number.
+                    continue
+                gap = year - basis_year
+                factor = _year_step_for(tier, rnd, cfg) ** gap
+                value = int(round(basis_value * factor))
+                if value <= 0:
+                    continue
+                row["rankDerivedValue"] = value
+                row["confidenceBucket"] = "low"
+                row["confidenceLabel"] = (
+                    "Low — derived from the nearest priced future year (no market row)"
+                )
+                row["confidenceBasis"] = "derived_year_step"
+                row["confidenceAxes"] = None
+                row["confidenceReasons"] = None
+                row["pickYearDiscount"] = round(factor, 4)
+                row["pickValueProvenance"] = {
+                    "class": "derived_year_step",
+                    "family": "measured_vendor_year_step_v1",
+                    "classification": "PRIOR",
+                    "basis": basis_name,
+                    "basisYear": basis_year,
+                    "factor": round(factor, 4),
+                    # WHICH quantity the factor multiplied.  The
+                    # injection-time derivation of the same family steps
+                    # the template year's per-SOURCE values; this one
+                    # steps the template year's published board value.
+                    # Same model, different basis quantity — naming it
+                    # is the difference between a reproducible stamp and
+                    # a merely plausible one.
+                    "appliedTo": "canonical_board_value",
+                }
+                derived[name] = value
+                legacy = players_by_name.get(row.get("legacyRef") or name)
+                if isinstance(legacy, dict):
+                    legacy["rankDerivedValue"] = value
+
+    # ── 2. Round-step completion for unpriced future tier rows ──
     for year in future_years:
         for tier in ("Early", "Mid", "Late"):
             for rnd in range(2, 7):
@@ -7419,7 +7532,7 @@ def _complete_future_pick_values(
                 if isinstance(legacy, dict):
                     legacy["rankDerivedValue"] = value
 
-    # ── 2. Generic-grade rows (uniform-tier EV) ──
+    # ── 3. Generic-grade rows (uniform-tier EV) ──
     for year in future_years:
         for rnd in range(1, 7):
             tiers = [
@@ -7489,7 +7602,7 @@ def _complete_future_pick_values(
             legacy["_canonicalConsensusRank"] = None
             legacy["sourceCount"] = 0
 
-    # ── 3. Provenance on every remaining pick row ──
+    # ── 4. Provenance on every remaining pick row ──
     for row in players_array:
         if row.get("assetClass") != "pick" or row.get("pickValueProvenance"):
             continue
@@ -7509,7 +7622,12 @@ def _complete_future_pick_values(
         derivation = (synthetic_pick_derivations or _EMPTY_PICK_DERIVATIONS).get(
             _canonical_match_key(cname)
         )
-        if derivation is not None:
+        # A derivation ENTRY is not a derived VALUE.  The injection
+        # records one for every synthetic row it seeds, including rows
+        # whose cloned sources then failed to blend — and stamping
+        # ``derived_year_step`` on a row carrying no value claims a
+        # derivation that did not produce a number.  Require the value.
+        if derivation is not None and _finite_value(row) is not None:
             row["pickValueProvenance"] = {
                 "class": "derived_year_step",
                 "family": derivation.get("family"),

--- a/tests/api/test_future_pick_year_step_completion.py
+++ b/tests/api/test_future_pick_year_step_completion.py
@@ -1,0 +1,387 @@
+"""The future-pick horizon guarantee must not depend on which vendor
+keys survived in the raw scrape JSON.
+
+INCIDENT (2026-08-18T17:11Z refresh, reproduced on pristine ``main``).
+``scripts/validate_api_contract.py --lane structural`` — the BLOCKING
+pull-request gate — reported 20 errors::
+
+    pick_completeness_census:2029 Early 2nd:missing_or_unpriced
+    pick_completeness_census:2029 Round 2:missing_or_unpriced
+    ... (every tier and generic grade, rounds 2 through 6)
+
+turning every open pull request red at once.
+
+WHAT WAS ACTUALLY BROKEN.  Not the evidence.  At that commit BOTH vendor
+pick boards were complete on disk — 36 ``ktcSfTep`` rows and 84
+``idpTradeCalc`` rows, covering every 2028 tier through round 4.  What
+thinned out was the scrape's *in-JSON* per-source pick values, and that
+is the only population ``_inject_far_future_pick_sources`` can see: it
+clones the template year's raw entry, so a synthetic far-future row can
+only ever vote on the in-JSON sources.  ``ktcSfTep``'s pick values reach
+a row through the CSV enrichment instead, and the CSVs correctly carry
+no far-future year with which to enrich a synthetic row.  With the
+in-JSON side thinned, the 2029 rows in rounds 2-6 had NO voting source
+at all and blended to ``None`` — on a board whose evidence was intact.
+
+The round-step rung could not repair it either: ``derivedRoundModel``
+configures steps only for the vendor-uncovered rounds (5-6), so rounds
+2-4 had no rung, and rounds 5-6 then found their round-4 basis missing.
+
+THE REPAIR is a year-step rung in ``_complete_future_pick_values``,
+anchored on the CANONICAL BOARD value of the nearest priced earlier
+future year rather than on whichever raw keys survived — same
+``derivedYearModel`` family, same measured per-(tier, round) step,
+compounded across the gap.
+
+These tests are deterministic unit tests over the completion owner: no
+network, no live board, no absolute counts.  They assert the invariant
+(*every* valid cell), and each one proves it inspected a non-empty set
+before asserting anything about it.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.api.confidence import CONFIDENCE_BASES
+from src.api.data_contract import (
+    _complete_future_pick_values,
+    _load_pick_year_discount,
+    _round_suffix,
+    _year_step_for,
+)
+
+TIERS = ("Early", "Mid", "Late")
+VENDOR_ROUNDS = (1, 2, 3, 4)  # the rounds both pick markets publish
+ALL_ROUNDS = (1, 2, 3, 4, 5, 6)
+
+
+def _tier_name(year: int, tier: str, rnd: int) -> str:
+    return f"{year} {tier} {_round_suffix(rnd)}"
+
+
+def _pick_row(name: str, value: float | None) -> dict:
+    """A pick row carrying only what the completion owner reads."""
+    return {
+        "assetClass": "pick",
+        "canonicalName": name,
+        "displayName": name,
+        "rankDerivedValue": value,
+    }
+
+
+def _board(
+    current_year: int,
+    priced: dict[str, float],
+    *,
+    unpriced: list[str],
+) -> tuple[list[dict], dict]:
+    """Build a pick-only ``playersArray`` plus its legacy mirror."""
+    rows = [_pick_row(n, v) for n, v in priced.items()]
+    rows += [_pick_row(n, None) for n in unpriced]
+    legacy = {r["canonicalName"]: dict(r) for r in rows}
+    return rows, legacy
+
+
+def _healthy_template_year(year: int, base: float = 4000.0) -> dict[str, float]:
+    """A fully priced vendor-covered year: 3 tiers x rounds 1-4."""
+    out: dict[str, float] = {}
+    for t_i, tier in enumerate(TIERS):
+        for rnd in VENDOR_ROUNDS:
+            # strictly decreasing across tiers and across rounds
+            out[_tier_name(year, tier, rnd)] = round(base * (0.9**t_i) * (0.65 ** (rnd - 1)), 1)
+    return out
+
+
+def _by_name(rows: list[dict]) -> dict[str, dict]:
+    return {str(r.get("canonicalName")): r for r in rows}
+
+
+def _value(rows: list[dict], name: str):
+    row = _by_name(rows).get(name)
+    return None if row is None else row.get("rankDerivedValue")
+
+
+def _finite(v) -> bool:
+    return isinstance(v, (int, float)) and not isinstance(v, bool) and v > 0
+
+
+class TestYearStepCompletion(unittest.TestCase):
+    """The incident, reproduced at the owner and pinned green."""
+
+    def test_reproduces_incident_shape_and_completes_every_cell(self):
+        """RED shape: template year priced, far-future rows exist but the
+        blend gave them nothing.  Every valid cell must come back finite.
+        """
+        current = 2026
+        horizon_year = current + 3
+        priced = _healthy_template_year(current + 2)  # 2028, vendor-covered
+        # Every 2029 tier row exists (the injection created them) but the
+        # blend priced none of them — the measured incident state.
+        unpriced = [_tier_name(horizon_year, t, r) for t in TIERS for r in ALL_ROUNDS]
+        rows, legacy = _board(current, priced, unpriced=unpriced)
+
+        self.assertTrue(unpriced, "non-vacuity: the RED set must be non-empty")
+        for name in unpriced:
+            self.assertIsNone(_value(rows, name), f"{name} must start unpriced")
+
+        _complete_future_pick_values(rows, legacy, current)
+
+        for name in unpriced:
+            self.assertTrue(
+                _finite(_value(rows, name)),
+                f"{name} left unpriced after completion",
+            )
+        # ...and the generic grade for every round.
+        for rnd in ALL_ROUNDS:
+            generic = f"{horizon_year} Round {rnd}"
+            self.assertTrue(
+                _finite(_value(rows, generic)),
+                f"{generic} left unpriced after completion",
+            )
+
+    def test_derived_value_equals_the_approved_model(self):
+        """The number is reproducible from the config, not invented."""
+        current = 2026
+        template, target = current + 2, current + 3
+        priced = _healthy_template_year(template)
+        unpriced = [_tier_name(target, t, r) for t in TIERS for r in ALL_ROUNDS]
+        rows, legacy = _board(current, priced, unpriced=unpriced)
+
+        _complete_future_pick_values(rows, legacy, current)
+
+        cfg = _load_pick_year_discount()
+        checked = 0
+        for tier in TIERS:
+            for rnd in VENDOR_ROUNDS:
+                basis = priced[_tier_name(template, tier, rnd)]
+                expected = int(round(basis * _year_step_for(tier, rnd, cfg) ** (target - template)))
+                self.assertEqual(
+                    _value(rows, _tier_name(target, tier, rnd)),
+                    expected,
+                    f"{_tier_name(target, tier, rnd)} is not basis x yearStep",
+                )
+                checked += 1
+        self.assertEqual(checked, len(TIERS) * len(VENDOR_ROUNDS))
+
+    def test_multi_year_gap_compounds_the_step(self):
+        """A two-year gap is ``step ** 2``, not ``step``."""
+        current = 2026
+        template, target = current + 1, current + 3  # 2027 -> 2029, gap 2
+        priced = _healthy_template_year(template)
+        unpriced = [
+            _tier_name(y, t, r) for y in (current + 2, target) for t in TIERS for r in ALL_ROUNDS
+        ]
+        rows, legacy = _board(current, priced, unpriced=unpriced)
+
+        _complete_future_pick_values(rows, legacy, current)
+
+        cfg = _load_pick_year_discount()
+        # 2028 fills from 2027 (gap 1); 2029 then fills from 2028 (gap 1),
+        # so the compounded product must equal step**2 off the template.
+        for tier in TIERS:
+            for rnd in VENDOR_ROUNDS:
+                basis = priced[_tier_name(template, tier, rnd)]
+                step = _year_step_for(tier, rnd, cfg)
+                mid = int(round(basis * step))
+                self.assertEqual(_value(rows, _tier_name(current + 2, tier, rnd)), mid)
+                self.assertEqual(
+                    _value(rows, _tier_name(target, tier, rnd)), int(round(mid * step))
+                )
+
+    def test_direct_evidence_outranks_derivation(self):
+        """A row that already carries a value is never touched."""
+        current = 2026
+        template, target = current + 2, current + 3
+        priced = _healthy_template_year(template)
+        # A *directly priced* far-future row, deliberately far off the model.
+        direct_name = _tier_name(target, "Early", 2)
+        priced[direct_name] = 12.0
+        unpriced = [
+            _tier_name(target, t, r)
+            for t in TIERS
+            for r in ALL_ROUNDS
+            if _tier_name(target, t, r) != direct_name
+        ]
+        rows, legacy = _board(current, priced, unpriced=unpriced)
+
+        _complete_future_pick_values(rows, legacy, current)
+
+        self.assertEqual(_value(rows, direct_name), 12.0, "direct evidence was overwritten")
+        row = _by_name(rows)[direct_name]
+        self.assertEqual(
+            (row.get("pickValueProvenance") or {}).get("class"),
+            "direct_market_blend",
+            "a directly priced row must not be relabelled as derived",
+        )
+        # non-vacuity: the surrounding cells DID derive.
+        self.assertTrue(_finite(_value(rows, _tier_name(target, "Mid", 2))))
+
+    def test_no_future_basis_stays_unavailable_and_never_zero(self):
+        """MISSING IS NEVER ZERO.  With no earlier *future* year priced,
+        the row keeps no value and says why."""
+        current = 2026
+        target = current + 3
+        # Only the CURRENT draft year is priced.  Its rows are
+        # rookie-pool-tethered slot picks — a different quantity — and a
+        # vendor-priced year takes no year discount, so it may not be a
+        # basis.  Nothing else exists to step from.
+        priced = _healthy_template_year(current)
+        unpriced = [_tier_name(target, t, r) for t in TIERS for r in ALL_ROUNDS]
+        rows, legacy = _board(current, priced, unpriced=unpriced)
+
+        _complete_future_pick_values(rows, legacy, current)
+
+        for name in unpriced:
+            value = _value(rows, name)
+            self.assertIsNone(value, f"{name} must stay unpriced, got {value!r}")
+            self.assertNotEqual(value, 0, f"{name} became zero-as-missing")
+            prov = _by_name(rows)[name].get("pickValueProvenance") or {}
+            self.assertEqual(prov.get("class"), "unavailable", f"{name} provenance: {prov}")
+            self.assertTrue(prov.get("reason"), f"{name} unavailable with no reason")
+
+    def test_current_year_is_never_used_as_a_basis(self):
+        """Explicitly: the current draft year cannot leak into a future
+        year's derivation even when it is the only priced year."""
+        current = 2026
+        priced = _healthy_template_year(current)
+        first_future = _tier_name(current + 1, "Early", 1)
+        rows, legacy = _board(current, priced, unpriced=[first_future])
+
+        _complete_future_pick_values(rows, legacy, current)
+
+        self.assertIsNone(_value(rows, first_future))
+        prov = _by_name(rows)[first_future].get("pickValueProvenance") or {}
+        self.assertEqual(prov.get("class"), "unavailable")
+
+
+class TestProvenanceAndOrdering(unittest.TestCase):
+    def test_every_derived_row_carries_distinguishable_provenance(self):
+        current = 2026
+        template, target = current + 2, current + 3
+        priced = _healthy_template_year(template)
+        unpriced = [_tier_name(target, t, r) for t in TIERS for r in ALL_ROUNDS]
+        rows, legacy = _board(current, priced, unpriced=unpriced)
+
+        _complete_future_pick_values(rows, legacy, current)
+
+        seen_year, seen_round = 0, 0
+        for name in unpriced:
+            row = _by_name(rows)[name]
+            prov = row.get("pickValueProvenance") or {}
+            self.assertIn(
+                prov.get("class"),
+                {"derived_year_step", "derived_round_step"},
+                f"{name} derived without a derivation class: {prov}",
+            )
+            self.assertEqual(prov.get("classification"), "PRIOR", f"{name}: {prov}")
+            self.assertTrue(prov.get("basis"), f"{name} names no basis: {prov}")
+            self.assertTrue(prov.get("family"), f"{name} names no family: {prov}")
+            if prov["class"] == "derived_year_step":
+                seen_year += 1
+                # The board-anchored rung must be distinguishable from
+                # the injection-time derivation of the SAME family.
+                self.assertEqual(prov.get("appliedTo"), "canonical_board_value", f"{name}")
+                self.assertEqual(prov.get("basisYear"), template, f"{name}")
+            else:
+                seen_round += 1
+            self.assertIn(row.get("confidenceBasis"), CONFIDENCE_BASES, f"{name}")
+        self.assertTrue(seen_year, "non-vacuity: no year-step derivation exercised")
+        self.assertTrue(seen_round, "non-vacuity: no round-step derivation exercised")
+
+    def test_derived_year_step_is_a_registered_confidence_basis(self):
+        self.assertIn("derived_year_step", CONFIDENCE_BASES)
+
+    def test_tier_ordering_survives_the_year_step(self):
+        """An earlier pick must stay worth more than a later one — the
+        census' companion ``pick_tier_ordering`` check."""
+        current = 2026
+        template, target = current + 2, current + 3
+        priced = _healthy_template_year(template)
+        unpriced = [_tier_name(target, t, r) for t in TIERS for r in ALL_ROUNDS]
+        rows, legacy = _board(current, priced, unpriced=unpriced)
+
+        _complete_future_pick_values(rows, legacy, current)
+
+        checked = 0
+        for rnd in ALL_ROUNDS:
+            early, mid, late = (_value(rows, _tier_name(target, t, rnd)) for t in TIERS)
+            self.assertTrue(
+                early > mid > late,
+                f"round {rnd} tier ordering inverted: {early} / {mid} / {late}",
+            )
+            checked += 1
+        self.assertEqual(checked, len(ALL_ROUNDS))
+
+    def test_generic_grade_is_the_mean_of_its_three_tiers(self):
+        current = 2026
+        template, target = current + 2, current + 3
+        priced = _healthy_template_year(template)
+        unpriced = [_tier_name(target, t, r) for t in TIERS for r in ALL_ROUNDS]
+        rows, legacy = _board(current, priced, unpriced=unpriced)
+
+        _complete_future_pick_values(rows, legacy, current)
+
+        for rnd in ALL_ROUNDS:
+            tiers = [_value(rows, _tier_name(target, t, rnd)) for t in TIERS]
+            self.assertEqual(
+                _value(rows, f"{target} Round {rnd}"),
+                int(round(sum(tiers) / 3)),
+            )
+
+
+class TestGenericAcrossTheClock(unittest.TestCase):
+    """The repair may not be keyed to 2029, or to any literal year."""
+
+    def test_horizon_self_rolls_for_any_current_year(self):
+        cfg = _load_pick_year_discount()
+        horizon = int(cfg.get("horizonYears") or 3)
+        exercised = 0
+        for current in (2026, 2027, 2030, 2044):
+            template = current + horizon - 1
+            target = current + horizon
+            priced = _healthy_template_year(template)
+            unpriced = [_tier_name(target, t, r) for t in TIERS for r in ALL_ROUNDS]
+            rows, legacy = _board(current, priced, unpriced=unpriced)
+
+            _complete_future_pick_values(rows, legacy, current)
+
+            for name in unpriced:
+                self.assertTrue(
+                    _finite(_value(rows, name)),
+                    f"current_year={current}: {name} left unpriced",
+                )
+                exercised += 1
+        self.assertEqual(exercised, 4 * len(TIERS) * len(ALL_ROUNDS))
+
+    def test_source_family_loss_does_not_erase_unrelated_derived_rows(self):
+        """Losing coverage for one round must not take the others with it."""
+        current = 2026
+        template, target = current + 2, current + 3
+        priced = _healthy_template_year(template)
+        # Simulate a vendor dropping round 3 for the template year too:
+        # that column has no basis anywhere, the rest still derive.
+        for tier in TIERS:
+            priced.pop(_tier_name(template, tier, 3))
+        unpriced = [_tier_name(target, t, r) for t in TIERS for r in ALL_ROUNDS]
+        unpriced += [_tier_name(template, t, 3) for t in TIERS]
+        rows, legacy = _board(current, priced, unpriced=unpriced)
+
+        _complete_future_pick_values(rows, legacy, current)
+
+        survived = 0
+        for tier in TIERS:
+            for rnd in (1, 2, 4):
+                self.assertTrue(
+                    _finite(_value(rows, _tier_name(target, tier, rnd))),
+                    f"{_tier_name(target, tier, rnd)} was erased by an unrelated gap",
+                )
+                survived += 1
+            # The genuinely evidence-free column refuses, and never as 0.
+            for year in (template, target):
+                self.assertIsNone(_value(rows, _tier_name(year, tier, 3)))
+        self.assertEqual(survived, len(TIERS) * 3)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## ⚠️ Read first — this overlaps PR #910

**#910 (Lane 5) already fixes the reported incident**, as audit finding F-30, in the same function (`_complete_future_pick_values`), at the same insertion point, adding the same `derived_year_step` confidence basis. I verified that independently: with #910's code and the exact failing payload, `structuralErrors` goes 20 → 0.

**These two PRs will conflict textually. Do not merge both blindly.** §"Merge order" below has a recommendation. The one thing this PR has that #910 does not is a measured gap — see §"Where this differs from #910".

Claude 5 owns the integration decision here; this PR exists to hand over evidence and a tested alternative, not to supersede it.

---

## Root cause

**First broken transformation:** `_inject_far_future_pick_sources` (`src/api/data_contract.py`) seeds synthetic far-future pick rows by cloning the template year's entry out of `players_by_name` — the **raw scraper payload** — and that population is strictly poorer than the one the canonical board uses for the very same template year.

`ktcSfTep`'s pick values (all 36 vendor pick rows) reach a row through the **CSV enrichment**, which runs later and correctly carries no far-future year with which to enrich a synthetic row. So a synthetic row can only ever vote on the in-JSON sources. The raw pick entries carry `ktc` — which is *not* a registered ranking source, it is a legacy display key — and `idpTradeCalc`.

Consequence: **every 2029 row on the board rests on `idpTradeCalc` alone**, on healthy days too. Measured on the current healthy board, all eighteen 2029 tier rows report `matchedSources: ['idpTradeCalc']`. The horizon has been a single-vendor dependency the whole time.

When the 17:11 scrape's in-JSON `idpTradeCalc` pick values collapsed to the round-1 tiers, the 2029 rows in rounds 2–6 had **no voting source at all** and blended to `None`.

The round-step rung could not repair it: `derivedRoundModel` configures steps only for the vendor-uncovered rounds (5–6), so rounds 2–4 had no rung, and 5–6 then found their round-4 basis missing. The generic grade needs three priced tiers, so it fell too. 18 tier cells + 6 generic cells → **20 census errors** (R1 survived).

## Why this is inherited

Reproduced on pristine `main` — no lane changes — at `f9444f7` (`chore: automated data refresh 2026-08-18T17:14:18Z`), which was `main` for roughly two hours, in a clean worktree with that commit's own payload and CSVs:

```
$ python scripts/validate_api_contract.py --lane structural
[contract] ok=False errors=20 warnings=13 players=983
[contract] structuralErrors=20 sourceHealthErrors=0
[contract][error] pick_completeness_census:2029 Early 2nd:missing_or_unpriced
[contract][error] pick_completeness_census:2029 Round 2:missing_or_unpriced
... (every tier + generic grade, rounds 2 through 6)
```

That is the **blocking** PR lane, which is why unrelated PRs went red together. Deterministic: the same payload reproduces it every run.

**It is currently latent, not resolved.** The 19:18 refresh restored the in-JSON values, so `main` is green again by luck. The next degraded scrape reproduces it.

## Source evidence — what existed, what did not

The evidence was **never missing**. At the failing commit:

| file | pick rows | 2028 coverage |
|---|---|---|
| `CSVs/site_raw/ktcSfTep.csv` | 36 | Early/Mid/Late × rounds 1–4 ✔ |
| `CSVs/site_raw/idpTradeCalc.csv` | 84 | Early/Mid/Late × rounds 1–4 ✔ |

Both vendor boards were complete on disk. What thinned was only the scrape's in-JSON per-source values (`pickAnchors[idpTradeCalc]` 84 → 16). So this is a **code defect exposed by a transient source hiccup**, not a source blocker: the approved derivation had everything it needed and could not see it.

This does not disturb **F-22**. If anything it corroborates its correction — the canonical contract does independently read the CSVs and did obtain all 36 vendor pick rows here. No new evidence of canonical pick-value corruption; F-22 stays P2. `scripts/audit_status.py` reports no drift (43 Criticals, unchanged).

## Why the fix is canonical

`_complete_future_pick_values` is the declared owner of the horizon guarantee — *"every valid pick through the horizon ends finite"* — but its three rungs had no year-step among them; year-stepping happened only at injection. So the owner could not repair a failed injection. That gap is the defect; the fix closes it at the owner. No consumer was touched.

## Derivation methodology

Approved model, unchanged: `config/weights/pick_year_discount.json::derivedYearModel`, classification **PRIOR**.

```
value(Y, tier, round) = value(Ybasis, tier, round) × yearStep(tier, round) ** (Y − Ybasis)
```

* `Ybasis` = nearest **priced earlier future year**. Never the current draft year: those rows are rookie-pool-tethered slot picks (a different quantity) and vendor-priced years take no year discount at all (T-3/C-2).
* `yearStep` via the existing shared `_year_step_for` (`stepByTierRound → stepByRound → stepFallback`).
* **Domain is the config's own measured surface** — the rounds `derivedYearModel` publishes cells for — so rounds no year cell covers still fall to the round-step rung, exactly as on a healthy board.
* Runs **before** the round-step rung, so a year-stepped round 4 can serve as the basis for rounds 5–6.

What changes versus the injection-time derivation is only the **basis quantity**: the published board value rather than the template year's raw per-source values. That is precisely what makes the guarantee independent of which raw keys survived.

Nothing is keyed to 2029. The horizon self-rolls with `current_year`; tests exercise 2026, 2027, 2030 and 2044.

## Provenance

Every derived row carries `pickValueProvenance` with `class`, `family`, `classification: PRIOR`, `basis`, `basisYear`, `factor` — plus `appliedTo: "canonical_board_value"`, which distinguishes this rung from the injection-time derivation of the *same* family. Two stamps of one model that are not interchangeable should not read identically.

On the previously-failing payload:

```
2029 Early 1st  4497  derived_year_step   basis=2028 Early 1st  (blended — injection)
2029 Early 2nd  2710  derived_year_step   basis=2028 Early 2nd  appliedTo=canonical_board_value
2029 Early 4th  1436  derived_year_step   basis=2028 Early 4th  appliedTo=canonical_board_value
2029 Early 5th  1334  derived_round_step  basis=2029 Early 4th
2029 Round 2    2549  derived_uniform_tier_ev
```

**Also fixed: a derivation _entry_ is not a derived _value_.** The injection records one for every synthetic row it seeds, including rows whose cloned sources then failed to blend — so the provenance pass was stamping `derived_year_step` on rows carrying no value at all, claiming a derivation that produced no number. It now requires the value, and such a row reports `unavailable` with a reason instead.

## Missing semantics

Nothing becomes zero. With no priced earlier future year the row keeps **no** value and reports `class: "unavailable"` with a reason. Pinned by `test_no_future_basis_stays_unavailable_and_never_zero` (asserts `is None` *and* `!= 0`) and `test_current_year_is_never_used_as_a_basis`.

Direct evidence outranks derivation absolutely: a row already carrying a finite value is never touched, and is never relabelled as derived. On a healthy board the rung is **completely inert** (see below).

## Identity

No identity is minted, renamed, or parsed here. The rung reprices existing rows looked up by their canonical board names and appends only the generic-grade rows the pre-existing rung already appended. `tests/identity/` and `tests/picks/` pass unchanged; tier ↔ generic ↔ slot resolution is untouched.

Tier ordering holds in every round — the step surface is already PAVA-projected monotone at load (F-1), so a shared per-round factor cannot invert Early > Mid > Late. Verified on the repaired board and pinned by `test_tier_ordering_survives_the_year_step`.

## Tests — red before, green after

New: `tests/api/test_future_pick_year_step_completion.py`, 12 deterministic unit tests over the completion owner (no network, no live board, no absolute counts; each proves it inspected a non-empty set first).

* On pristine `main`: **10 of 12 fail.** The 2 that pass are the missing-is-never-zero ones — `main` already refuses honestly there, and these pin that it stays that way.
* With this change: **12 of 12 pass.**

Contract gate, at the failing commit `f9444f7`:

| lane | before | after |
|---|---|---|
| `--lane structural` (blocking on PRs) | `structuralErrors=20` | `errors=0 ok=True` |
| `--lane full` (deploy gate) | `errors=20` | `errors=0 ok=True` |

Full local gate run:

* `pytest tests/ -m "not livedata"` — **8169 passed, 40 skipped, 371 subtests passed**
* `ruff format --check .` and `ruff check .` (pinned `ruff~=0.6.0`) — clean repo-wide
* `check_decision_coercions.py` — clean, no new coercions
* `audit_status.py` — no drift · `check_planning_integrity.py` — clean · `check_product_plan_governance.py` — clean
* Python import gate — passes
* `check_source_health.py` — 0 contract source-health errors

**Inertness on a healthy board:** rebuilt the current `main` contract before and after — 1108 rows, **0 changed values, 0 changed ranks, 0 changed provenance, 0 changed confidence bases**. The rung only fires where the blend produced nothing.

**Cross-validation:** the board-anchored derivation reproduces what the healthy vendor-anchored path produces for the same cells to within ~0.3% (2029 Early 2nd: 2710 vs 2703).

## Where this differs from #910

#910's rung completes a row **from the build's own recorded derivation record** (`basisName` + `factor` from the injection). That has a real virtue — value and provenance cannot disagree — and it fixes the observed incident.

Its precondition is that a derivation record exists, which means it only repairs rows the **injection created**. The injection no-ops for any year that already has *any* tier row. So the first time a vendor publishes **partial** coverage of the horizon year — exactly the shape `idpTradeCalc` had for 2027/2028 in the failing payload — no record is recorded and the rung cannot fire.

Measured, not asserted (probe: unpriced rounds 2–6 rows present, no derivation record, 2028 fully priced):

| | 2029 tier rows left unpriced | 2029 generic rows never built |
|---|---|---|
| #910 | **15** | **5** |
| this PR | 0 | 0 |

That case would fail the census exactly as the original incident did.

## Cross-lane effect

Currently red or re-running: **#911, #912, #913, #914, #915** (and any PR whose *Validate PR* job runs the structural contract lane). They are green again only because the 19:18 refresh healed the data — merging a fix is what prevents the next recurrence.

This PR touches no lane's surface: it changes one canonical function plus one closed-set entry, and no engine, route, or frontend behaviour. It does **not** touch the V1 completion percentage, the ledger, the denominator, or any lane's verification status.

Overlap check across open lane branches — only #910 and #914 touch these files at all, and #914's `data_contract.py` hunks are in `stamp_optimal_lineups` / `build_api_data_contract`, far from this function (no conflict expected).

## Merge order

1. **Claude 5 reviews and decides between this rung and #910's** — they are alternatives, not complements, and will conflict.
   * Recommended: keep the more general basis search (this PR) so partial future-year publication is covered, and fold in #910's provenance-consistency property if desired; or merge #910 and cherry-pick this PR's 12 invariant tests + the generality fix on top.
2. Merge only if independently validated.
3. Rebase and re-run the affected V1 lane PRs afterwards.

## Known limitations

* The deeper architectural issue is **not** fixed here and is named rather than papered over: synthetic far-future rows still cannot receive CSV-sourced voting values, so on a healthy board 2029 remains an `idpTradeCalc`-only blend. Making the injection see the enriched source population is a larger change with real blast radius on live 2029 values; this PR makes the *horizon guarantee* independent of it. Worth a follow-up unit.
* If a future tier **row does not exist at all** (the raw payload lacks that tier+round for the template year), neither this rung nor #910's can price it — there is nothing to reprice. That is a genuinely evidence-free state and would surface as a census failure, correctly.
* `derivedYearModel` and `derivedRoundModel` remain classification **PRIOR**; this PR does not change their calibration or promote either.
* No deployment or production verification is claimed — nothing here was observed on prod.

---
_Generated by [Claude Code](https://claude.ai/code/session_019tyheZCVKefBq6CcSB8Dxz)_