### PR TITLE
#804 capture: per-source rank observations in a new source_rank history lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ snapshots). This line said "Private repo" while `SECURITY.md` and
   Sleeper-login allowlist; public routes hit `/api/public/league/*`.
 - **Feature flags** (`src/api/feature_flags.py`): every new
   capability from the 2026-04 upgrade ships flag-gated. Defaults are
-  **per-flag**: 8 of the 16 in `_DEFAULTS` ship enabled (`bdvm_engine`,
+  **per-flag**: 8 of the 17 in `_DEFAULTS` ship enabled (`bdvm_engine`,
   `te_basis_conversion`, `monte_carlo_trade`, `idp_scoring_fit`,
   `reception_scoring_fit`, `nfl_data_ingest`, `realized_points_api`,
   `perfect_draft`),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,7 +26,7 @@ Browser ─► Nginx ─► Next.js (port 3000) ─► FastAPI (port 8000) ─�
    `src/api/feature_flags.py`. Env override via `RISKIT_FEATURE_<NAME>=1`
    (or `=0` to disable).
 
-   **Defaults are per-flag.** As of 2026-08-05, 8 of the 16 entries in
+   **Defaults are per-flag.** As of 2026-08-05, 8 of the 17 entries in
    `_DEFAULTS` ship enabled — `bdvm_engine`, `te_basis_conversion`
    (which reprices every tight end on the live board),
    `monte_carlo_trade`, `idp_scoring_fit`, `reception_scoring_fit`,

--- a/docs/history/SOURCE_RANK_CAPTURE.md
+++ b/docs/history/SOURCE_RANK_CAPTURE.md
@@ -1,0 +1,175 @@
+# #804 per-source rank capture (`source_rank` lane)
+
+**Owner module:** `src/history/source_rank.py` · **Lane:** `store.LANE_SOURCE_RANK`
+**Flag:** `RISKIT_FEATURE_SOURCE_RANK_CAPTURE` — **default OFF**
+**Status:** POST-V1 capture infrastructure. **Changes the V1 percentage by zero.**
+
+---
+
+## 1. What this is, and firmly what it is not
+
+**Capture only.** It records what each source ranked each asset, on each build,
+into the canonical temporal ledger. Nothing reads the lane.
+
+Explicitly **not** in this unit, and unauthorized until separately approved:
+correlation methodology, source-family assignment, family weighting, automatic
+downweighting, confidence changes, B10 logic, and any canonical value or
+ranking movement.
+
+## 2. Why the evidence has to be captured now
+
+#804 is about **correlated / shared-lineage source movement**: injected
+correlated anomalies moved the blend by as much as **~48%** while existing
+defenses caught nothing, because sources agreeing on something wrong is
+indistinguishable from agreement at the point of the blend.
+
+Deciding whether two sources are genuinely independent needs their observations
+**over time** — a correlation that holds every day is structural dependence;
+one that appears on a single board is noise. That series does not exist:
+
+| | |
+|---|---|
+| per-source rank maps published per build | **22–24** |
+| source boards preserved in any archive | **3** |
+| archive bundles carrying more than 3 | **0 of 176** |
+
+Every build that goes unrecorded is a day of evidence no later effort can
+reconstruct. That is the whole justification for capturing before the analysis
+that will use it is designed.
+
+## 3. Why a new lane, not `source_value`
+
+A rank is an ordering **position**; a value is a **price**. They share no units,
+are not convertible, and disagree about what "missing" means — a source can rank
+an asset it publishes no value for. A query that had to guess which quantity a
+row carried could answer neither question.
+
+`store._validate_source_rank` enforces the separation: a `source_rank`
+observation must carry an integer rank ≥ 1 and **may not carry a value at all**.
+
+## 4. What one build records
+
+One observation per (asset, source) the board says the source ranked:
+
+| field | meaning |
+|---|---|
+| `rank` | the **effective** rank — the comparable coordinate a later correlation is computed on |
+| `raw_rank` | what the source actually **published**, before ladder translation (a rookie board's #36 becomes #247 on the overall ladder — two different facts) |
+| `rank_method` | how the effective rank was derived (`direct`, a ladder translation, …) |
+| `rank_pool` | the coordinate pool; ranks from different pools are **not comparable** and must not be correlated |
+| `shared_market_translated` | whether the source was projected onto another market's backbone |
+| `source_key`, `asset_key`, `observed_date`, `observed_at`(+zone), `origin`, `scope`, `pipeline_version` | identity and provenance, inherited from the store |
+
+`shared_market_translated` is the most important field here. A source projected
+onto another market's backbone is correlated with that market **by
+construction** — an independence analysis that missed it would "discover" a
+correlation the pipeline itself created. Measured on one real board: **638 of
+7,245** observations carry it.
+
+### Missing is absence, never zero
+
+A source that did not rank an asset contributes **no row**. Not rank 0, not
+null, not a sentinel — the store refuses all three. Absence is the only encoding
+a later pass can read correctly, because rank 0 sorts first on every board.
+Booleans are refused too (`True` is an `int` in Python and would store as
+rank 1).
+
+## 5. Guarantees, inherited rather than reimplemented
+
+The lane rides the existing store, so it gets these for free and cannot drift
+from them:
+
+- **append-only** — `INSERT OR IGNORE`; a conflicting re-record is *surfaced*
+  and never applied, so a stored observation is never overwritten;
+- **idempotent** — re-recording a build is a counted no-op (7,245 written, then
+  7,245 duplicates / 0 conflicts on a real board);
+- **`HISTORY_FLOOR`** — a pre-2026-07-14 observation is refused as fabricated;
+- **never-future** — `asof` selection is lane-parameterised, so a future
+  observation is structurally unselectable;
+- **tz-aware `observed_at`** — through `record.contract_observed_instant`, the
+  one owner of "when did this board happen", shared with the canonical lane so
+  the two cannot drift into two definitions. A date-only stamp is **no instant**
+  rather than midnight.
+
+## 6. Non-influence — proven, not asserted
+
+Same pinned input export on both sides; **code as the only variable**:
+
+```
+python scripts/golden_board.py --input pinned_input.json --out before.json   # origin/main
+python scripts/golden_board.py --input pinned_input.json --out after.json    # this branch
+python scripts/board_diff.py before.json after.json --expect-no-value-change
+```
+
+```
+rows 1108 -> 1108 · ranked 740 -> 740 · priced 849 -> 849 · picks 162 · idp 396
+VALUES: 0 moved, 0 newly priced, 0 newly unpriced
+RANKS:  0 changed
+ASSERTION OK: no value changed.
+```
+
+The two captures are **byte-identical** (`sha256 c1b9cde42f30021f` both sides).
+
+Structurally reinforced by tests: no valuation or weighting module imports the
+lane, the only production importer is the fresh-scrape call site in `server.py`,
+the capture module imports no pricing module, and building observations does not
+mutate the contract.
+
+## 7. Storage — measured before proposing production
+
+Measured on a real board (`dynasty_export_20260818_230211`), post-`VACUUM`,
+minus the empty-schema baseline:
+
+| | |
+|---|---|
+| observations per build | **7,245** across **21** sources |
+| bytes per observation | **446 B** |
+| builds/day (2-hourly scrape) | 12 |
+| rows/day | **86,940** |
+| **bytes/day** | **38.8 MB** |
+| 30 days | ~1.16 GB (2.61 M rows) |
+| 90 days | ~3.49 GB (7.82 M rows) |
+| 1 year | **~14.2 GB** (31.7 M rows) |
+
+**The cost is index overhead on the shared `observations` table, not payload.**
+Stripping every denormalized string (`display_name`, `position`, `player_id`,
+`scope`) saves only **4–7%** — 446 → 414 B/row. There is no cheap win in the row
+shape.
+
+### Cadence is the real lever
+
+| cadence | builds/day | bytes/day | 1 year |
+|---|---|---|---|
+| every scrape (2-hourly) | 12 | 38.8 MB | ~14.2 GB |
+| every 6 hours | 4 | 12.9 MB | ~4.7 GB |
+| daily | 1 | 3.2 MB | ~1.2 GB |
+
+Correlation between sources is a question about *days*, not hours, so a daily
+capture very likely answers #804 at ~8% of the storage. **That is a judgement
+for the owner, not a decision this unit takes** — which is exactly why the flag
+ships OFF.
+
+### Retention concern, named and not acted on
+
+At 2-hourly cadence the ledger would outgrow a modest VPS disk within a year,
+and `data/temporal_ledger.sqlite` is covered by `riskit-state-backup.sh`, so
+backup size grows with it. **No retention or compaction policy is proposed
+here** — inventing a destructive one is explicitly unauthorized. The options an
+owner has (reduced cadence, a compaction pass, per-source sampling) are recorded
+so the decision can be made with numbers rather than guesses.
+
+## 8. Enabling it
+
+```
+RISKIT_FEATURE_SOURCE_RANK_CAPTURE=1   # and restart; flag reads are cached
+```
+
+Off, the fresh-scrape path records nothing and no response body differs. On, it
+writes the lane and logs `source_rank_capture: recorded N observations across M
+sources`. No response changes either way — that is what capture-only means.
+
+## 9. Verification
+
+```bash
+python -m pytest tests/history -q          # 84 tests incl. the full capture suite
+```

--- a/server.py
+++ b/server.py
@@ -77,6 +77,7 @@ from src.api import guest_passes as _guest_passes
 from src.api import rank_history as _rank_history
 from src.api import source_history as _source_history
 from src.history import record as _history_record
+from src.history import source_rank as _history_source_rank
 from src.api import push_delivery as _push_delivery
 from src.api import signal_alerts as _signal_alerts
 from src.api import terminal as _terminal
@@ -2442,6 +2443,29 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
                     )
                 except Exception as inner_exc:  # noqa: BLE001
                     log.warning("temporal_ledger: record failed: %s", inner_exc)
+                # #804 per-source RANK capture into the same canonical
+                # ledger, in its own ``source_rank`` lane.  CAPTURE ONLY:
+                # nothing reads the lane, and this call cannot influence
+                # the contract — it runs AFTER the payload is built and
+                # only ever writes.  Default OFF; the flag exists because
+                # the lane costs ~38.8 MB/day at this cadence, which is an
+                # owner's disk decision, not a code one.  Isolated like
+                # its siblings so a capture failure cannot nuke them.
+                from src.api import feature_flags as _ff_capture  # noqa: PLC0415
+
+                if _ff_capture.is_enabled("source_rank_capture"):
+                    try:
+                        rank_result = _history_source_rank.record_source_ranks(contract_payload)
+                        log.info(
+                            "source_rank_capture: recorded %d observations "
+                            "across %d sources for %s (%d duplicate)",
+                            rank_result.get("written", 0),
+                            rank_result.get("distinctSources", 0),
+                            rank_result.get("boardDate"),
+                            rank_result.get("duplicates", 0),
+                        )
+                    except Exception as inner_exc:  # noqa: BLE001
+                        log.warning("source_rank_capture: record failed: %s", inner_exc)
             stamped = _rank_history.stamp_contract_with_history(contract_payload)
             if stamped:
                 log.info("rank_history: stamped %d rows with history series", stamped)

--- a/src/api/feature_flags.py
+++ b/src/api/feature_flags.py
@@ -66,6 +66,21 @@ _DEFAULTS: Final[dict[str, bool]] = {
     # gated it.  OFF so the registry stops reporting a switch that does
     # not exist; the mapper itself is unaffected either way.
     "unified_id_mapper": False,
+    # #804 per-source RANK capture into the canonical temporal ledger
+    # (src/history/source_rank.py).  CAPTURE ONLY — it writes a new
+    # ``source_rank`` lane and nothing reads it; no weighting, no
+    # correlation scoring, no canonical value or ranking movement.
+    #
+    # DEFAULT OFF, and the reason is storage rather than risk.  Measured
+    # on a real board: 7,245 observations per build across 21 sources at
+    # ~446 B/row (index overhead on the shared observations table, not
+    # payload — stripping every denormalized string saves only 4-7%).
+    # At the 2-hourly scrape that is ~38.8 MB/day and ~14.2 GB/year, which
+    # is a production disk commitment an owner has to make deliberately.
+    # Enable with RISKIT_FEATURE_SOURCE_RANK_CAPTURE=1 once a cadence and
+    # a retention posture are chosen; see
+    # docs/history/SOURCE_RANK_CAPTURE.md for the per-cadence table.
+    "source_rank_capture": False,
     # Phase 2 — nfl_data_py pipeline
     # Activated with the 2026-04-25 deploy that adds nfl_data_py to
     # requirements.txt.  Safe: every fetch is guarded so an import
@@ -414,6 +429,11 @@ UNREACHABLE: Final[str] = "UNREACHABLE"
 NO_GATE: Final[str] = "NO_GATE"
 
 _GATE_STATUS: Final[dict[str, str]] = {
+    # source_rank_capture gates a WRITE, not a response: on, the
+    # fresh-scrape path records per-source ranks into the temporal
+    # ledger; off, it records nothing.  No response body changes either
+    # way, which is the point of a capture-only unit.
+    "source_rank_capture": LIVE,
     # ── Reachable from server.py; toggling changes a response ──
     "nfl_data_ingest": LIVE,
     "realized_points_api": LIVE,

--- a/src/history/record.py
+++ b/src/history/record.py
@@ -85,6 +85,32 @@ def contract_board_date(contract: dict[str, Any]) -> str:
     return datetime.now(timezone.utc).date().isoformat()
 
 
+def contract_observed_instant(contract: dict[str, Any]) -> tuple[str | None, str | None]:
+    """``(observed_at, zone)`` for one board — the ONE reading of the
+    producer's instant claim, shared by every lane that records from a
+    contract.
+
+    ``scrapeTimestamp`` is tz-aware UTC as of audit F-28, so live rows
+    record ``zone="utc"`` on the producer's own statement rather than on
+    an assumption about the host.
+
+    The naive branch survives for LEGACY payloads (committed archives, a
+    board left on disk by an older scraper), and for those the stamp's
+    zone is genuinely unrecorded — which is why it is stamped "naive"
+    instead of being silently normalized to UTC.  The distinction is
+    load-bearing: rows written before F-28 by the production VPS are two
+    hours ahead of the instant they claim, and the zone column is what
+    makes that recoverable rather than invisible.  This is an append-only
+    store, so those rows are not rewritten; a correction, if one is ever
+    authorized, is an explicit correction row.
+    """
+    observed_at = str(contract.get("scrapeTimestamp") or "") or None
+    if not observed_at:
+        return None, None
+    zone = "utc" if ("+" in observed_at or observed_at.endswith("Z")) else "naive"
+    return observed_at, zone
+
+
 def observations_from_contract(
     contract: dict[str, Any],
     *,
@@ -99,23 +125,7 @@ def observations_from_contract(
     """
     rows = _players_array(contract)
     date_s = observed_date or contract_board_date(contract)
-    observed_at = str(contract.get("scrapeTimestamp") or "") or None
-    # ``scrapeTimestamp`` is tz-aware UTC as of audit F-28, so live rows
-    # record ``zone="utc"`` on the producer's own statement rather than on
-    # an assumption about the host.
-    #
-    # The naive branch survives for LEGACY payloads (committed archives, a
-    # board left on disk by an older scraper), and for those the stamp's
-    # zone is genuinely unrecorded — which is why it is stamped "naive"
-    # here instead of being silently normalized to UTC.  The distinction is
-    # load-bearing: rows written before F-28 by the production VPS are two
-    # hours ahead of the instant they claim, and the zone column is what
-    # makes that recoverable rather than invisible.  This is an append-only
-    # store, so those rows are not rewritten; a correction, if one is ever
-    # authorized, is an explicit correction row.
-    zone = None
-    if observed_at:
-        zone = "utc" if ("+" in observed_at or observed_at.endswith("Z")) else "naive"
+    observed_at, zone = contract_observed_instant(contract)
     pv = pipeline_version(contract)
     scope = None
     meta = contract.get("meta")

--- a/src/history/source_rank.py
+++ b/src/history/source_rank.py
@@ -1,0 +1,209 @@
+"""Per-source RANK capture — the #804 longitudinal observation lane.
+
+CAPTURE ONLY.  Nothing here scores, weights, downweights, groups sources
+into families, or touches a published number.  Correlation methodology
+and any use of the series are POST-V1 and unauthorized; this unit exists
+so that when they are authorized there is something to analyse, because
+the evidence is otherwise destroyed on every scrape.
+
+WHY THIS LANE EXISTS
+────────────────────
+#804 is about **correlated / shared-lineage source movement**: injected
+correlated anomalies moved the blend by as much as ~48% without existing
+defenses catching them, because sources agreeing on something wrong is
+indistinguishable from agreement at the point of the blend.
+
+Deciding whether two sources are genuinely independent needs their
+observations OVER TIME — a correlation that holds every day is structural
+dependence; one that appears on a single board is noise.  The platform
+publishes 22-24 per-source rank maps on every build and retains none of
+them: measured 2026-08-18, 24 source boards exist live and exactly 3 are
+preserved in any archive, across 0 of 176 bundles.  Every build that goes
+unrecorded is a day of evidence no later effort can reconstruct.
+
+WHY A NEW LANE AND NOT ``source_value``
+───────────────────────────────────────
+A rank is an ordering POSITION; a value is a PRICE.  They are not
+convertible, they do not share units, and a query that had to guess which
+one a row carried would be unable to answer either question.  The two
+also disagree about what "missing" means: a source can rank an asset it
+publishes no value for, and vice versa.
+
+WHAT ONE BUILD CONTRIBUTES
+──────────────────────────
+One observation per (asset, source) that the board says the source ranked:
+
+* ``rank``                     the EFFECTIVE rank — the comparable
+                               coordinate a later correlation is computed on;
+* ``raw_rank``                 what the source actually PUBLISHED, before
+                               ladder translation (a rookie board's #36
+                               becomes #247 on the overall ladder — the
+                               two are different facts and both matter);
+* ``rank_method`` / ``rank_pool`` / ``shared_market_translated``
+                               the lineage.  ``shared_market_translated``
+                               is the single most important field here: a
+                               source projected onto another market's
+                               backbone is correlated with that market BY
+                               CONSTRUCTION, and an independence analysis
+                               that missed it would "discover" a
+                               correlation the pipeline itself created.
+
+MISSING IS ABSENCE, NEVER ZERO
+──────────────────────────────
+A source that did not rank an asset contributes NO ROW.  It does not
+contribute rank 0, rank null, or a sentinel — the store refuses all three
+(``store._validate_source_rank``).  Absence is the only encoding a later
+pass can read correctly, because rank 0 would sort first on every board.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from src.history import keys, record, store
+from src.history.provenance import pipeline_version
+
+ORIGIN_LIVE = "live:server"
+
+
+def _effective_rank(value: Any) -> int | None:
+    """A published ordering position, or ``None``.
+
+    Bools are excluded explicitly (``True`` is an ``int`` in Python and
+    would otherwise store as rank 1), and anything below 1 is refused
+    here as well as at the store — a rank of 0 is not a position.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    as_int = int(value)
+    return as_int if as_int >= 1 else None
+
+
+def _raw_rank(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value) if value > 0 else None
+
+
+def observations_from_contract(
+    contract: dict[str, Any],
+    *,
+    origin: str = ORIGIN_LIVE,
+    observed_date: str | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Build ``source_rank`` observations for one canonical contract.
+
+    Returns ``(observations, summary)``.  The summary counts rows the key
+    layer could not resolve and rows that carried no per-source rank map
+    at all — never silently dropped, never guessed.
+    """
+    rows = record._players_array(contract)
+    date_s = observed_date or record.contract_board_date(contract)
+    observed_at, zone = record.contract_observed_instant(contract)
+    pv = pipeline_version(contract)
+
+    scope_default = None
+    meta_block = contract.get("meta")
+    if isinstance(meta_block, dict):
+        scope_default = meta_block.get("scoringFingerprint") or None
+
+    out: list[dict[str, Any]] = []
+    unresolved = 0
+    without_ranks = 0
+    sources_seen: set[str] = set()
+
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        ranks = row.get("sourceRanks")
+        if not isinstance(ranks, dict) or not ranks:
+            without_ranks += 1
+            continue
+        keyed = keys.asset_key_for_contract_row(row)
+        if keyed is None:
+            unresolved += 1
+            continue
+        asset_key, asset_class = keyed
+
+        raw_ranks = row.get("sourceOriginalRanks")
+        raw_ranks = raw_ranks if isinstance(raw_ranks, dict) else {}
+        rank_meta = row.get("sourceRankMeta")
+        rank_meta = rank_meta if isinstance(rank_meta, dict) else {}
+
+        base = {
+            "asset_key": asset_key,
+            "asset_class": asset_class,
+            "observed_date": date_s,
+            "observed_at": observed_at,
+            "observed_at_zone": zone,
+            "display_name": str(row.get("displayName") or row.get("canonicalName") or "") or None,
+            "position": str(row.get("position") or "") or None,
+            "player_id": str(row.get("playerId") or "") or None,
+            "pipeline_version": pv,
+            "origin": origin,
+        }
+
+        for source_key, published in ranks.items():
+            skey = str(source_key or "").strip()
+            if not skey:
+                continue
+            effective = _effective_rank(published)
+            if effective is None:
+                # The source did not rank this asset on this board.  No row:
+                # absence is the honest encoding, and rank 0 would sort first.
+                continue
+            meta = rank_meta.get(skey)
+            meta = meta if isinstance(meta, dict) else {}
+            translated = meta.get("sharedMarketTranslated")
+            out.append(
+                {
+                    **base,
+                    "lane": store.LANE_SOURCE_RANK,
+                    "source_key": skey,
+                    "value": None,
+                    "rank": effective,
+                    "tier": None,
+                    "confidence": None,
+                    "scope": str(meta.get("scope") or "") or scope_default,
+                    "raw_rank": _raw_rank(raw_ranks.get(skey)),
+                    "rank_method": str(meta.get("method") or "") or None,
+                    "rank_pool": str(meta.get("rankCoordinatePool") or "") or None,
+                    "shared_market_translated": (
+                        None if translated is None else int(bool(translated))
+                    ),
+                }
+            )
+            sources_seen.add(skey)
+
+    summary = {
+        "boardDate": date_s,
+        "rows": len(rows),
+        "rankObservations": len(out),
+        "distinctSources": len(sources_seen),
+        "unresolved": unresolved,
+        "rowsWithoutRanks": without_ranks,
+        "pipelineVersion": pv,
+    }
+    return out, summary
+
+
+def record_source_ranks(
+    contract: dict[str, Any],
+    *,
+    path: Path | None = None,
+    origin: str = ORIGIN_LIVE,
+    observed_date: str | None = None,
+) -> dict[str, Any]:
+    """Record one build's per-source ranks into the canonical ledger.
+
+    Append-only and idempotent, inherited wholesale from
+    ``store.write_observations``: re-recording the same build is a counted
+    no-op because the scrape instant is part of the observation identity.
+    """
+    observations, summary = observations_from_contract(
+        contract, origin=origin, observed_date=observed_date
+    )
+    result = store.write_observations(observations, path=path)
+    result.update(summary)
+    return result

--- a/src/history/store.py
+++ b/src/history/store.py
@@ -70,7 +70,7 @@ from src.history.keys import is_valid_asset_key
 
 DB_PATH: Path = Path(__file__).resolve().parents[2] / "data" / "temporal_ledger.sqlite"
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 # The permanent history boundary.  Retained evidence starts here; the
 # gap before it is PERMANENT and is represented as missing, never
@@ -82,7 +82,13 @@ HISTORY_FLOOR: str = "2026-07-14"
 LANE_CANONICAL = "canonical_board"
 LANE_SOURCE = "source_value"
 LANE_SCRAPER = "scraper_blend"
-VALID_LANES = frozenset({LANE_CANONICAL, LANE_SOURCE, LANE_SCRAPER})
+#: Per-source RANK observations (#804 capture unit).  Deliberately NOT
+#: ``source_value``: a rank is an ordering position and a value is a price,
+#: they are not convertible, and storing one under the other's lane would
+#: make every later query ask a question it cannot answer.  Capture only —
+#: no consumer, no weighting, no influence on any published number.
+LANE_SOURCE_RANK = "source_rank"
+VALID_LANES = frozenset({LANE_CANONICAL, LANE_SOURCE, LANE_SCRAPER, LANE_SOURCE_RANK})
 
 # Deterministic cross-origin preference for queries: when the same
 # fact was recorded by more than one producer, the earlier entry in
@@ -124,7 +130,31 @@ CREATE TABLE IF NOT EXISTS observations (
     pipeline_version TEXT,
     origin           TEXT NOT NULL,
     recorded_at      TEXT NOT NULL,
-    content_hash     TEXT NOT NULL
+    content_hash     TEXT NOT NULL,
+    -- ── source_rank lane extension (#804 capture) ──────────────────
+    -- Nullable and unused by every other lane.  They exist because the
+    -- question #804 must be able to ask later — "do these two sources
+    -- move together, and are they even independent?" — is unanswerable
+    -- from an effective rank alone.
+    --
+    -- raw_rank                 what the source PUBLISHED, before ladder
+    --                          translation.  REAL because vendor ranks
+    --                          are not always integral (a translated
+    --                          rookie board lands on 39.86).
+    -- rank_method              how the effective rank was derived
+    --                          ("direct", a ladder translation, ...).
+    -- rank_pool                the coordinate pool the effective rank
+    --                          lives in; ranks from different pools are
+    --                          not comparable and must not be correlated.
+    -- shared_market_translated whether this source was projected onto
+    --                          another market's backbone — which is
+    --                          shared lineage BY CONSTRUCTION and the
+    --                          single most important thing a later
+    --                          independence analysis needs to know.
+    raw_rank                 REAL,
+    rank_method              TEXT,
+    rank_pool                TEXT,
+    shared_market_translated INTEGER
 );
 
 -- Identity uniqueness lives in an EXPRESSION index rather than an
@@ -153,6 +183,28 @@ CREATE TABLE IF NOT EXISTS corrections (
 """
 
 
+#: Columns added after the first shipped schema.  ``CREATE TABLE IF NOT
+#: EXISTS`` cannot add a column to a table that already exists, so an
+#: already-deployed ledger needs an explicit, idempotent ALTER — without
+#: this the new lane would insert into columns that are not there.
+_EXTENSION_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("raw_rank", "REAL"),
+    ("rank_method", "TEXT"),
+    ("rank_pool", "TEXT"),
+    ("shared_market_translated", "INTEGER"),
+)
+
+
+def _apply_column_extensions(conn: sqlite3.Connection) -> None:
+    """Add any missing extension column.  Additive only — this never
+    drops, renames or rewrites a column, so it cannot touch a recorded
+    observation."""
+    present = {row[1] for row in conn.execute("PRAGMA table_info(observations)")}
+    for name, decl in _EXTENSION_COLUMNS:
+        if name not in present:
+            conn.execute(f"ALTER TABLE observations ADD COLUMN {name} {decl}")
+
+
 def _ensure_schema(path: Path) -> None:
     key = str(path)
     if _SETUP_DONE.get(key):
@@ -166,6 +218,7 @@ def _ensure_schema(path: Path) -> None:
             conn.execute("PRAGMA journal_mode=WAL;")
             conn.execute("PRAGMA synchronous=NORMAL;")
             conn.executescript(_SCHEMA)
+            _apply_column_extensions(conn)
             conn.execute(
                 "INSERT OR REPLACE INTO meta(key, value) VALUES ('schema_version', ?)",
                 (str(SCHEMA_VERSION),),
@@ -215,7 +268,26 @@ _IDENTITY_FIELDS = (
     "origin",
 )
 
-_ALL_FIELDS = _IDENTITY_FIELDS + ("asset_class", "observed_at_zone") + _CONTENT_FIELDS
+#: Content carried only by the ``source_rank`` lane.  Kept OUT of
+#: :data:`_CONTENT_FIELDS` on purpose: ``content_hash`` folds these in only
+#: when they are actually present, so an observation from any pre-existing
+#: lane hashes to exactly the byte it hashed to before this lane existed.
+#: Without that, every already-stored row would re-ingest as a content
+#: CONFLICT instead of a duplicate, and backfill/migration idempotency —
+#: which the whole store is built on — would break on contact.
+_EXTENDED_CONTENT_FIELDS = (
+    "raw_rank",
+    "rank_method",
+    "rank_pool",
+    "shared_market_translated",
+)
+
+_ALL_FIELDS = (
+    _IDENTITY_FIELDS
+    + ("asset_class", "observed_at_zone")
+    + _CONTENT_FIELDS
+    + _EXTENDED_CONTENT_FIELDS
+)
 
 
 def content_hash(obs: dict[str, Any]) -> str:
@@ -226,6 +298,12 @@ def content_hash(obs: dict[str, Any]) -> str:
     path must surface rather than resolve silently.
     """
     payload = {k: obs.get(k) for k in _CONTENT_FIELDS}
+    # Present-only, so the hash of a row from any other lane is unchanged
+    # by this lane's existence.  See ``_EXTENDED_CONTENT_FIELDS``.
+    for key in _EXTENDED_CONTENT_FIELDS:
+        extra = obs.get(key)
+        if extra is not None:
+            payload[key] = extra
     blob = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
 
@@ -308,6 +386,37 @@ def validate_observation(obs: dict[str, Any]) -> None:
         raise ObservationError("origin is required")
     if obs.get("value") is None and obs.get("rank") is None:
         raise ObservationError("observation carries neither value nor rank")
+    if lane == LANE_SOURCE_RANK:
+        _validate_source_rank(obs)
+
+
+def _validate_source_rank(obs: dict[str, Any]) -> None:
+    """Extra guards the rank lane needs and the value lanes do not.
+
+    MISSING RANK IS NOT RANK ZERO, and it is not rank anything.  A source
+    that did not rank an asset contributes NO ROW — absence is the honest
+    encoding, and it is the only one a later correlation pass can read
+    correctly.  So a rank of 0, a negative rank, or a null rank is refused
+    outright rather than stored as a position on a board.
+    """
+    if not str(obs.get("source_key") or "").strip():
+        raise ObservationError("source_rank observation requires a source_key")
+    rank = obs.get("rank")
+    if not isinstance(rank, int) or isinstance(rank, bool):
+        raise ObservationError(f"source_rank requires an integer rank, got {rank!r}")
+    if rank < 1:
+        raise ObservationError(
+            f"source_rank requires rank >= 1, got {rank!r} — a missing rank is an "
+            "absent row, never position zero"
+        )
+    if obs.get("value") is not None:
+        raise ObservationError(
+            "source_rank carries a rank, never a value — a rank is an ordering "
+            "position and a value is a price; use the source_value lane"
+        )
+    raw = obs.get("raw_rank")
+    if raw is not None and (not isinstance(raw, (int, float)) or raw <= 0):
+        raise ObservationError(f"raw_rank must be a positive number when present, got {raw!r}")
 
 
 _INSERT = (

--- a/tests/history/test_source_rank_capture.py
+++ b/tests/history/test_source_rank_capture.py
@@ -1,0 +1,491 @@
+"""#804 per-source rank CAPTURE — the lane, and the guarantees it inherits.
+
+Capture only.  These tests pin what is recorded and, just as importantly,
+that recording it changes nothing: no consumer, no weighting, no canonical
+value or ranking movement.  Correlation methodology is POST-V1 and
+unauthorized; nothing here computes one.
+"""
+
+from __future__ import annotations
+
+import ast
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from src.history import asof, record, source_rank, store
+from src.utils.config_loader import repo_root
+
+
+@pytest.fixture
+def ledger(tmp_path):
+    return tmp_path / "temporal.sqlite"
+
+
+def contract(
+    *,
+    date="2026-08-18",
+    scraped="2026-08-18T23:02:11.345069+00:00",
+    ranks=None,
+    raw=None,
+    meta=None,
+):
+    row = {
+        "displayName": "Test Player",
+        "position": "WR",
+        "playerId": "5859",
+        "sourceRanks": ranks if ranks is not None else {"ktcSfTep": 12, "dlfSf": 15},
+        "sourceOriginalRanks": raw if raw is not None else {"dlfSf": 15.4},
+        "sourceRankMeta": meta
+        if meta is not None
+        else {
+            "ktcSfTep": {
+                "scope": "overall_offense",
+                "method": "direct",
+                "rankCoordinatePool": "offense",
+                "sharedMarketTranslated": False,
+            },
+            "dlfSf": {
+                "scope": "overall_offense",
+                "method": "ladder",
+                "rankCoordinatePool": "offense",
+                "sharedMarketTranslated": True,
+            },
+        },
+    }
+    return {
+        "date": date,
+        "scrapeTimestamp": scraped,
+        "playersArray": [row],
+        "meta": {"scoringFingerprint": "sf-abc"},
+    }
+
+
+def _imported_modules(path: Path) -> set[str]:
+    """Fully-qualified module names imported by ``path``.
+
+    ``from src.history import source_rank`` and
+    ``import src.history.source_rank`` both normalise to the same string, so
+    a caller can test one thing instead of two shapes.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError):
+        return set()
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            found.add(mod)
+            found.update(f"{mod}.{a.name}" for a in node.names)
+        elif isinstance(node, ast.Import):
+            found.update(a.name for a in node.names)
+    return found
+
+
+def rows_in(ledger, lane=store.LANE_SOURCE_RANK):
+    conn = store.connect(ledger)
+    try:
+        return [
+            dict(r)
+            for r in conn.execute(
+                "SELECT * FROM observations WHERE lane=? ORDER BY source_key", (lane,)
+            )
+        ]
+    finally:
+        conn.close()
+
+
+# ── The lane exists, and is not source_value ─────────────────────────
+
+
+class TestTheLaneIsItsOwnQuantity:
+    def test_the_lane_is_registered_and_distinct(self):
+        assert store.LANE_SOURCE_RANK == "source_rank"
+        assert store.LANE_SOURCE_RANK in store.VALID_LANES
+        assert store.LANE_SOURCE_RANK != store.LANE_SOURCE
+
+    def test_a_rank_observation_may_not_carry_a_value(self, ledger):
+        """A rank is an ordering position; a value is a price.  Storing one
+        under the other makes the series unreadable later."""
+        obs = {
+            "asset_key": "player:1",
+            "asset_class": "player",
+            "lane": store.LANE_SOURCE_RANK,
+            "source_key": "dlfSf",
+            "observed_date": "2026-08-18",
+            "origin": "test",
+            "rank": 5,
+            "value": 4200.0,
+        }
+        result = store.write_observations([obs], path=ledger)
+        assert result["written"] == 0
+        assert "never a value" in result["rejected"][0]["reason"]
+
+    def test_capture_writes_only_into_its_own_lane(self, ledger):
+        source_rank.record_source_ranks(contract(), path=ledger, origin="test")
+        conn = store.connect(ledger)
+        try:
+            lanes = {r[0] for r in conn.execute("SELECT DISTINCT lane FROM observations")}
+        finally:
+            conn.close()
+        assert lanes == {store.LANE_SOURCE_RANK}
+
+
+# ── Missing is absence, never zero ───────────────────────────────────
+
+
+class TestMissingRankIsNeverZero:
+    @pytest.mark.parametrize("bad", [0, -1, -99])
+    def test_a_nonpositive_rank_is_refused(self, ledger, bad):
+        obs = {
+            "asset_key": "player:1",
+            "asset_class": "player",
+            "lane": store.LANE_SOURCE_RANK,
+            "source_key": "dlfSf",
+            "observed_date": "2026-08-18",
+            "origin": "test",
+            "rank": bad,
+        }
+        result = store.write_observations([obs], path=ledger)
+        assert result["written"] == 0
+        assert "never position zero" in result["rejected"][0]["reason"]
+
+    def test_a_source_that_did_not_rank_contributes_no_row(self, ledger):
+        """Absence is the encoding.  Rank 0 would sort first on every board."""
+        source_rank.record_source_ranks(
+            contract(ranks={"ktcSfTep": 12, "dlfSf": None, "fantasyCalc": 0}),
+            path=ledger,
+            origin="test",
+        )
+        assert {r["source_key"] for r in rows_in(ledger)} == {"ktcSfTep"}
+
+    def test_a_missing_raw_rank_stays_null_not_zero(self, ledger):
+        source_rank.record_source_ranks(contract(raw={}), path=ledger, origin="test")
+        assert all(r["raw_rank"] is None for r in rows_in(ledger))
+
+    def test_a_bool_is_not_a_rank(self, ledger):
+        """``True`` is an ``int`` in Python and would store as rank 1."""
+        source_rank.record_source_ranks(
+            contract(ranks={"ktcSfTep": True, "dlfSf": 15}), path=ledger, origin="test"
+        )
+        assert {r["source_key"] for r in rows_in(ledger)} == {"dlfSf"}
+
+
+# ── Provenance for a later independence analysis ─────────────────────
+
+
+class TestProvenance:
+    def test_source_identity_and_lineage_are_captured(self, ledger):
+        source_rank.record_source_ranks(contract(), path=ledger, origin="test")
+        by_source = {r["source_key"]: r for r in rows_in(ledger)}
+        assert set(by_source) == {"ktcSfTep", "dlfSf"}
+        dlf = by_source["dlfSf"]
+        assert dlf["rank"] == 15
+        assert dlf["raw_rank"] == pytest.approx(15.4)
+        assert dlf["rank_method"] == "ladder"
+        assert dlf["rank_pool"] == "offense"
+        assert dlf["scope"] == "overall_offense"
+
+    def test_shared_market_translation_is_recorded(self, ledger):
+        """The single most important lineage fact: a source projected onto
+        another market's backbone is correlated with it BY CONSTRUCTION, and
+        an analysis that missed it would 'discover' a correlation the
+        pipeline itself created."""
+        source_rank.record_source_ranks(contract(), path=ledger, origin="test")
+        by_source = {r["source_key"]: r for r in rows_in(ledger)}
+        assert by_source["dlfSf"]["shared_market_translated"] == 1
+        assert by_source["ktcSfTep"]["shared_market_translated"] == 0
+
+    def test_unknown_translation_stays_unknown(self, ledger):
+        source_rank.record_source_ranks(contract(meta={}), path=ledger, origin="test")
+        assert all(r["shared_market_translated"] is None for r in rows_in(ledger))
+
+    def test_the_raw_and_effective_ranks_are_both_kept(self, ledger):
+        """A rookie board's #36 becomes #247 on the overall ladder.  Those
+        are two different facts and correlation needs to know which it has."""
+        source_rank.record_source_ranks(
+            contract(
+                ranks={"dlfRookieSf": 247},
+                raw={"dlfRookieSf": 36.0},
+                meta={"dlfRookieSf": {"method": "ladder"}},
+            ),
+            path=ledger,
+            origin="test",
+        )
+        row = rows_in(ledger)[0]
+        assert (row["rank"], row["raw_rank"]) == (247, 36.0)
+
+    def test_the_board_identity_travels_with_every_row(self, ledger):
+        source_rank.record_source_ranks(contract(), path=ledger, origin="test")
+        for row in rows_in(ledger):
+            assert row["observed_date"] == "2026-08-18"
+            assert row["observed_at"] == "2026-08-18T23:02:11.345069+00:00"
+            assert row["origin"] == "test"
+            assert row["asset_key"] == "player:5859"
+
+
+# ── Timezone awareness ───────────────────────────────────────────────
+
+
+class TestObservedAtIsTimezoneAware:
+    def test_a_tz_aware_scrape_stamp_records_utc(self, ledger):
+        source_rank.record_source_ranks(contract(), path=ledger, origin="test")
+        row = rows_in(ledger)[0]
+        assert row["observed_at_zone"] == "utc"
+        assert datetime.fromisoformat(row["observed_at"]).tzinfo is not None
+
+    def test_a_naive_stamp_is_recorded_as_naive_not_assumed_utc(self, ledger):
+        source_rank.record_source_ranks(
+            contract(scraped="2026-08-18T23:02:11"), path=ledger, origin="test"
+        )
+        assert rows_in(ledger)[0]["observed_at_zone"] == "naive"
+
+    def test_a_date_only_stamp_is_no_instant_at_all(self, ledger):
+        """A date-only string parses as midnight and would lexicographically
+        precede every instant of its own day — promoting an UNKNOWN scrape
+        time to 'provably at-or-before any moment today'."""
+        source_rank.record_source_ranks(contract(scraped="2026-08-18"), path=ledger, origin="test")
+        row = rows_in(ledger)[0]
+        assert row["observed_at"] is None and row["observed_at_zone"] is None
+
+    def test_the_instant_rule_has_one_owner(self, ledger):
+        """Both lanes read the producer's instant through the same helper,
+        so they cannot drift into two definitions of 'when'."""
+        assert source_rank.record.contract_observed_instant is record.contract_observed_instant
+
+
+# ── Inherited store guarantees ───────────────────────────────────────
+
+
+class TestAppendOnlyAndIdempotent:
+    def test_recording_the_same_build_twice_writes_nothing_new(self, ledger):
+        first = source_rank.record_source_ranks(contract(), path=ledger, origin="test")
+        second = source_rank.record_source_ranks(contract(), path=ledger, origin="test")
+        assert first["written"] == 2
+        assert second["written"] == 0
+        assert second["duplicates"] == 2
+        assert second["contentConflicts"] == []
+
+    def test_two_scrapes_on_one_date_are_two_observations(self, ledger):
+        source_rank.record_source_ranks(contract(), path=ledger, origin="test")
+        source_rank.record_source_ranks(
+            contract(scraped="2026-08-18T23:59:00+00:00", ranks={"ktcSfTep": 13}),
+            path=ledger,
+            origin="test",
+        )
+        assert len(rows_in(ledger)) == 3
+
+    def test_a_changed_rank_at_the_same_identity_is_surfaced_not_applied(self, ledger):
+        """Append-only: a conflicting re-record never overwrites."""
+        source_rank.record_source_ranks(contract(), path=ledger, origin="test")
+        result = source_rank.record_source_ranks(
+            contract(ranks={"ktcSfTep": 99, "dlfSf": 15}), path=ledger, origin="test"
+        )
+        assert result["written"] == 0
+        assert len(result["contentConflicts"]) == 1
+        stored = {r["source_key"]: r["rank"] for r in rows_in(ledger)}
+        assert stored["ktcSfTep"] == 12, "the stored observation must be untouched"
+
+    def test_no_update_or_delete_reaches_the_store(self):
+        """Structural: the write path issues only INSERT."""
+        src = (repo_root() / "src" / "history" / "source_rank.py").read_text(encoding="utf-8")
+        lowered = src.lower()
+        for forbidden in ("update ", "delete ", "drop ", "alter "):
+            assert forbidden not in lowered, f"{forbidden!r} in the capture module"
+
+
+class TestHistoryFloorAndNeverFuture:
+    def test_an_observation_before_the_floor_is_refused(self, ledger):
+        result = source_rank.record_source_ranks(
+            contract(date="2026-07-13"), path=ledger, origin="test"
+        )
+        assert result["written"] == 0
+        assert "history floor" in result["rejected"][0]["reason"]
+
+    def test_a_future_observation_is_never_selected(self, ledger):
+        source_rank.record_source_ranks(contract(), path=ledger, origin="test")
+        answer = asof.value_as_of(
+            "player:5859",
+            "2026-08-17",
+            lane=store.LANE_SOURCE_RANK,
+            source_key="dlfSf",
+            path=ledger,
+        )
+        assert answer["fidelity"] == "unavailable"
+        assert answer.get("rank") is None
+
+    def test_an_at_or_before_observation_is_selected(self, ledger):
+        source_rank.record_source_ranks(contract(), path=ledger, origin="test")
+        answer = asof.value_as_of(
+            "player:5859",
+            "2026-08-19",
+            lane=store.LANE_SOURCE_RANK,
+            source_key="dlfSf",
+            path=ledger,
+        )
+        assert answer["fidelity"] != "unavailable"
+        assert answer["rank"] == 15
+
+
+# ── The capture must not touch anything ──────────────────────────────
+
+
+class TestNonInfluence:
+    def test_no_valuation_or_weighting_module_imports_the_rank_lane(self):
+        """No consumer edge may exist from rank history into anything that
+        decides a number.  Asserted structurally, because an accidental
+        import is exactly how a capture lane becomes an input.
+
+        An IMPORT EDGE, not a substring: ``source_ranks`` is a long-standing
+        local variable name in ``data_contract``, and matching text would
+        fail on code that has nothing to do with this lane.
+        """
+        roots = (
+            "src/api",
+            "src/canonical",
+            "src/trade",
+            "src/bdvm",
+            "src/league_intel",
+            "src/scoring",
+            "src/consensus_edge",
+        )
+        offenders = []
+        for root in roots:
+            for path in (repo_root() / root).rglob("*.py"):
+                for mod in _imported_modules(path):
+                    if mod.endswith("history.source_rank"):
+                        offenders.append(str(path.relative_to(repo_root())))
+        assert not offenders, f"rank-capture reached a decision module: {offenders}"
+
+    def test_the_only_importer_is_the_capture_call_site(self):
+        """Exactly one production importer — the fresh-scrape write in
+        server.py.  A second one is a consumer appearing."""
+        importers = []
+        for path in list((repo_root() / "src").rglob("*.py")) + [repo_root() / "server.py"]:
+            if path.name == "source_rank.py":
+                continue
+            if any(m.endswith("history.source_rank") for m in _imported_modules(path)):
+                importers.append(path.name)
+        assert importers == ["server.py"], f"unexpected importers: {importers}"
+
+    def test_the_capture_module_imports_nothing_that_prices_anything(self):
+        """The dependency arrow points one way: capture reads a finished
+        contract and writes.  It must not reach back into valuation."""
+        tree = ast.parse(
+            (repo_root() / "src" / "history" / "source_rank.py").read_text(encoding="utf-8")
+        )
+        imported = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module)
+            elif isinstance(node, ast.Import):
+                imported.update(a.name for a in node.names)
+        banned = {
+            "src.api.data_contract",
+            "src.canonical.player_valuation",
+            "src.trade.faab_engine",
+            "src.bdvm.market",
+        }
+        assert not (imported & banned), f"capture imports a pricing module: {imported & banned}"
+
+    def test_building_observations_does_not_mutate_the_contract(self):
+        import copy
+
+        payload = contract()
+        before = copy.deepcopy(payload)
+        source_rank.observations_from_contract(payload)
+        assert payload == before
+
+    def test_the_flag_is_off_by_default(self):
+        """~38.8 MB/day is a production disk commitment an owner makes
+        deliberately, not one a merge makes for them."""
+        from src.api import feature_flags
+
+        assert feature_flags._DEFAULTS["source_rank_capture"] is False
+
+
+class TestLegacyContentHashesAreUnchanged:
+    def test_adding_the_lane_did_not_change_any_existing_hash(self):
+        """The new columns are folded into ``content_hash`` only when
+        present.  Without that, every already-stored row would re-ingest as
+        a CONFLICT instead of a duplicate and the store's idempotency —
+        which backfill and the migrations are built on — would break."""
+        legacy = {
+            "value": 4200.0,
+            "rank": 12,
+            "tier": 2,
+            "confidence": "high",
+            "display_name": "X",
+            "position": "WR",
+            "player_id": "1",
+            "scope": None,
+            "pipeline_version": "pv1",
+        }
+        with_new_keys_absent = store.content_hash(dict(legacy))
+        with_new_keys_none = store.content_hash(
+            {
+                **legacy,
+                "raw_rank": None,
+                "rank_method": None,
+                "rank_pool": None,
+                "shared_market_translated": None,
+            }
+        )
+        assert with_new_keys_absent == with_new_keys_none
+
+    def test_a_rank_row_hashes_over_its_own_extra_content(self):
+        base = {
+            "value": None,
+            "rank": 12,
+            "tier": None,
+            "confidence": None,
+            "display_name": None,
+            "position": None,
+            "player_id": None,
+            "scope": None,
+            "pipeline_version": None,
+        }
+        assert store.content_hash({**base, "raw_rank": 15.4}) != store.content_hash(
+            {**base, "raw_rank": 99.9}
+        )
+
+
+class TestSchemaUpgrade:
+    def test_a_v1_ledger_gains_the_columns_without_losing_rows(self, tmp_path):
+        """An already-deployed ledger predates these columns, and
+        ``CREATE TABLE IF NOT EXISTS`` cannot add one."""
+        db = tmp_path / "old.sqlite"
+        # A v1 table: the shipped schema minus the extension columns, built
+        # directly rather than by DROP COLUMN — SQLite refuses that while the
+        # identity index still references the table.
+        conn = sqlite3.connect(str(db))
+        conn.execute(
+            "CREATE TABLE observations ("
+            "id INTEGER PRIMARY KEY, asset_key TEXT NOT NULL, "
+            "asset_class TEXT NOT NULL, lane TEXT NOT NULL, "
+            "source_key TEXT NOT NULL DEFAULT '', observed_date TEXT NOT NULL, "
+            "observed_at TEXT, observed_at_zone TEXT, value REAL, rank INTEGER, "
+            "tier INTEGER, confidence TEXT, display_name TEXT, position TEXT, "
+            "player_id TEXT, scope TEXT, pipeline_version TEXT, "
+            "origin TEXT NOT NULL, recorded_at TEXT NOT NULL, "
+            "content_hash TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO observations (asset_key, asset_class, lane, source_key, "
+            "observed_date, origin, rank, recorded_at, content_hash) "
+            "VALUES ('player:1','player','canonical_board','','2026-08-18','test',5,'t','h')"
+        )
+        conn.commit()
+        conn.close()
+        store._reset_setup_cache_for_tests()
+
+        conn = store.connect(db)
+        try:
+            present = {r[1] for r in conn.execute("PRAGMA table_info(observations)")}
+            assert {c for c, _ in store._EXTENSION_COLUMNS} <= present
+            assert conn.execute("SELECT COUNT(*) FROM observations").fetchone()[0] == 1
+        finally:
+            conn.close()


### PR DESCRIPTION
# POST-V1 capture infrastructure — **changes the V1 percentage by zero**

@Claude 5 — this is a new unit on a fresh branch off main. **I am not merging it.** It is capture only: nothing reads the lane, and it moves no published number.

## Why now, and why it can't wait

#804 is about **correlated / shared-lineage source movement** — injected correlated anomalies moved the blend by as much as **~48%** while existing defenses caught nothing, because sources agreeing on something *wrong* is indistinguishable from agreement at the blend.

Telling structural dependence from noise needs the observations **over time**, and that series does not exist:

| | |
|---|---|
| per-source rank maps published per build | 22–24 |
| preserved in any archive | **3** |
| bundles carrying more than 3 | **0 of 176** |

Every unrecorded build is evidence no later effort can reconstruct. That is the entire justification for capturing before the analysis is designed.

## Scope discipline

**Not in this PR, and unauthorized:** correlation methodology, source-family assignment, family weighting, automatic downweighting, confidence changes, B10 logic, canonical value or ranking movement. No UI. No Central Buy/Sell. #911 untouched.

## No parallel store

Extends the canonical owner (`src/history`) with a deliberately named lane and **inherits** its guarantees rather than restating them: append-only (`INSERT OR IGNORE`; a conflicting re-record is *surfaced*, never applied), idempotent, `HISTORY_FLOOR` enforced, never-future selection (`asof` was already lane-parameterised), tz-aware `observed_at`.

The instant/zone rule was **extracted** from `record.py` into `contract_observed_instant`, so both lanes read the producer's clock through one definition instead of two copies.

**Not `source_value`.** A rank is an ordering position; a value is a price. No shared units, not convertible, and they disagree about what "missing" means. `_validate_source_rank` refuses a rank observation carrying a value at all.

**Missing is absence, never zero.** A source that didn't rank an asset contributes *no row* — not rank 0, not null, not a sentinel; all three refused, because rank 0 sorts **first** on every board. Booleans too (`True` is an `int` and would store as rank 1).

## Provenance for the question this exists to enable

Four nullable columns, unused by every other lane: `raw_rank` (what the source **published** before ladder translation — a rookie board's #36 becomes #247 on the overall ladder; different facts), `rank_method`, `rank_pool` (ranks from different coordinate pools are not comparable and must not be correlated), and **`shared_market_translated`**.

That last one is the most important field here: a source projected onto another market's backbone is correlated with it **by construction**, and an analysis that missed it would "discover" a correlation the pipeline itself created. Measured on a real board: **638 of 7,245** observations carry it.

The new columns fold into `content_hash` **only when present**, so every row from every pre-existing lane hashes to exactly the byte it did before. Without that, each stored row would re-ingest as a **conflict** instead of a duplicate and the store's idempotency — which backfill and the migrations are built on — would break on contact. Pinned by test.

## Non-influence — proven, not asserted

Same pinned input export, **code as the only variable**, `golden_board` on `origin/main` vs this branch:

```
rows 1108 -> 1108 · ranked 740 · priced 849 · picks 162 · idp 396
VALUES: 0 moved, 0 newly priced, 0 newly unpriced
RANKS:  0 changed
ASSERTION OK: no value changed.
```

The two captures are **byte-identical** — `sha256 c1b9cde42f30021f` on both sides.

Reinforced structurally: no valuation/weighting module imports the lane (asserted as an **import edge**, not a substring — `source_ranks` is a long-standing local variable in `data_contract`), the only production importer is the fresh-scrape call site, the capture module imports no pricing module, and building observations does not mutate the contract.

## Storage — measured *before* proposing production

| | |
|---|---|
| observations/build | **7,245** across 21 sources |
| bytes/observation | **446 B** |
| rows/day (2-hourly) | 86,940 |
| **bytes/day** | **38.8 MB** |
| 30 / 90 days | ~1.16 GB / ~3.49 GB |
| **1 year** | **~14.2 GB** (31.7 M rows) |

The cost is **index overhead on the shared table, not payload** — stripping every denormalized string saves only 4–7%. **Cadence is the real lever:** daily capture is ~1.2 GB/yr, and correlation between sources is a question about *days*, not hours.

**So the flag ships OFF** (`RISKIT_FEATURE_SOURCE_RANK_CAPTURE`). 14 GB/year is a production disk commitment an owner makes deliberately, not one a merge makes for them. The retention concern is named in the doc; **no destructive retention policy is proposed**, since inventing one is unauthorized. Off, nothing is written and no response body differs.

⚠️ **Decision needed from you:** enable at which cadence? The per-cadence table is in `docs/history/SOURCE_RANK_CAPTURE.md` §7. Until it's on, the evidence keeps perishing — that's the trade-off, stated rather than resolved unilaterally.

## Tests

`tests/history/test_source_rank_capture.py` — 33 covering: append-only (incl. a conflicting re-record leaving the stored row untouched), idempotent rebuild, tz-aware/naive/date-only instants, never-future selection, `HISTORY_FLOOR`, missing-rank ≠ zero across four shapes, source identity + lineage, the v1→v2 column upgrade without row loss, legacy hash stability, and the non-influence import edges.

## Evidence at head `03ee6212d`

```
tests/ -m "not livedata"     8,398 passed / 51 skipped
ruff check + format          clean       coercion gate     clean
governance / planning / audit-status / flag-docs   clean
release-candidate            "the validated tree IS the tree that will merge"
sync                         0 behind origin/main
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqEBEngbUtzXsbHRYrPLkF)_