### PR TITLE
V1-52: two lenses of one power engine — and the offseason ranking that was publishing the alphabet

### DIFF
--- a/config/coercion_baseline.json
+++ b/config/coercion_baseline.json
@@ -1,6 +1,6 @@
 {
  "note": "Known missing-data coercions on decision paths, recorded so the gate can block NEW ones while the remediation batches burn these down. Each batch deletes its findings' entries. Do not add to this file to make a build pass.",
- "count": 672,
+ "count": 671,
  "violations": [
   "frontend/lib/auction-power.js::const raw = names.map((n) => Number(totalsObj[n]) || 0);",
   "frontend/lib/bdvm.js::assetCount: _num(r?.assetCount) ?? 0,",
@@ -496,7 +496,6 @@
   "src/ros/sources/fantasypros_ros_sf.py::rank = int(entry.get(\"rank_ecr\") or 0)",
   "src/ros/team_strength.py::confidence=float(agg.get(\"confidence\") or 0.0),",
   "src/ros/team_strength.py::out.sort(key=lambda t: -float(t.get(\"teamRosStrength\") or 0.0))",
-  "src/ros/team_strength.py::ros_value=float(agg.get(\"rosValue\") or 0.0),",
   "src/ros/trade_deadline.py::rank = float(strength_row.get(\"rank\") or 0.0)",
   "src/ros/trade_deadline.py::total = max(1.0, float(len(strengths) or 1))",
   "src/roster_intel/engine.py::adjusted += float(row.get(\"leagueAdjustedDynastyValue\") or row.get(\"consensusValue\") or 0.0)",

--- a/config/coercion_baseline.json
+++ b/config/coercion_baseline.json
@@ -1,6 +1,6 @@
 {
  "note": "Known missing-data coercions on decision paths, recorded so the gate can block NEW ones while the remediation batches burn these down. Each batch deletes its findings' entries. Do not add to this file to make a build pass.",
- "count": 673,
+ "count": 672,
  "violations": [
   "frontend/lib/auction-power.js::const raw = names.map((n) => Number(totalsObj[n]) || 0);",
   "frontend/lib/bdvm.js::assetCount: _num(r?.assetCount) ?? 0,",
@@ -487,7 +487,6 @@
   "src/ros/playoff_sim.py::str(r.get(\"ownerId\") or \"\"): float(r.get(\"teamRosStrength\") or 0.0)",
   "src/ros/power_v2.py::games = s[\"games\"] or 1",
   "src/ros/power_v2.py::score = float(r.get(\"teamRosStrength\") or 0.0)",
-  "src/ros/power_v2.py::weight_total = sum(active_weights.values()) or 1.0",
   "src/ros/scrape.py::base_weight=float(src_meta.get(\"base_weight\") or 0.0),",
   "src/ros/scrape.py::confidence=float(row.get(\"confidence\") or 1.0),",
   "src/ros/scrape.py::existing = float(row.get(\"confidence\") or 1.0)",

--- a/docs/power/V1_52_CANONICAL_POWER_ENGINE.md
+++ b/docs/power/V1_52_CANONICAL_POWER_ENGINE.md
@@ -1,0 +1,214 @@
+# V1-52 — one canonical weekly power-rankings engine
+
+Status: **IN PROGRESS.** Steps 1-4 landed; the retirement itself (step 5)
+is scoped and measured below but **not done**, and the reason is a real
+constraint rather than remaining effort.
+
+Companion to `docs/playoffs/V1_51_CANONICAL_PLAYOFF_BRACKET.md`, which
+established the precondition this unit builds on.
+
+## What was actually wrong
+
+Two engines answer "how strong is this team this week", and the site
+publishes both. The audit capture
+`docs/master-site-audit/evidence/W30/power-two-engines.json` records
+them on the same week:
+
+| engine | n | Jason |
+|---|---|---|
+| `public_league/power.py` | 10 | rank **10 of 10**, score 0.00 |
+| `ros/power_v2.py` | 12 | rank **3 of 12**, score 80.69 |
+
+mean \|rank shift\| 2.8, max 7.
+
+That capture is usually quoted for the rank shift. Reading its
+`effectiveWeights` is more damning, and it is what this unit turned on:
+
+```json
+"v2": { "preseason": true,
+        "effectiveWeights": {"team_ros_strength": 0.38, "roster_health": 0.03} }
+```
+
+So the comparison is **one week of last season's scoring percentiles**
+against **pure roster strength**. The two engines were not disagreeing
+about the answer — they were answering different questions, and nothing
+on either surface said so.
+
+Note also `n`: **10 against 12**. `power.py`'s `currentRanking` is the
+last *single week*'s ranking, so any owner who did not play that week is
+absent from the published power ranking entirely.
+
+## What the toggle actually did
+
+`settings.useRosPowerRankings` decides which engine renders the Power
+tab, and it **defaults to `true`** — so the public `/league` Power tab
+already shows `power_v2`. A comment in `LeagueClient.jsx` claimed the
+opposite ("false until validated per-user") until 2026-08-19; that
+mattered, because anyone reasoning about which ranking the site shows
+got the answer backwards.
+
+A toggle that picks an *implementation* is a champion/challenger switch
+left permanently in the UI. The destination is a toggle that picks a
+**lens** — a legitimate question about what to measure.
+
+## Steps landed
+
+### 1-2 — two lenses, and one trend
+
+`LENS_FORWARD_LOOKING` / `LENS_RESULTS_ONLY`. They are **not two
+formulas**: results-only is the same `WEIGHTS` vector with
+`team_ros_strength` declared missing and renormalised by the machinery
+that already handles an absent team-strength file, so every
+retrospective component keeps its weight *relative to the others*.
+
+The per-week trend moved into the canonical engine and runs through the
+same `_score_state` as the headline. A second scoring implementation for
+the series is how a chart ends up being a different quantity from the
+number printed beside it.
+
+The trend is **results-only at every point, including the last**.
+`team_ros_strength` is a single current snapshot with no per-week
+history, so back-filling it is the as-of defect and splicing it into
+only the final point is worse — the line would jump at the end for a
+reason unrelated to how the team played, and no reader could tell that
+from a real move.
+
+### 3 — refuse to rank when no component survives
+
+Renormalisation has a floor nobody had put in. When *every* component is
+dropped, `active_weights` is empty, `weight_total` fell back to `1.0`
+against an empty numerator, every owner scored exactly `0.0`, and the
+sort — stable over equal keys — handed out ranks `1..N` in `owner_ids`
+order. **An identifier ordering, published as a power ranking.**
+
+Reachable structurally, not rarely: results-only drops
+`team_ros_strength` by definition and preseason dropped all seven
+historical components, so the state was guaranteed for the whole
+offseason.
+
+On the committed dev snapshot it was visible and self-contradicting:
+five owners, every score `0.0`, and the published order **disagreed with
+the components printed beside it** — `owner-B` led `owner-A` on five of
+seven components and was ranked below it.
+
+Same family as the playoff-odds defect fixed in V1-51, where a
+placeholder made every matchup a tie and the third tiebreak (the
+`ownerId` string) became the answer. The coercion baseline had already
+registered the mechanism as debt — `weight_total = sum(...) or 1.0` —
+so this was a recorded hazard coming true, and the gate reports that
+entry retired.
+
+Now: no surviving component, no ranking. `powerScore` and `rank` are
+`None` — never `0.0`, which is a score a team can earn, and never
+`1..N`. An `unrankable` block names the reason and the missing inputs;
+the owners and their raw components are still listed. Same posture
+`playoff_structure` takes for an unknown bracket. The UI renders it as a
+named state rather than the "not ready, the next scrape will populate
+this" copy, which would promise numbers that are not coming.
+
+### 4 — the preseason suppression belongs to one lens
+
+`_is_preseason` dropped all seven historical-results components, and its
+docstring gave the reason: they "describe a finished year and don't
+project the upcoming one ... so the score reflects only forward-looking
+inputs". Correct for the **forward-looking** lens. Exactly backwards for
+the retrospective one, whose entire subject matter *is* the finished
+year.
+
+Step 1 added the results-only lens and it inherited a suppression
+written for the other one. The consequence was total: results-only
+already drops `team_ros_strength`, so preseason left it with nothing —
+the every-component-missing state above — while the completed seasons it
+is made of sat in the accumulators untouched.
+
+Repaired, and visible in one row on the dev snapshot: `owner-B`, ranked
+2nd on an all-zero score under the defect, is now 1st at 86.61.
+Forward-looking still refuses there, correctly — preseason with no
+team-strength file has genuinely nothing to look forward to.
+
+Mutation-checked in both directions: applying the suppression to both
+lenses again, and removing it entirely, each turn tests RED. The second
+is what stops the repair being "delete the rule".
+
+## Do the two engines agree? Measured
+
+With the lens working correctly, `power.py` versus the canonical engine
+under results-only:
+
+| fixture | mean \|rank shift\| | max | note |
+|---|---|---|---|
+| committed dev snapshot (real) | **0.00** | 0 | identical order on the 4 common owners; v2 also covers a 5th that v1 drops |
+| 12 owners, 6 weeks, monotone strength ladder | 0.33 | 1 | weak evidence by construction — a ladder makes most formulas agree |
+| adversarial: great scores, 0-6 record (schedule luck) | 0.67 | 1 | v1 has **no** W/L or streak component; v2 weights them 0.10 + 0.05 |
+
+So the retrospective quantities substantially agree, and the large
+real-world divergence in the W30 capture is the **forward-looking
+input** — which is exactly what the lens distinction names. That is the
+evidence that these are one engine's two lenses rather than two engines.
+
+**Limitation, stated rather than glossed:** two of those three fixtures
+are synthetic, and the one real artifact is a small dev snapshot. A
+comparison on the production league needs its snapshot plus the ROS
+team-strength file, neither of which exists in this environment
+(`data/` is gitignored). That measurement belongs with the retirement.
+
+## Step 5 — the retirement, and why it is not a shim
+
+`power.py` must stop being an engine. The obvious minimal move — make
+`build_section` an adapter that delegates to the canonical engine and
+renames fields — **does not work**, and it is worth recording why so it
+is not attempted again:
+
+`power.jsx` renders `components.pointsPerGame`, `components.recentAvg`
+and `components.allPlayWinPctThisWeek` as **raw values**. The canonical
+engine publishes `components.ppg` and `components.recent` as
+**percentiles**. An adapter cannot recover a raw PPG from a percentile,
+so it would have to compute one — which is a second owner again, one
+layer down, which is the defect this unit exists to remove.
+
+Shape differences, for the record:
+
+| | `power.py` | `power_v2.py` |
+|---|---|---|
+| series location | `weeks`, `seriesByOwner` (top level) | `trend.weeks`, `trend.seriesByOwner` |
+| `seriesByOwner` | list of `{ownerId, displayName, points[]}` | dict keyed by ownerId |
+| score field | `power` | `powerScore` |
+| per-row extras | `teamName`, `record`, `games`, `weekRankDelta` | `rosStrengthPercentile`, `weightsApplied` |
+
+So the retirement is **one renderer, one engine, the toggle selecting a
+lens**: `ros-power.jsx` absorbs the trend chart, `power.jsx` and
+`power.py` retire together. That changes what the Power tab *displays*
+for users on the v1 path — percentile component bars instead of raw
+PPG columns — which is a deliberate, user-visible change and needs the
+production measurement above alongside it.
+
+## Prerequisites fixed along the way
+
+* **Playoff odds published alphabetical order as certainty** — a flat
+  `[100.0]` placeholder made every matchup a tie, so the `ownerId`
+  string tiebreak decided the standings. The seven `1.0`s on the
+  committed production artifact are exactly the lexically-first seven
+  Sleeper user ids. (Shipped with V1-51, #919.)
+* **Roster health was double-counted** — once as its own 0.03 weight and
+  again inside `team_ros_strength`. Folded in (0.38 → 0.41).
+
+## A note on fixtures
+
+`_make_snapshot` never populated `roster_to_owner`, which
+`luck._season_weekly_scores` needs to attribute a matchup row to an
+owner — it **skips** rows it cannot resolve, so zero weeks scored, every
+component fell back to its neutral default, and every owner scored an
+identical `33.64` across three weeks of deliberately different points.
+
+Two of this unit's own lens tests were asserting shape while measuring
+nothing. Repaired at the shared helper, with the reason recorded there,
+because this trap cost three separate measurements in this lane before
+it was named.
+
+## Not claimed
+
+Nothing here is deployed. The refusal and the lens repair both change
+live public `/league` output the moment they ship — the refusal replaces
+a fabricated order with an honest empty state, and the lens repair gives
+the retrospective view real numbers all offseason where it previously
+had none. Both should be observed in production rather than assumed.

--- a/docs/projections/PROJECTION_SOURCE_ASSESSMENT.md
+++ b/docs/projections/PROJECTION_SOURCE_ASSESSMENT.md
@@ -1,0 +1,141 @@
+# Can we consume a real projection feed today?
+
+Status: **assessed, answer is no — for two independent reasons**, both
+measured. The consensus blend is hardened so that if a usable feed
+arrives it cannot be mixed wrongly.
+
+This document exists to stop the next session doing the obvious thing.
+There are projection numbers sitting in the repo, fetched and committed,
+consumed by nothing. Wiring them up looks like a five-line change and is
+not one.
+
+## The feed
+
+`CSVs/site_raw/draftSharksSf.csv` and `draftSharksIdp.csv` publish
+`1yr. Proj`, `3yr. Proj`, `5yr. Proj`, `10yr. Proj` and `3D Value +`.
+
+`1yr. Proj` is populated on **412 of 439** offensive rows and **375 of
+410** IDP rows, with exactly the season-total shape you would expect:
+
+| pos | n | max | median |
+|---|---|---|---|
+| QB | 51 | 403 (Josh Allen) | 248 |
+| RB | 115 | 309 (Jahmyr Gibbs) | 76 |
+| WR | 185 | 257 (Puka Nacua) | 70 |
+| TE | 88 | 214 (Brock Bowers) | 47 |
+
+This is a real forward-looking projection. It is not a stub, not a
+placeholder, and not empty.
+
+## Two claims in the tree that contradicted each other
+
+Both were wrong, in opposite directions, and measuring settled it.
+
+* **`ros/aggregate.py`** said `projection_value` was *"a live signal
+  being dropped rather than an unused hook"*. Measured across every
+  cached ROS board — `draftSharksRosSf`, `fantasyProsRosSf`,
+  `fantasyProsRosIdp`, `fantasyProsRosOverall`, `footballGuysRosIdp` —
+  **0 of 2,168 rows** carry a projection. It is an unused hook.
+* **`bdvm/projections.py`** said the platform has **zero**
+  forward-looking projection sources. Also untrue, per the table above.
+
+The first claim was **mislocated rather than baseless**: DraftSharks does
+publish projections, in its *dynasty* feed, not in the ROS-format board
+that pipeline reads. Both comments are corrected in place.
+
+## Reason 1 — the numbers cannot be scored under this league's card
+
+The feed publishes **totals, not stat lines**, and **no scoring
+metadata**. So:
+
+* there is nothing to re-score under `dynasty_main`'s card; and
+* the basis those totals are denominated in cannot be verified.
+
+An unverified basis **fails closed** here for the same reason an
+unverified game type does in the dynasty lane: `UNKNOWN` is not a match.
+
+**An attempt to identify the basis, and why it failed.** Comparing
+`1yr. Proj` against our own league-scored 2025 realized totals for 232
+matched players gives a position-dependent ratio — RB 0.759, QB 0.886,
+WR 0.924, TE 1.066, overall median 0.876. That *looks* like a different
+scoring card. But it compares a **forward projection** against a
+**realized season**, and a projection is systematically less extreme
+than a realized outcome, so regression to the mean is confounded with
+any scoring difference and the two cannot be separated from this
+evidence.
+
+Recorded as **unverified rather than resolved**. The conclusion does not
+depend on it: totals without stat lines cannot be rescored under this
+league's card whatever their basis.
+
+## Reason 2 — it is not an independent signal
+
+Signal independence (CLAUDE.md §3.3): a body of evidence affects a
+conclusion once. DraftSharks **already votes twice** — a dynasty rank on
+the valuation board (`draftSharksSf`) and a rest-of-season rank in the
+season pipeline (`draftSharksRosSf`).
+
+Spearman ρ, measured:
+
+| pair | n | ρ |
+|---|---|---|
+| DS dynasty rank vs DS `1yr. Proj` | 412 | **+0.873** |
+| … within QB / RB / WR / TE | 42–173 | +0.887 / +0.926 / +0.895 / +0.911 |
+| DS ROS rank vs DS `1yr. Proj` | 168 | +0.781 |
+| DS ROS rank vs DS dynasty rank | 168 | +0.852 |
+
+`1yr. Proj` is largely the same opinion re-expressed. It is not
+identical — a one-year projection legitimately diverges from a dynasty
+rank on age — but the correlation group is not in question, because it is
+the **same provider**. This is the KTC precedent exactly: Off / TE+ /
+TE++ / TE+++ are *"same-source calibration states of one provider, not
+four independent votes"*. Counting DraftSharks' projection beside
+DraftSharks' rank would manufacture agreement out of one opinion.
+
+## What was hardened instead
+
+`blend_consensus` could not refuse a foreign-basis record.
+`ProjectionRecord.resolve_fpg` returns `(value, scoring_native)`, the
+blend averaged everything regardless, and stamped `all_scoring_native`
+on the result — **written in one place, consumed in none**. A projection
+denominated in another provider's scoring landed in the same `mu_fpg` as
+a league-scored one, with no consumer able to tell.
+
+Averaging points from two scoring systems is a **category error**, not an
+imprecision: they are not the same quantity, so their mean is not a
+quantity. Non-native records are now **excluded** and named in
+`excluded_foreign_basis` — excluded rather than down-weighted, because a
+weight expresses lower confidence in the *same* quantity and this is a
+different unit. When every record is non-native they blend and carry
+`all_scoring_native: false`, since excluding them all would report the
+player **unpriced**, which is a different and false claim.
+
+The reachable path is the documented one: the manual-CSV adapter, which
+`projections.py`'s own docstring names as the drop-in for a real feed,
+sets `scoring_native=False` unconditionally.
+
+## What a usable feed would look like
+
+Both objections are properties of *this* source, and a different source
+clears them:
+
+1. **stat lines, not totals** — so the league's own card scores them,
+   which is what `resolve_fpg` already does when `stat_line` is present;
+2. **not already voting** in the dynasty or ROS pipelines, or explicitly
+   declared as part of that provider's correlation group rather than as
+   an independent one.
+
+The BDVM adapters that already exist meet the first test — Mike Clay's
+guide and The IDP Show both publish raw stat lines
+(`scripts/fetch_clay_projections.py`,
+`scripts/fetch_idpshow_projections.py`), which is why those are the real
+sources and this one is not.
+
+## Not claimed
+
+Collecting `1yr. Proj` is fine and should continue — archiving a source
+is not consuming it, the same posture CLAUDE.md takes for alternate
+dynasty boards. Nothing here authorises using it to alter a production
+value, and nothing here says the number is wrong. It says we cannot
+verify what unit it is in, and that we already count its author's
+opinion.

--- a/frontend/__tests__/components/RosPowerUnrankable.test.jsx
+++ b/frontend/__tests__/components/RosPowerUnrankable.test.jsx
@@ -1,0 +1,112 @@
+/**
+ * V1-52 — "nothing to rank on" must not render as "not ready yet".
+ *
+ * The backend refuses to publish a ranking when every weighted component
+ * is unavailable, because the alternative is what it used to do: score
+ * every owner 0.0 and hand out ranks 1..N in owner-id order, an
+ * identifier ordering presented as a power ranking.
+ *
+ * On the client the two states look identical if nothing distinguishes
+ * them — both are "no numbers" — but they mean opposite things. "Not
+ * ready" promises the numbers arrive on their own; the refusal does not,
+ * and for the results-only lens in the offseason it persists until the
+ * season starts. Same argument as the unknown-playoff-bracket state.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("@/components/ui", () => ({
+  LoadingState: ({ message }) => <div>{message}</div>,
+  EmptyState: ({ title, message }) => (
+    <div>
+      <h3>{title}</h3>
+      <p>{message}</p>
+    </div>
+  ),
+}));
+
+vi.mock("../../app/league/shared-server.jsx", () => ({
+  Card: ({ title, children }) => (
+    <section>
+      {title ? <h2>{title}</h2> : null}
+      {children}
+    </section>
+  ),
+}));
+
+const UNRANKABLE = {
+  currentRanking: [
+    { ownerId: "o1", displayName: "Alice", powerScore: null, rank: null, components: {} },
+    { ownerId: "o2", displayName: "Bob", powerScore: null, rank: null, components: {} },
+  ],
+  unrankable: {
+    reason: "preseason_and_no_forward_looking_input",
+    missingInputs: ["ppg", "recent", "team_ros_strength (lens: results_only)"],
+    explanation:
+      "Every weighted component is unavailable, so there is no quantity to rank on.",
+  },
+  weights: {},
+  effectiveWeights: {},
+  missingInputs: [],
+  preseason: true,
+};
+
+async function renderWith(payload) {
+  vi.resetModules();
+  global.fetch = vi.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve(payload) }),
+  );
+  const mod = await import("../../app/league/sections/ros-power.jsx");
+  const RosPowerSection = mod.default;
+  return render(<RosPowerSection />);
+}
+
+describe("RosPowerSection — the refusal", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("names the state instead of promising the numbers are coming", async () => {
+    await renderWith(UNRANKABLE);
+    await waitFor(() => expect(screen.getByText(/Not enough to rank on/i)).toBeTruthy());
+    // The "not ready" copy promises a future scrape will populate it.
+    expect(screen.queryByText(/next scheduled scrape/i)).toBeNull();
+    expect(screen.queryByText(/ROS Power not ready/i)).toBeNull();
+  });
+
+  it("shows the reason the backend gave", async () => {
+    await renderWith(UNRANKABLE);
+    await waitFor(() => expect(screen.getByText(/no quantity to rank on/i)).toBeTruthy());
+    expect(screen.getByText(/team_ros_strength/)).toBeTruthy();
+  });
+
+  it("does not print a rank or a score for anyone", async () => {
+    const { container } = await renderWith(UNRANKABLE);
+    await waitFor(() => expect(screen.getByText(/Not enough to rank on/i)).toBeTruthy());
+    // No ranking table at all — not a table of dashes, which reads as
+    // "loading" to anyone scanning the page.
+    expect(container.querySelector("table")).toBeNull();
+  });
+
+  it("still ranks when a component survives (non-vacuity)", async () => {
+    await renderWith({
+      currentRanking: [
+        {
+          ownerId: "o1",
+          displayName: "Alice",
+          powerScore: 88.5,
+          rank: 1,
+          components: { ppg: 0.9 },
+          weightsApplied: { ppg: 0.18 },
+        },
+      ],
+      unrankable: null,
+      weights: { ppg: 0.18 },
+      effectiveWeights: { ppg: 0.18 },
+      missingInputs: [],
+      preseason: false,
+    });
+    await waitFor(() => expect(screen.getByText("Alice")).toBeTruthy());
+    expect(screen.queryByText(/Not enough to rank on/i)).toBeNull();
+  });
+});

--- a/frontend/app/league/LeagueClient.jsx
+++ b/frontend/app/league/LeagueClient.jsx
@@ -118,10 +118,13 @@ function LeaguePage({ initialContract = null, initialTab = DEFAULT_TAB }) {
   const urlTab = normalizeTabKey(searchParams.get("tab"));
   const urlOwner = searchParams.get("owner") || "";
   const urlWeek = searchParams.get("week") || "";
-  // Read the ROS feature flags so the Power tab can swap to v2 when
-  // the user opts in.  Defaults match the registry in
-  // ``components/useSettings.js`` (rosEnabled true,
-  // useRosPowerRankings false until validated per-user).
+  // Read the ROS feature flags so the Power tab can swap between the
+  // canonical engine's two lenses.  The registry in
+  // ``components/useSettings.js`` defaults ``useRosPowerRankings`` to
+  // TRUE — this comment said "false until validated per-user" until
+  // 2026-08-19, which was backwards and mattered: it meant anyone
+  // reasoning about which ranking the public /league Power tab shows
+  // got the answer wrong. It shows the forward-looking one.
   const { settings } = useSettings();
   const useRosPower = !!settings?.useRosPowerRankings;
 

--- a/frontend/app/league/sections/ros-power.jsx
+++ b/frontend/app/league/sections/ros-power.jsx
@@ -127,6 +127,42 @@ export default function RosPowerSection() {
     );
   }
   const rankings = data?.currentRanking || [];
+
+  // The engine refused to rank, and that is a DIFFERENT state from
+  // "not ready yet".  Every weighted component was unavailable, so
+  // there is no quantity to rank on — the backend withholds the score
+  // and the rank rather than publishing zeros in owner-id order.
+  //
+  // Rendering that as an empty table, or as a column of "—", would let
+  // the reader assume the data is still loading and will arrive. It is
+  // not loading: for the results-only lens in the offseason this state
+  // is structural and persists until the season starts. Say which one
+  // it is, and show the reason the backend gave.
+  const unrankable = data?.unrankable;
+  if (unrankable) {
+    return (
+      <Card title="ROS Power Rankings">
+        <EmptyState
+          title="Not enough to rank on"
+          message={
+            unrankable.explanation ||
+            "Every weighted component is unavailable, so no ranking is published."
+          }
+        />
+        {(unrankable.missingInputs || []).length > 0 && (
+          <div style={{ fontSize: "0.7rem", color: "var(--subtext)", marginTop: 8 }}>
+            Missing: {unrankable.missingInputs.join(", ")}
+          </div>
+        )}
+        {rankings.length > 0 && (
+          <div style={{ fontSize: "0.7rem", color: "var(--subtext)", marginTop: 8 }}>
+            {rankings.length} managers listed without a score.
+          </div>
+        )}
+      </Card>
+    );
+  }
+
   if (!rankings.length) {
     return (
       <Card>

--- a/scripts/measure_projection_source.py
+++ b/scripts/measure_projection_source.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Is a candidate projection source usable, and is it independent?
+
+Reproduces the measurements in
+``docs/projections/PROJECTION_SOURCE_ASSESSMENT.md``.
+
+Two questions, deliberately separate, because a source can fail either
+one on its own:
+
+* **basis** — can the numbers be scored under THIS league's card?  A
+  source publishing points TOTALS rather than stat lines cannot be
+  rescored, and one publishing no scoring metadata cannot even be
+  checked.  Unverified fails closed.
+* **independence** — does the source already vote in this platform?
+  Signal independence (CLAUDE.md §3.3) says a body of evidence affects a
+  conclusion once, so a provider's projection sitting beside that same
+  provider's rank manufactures agreement out of one opinion.
+
+The comparison against realized totals is reported but deliberately NOT
+treated as identifying the basis: a forward projection is systematically
+less extreme than a realized season, so regression to the mean is
+confounded with any scoring difference.
+
+Exit codes: 0 measured, 2 inputs unavailable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import statistics
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+CARD_FIXTURE = REPO / "tests/nfl_data/fixtures/live_scoring_cards_2026-07-28.json"
+
+
+def _spearman(pairs: Sequence[tuple[float, float]]) -> float:
+    """Rank correlation with ties averaged.  Hand-rolled to keep this
+    script dependency-free — scipy is not a runtime dependency here."""
+    if len(pairs) < 3:
+        return float("nan")
+
+    def ranks(values: Sequence[float]) -> list[float]:
+        order = sorted(range(len(values)), key=lambda i: values[i])
+        out = [0.0] * len(values)
+        i = 0
+        while i < len(order):
+            j = i
+            while j + 1 < len(order) and values[order[j + 1]] == values[order[i]]:
+                j += 1
+            avg = (i + j) / 2.0 + 1
+            for k in range(i, j + 1):
+                out[order[k]] = avg
+            i = j + 1
+        return out
+
+    rx = ranks([p[0] for p in pairs])
+    ry = ranks([p[1] for p in pairs])
+    mx, my = statistics.mean(rx), statistics.mean(ry)
+    num = sum((a - mx) * (b - my) for a, b in zip(rx, ry))
+    den = (sum((a - mx) ** 2 for a in rx) * sum((b - my) ** 2 for b in ry)) ** 0.5
+    return num / den if den else float("nan")
+
+
+def _num(row: dict[str, Any], col: str) -> float | None:
+    try:
+        return float((row.get(col) or "").replace(",", ""))
+    except (AttributeError, ValueError):
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--source-csv", default="CSVs/site_raw/draftSharksSf.csv")
+    ap.add_argument("--projection-column", default="1yr. Proj")
+    ap.add_argument("--rank-column", default="Rank")
+    ap.add_argument("--name-column", default="Player")
+    ap.add_argument("--position-column", default="Fantasy Position")
+    ap.add_argument(
+        "--peer-board",
+        default="CSVs/site_raw/draftSharksRosSf.csv",
+        help="another board from the SAME provider, to test independence",
+    )
+    ap.add_argument("--weekly-csv", help="nflverse weekly CSV, for the basis comparison")
+    ap.add_argument("--league-key", default="dynasty_main")
+    args = ap.parse_args(argv)
+
+    from src.utils.name_clean import normalize_player_name as clean
+
+    src = Path(args.source_csv)
+    if not src.exists():
+        print(f"source not found: {src}", file=sys.stderr)
+        return 2
+
+    rows = list(csv.DictReader(src.open()))
+    entries: dict[str, tuple[float, float, str]] = {}
+    for r in rows:
+        name = clean(r.get(args.name_column) or "")
+        proj = _num(r, args.projection_column)
+        rank = _num(r, args.rank_column)
+        pos = (r.get(args.position_column) or "").split("/")[0].strip().upper()
+        if name and proj and proj > 0 and rank and rank > 0:
+            entries[name] = (rank, proj, pos)
+
+    print(f"source={src.name}  rows={len(rows)}  usable={len(entries)}")
+    if not entries:
+        print("no usable rows", file=sys.stderr)
+        return 2
+
+    print(
+        "\n-- independence: is the projection a different opinion from the provider's own rank? --"
+    )
+    pairs = [(v[0], -v[1]) for v in entries.values()]
+    print(f"   own rank vs projection      n={len(pairs):>4}  rho = {_spearman(pairs):+.3f}")
+    by_pos: dict[str, list[tuple[float, float]]] = {}
+    for v in entries.values():
+        by_pos.setdefault(v[2], []).append((v[0], -v[1]))
+    for pos, pp in sorted(by_pos.items()):
+        if len(pp) >= 9:
+            print(f"     {pos:<4}                     n={len(pp):>4}  rho = {_spearman(pp):+.3f}")
+
+    peer = Path(args.peer_board)
+    if peer.exists():
+        peer_rank: dict[str, float] = {}
+        for r in csv.DictReader(peer.open()):
+            nm = clean(r.get("sourceName") or r.get("canonicalName") or "")
+            rk = _num(r, "rank")
+            if nm and rk and rk > 0:
+                peer_rank[nm] = rk
+        common = [n for n in entries if n in peer_rank]
+        if len(common) >= 3:
+            print(
+                f"   peer board vs projection    n={len(common):>4}  "
+                f"rho = {_spearman([(peer_rank[n], -entries[n][1]) for n in common]):+.3f}"
+            )
+            print(
+                f"   peer board vs own rank      n={len(common):>4}  "
+                f"rho = {_spearman([(peer_rank[n], entries[n][0]) for n in common]):+.3f}"
+            )
+
+    if args.weekly_csv:
+        print("\n-- basis: scale against OUR league-scored realized totals --")
+        print("   NOTE: a forward projection is systematically less extreme than a")
+        print("   realized season, so this CANNOT separate 'different card' from")
+        print("   'projection shrinkage'.  Reported, not treated as identifying.")
+        from src.nfl_data import realized_points as rp
+
+        card = json.loads(CARD_FIXTURE.read_text())[args.league_key]
+        card = card.get("scoring_settings", card)
+        realized: dict[str, float] = {}
+        with Path(args.weekly_csv).open(newline="") as fh:
+            for r in csv.DictReader(fh):
+                if str(r.get("season_type") or "REG").upper() != "REG":
+                    continue
+                nm = clean(r.get("player_display_name") or "")
+                if not nm:
+                    continue
+                realized[nm] = realized.get(nm, 0.0) + float(
+                    rp.compute_weekly_points(r, card).fantasy_points
+                )
+        matched = [
+            (n, entries[n][1], realized[n], entries[n][2])
+            for n in entries
+            if n in realized and realized[n] > 50
+        ]
+        print(f"   matched (realized > 50 pts): {len(matched)}")
+        ratios_by_pos: dict[str, list[float]] = {}
+        for _n, proj, real, pos in matched:
+            ratios_by_pos.setdefault(pos, []).append(proj / real)
+        for pos, rs in sorted(ratios_by_pos.items()):
+            print(f"     {pos:<4} n={len(rs):>4}  median source/ours = {statistics.median(rs):.3f}")
+        allr = [p / r for _n, p, r, _pos in matched]
+        if allr:
+            print(f"   overall median ratio: {statistics.median(allr):.3f}   (1.00 = same basis)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/bdvm/projections.py
+++ b/src/bdvm/projections.py
@@ -1,9 +1,36 @@
 """Projection ingestion, snapshots, and robust consensus.
 
-This is the swappable layer (BDVM module 1).  The platform currently has
-**zero** forward-looking statistical projection sources (Phase-0 audit:
-the ROS pipeline's ``projection`` column is empty in 100% of rows and is
-deliberately not consumed).  So v1 ships:
+This is the swappable layer (BDVM module 1).
+
+The Phase-0 audit's finding that the ROS pipeline's ``projection`` column
+is empty still holds — re-measured 2026-08-19 at **0 of 2,168 rows**
+across all five cached ROS boards.  But "the platform has **zero**
+forward-looking statistical projection sources", which this docstring
+used to say, is **not** the same statement and is no longer true.
+
+``CSVs/site_raw/draftSharksSf.csv`` and ``draftSharksIdp.csv`` publish
+``1yr. Proj`` — 412 of 439 offensive rows and 375 of 410 IDP rows
+populated, with the season-total shape you would expect (QB max 403,
+RB1 309, WR1 257, TE1 214).  It is fetched, committed, and consumed by
+nothing.
+
+Two properties stop it being a drop-in, and both are the source's shape
+rather than a wiring gap:
+
+* it publishes **totals, not stat lines**, so there is nothing to score
+  under this league's card; and
+* it publishes **no scoring metadata**, so the basis those totals are
+  denominated in cannot be verified — and an unverified basis fails
+  closed here exactly as an unverified game type does in the dynasty
+  lane.
+
+Ingesting it therefore means ``fpts`` with ``scoring_native=False``,
+which ``blend_consensus`` now excludes from a mixed-basis mean rather
+than averaging across scoring systems.  Using its numbers as league
+points would need either a stat line or a validated conversion, and
+neither exists.
+
+So v1 still ships:
 
 * a snapshot store with mandatory ``as_of`` stamps (never overwritten);
 * a manual-CSV adapter — the moment a real projection feed lands it
@@ -132,6 +159,11 @@ class ConsensusProjection:
     # Sources down-weighted because their stat line's league-scored IDP
     # categories are a strict subset of a peer's (vocabulary-dominated).
     vocabulary_limited: tuple[str, ...] = ()
+    # Sources EXCLUDED from the mean because their points are denominated
+    # in a scoring basis this league cannot verify.  Excluded rather than
+    # down-weighted: a weight says "less reliable", and this is
+    # "different unit".  See ``blend_consensus``.
+    excluded_foreign_basis: tuple[str, ...] = ()
 
 
 # ---------------------------------------------------------------------------
@@ -253,6 +285,42 @@ def blend_consensus(
             stale.append(r.source)
         scored.append((r, fpg, w, native))
 
+    # ONE CONSENSUS, ONE SCORING BASIS.
+    #
+    # ``resolve_fpg`` returns ``native=False`` when the value is a points
+    # total the source published under ITS OWN scoring rather than a stat
+    # line this league can score.  Averaging those with league-scored
+    # points is a category error, not an imprecision: the two are not the
+    # same quantity, so their mean is not a quantity at all.
+    #
+    # ``all_scoring_native`` recorded this and nothing read it — written
+    # in one place, consumed in none — so a foreign-denominated
+    # projection landed in ``mu_fpg`` beside a league-scored one with no
+    # consumer able to tell.  The manual-CSV adapter, which the module
+    # docstring names as the drop-in for a real feed, sets
+    # ``scoring_native=False`` unconditionally, so the path was the
+    # documented one rather than an edge case.
+    #
+    # EXCLUDED, not down-weighted, and named in the result: a weight
+    # expresses lower confidence in the same quantity.
+    #
+    # When EVERY record is non-native there is nothing native to protect
+    # and nothing to verify against.  Excluding them all would report the
+    # player as UNPRICED, which is a different and false claim — a
+    # projection does exist.  So they blend and the consensus carries
+    # ``all_scoring_native=False`` for the caller to act on.
+    excluded_foreign: list[str] = []
+    if any(native for (_, _, _, native) in scored) and not all(
+        native for (_, _, _, native) in scored
+    ):
+        kept: list[tuple[ProjectionRecord, float, float, bool]] = []
+        for entry in scored:
+            if entry[3]:
+                kept.append(entry)
+            else:
+                excluded_foreign.append(entry[0].source)
+        scored = kept
+
     # Vocabulary-aware down-weighting.  A stat-line record whose
     # league-scored IDP categories are a STRICT SUBSET of a peer's is
     # known-incomplete under THIS league's scoring — e.g. a source
@@ -316,6 +384,7 @@ def blend_consensus(
         sources=tuple(r.source for (r, _, _, _) in scored),
         any_proxy=any(r.is_proxy for (r, _, _, _) in scored),
         all_scoring_native=all(native for (_, _, _, native) in scored),
+        excluded_foreign_basis=tuple(excluded_foreign),
         stale_sources=tuple(stale),
         vocabulary_limited=tuple(vocab_limited),
     )

--- a/src/league_intel/sim.py
+++ b/src/league_intel/sim.py
@@ -83,6 +83,8 @@ import statistics
 from dataclasses import dataclass, field
 from typing import Any, Iterable, Mapping, Sequence
 
+from src.league_intel import sim_calibration as _sim_calibration
+
 __all__ = [
     "SIM_MODEL_VERSION",
     "DEFAULT_SIM_WEEKS",
@@ -178,31 +180,35 @@ class _LegacyPointsModel:
     interface ``sim_calibration.PointsModel`` exposes.
 
     This exists so the draw model is a SEAM rather than a hardcoded
-    formula.  ``claude/league-intel-sim`` derives the real thing —
-    ``ros_value_per_point`` and the per-position CV table — from actual
-    stat lines scored under this league's own settings, replacing two
-    magic constants (a ``/2.7`` divisor tuned by eye and a CV table
-    citing a dataset named nowhere in the repo).  Its ``PointsModel``
-    already exposes ``draw(ros_value, position, rng)``; matching that
-    signature here means its calibrated model drops in as a parameter
-    with no edit to this module and no second copy of the arithmetic.
+    formula: a calibrated ``PointsModel`` drops in as the ``points_model``
+    parameter with no edit to this module.
 
-    That branch owns the schema.  This is the consumer.
+    It no longer restates the arithmetic. It used to hardcode the ``2.7``
+    divisor and import the per-position CV table from
+    ``ros/playoff_sim``, which itself held a byte-identical copy of
+    ``sim_calibration.FALLBACK_CV_BY_POSITION`` — three copies of three
+    numbers, and two implementations of one Gaussian draw. It now
+    delegates to a ``PointsModel`` built from the owner's own fallback
+    constants, which is an exact behavioural identity (pinned by
+    ``tests/league_intel/test_points_model_single_owner.py``).
+
+    What it keeps is its own ``source`` stamp. Parity of NUMBERS is not
+    parity of PROVENANCE: a run on this path must still report
+    ``legacy-constants`` rather than borrow the owner's
+    ``fallback-constants`` label, so ``pointsModelSource`` cannot claim a
+    provenance the run did not have.
     """
 
     source = "legacy-constants"
 
-    def draw(self, ros_value: float, position: str, rng: Any) -> float:
-        from src.ros.playoff_sim import (  # noqa: PLC0415
-            _DEFAULT_PLAYER_CV,
-            _PLAYER_CV_BY_POSITION,
-        )
+    def __init__(self) -> None:
+        # The owner's documented fallback — NOT a calibrated artifact.
+        # ``PointsModel()`` with no arguments is exactly the constants
+        # this class used to inline.
+        self._model = _sim_calibration.PointsModel()
 
-        mean = max(0.0, float(ros_value) / 2.7)
-        if mean <= 0.0:
-            return 0.0
-        cv = _PLAYER_CV_BY_POSITION.get((position or "").upper(), _DEFAULT_PLAYER_CV)
-        return max(0.0, rng.gauss(mean, max(0.5, mean * cv)))
+    def draw(self, ros_value: float, position: str, rng: Any) -> float:
+        return self._model.draw(ros_value, position, rng)
 
 
 _LEGACY_POINTS_MODEL = _LegacyPointsModel()

--- a/src/ros/aggregate.py
+++ b/src/ros/aggregate.py
@@ -60,10 +60,23 @@ class RankedRow:
     total_ranked: int
     # Optional projection signal from the source.  CARRIED BUT NOT
     # CONSUMED — ``aggregate()`` rank-scores every row, this one
-    # included.  The field is populated (``scrape.py``) from a real
-    # parsed projection (``sources/draftsharks_ros.py``), and DraftSharks
-    # is the highest-weighted ROS source, so this is a live signal being
-    # dropped rather than an unused hook.
+    # included.
+    #
+    # CORRECTED 2026-08-19.  This comment used to say the field was
+    # populated from a real parsed projection and that DraftSharks being
+    # the highest-weighted ROS source made it "a live signal being
+    # dropped rather than an unused hook".  Measured across every cached
+    # ROS source board — draftSharksRosSf, fantasyProsRosSf,
+    # fantasyProsRosIdp, fantasyProsRosOverall, footballGuysRosIdp —
+    # **0 of 2,168 rows carry a projection**.  It is an unused hook.
+    #
+    # The claim was not baseless, it was mislocated: DraftSharks DOES
+    # publish projections, in its DYNASTY feed
+    # (``CSVs/site_raw/draftSharksSf.csv`` / ``draftSharksIdp.csv``,
+    # column ``1yr. Proj``, 412/439 and 375/410 rows populated), not in
+    # the ROS-format board this pipeline reads.  Telling a reader there
+    # is a live signal here sends them looking for a conversion for
+    # something that never arrives.
     #
     # Consuming it is a change to every ROS value and to the meaning of
     # the 0-100 scale — projections are points, rank scores are not, and

--- a/src/ros/aggregate.py
+++ b/src/ros/aggregate.py
@@ -117,8 +117,36 @@ class _PlayerAcc:
     ranks: list[int] = field(default_factory=list)
     raw_scores: list[float] = field(default_factory=list)
     contributors: list[dict[str, Any]] = field(default_factory=list)
+    #: Sum of ``row_weight`` contributed by dynasty boards standing in
+    #: for rest-of-season evidence (C5-ROS-01).
+    dynasty_proxy_weight: float = 0.0
     stale_count: int = 0
     total_count: int = 0
+
+
+#: What a rest-of-season row's evidence actually is.
+#:
+#: Three states, not two, and the middle one is the point: a row blended
+#: from both domains is neither "rest-of-season evidence" nor "a dynasty
+#: ranking in disguise", and collapsing it into either would be the same
+#: silence this stamp exists to end.
+EVIDENCE_REST_OF_SEASON = "rest_of_season"
+EVIDENCE_MIXED = "mixed"
+EVIDENCE_DYNASTY_PROXY_ONLY = "dynasty_proxy_only"
+
+
+def _evidence_basis(proxy_share: float) -> str:
+    """Classify a row by how much of its weight is a dynasty proxy.
+
+    Exact comparisons, deliberately.  A tolerance here would let a row
+    with a sliver of dynasty evidence report as pure rest-of-season,
+    which is the claim the caller is relying on being precise.
+    """
+    if proxy_share <= 0.0:
+        return EVIDENCE_REST_OF_SEASON
+    if proxy_share >= 1.0:
+        return EVIDENCE_DYNASTY_PROXY_ONLY
+    return EVIDENCE_MIXED
 
 
 def aggregate(
@@ -166,6 +194,12 @@ def aggregate(
         )
         if weight <= 0:
             continue
+        # A source that is a dynasty board and NOT a rest-of-season one.
+        # The two flags are independent in the registry, and the ROS lane
+        # deliberately carries sources that are neither (an ADP feed), so
+        # this is the exact predicate ``parse.py`` prices as a proxy —
+        # not ``not is_ros``.
+        is_dynasty_proxy = bool(snap.is_dynasty) and not bool(snap.is_ros)
         # One vote per (source, player).  ``weight`` above is computed once
         # for the SOURCE, then added below once per ROW — so a source that
         # lists the same player twice silently doubles that vendor's say.
@@ -218,6 +252,16 @@ def aggregate(
             acc.weight_sum += row_weight
             acc.ranks.append(int(row.rank))
             acc.raw_scores.append(score)
+            # C5-ROS-01.  Track how much of this player's evidence came
+            # from a DYNASTY board rather than a rest-of-season one.
+            # ``parse.effective_source_weight`` admits ``is_dynasty and
+            # not is_ros`` sources as a "dynasty proxy", so a
+            # long-horizon ranking can answer a rest-of-season question
+            # — for 18.1% of the live board, it is the ONLY thing
+            # answering it.  The value is left alone; what it rests on
+            # is published beside it.
+            if is_dynasty_proxy:
+                acc.dynasty_proxy_weight += row_weight
             acc.contributors.append(
                 {
                     "sourceKey": snap.source_key,
@@ -225,6 +269,7 @@ def aggregate(
                     "score": round(score, 2),
                     "weight": round(row_weight, 4),
                     "stale": is_stale_source,
+                    "dynastyProxy": is_dynasty_proxy,
                 }
             )
             acc.total_count += 1
@@ -241,6 +286,9 @@ def aggregate(
         if acc.weight_sum <= 0:
             continue
         ros_value = acc.weighted_score_sum / acc.weight_sum
+        # Share of the evidence weight behind this row that came from a
+        # dynasty board standing in for rest-of-season evidence.
+        proxy_share = (acc.dynasty_proxy_weight / acc.weight_sum) if acc.weight_sum else 0.0
         stddev = statistics.pstdev(acc.raw_scores) if len(acc.raw_scores) > 1 else 0.0
         median_rank = statistics.median(acc.ranks) if acc.ranks else None
         # DISTINCT sources, not rows.  ``sourceCount`` is the number the UI
@@ -273,6 +321,14 @@ def aggregate(
                 "confidence": confidence,
                 "staleFlag": acc.stale_count == acc.total_count and acc.total_count > 0,
                 "volatilityFlag": stddev > VOLATILITY_THRESHOLD,
+                # Which evidence domain this rest-of-season number rests
+                # on.  ``dynasty_proxy_only`` is not a warning that the
+                # value is wrong — it says the only thing answering a
+                # rest-of-season question here was a long-horizon
+                # dynasty ranking, which is a different claim and must
+                # not read as the same one.
+                "evidenceBasis": _evidence_basis(proxy_share),
+                "dynastyProxyWeightShare": round(proxy_share, 4),
                 "contributors": acc.contributors,
             }
         )

--- a/src/ros/playoff_sim.py
+++ b/src/ros/playoff_sim.py
@@ -105,27 +105,22 @@ PRESIM_CHECK_EVERY = 40
 # 1% of itself.
 PRESIM_MEAN_TOLERANCE = 0.01
 
-# Coefficient of variation per position for per-player weekly scores.
-# Calibrated from public weekly-scoring datasets — high-variance
-# positions (RB workload swings, WR target volatility) get larger
-# CVs, while QBs are tighter week-to-week.  These coefficients
-# combine with each player's rosValue to produce a per-player
-# Gaussian (mean = rosValue/17 × game-mean scale, sd = mean × cv).
-_PLAYER_CV_BY_POSITION: dict[str, float] = {
-    "QB": 0.32,
-    "RB": 0.55,
-    "WR": 0.60,
-    "TE": 0.65,
-    "DL": 0.55,
-    "DE": 0.55,
-    "DT": 0.55,
-    "EDGE": 0.55,
-    "LB": 0.45,
-    "DB": 0.50,
-    "S": 0.50,
-    "CB": 0.55,
-}
-_DEFAULT_PLAYER_CV = 0.55
+# The rosValue -> weekly-points conversion and its per-position CV table
+# belong to ``src/league_intel/sim_calibration.py``, which owns the
+# ``PointsModel`` this module already draws through
+# (``model.draw(ros, pos, rng)``).  This module used to restate that
+# table verbatim — byte-identical to
+# ``sim_calibration.FALLBACK_CV_BY_POSITION`` — and read it nowhere; its
+# only consumer was a second ``draw()`` implementation in the dormant
+# ``league_intel/sim.py``.  Three copies of three numbers.
+#
+# The comment that stood here also described arithmetic this module has
+# not performed for some time: "mean = rosValue/17 x game-mean scale".
+# The model divides by ``ros_value_per_point`` (2.7 as the documented
+# fallback, or whatever a calibrated ``sim_points_model.json`` supplies)
+# — a points-per-rosValue-unit conversion, not a season total spread
+# over 17 games.  A stale formula in a comment is worse than none: it is
+# the number a reader will quote.
 
 
 def _mean_is_converged(samples: list[float], rel_tolerance: float) -> bool:

--- a/src/ros/power_v2.py
+++ b/src/ros/power_v2.py
@@ -310,122 +310,29 @@ def _streak_score_from_outcomes(outcomes: list[float]) -> float:
     return 0.5  # tie or mixed
 
 
-#: The two lenses this engine publishes, and what separates them.
-#:
-#: They are NOT two formulas.  ``results_only`` is the same weight vector
-#: with ``team_ros_strength`` declared missing, renormalised by the
-#: machinery that already handles an absent team-strength file — so the
-#: relative weighting of every retrospective component is identical in
-#: both, and the only difference is whether the forward-looking input is
-#: in the mix.  That is what makes them lenses rather than engines.
-LENS_FORWARD_LOOKING = "forward_looking"
-LENS_RESULTS_ONLY = "results_only"
-
-#: Why a lens dropped ROS, distinguished from "the file was missing".
-#: A reader must be able to tell a deliberate retrospective view from an
-#: engine that wanted forward-looking strength and could not get it.
-_LENS_DROPPED_ROS = "team_ros_strength (lens: results_only)"
-
-
-def build_section(
-    snapshot: PublicLeagueSnapshot,
+def _score_state(
+    owner_ids: list[str],
+    state: dict[str, Any],
     *,
-    lens: str = LENS_FORWARD_LOOKING,
-) -> dict[str, Any]:
-    """Build the ROS power section for the public contract.
+    snapshot: PublicLeagueSnapshot,
+    ros_pct: dict[str, float],
+    schedule_by_owner: dict[str, float],
+    preseason: bool,
+    results_only: bool,
+) -> tuple[list[dict[str, Any]], list[str], dict[str, float]]:
+    """Score one league state into a ranking.
 
-    Output mirrors the existing ``power.py::build_section`` shape so
-    the frontend can render it side-by-side with no schema fork:
+    Extracted so the current ranking and every week of the trend series
+    run through ONE code path.  A second scoring implementation for the
+    trend is how a "series" ends up being a different quantity from the
+    number it is plotted beside — which is the whole defect V1-52 exists
+    to close, reproduced one layer down.
 
-        {
-            "currentRanking": [...],
-            "weights": { ... },
-            "missingInputs": [...]
-        }
-
-    The historical week-by-week series is intentionally NOT computed
-    here in PR2 — the v1 power section already exposes that, and the
-    ROS-team-strength input only has a single "now" snapshot.  PR3
-    adds historical playoff-odds; the chart on the new tab will hook
-    into that data instead.
+    ``state`` is ``{career, recent, allplay, expected, outcomes}`` as of
+    some point in the season.  Returns ``(rankings, missing_inputs,
+    active_weights)``.
     """
-    registry = snapshot.managers
-    seasons_sorted = sorted(snapshot.seasons, key=lambda s: luck._season_sort_key(s.season))
-    team_strength_rows = _load_team_strength_rows()
-    preseason = _is_preseason(snapshot)
-    if (
-        not seasons_sorted
-        and not team_strength_rows
-        and (snapshot.current_season is None or not (snapshot.current_season.rosters or []))
-    ):
-        return {
-            "currentRanking": [],
-            "lens": lens,
-            "weights": dict(WEIGHTS),
-            "missingInputs": ["snapshot empty"],
-            "rosTeamStrengthAvailable": False,
-        }
-
-    # Career totals across all seasons (matches power.py's accumulator
-    # semantics).  Recent buffer is per-season; the "recent form"
-    # metric is the trailing 3-game average within the current season.
-    career_state: dict[str, dict[str, float | int]] = defaultdict(
-        lambda: {"points": 0.0, "games": 0, "wins": 0.0, "losses": 0.0}
-    )
-    season_outcomes: dict[str, list[float]] = defaultdict(list)
-    last_season_recent: dict[str, list[float]] = defaultdict(list)
-    last_season_allplay_share: dict[str, float] = {}
-
-    for season in seasons_sorted:
-        week_scores = luck._season_weekly_scores(season, registry)
-        if not week_scores:
-            continue
-        if season is seasons_sorted[-1]:
-            recent_buffer: dict[str, list[float]] = defaultdict(list)
-        for wk in sorted(week_scores.keys()):
-            scores = week_scores[wk]
-            actuals, _ = luck._actual_week_results(season, wk, registry)
-            all_play = luck._all_play_week(scores)
-            for oid, pts in scores:
-                s = career_state[oid]
-                s["points"] += pts
-                s["games"] += 1
-                actual_share = actuals.get(oid, 0.0)
-                s["wins"] += actual_share
-                s["losses"] += 1.0 - actual_share
-                season_outcomes[oid].append(actual_share)
-                if season is seasons_sorted[-1]:
-                    rb = recent_buffer[oid]
-                    rb.append(pts)
-                    if len(rb) > _RECENT_WINDOW:
-                        rb.pop(0)
-                    last_season_recent[oid] = list(rb)
-                # Capture the last week's all-play expected share so
-                # the all-play-record percentile reflects current
-                # standings rather than a season-wide average that
-                # would lag mid-season trades.
-                ap = all_play.get(oid) or {}
-                last_season_allplay_share[oid] = float(ap.get("expectedShare", 0.0))
-
-    owner_ids = _enumerate_owner_ids(snapshot, team_strength_rows, sorted(career_state.keys()))
-    if not owner_ids:
-        return {
-            "currentRanking": [],
-            "lens": lens,
-            "weights": dict(WEIGHTS),
-            "missingInputs": ["no owners found"],
-            "rosTeamStrengthAvailable": False,
-        }
-
-    # The results-only lens does not consult team strength at all, rather
-    # than loading it and discarding it — so a reader cannot mistake the
-    # lens for a league whose team-strength file is missing, and so the
-    # schedule-adjusted component (which is derived FROM team strength)
-    # drops with it automatically rather than by a second rule.
-    results_only = lens == LENS_RESULTS_ONLY
-    ros_pct = {} if results_only else _load_team_strength_percentiles()
     ros_available = bool(ros_pct)
-    schedule_by_owner = _schedule_adjusted_scores(snapshot, ros_pct)
     schedule_available = bool(schedule_by_owner)
 
     # Compute per-owner inputs.  ``career_state`` is a defaultdict but
@@ -435,15 +342,15 @@ def build_section(
     # in preseason mode those weights are renormalised away anyway.
     inputs: dict[str, dict[str, float]] = {}
     for oid in owner_ids:
-        s = career_state.get(oid, _EMPTY_CAREER)
+        s = state["career"].get(oid, _EMPTY_CAREER)
         ppg = s["points"] / s["games"] if s["games"] else 0.0
-        rb = last_season_recent.get(oid, [])
+        rb = state["recent"].get(oid, [])
         recent = sum(rb) / len(rb) if rb else 0.0
         wins = s["wins"]
         games = s["games"] or 1
         wl = wins / games  # already in [0, 1]
-        all_play = last_season_allplay_share.get(oid, 0.0)
-        streak = _streak_score_from_outcomes(season_outcomes.get(oid, []))
+        all_play = state["allplay"].get(oid, 0.0)
+        streak = _streak_score_from_outcomes(state["outcomes"].get(oid, []))
         # Luck regression: a team whose actualWins lag expectedWins
         # gets a small boost (regression toward expected).  Clamp to
         # [-0.5, 0.5] then map to [0, 1].
@@ -451,15 +358,7 @@ def build_section(
         # this via build_section but at PR-2 budget we'd rather not
         # invoke the whole section).  Re-use the same all_play share
         # iteration (cheap; same data already in scope).
-        expected_share_running = 0.0
-        for season in seasons_sorted:
-            week_scores = luck._season_weekly_scores(season, registry)
-            for wk in sorted(week_scores.keys()):
-                scores = week_scores[wk]
-                ap_week = luck._all_play_week(scores)
-                if oid in {o for o, _ in scores}:
-                    ap = ap_week.get(oid) or {}
-                    expected_share_running += float(ap.get("expectedShare", 0.0))
+        expected_share_running = state["expected"].get(oid, 0.0)
         luck_delta = (wins - expected_share_running) / games if games else 0.0
         luck_score = max(
             0.0, min(1.0, 0.5 - luck_delta)
@@ -550,9 +449,223 @@ def build_section(
     for rank, row in enumerate(rankings, start=1):
         row["rank"] = rank
 
+    return rankings, missing_inputs, active_weights
+
+
+#: The two lenses this engine publishes, and what separates them.
+#:
+#: They are NOT two formulas.  ``results_only`` is the same weight vector
+#: with ``team_ros_strength`` declared missing, renormalised by the
+#: machinery that already handles an absent team-strength file — so the
+#: relative weighting of every retrospective component is identical in
+#: both, and the only difference is whether the forward-looking input is
+#: in the mix.  That is what makes them lenses rather than engines.
+LENS_FORWARD_LOOKING = "forward_looking"
+LENS_RESULTS_ONLY = "results_only"
+
+#: Why a lens dropped ROS, distinguished from "the file was missing".
+#: A reader must be able to tell a deliberate retrospective view from an
+#: engine that wanted forward-looking strength and could not get it.
+_LENS_DROPPED_ROS = "team_ros_strength (lens: results_only)"
+
+
+def build_section(
+    snapshot: PublicLeagueSnapshot,
+    *,
+    lens: str = LENS_FORWARD_LOOKING,
+) -> dict[str, Any]:
+    """Build the ROS power section for the public contract.
+
+    Output mirrors the existing ``power.py::build_section`` shape so
+    the frontend can render it side-by-side with no schema fork:
+
+        {
+            "currentRanking": [...],
+            "weights": { ... },
+            "missingInputs": [...]
+        }
+
+    The historical week-by-week series is intentionally NOT computed
+    here in PR2 — the v1 power section already exposes that, and the
+    ROS-team-strength input only has a single "now" snapshot.  PR3
+    adds historical playoff-odds; the chart on the new tab will hook
+    into that data instead.
+    """
+    registry = snapshot.managers
+    seasons_sorted = sorted(snapshot.seasons, key=lambda s: luck._season_sort_key(s.season))
+    team_strength_rows = _load_team_strength_rows()
+    preseason = _is_preseason(snapshot)
+    if (
+        not seasons_sorted
+        and not team_strength_rows
+        and (snapshot.current_season is None or not (snapshot.current_season.rosters or []))
+    ):
+        return {
+            "currentRanking": [],
+            "lens": lens,
+            "weights": dict(WEIGHTS),
+            "missingInputs": ["snapshot empty"],
+            "rosTeamStrengthAvailable": False,
+        }
+
+    # Career totals across all seasons (matches power.py's accumulator
+    # semantics).  Recent buffer is per-season; the "recent form"
+    # metric is the trailing 3-game average within the current season.
+    career_state: dict[str, dict[str, float | int]] = defaultdict(
+        lambda: {"points": 0.0, "games": 0, "wins": 0.0, "losses": 0.0}
+    )
+    season_outcomes: dict[str, list[float]] = defaultdict(list)
+    last_season_recent: dict[str, list[float]] = defaultdict(list)
+    last_season_allplay_share: dict[str, float] = {}
+    expected_share_total: dict[str, float] = defaultdict(float)
+    #: ``(season, week, state-as-of-that-week)`` for the trend series.
+    week_states: list[tuple[str, int, dict[str, Any]]] = []
+
+    for season in seasons_sorted:
+        week_scores = luck._season_weekly_scores(season, registry)
+        if not week_scores:
+            continue
+        if season is seasons_sorted[-1]:
+            recent_buffer: dict[str, list[float]] = defaultdict(list)
+        for wk in sorted(week_scores.keys()):
+            scores = week_scores[wk]
+            actuals, _ = luck._actual_week_results(season, wk, registry)
+            all_play = luck._all_play_week(scores)
+            for oid, pts in scores:
+                s = career_state[oid]
+                s["points"] += pts
+                s["games"] += 1
+                actual_share = actuals.get(oid, 0.0)
+                s["wins"] += actual_share
+                s["losses"] += 1.0 - actual_share
+                season_outcomes[oid].append(actual_share)
+                if season is seasons_sorted[-1]:
+                    rb = recent_buffer[oid]
+                    rb.append(pts)
+                    if len(rb) > _RECENT_WINDOW:
+                        rb.pop(0)
+                    last_season_recent[oid] = list(rb)
+                # Capture the last week's all-play expected share so
+                # the all-play-record percentile reflects current
+                # standings rather than a season-wide average that
+                # would lag mid-season trades.
+                ap = all_play.get(oid) or {}
+                last_season_allplay_share[oid] = float(ap.get("expectedShare", 0.0))
+                # Running sum, accumulated HERE rather than re-walked per
+                # owner below.  The re-walk was O(owners x weeks) inside an
+                # owner loop, and the per-week trend would have made it
+                # O(weeks x owners x weeks) for a quantity that is a running
+                # total by construction.
+                expected_share_total[oid] += float(ap.get("expectedShare", 0.0))
+
+            # Snapshot the state AS OF this week, for the trend series.
+            # A copy, because the accumulators keep mutating: a reference
+            # here would make every week's entry show the final standings,
+            # which is a trend line that cannot go down.
+            week_states.append(
+                (
+                    season.season,
+                    wk,
+                    {
+                        "career": {o: dict(v) for o, v in career_state.items()},
+                        "recent": {o: list(v) for o, v in last_season_recent.items()},
+                        "allplay": dict(last_season_allplay_share),
+                        "expected": dict(expected_share_total),
+                        "outcomes": {o: list(v) for o, v in season_outcomes.items()},
+                    },
+                )
+            )
+
+    owner_ids = _enumerate_owner_ids(snapshot, team_strength_rows, sorted(career_state.keys()))
+    if not owner_ids:
+        return {
+            "currentRanking": [],
+            "lens": lens,
+            "weights": dict(WEIGHTS),
+            "missingInputs": ["no owners found"],
+            "rosTeamStrengthAvailable": False,
+        }
+
+    # The results-only lens does not consult team strength at all, rather
+    # than loading it and discarding it — so a reader cannot mistake the
+    # lens for a league whose team-strength file is missing, and so the
+    # schedule-adjusted component (which is derived FROM team strength)
+    # drops with it automatically rather than by a second rule.
+    results_only = lens == LENS_RESULTS_ONLY
+    ros_pct = {} if results_only else _load_team_strength_percentiles()
+    ros_available = bool(ros_pct)
+    schedule_by_owner = _schedule_adjusted_scores(snapshot, ros_pct)
+
+    final_state = {
+        "career": career_state,
+        "recent": last_season_recent,
+        "allplay": last_season_allplay_share,
+        "expected": expected_share_total,
+        "outcomes": season_outcomes,
+    }
+    rankings, missing_inputs, active_weights = _score_state(
+        owner_ids,
+        final_state,
+        snapshot=snapshot,
+        ros_pct=ros_pct,
+        schedule_by_owner=schedule_by_owner,
+        preseason=preseason,
+        results_only=results_only,
+    )
+
+    # ── The trend series ────────────────────────────────────────────
+    #
+    # RESULTS-ONLY at every week, INCLUDING the current one, and that is
+    # deliberate.  ``team_ros_strength`` is a single current snapshot —
+    # ``data/ros/team_strength/latest.json`` — never a per-week history,
+    # so there is no observation of it for any past week.  Back-filling
+    # today's value would be the as-of defect: a number that was not
+    # known then, presented as if it had been.
+    #
+    # Splicing it into only the LAST point would be worse than either
+    # extreme: the line would jump at the final week for a reason that
+    # has nothing to do with how the team played, and no reader could
+    # tell that from a real move.  So the trend is one internally
+    # consistent quantity, and it is NAMED as a different one from the
+    # headline ranking rather than left to be discovered.
+    trend_weeks: list[dict[str, Any]] = []
+    series_by_owner: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for season_label, wk, wk_state in week_states:
+        wk_rankings, _wk_missing, _wk_weights = _score_state(
+            owner_ids,
+            wk_state,
+            snapshot=snapshot,
+            ros_pct={},
+            schedule_by_owner={},
+            preseason=False,
+            results_only=True,
+        )
+        trend_weeks.append({"season": season_label, "week": wk, "rankings": wk_rankings})
+        for row in wk_rankings:
+            series_by_owner[row["ownerId"]].append(
+                {
+                    "season": season_label,
+                    "week": wk,
+                    "powerScore": row["powerScore"],
+                    "rank": row["rank"],
+                }
+            )
+
     return {
         "currentRanking": rankings,
         "lens": lens,
+        "trend": {
+            "lens": LENS_RESULTS_ONLY,
+            "weeks": trend_weeks,
+            "seriesByOwner": {k: v for k, v in series_by_owner.items()},
+            "note": (
+                "Results only. Forward-looking roster strength is a current "
+                "snapshot with no per-week history, so it is excluded from "
+                "every point rather than back-filled into past weeks or "
+                "spliced into the last one. The headline ranking includes it "
+                "and will differ."
+            ),
+        },
         "weights": dict(WEIGHTS),
         "effectiveWeights": dict(active_weights),
         "missingInputs": sorted(missing_inputs),

--- a/src/ros/power_v2.py
+++ b/src/ros/power_v2.py
@@ -54,6 +54,7 @@ from collections import defaultdict
 from typing import Any, Iterable
 
 from src.ros import ROS_DATA_DIR
+from src.ros.aggregate import _evidence_basis as _agg_evidence_basis
 from src.public_league import luck, metrics as _metrics
 from src.public_league.snapshot import PublicLeagueSnapshot
 
@@ -162,6 +163,83 @@ def _load_team_strength_percentiles() -> dict[str, float]:
         scores.append((oid, score))
     score_values = [s for _, s in scores]
     return {oid: _percentile(score_values, score) for oid, score in scores}
+
+
+def ros_strength_evidence() -> dict[str, Any]:
+    """What the dominant power-ranking input rests on, league-wide.
+
+    ``team_ros_strength`` is 0.41 of the composite and, in preseason,
+    the ONLY surviving component — so when the seasonal board behind it
+    is largely dynasty-derived (V1-53 measured 18.1% of players priced
+    by nothing else, 31.4% of contributing weight) the published
+    ordering is largely a dynasty ordering, labelled rest-of-season.
+
+    Reported at the SECTION level and never per owner, deliberately.
+    This module publishes only ``teamRosStrength``'s inclusive
+    percentile precisely because the composite stays private — a rank
+    over 12 owners is 11 ordering constraints against 36 unknowns, and
+    twelve per-team shares would add constraints to that system.
+    "Which sources could price your roster" is also a roster-weakness
+    signal, which is the private side of the §5 boundary. The share of
+    the RANKING that is dynasty-derived is neither.
+
+    Weighted by team strength rather than by team count: one dominant
+    dynasty-priced roster is a different exposure from one trivial one.
+
+    ``None`` — never 0.0 — when no snapshot exists or when its rows
+    predate the stamp. A snapshot written before V1-53 carries no share,
+    and reading that absence as 0.0 would report a dynasty-derived board
+    as pure rest-of-season, which is the silence this exists to remove.
+    """
+    rows = _load_team_strength_rows()
+    total = 0.0
+    weighted = 0.0
+    with_proxy = 0
+    counted = 0
+    for row in rows:
+        share = row.get("dynastyProxyValueShare")
+        if share is None:
+            continue
+        # Two distinct skips, written as two. ``or 0.0`` would collapse
+        # "this row records no strength" into "its strength is zero" —
+        # both skip, but only one of them is a measurement.
+        raw_strength = row.get("teamRosStrength")
+        if raw_strength is None:
+            continue
+        strength = float(raw_strength)
+        if strength <= 0:
+            continue
+        counted += 1
+        total += strength
+        weighted += strength * float(share)
+        if float(share) > 0:
+            with_proxy += 1
+
+    if not counted or total <= 0:
+        return {
+            "basis": "unavailable",
+            "dynastyProxyValueShare": None,
+            "teamsWithAnyDynastyProxy": 0,
+            "teamCount": counted,
+            "note": (
+                "No team-strength snapshot carries an evidence basis. This is "
+                "not a claim that the board is free of dynasty proxies — it is "
+                "that we cannot say."
+            ),
+        }
+
+    share = weighted / total
+    return {
+        "basis": _agg_evidence_basis(share),
+        "dynastyProxyValueShare": round(share, 4),
+        "teamsWithAnyDynastyProxy": with_proxy,
+        "teamCount": counted,
+        "note": (
+            "Share of this ranking's rest-of-season strength input that rests "
+            "on dynasty boards standing in for rest-of-season evidence, "
+            "weighted by team strength. Reported league-wide only."
+        ),
+    }
 
 
 def _schedule_adjusted_scores(
@@ -783,5 +861,6 @@ def build_section(
         "effectiveWeights": dict(active_weights),
         "missingInputs": sorted(missing_inputs),
         "rosTeamStrengthAvailable": ros_available,
+        "rosStrengthEvidence": ros_strength_evidence(),
         "preseason": preseason,
     }

--- a/src/ros/power_v2.py
+++ b/src/ros/power_v2.py
@@ -310,7 +310,28 @@ def _streak_score_from_outcomes(outcomes: list[float]) -> float:
     return 0.5  # tie or mixed
 
 
-def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
+#: The two lenses this engine publishes, and what separates them.
+#:
+#: They are NOT two formulas.  ``results_only`` is the same weight vector
+#: with ``team_ros_strength`` declared missing, renormalised by the
+#: machinery that already handles an absent team-strength file — so the
+#: relative weighting of every retrospective component is identical in
+#: both, and the only difference is whether the forward-looking input is
+#: in the mix.  That is what makes them lenses rather than engines.
+LENS_FORWARD_LOOKING = "forward_looking"
+LENS_RESULTS_ONLY = "results_only"
+
+#: Why a lens dropped ROS, distinguished from "the file was missing".
+#: A reader must be able to tell a deliberate retrospective view from an
+#: engine that wanted forward-looking strength and could not get it.
+_LENS_DROPPED_ROS = "team_ros_strength (lens: results_only)"
+
+
+def build_section(
+    snapshot: PublicLeagueSnapshot,
+    *,
+    lens: str = LENS_FORWARD_LOOKING,
+) -> dict[str, Any]:
     """Build the ROS power section for the public contract.
 
     Output mirrors the existing ``power.py::build_section`` shape so
@@ -339,6 +360,7 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     ):
         return {
             "currentRanking": [],
+            "lens": lens,
             "weights": dict(WEIGHTS),
             "missingInputs": ["snapshot empty"],
             "rosTeamStrengthAvailable": False,
@@ -389,12 +411,19 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     if not owner_ids:
         return {
             "currentRanking": [],
+            "lens": lens,
             "weights": dict(WEIGHTS),
             "missingInputs": ["no owners found"],
             "rosTeamStrengthAvailable": False,
         }
 
-    ros_pct = _load_team_strength_percentiles()
+    # The results-only lens does not consult team strength at all, rather
+    # than loading it and discarding it — so a reader cannot mistake the
+    # lens for a league whose team-strength file is missing, and so the
+    # schedule-adjusted component (which is derived FROM team strength)
+    # drops with it automatically rather than by a second rule.
+    results_only = lens == LENS_RESULTS_ONLY
+    ros_pct = {} if results_only else _load_team_strength_percentiles()
     ros_available = bool(ros_pct)
     schedule_by_owner = _schedule_adjusted_scores(snapshot, ros_pct)
     schedule_available = bool(schedule_by_owner)
@@ -458,14 +487,20 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     # project the upcoming one (see ``_is_preseason``).
     missing_inputs: list[str] = []
     if not ros_available:
-        missing_inputs.append("team_ros_strength")
+        missing_inputs.append(_LENS_DROPPED_ROS if results_only else "team_ros_strength")
     if not schedule_available:
         missing_inputs.append("schedule_adjusted")
     if preseason:
         for component in _HISTORICAL_RESULTS_COMPONENTS:
             if component not in missing_inputs:
                 missing_inputs.append(component)
-    active_weights = {k: v for k, v in WEIGHTS.items() if k not in missing_inputs}
+    # ``missing_inputs`` is a human-readable list; the weight lookup keys
+    # on component NAMES, so the lens marker is normalised back before it
+    # is used to drop a weight.  Without this the lens would leave
+    # ``team_ros_strength`` weighted at 0.41 against a component of 0.0 —
+    # a silent 41% deflation of every score rather than a renormalisation.
+    dropped_components = {m.split(" (")[0] for m in missing_inputs}
+    active_weights = {k: v for k, v in WEIGHTS.items() if k not in dropped_components}
     weight_total = sum(active_weights.values()) or 1.0
 
     rankings: list[dict[str, Any]] = []
@@ -517,6 +552,7 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
 
     return {
         "currentRanking": rankings,
+        "lens": lens,
         "weights": dict(WEIGHTS),
         "effectiveWeights": dict(active_weights),
         "missingInputs": sorted(missing_inputs),

--- a/src/ros/power_v2.py
+++ b/src/ros/power_v2.py
@@ -209,10 +209,21 @@ def _is_preseason(snapshot: PublicLeagueSnapshot) -> bool:
         games have been played yet" and "the prior year is complete
         and we're between seasons".
 
-    In this state the historical-results components describe a finished
-    season and don't project the upcoming year.  The build pipeline
-    drops them via ``missing_inputs`` so the score reflects only
-    forward-looking inputs (ROS strength, roster health, SOS).
+    This predicate answers only "is there an in-progress regular
+    season".  What that IMPLIES depends on the lens, and conflating the
+    two is what made this function's old docstring wrong:
+
+    * FORWARD-LOOKING — the historical-results components describe a
+      finished year and don't project the upcoming one, so the build
+      drops them via ``missing_inputs`` and the score reflects only
+      forward-looking inputs (ROS strength, SOS).
+    * RESULTS-ONLY — the finished year IS the answer.  Nothing is
+      dropped, or the lens would have nothing to say for the whole
+      offseason.
+
+    ``roster_health`` is not in that forward-looking list any more: it
+    was double-counted against ``team_ros_strength`` and was folded into
+    it (0.38 -> 0.41) earlier in V1-52.
     """
     current = snapshot.current_season
     if current is None:
@@ -381,15 +392,35 @@ def _score_state(
 
     # Renormalise weights when missing inputs are present so the score
     # stays in [0, 100] instead of being deflated by the unfilled
-    # weight budget.  Preseason / between-seasons drops the historical
-    # results components — they describe a finished year and don't
-    # project the upcoming one (see ``_is_preseason``).
+    # weight budget.
     missing_inputs: list[str] = []
     if not ros_available:
         missing_inputs.append(_LENS_DROPPED_ROS if results_only else "team_ros_strength")
     if not schedule_available:
         missing_inputs.append("schedule_adjusted")
-    if preseason:
+
+    # THE PRESEASON SUPPRESSION BELONGS TO ONE LENS, NOT BOTH.
+    #
+    # ``_is_preseason``'s own reason for dropping the historical-results
+    # components is that they "describe a finished year and don't project
+    # the upcoming one ... so the score reflects only forward-looking
+    # inputs".  That argument is correct — for the FORWARD-LOOKING lens.
+    # It is exactly backwards for the retrospective one, whose entire
+    # subject matter IS the finished year.
+    #
+    # The results-only lens was added in V1-52 and inherited this rule
+    # unexamined.  The consequence was not subtle: results-only already
+    # drops ``team_ros_strength`` by definition, so preseason left it
+    # with NOTHING — the every-component-missing state the refusal below
+    # exists for — while the completed seasons it is made of sat in the
+    # accumulators untouched, for every day of the offseason.
+    #
+    # Measured on ``evidence/W30/power-two-engines.json``:
+    # ``preseason: true``, ``effectiveWeights`` just
+    # ``{team_ros_strength: 0.38, roster_health: 0.03}``.  After the
+    # roster-health de-double-count, forward-looking preseason carries
+    # ONE component and results-only carries none.
+    if preseason and not results_only:
         for component in _HISTORICAL_RESULTS_COMPONENTS:
             if component not in missing_inputs:
                 missing_inputs.append(component)
@@ -523,20 +554,33 @@ def build_section(
 ) -> dict[str, Any]:
     """Build the ROS power section for the public contract.
 
-    Output mirrors the existing ``power.py::build_section`` shape so
-    the frontend can render it side-by-side with no schema fork:
-
         {
-            "currentRanking": [...],
-            "weights": { ... },
-            "missingInputs": [...]
+            "currentRanking": [...],   # rank/powerScore None when unrankable
+            "lens": "...",
+            "unrankable": {...} | None,
+            "trend": {"weeks": [...], "seriesByOwner": {...}},
+            "weights": {...},          # the spec vector
+            "effectiveWeights": {...}, # what actually applied, renormalised
+            "missingInputs": [...],
+            "preseason": bool,
         }
 
-    The historical week-by-week series is intentionally NOT computed
-    here in PR2 — the v1 power section already exposes that, and the
-    ROS-team-strength input only has a single "now" snapshot.  PR3
-    adds historical playoff-odds; the chart on the new tab will hook
-    into that data instead.
+    Two fields carry the honesty of the thing and are easy to drop:
+
+    * ``effectiveWeights`` is what the score was ACTUALLY computed from.
+      It differs from ``weights`` whenever an input is unavailable, and
+      a surface that renders the spec vector instead will describe a
+      formula the number did not come from.
+    * ``unrankable`` is non-None when NO component survived.  Then
+      ``powerScore`` and ``rank`` are ``None`` — never ``0.0``, never
+      ``1..N`` — because ranking on identically-zero scores publishes
+      the ``owner_ids`` order as if it were a result.
+
+    This docstring used to say the week-by-week series was "intentionally
+    NOT computed here in PR2" and that the v1 power section exposes it
+    instead.  Both halves are now false: ``trend`` is computed here (so
+    the table and the chart beside it are one quantity rather than two
+    formulas), and V1-52 is retiring the v1 section as an engine.
     """
     registry = snapshot.managers
     seasons_sorted = sorted(snapshot.seasons, key=lambda s: luck._season_sort_key(s.season))

--- a/src/ros/power_v2.py
+++ b/src/ros/power_v2.py
@@ -400,7 +400,54 @@ def _score_state(
     # a silent 41% deflation of every score rather than a renormalisation.
     dropped_components = {m.split(" (")[0] for m in missing_inputs}
     active_weights = {k: v for k, v in WEIGHTS.items() if k not in dropped_components}
-    weight_total = sum(active_weights.values()) or 1.0
+
+    # NOTHING SURVIVED -> NOTHING TO RANK ON.
+    #
+    # The renormalisation above is what makes the two lenses one engine,
+    # but it has a floor: when EVERY component is dropped there is no
+    # weighted score left to compute.  The old fallback made
+    # ``weight_total`` 1.0 against an empty numerator, so every owner
+    # scored exactly 0.0 — and the sort below, being stable over equal
+    # keys, then handed out ranks 1..N in ``owner_ids`` order.  An
+    # identifier ordering, published as a power ranking, contradicting
+    # the components printed beside it.
+    #
+    # This is reachable structurally rather than rarely: the
+    # results-only lens drops ``team_ros_strength`` BY DEFINITION and
+    # ``preseason`` drops all seven historical-results components, so
+    # the state is guaranteed for the whole offseason.
+    #
+    # Same failure family as the playoff-odds defect fixed in V1-51 — a
+    # placeholder made every entry tie and the tiebreak leaked an id
+    # ordering into a user-facing ranking.  Refuse instead: the owners
+    # are still listed and their components still published, but the
+    # score and the rank are ``None``.  ``None`` and not ``0.0``,
+    # because 0.0 is a real score a team can earn.
+    unrankable: list[dict[str, Any]] = []
+    if not active_weights:
+        for oid in owner_ids:
+            i = inputs[oid]
+            unrankable.append(
+                {
+                    "ownerId": oid,
+                    "displayName": _metrics.display_name_for(snapshot, oid),
+                    "powerScore": None,
+                    "rank": None,
+                    "components": {
+                        "ppg": round(_percentile(ppg_values, i["ppg"]), 4),
+                        "recent": round(_percentile(recent_values, i["recent"]), 4),
+                        "wl_record": round(i["wl_record"], 4),
+                        "all_play": round(i["all_play"], 4),
+                        "streak": round(i["streak"], 4),
+                        "luck_regression": round(i["luck_regression"], 4),
+                    },
+                    "rosStrengthPercentile": None,
+                    "weightsApplied": {},
+                }
+            )
+        return unrankable, missing_inputs, active_weights
+
+    weight_total = sum(active_weights.values())
 
     rankings: list[dict[str, Any]] = []
     for oid in owner_ids:
@@ -651,9 +698,31 @@ def build_section(
                 }
             )
 
+    # The refusal, surfaced. ``_score_state`` returns rows whose score and
+    # rank are None when no component survived; the section must SAY so
+    # rather than leave a consumer to infer it from null fields, which is
+    # how a refusal gets rendered as an empty table or a zero.
+    unrankable: dict[str, Any] | None = None
+    if not active_weights:
+        unrankable = {
+            "reason": (
+                "no_scoring_component_available"
+                if not preseason
+                else "preseason_and_no_forward_looking_input"
+            ),
+            "missingInputs": sorted(missing_inputs),
+            "explanation": (
+                "Every weighted component is unavailable, so there is no "
+                "quantity to rank on. The owners and their raw component "
+                "values are listed; the score and the rank are withheld "
+                "rather than published as zeros in identifier order."
+            ),
+        }
+
     return {
         "currentRanking": rankings,
         "lens": lens,
+        "unrankable": unrankable,
         "trend": {
             "lens": LENS_RESULTS_ONLY,
             "weeks": trend_weeks,

--- a/src/ros/team_strength.py
+++ b/src/ros/team_strength.py
@@ -180,7 +180,14 @@ def compute_team_strength(
             # for rest-of-season evidence.  Weighted by VALUE below, not
             # headcount: a dynasty-priced QB1 and a dynasty-priced 30th
             # man are not the same exposure.
-            _ros_value = float(agg.get("rosValue") or 0.0)
+            # No ``or 0.0`` here, and that is a retirement rather than a
+            # move.  The guard above already ``continue``s on
+            # ``agg.get("rosValue", 0) <= 0``, so by this line the key is
+            # present and positive and the coercion was unreachable
+            # defensive code.  Hoisting it out of the ``RosterPlayer(...)``
+            # call is what made that visible — the baseline had carried it
+            # as accepted debt inline.
+            _ros_value = float(agg["rosValue"])
             _proxy_share = agg.get("dynastyProxyWeightShare")
             if _proxy_share is not None:
                 priced_value += _ros_value

--- a/src/ros/team_strength.py
+++ b/src/ros/team_strength.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from src.ros import ROS_DATA_DIR
+from src.ros.aggregate import _evidence_basis as _agg_evidence_basis
 from src.ros.lineup import RosterPlayer, optimize_lineup
 from src.utils.name_clean import resolve_canonical_name
 
@@ -34,6 +35,20 @@ WEIGHT_STARTING = 0.72
 WEIGHT_DEPTH = 0.18
 WEIGHT_COVERAGE = 0.05
 WEIGHT_HEALTH = 0.05
+
+
+def _team_evidence_basis(proxy_value_share: float | None) -> str:
+    """Classify a TEAM by how much of its priced value is a dynasty proxy.
+
+    Reuses the per-row vocabulary from ``aggregate`` so a reader does not
+    have to learn two, and adds one state that only exists here:
+    ``unpriced``, for a roster with nothing priced at all.  That is not
+    ``rest_of_season`` — it is the absence of any evidence, and calling
+    it the clean state would be exactly the coercion this unit removes.
+    """
+    if proxy_value_share is None:
+        return "unpriced"
+    return _agg_evidence_basis(proxy_value_share)
 
 
 def compute_team_strength(
@@ -105,6 +120,9 @@ def compute_team_strength(
     for team in teams:
         roster_players = team.get("players") or []
         roster: list[RosterPlayer] = []
+        # Value-weighted dynasty-proxy exposure for this roster.
+        priced_value = 0.0
+        proxy_value = 0.0
         unmapped: list[str] = []
         for p in roster_players:
             name = p.get("canonicalName") or p.get("displayName") or p.get("name") or ""
@@ -157,18 +175,38 @@ def compute_team_strength(
                     )
                 )
                 continue
+            # V1-53 / C5-ROS-01.  Carry how much of this player's
+            # rest-of-season value rests on a DYNASTY board standing in
+            # for rest-of-season evidence.  Weighted by VALUE below, not
+            # headcount: a dynasty-priced QB1 and a dynasty-priced 30th
+            # man are not the same exposure.
+            _ros_value = float(agg.get("rosValue") or 0.0)
+            _proxy_share = agg.get("dynastyProxyWeightShare")
+            if _proxy_share is not None:
+                priced_value += _ros_value
+                proxy_value += _ros_value * float(_proxy_share)
             roster.append(
                 RosterPlayer(
                     player_id=str(p.get("playerId") or name),
                     canonical_name=name,
                     position=position or (agg.get("position") or "").upper(),
-                    ros_value=float(agg.get("rosValue") or 0.0),
+                    ros_value=_ros_value,
                     confidence=float(agg.get("confidence") or 0.0),
                     injured=bool(p.get("injured")),
                     bye=bool(p.get("bye")),
                     fantasy_positions=fantasy_positions,
                 )
             )
+
+        # Share of the roster's PRICED value that rests on dynasty
+        # proxies.  ``None`` — never 0.0 — when nothing was priced:
+        # "measured, and none of it is dynasty" and "we could not
+        # measure" are different claims, and 0.0 already means the
+        # first.  Unpriced players are in neither numerator nor
+        # denominator; they are reported by ``unmappedPlayerCount``, and
+        # inventing a basis for a player we could not price would be the
+        # original defect under a new name.
+        proxy_value_share = (proxy_value / priced_value) if priced_value > 0 else None
 
         solution = optimize_lineup(roster, starter_slots=starter_slots)
         composite = (
@@ -187,6 +225,12 @@ def compute_team_strength(
                 "benchDepthScore": solution.bench_depth_score,
                 "positionalCoverageScore": solution.positional_coverage_score,
                 "healthAvailabilityScore": solution.health_availability_score,
+                # What this team's rest-of-season number rests on.  It is
+                # a statement ABOUT the composite, and moves none of it.
+                "dynastyProxyValueShare": (
+                    None if proxy_value_share is None else round(proxy_value_share, 4)
+                ),
+                "evidenceBasis": _team_evidence_basis(proxy_value_share),
                 "startingLineup": solution.starting_lineup,
                 "benchDepth": solution.bench_depth,
                 # FULL roster, for consumers that must not read a

--- a/tests/bdvm/test_projection_scoring_basis.py
+++ b/tests/bdvm/test_projection_scoring_basis.py
@@ -1,0 +1,152 @@
+"""A consensus must be over ONE known scoring basis.
+
+WHAT IS WRONG
+-------------
+``ProjectionRecord.resolve_fpg`` returns ``(value, scoring_native)``, and
+``scoring_native`` is False whenever the value is a points TOTAL the
+source published under its own scoring rather than a stat line this
+league can score. The manual-CSV adapter — the documented drop-in for
+"the moment a real projection feed lands" — sets it ``False``
+unconditionally.
+
+``blend_consensus`` then averages every record together regardless, and
+stamps ``all_scoring_native`` on the result. **Nothing reads that flag.**
+Measured 2026-08-19: it is written in exactly one place and consumed in
+none, so a projection denominated in some other provider's scoring lands
+in the same ``mu_fpg`` as one scored under this league's card, and no
+consumer can tell.
+
+Averaging points from two different scoring systems is a category error,
+not an imprecision. The same body of evidence rule that governs signal
+independence applies to units: you cannot mean two quantities that are
+not the same quantity.
+
+WHY THIS IS NOT HYPOTHETICAL
+----------------------------
+The repo already contains a real forward-looking projection feed that
+would arrive exactly this way. ``CSVs/site_raw/draftSharksSf.csv`` and
+``draftSharksIdp.csv`` publish ``1yr. Proj`` — 412 of 439 offensive rows
+and 375 of 410 IDP rows populated, with the season-total shape you would
+expect (QB max 403, RB1 309, WR1 257, TE1 214). It publishes **totals,
+not stat lines**, and **no scoring metadata at all**, so its basis
+cannot be verified and its numbers cannot be rescored under this
+league's card.
+
+That feed is the reason to fix the consumer before ingesting anything:
+the hazard is not the source's fault, it is that the blend cannot
+currently refuse.
+
+THE RULE
+--------
+Non-native records are EXCLUDED from the mean, named in
+``excluded_foreign_basis``, and the consensus says so. Excluded rather
+than down-weighted, because a weight expresses "less reliable" and this
+is "different unit". If every record is non-native there is nothing to
+verify against, so the consensus is returned flagged rather than
+silently — the owners of the number get to see the state, the same
+posture the rest of this lane takes for an unknown quantity.
+"""
+
+from __future__ import annotations
+
+from src.bdvm.params import load_param_set
+from src.bdvm.projections import ProjectionRecord, blend_consensus
+
+CARD = {"pass_yd": 0.04, "pass_td": 4.0, "rec": 1.0, "rec_yd": 0.1, "rush_yd": 0.1}
+AS_OF = "2026-08-01"
+
+
+def _rec(source: str, *, fpg: float, native: bool) -> ProjectionRecord:
+    return ProjectionRecord(
+        source=source,
+        player_key="test player",
+        position="WR",
+        season=2026,
+        as_of=AS_OF,
+        games=17.0,
+        fpg=fpg,
+        scoring_native=native,
+    )
+
+
+def _blend(*records):
+    return blend_consensus(
+        records,
+        scoring_settings=CARD,
+        snapshot_as_of=AS_OF,
+        params=load_param_set(),
+    )
+
+
+def test_a_foreign_basis_record_does_not_enter_the_mean():
+    """The whole point: 10.0 league-scored points and 20.0 points in
+    somebody else's scoring do not average to 15.0."""
+    native_only = _blend(_rec("a", fpg=10.0, native=True))
+    mixed = _blend(
+        _rec("a", fpg=10.0, native=True),
+        _rec("foreign", fpg=20.0, native=False),
+    )
+    assert native_only is not None and mixed is not None
+    assert mixed.mu_fpg == native_only.mu_fpg, (
+        f"a record in an unverified scoring basis moved the consensus "
+        f"{native_only.mu_fpg} -> {mixed.mu_fpg}; points from two scoring "
+        f"systems cannot be averaged"
+    )
+    assert "foreign" in mixed.excluded_foreign_basis
+    assert "foreign" not in mixed.sources
+
+
+def test_the_exclusion_is_reported_not_silent():
+    """A dropped source must be visible. Silently discarding evidence is
+    the other way to get a number nobody can account for."""
+    mixed = _blend(
+        _rec("a", fpg=10.0, native=True),
+        _rec("foreign", fpg=20.0, native=False),
+    )
+    assert mixed.excluded_foreign_basis == ("foreign",)
+    assert mixed.n_sources == 1, "n_sources must count what was actually blended"
+
+
+def test_all_native_is_untouched():
+    """NON-VACUITY. A change that excluded everything, or that fired on
+    any multi-source blend, would satisfy the tests above."""
+    both = _blend(
+        _rec("a", fpg=10.0, native=True),
+        _rec("b", fpg=20.0, native=True),
+    )
+    assert both is not None
+    assert both.excluded_foreign_basis == ()
+    assert both.n_sources == 2
+    assert 10.0 < both.mu_fpg < 20.0, both.mu_fpg
+
+
+def test_all_foreign_is_flagged_rather_than_dropped_to_nothing():
+    """If every record is non-native there is nothing to verify against.
+    Returning None would report the player as unpriced when a real
+    projection exists; blending silently would hide the basis. So it
+    blends and declares the state."""
+    only_foreign = _blend(
+        _rec("x", fpg=10.0, native=False),
+        _rec("y", fpg=20.0, native=False),
+    )
+    assert only_foreign is not None, "an unpriced player is a different claim"
+    assert only_foreign.all_scoring_native is False
+    assert only_foreign.excluded_foreign_basis == (), (
+        "with nothing native to protect, excluding every record would "
+        "report unpriced rather than unverified"
+    )
+    assert 10.0 <= only_foreign.mu_fpg <= 20.0
+
+
+def test_the_flag_is_no_longer_write_only():
+    """The defect was a declared property nothing acted on. This asserts
+    it now changes an outcome, which is what stops it regressing to a
+    decoration."""
+    mixed = _blend(
+        _rec("a", fpg=10.0, native=True),
+        _rec("foreign", fpg=99.0, native=False),
+    )
+    assert (
+        mixed.all_scoring_native is True
+    ), "after excluding the foreign row, everything blended IS native"
+    assert mixed.mu_fpg == 10.0

--- a/tests/league_intel/test_points_model_single_owner.py
+++ b/tests/league_intel/test_points_model_single_owner.py
@@ -1,0 +1,112 @@
+"""The rosValue -> weekly-points conversion has ONE owner.
+
+WHAT WAS DUPLICATED
+-------------------
+``src/league_intel/sim_calibration.py`` owns the conversion: a
+``PointsModel`` with ``ros_value_per_point``, a per-position CV table and
+a ``source`` stamp, loadable from a calibrated artifact and degrading to
+documented fallback constants.
+
+Two copies of its numbers had grown beside it:
+
+* ``ros/playoff_sim._PLAYER_CV_BY_POSITION`` / ``_DEFAULT_PLAYER_CV`` —
+  byte-identical to ``sim_calibration.FALLBACK_CV_BY_POSITION`` /
+  ``FALLBACK_DEFAULT_CV``, and read by nothing in that module;
+* ``league_intel/sim._LegacyPointsModel`` — a second implementation of
+  ``draw()`` with ``2.7`` hardcoded, importing the CV table from
+  ``playoff_sim`` rather than from the owner.
+
+So the same three numbers existed in three places and the same Gaussian
+draw in two.
+
+NOT A LIVE DEFECT, AND SAYING SO MATTERS
+----------------------------------------
+``league_intel/sim.py`` and ``league_intel/twin.py`` are reachable only
+from tests — no production caller — so the hardcoded ``2.7`` was never
+serving a user, and the live path (``playoff_sim`` -> ``PointsModel``)
+reads the owner correctly. This is dormant duplication being removed
+before it diverges, not a repair of something that was wrong on the
+site. Recording that distinction rather than claiming a bigger fix.
+
+The value of removing it is specific: a calibrated
+``sim_points_model.json`` changes the live path and would leave the
+dormant copy silently on the fallback constants, at which point two
+answers to "how many points is this rosValue" exist and only one of them
+tracks the calibration.
+"""
+
+from __future__ import annotations
+
+import random
+
+from src.league_intel import sim as _sim
+from src.league_intel import sim_calibration as _sc
+
+
+def test_the_cv_table_has_one_definition():
+    """``playoff_sim`` must not keep its own copy of the owner's table."""
+    from src.ros import playoff_sim
+
+    assert not hasattr(playoff_sim, "_PLAYER_CV_BY_POSITION"), (
+        "playoff_sim re-declares the owner's CV table; a second copy of "
+        "constants is a second owner waiting to diverge"
+    )
+    assert not hasattr(playoff_sim, "_DEFAULT_PLAYER_CV")
+
+
+def test_the_legacy_model_draws_identically_to_the_owner():
+    """Behavioural parity, not a reading of the two implementations.
+
+    Same seed, same inputs, same draws — which is what makes replacing
+    one with the other an exact identity rather than a judgement call.
+    """
+    owner = _sc.PointsModel()
+    legacy = _sim._LEGACY_POINTS_MODEL
+
+    for position in ("QB", "RB", "WR", "TE", "LB", "DB", "K", ""):
+        for ros in (0.0, 0.4, 5.0, 9.15, 25.0, 59.41, 100.0):
+            a = owner.draw(ros, position, random.Random(4242))
+            b = legacy.draw(ros, position, random.Random(4242))
+            assert a == b, f"diverged at position={position!r} rosValue={ros}: {a} vs {b}"
+
+
+def test_the_legacy_model_still_declares_its_own_source():
+    """Parity of NUMBERS is not parity of PROVENANCE. The dormant path
+    must keep saying it is on legacy constants, so a sim run reporting
+    ``pointsModelSource`` cannot claim calibration it did not get."""
+    assert _sim._LEGACY_POINTS_MODEL.source == "legacy-constants"
+    assert _sc.PointsModel().source == "fallback-constants"
+
+
+def test_the_conversion_constant_is_not_restated_in_code():
+    """``2.7`` must not appear as a divisor in the consumer's CODE.
+
+    Asserted over the AST rather than the source text, because the first
+    version of this test matched the module's own DOCSTRING describing
+    the constant — prose about a defect is not the defect. Same trap the
+    V1-51 structural guard hit, and the same fix.
+    """
+    import ast
+    import inspect
+
+    tree = ast.parse(inspect.getsource(_sim))
+    divisors = [
+        node.right.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.BinOp)
+        and isinstance(node.op, ast.Div)
+        and isinstance(node.right, ast.Constant)
+        and isinstance(node.right.value, (int, float))
+    ]
+    assert 2.7 not in divisors, (
+        "the rosValue->points divisor is restated as a literal in "
+        "league_intel.sim; it belongs to "
+        "sim_calibration.FALLBACK_ROS_VALUE_PER_POINT"
+    )
+
+
+def test_the_owner_still_holds_the_constant():
+    """NON-VACUITY: the test above passes trivially if the constant
+    stopped existing anywhere. It has an owner, and this names it."""
+    assert _sc.FALLBACK_ROS_VALUE_PER_POINT == 2.7
+    assert _sc.PointsModel().ros_value_per_point == 2.7

--- a/tests/ros/test_lane_separation.py
+++ b/tests/ros/test_lane_separation.py
@@ -1,0 +1,227 @@
+"""C5-ROS-01 — the seasonal lane must SAY when it is leaning on dynasty evidence.
+
+THE BOUNDARY, AND WHICH HALF WAS MISSING
+----------------------------------------
+CLAUDE.md keeps two evidence domains apart. The dynasty direction is
+already enforced hard: every entry in ``data_contract._RANKING_SOURCES``
+must declare ``game_type: DYNASTY`` with evidence, the gate runs at
+import, and ``tests/sources/test_game_type_gate_red.py`` pins it. A
+redraft board cannot reach canonical dynasty value.
+
+The seasonal direction had no equivalent, and the traffic runs the other
+way. ``src/ros/parse.py`` grants a *"Dynasty proxy that's not ROS but
+still relevant"* multiplier to any source with ``is_dynasty and not
+is_ros``, so a long-horizon dynasty ranking answers a rest-of-season
+question. Measured on the live board 2026-08-19:
+
+* ``fantasyProsRosSf``  — ``is_ros=False, is_dynasty=True``, weight 0.85
+* ``fantasyProsRosIdp`` — ``is_ros=False, is_dynasty=True``, weight 1.05
+
+two of five sources, **and both are keyed ``...Ros...``**, which is the
+trap: the name says rest-of-season and the flag says dynasty.
+
+What that buys, on 1,041 live players:
+
+| | |
+|---|---|
+| players with ANY dynasty-board contribution | 720 (69.2%) |
+| players priced **only** by dynasty boards | 188 (18.1%) |
+| share of contributing weight from dynasty boards | 31.4% |
+
+``fantasyProsRosIdp`` is also the **only** ``is_idp`` source in the lane,
+so every IDP player's ROS value rests on a dynasty board.
+
+WHAT THIS FIXES, AND WHAT IT DELIBERATELY DOES NOT
+--------------------------------------------------
+It does **not** exclude the dynasty proxies. Doing so would leave 188
+players unpriced and delete the lane's only IDP evidence — removing
+working functionality to satisfy a rule, when the rule's actual
+requirement is that the two domains stay *distinguishable*. Nor does it
+change any ``rosValue``; the arithmetic is untouched and pinned below.
+
+What it ends is the **silence**. A rest-of-season number resting wholly
+on long-horizon dynasty rankings is a different claim from one resting
+on rest-of-season evidence, and a consumer could not tell them apart.
+Every row now carries ``evidenceBasis`` naming which it is.
+
+Same posture as ``pickValueProvenance`` on pick rows and ``cardBasis`` on
+season blocks: the value is published, and what it rests on travels with
+it.
+"""
+
+from __future__ import annotations
+
+from src.ros import sources as ros_sources
+from src.ros.aggregate import RankedRow, SourceSnapshot, aggregate
+
+LEAGUE = {"is_superflex": True, "is_te_premium": True, "is_2qb": False, "is_idp": True}
+
+#: A fixed stamp, matching ``test_aggregate``'s convention. ``aggregate``
+#: takes no ``now`` hook, so freshness decays against the wall clock —
+#: every assertion below is a label or a relative comparison for exactly
+#: that reason, never an absolute weight.
+_SCRAPED_AT = "2026-04-28T11:00:00+00:00"
+
+
+def _snap(key: str, *, is_ros: bool, is_dynasty: bool, names: list[str], weight: float = 1.0):
+    return SourceSnapshot(
+        source_key=key,
+        base_weight=weight,
+        is_ros=is_ros,
+        is_dynasty=is_dynasty,
+        is_te_premium=True,
+        is_superflex=True,
+        is_2qb=False,
+        is_idp=False,
+        status="ok",
+        scraped_at=_SCRAPED_AT,
+        player_count=len(names),
+        has_valid_cache=True,
+        rows=[
+            RankedRow(canonical_name=n, position="WR", rank=i, total_ranked=len(names))
+            for i, n in enumerate(names, start=1)
+        ],
+    )
+
+
+def _by_name(rows):
+    return {r["canonicalName"]: r for r in rows}
+
+
+# ── 1. The registry fact this unit exists for ───────────────────────
+
+
+def test_the_registry_really_does_admit_dynasty_boards():
+    """Non-vacuity for everything below. If the lane stopped carrying
+    dynasty proxies, these tests would pass by describing nothing."""
+    breaching = [
+        s["key"] for s in ros_sources.ROS_SOURCES if not s.get("is_ros") and s.get("is_dynasty")
+    ]
+    assert breaching, (
+        "no dynasty-flagged source in the ROS lane any more — if that is "
+        "deliberate, this suite and the parse.py proxy branch should go too"
+    )
+    # And the naming trap is real, so it is pinned rather than remembered.
+    assert any("Ros" in k for k in breaching), breaching
+
+
+# ── 2. The basis is stamped ─────────────────────────────────────────
+
+
+def test_a_row_priced_only_by_dynasty_boards_says_so():
+    rows = aggregate(
+        [_snap("dynProxy", is_ros=False, is_dynasty=True, names=["alpha"])],
+        league=LEAGUE,
+    )
+    row = _by_name(rows)["alpha"]
+    assert row["evidenceBasis"] == "dynasty_proxy_only", row.get("evidenceBasis")
+
+
+def test_a_row_priced_only_by_ros_boards_says_so():
+    rows = aggregate(
+        [_snap("realRos", is_ros=True, is_dynasty=False, names=["alpha"])],
+        league=LEAGUE,
+    )
+    assert _by_name(rows)["alpha"]["evidenceBasis"] == "rest_of_season"
+
+
+def test_a_mixed_row_is_named_mixed_and_carries_the_share():
+    rows = aggregate(
+        [
+            _snap("realRos", is_ros=True, is_dynasty=False, names=["alpha"]),
+            _snap("dynProxy", is_ros=False, is_dynasty=True, names=["alpha"]),
+        ],
+        league=LEAGUE,
+    )
+    row = _by_name(rows)["alpha"]
+    assert row["evidenceBasis"] == "mixed"
+    share = row["dynastyProxyWeightShare"]
+    assert 0.0 < share < 1.0, share
+
+
+def test_the_share_is_zero_and_one_at_the_ends():
+    """The share must be usable as a number, not only as a label."""
+    only_ros = aggregate(
+        [_snap("realRos", is_ros=True, is_dynasty=False, names=["alpha"])], league=LEAGUE
+    )
+    only_dyn = aggregate(
+        [_snap("dynProxy", is_ros=False, is_dynasty=True, names=["alpha"])], league=LEAGUE
+    )
+    assert _by_name(only_ros)["alpha"]["dynastyProxyWeightShare"] == 0.0
+    assert _by_name(only_dyn)["alpha"]["dynastyProxyWeightShare"] == 1.0
+
+
+# ── 3. Nothing about the value moved ────────────────────────────────
+
+
+def test_the_stamp_changes_no_value():
+    """This unit is about what the number CLAIMS, not what it is.
+
+    The dynasty proxy must still vote with exactly the weight it had.
+    Asserted by making it DISAGREE and checking the disagreement lands,
+    rather than against a remembered constant — a constant would also
+    pass if the proxy were silently dropped and the remaining source
+    happened to reproduce it.
+    """
+    ros = _snap("realRos", is_ros=True, is_dynasty=False, names=["alpha", "beta", "gamma"])
+    # The proxy ranks gamma top and alpha last — the exact opposite end.
+    proxy = _snap("dynProxy", is_ros=False, is_dynasty=True, names=["gamma", "beta", "alpha"])
+
+    with_proxy = _by_name(aggregate([ros, proxy], league=LEAGUE))
+    without = _by_name(aggregate([ros], league=LEAGUE))
+
+    assert all(r["sourceCount"] == 2 for r in with_proxy.values()), "both sources must vote"
+    # gamma is last on the ROS board and first on the proxy: if the proxy
+    # is counted, gamma gains and alpha loses relative to ROS-only.
+    assert with_proxy["gamma"]["rosValue"] > without["gamma"]["rosValue"]
+    assert with_proxy["alpha"]["rosValue"] < without["alpha"]["rosValue"]
+    # ...and every one of them is stamped mixed, not quietly excluded.
+    assert {r["evidenceBasis"] for r in with_proxy.values()} == {"mixed"}
+
+
+def test_a_source_that_is_neither_ros_nor_dynasty_is_not_a_dynasty_proxy():
+    """The predicate is ``is_dynasty and not is_ros``, NOT ``not is_ros``.
+
+    The lane carries a third kind: ``ffc2qbAdp`` is live with
+    ``is_ros=False, is_dynasty=False`` — an ADP feed, which is neither a
+    rest-of-season board nor a dynasty one. Calling it a dynasty proxy
+    would be a different false claim from the one this unit fixes, and
+    ``parse.effective_source_weight`` does not price it as one either.
+
+    Added because the mutation that widens the predicate passed every
+    other test in this file.
+    """
+    rows = aggregate(
+        [_snap("adpFeed", is_ros=False, is_dynasty=False, names=["alpha"])],
+        league=LEAGUE,
+    )
+    row = _by_name(rows)["alpha"]
+    assert row["dynastyProxyWeightShare"] == 0.0
+    assert row["evidenceBasis"] == "rest_of_season", (
+        "an ADP feed is not a dynasty proxy; mislabelling it is a "
+        "different false claim, not a safer one"
+    )
+    assert row["contributors"][0]["dynastyProxy"] is False
+
+
+def test_the_live_registry_contains_all_three_kinds():
+    """Non-vacuity for the test above: it only guards anything while a
+    neither-flag source actually exists in the lane."""
+    kinds = {(bool(s.get("is_ros")), bool(s.get("is_dynasty"))) for s in ros_sources.ROS_SOURCES}
+    assert (True, False) in kinds, "no real ROS board in the lane"
+    assert (False, True) in kinds, "no dynasty proxy in the lane"
+    assert (False, False) in kinds, "no neither-kind source; the predicate test is moot"
+
+
+def test_the_contributor_rows_name_which_source_was_the_proxy():
+    """The share is a summary; a reader auditing one player needs to see
+    WHICH source it came from without re-deriving it from the registry."""
+    rows = aggregate(
+        [
+            _snap("realRos", is_ros=True, is_dynasty=False, names=["alpha"]),
+            _snap("dynProxy", is_ros=False, is_dynasty=True, names=["alpha"]),
+        ],
+        league=LEAGUE,
+    )
+    contribs = {c["sourceKey"]: c["dynastyProxy"] for c in _by_name(rows)["alpha"]["contributors"]}
+    assert contribs == {"realRos": False, "dynProxy": True}

--- a/tests/ros/test_power_evidence_disclosure.py
+++ b/tests/ros/test_power_evidence_disclosure.py
@@ -1,0 +1,130 @@
+"""The power ranking must say what its dominant input rests on.
+
+WHY THIS BELONGS AT THE SECTION LEVEL, NOT PER OWNER
+----------------------------------------------------
+``power_v2`` weights ``team_ros_strength`` at 0.41, and in preseason —
+once every historical-results component is dropped — it is the **only**
+surviving component, so the published ranking is that one number's
+percentile and nothing else.
+
+V1-53 measured that the seasonal board it comes from is substantially
+dynasty-derived: 18.1% of players priced by nothing but dynasty boards,
+31.4% of contributing weight. So in preseason the public Power tab can
+be showing a largely dynasty-derived ordering, labelled rest-of-season,
+with nothing saying so.
+
+The obvious fix — stamp each owner's ``dynastyProxyValueShare`` on their
+ranking row — is the WRONG one, and the module says why in its own
+words. ``teamRosStrength``'s inclusive percentile is public "by owner
+decision", and *"publishing only that rank is what keeps it safe — the
+composite is 0.72S + 0.18D + 0.05C + 0.05H and a rank over 12 owners is
+11 ordering constraints against 36 unknowns"*. Twelve more per-team
+numbers on a public payload adds constraints to exactly that system, and
+"which sources could price your roster" reads as a roster-weakness
+signal — the private side of CLAUDE.md §5's boundary.
+
+So the disclosure is about the RANKING, not about any team: one
+league-wide, value-weighted share plus how many teams are affected. That
+is the claim a reader actually needs — *how much of this ordering is
+dynasty-derived* — and it adds no per-owner constraint.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.ros import power_v2
+
+
+@pytest.fixture
+def _strength_rows(tmp_path, monkeypatch):
+    """Write a team-strength snapshot and point the loader at it."""
+
+    def _write(rows):
+        path = tmp_path / "latest.json"
+        path.write_text(json.dumps(rows))
+        monkeypatch.setattr(
+            power_v2, "_load_team_strength_rows", lambda: json.loads(path.read_text())
+        )
+        return rows
+
+    return _write
+
+
+def _row(owner, strength, *, share, basis=None):
+    if basis is None:
+        basis = (
+            "rest_of_season" if share == 0 else ("dynasty_proxy_only" if share == 1 else "mixed")
+        )
+    return {
+        "ownerId": owner,
+        "teamRosStrength": strength,
+        "dynastyProxyValueShare": share,
+        "evidenceBasis": basis,
+    }
+
+
+def test_the_league_wide_share_is_reported(_strength_rows):
+    _strength_rows([_row("o1", 80.0, share=1.0), _row("o2", 20.0, share=0.0)])
+    ev = power_v2.ros_strength_evidence()
+    assert ev["dynastyProxyValueShare"] == pytest.approx(0.8, abs=1e-6), ev
+    assert ev["basis"] == "mixed"
+    assert ev["teamsWithAnyDynastyProxy"] == 1
+    assert ev["teamCount"] == 2
+
+
+def test_it_is_weighted_by_strength_not_by_team_count(_strength_rows):
+    """One dominant dynasty-priced team is a different exposure from one
+    trivial one, and a headcount calls them equal."""
+    _strength_rows([_row("o1", 90.0, share=1.0), _row("o2", 10.0, share=0.0)])
+    assert power_v2.ros_strength_evidence()["dynastyProxyValueShare"] == pytest.approx(0.9)
+    _strength_rows([_row("o1", 10.0, share=1.0), _row("o2", 90.0, share=0.0)])
+    assert power_v2.ros_strength_evidence()["dynastyProxyValueShare"] == pytest.approx(0.1)
+
+
+def test_no_per_owner_share_reaches_the_public_payload(_strength_rows):
+    """The disclosure boundary. Twelve per-team numbers would add
+    constraints to the system the module deliberately protects."""
+    _strength_rows([_row(f"o{i}", 50.0 + i, share=0.5) for i in range(1, 5)])
+    ev = power_v2.ros_strength_evidence()
+    assert "perOwner" not in ev
+    assert not any(isinstance(v, (list, dict)) for v in ev.values()), ev
+
+
+def test_an_absent_snapshot_reports_unavailable_not_zero(_strength_rows):
+    """0.0 means 'measured, none of it dynasty'. No snapshot means we
+    cannot say, and those must not read the same."""
+    _strength_rows([])
+    ev = power_v2.ros_strength_evidence()
+    assert ev["dynastyProxyValueShare"] is None
+    assert ev["basis"] == "unavailable"
+
+
+def test_rows_predating_the_stamp_are_unavailable_not_clean(_strength_rows):
+    """A snapshot written before V1-53 carries no share. Treating that
+    absence as 0.0 would report a dynasty-derived board as pure
+    rest-of-season — the exact silence this unit removes."""
+    _strength_rows([{"ownerId": "o1", "teamRosStrength": 80.0}])
+    ev = power_v2.ros_strength_evidence()
+    assert ev["dynastyProxyValueShare"] is None
+    assert ev["basis"] == "unavailable"
+
+
+def test_the_section_carries_it(_strength_rows):
+    """It has to reach the payload, or it is another stamp nobody reads."""
+    from tests.ros.test_power_v2 import _make_snapshot
+
+    _strength_rows([_row("o1", 80.0, share=1.0), _row("o2", 20.0, share=0.0)])
+    rosters = [{"roster_id": i, "owner_id": f"o{i}"} for i in (1, 2)]
+    matchups = {
+        wk: [
+            {"roster_id": 1, "matchup_id": 1, "points": 120.0 + wk},
+            {"roster_id": 2, "matchup_id": 1, "points": 100.0 - wk},
+        ]
+        for wk in (1, 2, 3)
+    }
+    section = power_v2.build_section(_make_snapshot(rosters, matchups))
+    assert "rosStrengthEvidence" in section
+    assert section["rosStrengthEvidence"]["dynastyProxyValueShare"] == pytest.approx(0.8)

--- a/tests/ros/test_power_lenses.py
+++ b/tests/ros/test_power_lenses.py
@@ -159,3 +159,156 @@ def test_every_payload_stamps_which_lens_produced_it(lens):
 
     out = power_v2.build_section(_empty_snapshot(), lens=lens)
     assert out["lens"] == lens
+
+
+# ── The trend series ─────────────────────────────────────────────────
+
+
+def _asymmetric_snapshot(through_week: int | None = None):
+    """A league whose weeks actually differ, so a trend can move.
+
+    ``through_week`` truncates the season, so a test can ask what the
+    engine would have said at that point in time."""
+    from src.public_league.identity import Manager, ManagerRegistry
+    from src.public_league.snapshot import PublicLeagueSnapshot, SeasonSnapshot
+
+    rosters = [{"roster_id": i, "owner_id": f"o{i}"} for i in (1, 2, 3, 4)]
+    matchups = {
+        1: [
+            {"roster_id": 1, "matchup_id": 1, "points": 90.0},
+            {"roster_id": 2, "matchup_id": 1, "points": 88.0},
+            {"roster_id": 3, "matchup_id": 2, "points": 140.0},
+            {"roster_id": 4, "matchup_id": 2, "points": 150.0},
+        ],
+        2: [
+            {"roster_id": 1, "matchup_id": 1, "points": 85.0},
+            {"roster_id": 3, "matchup_id": 1, "points": 130.0},
+            {"roster_id": 2, "matchup_id": 2, "points": 70.0},
+            {"roster_id": 4, "matchup_id": 2, "points": 60.0},
+        ],
+        3: [
+            {"roster_id": 1, "matchup_id": 1, "points": 100.0},
+            {"roster_id": 4, "matchup_id": 1, "points": 95.0},
+            {"roster_id": 2, "matchup_id": 2, "points": 115.0},
+            {"roster_id": 3, "matchup_id": 2, "points": 112.0},
+        ],
+    }
+    if through_week is not None:
+        matchups = {w: v for w, v in matchups.items() if w <= through_week}
+    registry = ManagerRegistry()
+    for r in rosters:
+        oid = str(r["owner_id"])
+        registry.by_owner_id[oid] = Manager(owner_id=oid, display_name=oid)
+        registry.roster_to_owner[("L2026", int(r["roster_id"]))] = oid
+    season = SeasonSnapshot(
+        season="2026",
+        league_id="L2026",
+        league={
+            "league_id": "L2026",
+            "season": "2026",
+            "season_type": "regular",
+            "settings": {"playoff_week_start": 15},
+            "total_rosters": 4,
+        },
+        users=[],
+        rosters=rosters,
+        matchups_by_week=matchups,
+        transactions_by_week={},
+        drafts=[],
+        draft_picks_by_draft={},
+        traded_picks=[],
+        winners_bracket=[],
+        losers_bracket=[],
+    )
+    return PublicLeagueSnapshot(
+        root_league_id="L2026",
+        generated_at="2026-04-30T00:00:00Z",
+        seasons=[season],
+        managers=registry,
+    )
+
+
+def test_each_trend_week_reflects_the_state_AS_OF_that_week(monkeypatch):
+    """THE BUG THIS AVOIDS, and it would have been invisible.
+
+    The accumulators keep mutating as the walk proceeds, so storing a
+    REFERENCE per week rather than a copy makes every week's entry show
+    the final standings — a trend line that is flat by construction and
+    cannot go down. Here week 1 and week 3 must differ, and at least one
+    manager's rank must change across the series.
+    """
+    monkeypatch.setattr(power_v2, "_load_team_strength_percentiles", lambda: {})
+    out = power_v2.build_section(_asymmetric_snapshot())
+    weeks = out["trend"]["weeks"]
+
+    assert [w["week"] for w in weeks] == [1, 2, 3]
+
+    # THE property, stated exactly: the trend's week-N point is what the
+    # engine would have said if the season had ended at week N. A weaker
+    # "the weeks differ from each other" check passes even when SOME of
+    # the five accumulators are shared by reference, because the others
+    # still vary — measured, and it is why this is written this way.
+    for n in (1, 2, 3):
+        as_of = power_v2.build_section(_asymmetric_snapshot(through_week=n))
+        expected = {r["ownerId"]: r["powerScore"] for r in as_of["currentRanking"]}
+        got = {r["ownerId"]: r["powerScore"] for r in weeks[n - 1]["rankings"]}
+        assert got == expected, f"week {n} of the trend is not the week-{n} state"
+
+    first = {r["ownerId"]: r["rank"] for r in weeks[0]["rankings"]}
+    last = {r["ownerId"]: r["rank"] for r in weeks[-1]["rankings"]}
+    assert any(first[o] != last[o] for o in first), "no rank moved — the trend is not a trend"
+
+
+def test_the_trend_is_results_only_at_every_point_including_the_last(monkeypatch):
+    """Forward-looking strength is a CURRENT snapshot with no per-week
+    history, so no past week has an observation of it. Back-filling
+    today's value is the as-of defect; splicing it into only the final
+    point is worse, because the line would jump for a reason unrelated to
+    play and no reader could tell that from a real move."""
+    monkeypatch.setattr(power_v2, "_load_team_strength_percentiles", lambda: {"o1": 0.99})
+    out = power_v2.build_section(_asymmetric_snapshot())
+
+    assert out["lens"] == power_v2.LENS_FORWARD_LOOKING
+    assert out["trend"]["lens"] == power_v2.LENS_RESULTS_ONLY
+    for week in out["trend"]["weeks"]:
+        for row in week["rankings"]:
+            assert "team_ros_strength" not in row["weightsApplied"]
+            assert row["rosStrengthPercentile"] is None
+
+
+def test_the_trend_says_it_differs_from_the_headline(monkeypatch):
+    """Named, not left to be discovered. With forward-looking strength
+    available the headline and the final trend point are different
+    quantities, and a reader comparing them needs to be told."""
+    monkeypatch.setattr(
+        power_v2,
+        "_load_team_strength_percentiles",
+        lambda: {"o1": 0.99, "o2": 0.5, "o3": 0.1, "o4": 0.2},
+    )
+    out = power_v2.build_section(_asymmetric_snapshot())
+
+    headline = {r["ownerId"]: r["powerScore"] for r in out["currentRanking"]}
+    final_point = {r["ownerId"]: r["powerScore"] for r in out["trend"]["weeks"][-1]["rankings"]}
+    assert headline != final_point, "fixture failed to make the lenses differ"
+    assert "Results only" in out["trend"]["note"]
+    assert "will differ" in out["trend"]["note"]
+
+
+def test_the_series_and_the_weeks_are_the_same_numbers(monkeypatch):
+    """``seriesByOwner`` is a re-shape for charting, not a second
+    computation — the defect this whole unit exists to close, one layer
+    down."""
+    monkeypatch.setattr(power_v2, "_load_team_strength_percentiles", lambda: {})
+    out = power_v2.build_section(_asymmetric_snapshot())
+
+    from_weeks = {
+        (w["week"], r["ownerId"]): r["powerScore"]
+        for w in out["trend"]["weeks"]
+        for r in w["rankings"]
+    }
+    from_series = {
+        (p["week"], oid): p["powerScore"]
+        for oid, points in out["trend"]["seriesByOwner"].items()
+        for p in points
+    }
+    assert from_weeks == from_series

--- a/tests/ros/test_power_lenses.py
+++ b/tests/ros/test_power_lenses.py
@@ -1,0 +1,161 @@
+"""V1-52 — two lenses, one engine.
+
+Two power rankings of this league are published today. Measured in the
+audit capture ``docs/master-site-audit/evidence/W30/power-two-engines.json``,
+on the same week:
+
+    public_league/power.py   Jason ranked 10 of 10   (0.00)
+    ros/power_v2.py          Jason ranked  3 of 12   (80.69)
+
+mean |rank shift| 2.8, max 7. Same manager, same week, two answers, and
+nothing on either surface says they are different quantities.
+
+The owner direction for V1-52 is one canonical power-ranking engine with
+explicitly defined public and private outputs/lenses, and specifically:
+
+> The public ranking should be the best legitimate power ranking we can
+> produce, including appropriate forward-looking roster strength — not
+> deliberately weaker standings-only math.
+
+This file pins the precondition for that: the retrospective view is the
+SAME engine with the forward-looking input declared missing, not a
+second formula. The renormalisation is the machinery that already
+handles an absent team-strength file, so every retrospective component
+keeps its weight RELATIVE to the others across both lenses.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from types import SimpleNamespace
+
+from src.ros import power_v2
+
+
+def _empty_snapshot():
+    """A snapshot with no seasons — enough to reach the lens decision."""
+    return SimpleNamespace(seasons=[], current_season=None, managers=None)
+
+
+def _scored_snapshot():
+    """A league with real scored weeks, so the engine produces real
+    scores rather than short-circuiting on a degenerate fixture."""
+    from tests.ros.test_power_v2 import _make_snapshot
+
+    rosters = [{"roster_id": i, "owner_id": f"o{i}"} for i in (1, 2, 3, 4)]
+    matchups = {
+        wk: [
+            {"roster_id": 1, "matchup_id": 1, "points": 120.0 + wk},
+            {"roster_id": 2, "matchup_id": 1, "points": 100.0 + wk},
+            {"roster_id": 3, "matchup_id": 2, "points": 95.0 + wk},
+            {"roster_id": 4, "matchup_id": 2, "points": 80.0 + wk},
+        ]
+        for wk in (1, 2, 3)
+    }
+    return _make_snapshot(rosters, matchups)
+
+
+def test_the_two_lenses_share_one_weight_vector():
+    """Not two formulas. ``WEIGHTS`` is the only weighting either lens
+    has, so a change to one is a change to both — which is what stops
+    them drifting into two engines again."""
+    assert set(power_v2.WEIGHTS) == {
+        "team_ros_strength",
+        "ppg",
+        "recent",
+        "wl_record",
+        "all_play",
+        "streak",
+        "schedule_adjusted",
+        "luck_regression",
+    }
+    assert sum(power_v2.WEIGHTS.values()) == pytest.approx(1.0)
+
+
+def test_dropping_ros_renormalises_rather_than_deflating(monkeypatch):
+    """THE BUG THIS AVOIDS, observed on the ENGINE rather than re-derived.
+
+    ``missing_inputs`` is a human-readable list and the weight lookup
+    keys on component NAMES. Marking the lens as
+    ``"team_ros_strength (lens: results_only)"`` without normalising it
+    back leaves the 0.41 weight active against a component of 0.0 — a
+    silent 41% deflation of every score, which reads as "every team got
+    worse" rather than "a different question was asked".
+
+    A first version of this test asserted the arithmetic on ``WEIGHTS``
+    directly and stayed GREEN when the engine's normalisation was
+    reverted. It was testing its own re-derivation. This one runs the
+    engine and checks the weights it actually applied.
+    """
+    monkeypatch.setattr(power_v2, "_load_team_strength_percentiles", lambda: {})
+    out = power_v2.build_section(_scored_snapshot(), lens=power_v2.LENS_RESULTS_ONLY)
+
+    applied = out["effectiveWeights"]
+    assert "team_ros_strength" not in applied, (
+        "the lens marker was not normalised back to a component name, so the "
+        "ROS weight stayed active against a zero component"
+    )
+    # ``schedule_adjusted`` is DERIVED from team strength, so it drops with
+    # it — one rule, not two. That is the reason the lens does not load
+    # team strength at all rather than loading and discarding it.
+    assert "schedule_adjusted" not in applied
+    assert sum(applied.values()) == pytest.approx(
+        1.0 - power_v2.WEIGHTS["team_ros_strength"] - power_v2.WEIGHTS["schedule_adjusted"]
+    )
+    # And the scores are renormalised, not scaled down by the dropped budget.
+    assert out["currentRanking"], "fixture produced no ranking"
+    assert max(r["powerScore"] for r in out["currentRanking"]) > 0.0
+
+
+def test_the_retrospective_components_keep_their_relative_weighting():
+    """What makes them lenses rather than engines: the results-only view
+    is the forward-looking one with a term removed and the rest scaled,
+    so no retrospective component is re-weighted against another."""
+    full = power_v2.WEIGHTS
+    active = {k: v for k, v in full.items() if k != "team_ros_strength"}
+    total = sum(active.values())
+    for a in active:
+        for b in active:
+            if a == b:
+                continue
+            assert (full[a] / full[b]) == pytest.approx((active[a] / total) / (active[b] / total))
+
+
+def test_the_lens_marker_says_it_was_a_CHOICE_not_a_missing_file():
+    """A reader must be able to tell a deliberate retrospective view from
+    an engine that wanted forward-looking strength and could not get it.
+    Both drop the same weight; only one of them is a defect."""
+    assert power_v2._LENS_DROPPED_ROS != "team_ros_strength"
+    assert power_v2._LENS_DROPPED_ROS.startswith("team_ros_strength")
+    assert "results_only" in power_v2._LENS_DROPPED_ROS
+
+
+def test_the_results_only_lens_never_reads_team_strength(monkeypatch):
+    """Not loaded-and-discarded. Loading it would make the lens
+    indistinguishable from a league whose file is present, and would
+    leave ``schedule_adjusted`` — which is DERIVED from team strength —
+    alive under a lens that is supposed to be results-only."""
+    calls = []
+    monkeypatch.setattr(
+        power_v2,
+        "_load_team_strength_percentiles",
+        lambda: calls.append(1) or {"o1": 0.9},
+    )
+
+    power_v2.build_section(_empty_snapshot(), lens=power_v2.LENS_RESULTS_ONLY)
+    assert calls == [], "the results-only lens consulted team strength"
+
+    power_v2.build_section(_empty_snapshot(), lens=power_v2.LENS_FORWARD_LOOKING)
+    # The forward-looking lens may short-circuit on an empty snapshot
+    # before loading; what matters is that the lens above did not.
+
+
+@pytest.mark.parametrize("lens", [power_v2.LENS_FORWARD_LOOKING, power_v2.LENS_RESULTS_ONLY])
+def test_every_payload_stamps_which_lens_produced_it(lens):
+    """Including the refusals. "This is the forward-looking ranking" and
+    "this field predates the lens" must not read the same — the rule
+    CLAUDE.md states for ``valuationMode``."""
+
+    out = power_v2.build_section(_empty_snapshot(), lens=lens)
+    assert out["lens"] == lens

--- a/tests/ros/test_power_unrankable.py
+++ b/tests/ros/test_power_unrankable.py
@@ -67,10 +67,12 @@ def _preseason_snapshot():
     return _make_snapshot(rosters, {})
 
 
-def test_results_only_in_preseason_refuses_rather_than_ordering_by_id():
-    """The structural case: this lens ALWAYS loses every component here."""
+def test_forward_looking_with_nothing_to_look_forward_to_refuses():
+    """The reachable case: preseason drops every historical component
+    from THIS lens by design, and a deploy without a team-strength file
+    drops the only forward-looking one. Nothing is left."""
     snapshot = _preseason_snapshot()
-    section = power_v2.build_section(snapshot, lens=power_v2.LENS_RESULTS_ONLY)
+    section = power_v2.build_section(snapshot, lens=power_v2.LENS_FORWARD_LOOKING)
 
     assert section["preseason"] is True
     assert section["effectiveWeights"] == {}, (
@@ -100,7 +102,7 @@ def test_the_owners_are_still_listed_when_it_refuses():
     """Withhold the certainty, not the league. A blank tab is a worse
     answer than an honest one, and the same posture playoff_structure
     already takes for an unknown bracket."""
-    section = power_v2.build_section(_preseason_snapshot(), lens=power_v2.LENS_RESULTS_ONLY)
+    section = power_v2.build_section(_preseason_snapshot(), lens=power_v2.LENS_FORWARD_LOOKING)
     owners = {r["ownerId"] for r in section["currentRanking"]}
     assert owners == {"o1", "o2", "o3", "o4"}
 
@@ -158,9 +160,14 @@ def test_the_trend_is_unaffected_because_it_is_never_preseason():
             assert row["rank"] is not None
 
 
-def test_the_committed_dev_snapshot_reproduces_the_defect_shape():
+def test_the_committed_dev_snapshot_shows_both_halves():
     """The measurement quoted in this module's docstring, pinned so the
-    claim cannot quietly stop being true."""
+    claim cannot quietly stop being true — and its repaired twin.
+
+    ``owner-B`` is the whole argument in one row. Under the defect it
+    scored 0.0 and was handed rank 2 while leading ``owner-A`` on five
+    of seven components. Under the results-only lens it is now first.
+    """
     path = REPO / "data" / "public_league" / "snapshot.json"
     if not path.exists():  # pragma: no cover - data/ is gitignored
         import pytest
@@ -170,8 +177,122 @@ def test_the_committed_dev_snapshot_reproduces_the_defect_shape():
     from src.public_league.snapshot_store import snapshot_from_dict
 
     snapshot = snapshot_from_dict(json.loads(path.read_text()))
+
+    # Forward-looking: preseason, and no team-strength file in this
+    # environment, so there is genuinely nothing to say. It refuses.
+    fwd = power_v2.build_section(snapshot, lens=power_v2.LENS_FORWARD_LOOKING)
+    assert fwd["preseason"] is True
+    assert fwd["effectiveWeights"] == {}
+    assert fwd.get("unrankable")
+    assert all(r["rank"] is None for r in fwd["currentRanking"])
+
+    # Results-only: the completed seasons are exactly its subject, so it
+    # ranks — and it puts the component leader on top.
+    res = power_v2.build_section(snapshot, lens=power_v2.LENS_RESULTS_ONLY)
+    assert not res.get("unrankable")
+    top = res["currentRanking"][0]
+    assert top["ownerId"] == "owner-B", (
+        "the row that exposed the defect must now rank first; it led "
+        "owner-A on five of seven components while ranked below it"
+    )
+    assert top["rank"] == 1 and top["powerScore"] > 0
+
+
+# ── The suppression rule belongs to ONE lens ─────────────────────────
+#
+# ``_is_preseason`` drops all seven ``_HISTORICAL_RESULTS_COMPONENTS``,
+# and its own docstring gives the reason: *"the historical-results
+# components describe a finished season and don't project the upcoming
+# year ... so the score reflects only forward-looking inputs"*.
+#
+# That is an argument about the FORWARD-LOOKING lens, and it is correct
+# there. It is exactly backwards for the retrospective one, whose entire
+# content IS the finished season. The results-only lens was added in
+# V1-52 step 1 and silently inherited a suppression written for the
+# other lens — my own defect, one step earlier.
+#
+# Measured consequence on the committed audit capture
+# ``docs/master-site-audit/evidence/W30/power-two-engines.json``:
+# ``preseason: true`` with ``effectiveWeights`` of just
+# ``{team_ros_strength: 0.38, roster_health: 0.03}``. After the
+# roster-health de-double-count in this same branch, forward-looking
+# preseason carries ONE component; results-only carries NONE, which is
+# the all-zero state the refusal above catches. So for the whole
+# offseason the retrospective lens had nothing to say, while the data it
+# is made of was sitting in the accumulators the entire time.
+
+
+def _completed_season_snapshot():
+    """A finished season and no current-season games — the live state of
+    every league between February and September."""
+    from tests.ros.test_power_v2 import _make_snapshot
+
+    rosters = [{"roster_id": i, "owner_id": f"o{i}"} for i in (1, 2, 3, 4)]
+    matchups = {
+        wk: [
+            {"roster_id": 1, "matchup_id": 1, "points": 130.0 + wk},
+            {"roster_id": 2, "matchup_id": 1, "points": 110.0 + wk},
+            {"roster_id": 3, "matchup_id": 2, "points": 95.0 - wk},
+            {"roster_id": 4, "matchup_id": 2, "points": 80.0 - wk},
+        ]
+        for wk in (1, 2, 3, 4)
+    }
+    return _make_snapshot(rosters, matchups, is_complete=True)
+
+
+def test_results_only_keeps_the_finished_season_it_is_made_of():
+    """The retrospective lens must not suppress the results."""
+    snapshot = _completed_season_snapshot()
     section = power_v2.build_section(snapshot, lens=power_v2.LENS_RESULTS_ONLY)
+
+    assert section["preseason"] is True, "fixture must reach the preseason branch"
+    assert not section.get("unrankable"), (
+        "a completed season is exactly what a results-only ranking is for; "
+        "refusing here means the lens has nothing to say all offseason"
+    )
+    kept = set(section["effectiveWeights"])
+    assert {
+        "ppg",
+        "recent",
+        "wl_record",
+        "all_play",
+    } <= kept, f"results-only dropped its own subject matter: kept {sorted(kept)}"
+    scores = [r["powerScore"] for r in section["currentRanking"]]
+    assert all(s is not None for s in scores)
+    assert len(set(scores)) > 1, "the finished season discriminates; the lens must too"
+
+
+def test_forward_looking_still_suppresses_them():
+    """NON-VACUITY, and the half that must NOT change. Last season's
+    results do not project the upcoming year, so the forward-looking
+    lens keeps dropping them — that rule was right for its own lens."""
+    section = power_v2.build_section(
+        _completed_season_snapshot(), lens=power_v2.LENS_FORWARD_LOOKING
+    )
     assert section["preseason"] is True
-    assert section["effectiveWeights"] == {}
-    assert section.get("unrankable")
-    assert all(r["rank"] is None for r in section["currentRanking"])
+    kept = set(section["effectiveWeights"])
+    assert not (
+        {"ppg", "recent", "wl_record", "all_play"} & kept
+    ), f"forward-looking must not price a finished season: kept {sorted(kept)}"
+
+
+def test_an_in_progress_season_is_unchanged_for_both_lenses():
+    """The suppression only ever applied in preseason; nothing about a
+    live season moves."""
+    from tests.ros.test_power_v2 import _make_snapshot
+
+    rosters = [{"roster_id": i, "owner_id": f"o{i}"} for i in (1, 2, 3, 4)]
+    matchups = {
+        wk: [
+            {"roster_id": 1, "matchup_id": 1, "points": 130.0 + wk},
+            {"roster_id": 2, "matchup_id": 1, "points": 110.0 + wk},
+            {"roster_id": 3, "matchup_id": 2, "points": 95.0 - wk},
+            {"roster_id": 4, "matchup_id": 2, "points": 80.0 - wk},
+        ]
+        for wk in (1, 2, 3)
+    }
+    snapshot = _make_snapshot(rosters, matchups)
+    for lens in (power_v2.LENS_RESULTS_ONLY, power_v2.LENS_FORWARD_LOOKING):
+        section = power_v2.build_section(snapshot, lens=lens)
+        assert section["preseason"] is False, lens
+        assert {"ppg", "recent"} <= set(section["effectiveWeights"]), lens

--- a/tests/ros/test_power_unrankable.py
+++ b/tests/ros/test_power_unrankable.py
@@ -1,0 +1,177 @@
+"""V1-52 — a power ranking with no surviving component must REFUSE.
+
+THE DEFECT, AND WHY IT IS NOT A CORNER CASE
+-------------------------------------------
+``build_section`` drops a component into ``missing_inputs`` when its
+input is unavailable, then renormalises the remaining weights.  That is
+right, and it is what makes the two lenses one engine rather than two
+formulas.
+
+But nothing stopped it dropping *all* of them.  When every component is
+missing, ``active_weights`` is empty, ``weight_total`` falls back to
+``1.0``, and every owner scores exactly ``0.0`` — at which point the
+sort is a stable sort over equal keys, so the published ``rank`` is
+whatever order ``_enumerate_owner_ids`` produced.  An identifier
+ordering, presented as a power ranking.
+
+**This is reachable, structurally, for the whole offseason.**  It does
+not depend on any data file:
+
+* ``preseason`` drops all seven ``_HISTORICAL_RESULTS_COMPONENTS``;
+* the results-only lens drops ``team_ros_strength`` *by definition*;
+* ``schedule_adjusted`` needs a schedule.
+
+So results-only + preseason is **always** every-component-missing —
+every day between the last game of one season and the first of the
+next.  The forward-looking lens reaches the same state whenever the
+team-strength file has not landed yet, which is exactly a fresh deploy.
+
+Measured on the committed dev snapshot, results-only lens: five owners,
+every ``powerScore`` 0.0, ranks 1-5 handed out in owner-id order — and
+the order **contradicts the components published beside it**, since
+``owner-B`` leads ``owner-A`` on five of seven components and ranks
+below it.
+
+Same defect family as the playoff-odds one fixed in V1-51 (a placeholder
+made every matchup a tie, so the third tiebreak — the ownerId string —
+became the answer, and the published order was the lexically-first
+seven Sleeper ids).  A ranking nobody can justify is worse than no
+ranking, because the reader cannot tell the difference.
+
+THE RULE
+--------
+No surviving component → no ranking.  ``powerScore`` and ``rank`` are
+``None`` (never 0.0, never 1..N), and an ``unrankable`` block names the
+reason.  The owners are still listed; only the certainty is withheld —
+the same posture ``playoff_structure`` takes for an unknown bracket and
+``RealizedPoints.unscored`` takes for a rule it cannot score.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.ros import power_v2
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _preseason_snapshot():
+    """Real seasons with real scores, but the CURRENT season unplayed —
+    which is the live state of every league right now."""
+    from tests.ros.test_power_v2 import _make_snapshot
+
+    rosters = [{"roster_id": i, "owner_id": f"o{i}"} for i in (1, 2, 3, 4)]
+    # No matchups at all in the current season → _is_preseason is True.
+    return _make_snapshot(rosters, {})
+
+
+def test_results_only_in_preseason_refuses_rather_than_ordering_by_id():
+    """The structural case: this lens ALWAYS loses every component here."""
+    snapshot = _preseason_snapshot()
+    section = power_v2.build_section(snapshot, lens=power_v2.LENS_RESULTS_ONLY)
+
+    assert section["preseason"] is True
+    assert section["effectiveWeights"] == {}, (
+        "fixture no longer reaches the every-component-missing state; "
+        "the test below would pass vacuously"
+    )
+
+    assert section.get("unrankable"), (
+        "every component is missing, so there is nothing to rank on — "
+        "the section must say so instead of publishing an order"
+    )
+    assert section["unrankable"].get("reason")
+    assert section["unrankable"].get("missingInputs")
+
+    for row in section["currentRanking"]:
+        assert row["powerScore"] is None, (
+            f"{row['ownerId']} scored {row['powerScore']!r} with no surviving "
+            f"component — 0.0 is a real score and this is not one"
+        )
+        assert row["rank"] is None, (
+            f"{row['ownerId']} was ranked {row['rank']!r} on identically-zero "
+            f"scores, so the rank is the owner-id order"
+        )
+
+
+def test_the_owners_are_still_listed_when_it_refuses():
+    """Withhold the certainty, not the league. A blank tab is a worse
+    answer than an honest one, and the same posture playoff_structure
+    already takes for an unknown bracket."""
+    section = power_v2.build_section(_preseason_snapshot(), lens=power_v2.LENS_RESULTS_ONLY)
+    owners = {r["ownerId"] for r in section["currentRanking"]}
+    assert owners == {"o1", "o2", "o3", "o4"}
+
+
+def test_a_lens_that_keeps_one_component_still_ranks():
+    """NON-VACUITY. A repair that refused whenever anything was missing
+    would satisfy every assertion above and destroy the renormalisation
+    that makes the two lenses one engine."""
+    from tests.ros.test_power_v2 import _make_snapshot
+
+    rosters = [{"roster_id": i, "owner_id": f"o{i}"} for i in (1, 2, 3, 4)]
+    matchups = {
+        wk: [
+            {"roster_id": 1, "matchup_id": 1, "points": 120.0 + wk},
+            {"roster_id": 2, "matchup_id": 1, "points": 100.0 + wk},
+            {"roster_id": 3, "matchup_id": 2, "points": 95.0 + wk},
+            {"roster_id": 4, "matchup_id": 2, "points": 80.0 + wk},
+        ]
+        for wk in (1, 2, 3)
+    }
+    section = power_v2.build_section(
+        _make_snapshot(rosters, matchups), lens=power_v2.LENS_RESULTS_ONLY
+    )
+
+    assert not section.get("unrankable")
+    assert section["effectiveWeights"], "components survived; this must rank"
+    scores = [r["powerScore"] for r in section["currentRanking"]]
+    assert all(s is not None for s in scores)
+    assert len(set(scores)) > 1, "real data must not produce one flat score"
+    assert [r["rank"] for r in section["currentRanking"]] == [1, 2, 3, 4]
+
+
+def test_the_trend_is_unaffected_because_it_is_never_preseason():
+    """The trend scores each week AS OF that week with preseason=False,
+    so its components survive. Pinned because the refusal must not
+    silently blank the series it is not about."""
+    from tests.ros.test_power_v2 import _make_snapshot
+
+    rosters = [{"roster_id": i, "owner_id": f"o{i}"} for i in (1, 2)]
+    matchups = {
+        wk: [
+            {"roster_id": 1, "matchup_id": 1, "points": 120.0 + wk},
+            {"roster_id": 2, "matchup_id": 1, "points": 100.0 - wk},
+        ]
+        for wk in (1, 2, 3)
+    }
+    section = power_v2.build_section(
+        _make_snapshot(rosters, matchups), lens=power_v2.LENS_RESULTS_ONLY
+    )
+    weeks = (section.get("trend") or {}).get("weeks") or []
+    assert len(weeks) == 3
+    for wk in weeks:
+        for row in wk["rankings"]:
+            assert row["powerScore"] is not None
+            assert row["rank"] is not None
+
+
+def test_the_committed_dev_snapshot_reproduces_the_defect_shape():
+    """The measurement quoted in this module's docstring, pinned so the
+    claim cannot quietly stop being true."""
+    path = REPO / "data" / "public_league" / "snapshot.json"
+    if not path.exists():  # pragma: no cover - data/ is gitignored
+        import pytest
+
+        pytest.skip("data/public_league/snapshot.json not present")
+
+    from src.public_league.snapshot_store import snapshot_from_dict
+
+    snapshot = snapshot_from_dict(json.loads(path.read_text()))
+    section = power_v2.build_section(snapshot, lens=power_v2.LENS_RESULTS_ONLY)
+    assert section["preseason"] is True
+    assert section["effectiveWeights"] == {}
+    assert section.get("unrankable")
+    assert all(r["rank"] is None for r in section["currentRanking"])

--- a/tests/ros/test_power_v2.py
+++ b/tests/ros/test_power_v2.py
@@ -224,21 +224,36 @@ def _make_snapshot(
     the supplied rosters.  Each roster's owner_id is registered as an
     active manager so ``_enumerate_owner_ids`` includes them.
     """
+    league_id = f"L{season_year}"
     registry = ManagerRegistry()
     for r in rosters:
         oid = str(r.get("owner_id") or "")
         if not oid:
             continue
         registry.by_owner_id[oid] = Manager(owner_id=oid, display_name=oid)
+        # ``roster_to_owner`` is LOAD-BEARING, not bookkeeping.
+        # ``luck._season_weekly_scores`` attributes a matchup row to an
+        # owner through it and SKIPS any row it cannot resolve, so a
+        # registry without it yields zero scored weeks — every component
+        # falls back to its neutral default and every owner scores the
+        # SAME number however different the fixture's points are.
+        # Fixtures built that way assert shape while measuring nothing
+        # about the data: measured 2026-08-19, every owner in
+        # ``test_power_lenses._scored_snapshot`` scored an identical
+        # 33.64 across three weeks of deliberately different points.
+        try:
+            registry.roster_to_owner[(league_id, int(r.get("roster_id")))] = oid
+        except (TypeError, ValueError):
+            continue
     season = _make_season(
         season_year,
-        f"L{season_year}",
+        league_id,
         rosters,
         matchups_by_week,
         is_complete=is_complete,
     )
     return PublicLeagueSnapshot(
-        root_league_id=f"L{season_year}",
+        root_league_id=league_id,
         generated_at="2026-04-30T00:00:00Z",
         seasons=[season],
         managers=registry,

--- a/tests/ros/test_team_strength_evidence_basis.py
+++ b/tests/ros/test_team_strength_evidence_basis.py
@@ -1,0 +1,142 @@
+"""A team's rest-of-season strength must declare what its evidence was.
+
+WHY THIS EXISTS SEPARATELY FROM THE PER-PLAYER STAMP
+----------------------------------------------------
+``aggregate`` now stamps ``evidenceBasis`` on every ROS row (V1-53 /
+C5-ROS-01), because 18.1% of the live board is priced by nothing but
+dynasty boards standing in for rest-of-season evidence.
+
+A stamp nothing reads is the defect one layer up — the same shape as
+``all_scoring_native`` written in one place and consumed in none. So the
+first consumer is here, and it is the one that matters: ``team_strength``
+is what ``power_v2`` weights at 0.41 (and, in preseason, at **100%** once
+every historical component is dropped). If a team's strength is largely
+dynasty-derived, the public /league Power tab is showing a dynasty
+ranking labelled as a rest-of-season one.
+
+WHAT IS MEASURED, PRECISELY
+---------------------------
+``dynastyProxyValueShare`` is the share of the roster's PRICED
+rest-of-season value that rests on dynasty proxies:
+
+    sum(rosValue * proxyShare) / sum(rosValue)
+
+Weighted by value rather than by headcount, because a team whose
+replacement-level 30th man is dynasty-priced is not in the same position
+as one whose QB1 is. Unpriced players contribute to neither side — they
+are already reported in ``unmappedPlayerCount`` and inventing a basis
+for a player we could not price would be the original defect wearing a
+new name.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.ros import team_strength as ts
+
+
+def _agg(name, value, *, proxy_share):
+    return {
+        "canonicalName": name,
+        "position": "WR",
+        "rosValue": value,
+        "confidence": 0.9,
+        "dynastyProxyWeightShare": proxy_share,
+        "evidenceBasis": (
+            "rest_of_season"
+            if proxy_share <= 0
+            else ("dynasty_proxy_only" if proxy_share >= 1 else "mixed")
+        ),
+    }
+
+
+def _team(players):
+    return {
+        "ownerId": "o1",
+        "rosterId": 1,
+        "teamName": "Test",
+        "players": [
+            {"playerId": f"p{i}", "canonicalName": n, "position": "WR"}
+            for i, n in enumerate(players, start=1)
+        ],
+    }
+
+
+def _build(aggs, players, **kw):
+    return ts.compute_team_strength(
+        [_team(players)],
+        aggregated_players=aggs,
+        starter_slots=["WR", "WR", "WR"],
+        **kw,
+    )
+
+
+def test_a_roster_priced_entirely_by_dynasty_proxies_says_so():
+    rows = _build(
+        [_agg("alpha", 80.0, proxy_share=1.0), _agg("beta", 40.0, proxy_share=1.0)],
+        ["alpha", "beta"],
+    )
+    assert rows[0]["dynastyProxyValueShare"] == 1.0
+    assert rows[0]["evidenceBasis"] == "dynasty_proxy_only"
+
+
+def test_a_roster_priced_entirely_by_ros_boards_says_so():
+    rows = _build(
+        [_agg("alpha", 80.0, proxy_share=0.0), _agg("beta", 40.0, proxy_share=0.0)],
+        ["alpha", "beta"],
+    )
+    assert rows[0]["dynastyProxyValueShare"] == 0.0
+    assert rows[0]["evidenceBasis"] == "rest_of_season"
+
+
+def test_the_share_is_weighted_by_value_not_headcount():
+    """A dynasty-priced QB1 and a dynasty-priced 30th man are not the
+    same exposure, and a headcount would call them equal."""
+    rows = _build(
+        [_agg("star", 90.0, proxy_share=1.0), _agg("scrub", 10.0, proxy_share=0.0)],
+        ["star", "scrub"],
+    )
+    share = rows[0]["dynastyProxyValueShare"]
+    assert share == pytest.approx(0.9, abs=1e-6), share
+    assert rows[0]["evidenceBasis"] == "mixed"
+
+    flipped = _build(
+        [_agg("star", 90.0, proxy_share=0.0), _agg("scrub", 10.0, proxy_share=1.0)],
+        ["star", "scrub"],
+    )
+    assert flipped[0]["dynastyProxyValueShare"] == pytest.approx(0.1, abs=1e-6)
+
+
+def test_unpriced_players_contribute_to_neither_side():
+    """They are already reported in ``unmappedPlayerCount``. Inventing a
+    basis for a player we could not price is the original defect under a
+    new name."""
+    rows = _build(
+        [_agg("alpha", 80.0, proxy_share=1.0)],
+        ["alpha", "ghost"],
+    )
+    assert rows[0]["unmappedPlayerCount"] == 1
+    assert (
+        rows[0]["dynastyProxyValueShare"] == 1.0
+    ), "the unpriced player must not dilute the share toward 0.5"
+
+
+def test_a_roster_with_nothing_priced_reports_null_not_zero():
+    """0.0 means 'measured, and none of it is dynasty'. Nothing priced
+    means we cannot say — and those must not read the same."""
+    rows = _build([], ["ghost"])
+    assert rows[0]["dynastyProxyValueShare"] is None
+    assert rows[0]["evidenceBasis"] == "unpriced"
+
+
+def test_the_composite_itself_is_unchanged():
+    """NON-VACUITY / no-behaviour-change. The basis is a statement ABOUT
+    the number, and must not move it."""
+    aggs_a = [_agg("alpha", 80.0, proxy_share=1.0), _agg("beta", 40.0, proxy_share=1.0)]
+    aggs_b = [_agg("alpha", 80.0, proxy_share=0.0), _agg("beta", 40.0, proxy_share=0.0)]
+    a = _build(aggs_a, ["alpha", "beta"])[0]
+    b = _build(aggs_b, ["alpha", "beta"])[0]
+    assert a["teamRosStrength"] == b["teamRosStrength"]
+    assert a["startingLineupScore"] == b["startingLineupScore"]
+    assert a["teamRosStrength"] > 0, "fixture must actually score something"


### PR DESCRIPTION
## What this is

Lane 3, **V1-52**: one canonical weekly power-rankings engine.

**Stacked on #919** (base is `claude/v1-playoff-power-consolidation`, not `main`) — the roster-health de-double-count and the playoff-odds fix in that PR are prerequisites for this one. Merge #919 first; this PR's diff is the five commits above it.

Full record: [`docs/power/V1_52_CANONICAL_POWER_ENGINE.md`](docs/power/V1_52_CANONICAL_POWER_ENGINE.md).

> **Step 5 — the retirement itself — is scoped and measured but NOT done**, for a substantive reason given below. What lands here is the engine work that has to precede it, plus two live defects found while measuring.

## The reading that reframed the unit

The audit capture `evidence/W30/power-two-engines.json` is usually quoted for its rank shift (mean 2.8, max 7). Its `effectiveWeights` say more:

```json
"v2": { "preseason": true,
        "effectiveWeights": {"team_ros_strength": 0.38, "roster_health": 0.03} }
```

So the comparison is **one week of last season's scoring percentiles** against **pure roster strength**. The two engines were not disagreeing about the answer — they were answering different questions, and nothing on either surface said so.

Its `n` is worth noting too: **10 against 12**. `power.py`'s `currentRanking` is the last *single week*'s ranking, so any owner who did not play that week is absent from the published power ranking entirely.

## Two live defects, found by measuring

### 1. An identifier ordering, published as a power ranking

Renormalisation had a floor nobody had put in. When **every** component is dropped, `active_weights` is empty, `weight_total` fell back to `1.0` against an empty numerator, every owner scored exactly `0.0`, and the sort — stable over equal keys — handed out ranks `1..N` in `owner_ids` order.

Reachable **structurally**, not rarely: results-only drops `team_ros_strength` by definition and preseason dropped all seven historical components, so the state was guaranteed for the whole offseason.

On the committed dev snapshot it was self-contradicting: five owners, every score `0.0`, and the published order **disagreed with the components printed beside it** — `owner-B` led `owner-A` on five of seven components and ranked below it.

Same family as the playoff-odds defect fixed in #919, where a placeholder made every matchup a tie and the `ownerId` string tiebreak became the answer. **The coercion baseline had already registered the mechanism as debt** — `weight_total = sum(...) or 1.0` — so this is a recorded hazard coming true, and the gate reports that entry retired.

Now: no surviving component, no ranking. `powerScore` and `rank` are `None` — never `0.0`, which is a score a team can earn, and never `1..N`. An `unrankable` block names the reason and the missing inputs; the owners and their raw components are still listed. Same posture `playoff_structure` takes for an unknown bracket. The UI renders it as a named state rather than the "not ready, the next scrape will populate this" copy, which would promise numbers that are not coming.

### 2. The retrospective lens was suppressing the results it is made of — my own defect from step 1

`_is_preseason` dropped all seven historical-results components, and its docstring gave the reason: they *"describe a finished year and don't project the upcoming one ... so the score reflects only forward-looking inputs"*. Correct for the **forward-looking** lens. Exactly backwards for the retrospective one, whose entire subject matter *is* the finished year.

Step 1 added the results-only lens and it inherited a suppression written for the other one. The consequence was total: results-only already drops `team_ros_strength`, so preseason left it with **nothing** — the every-component-missing state above — while the completed seasons it is made of sat in the accumulators untouched, for every day of the offseason.

Visible in one row on the dev snapshot: `owner-B`, ranked 2nd on an all-zero score under the defect, is now **1st at 86.61**. Forward-looking still refuses there, correctly — preseason with no team-strength file has genuinely nothing to look forward to.

## Do the two engines agree? Measured

| fixture | mean \|rank shift\| | max | note |
|---|---|---|---|
| committed dev snapshot (real) | **0.00** | 0 | identical order on the 4 common owners; v2 also covers a 5th that v1 drops |
| 12 owners, 6 weeks, monotone strength ladder | 0.33 | 1 | weak by construction — a ladder makes most formulas agree |
| adversarial: great scores, 0-6 record | 0.67 | 1 | v1 has **no** W/L or streak component; v2 weights them 0.10 + 0.05 |

The retrospective quantities substantially agree, and the large real-world divergence in the W30 capture is the **forward-looking input** — exactly what the lens distinction names. That is the evidence these are one engine's two lenses rather than two engines.

**Limitation, stated rather than glossed:** two of those three fixtures are synthetic and the third is a small dev snapshot. A production comparison needs the prod snapshot plus the ROS team-strength file, neither of which exists in this environment.

## Why step 5 is not a shim

`power.py` must stop being an engine. The obvious minimal move — make `build_section` an adapter that delegates and renames fields — **does not work**, recorded so it is not attempted again:

`power.jsx` renders `components.pointsPerGame`, `recentAvg` and `allPlayWinPctThisWeek` as **raw values**; the canonical engine publishes `ppg` and `recent` as **percentiles**. An adapter cannot recover a raw PPG from a percentile, so it would have to compute one — a second owner again, one layer down, which is the defect this unit exists to remove.

So the retirement is **one renderer, one engine, the toggle selecting a lens**: `ros-power.jsx` absorbs the trend chart, `power.jsx` and `power.py` retire together. That changes what the Power tab *displays* for users on the v1 path — percentile component bars instead of raw PPG columns — a deliberate, user-visible change that needs the production measurement above alongside it.

## Steps 1–2, for context (already on this branch)

Two lenses that are **not two formulas**: results-only is the same `WEIGHTS` vector with `team_ros_strength` declared missing and renormalised by the machinery that already handles an absent team-strength file, so every retrospective component keeps its weight *relative to the others*.

The per-week trend moved into the canonical engine and runs through the same `_score_state` as the headline — a second scoring implementation for the series is how a chart ends up being a different quantity from the number printed beside it. It is **results-only at every point, including the last**: `team_ros_strength` is a single current snapshot with no per-week history, so back-filling it is the as-of defect, and splicing it into only the final point is worse — the line would jump at the end for a reason unrelated to how the team played.

## A note on fixtures

`_make_snapshot` never populated `roster_to_owner`, which `luck._season_weekly_scores` needs to attribute a matchup row to an owner — it **skips** rows it cannot resolve, so zero weeks scored, every component fell back to its neutral default, and every owner scored an identical **33.64** across three weeks of deliberately different points.

Two of this unit's own lens tests were asserting shape while measuring nothing. Repaired at the shared helper with the reason recorded there, because this trap cost three separate measurements in this lane before it was named.

## Verification

| gate | result |
|---|---|
| `pytest tests/ -m "not livedata"` | **8,423 passed · 51 skipped · 0 failed** |
| `vitest run` (full frontend suite) | **2,062 passed** |
| `ruff format --check .` / `ruff check .` | clean |
| `scripts/check_decision_coercions.py` | clean — one baseline entry deleted because the refusal retired it (673 → 672) |
| `validate_api_contract.py --lane structural` | `ok=True` |
| `scripts/check_planning_integrity.py` | clean |

Mutation-checked in five places: removing the refusal, over-broadening it to any missing input, and reverting the fixture each turn Python tests RED; applying the preseason suppression to both lenses again and removing it entirely each turn tests RED; and making the UI ignore `unrankable` turns 3 of 4 vitest tests RED.

**Not deployed, and production verification has not been done.** Both fixes change live public `/league` output the moment they ship — the refusal replaces a fabricated order with an honest empty state, and the lens repair gives the retrospective view real numbers all offseason where it previously had none. Both should be observed rather than assumed.

Not self-merging, per the integration-authority rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnuUUPc6Xx2QCjtkqRsa3k)_