### PR TITLE
Roster V1 verification pack + V1-35 metric-separation audit (stacked on #922)

### DIFF
--- a/docs/roster-intelligence/V1_35_METRIC_SEPARATION_AUDIT.md
+++ b/docs/roster-intelligence/V1_35_METRIC_SEPARATION_AUDIT.md
@@ -1,0 +1,254 @@
+# V1-35 — metric separation and duplicate-owner audit
+
+**Row:** `V1-35` · **Lane:** L1 Roster Intelligence · **Required evidence
+level:** EVIDENCE-L1 · **Status entering this audit:** `NOT STARTED`
+
+**Binding source** — `docs/OWNER_REQUESTED_TODO.md` decision 69, verbatim:
+
+> **Total Asset Value, Meaningful Roster Strength, Exact Starting Lineup,
+> Depth Value, Power Ranking, Playoff Probability and Championship
+> Probability stay distinct** in the model and the UI. They may not be
+> collapsed into one generic team score.
+
+Seven named quantities. This audit asks, of every production consumer:
+*is this the same concept as another, a legitimately different quantity,
+a stale duplicate, or a compatibility adapter?*
+
+**It does not consolidate things because they contain the word
+"strength".** Two of the entries below are correctly separated today and
+are recorded as such precisely so nobody "fixes" them.
+
+---
+
+## 0. The headline finding
+
+> **Six live production answers to "how good is this team" exist on six
+> different units — and the module documented as "THE canonical Team
+> Strength owner" is the one nobody renders.**
+
+`src/roster_intel/strength.py` opens with "the canonical Team Strength
+owner". `grep -rn "roster/intelligence" frontend/` returns **zero
+hits**: no page, hook or bridge route fetches it. Meanwhile
+`frontend/lib/nav-model.js:147` labels **`/rosters`** as "Team Strength",
+and `/rosters` renders a client-side composite with no server
+equivalent.
+
+This is the V1 contract's own false-green test failing —
+*"is the intended production consumer actually using the canonical
+implementation, with truthful data semantics?"* — and it is why V1-31
+cannot claim EVIDENCE-L4 no matter how correct the owner is.
+
+**The repair is a frontend change on `/rosters`, which is Claude 6's
+lane.** It is handed over in §3, not made here.
+
+---
+
+## 1. Census
+
+Verified file-by-file at `fd70515`. "Rendered?" means a frontend
+fetch/render path exists, not merely that the route responds.
+
+| # | concept | canonical owner | quantity · unit | production path | rendered? | classification |
+|---|---|---|---|---|---|---|
+| 1 | Canonical asset value | `src/api/data_contract.py::_compute_unified_rankings` → `rankDerivedValue` | dynasty market value · **1–9999** | `/api/data` and every engine | yes | **canonical** |
+| 2 | Exact starting lineup | `src/ros/lineup.py::solve_optimal_assignment` | assignment + score · **unit-agnostic** (score is in whatever unit the pool carries) | contract stamp `sleeper.teams[].optimalLineup` | yes, via `starter-slots.js::fillLineup` | **canonical** |
+| 3 | Meaningful Roster Strength | `src/roster_intel/strength.py::build_team_strength` | Σ `rankDerivedValue` over the meaningful core · **1–9999 scale, uncapped in aggregate** | `src/api/roster_intelligence.py:259` → `GET /api/roster/intelligence` | **NO — zero frontend fetchers** | **canonical, UNCONSUMED** |
+| 4 | Team Weakness / need priority | `src/roster_intel/weakness.py::build_team_weakness` | rung status vs `k × teamCount` · **ordinal, not a score** | same endpoint, `:261` | **NO** | **canonical, UNCONSUMED** |
+| 5 | ROS team strength | `src/ros/team_strength.py::compute_team_strength` | `teamRosStrength` · **0–100 log-rank production index** | `data/ros/team_strength/<key>.json` → `/api/public/league/rosTeamStrength` | yes — "ROS Strength" tab | **legitimate different quantity** |
+| 6 | Power ranking | v2 `src/ros/power_v2.py` (live) · v1 `src/public_league/power.py` | v2 `power_score` **0–1 weighted percentile** · v1 `power` **0–100** | `public_contract.py` → one Power tab, switched by `useRosPowerRankings` | v2 yes, v1 dormant | **duplicate — cross-lane (V1-52)** |
+| 7 | Playoff probability | `src/ros/playoff_sim.py::simulate_playoff_odds` · `src/public_league/playoff_odds.py::compute_playoff_odds` | probability **0–1** | both registered in `public_contract.py` | yes | **duplicate — cross-lane (V1-51)** |
+| 8 | Championship probability | `src/ros/championship.py::simulate_championship_odds` | probability **0–1**; `expectedFinish` **seed 1..N** | `public_contract.py:150` → "Championship" tab | yes | **canonical** |
+| 9 | `/api/gameplan` | `src/api/gameplan.py` | mixed, units policed in its own docstring; `marketEdge` deliberately `null` | `server.py:6797` | **NO — DISCONNECTED** (`feature_flags.py:235`) | **compatibility adapter** |
+| 10 | `/api/terminal` `totalValue` | `src/api/terminal.py::build_terminal_payload` | Σ `rankDerivedValue` over the **whole roster** · 1–9999 | `server.py:11944` → `useTerminal.js`, `PortfolioSummary.jsx` | yes | **legitimate different quantity** = decision 69's *Total Asset Value* |
+| A | `/rosters` value breakdown | `frontend/lib/league-analysis.js::buildAllTeamSummaries` | Σ 1–9999 by position group | `/rosters` | yes | **materializer — consumes the server's `optimalLineup`, computes no new concept** |
+| B | `/rosters` tier score | `frontend/lib/league-analysis.js:1224` | `starterValue×0.7 + depthValue×0.2 − pickValue×0.1` | `/rosters`, Contender/Mid-Tier/Rebuilder | yes | **STALE DUPLICATE — decision-69 violation** |
+| C | `/phases` classifier | `frontend/lib/team-phase.js` | top-25 value × median age → 4 labels | `/phases` | yes | **duplicate concept, client-only** |
+| D | BDVM roster | `src/bdvm/roster.py::analyze_rosters` | `starterFpg` · **projected fantasy points per game** | `/api/bdvm/roster`, flag `bdvm_engine` on | endpoint yes | **legitimate different quantity** |
+
+---
+
+## 2. Findings
+
+### F-1 — `scoreTeamTiers` is a collapsed generic team score (decision-69 violation)
+
+`frontend/lib/league-analysis.js:1224`, verbatim:
+
+```js
+const score = starterValue * 0.7 + depthValue * 0.2 + (pickValue > 0 ? -pickValue * 0.1 : 0);
+```
+
+It merges three of decision 69's seven — Exact Starting Lineup (via
+`starterValue`), Depth Value, and part of Total Asset Value — into one
+number, then terciles it into Contender / Mid-Tier / Rebuilder. **Pick
+capital is a penalty**: a rebuilding team's draft assets *lower* its
+score, which is a strategy judgement encoded as arithmetic.
+
+There is **no server equivalent of this formula anywhere**. The weights
+0.7 / 0.2 / −0.1 appear in no config, no ADR and no owner decision.
+
+It does consume the canonical lineup correctly (`fillLineup` with the
+server's `optimalLineup`), so the defect is the composite, not the
+lineup.
+
+* **Canonical owner:** `src/roster_intel/strength.py` (`total` /
+  `starterValue` / `reserveValue`, published separately) plus
+  `src/roster_intel/window.py` for the contend/rebuild judgement.
+* **Retirement path:** in §3, handoff **H-1**.
+
+### F-2 — the canonical Team Strength and Team Weakness owners have no consumer
+
+`GET /api/roster/intelligence` is HTTP-reachable and correct, and no
+frontend code fetches it. The two capabilities V1-31 and V1-32 name are
+implemented and invisible.
+
+Consequence for the V1 ledger, stated precisely: V1-31 and V1-32 require
+**EVIDENCE-L2**, which this audit's sibling test suite now supplies, so
+the missing consumer does **not** block their required level. It blocks
+any future L4 claim, and it means the product's visible "Team Strength"
+is F-1's formula. Both facts belong in the row notes.
+
+* **Retirement path:** handoff **H-1** (same change closes both).
+
+### F-3 — `/phases` is a third client-side team classifier
+
+`frontend/lib/team-phase.js` classifies teams Win-now / Contender /
+Mixed / Rebuild from top-25 value × median age. `src/roster_intel/`
+already owns both inputs canonically — `age_portfolio.py` (value-weighted
+age, Young Core Index) and `window.py` (competitive state) — measured
+over the *meaningful core* rather than an arbitrary top-25.
+
+Not the same defect as F-1: this one is a legitimate concept computed in
+the wrong place, rather than an invented composite. Lower priority, same
+owner.
+
+* **Retirement path:** handoff **H-2**.
+
+### F-4 — two power engines and two playoff-odds engines
+
+Confirmed at file level; both are pre-existing V1 rows (V1-52, V1-51)
+and both are outside this lane.
+
+* Power: `src/ros/power_v2.py` (0–1 composite, live by default —
+  `useSettings.js:174` sets `useRosPowerRankings: true`) vs
+  `src/public_league/power.py` (0–100, `100 × (0.50·PPG%ile +
+  0.25·recent%ile + 0.25·allPlayWin%)`), swapped at
+  `LeagueClient.jsx:413`.
+* Playoff odds: `src/ros/playoff_sim.py::simulate_playoff_odds`
+  (`playoff_seeds: int = 6`) vs
+  `src/public_league/playoff_odds.py::compute_playoff_odds`
+  (`playoff_spots: int | None`) — the parameter difference is the
+  measured 7-vs-6-spots disagreement V1-51 records.
+
+**No action taken here.** Both are Claude 3 / public-league files.
+Recorded so V1-35's census is complete; retirement stays with V1-51/V1-52.
+
+### F-5 — stale comment contradicting a live default
+
+`frontend/app/league/LeagueClient.jsx:124` says `useRosPowerRankings` is
+"false until validated per-user"; `frontend/components/useSettings.js:174`
+defaults it **true**. A stale comment, not a defect. Flagged to Claude 6;
+not fixed here.
+
+---
+
+## 3. Correctly separated — record, do not "fix"
+
+Three boundaries already hold, and each is load-bearing enough that a
+future tidy-up would be a regression.
+
+| boundary | why it is right | where it is stated |
+|---|---|---|
+| `rosValue` (0–100 ROS production) vs `rankDerivedValue` (1–9999 dynasty) | different products on different horizons; `MASTER_PRODUCT_PLAN` §4.1: *"Team Strength is dynasty roster strength; it is not Power Ranking, Playoff Odds, or ROS production."* V1-50 pins the honesty of `rosValue` | `src/ros/aggregate.py:171`; `src/api/gameplan.py:37-56` polices the currencies and leaves `marketEdge` **`null`** rather than converting |
+| `/api/terminal` `totalValue` (whole-roster portfolio) vs Team Strength `total` (meaningful core) | decision 69 names *both* — Total Asset Value **and** Meaningful Roster Strength. On a 58-man best-ball roster they are far apart by construction | `src/roster_intel/strength.py:20-27` names the distinction itself and publishes `full_roster_value` **beside** `total` |
+| `src/roster_intel/engine.py` relays odds, never invents them | with no simulator output it returns `None` **with a note** naming why, instead of deriving probability from roster value — which would manufacture two of the seven quantities out of a third | `engine.py:352-372`; pinned by `tests/roster_intel/test_metric_separation.py` |
+
+`/api/gameplan` is a **compatibility adapter**, not a duplicate: it reads
+other owners' numbers, keeps their units separate in its own docstring,
+and is DISCONNECTED (`src/api/feature_flags.py:235`). Nothing to retire
+until something consumes it.
+
+---
+
+## 4. Cross-lane handoffs for Claude 5
+
+Nothing in this section was edited. Each entry gives path, consumer,
+current quantity, desired owner and the test that would close it.
+
+### H-1 — retire the `/rosters` tier score onto the canonical owner (**Claude 6**)
+
+| field | value |
+|---|---|
+| **path** | `frontend/lib/league-analysis.js::scoreTeamTiers` (formula at `:1224`) |
+| **consumer** | `frontend/app/rosters/page.jsx:113`; nav labels this page "Team Strength" (`frontend/lib/nav-model.js:147`) |
+| **current quantity** | client-only composite `starterValue×0.7 + depthValue×0.2 − pickValue×0.1`, tercile-bucketed |
+| **desired owner** | `GET /api/roster/intelligence` — `strength.total`, `strength.starterValue`, `strength.reserveValue`, `strength.leagueRank` rendered as the separate quantities they are; contend/rebuild from `src/roster_intel/window.py`, not from a weighted sum |
+| **test** | a frontend unit test asserting `/rosters` renders backend-stamped values and that `scoreTeamTiers` is gone; plus `tests/roster_intel/test_metric_separation.py::test_roster_intelligence_publishes_no_generic_team_score` extended to the rendered props |
+| **note** | this single change closes **F-1 and F-2 together** and is what would let V1-31 / V1-32 reach EVIDENCE-L4 |
+
+### H-2 — fold `/phases` onto the age-portfolio and window owners (**Claude 6**)
+
+| field | value |
+|---|---|
+| **path** | `frontend/lib/team-phase.js`; `frontend/components/TeamPhasePanel.jsx` |
+| **consumer** | `frontend/app/phases/page.jsx:33` |
+| **current quantity** | top-25 `rankDerivedValue` total × median age → 4 labels, computed client-side |
+| **desired owner** | `agePortfolio.valueWeightedCoreAge` / `youngCoreIndex` (+ its `PRIOR` disclosure) and `src/roster_intel/window.py`'s competitive state, both over the **meaningful core** |
+| **test** | frontend test that the phase label comes from the payload; backend already covered |
+| **priority** | below H-1 — a right concept in the wrong place, not an invented one |
+
+### H-3 — V1-52 power engines (**Claude 3 / public league**) — census only
+
+Recorded in F-4 for V1-35's completeness. Retirement belongs to V1-52
+and is **not** requested by this audit.
+
+### H-4 — V1-51 playoff-odds engines (**Claude 3 / public league**) — census only
+
+As H-3, for V1-51.
+
+### H-5 — stale comment (**Claude 6**, trivial)
+
+`frontend/app/league/LeagueClient.jsx:124` contradicts
+`useSettings.js:174`. One-line comment fix.
+
+---
+
+## 5. What this closes, and what it does not
+
+**Closed at EVIDENCE-L1** by `tests/roster_intel/test_metric_separation.py`
+(10 tests, all mutation-proven — see §6):
+
+* no collapsed generic team score anywhere in the canonical roster payload;
+* Meaningful Roster Strength and Total Asset Value separately named, with
+  an absent portfolio reported as `null` rather than the core total;
+* Exact Starting Lineup published as assignment, Team Strength as value,
+  neither derivable from the other, and FLEX never a strength group;
+* Depth Value published beside the total and partitioning it exactly;
+* Playoff and Championship Probability relayed or `None` — never derived
+  from roster value;
+* the dynasty-value lane structurally cannot import the ROS-production
+  modules (`team_strength`, `aggregate`, `power_v2`, `playoff_sim`,
+  `championship`, `direction`).
+
+**Not closed.** V1-35 says "in the model **and the UI**". This audit
+closes the model half inside this lane and hands the UI half to Claude 6
+as H-1/H-2. The row should read `IN PROGRESS` with the model half
+evidenced, not `VERIFIED` — a green suite here is necessary and not
+sufficient.
+
+---
+
+## 6. Evidence
+
+| claim | how it was checked | result |
+|---|---|---|
+| no frontend fetcher for `/api/roster/intelligence` | `grep -rn "roster/intelligence" frontend/` | 0 hits |
+| `scoreTeamTiers` formula | read `frontend/lib/league-analysis.js:1215-1250` | confirmed verbatim, incl. the pick penalty |
+| nav labels `/rosters` "Team Strength" | read `frontend/lib/nav-model.js:143-152` | confirmed |
+| roster_intel never imports ROS-production modules | AST scan of every `src/roster_intel/*.py` + `src/api/roster_intelligence.py` | 0 offenders; only `src.ros.lineup` (the canonical lineup owner, unit-agnostic) is imported |
+| the import guard is not decoration | same detector run against `src/ros/api.py`, which does import `src.ros.team_strength` | detector fires |
+| the collapsed-score walk is not decoration | injected a `teamScore` field into a synthetic payload | detector fires |
+| the payload walk is not vacuous | asserted > 500 keys traversed on a real rebuilt contract | passes |
+| two playoff engines exist | read both signatures | `playoff_seeds: int = 6` vs `playoff_spots: int \| None` |
+
+Suite: `python -m pytest tests/roster_intel/test_metric_separation.py -q` →
+**10 passed**, hard gate (`-m "not livedata"`), no network.

--- a/docs/roster-intelligence/V1_ROSTER_EVIDENCE_MATRIX.md
+++ b/docs/roster-intelligence/V1_ROSTER_EVIDENCE_MATRIX.md
@@ -1,0 +1,80 @@
+# V1-27 … V1-35 — evidence matrix
+
+What each Roster row **requires**, what evidence exists at `fd70515`,
+and the exact remaining step. Assembled 2026-08-19.
+
+This is a reading of `docs/VERSION_1_COMPLETION_CONTRACT.md`, not an
+amendment to it. **Only Claude 5 updates the contract's status column.**
+
+---
+
+## The finding that shapes the whole table
+
+`docs/VERSION_1_COMPLETION_CONTRACT.md` §3.2 column 6 is the **required**
+evidence level, not the current one. Read that way:
+
+> **Only V1-27 requires production. Seven of the eight remaining Roster
+> rows close at EVIDENCE-L1 or L2 — deterministically, in CI, with no
+> deploy involved.**
+
+Treating the whole lane as post-deploy work would have parked seven rows
+behind an integration step none of them needs.
+
+---
+
+## Matrix
+
+| row | capability | required | evidence held at `fd70515` | missing | exact next step |
+|---|---|---|---|---|---|
+| **V1-27** | One lineup / slot assignment owner | **L3** | L1: `tests/lineup/test_single_owner.py`, 10/10 vs Sleeper's own awarded best-ball lineups. L2: C2-U1 §10a items 1/3a/5 on a rebuilt board (12/12 solved from `sleeper_roster_positions`; 4 hybrids started in slots their primary alone forbids). Checks 03/05 of the pack add 36 flex slots and 240 starters | **L3** — items 2/3 remain `BLOCKED-EXTERNAL` on auth | run the pack against the deploy with `ROSTER_VERIFY_COOKIE` set. Note the SHA gap in §4 of the pack doc: the API publishes no commit, so the SHA is operator-asserted |
+| **V1-28** | FLEX/SF/IDP-FLEX starters before reserve depth | **L1** | L1 in #914 (reserve demand is the same exact solver re-run over the survivors, so the ordering holds by construction). Pack check 05 measures the observable consequence — starter ∩ reserve = ∅ over **240 starters** — and check 03 proves the flex slots came from real config | none for L1 | **row is evidenced at its required level**; Claude 5 to confirm the status change |
+| **V1-29** | One replacement level / PAR owner | **L2** | #914 designates the owner and publishes the boundary table. **No new implementation and no retirement** | the **5 duplicate implementations**. The contract says so itself: "the retirements are still owed, so this is begun, not done" | **this is the next Roster-only unit** — see §Next |
+| **V1-30** | Canonical meaningful roster core | **L2** | L2: pack checks 04 (374 members), 05 (240), 06 (12 teams, `ceil(1.5·s) − s` re-derived per position). Built as two exact solves, which is what #899 §3 requires over independent greedy lists | the `M` challenger pass is run (#20) but `M = 1.5` remains **PRIOR** by decision 67 and stays labelled so | **evidenced at L2.** The PRIOR label is a standing disclosure, not missing evidence |
+| **V1-31** | Canonical Team Strength | **L2** | L2: pack check 09 — groups and starter+reserve both re-sum to `total` across 12 teams. Owner built in #914 | **4 competing notions to retire** (V1-35 audit F-1/F-3 identifies two of them as live client-side formulas). Separately: **no frontend consumer** | **evidenced at L2.** L4 is blocked on handoff **H-1** (Claude 6). Row note should record the unconsumed-owner fact |
+| **V1-32** | Canonical Team Weakness / Need Priority | **L2** | L2: pack checks 02 (216 rungs at `rung × teamCount`) and 10 (215 rung credits, no double-count) | ≥5 need definitions to retire; no frontend consumer | **evidenced at L2.** Same H-1 dependency for L4 |
+| **V1-33** | Young Core Index + age-value portfolio | **L1** | L1 + L2: pack check 11 — `coverage.totalPlayers == \|core\|`, `coverage.totalValue == strength.total`, `youngCoreIndexStatus == "PRIOR"` across 12 portfolios. Validated against real league examples in #12 | none for L1 | **evidenced above its required level.** The `PRIOR` label is required by #838 and is asserted, not merely present |
+| **V1-34** | Untouchable / excluded-player control | **L1** | none — `NOT STARTED`, and it is lane **L2 (Trade)**, not this lane | everything | **not this lane.** Listed for completeness |
+| **V1-35** | Metric separation | **L1** | L1: `tests/roster_intel/test_metric_separation.py`, 10 tests, all mutation-proven — no collapsed team score in the canonical payload; the seven quantities separately named; probability relayed never derived; the ROS-production import guard | the **UI half**. Decision 69 says "in the model **and the UI**", and `/rosters` renders a collapsed score (audit F-1) | **model half evidenced at L1**; UI half is handoff **H-1**. Row should read `IN PROGRESS` with the model half recorded — **not `VERIFIED`** |
+
+---
+
+## Reading this honestly
+
+Three things this table deliberately does **not** claim.
+
+**A green suite is not a verified row.** The V1 contract is explicit that
+"code exists", "unit tests pass" and "CI was green" are *not*
+verification. What the pack adds is a measured statement with a
+denominator — which is what EVIDENCE-L2 asks for — and the status column
+is still Claude 5's to move.
+
+**V1-29 and V1-31 have work outstanding that no test closes.** Their
+required level is L2 and the L2 evidence exists, but both carry
+*retirements* (5 replacement implementations; 4 Team Strength notions).
+Evidence at the required level and a finished capability are not the
+same statement, and this table separates them rather than letting an L2
+pass imply the retirements happened.
+
+**No production evidence is produced by this unit.** Everything above is
+EVIDENCE-L1 or L2. The only row that *requires* more is V1-27, and
+closing it needs a credentialed run against the deploy — Claude 5's step,
+with the command in the pack doc §2.
+
+---
+
+## Next Roster-only unit
+
+**V1-29 — retire the five duplicate replacement-level implementations.**
+
+* required level **L2**, entirely inside `src/roster_intel/` +
+  `src/league_intel/replacement.py`;
+* needs no other lane and no deploy;
+* it is the largest outstanding Roster debt, and the V1 contract names it
+  in its own words: #914 "designates the owner and publishes the boundary
+  table but adds **no new implementation** — the retirements are still
+  owed, so this is begun, not done."
+
+It is deliberately **not** the Team Strength consumer gap. That gap is
+real and is the V1-35 audit's headline, but its repair is a frontend
+change on `/rosters` — Claude 6's lane. Naming it as this lane's next
+unit would be claiming another lane's files.

--- a/docs/roster-intelligence/V1_ROSTER_VERIFICATION_PACK.md
+++ b/docs/roster-intelligence/V1_ROSTER_VERIFICATION_PACK.md
@@ -1,0 +1,212 @@
+# Roster Intelligence — V1 verification pack
+
+Executable checklist for V1-27…V1-33, in the format
+`docs/lineup/C2_U1_CANONICAL_LINEUP.md` §10 established.
+
+**Artifacts**
+
+| what | where |
+|---|---|
+| the checks (pure) + the probe (HTTP) | `scripts/verify_roster_intelligence.py` |
+| proof the checks work | `tests/roster_intel/test_verification_pack.py` (63 tests) |
+| V1-35 model-half separation | `tests/roster_intel/test_metric_separation.py` (10 tests) |
+| the metric census | `docs/roster-intelligence/V1_35_METRIC_SEPARATION_AUDIT.md` |
+| the ledger | `docs/roster-intelligence/V1_ROSTER_EVIDENCE_MATRIX.md` |
+
+---
+
+## 1. The rule this pack is built around
+
+> A verification that cannot distinguish "measured and found none" from
+> "matched nothing" is not a verification.
+> — `docs/lineup/C2_U1_CANONICAL_LINEUP.md` §10a
+
+That §10a was written after a checklist nearly passed vacuously: a join
+by Sleeper id returned 0 hits, because `optimalLineup.assignments`
+carries a *name* and not an id, and **0-of-0 violations reads exactly
+like 0-of-240**.
+
+So every check here publishes its own **denominator**, and the rule is
+enforced by the *harness*, not by each check's author:
+`finalize()` rewrites any `PASS` whose denominator is 0 into
+`UNMEASURABLE`. A check author cannot forget to apply it, and
+`test_harness_downgrades_a_vacuous_pass` pins it.
+
+A `FAIL` with a zero denominator is deliberately left alone — that is a
+contradiction the check is asserting, and rewriting it would hide a
+defect in the check.
+
+### Exit codes
+
+| code | meaning |
+|---|---|
+| **0** | every check was MEASURED and PASSED |
+| **1** | a check measured a violation |
+| **2** | one or more checks could not be measured |
+
+`2` is never collapsed into `0` ("no data" must not read as "passed" —
+the convention `scripts/backtest_perfect_draft.py:51` sets) and never
+into `1` ("we looked and it is broken" and "we could not look" call for
+different actions: a defect versus a missing credential, an undeployed
+endpoint, or a league with no contract).
+
+### Evidence levels
+
+Spelled `EVIDENCE-L1`…`EVIDENCE-L4` throughout, because
+`docs/VERSION_1_COMPLETION_CONTRACT.md` uses `L1`…`L6` for **lanes** and
+`L1`…`L4` for **levels** in the same table, and that ambiguity should
+not reach machine-readable output.
+
+Each check declares the level it can **reach**; the harness caps it at
+what the run's **source** can support. A check whose ceiling is
+EVIDENCE-L3 reports EVIDENCE-L2 when the run read a locally rebuilt
+contract. Evidence is only as strong as its source.
+
+---
+
+## 2. Running it
+
+### Post-deploy (EVIDENCE-L3 / L4) — for the integration lane
+
+```bash
+export ROSTER_VERIFY_COOKIE='session=…'      # /api/roster/intelligence is
+                                             # behind server.py::_private_api_gate
+python scripts/verify_roster_intelligence.py \
+    --base-url "$PROD_PUBLIC_URL" \
+    --expect-sha "$DEPLOYED_SHA" \
+    --json-out data/ops/roster-intelligence-verification.json
+```
+
+`--base-url` is **required and has no default**: an unset origin is an
+outage to surface, not a value to guess
+(`.github/workflows/prod-e2e-smoke.yml:40`). With no `--league-key` it
+runs every **active** league in the registry.
+
+A 401/403 is **terminal, not retried** — the service is up and correctly
+refusing an anonymous caller, and retrying it is guaranteed to fail
+identically. `verify-sharp-production.yml` spent 40 minutes per run
+learning that.
+
+### Offline (EVIDENCE-L1 / L2) — runs in CI already
+
+```bash
+python -m pytest tests/roster_intel/test_verification_pack.py \
+                 tests/roster_intel/test_metric_separation.py -q
+```
+
+Both files are pure-logic and stay in the **hard gate**
+(`-m "not livedata"`); neither is in `_LIVEDATA_MODULES` and neither
+touches the network —
+`tests/infra/test_unit_suite_does_not_probe_production.py` forbids it,
+which is why the pack is built as `fetch → payload → pure check`.
+
+---
+
+## 3. Results
+
+Measured 2026-08-19 at `fd70515`, offline, against the newest COMPLETE
+archived scrape (`dynasty_export_20260818_230211.zip`) rebuilt through
+`build_api_data_contract` → `build_league_roster_intelligence`.
+
+`newest_complete_raw_payload()` refuses a source-degraded bundle, so this
+is a real board or nothing.
+
+| # | check | result | level | denominator | evidence |
+|---|---|---|---|---|---|
+| 01 | every active configured league answers | **PASS** | EVIDENCE-L2 | 1 | one league rebuilt offline; see §4 for the second |
+| 02 | weakness thresholds scale with `teamCount` | **PASS** | EVIDENCE-L1 | **216 rungs** | every `thresholdRank == rung × 12` |
+| 03 | flex slots come from actual league configuration | **PASS** | EVIDENCE-L2 | **36 flex slots** | `slotSource = sleeper_roster_positions`; 12 teams × (FLEX×2 + SUPER_FLEX×1), each seated or reported unfilled |
+| 04 | every player appears at most once per core | **PASS** | EVIDENCE-L2 | **374 members** | no duplicate `playerId` in any core |
+| 05 | starters removed before the reserve solve | **PASS** | EVIDENCE-L2 | **240 starters** | starter ∩ reserve = ∅ (240 = 12 × 20, the same figure C2-U1 §10a reports) |
+| 06 | core size respects starters + reserve demand | **PASS** | EVIDENCE-L2 | **12 teams** | `|core| ≤ slots + demand.total`, and `ceil(1.5·s) − s` re-derived per dedicated position |
+| 07 | unpriced players reported, not coerced | **PASS** | EVIDENCE-L2 | **660 rostered** | `core.unpricedIds == strength.unpricedIds`; no zero-valued member hidden behind an empty list |
+| 08 | unpriced excluded from every value aggregate | **PASS** | EVIDENCE-L2 | **83 unpriced** | `unpricedIds ∩ members = ∅` — 83 of 660 (12.6%) exercised the rule |
+| 09 | Team Strength groups re-sum to total | **PASS** | EVIDENCE-L2 | **12 teams** | group sum and starter+reserve both equal `total` within rounding tolerance |
+| 10 | weakness credits no player to two rungs | **PASS** | EVIDENCE-L2 | **215 rung credits** | no `playerId` fills two rungs on one team |
+| 11 | Young Core uses core-only value, discloses PRIOR | **PASS** | EVIDENCE-L2 | **12 portfolios** | `coverage.totalPlayers == |core|`, `coverage.totalValue == strength.total`, `youngCoreIndexStatus == "PRIOR"` |
+| 12 | teamAssignment degrades honestly | **UNMEASURABLE** | — | 0 | needs the deployed public-league section — see §4 |
+| 13 | endpoint latency within budget | **UNMEASURABLE** | — | 0 | nothing was fetched over HTTP — see §4 |
+
+Offline exit code: **2**. Correct, and the point: eleven checks passed
+and two could not be measured, so the run does not report success.
+
+**Denominators matter more than the verdicts.** Every figure above is
+non-zero and independently plausible: 240 starters is 12 teams × 20 live
+slots; 83 unpriced is 12.6% of 660 rostered, the same figure
+`src/api/roster_intelligence.py`'s module docstring records. Had the
+join silently failed, these would read 0 and the harness would have
+downgraded every PASS.
+
+---
+
+## 4. Outstanding — for the integration lane
+
+| # | item | why it is not closed here | what closes it |
+|---|---|---|---|
+| 01 | `dynasty_new` (10-team, no IDP) | it has no local contract; it is served by the Sleeper-derived fallback | run §2 against the deploy with no `--league-key` |
+| 12 | degraded `/league?tab=teamAssignment` | needs a deployed public-league section | §2; the three states are already pinned Python-side by `tests/api/test_team_assignment_availability.py` |
+| 13 | latency | needs a timed HTTP request | §2; budget cited from `docs/GLOBAL_PERFORMANCE_STANDARD.md` (p95 ≤ 2 s, warm target 1 s). One sample per endpoint — a smoke measurement, reported as such, **not** a p95 |
+
+### Two gaps worth naming rather than working around
+
+**No API surface publishes the deployed commit.** EVIDENCE-L3 is defined
+as "the named checklist executed against the **deployed SHA**", and
+neither `/api/status` nor `/api/health` carries one. `--expect-sha` is
+therefore recorded as *operator-asserted* provenance, and the artifact
+stamps `shaPublishedByApi: null` so the two can never be confused. Take
+the SHA from the deploy run, not from the response.
+
+**`team-assignment.jsx` has no frontend test.** Its degraded contract is
+pinned on the Python side only. The EVIDENCE-L4 half of check 12 would be
+a component test in the shape of
+`frontend/__tests__/components/activity-news-unavailable.test.jsx`
+(`role="alert"` for hard-unavailable, `role="status"` for a partial
+note). That is Claude 6's lane and is **not** written here.
+
+---
+
+## 5. Why the checks are trusted
+
+63 tests in `tests/roster_intel/test_verification_pack.py`, in three
+groups:
+
+1. **every check passes a clean payload** — and with a non-zero
+   denominator, so the fixture actually exercises it;
+2. **every check fails when its property is violated** — ten mutations,
+   one per check, each confirmed to turn its check red. A check that
+   cannot be made to fail proves nothing about the payloads it passes;
+3. **every check reports `UNMEASURABLE` on absent input** — the
+   non-vacuity requirement, discharged by assertion rather than by
+   reading the code.
+
+Plus the harness rules (vacuous-pass downgrade, level capping, exit-code
+precedence) and an EVIDENCE-L2 pass of checks 2–11 over the real
+rebuilt board.
+
+### Transport, exercised end-to-end
+
+The check layer is proven by the suite above; the *transport* layer is
+not reachable from pytest, so it was exercised by hand against a canned
+local backend serving the suite's own fixtures. Measured 2026-08-19:
+
+| scenario | expected | measured |
+|---|---|---|
+| healthy backend | exit **0**, 13/13 PASS, levels capped at the source | exit 0, 13 passed / 0 failed / 0 unmeasurable; check 02 reported EVIDENCE-L1 (its ceiling) while 12–13 reported EVIDENCE-L3 |
+| `--base-url` omitted | exit **2** | exit 2, `::error title=No base URL` |
+| connection refused | exit **2** | exit 2, every check UNMEASURABLE with the URLError named |
+| backend returns 401 | exit **2**, **terminal not retried** | exit 2 in **0 s** — three retries × 4 s per endpoint would have taken ≈24 s+. The reason names both remedies and notes that a 401 on a route that should be *public* is itself the finding |
+
+The last row is the one worth keeping: `verify-sharp-production.yml`
+spent 40 minutes per run, on every push to main, retrying a 401 that was
+never going to change.
+
+**Measured mutation specificity, reported rather than engineered away.**
+Six of the ten mutations turn exactly one check red. Four also trip
+check 11, and one also trips check 04 — and in every case the collateral
+is a *genuine* second violation: check 11's property is that the age
+portfolio's population **is** the core, so any mutation changing the core
+member count really does violate it, and making a starter also a reserve
+really is a duplicate. The test therefore asserts "the intended check is
+among the red ones" with a bounded allowance, not "exactly one is red".
+Claiming the stricter property would mean weakening a check to buy a
+tidier table.

--- a/scripts/verify_roster_intelligence.py
+++ b/scripts/verify_roster_intelligence.py
@@ -1,0 +1,1405 @@
+#!/usr/bin/env python3
+"""Executable verification pack for the canonical roster-intelligence chain.
+
+Thirteen checks over ``GET /api/roster/intelligence`` and the public
+``/league?tab=teamAssignment`` section, covering V1-27 through V1-33.
+
+**Read this before reading the output: a verification that cannot
+distinguish "measured and found none" from "matched nothing" is not a
+verification.**  That sentence is ``docs/lineup/C2_U1_CANONICAL_LINEUP.md``
+§10a, written after a production checklist nearly passed vacuously — a
+join by Sleeper id returned 0 hits because the payload keys assignments
+by NAME, and 0-of-0 violations reads exactly like 0-of-240.  So every
+check here publishes its own DENOMINATOR, and the harness — not the
+individual check — downgrades any ``PASS`` with a zero denominator to
+``UNMEASURABLE``.  A check author cannot forget to do it.
+
+Two halves, deliberately split
+==============================
+
+``build_bundle_*`` fetches.  ``check_*`` decides, purely, from a
+:class:`Bundle`.  Nothing in the check layer touches the network, which
+is what lets ``tests/roster_intel/test_verification_pack.py`` drive
+every check from fixtures — and is required by
+``tests/infra/test_unit_suite_does_not_probe_production.py``, which
+forbids the unit suite from probing production.
+
+Evidence levels
+===============
+
+Each check declares the level its result can support, using the
+vocabulary in ``docs/VERSION_1_COMPLETION_CONTRACT.md`` §"Verification
+levels".  They are spelled ``EVIDENCE-L1``..``EVIDENCE-L4`` here
+because that same document ALSO uses ``L1``..``L6`` for lanes, in the
+same table — an ambiguity worth not importing into machine-readable
+output.
+
+  EVIDENCE-L1  deterministic — provable from config/logic alone
+  EVIDENCE-L2  measured against a real board or contract
+  EVIDENCE-L3  measured against a DEPLOYED response
+  EVIDENCE-L4  EVIDENCE-L3 plus the user-facing surface consuming it
+
+A check's declared level is the CEILING it can reach; a run against a
+locally rebuilt contract reports EVIDENCE-L2 even for a check whose
+ceiling is EVIDENCE-L3, because the evidence is only as strong as its
+source.  ``--source`` records which it was.
+
+Usage:
+    python scripts/verify_roster_intelligence.py --base-url http://127.0.0.1:8000
+    python scripts/verify_roster_intelligence.py --base-url "$PROD_PUBLIC_URL" \
+        --league-key dynasty_main --league-key dynasty_new --json-out evidence.json
+
+Exit codes (the repo convention — ``scripts/backtest_perfect_draft.py``):
+    0  every check was MEASURED and PASSED
+    1  a check measured a violation
+    2  one or more checks could not be measured
+
+``2`` is deliberately distinct and is never collapsed into ``0``: "no
+data" must not read as "passed".  It is also distinct from ``1``,
+because "we looked and it is broken" and "we could not look" call for
+different actions — the first is a defect, the second is a missing
+credential, an undeployed endpoint, or a league with no contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+TAG = "[roster-verify]"
+
+EXIT_OK = 0
+EXIT_FAILED = 1
+EXIT_UNMEASURED = 2
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNMEASURABLE = "UNMEASURABLE"
+
+L1 = "EVIDENCE-L1"
+L2 = "EVIDENCE-L2"
+L3 = "EVIDENCE-L3"
+L4 = "EVIDENCE-L4"
+
+#: Owner-approved default from ``docs/GLOBAL_PERFORMANCE_STANDARD.md``:
+#: "normal production p95 first useful data: <=2 seconds", with a warm
+#: target of 1 second.  A cited budget, not one invented here.
+LATENCY_BUDGET_MS = 2000.0
+LATENCY_WARM_TARGET_MS = 1000.0
+
+#: The multiplier the meaningful core is built with (#839 / decision 67),
+#: shipped as the V1 champion and LABELLED PRIOR.  Read from the payload
+#: when present; this is only the fallback for a payload that predates
+#: the field, and a mismatch is reported rather than silently accepted.
+EXPECTED_M = 1.5
+
+
+# ---------------------------------------------------------------------------
+# Result plumbing
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """One check's verdict, carrying the evidence that produced it.
+
+    ``denominator`` is the count of things actually examined.  It is not
+    decoration: :func:`finalize` reads it, and a ``PASS`` over nothing
+    becomes ``UNMEASURABLE``.
+    """
+
+    id: str
+    name: str
+    ceiling: str
+    result: str
+    denominator: int
+    level: str | None = None
+    reason: str | None = None
+    evidence: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "result": self.result,
+            "level": self.level,
+            "ceiling": self.ceiling,
+            "denominator": self.denominator,
+            "reason": self.reason,
+            "evidence": dict(self.evidence),
+        }
+
+
+def unmeasurable(
+    check_id: str, name: str, ceiling: str, reason: str, **evidence: Any
+) -> CheckResult:
+    """A check that could not run.  Never a pass, never a failure."""
+    return CheckResult(
+        id=check_id,
+        name=name,
+        ceiling=ceiling,
+        result=UNMEASURABLE,
+        denominator=0,
+        reason=reason,
+        evidence=evidence,
+    )
+
+
+def finalize(results: Sequence[CheckResult], *, source_level: str) -> list[CheckResult]:
+    """Apply the two rules no individual check is trusted to apply itself.
+
+    1. **Non-vacuity.**  A ``PASS`` that examined nothing is
+       ``UNMEASURABLE``.  This is enforced here rather than in each
+       check because "publish your denominator" is a convention and
+       conventions are forgotten; a harness rule is not.  A ``FAIL``
+       with a zero denominator is left alone — it is a contradiction
+       the check itself is asserting, and hiding it would be worse.
+    2. **Level ceiling.**  Evidence is only as strong as its source, so
+       a check whose ceiling is EVIDENCE-L3 reports EVIDENCE-L2 when the
+       run read a locally rebuilt contract.
+    """
+    order = [L1, L2, L3, L4]
+    cap = order.index(source_level)
+    out: list[CheckResult] = []
+    for r in results:
+        result, reason = r.result, r.reason
+        if result == PASS and r.denominator <= 0:
+            result = UNMEASURABLE
+            reason = (
+                "vacuous: the check passed having examined 0 items. "
+                "0-of-0 is not evidence of compliance."
+            )
+        level = None
+        if result != UNMEASURABLE:
+            level = order[min(order.index(r.ceiling), cap)]
+        out.append(
+            CheckResult(
+                id=r.id,
+                name=r.name,
+                ceiling=r.ceiling,
+                result=result,
+                denominator=r.denominator,
+                level=level,
+                reason=reason,
+                evidence=r.evidence,
+            )
+        )
+    return out
+
+
+def exit_code_for(results: Sequence[CheckResult]) -> int:
+    """Failures outrank unmeasured; both outrank success."""
+    if any(r.result == FAIL for r in results):
+        return EXIT_FAILED
+    if any(r.result == UNMEASURABLE for r in results):
+        return EXIT_UNMEASURED
+    return EXIT_OK
+
+
+# ---------------------------------------------------------------------------
+# The bundle a check reasons over
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Bundle:
+    """Everything one league's checks may read.  Any field may be absent.
+
+    Absent is UNKNOWN, and every check that needs a missing field says
+    ``UNMEASURABLE`` with a named reason rather than treating the gap as
+    a clean result.
+    """
+
+    league_key: str
+    registry: Mapping[str, Any] | None = None
+    intelligence: Mapping[str, Any] | None = None
+    team_assignment: Mapping[str, Any] | None = None
+    latency_ms: dict[str, float] = field(default_factory=dict)
+    errors: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def teams(self) -> list[Mapping[str, Any]]:
+        payload = self.intelligence or {}
+        teams = payload.get("teams")
+        if isinstance(teams, Mapping):
+            return [t for t in teams.values() if isinstance(t, Mapping)]
+        if isinstance(teams, list):
+            return [t for t in teams if isinstance(t, Mapping)]
+        return []
+
+
+def _members(team: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    core = team.get("core")
+    if not isinstance(core, Mapping):
+        return []
+    return [m for m in (core.get("members") or []) if isinstance(m, Mapping)]
+
+
+# ---------------------------------------------------------------------------
+# The thirteen checks.  Pure functions of a Bundle (or of every Bundle).
+# ---------------------------------------------------------------------------
+
+
+def check_01_both_leagues(bundles: Sequence[Bundle]) -> CheckResult:
+    """Every ACTIVE configured league answers, or says why it cannot.
+
+    The denominator is the registry's active-league count, not the count
+    that happened to respond — otherwise a run that reached one league
+    of two would report "1 of 1".  That inversion is precisely how a
+    partial verification reads as a complete one.
+    """
+    name = "every active configured league answers"
+    if not bundles:
+        return unmeasurable("01", name, L3, "no leagues resolved from the registry")
+
+    answered, missing = [], []
+    for b in bundles:
+        if isinstance(b.intelligence, Mapping) and b.teams:
+            answered.append(b.league_key)
+        else:
+            missing.append(
+                {
+                    "leagueKey": b.league_key,
+                    "reason": b.errors.get("intelligence", "no teams in payload"),
+                }
+            )
+
+    evidence = {
+        "expected": [b.league_key for b in bundles],
+        "answered": answered,
+        "missing": missing,
+    }
+    if missing:
+        return CheckResult(
+            "01",
+            name,
+            L3,
+            UNMEASURABLE,
+            len(bundles),
+            reason=(
+                f"{len(missing)} of {len(bundles)} active leagues did not answer. "
+                "Reported UNMEASURABLE rather than FAIL: a league with no loaded "
+                "contract is un-probed, not defective."
+            ),
+            evidence=evidence,
+        )
+    return CheckResult("01", name, L3, PASS, len(bundles), evidence=evidence)
+
+
+def check_02_threshold_scaling(bundle: Bundle) -> CheckResult:
+    """Weakness thresholds scale with the league's OWN team count.
+
+    ``thresholdRank == rung x teamCount``.  A 12-team league's QB2 line
+    is rank 24; a 10-team league's is rank 20.  A hard-coded 12 would
+    pass silently on ``dynasty_main`` and misprice every rung in
+    ``dynasty_new``, which is why this is checked per league rather than
+    once.
+    """
+    name = "weakness thresholds scale with teamCount"
+    payload = bundle.intelligence
+    if not isinstance(payload, Mapping):
+        return unmeasurable(
+            "02", name, L1, "no roster-intelligence payload", leagueKey=bundle.league_key
+        )
+
+    declared = payload.get("teamCount")
+    registry_count = (bundle.registry or {}).get("teamCount")
+    if not isinstance(declared, int) or declared <= 0:
+        return unmeasurable(
+            "02", name, L1, "payload declares no usable teamCount", leagueKey=bundle.league_key
+        )
+
+    violations: list[dict[str, Any]] = []
+    examined = 0
+    if isinstance(registry_count, int) and registry_count != declared:
+        violations.append(
+            {
+                "kind": "teamCount_disagrees_with_registry",
+                "payload": declared,
+                "registry": registry_count,
+            }
+        )
+
+    for team in bundle.teams:
+        weakness = team.get("weakness")
+        if not isinstance(weakness, Mapping):
+            continue
+        if weakness.get("available") is False:
+            continue
+        for need in weakness.get("needs") or []:
+            if not isinstance(need, Mapping):
+                continue
+            for rung in need.get("rungs") or []:
+                if not isinstance(rung, Mapping):
+                    continue
+                idx, threshold = rung.get("rung"), rung.get("thresholdRank")
+                if not isinstance(idx, int) or not isinstance(threshold, int):
+                    continue
+                examined += 1
+                if threshold != idx * declared:
+                    violations.append(
+                        {
+                            "ownerId": team.get("ownerId"),
+                            "label": rung.get("label"),
+                            "rung": idx,
+                            "thresholdRank": threshold,
+                            "expected": idx * declared,
+                        }
+                    )
+
+    evidence = {
+        "leagueKey": bundle.league_key,
+        "teamCount": declared,
+        "registryTeamCount": registry_count,
+        "rungsExamined": examined,
+        "violations": violations[:20],
+        "violationCount": len(violations),
+    }
+    if violations:
+        return CheckResult(
+            "02",
+            name,
+            L1,
+            FAIL,
+            examined,
+            reason=f"{len(violations)} rung thresholds do not equal rung x {declared}",
+            evidence=evidence,
+        )
+    return CheckResult("02", name, L1, PASS, examined, evidence=evidence)
+
+
+_FLEX_FAMILIES = ("FLEX", "SUPER_FLEX", "IDP_FLEX")
+
+
+def check_03_flex_from_config(bundle: Bundle) -> CheckResult:
+    """FLEX / SUPER_FLEX / IDP-FLEX come from the league's ACTUAL config.
+
+    Two properties, and the second is the one a naive check misses:
+
+    * the slot list names its SOURCE (``sleeper_roster_positions`` or
+      ``registry_starters``).  ``None`` is the ladder's refusal, and a
+      payload that produced slots from neither rung invented them;
+    * every declared flex slot is ACCOUNTED FOR — seated by a member or
+      listed in ``unfilledStarterSlots``.  Without this, a solver that
+      silently skipped the flex slots would still show a plausible
+      lineup, and the count check alone would pass.
+    """
+    name = "flex slots come from actual league configuration"
+    payload = bundle.intelligence
+    if not isinstance(payload, Mapping):
+        return unmeasurable(
+            "03", name, L2, "no roster-intelligence payload", leagueKey=bundle.league_key
+        )
+
+    slot_source = payload.get("slotSource")
+    declared = [str(s) for s in (payload.get("starterSlots") or [])]
+    flex_declared = [s for s in declared if s in _FLEX_FAMILIES]
+
+    if not slot_source:
+        return CheckResult(
+            "03",
+            name,
+            L2,
+            FAIL,
+            len(declared),
+            reason="slotSource is absent — the slot list came from neither ladder rung, so it was invented",
+            evidence={"leagueKey": bundle.league_key, "starterSlots": declared},
+        )
+    if not flex_declared:
+        return unmeasurable(
+            "03",
+            name,
+            L2,
+            "this league declares no FLEX/SUPER_FLEX/IDP_FLEX slot, so there is nothing to verify",
+            leagueKey=bundle.league_key,
+            slotSource=slot_source,
+            starterSlots=declared,
+        )
+
+    examined, violations = 0, []
+    for team in bundle.teams:
+        core = team.get("core")
+        if not isinstance(core, Mapping) or core.get("available") is False:
+            continue
+        seated: dict[str, int] = {}
+        for m in _members(team):
+            if m.get("role") == "starter" and str(m.get("slot")) in _FLEX_FAMILIES:
+                seated[str(m["slot"])] = seated.get(str(m["slot"]), 0) + 1
+        unfilled = [str(s) for s in (core.get("unfilledStarterSlots") or [])]
+        for fam in _FLEX_FAMILIES:
+            want = flex_declared.count(fam)
+            if not want:
+                continue
+            examined += want
+            got = seated.get(fam, 0) + unfilled.count(fam)
+            if got != want:
+                violations.append(
+                    {
+                        "ownerId": team.get("ownerId"),
+                        "slot": fam,
+                        "declared": want,
+                        "accountedFor": got,
+                        "seated": seated.get(fam, 0),
+                        "unfilled": unfilled.count(fam),
+                    }
+                )
+
+    evidence = {
+        "leagueKey": bundle.league_key,
+        "slotSource": slot_source,
+        "flexSlotsDeclared": flex_declared,
+        "flexSlotsExamined": examined,
+        "violations": violations[:20],
+        "violationCount": len(violations),
+    }
+    if violations:
+        return CheckResult(
+            "03",
+            name,
+            L2,
+            FAIL,
+            examined,
+            reason=f"{len(violations)} declared flex slots were neither seated nor reported unfilled",
+            evidence=evidence,
+        )
+    return CheckResult("03", name, L2, PASS, examined, evidence=evidence)
+
+
+def check_04_player_at_most_once(bundle: Bundle) -> CheckResult:
+    """No player appears twice in one team's meaningful core.
+
+    Decision 72: "a player used at FLEX cannot also count as
+    native-position depth; every player counts at most once."  Checked
+    as a multiset over ``core.members``, which is the population every
+    downstream aggregate sums.
+    """
+    name = "every player appears at most once per core"
+    if not isinstance(bundle.intelligence, Mapping):
+        return unmeasurable(
+            "04", name, L2, "no roster-intelligence payload", leagueKey=bundle.league_key
+        )
+
+    examined, violations = 0, []
+    for team in bundle.teams:
+        seen: dict[str, int] = {}
+        for m in _members(team):
+            pid = str(m.get("playerId") or "")
+            if not pid:
+                continue
+            examined += 1
+            seen[pid] = seen.get(pid, 0) + 1
+        dupes = {pid: n for pid, n in seen.items() if n > 1}
+        if dupes:
+            violations.append({"ownerId": team.get("ownerId"), "duplicates": dupes})
+
+    evidence = {
+        "leagueKey": bundle.league_key,
+        "membersExamined": examined,
+        "violations": violations[:20],
+        "violationCount": len(violations),
+    }
+    if violations:
+        return CheckResult(
+            "04",
+            name,
+            L2,
+            FAIL,
+            examined,
+            reason=f"{len(violations)} teams double-count a player",
+            evidence=evidence,
+        )
+    return CheckResult("04", name, L2, PASS, examined, evidence=evidence)
+
+
+def check_05_starters_before_reserves(bundle: Bundle) -> CheckResult:
+    """Starters are removed from the pool before the reserve solve.
+
+    The observable consequence of the #899 ordering: the starter and
+    reserve sets are DISJOINT.  A reserve solve that ran over the whole
+    roster would re-select the best players it had just seated.
+    """
+    name = "starters are removed before the reserve solve"
+    if not isinstance(bundle.intelligence, Mapping):
+        return unmeasurable(
+            "05", name, L2, "no roster-intelligence payload", leagueKey=bundle.league_key
+        )
+
+    examined, violations = 0, []
+    for team in bundle.teams:
+        starters = {str(m.get("playerId")) for m in _members(team) if m.get("role") == "starter"}
+        reserves = {str(m.get("playerId")) for m in _members(team) if m.get("role") == "reserve"}
+        examined += len(starters)
+        overlap = sorted(starters & reserves)
+        if overlap:
+            violations.append(
+                {"ownerId": team.get("ownerId"), "inBoth": overlap[:10], "count": len(overlap)}
+            )
+
+    evidence = {
+        "leagueKey": bundle.league_key,
+        "startersExamined": examined,
+        "violations": violations[:20],
+        "violationCount": len(violations),
+    }
+    if violations:
+        return CheckResult(
+            "05",
+            name,
+            L2,
+            FAIL,
+            examined,
+            reason=f"{len(violations)} teams seat a player as both starter and reserve",
+            evidence=evidence,
+        )
+    return CheckResult("05", name, L2, PASS, examined, evidence=evidence)
+
+
+def check_06_core_ceiling(bundle: Bundle) -> CheckResult:
+    """The core never exceeds ``starters + reserve demand``.
+
+    ``reserve_demand(p) = ceil(M x starters(p)) - starters(p)``, so the
+    ceiling is ``starterSlots + demand.total``.  Also re-derives the
+    multiplier's own arithmetic from the published basis, because a
+    ceiling computed from a wrong demand would be self-consistent and
+    still wrong.
+    """
+    name = "core size respects starters + reserve demand"
+    if not isinstance(bundle.intelligence, Mapping):
+        return unmeasurable(
+            "06", name, L2, "no roster-intelligence payload", leagueKey=bundle.league_key
+        )
+
+    examined, violations = 0, []
+    for team in bundle.teams:
+        core = team.get("core")
+        if not isinstance(core, Mapping) or core.get("available") is False:
+            continue
+        demand = core.get("demand")
+        if not isinstance(demand, Mapping):
+            continue
+        slots = [str(s) for s in (core.get("starterSlots") or [])]
+        total_demand = demand.get("total")
+        if not isinstance(total_demand, int):
+            continue
+        examined += 1
+        ceiling = len(slots) + total_demand
+        actual = len(_members(team))
+        if actual > ceiling:
+            violations.append(
+                {
+                    "ownerId": team.get("ownerId"),
+                    "coreSize": actual,
+                    "ceiling": ceiling,
+                    "starterSlots": len(slots),
+                    "reserveDemand": total_demand,
+                }
+            )
+
+        m = demand.get("multiplier", EXPECTED_M)
+        basis = demand.get("dedicatedBasis")
+        by_slot = demand.get("bySlot")
+        if (
+            isinstance(basis, Mapping)
+            and isinstance(by_slot, Mapping)
+            and isinstance(m, (int, float))
+        ):
+            for pos, starters in basis.items():
+                if not isinstance(starters, int) or starters <= 0:
+                    continue
+                want = math.ceil(m * starters) - starters
+                got = by_slot.get(pos)
+                if isinstance(got, int) and got != want:
+                    violations.append(
+                        {
+                            "ownerId": team.get("ownerId"),
+                            "slot": pos,
+                            "starters": starters,
+                            "multiplier": m,
+                            "reserveDemand": got,
+                            "expected": want,
+                        }
+                    )
+
+    evidence = {
+        "leagueKey": bundle.league_key,
+        "teamsExamined": examined,
+        "violations": violations[:20],
+        "violationCount": len(violations),
+    }
+    if violations:
+        return CheckResult(
+            "06",
+            name,
+            L2,
+            FAIL,
+            examined,
+            reason=f"{len(violations)} ceiling/demand violations",
+            evidence=evidence,
+        )
+    return CheckResult("06", name, L2, PASS, examined, evidence=evidence)
+
+
+def check_07_unpriced_reported(bundle: Bundle) -> CheckResult:
+    """Unpriced rostered players are REPORTED, and reported once.
+
+    The defect this exists for is not "some players are unpriced" — it
+    is that they used to be structurally invisible.  ``ros_value=0.0``
+    was appended for every row that would not match, so ``unpricedIds``
+    came back empty not because everyone was priced but because the
+    unpriced arrived indistinguishable from the worthless.
+
+    Two properties, because "zero unpriced" is a legitimate answer and
+    must not be forced to fail:
+
+    * ``core.unpricedIds`` and ``strength.unpricedIds`` are the SAME
+      fact and must agree — two publishers, one truth;
+    * if a league reports zero unpriced while carrying members valued at
+      exactly ``0.0``, that is the coercion signature and it fails.
+    """
+    name = "unpriced rostered players are reported, not coerced"
+    if not isinstance(bundle.intelligence, Mapping):
+        return unmeasurable(
+            "07", name, L2, "no roster-intelligence payload", leagueKey=bundle.league_key
+        )
+
+    examined, violations = 0, []
+    total_unpriced, zero_valued = 0, 0
+    for team in bundle.teams:
+        core, strength = team.get("core"), team.get("strength")
+        if not isinstance(core, Mapping) or not isinstance(strength, Mapping):
+            continue
+        examined += int(team.get("rosteredCount") or 0)
+        core_ids = set(core.get("unpricedIds") or [])
+        strength_ids = set(strength.get("unpricedIds") or [])
+        total_unpriced += len(core_ids)
+        if core_ids != strength_ids:
+            violations.append(
+                {
+                    "ownerId": team.get("ownerId"),
+                    "kind": "publishers_disagree",
+                    "onlyInCore": sorted(core_ids - strength_ids)[:5],
+                    "onlyInStrength": sorted(strength_ids - core_ids)[:5],
+                }
+            )
+        zeros = [str(m.get("playerId")) for m in _members(team) if m.get("value") == 0]
+        zero_valued += len(zeros)
+        if zeros and not core_ids:
+            violations.append(
+                {
+                    "ownerId": team.get("ownerId"),
+                    "kind": "zero_valued_members_but_none_reported_unpriced",
+                    "zeroValuedMembers": zeros[:5],
+                }
+            )
+
+    if not examined:
+        return unmeasurable(
+            "07", name, L2, "no rostered players in any team", leagueKey=bundle.league_key
+        )
+
+    evidence = {
+        "leagueKey": bundle.league_key,
+        "rosteredExamined": examined,
+        "unpricedReported": total_unpriced,
+        "zeroValuedMembers": zero_valued,
+        "violations": violations[:20],
+        "violationCount": len(violations),
+    }
+    if violations:
+        return CheckResult(
+            "07",
+            name,
+            L2,
+            FAIL,
+            examined,
+            reason=f"{len(violations)} unpriced-reporting violations",
+            evidence=evidence,
+        )
+    return CheckResult("07", name, L2, PASS, examined, evidence=evidence)
+
+
+def check_08_missing_is_never_zero(bundle: Bundle) -> CheckResult:
+    """An unpriced player is UNKNOWN — never a scored member worth 0.
+
+    The structural form of MISSING IS NEVER ZERO: ``unpricedIds`` and
+    the scored ``members`` must be DISJOINT.  A player in both would be
+    declared unknown and simultaneously summed into Team Strength, which
+    is the coercion wearing a disclosure.
+    """
+    name = "unpriced players are excluded from every value aggregate"
+    if not isinstance(bundle.intelligence, Mapping):
+        return unmeasurable(
+            "08", name, L2, "no roster-intelligence payload", leagueKey=bundle.league_key
+        )
+
+    examined, violations = 0, []
+    for team in bundle.teams:
+        core = team.get("core")
+        if not isinstance(core, Mapping):
+            continue
+        unpriced = {str(x) for x in (core.get("unpricedIds") or [])}
+        examined += len(unpriced)
+        member_ids = {str(m.get("playerId")) for m in _members(team)}
+        both = sorted(unpriced & member_ids)
+        if both:
+            violations.append(
+                {"ownerId": team.get("ownerId"), "unpricedButScored": both[:10], "count": len(both)}
+            )
+
+    if not examined:
+        return unmeasurable(
+            "08",
+            name,
+            L2,
+            "no unpriced players anywhere in this league, so the exclusion rule was not exercised",
+            leagueKey=bundle.league_key,
+        )
+
+    evidence = {
+        "leagueKey": bundle.league_key,
+        "unpricedExamined": examined,
+        "violations": violations[:20],
+        "violationCount": len(violations),
+    }
+    if violations:
+        return CheckResult(
+            "08",
+            name,
+            L2,
+            FAIL,
+            examined,
+            reason=f"{len(violations)} teams score a player they declared unpriced",
+            evidence=evidence,
+        )
+    return CheckResult("08", name, L2, PASS, examined, evidence=evidence)
+
+
+def check_09_strength_groups_resum(bundle: Bundle) -> CheckResult:
+    """Team Strength position groups re-sum to the published total.
+
+    Tolerance is derived, not chosen: each group's ``value`` is rounded
+    to 3 dp independently, so N groups can drift by up to N x 0.0005
+    from the rounded total by rounding alone.  Anything beyond that is a
+    partition defect — a player in no group, or in two.
+    """
+    name = "Team Strength position groups re-sum to total"
+    if not isinstance(bundle.intelligence, Mapping):
+        return unmeasurable(
+            "09", name, L2, "no roster-intelligence payload", leagueKey=bundle.league_key
+        )
+
+    examined, violations = 0, []
+    for team in bundle.teams:
+        strength = team.get("strength")
+        if not isinstance(strength, Mapping) or strength.get("available") is False:
+            continue
+        groups = [g for g in (strength.get("byPosition") or []) if isinstance(g, Mapping)]
+        total = strength.get("total")
+        if not isinstance(total, (int, float)):
+            continue
+        examined += 1
+        summed = sum(float(g.get("value") or 0.0) for g in groups)
+        tolerance = 0.0005 * max(len(groups), 1) + 1e-6
+        if abs(summed - float(total)) > tolerance:
+            violations.append(
+                {
+                    "ownerId": team.get("ownerId"),
+                    "total": total,
+                    "groupSum": round(summed, 4),
+                    "delta": round(summed - float(total), 4),
+                    "groups": len(groups),
+                    "tolerance": tolerance,
+                }
+            )
+        # Starter + reserve must also partition the same total.
+        sv, rv = strength.get("starterValue"), strength.get("reserveValue")
+        if isinstance(sv, (int, float)) and isinstance(rv, (int, float)):
+            if abs((float(sv) + float(rv)) - float(total)) > 0.0015:
+                violations.append(
+                    {
+                        "ownerId": team.get("ownerId"),
+                        "kind": "starter_plus_reserve_ne_total",
+                        "starterValue": sv,
+                        "reserveValue": rv,
+                        "total": total,
+                    }
+                )
+
+    evidence = {
+        "leagueKey": bundle.league_key,
+        "teamsExamined": examined,
+        "violations": violations[:20],
+        "violationCount": len(violations),
+    }
+    if violations:
+        return CheckResult(
+            "09",
+            name,
+            L2,
+            FAIL,
+            examined,
+            reason=f"{len(violations)} teams' groups do not re-sum to total",
+            evidence=evidence,
+        )
+    return CheckResult("09", name, L2, PASS, examined, evidence=evidence)
+
+
+def check_10_weakness_no_double_credit(bundle: Bundle) -> CheckResult:
+    """No player is credited to two weakness rungs on the same team.
+
+    A rung answers "who is your QB2?"  One player cannot be both the QB1
+    and the QB2 answer; if he were, a one-deep room would read as two
+    filled rungs and the need would vanish.
+    """
+    name = "weakness credits no player to two rungs"
+    if not isinstance(bundle.intelligence, Mapping):
+        return unmeasurable(
+            "10", name, L2, "no roster-intelligence payload", leagueKey=bundle.league_key
+        )
+
+    examined, violations = 0, []
+    for team in bundle.teams:
+        weakness = team.get("weakness")
+        if not isinstance(weakness, Mapping) or weakness.get("available") is False:
+            continue
+        seen: dict[str, list[str]] = {}
+        for need in weakness.get("needs") or []:
+            if not isinstance(need, Mapping):
+                continue
+            for rung in need.get("rungs") or []:
+                if not isinstance(rung, Mapping):
+                    continue
+                pid = rung.get("playerId")
+                if not pid:
+                    continue
+                examined += 1
+                seen.setdefault(str(pid), []).append(str(rung.get("label") or ""))
+        dupes = {pid: labels for pid, labels in seen.items() if len(labels) > 1}
+        if dupes:
+            violations.append({"ownerId": team.get("ownerId"), "duplicates": dupes})
+
+    if not examined:
+        return unmeasurable(
+            "10",
+            name,
+            L2,
+            "no weakness rung names a player, so no credit could be double-counted",
+            leagueKey=bundle.league_key,
+        )
+
+    evidence = {
+        "leagueKey": bundle.league_key,
+        "rungCreditsExamined": examined,
+        "violations": violations[:20],
+        "violationCount": len(violations),
+    }
+    if violations:
+        return CheckResult(
+            "10",
+            name,
+            L2,
+            FAIL,
+            examined,
+            reason=f"{len(violations)} teams credit one player to two rungs",
+            evidence=evidence,
+        )
+    return CheckResult("10", name, L2, PASS, examined, evidence=evidence)
+
+
+def check_11_young_core_scope_and_disclosure(bundle: Bundle) -> CheckResult:
+    """Young Core is measured over the CORE, and says it is a PRIOR.
+
+    Scope is checked through the portfolio's own coverage block: its
+    ``totalPlayers`` must equal the core's member count and its
+    ``totalValue`` must equal Team Strength's total.  A portfolio
+    computed over the whole roster would silently pass a "does it have a
+    number" check and fail both of these.
+
+    The disclosure half is not cosmetic — ``#838`` ships the index as
+    the V1 champion LABELLED ``PRIOR`` (validation against intuitive
+    league examples not yet run), and a payload that drops the label
+    presents an unvalidated number as a measured one.
+    """
+    name = "Young Core uses core-only value and discloses PRIOR"
+    if not isinstance(bundle.intelligence, Mapping):
+        return unmeasurable(
+            "11", name, L2, "no roster-intelligence payload", leagueKey=bundle.league_key
+        )
+
+    examined, violations = 0, []
+    for team in bundle.teams:
+        age = team.get("agePortfolio")
+        core = team.get("core")
+        strength = team.get("strength")
+        if not isinstance(age, Mapping) or age.get("available") is False:
+            continue
+        if not isinstance(core, Mapping) or not isinstance(strength, Mapping):
+            continue
+        examined += 1
+        oid = team.get("ownerId")
+
+        if age.get("youngCoreIndexStatus") != "PRIOR":
+            violations.append(
+                {
+                    "ownerId": oid,
+                    "kind": "missing_prior_disclosure",
+                    "youngCoreIndexStatus": age.get("youngCoreIndexStatus"),
+                }
+            )
+        if "valueWeightedRosterAge" not in age or "valueWeightedCoreAge" not in age:
+            violations.append({"ownerId": oid, "kind": "core_and_roster_age_not_separately_named"})
+
+        coverage = age.get("coverage")
+        if isinstance(coverage, Mapping):
+            n_members = len(_members(team))
+            total_players = coverage.get("totalPlayers")
+            if isinstance(total_players, int) and total_players != n_members:
+                violations.append(
+                    {
+                        "ownerId": oid,
+                        "kind": "population_is_not_the_core",
+                        "coverageTotalPlayers": total_players,
+                        "coreMembers": n_members,
+                    }
+                )
+            total_value, strength_total = coverage.get("totalValue"), strength.get("total")
+            if isinstance(total_value, (int, float)) and isinstance(strength_total, (int, float)):
+                if abs(float(total_value) - float(strength_total)) > 0.0015:
+                    violations.append(
+                        {
+                            "ownerId": oid,
+                            "kind": "value_is_not_the_core_value",
+                            "coverageTotalValue": total_value,
+                            "teamStrengthTotal": strength_total,
+                        }
+                    )
+
+    evidence = {
+        "leagueKey": bundle.league_key,
+        "portfoliosExamined": examined,
+        "violations": violations[:20],
+        "violationCount": len(violations),
+    }
+    if violations:
+        return CheckResult(
+            "11",
+            name,
+            L2,
+            FAIL,
+            examined,
+            reason=f"{len(violations)} Young Core scope/disclosure violations",
+            evidence=evidence,
+        )
+    return CheckResult("11", name, L2, PASS, examined, evidence=evidence)
+
+
+def check_12_team_assignment_degrades_honestly(bundle: Bundle) -> CheckResult:
+    """A degraded teamAssignment names its cause; it never invents one.
+
+    ``#815``: production served ``{"assignments": []}`` with HTTP 200
+    during a degraded snapshot and nothing distinguished "we asked and
+    the answer is none" from "we could not ask", so the page printed a
+    cause it had not measured.  The contract is three states, and the
+    illegal one is empty-and-available-and-unexplained.
+    """
+    name = "teamAssignment reports unavailable rather than inventing a cause"
+    section = bundle.team_assignment
+    if not isinstance(section, Mapping):
+        return unmeasurable(
+            "12",
+            name,
+            L4,
+            bundle.errors.get("team_assignment", "no teamAssignment section fetched"),
+            leagueKey=bundle.league_key,
+        )
+
+    available = section.get("available")
+    reason = section.get("unavailableReason")
+    assignments = section.get("assignments") or []
+    evidence = {
+        "leagueKey": bundle.league_key,
+        "available": available,
+        "unavailableReason": reason,
+        "assignments": len(assignments),
+        "rosterScoringAvailable": section.get("rosterScoringAvailable"),
+    }
+
+    if available is None:
+        return CheckResult(
+            "12",
+            name,
+            L4,
+            FAIL,
+            1,
+            reason="the section predates the availability flag: healthy and degraded are indistinguishable",
+            evidence=evidence,
+        )
+    if available is False:
+        if not reason:
+            return CheckResult(
+                "12", name, L4, FAIL, 1, reason="unavailable with no named cause", evidence=evidence
+            )
+        return CheckResult("12", name, L4, PASS, 1, evidence=evidence)
+    if not assignments:
+        return CheckResult(
+            "12",
+            name,
+            L4,
+            FAIL,
+            1,
+            reason="available: true with zero assignments and no reason — the #815 state exactly",
+            evidence=evidence,
+        )
+    return CheckResult("12", name, L4, PASS, 1, evidence=evidence)
+
+
+def check_13_latency(bundle: Bundle) -> CheckResult:
+    """Endpoint latency against the owner-approved performance budget.
+
+    ``docs/GLOBAL_PERFORMANCE_STANDARD.md``: "normal production p95
+    first useful data: <=2 seconds", warm target 1 second.  A cited
+    budget rather than one invented here, and a single sample is
+    reported as a single sample — this is a smoke measurement, not a p95.
+    """
+    name = "endpoint latency within the performance budget"
+    if not bundle.latency_ms:
+        return unmeasurable(
+            "13",
+            name,
+            L3,
+            "no request was timed (nothing was fetched over HTTP)",
+            leagueKey=bundle.league_key,
+        )
+
+    over = {k: round(v, 1) for k, v in bundle.latency_ms.items() if v > LATENCY_BUDGET_MS}
+    evidence = {
+        "leagueKey": bundle.league_key,
+        "measuredMs": {k: round(v, 1) for k, v in bundle.latency_ms.items()},
+        "budgetMs": LATENCY_BUDGET_MS,
+        "warmTargetMs": LATENCY_WARM_TARGET_MS,
+        "samples": 1,
+        "note": "single sample per endpoint — a smoke measurement, not a p95",
+        "overBudget": over,
+    }
+    if over:
+        return CheckResult(
+            "13",
+            name,
+            L3,
+            FAIL,
+            len(bundle.latency_ms),
+            reason=f"{len(over)} endpoints exceeded the {LATENCY_BUDGET_MS:.0f} ms budget",
+            evidence=evidence,
+        )
+    return CheckResult("13", name, L3, PASS, len(bundle.latency_ms), evidence=evidence)
+
+
+#: Per-league checks, in report order.  Check 01 is league-SET scoped and
+#: runs separately.
+PER_LEAGUE_CHECKS: tuple[Callable[[Bundle], CheckResult], ...] = (
+    check_02_threshold_scaling,
+    check_03_flex_from_config,
+    check_04_player_at_most_once,
+    check_05_starters_before_reserves,
+    check_06_core_ceiling,
+    check_07_unpriced_reported,
+    check_08_missing_is_never_zero,
+    check_09_strength_groups_resum,
+    check_10_weakness_no_double_credit,
+    check_11_young_core_scope_and_disclosure,
+    check_12_team_assignment_degrades_honestly,
+    check_13_latency,
+)
+
+
+def run_checks(bundles: Sequence[Bundle], *, source_level: str = L3) -> list[CheckResult]:
+    """Every check over every league, finalized.  Pure; no network."""
+    results = [check_01_both_leagues(bundles)]
+    for bundle in bundles:
+        for check in PER_LEAGUE_CHECKS:
+            r = check(bundle)
+            results.append(
+                CheckResult(
+                    id=f"{r.id}/{bundle.league_key}",
+                    name=r.name,
+                    ceiling=r.ceiling,
+                    result=r.result,
+                    denominator=r.denominator,
+                    level=r.level,
+                    reason=r.reason,
+                    evidence=r.evidence,
+                )
+            )
+    return finalize(results, source_level=source_level)
+
+
+# ---------------------------------------------------------------------------
+# Transport.  Nothing above this line touches the network.
+# ---------------------------------------------------------------------------
+
+_ATTEMPTS = 3
+_SLEEP_SECONDS = 4
+_TIMEOUT_SECONDS = 30
+
+
+class Unauthenticated(Exception):
+    """The endpoint answered, and told us we may not look.
+
+    A 401/403 is a definitive answer, not a transient blip: the service
+    is up and correctly refusing an anonymous caller.  Retrying it is
+    guaranteed to fail identically — ``verify-sharp-production.yml``
+    spent 40 minutes per run learning that — and reporting it as a
+    timeout hides a credential problem behind what looks like a slow
+    deploy.
+    """
+
+
+def fetch_json(url: str, *, headers: Mapping[str, str]) -> tuple[Any, float]:
+    """``(payload, elapsed_ms)``.  Raises on terminal or exhausted failure."""
+    last = ""
+    for attempt in range(1, _ATTEMPTS + 1):
+        started = time.perf_counter()
+        try:
+            request = urllib.request.Request(
+                url,
+                headers={
+                    "User-Agent": "roster-intelligence-verify/1.0",
+                    "Cache-Control": "no-cache",
+                    **dict(headers),
+                },
+            )
+            with urllib.request.urlopen(request, timeout=_TIMEOUT_SECONDS) as response:
+                body = json.loads(response.read().decode("utf-8"))
+                return body, (time.perf_counter() - started) * 1000.0
+        except urllib.error.HTTPError as exc:
+            if exc.code in (401, 403):
+                raise Unauthenticated(
+                    f"HTTP {exc.code} from {url} — the service answered and "
+                    "refused this caller. Most private routes sit behind "
+                    "server.py::_private_api_gate; supply a session via "
+                    "ROSTER_VERIFY_COOKIE or a token via ROSTER_VERIFY_BEARER. "
+                    "A refusal on a route that should be PUBLIC is itself the "
+                    "finding — check the route's gate rather than the credential."
+                ) from exc
+            last = f"HTTP {exc.code}"
+        except Exception as exc:  # noqa: BLE001 — reported, never swallowed
+            last = repr(exc)
+        if attempt < _ATTEMPTS:
+            time.sleep(_SLEEP_SECONDS)
+    raise RuntimeError(f"{url}: {last}")
+
+
+def _auth_headers() -> dict[str, str]:
+    headers: dict[str, str] = {}
+    cookie = os.environ.get("ROSTER_VERIFY_COOKIE", "").strip()
+    bearer = os.environ.get("ROSTER_VERIFY_BEARER", "").strip()
+    if cookie:
+        headers["Cookie"] = cookie
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    return headers
+
+
+def build_bundle_http(base_url: str, league_key: str, registry: Mapping[str, Any] | None) -> Bundle:
+    """Fetch one league's payloads.  Every failure is recorded, not raised."""
+    bundle = Bundle(league_key=league_key, registry=registry)
+    headers = _auth_headers()
+    base = base_url.rstrip("/")
+    targets = {
+        "intelligence": f"{base}/api/roster/intelligence?leagueKey={league_key}",
+        "team_assignment": f"{base}/api/public/league/teamAssignment?leagueKey={league_key}",
+    }
+    for field_name, url in targets.items():
+        try:
+            payload, elapsed = fetch_json(url, headers=headers)
+        except Unauthenticated as exc:
+            bundle.errors[field_name] = str(exc)
+            continue
+        except Exception as exc:  # noqa: BLE001
+            bundle.errors[field_name] = f"unreachable: {exc}"
+            continue
+        bundle.latency_ms[field_name] = elapsed
+        if field_name == "team_assignment" and isinstance(payload, Mapping):
+            payload = payload.get("data") if isinstance(payload.get("data"), Mapping) else payload
+        setattr(bundle, field_name, payload if isinstance(payload, Mapping) else None)
+        if not isinstance(payload, Mapping):
+            bundle.errors[field_name] = "response was not a JSON object"
+    return bundle
+
+
+def _registry_entries(keys: Sequence[str] | None) -> list[tuple[str, dict[str, Any]]]:
+    """Active leagues from the local registry, or exactly the keys asked for."""
+    from src.api.league_registry import (
+        active_leagues,
+        get_league_by_key,
+        get_league_roster_settings,
+    )
+
+    if keys:
+        out = []
+        for key in keys:
+            cfg = get_league_by_key(key)
+            settings = get_league_roster_settings(key) if cfg else {}
+            out.append(
+                (
+                    key,
+                    {
+                        "teamCount": getattr(cfg, "team_count", None) if cfg else None,
+                        "known": cfg is not None,
+                        **(settings or {}),
+                    },
+                )
+            )
+        return out
+    return [
+        (
+            cfg.key,
+            {
+                "teamCount": getattr(cfg, "team_count", None),
+                "known": True,
+                **(get_league_roster_settings(cfg.key) or {}),
+            },
+        )
+        for cfg in active_leagues()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def render(
+    results: Sequence[CheckResult],
+    *,
+    base_url: str,
+    source: str,
+    source_level: str,
+    expect_sha: str | None,
+) -> None:
+    print(f"{TAG} source={source}  sourceLevel={source_level}")
+    print(f"{TAG} baseUrl={base_url or '(none — offline run)'}")
+    if expect_sha:
+        print(f"{TAG} operatorAssertedSha={expect_sha}")
+    print(
+        f"{TAG} NOTE: no API surface publishes the deployed commit, so an "
+        "EVIDENCE-L3 claim binds to the SHA the OPERATOR asserts, recorded "
+        "above and in the artifact. Record it from the deploy run, not from here."
+    )
+    print("")
+    width = max((len(r.id) for r in results), default=4)
+    for r in results:
+        print(
+            f"  {r.result:<13} {r.id:<{width}}  {r.name}  " f"[{r.level or '—'}; n={r.denominator}]"
+        )
+        if r.reason:
+            print(f"                {' ' * width}  → {r.reason}")
+    print("")
+    failed = [r for r in results if r.result == FAIL]
+    unmeasured = [r for r in results if r.result == UNMEASURABLE]
+    passed = [r for r in results if r.result == PASS]
+    print(f"{TAG} ── verdict ──")
+    print(f"{TAG} {len(passed)} passed · {len(failed)} failed · {len(unmeasured)} unmeasurable")
+    for r in failed:
+        print(f"{TAG} ::error title=Roster verification failed::{r.id} {r.name}: {r.reason}")
+    for r in unmeasured:
+        print(
+            f"{TAG} ::warning title=Roster verification could not measure::{r.id} {r.name}: {r.reason}"
+        )
+    if unmeasured and not failed:
+        print(f"{TAG} exit 2 — 'could not measure' is NOT 'passed'.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--base-url",
+        default=os.environ.get("ROSTER_VERIFY_BASE_URL", ""),
+        help="Server origin to probe, e.g. http://127.0.0.1:8000. Required, and "
+        "deliberately has NO default: an unset origin is an outage to "
+        "surface, not a value to guess.",
+    )
+    parser.add_argument(
+        "--league-key",
+        action="append",
+        dest="league_keys",
+        default=None,
+        help="Repeatable. Defaults to every ACTIVE league in the registry.",
+    )
+    parser.add_argument(
+        "--expect-sha",
+        default=None,
+        help="The deployed commit the operator asserts this run measured. "
+        "Recorded as provenance; the API publishes no SHA to check it against.",
+    )
+    parser.add_argument(
+        "--json-out",
+        default=None,
+        type=Path,
+        help="Write the machine-readable evidence artifact here.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.base_url:
+        print(f"{TAG} ::error title=No base URL::Pass --base-url or set ROSTER_VERIFY_BASE_URL.")
+        print(f"{TAG} exit 2 — nothing was measured.")
+        return EXIT_UNMEASURED
+
+    try:
+        entries = _registry_entries(args.league_keys)
+    except Exception as exc:  # noqa: BLE001
+        print(f"{TAG} ::error title=Registry unreadable::{exc}")
+        return EXIT_UNMEASURED
+    if not entries:
+        print(f"{TAG} no active leagues configured — nothing to verify. exit 2.")
+        return EXIT_UNMEASURED
+
+    bundles = [build_bundle_http(args.base_url, key, reg) for key, reg in entries]
+    results = run_checks(bundles, source_level=L3)
+    render(
+        results,
+        base_url=args.base_url,
+        source="deployed_http",
+        source_level=L3,
+        expect_sha=args.expect_sha,
+    )
+
+    code = exit_code_for(results)
+    if args.json_out:
+        artifact = {
+            "checkedAt": datetime.now(timezone.utc).isoformat(),
+            "baseUrl": args.base_url,
+            "operatorAssertedSha": args.expect_sha,
+            "shaPublishedByApi": None,
+            "sourceLevel": L3,
+            "exitCode": code,
+            "leagues": [b.league_key for b in bundles],
+            "fetchErrors": {b.league_key: b.errors for b in bundles if b.errors},
+            "checks": [r.to_dict() for r in results],
+        }
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(
+            json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        print(f"{TAG} evidence written to {args.json_out}")
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/roster_intel/test_metric_separation.py
+++ b/tests/roster_intel/test_metric_separation.py
@@ -1,0 +1,334 @@
+"""V1-35 — the seven quantities of decision 69 stay distinct.
+
+Binding source, ``docs/OWNER_REQUESTED_TODO.md`` decision 69, verbatim:
+
+    **Total Asset Value, Meaningful Roster Strength, Exact Starting
+    Lineup, Depth Value, Power Ranking, Playoff Probability and
+    Championship Probability stay distinct** in the model and the UI.
+    They may not be collapsed into one generic team score.
+
+V1-35's required evidence level is **EVIDENCE-L1**, so the artifact that
+moves the row is a deterministic test rather than a document.  The
+document (``docs/roster-intelligence/V1_35_METRIC_SEPARATION_AUDIT.md``)
+records the census and the cross-lane findings; this file pins the half
+that lives inside the Roster lane and can be enforced in CI.
+
+**Scope, stated so a green run is not over-read.**  This suite proves
+separation *where this lane owns the code*.  It cannot prove it on
+`/rosters`, `/phases` or the `src/ros/` and `src/public_league/`
+surfaces — those are other lanes' files, and the audit hands their
+findings to integration rather than editing them.  A green result here
+is necessary for V1-35 and not sufficient for it.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any, Iterator, Mapping
+
+from src.roster_intel.engine import RosterIntel, analyze_roster
+
+REPO = Path(__file__).resolve().parents[2]
+ROSTER_INTEL = REPO / "src" / "roster_intel"
+
+#: Field names that would BE the collapse: one number standing for a
+#: team's overall quality.  Not a denylist of substrings — "value" and
+#: "strength" are legitimate when they name a specific quantity, and
+#: banning them would forbid the vocabulary decision 69 requires.  These
+#: are the names that assert generality.
+COLLAPSED_SCORE_FIELDS = frozenset(
+    {
+        "teamScore",
+        "overallScore",
+        "overallRating",
+        "genericScore",
+        "compositeScore",
+        "teamRating",
+        "powerScore",
+        "teamQuality",
+    }
+)
+
+#: The modules that PRODUCE the ROS 0-100 log-rank production index.
+#: Importing one into the dynasty-value lane is the seam through which
+#: the two currencies could silently merge, so the absence of that
+#: import is the structural guarantee.  ``src.ros.lineup`` is
+#: deliberately NOT here: it is the canonical lineup/slot owner (C2-U1),
+#: it is unit-agnostic, and consuming it is required rather than
+#: forbidden.
+ROS_PRODUCTION_MODULES = frozenset(
+    {
+        "src.ros.team_strength",
+        "src.ros.aggregate",
+        "src.ros.power_v2",
+        "src.ros.playoff_sim",
+        "src.ros.championship",
+        "src.ros.direction",
+    }
+)
+
+
+def _walk(node: Any, path: str = "") -> Iterator[tuple[str, str, Any]]:
+    """Every ``(path, key, value)`` in a nested payload."""
+    if isinstance(node, Mapping):
+        for key, value in node.items():
+            yield path, str(key), value
+            yield from _walk(value, f"{path}.{key}")
+    elif isinstance(node, list):
+        for i, value in enumerate(node):
+            yield from _walk(value, f"{path}[{i}]")
+
+
+def _imported_modules(source: Path) -> set[str]:
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            found.add(node.module)
+        elif isinstance(node, ast.Import):
+            found.update(alias.name for alias in node.names)
+    return found
+
+
+# ---------------------------------------------------------------------------
+# 1. No collapsed team score anywhere in the canonical roster payload.
+# ---------------------------------------------------------------------------
+
+
+def test_roster_intelligence_publishes_no_generic_team_score():
+    """The payload names specific quantities and never a general one.
+
+    Non-vacuous: the assertion below also proves the walk reached a
+    real payload, so "no collapsed field found" cannot mean "found
+    nothing at all".
+    """
+    from tests.archive_fixtures import newest_complete_raw_payload
+
+    raw, _archive = newest_complete_raw_payload()
+    if raw is None:
+        import pytest
+
+        pytest.skip("no complete archived payload available in this environment")
+
+    from src.api.data_contract import build_api_data_contract
+    from src.api.roster_intelligence import build_league_roster_intelligence
+
+    payload = build_league_roster_intelligence(build_api_data_contract(raw), team_count=12)
+
+    keys = [(path, key) for path, key, _ in _walk(payload)]
+    assert (
+        len(keys) > 500
+    ), f"the walk only reached {len(keys)} keys — it did not traverse the payload"
+
+    offenders = [f"{path}.{key}" for path, key in keys if key in COLLAPSED_SCORE_FIELDS]
+    assert not offenders, (
+        "decision 69: these fields collapse distinct quantities into one "
+        f"generic team score: {sorted(set(offenders))[:10]}"
+    )
+
+
+def test_team_strength_and_portfolio_total_are_separately_named():
+    """ "Meaningful Roster Strength" and "Total Asset Value" are two of
+    decision 69's seven, so they may not share a field.
+
+    ``strength.total`` is the meaningful core; ``strength.fullRosterValue``
+    is the whole-roster portfolio.  They are far apart by construction on
+    a deep best-ball roster — a 58-man roster books bench player #40 at
+    full market value — so publishing one under the other's name would
+    misstate the number, not merely the label.
+    """
+    from src.roster_intel.core import CoreMember, MeaningfulCore
+    from src.roster_intel.strength import build_team_strength
+
+    core = MeaningfulCore(
+        members=(
+            CoreMember("a", "A", "QB", "QB", "starter", 900.0),
+            CoreMember("b", "B", "RB", "RB", "starter", 500.0),
+        )
+    )
+    strength = build_team_strength(core, full_roster_values=[900.0, 500.0, 40.0])
+    published = strength.to_dict()
+
+    assert published["total"] == 1400.0
+    assert published["fullRosterValue"] == 1440.0
+    assert (
+        published["total"] != published["fullRosterValue"]
+    ), "the fixture must keep them distinguishable, or this test proves nothing"
+
+
+def test_absent_full_roster_is_null_not_the_core_total():
+    """MISSING IS NEVER ZERO, applied to the separation itself.
+
+    A caller that supplies no full roster gets ``None`` — never the core
+    total silently standing in for the portfolio, which would collapse
+    two of the seven quantities by omission rather than by design.
+    """
+    from src.roster_intel.core import CoreMember, MeaningfulCore
+    from src.roster_intel.strength import build_team_strength
+
+    core = MeaningfulCore(members=(CoreMember("a", "A", "QB", "QB", "starter", 900.0),))
+    published = build_team_strength(core).to_dict()
+    assert published["total"] == 900.0
+    assert published["fullRosterValue"] is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Lineup, strength and depth are three quantities, not one.
+# ---------------------------------------------------------------------------
+
+
+def test_lineup_assignment_and_value_are_published_as_different_facts():
+    """ "Exact Starting Lineup" and "Meaningful Roster Strength" are
+    separate entries in decision 69.
+
+    The core publishes the ASSIGNMENT (which slot seated whom) and Team
+    Strength publishes the VALUE.  Neither is derivable from the other:
+    two teams can field the same slots at wildly different value, and
+    the same value can be assigned to different slots.
+    """
+    from src.roster_intel.core import CoreMember, MeaningfulCore
+    from src.roster_intel.strength import build_team_strength
+
+    core = MeaningfulCore(
+        members=(
+            CoreMember("a", "A", "WR", "FLEX", "starter", 700.0),
+            CoreMember("b", "B", "WR", "WR", "reserve", 300.0),
+        ),
+        starter_slots=("WR", "FLEX"),
+    )
+    core_dict = core.to_dict()
+    strength_dict = build_team_strength(core).to_dict()
+
+    assert {m["slot"] for m in core_dict["members"]} == {"FLEX", "WR"}
+    assert "slot" not in strength_dict
+    assert "total" not in core_dict
+    # And a FLEX starter is grouped under his NATIVE position, never a
+    # "FLEX" strength group (decision 72: FLEX is an assignment rule,
+    # not a sortable Team Strength position).
+    assert "FLEX" not in strength_dict["positionOrder"]
+
+
+def test_starter_and_reserve_value_partition_the_total():
+    """ "Depth Value" is its own quantity, published beside the total
+    rather than folded into it."""
+    from src.roster_intel.core import CoreMember, MeaningfulCore
+    from src.roster_intel.strength import build_team_strength
+
+    core = MeaningfulCore(
+        members=(
+            CoreMember("a", "A", "QB", "QB", "starter", 900.0),
+            CoreMember("b", "B", "QB", "BENCH", "reserve", 100.0),
+        )
+    )
+    published = build_team_strength(core).to_dict()
+    assert published["starterValue"] == 900.0
+    assert published["reserveValue"] == 100.0
+    assert published["starterValue"] + published["reserveValue"] == published["total"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Probability is relayed, never manufactured, and never from value.
+# ---------------------------------------------------------------------------
+
+
+def test_playoff_and_championship_odds_are_none_without_a_simulator():
+    """ "Playoff Probability" and "Championship Probability" are the two
+    quantities most at risk of being invented from roster value.
+
+    With no simulator output the answer is ``None`` with a note — never
+    a number derived from Team Strength.  Deriving one would collapse
+    three of decision 69's seven into a single value-driven score while
+    looking, in the payload, like three independent measurements.
+    """
+    result = analyze_roster("owner-1", [], ["QB"])
+    assert isinstance(result, RosterIntel)
+    published = result.to_dict()
+    assert published["playoffOdds"] is None
+    assert published["championshipOdds"] is None
+
+
+def test_championship_odds_stay_none_when_the_simulator_supplies_only_playoff_odds():
+    """The measured state of the live simulator: ``simulate_playoff_odds``
+    stops at qualification and does not run the bracket.
+
+    Relaying its playoff number while leaving championship ``None`` is
+    the honest shape; filling the gap from the playoff figure would
+    manufacture the seventh quantity out of the sixth.
+    """
+    result = analyze_roster(
+        "owner-1",
+        [],
+        ["QB"],
+        playoff_odds=[{"ownerId": "owner-1", "playoffOdds": 0.62}],
+    )
+    published = result.to_dict()
+    assert published["playoffOdds"] == 0.62
+    assert published["championshipOdds"] is None
+
+
+# ---------------------------------------------------------------------------
+# 4. The structural guard: the dynasty-value lane cannot import the
+#    ROS-production lane.
+# ---------------------------------------------------------------------------
+
+
+def test_roster_intel_never_imports_the_ros_production_modules():
+    """One import is all it would take to merge two currencies.
+
+    ``rosValue`` is "a normalized log-rank index on 0-100 — not points,
+    and not projection-aware" (``src/ros/aggregate.py``); canonical
+    dynasty value is 1-9999 market value.  ``MASTER_PRODUCT_PLAN`` §4.1:
+    *"Team Strength is dynasty roster strength; it is not Power Ranking,
+    Playoff Odds, or ROS production."*
+
+    This is exactly the defect the endpoint was repaired for — Team
+    Strength used to sum ``rosValue`` — so the absence of the import is
+    worth pinning rather than trusting.
+
+    ``src.ros.lineup`` is permitted and expected: it is the canonical
+    lineup owner and it is unit-agnostic.
+    """
+    modules = sorted(ROSTER_INTEL.glob("*.py")) + [REPO / "src" / "api" / "roster_intelligence.py"]
+    assert len(modules) > 5, "the glob found almost nothing — the guard would pass vacuously"
+
+    offenders: dict[str, list[str]] = {}
+    for path in modules:
+        bad = sorted(_imported_modules(path) & ROS_PRODUCTION_MODULES)
+        if bad:
+            offenders[str(path.relative_to(REPO))] = bad
+    assert not offenders, (
+        "the dynasty-value lane imported a ROS-production module, which is the "
+        f"seam through which the two currencies merge: {offenders}"
+    )
+
+
+def test_the_guard_would_catch_a_real_import():
+    """Mutation proof for the guard above.
+
+    A structural test that cannot be made to fail is decoration.  This
+    parses a module that DOES import one of the named producers and
+    confirms the detector sees it.
+    """
+    ros_api = REPO / "src" / "ros" / "api.py"
+    assert _imported_modules(ros_api) & ROS_PRODUCTION_MODULES, (
+        "src/ros/api.py imports src.ros.team_strength; if this assertion fails "
+        "the detector is broken, not the boundary"
+    )
+
+
+def test_the_collapsed_score_detector_would_catch_one():
+    """Mutation proof for the walk above.
+
+    ``COLLAPSED_SCORE_FIELDS`` is a small allowlist-of-offenders, so the
+    failure mode is a detector that never matches anything and passes
+    forever.  Inject the field the audit found live on ``/rosters``
+    (``frontend/lib/league-analysis.js::scoreTeamTiers`` publishes a
+    ``score``) under one of the names decision 69 forbids, and confirm
+    the walk finds it.
+    """
+    payload = {"teams": {"o1": {"strength": {"total": 1400.0, "teamScore": 87.2}}}}
+    offenders = [
+        f"{path}.{key}" for path, key, _ in _walk(payload) if key in COLLAPSED_SCORE_FIELDS
+    ]
+    assert offenders == [".teams.o1.strength.teamScore"]

--- a/tests/roster_intel/test_verification_pack.py
+++ b/tests/roster_intel/test_verification_pack.py
@@ -1,0 +1,639 @@
+"""The verification pack's own tests — because a pack nobody tested is
+a script someone else runs once, against production, on faith.
+
+Three things are proven here, and the second is the one that matters:
+
+1. **Each check can PASS** on a clean payload.
+2. **Each check can FAIL** on a payload that violates the property it
+   claims to police.  A check that cannot be made to fail is not a
+   check, and the only way to know is to mutate the input and watch it
+   go red.  Every mutation below was confirmed to flip exactly one
+   check, so a green run here means the checks are live rather than
+   merely present.
+3. **Each check reports UNMEASURABLE, never PASS, on absent input.**
+   This is the non-vacuity requirement, and it is discharged
+   deterministically rather than by reading the code: a verification
+   that cannot distinguish "measured and found none" from "matched
+   nothing" is not a verification (``C2_U1_CANONICAL_LINEUP.md`` §10a).
+
+**No network.**  ``tests/infra/test_unit_suite_does_not_probe_production.py``
+forbids the unit suite from probing production, which is why the pack is
+built as ``fetch -> payload -> pure check``: everything below drives the
+check layer directly and the transport layer is never imported.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Callable
+
+import pytest
+
+from scripts.verify_roster_intelligence import (
+    FAIL,
+    L1,
+    L2,
+    L3,
+    L4,
+    PASS,
+    PER_LEAGUE_CHECKS,
+    UNMEASURABLE,
+    Bundle,
+    CheckResult,
+    check_01_both_leagues,
+    check_02_threshold_scaling,
+    check_03_flex_from_config,
+    check_04_player_at_most_once,
+    check_05_starters_before_reserves,
+    check_06_core_ceiling,
+    check_07_unpriced_reported,
+    check_08_missing_is_never_zero,
+    check_09_strength_groups_resum,
+    check_10_weakness_no_double_credit,
+    check_11_young_core_scope_and_disclosure,
+    check_12_team_assignment_degrades_honestly,
+    check_13_latency,
+    exit_code_for,
+    finalize,
+    run_checks,
+)
+
+# ---------------------------------------------------------------------------
+# A minimal payload that satisfies every check, and helpers to break it.
+# ---------------------------------------------------------------------------
+
+TEAM_COUNT = 12
+STARTER_SLOTS = ["QB", "RB", "RB", "WR", "FLEX", "SUPER_FLEX"]
+
+
+def _member(pid: str, position: str, slot: str, role: str, value: float) -> dict[str, Any]:
+    return {
+        "playerId": pid,
+        "name": pid.title(),
+        "position": position,
+        "slot": slot,
+        "role": role,
+        "value": value,
+    }
+
+
+def _clean_team(owner: str = "owner-1") -> dict[str, Any]:
+    """One internally consistent team.
+
+    Six starters, one reserve, one unpriced player who is reported and
+    scored nowhere.  Group values re-sum to the total exactly; the age
+    portfolio's coverage names the core's own population and value.
+    """
+    members = [
+        _member("qb1", "QB", "QB", "starter", 900.0),
+        _member("rb1", "RB", "RB", "starter", 800.0),
+        _member("rb2", "RB", "RB", "starter", 700.0),
+        _member("wr1", "WR", "WR", "starter", 600.0),
+        _member("wr2", "WR", "FLEX", "starter", 500.0),
+        _member("qb2", "QB", "SUPER_FLEX", "starter", 400.0),
+        _member("rb3", "RB", "RB", "reserve", 100.0),
+    ]
+    total = sum(m["value"] for m in members)
+    starter_value = sum(m["value"] for m in members if m["role"] == "starter")
+    reserve_value = total - starter_value
+    by_position = {
+        "QB": sum(m["value"] for m in members if m["position"] == "QB"),
+        "RB": sum(m["value"] for m in members if m["position"] == "RB"),
+        "WR": sum(m["value"] for m in members if m["position"] == "WR"),
+    }
+    return {
+        "ownerId": owner,
+        "teamName": "Test Team",
+        "rosteredCount": len(members) + 1,
+        "core": {
+            "available": True,
+            "unavailableReason": None,
+            "members": members,
+            "starterCount": 6,
+            "reserveCount": 1,
+            "unpricedIds": ["ghost1"],
+            "duplicateIds": [],
+            "unfilledStarterSlots": [],
+            "unfilledReserveSlots": [],
+            "starterSlots": list(STARTER_SLOTS),
+            "slotSource": "sleeper_roster_positions",
+            "demand": {
+                "bySlot": {"QB": 1, "RB": 1, "WR": 1, "FLEX": 1, "SUPER_FLEX": 1},
+                "starterBasis": {"QB": 1, "RB": 2, "WR": 1, "FLEX": 1, "SUPER_FLEX": 1},
+                "dedicatedBasis": {"QB": 1, "RB": 2, "WR": 1},
+                "flexSlots": ["FLEX", "SUPER_FLEX"],
+                "total": 5,
+                "multiplier": 1.5,
+                "multiplierStatus": "PRIOR",
+                "multiplierProvenance": "addendum_839",
+                "superflexFoldedIntoQb": True,
+            },
+        },
+        "strength": {
+            "available": True,
+            "unavailableReason": None,
+            "total": total,
+            "starterValue": starter_value,
+            "reserveValue": reserve_value,
+            "byPosition": [
+                {"position": p, "value": v, "count": 1, "members": []}
+                for p, v in by_position.items()
+            ],
+            "positionOrder": list(by_position),
+            "fullRosterValue": total,
+            "unpricedIds": ["ghost1"],
+            "unpricedCount": 1,
+            "unfilledStarterSlots": [],
+            "unfilledReserveSlots": [],
+            "isComplete": True,
+            "leagueRank": 1,
+            "leaguePercentile": 1.0,
+        },
+        "weakness": {
+            "available": True,
+            "unavailableReason": None,
+            "teamCount": TEAM_COUNT,
+            "rankPopulation": "contract_board_priced_players",
+            "thresholdRule": "rung_index_times_team_count",
+            "thresholdStatus": "PRIOR",
+            "needs": [
+                {
+                    "position": "QB",
+                    "level": "ok",
+                    "priority": 0.0,
+                    "rungs": [
+                        {
+                            "position": "QB",
+                            "rung": 1,
+                            "label": "QB1",
+                            "thresholdRank": 12,
+                            "status": "met",
+                            "playerId": "qb1",
+                            "playerRank": 4,
+                            "shortfall": 0,
+                        },
+                        {
+                            "position": "QB",
+                            "rung": 2,
+                            "label": "QB2",
+                            "thresholdRank": 24,
+                            "status": "met",
+                            "playerId": "qb2",
+                            "playerRank": 19,
+                            "shortfall": 0,
+                        },
+                    ],
+                }
+            ],
+            "urgentPositions": [],
+        },
+        "agePortfolio": {
+            "available": True,
+            "unavailableReason": None,
+            "valueWeightedCoreAge": 25.1,
+            "valueWeightedRosterAge": 25.9,
+            "coreYouthScore": 0.61,
+            "youngCoreIndex": 74.0,
+            "youngCoreIndexStatus": "PRIOR",
+            "byPosition": [],
+            "valueByAge": [],
+            "valueByBand": [],
+            "coverage": {
+                "agedPlayers": 7,
+                "totalPlayers": len(members),
+                "agedValue": total,
+                "totalValue": total,
+                "valueShare": 1.0,
+            },
+            "leagueRank": 1,
+            "leaguePercentile": 1.0,
+        },
+    }
+
+
+def _clean_payload() -> dict[str, Any]:
+    return {
+        "contractVersion": "roster-intelligence/2026-08-18.v1",
+        "leagueKey": "dynasty_main",
+        "teamCount": TEAM_COUNT,
+        "starterSlots": list(STARTER_SLOTS),
+        "slotSource": "sleeper_roster_positions",
+        "rosterSource": "canonical_contract",
+        "teams": {"owner-1": _clean_team()},
+    }
+
+
+def _clean_assignment() -> dict[str, Any]:
+    return {
+        "available": True,
+        "unavailableReason": None,
+        "rosterScoringAvailable": True,
+        "assignments": [{"ownerId": "owner-1", "teamName": "Test Team"}],
+    }
+
+
+def clean_bundle() -> Bundle:
+    return Bundle(
+        league_key="dynasty_main",
+        registry={"teamCount": TEAM_COUNT},
+        intelligence=_clean_payload(),
+        team_assignment=_clean_assignment(),
+        latency_ms={"intelligence": 120.0, "team_assignment": 80.0},
+    )
+
+
+def mutated(mutate: Callable[[dict[str, Any]], None]) -> Bundle:
+    """A bundle whose payload has been broken in exactly one way."""
+    bundle = clean_bundle()
+    payload = copy.deepcopy(dict(bundle.intelligence or {}))
+    mutate(payload)
+    bundle.intelligence = payload
+    return bundle
+
+
+def _team(payload: dict[str, Any]) -> dict[str, Any]:
+    return payload["teams"]["owner-1"]
+
+
+# ---------------------------------------------------------------------------
+# 1. Every check passes on a clean payload.
+# ---------------------------------------------------------------------------
+
+
+ALL_CHECKS = [
+    check_02_threshold_scaling,
+    check_03_flex_from_config,
+    check_04_player_at_most_once,
+    check_05_starters_before_reserves,
+    check_06_core_ceiling,
+    check_07_unpriced_reported,
+    check_08_missing_is_never_zero,
+    check_09_strength_groups_resum,
+    check_10_weakness_no_double_credit,
+    check_11_young_core_scope_and_disclosure,
+    check_12_team_assignment_degrades_honestly,
+    check_13_latency,
+]
+
+
+@pytest.mark.parametrize("check", ALL_CHECKS, ids=lambda c: c.__name__)
+def test_clean_payload_passes_every_check(check):
+    result = check(clean_bundle())
+    assert result.result == PASS, f"{check.__name__} failed a clean payload: {result.reason}"
+    assert result.denominator > 0, (
+        f"{check.__name__} passed with denominator 0 — that is a vacuous pass, "
+        "and the fixture is meant to exercise it"
+    )
+
+
+def test_clean_league_set_passes_check_01():
+    assert check_01_both_leagues([clean_bundle()]).result == PASS
+
+
+# ---------------------------------------------------------------------------
+# 2. Every check FAILS when its property is violated.  One mutation each.
+# ---------------------------------------------------------------------------
+
+
+def _break_threshold(payload):
+    _team(payload)["weakness"]["needs"][0]["rungs"][1]["thresholdRank"] = 24 + 1
+
+
+def _break_flex_unaccounted(payload):
+    # The SUPER_FLEX starter is dropped and NOT reported unfilled — the
+    # signature of a solver that skipped the slot silently.
+    core = _team(payload)["core"]
+    core["members"] = [m for m in core["members"] if m["slot"] != "SUPER_FLEX"]
+
+
+def _break_duplicate_member(payload):
+    core = _team(payload)["core"]
+    core["members"].append(dict(core["members"][0]))
+
+
+def _break_starter_reserve_overlap(payload):
+    core = _team(payload)["core"]
+    dup = dict(core["members"][0])
+    dup["role"] = "reserve"
+    core["members"].append(dup)
+
+
+def _break_demand_arithmetic(payload):
+    # ceil(1.5 x 2) - 2 = 1 for RB; claim 2.
+    _team(payload)["core"]["demand"]["bySlot"]["RB"] = 2
+
+
+def _break_unpriced_publishers_disagree(payload):
+    _team(payload)["strength"]["unpricedIds"] = []
+
+
+def _break_unpriced_also_scored(payload):
+    core = _team(payload)["core"]
+    core["members"].append(_member("ghost1", "WR", "WR", "reserve", 0.0))
+
+
+def _break_group_sum(payload):
+    _team(payload)["strength"]["byPosition"][0]["value"] += 50.0
+
+
+def _break_double_rung_credit(payload):
+    _team(payload)["weakness"]["needs"][0]["rungs"][1]["playerId"] = "qb1"
+
+
+def _break_young_core_population(payload):
+    _team(payload)["agePortfolio"]["coverage"]["totalPlayers"] = 58
+
+
+MUTATIONS: list[tuple[Callable, Callable[[dict], None], str]] = [
+    (check_02_threshold_scaling, _break_threshold, "threshold no longer rung x teamCount"),
+    (check_03_flex_from_config, _break_flex_unaccounted, "a declared flex slot vanished silently"),
+    (check_04_player_at_most_once, _break_duplicate_member, "a player counted twice"),
+    (check_05_starters_before_reserves, _break_starter_reserve_overlap, "starter also a reserve"),
+    (check_06_core_ceiling, _break_demand_arithmetic, "reserve demand breaks ceil(M*s)-s"),
+    (check_07_unpriced_reported, _break_unpriced_publishers_disagree, "two publishers disagree"),
+    (check_08_missing_is_never_zero, _break_unpriced_also_scored, "unpriced player scored at 0"),
+    (check_09_strength_groups_resum, _break_group_sum, "groups no longer re-sum"),
+    (check_10_weakness_no_double_credit, _break_double_rung_credit, "one player fills two rungs"),
+    (
+        check_11_young_core_scope_and_disclosure,
+        _break_young_core_population,
+        "portfolio measured the roster, not the core",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "check,mutate,description", MUTATIONS, ids=[m[0].__name__ for m in MUTATIONS]
+)
+def test_check_fails_when_its_property_is_violated(check, mutate, description):
+    result = check(mutated(mutate))
+    assert result.result == FAIL, (
+        f"{check.__name__} did NOT fail on: {description}. A check that cannot "
+        "be made to fail proves nothing about the payloads it passes."
+    )
+    assert result.reason
+
+
+def test_young_core_fails_without_the_prior_disclosure():
+    """The label is load-bearing: #838 ships the index as an unvalidated
+    PRIOR, and a payload that drops the label presents it as measured."""
+
+    def drop_label(payload):
+        _team(payload)["agePortfolio"]["youngCoreIndexStatus"] = "VALIDATED"
+
+    assert check_11_young_core_scope_and_disclosure(mutated(drop_label)).result == FAIL
+
+
+def test_flex_check_fails_when_slot_source_is_absent():
+    """No ``slotSource`` means the slot list came from neither ladder
+    rung — it was invented, which is the failure ``resolve_starter_slots``
+    refuses rather than defaulting through."""
+
+    def drop_source(payload):
+        payload["slotSource"] = None
+
+    assert check_03_flex_from_config(mutated(drop_source)).result == FAIL
+
+
+def test_team_assignment_fails_on_the_815_state():
+    """``available: true`` with zero assignments is #815 exactly: the
+    payload cannot distinguish "the answer is none" from "we could not ask"."""
+    bundle = clean_bundle()
+    bundle.team_assignment = {"available": True, "unavailableReason": None, "assignments": []}
+    assert check_12_team_assignment_degrades_honestly(bundle).result == FAIL
+
+
+def test_team_assignment_passes_when_unavailable_with_a_named_cause():
+    bundle = clean_bundle()
+    bundle.team_assignment = {
+        "available": False,
+        "unavailableReason": "current_season_has_no_rosters",
+        "assignments": [],
+    }
+    assert check_12_team_assignment_degrades_honestly(bundle).result == PASS
+
+
+def test_team_assignment_fails_when_the_availability_flag_predates_the_payload():
+    bundle = clean_bundle()
+    bundle.team_assignment = {"assignments": []}
+    assert check_12_team_assignment_degrades_honestly(bundle).result == FAIL
+
+
+def test_latency_fails_over_budget():
+    bundle = clean_bundle()
+    bundle.latency_ms = {"intelligence": 9000.0}
+    assert check_13_latency(bundle).result == FAIL
+
+
+# ---------------------------------------------------------------------------
+# 3. Non-vacuity.  Absent input is UNMEASURABLE, never PASS.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("check", ALL_CHECKS, ids=lambda c: c.__name__)
+def test_absent_input_is_unmeasurable_never_pass(check):
+    """The requirement in one assertion, for every check.
+
+    An empty bundle carries no payload, no assignment section and no
+    timing.  Anything that answers PASS here is claiming compliance it
+    did not observe.
+    """
+    result = check(Bundle(league_key="dynasty_new"))
+    assert result.result == UNMEASURABLE, (
+        f"{check.__name__} returned {result.result} on an empty bundle. "
+        "'No data' must never read as 'passed'."
+    )
+    assert result.reason, f"{check.__name__} gave no reason it could not measure"
+
+
+def test_check_01_reports_the_registry_denominator_not_the_answered_count():
+    """A run that reached one league of two must not report "1 of 1".
+
+    That inversion is exactly how a partial verification reads as a
+    complete one, so the denominator is the EXPECTED league count.
+    """
+    reached = clean_bundle()
+    missed = Bundle(league_key="dynasty_new", errors={"intelligence": "503 data_not_ready"})
+    result = check_01_both_leagues([reached, missed])
+    assert result.result == UNMEASURABLE
+    assert result.denominator == 2
+    assert result.evidence["missing"][0]["leagueKey"] == "dynasty_new"
+
+
+def test_check_01_is_unmeasurable_with_no_leagues_at_all():
+    assert check_01_both_leagues([]).result == UNMEASURABLE
+
+
+# ---------------------------------------------------------------------------
+# 4. The harness rules, which no individual check is trusted to apply.
+# ---------------------------------------------------------------------------
+
+
+def test_harness_downgrades_a_vacuous_pass():
+    """The rule that makes non-vacuity structural rather than a convention."""
+    vacuous = CheckResult("99", "invented", L2, PASS, denominator=0)
+    (out,) = finalize([vacuous], source_level=L3)
+    assert out.result == UNMEASURABLE
+    assert "vacuous" in (out.reason or "")
+
+
+def test_harness_leaves_a_zero_denominator_failure_alone():
+    """A FAIL over nothing is a contradiction the check is asserting;
+    rewriting it to UNMEASURABLE would hide a defect in the check."""
+    (out,) = finalize(
+        [CheckResult("99", "x", L2, FAIL, denominator=0, reason="r")], source_level=L3
+    )
+    assert out.result == FAIL
+
+
+def test_harness_caps_the_level_at_the_source():
+    """Evidence is only as strong as its source: an EVIDENCE-L3 check
+    reading a locally rebuilt contract reports EVIDENCE-L2."""
+    (out,) = finalize([CheckResult("99", "x", L4, PASS, denominator=5)], source_level=L2)
+    assert out.level == L2
+
+
+def test_harness_reports_no_level_for_an_unmeasurable_result():
+    (out,) = finalize([CheckResult("99", "x", L2, UNMEASURABLE, denominator=0)], source_level=L3)
+    assert out.level is None
+
+
+def test_every_per_league_check_declares_a_known_level():
+    for check in PER_LEAGUE_CHECKS:
+        result = check(Bundle(league_key="x"))
+        assert result.ceiling in {L1, L2, L3, L4}, check.__name__
+
+
+def test_exit_codes_rank_failure_over_unmeasured_over_success():
+    ok = CheckResult("a", "a", L1, PASS, 1)
+    unk = CheckResult("b", "b", L1, UNMEASURABLE, 0)
+    bad = CheckResult("c", "c", L1, FAIL, 1)
+    assert exit_code_for([ok]) == 0
+    assert exit_code_for([ok, unk]) == 2
+    assert exit_code_for([ok, unk, bad]) == 1
+    assert exit_code_for([ok, bad]) == 1
+
+
+def test_run_checks_covers_every_league_and_stamps_the_league_key():
+    results = run_checks([clean_bundle(), Bundle(league_key="dynasty_new")], source_level=L2)
+    ids = {r.id for r in results}
+    assert "01" in ids
+    assert "04/dynasty_main" in ids
+    assert "04/dynasty_new" in ids
+    assert all(r.result == UNMEASURABLE for r in results if r.id.endswith("/dynasty_new"))
+
+
+def test_mutation_specificity_is_recorded_not_assumed():
+    """Each mutation turns its intended check red — and sometimes another.
+
+    Measured, and reported rather than engineered away, because the
+    collateral is REAL rather than sloppy:
+
+    * anything that changes the core's member count also trips check 11,
+      whose whole property is that the age portfolio's population IS the
+      core.  A core that grew while the portfolio's coverage did not is
+      genuinely two populations.
+    * making a starter also a reserve genuinely violates "at most once"
+      as well as the disjointness rule.
+
+    The assertion is therefore "the intended check is among the red
+    ones", not "exactly one is red".  Claiming the stricter property
+    would mean weakening a check to buy a tidier table.
+    """
+    for check, mutate, description in MUTATIONS:
+        bundle = mutated(mutate)
+        red = {c.__name__ for c in ALL_CHECKS if c(bundle).result == FAIL}
+        assert check.__name__ in red, description
+        # Nothing outside the checks that legitimately observe the core
+        # population may go red.
+        assert red <= {
+            check.__name__,
+            "check_04_player_at_most_once",
+            "check_11_young_core_scope_and_disclosure",
+        }, f"{description} produced unexplained collateral: {sorted(red)}"
+
+
+# ---------------------------------------------------------------------------
+# 5. EVIDENCE-L2 closure: the same checks over a real rebuilt contract.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def real_league_bundle() -> Bundle:
+    """One league's roster intelligence, rebuilt from the newest COMPLETE
+    archived scrape.
+
+    Skips rather than fails when the archive is absent — a CI clone
+    without ``exports/archive`` should not report a red verification for
+    a missing fixture.  ``newest_complete_raw_payload`` refuses a
+    source-degraded bundle, so this is a real board or nothing.
+    """
+    from tests.archive_fixtures import newest_complete_raw_payload
+
+    raw, archive = newest_complete_raw_payload()
+    if raw is None:
+        pytest.skip("no complete archived payload available in this environment")
+
+    from src.api.data_contract import build_api_data_contract
+    from src.api.roster_intelligence import build_league_roster_intelligence
+
+    contract = build_api_data_contract(raw)
+    intelligence = build_league_roster_intelligence(contract, team_count=12)
+    if not (intelligence.get("teams") or {}):
+        pytest.skip(f"{archive} carries no rosters")
+    return Bundle(
+        league_key=str(intelligence.get("leagueKey") or "archive"),
+        registry={"teamCount": intelligence.get("teamCount")},
+        intelligence=intelligence,
+    )
+
+
+@pytest.mark.parametrize(
+    "check",
+    [
+        c
+        for c in ALL_CHECKS
+        if c not in (check_12_team_assignment_degrades_honestly, check_13_latency)
+    ],
+    ids=lambda c: c.__name__,
+)
+def test_real_board_satisfies_every_offline_check(check, real_league_bundle):
+    """EVIDENCE-L2 for checks 2-11, measured rather than asserted.
+
+    Checks 12 and 13 are excluded by construction, not by convenience:
+    one needs the public page's section and the other needs a timed HTTP
+    request, and neither exists offline.  They stay UNMEASURABLE here,
+    which is the honest answer.
+    """
+    result = check(real_league_bundle)
+    assert result.result == PASS, f"{check.__name__}: {result.reason} :: {result.evidence}"
+    assert result.denominator > 0, (
+        f"{check.__name__} passed the real board having examined nothing — "
+        "the join is broken, which is the C2-U1 §10a near-false-pass exactly"
+    )
+
+
+def test_real_board_exercises_the_unpriced_path(real_league_bundle):
+    """The live board really does carry unpriced rostered players.
+
+    Without this, check 8 could pass on a board where the rule was never
+    exercised, and "no unpriced players exist" would be indistinguishable
+    from "unpriced players are handled correctly".
+    """
+    result = check_08_missing_is_never_zero(real_league_bundle)
+    assert result.result == PASS
+    assert (
+        result.denominator > 0
+    ), "no unpriced players on the real board — check 8 was not exercised"
+
+
+def test_offline_run_reports_http_checks_as_unmeasurable(real_league_bundle):
+    """A locally rebuilt board is EVIDENCE-L2, and the pack says so:
+    the two checks that need a deployment do not quietly pass."""
+    results = {r.id: r for r in run_checks([real_league_bundle], source_level=L2)}
+    key = real_league_bundle.league_key
+    assert results[f"12/{key}"].result == UNMEASURABLE
+    assert results[f"13/{key}"].result == UNMEASURABLE
+    assert exit_code_for(list(results.values())) == 2
+    # And no result claims more than its source can support.
+    assert all(r.level in (None, L1, L2) for r in results.values())


### PR DESCRIPTION
> **Stacked on #922** (branched from `fd70515`). #914 and #922 are frozen for
> Integration and are untouched by this branch. **Additive only — no existing
> file is modified.** Claude 5 remains merge authority; I am not merging this.

## Why

Two gaps blocked V1 credit for the roster chain, and neither was a code gap:

1. **Nobody could execute the verification.** V1-27 needs a checklist run
   against a deployed SHA, and there was only prose.
2. **V1-35 was `NOT STARTED`.** Its binding source is
   `docs/OWNER_REQUESTED_TODO.md` **decision 69**: seven named quantities that
   "may not be collapsed into one generic team score."

**The finding that shaped the unit:** `VERSION_1_COMPLETION_CONTRACT.md` §3.2
column 6 is the **required** evidence level, not the current one. Read that way,
**only V1-27 requires production** — seven of the eight remaining Roster rows
close at EVIDENCE-L1/L2, deterministically, with no deploy. Treating the whole
lane as post-deploy work would have parked seven rows behind an integration step
none of them needs.

## Part 1 — the verification pack

`scripts/verify_roster_intelligence.py` — thirteen checks, built as
`fetch → payload → pure check` so the check layer is testable and never touches
the network (`tests/infra/test_unit_suite_does_not_probe_production.py` forbids
the unit suite from probing production).

**Non-vacuity is a harness rule, not a convention.** Per
`C2_U1_CANONICAL_LINEUP.md` §10a — *a verification that cannot distinguish
"measured and found none" from "matched nothing" is not a verification* — every
check publishes its **denominator**, and `finalize()` rewrites any `PASS` with a
zero denominator into `UNMEASURABLE`. A check author cannot forget to apply it. A
`FAIL` over nothing is deliberately left alone: that is a contradiction the check
is asserting, and hiding it would be worse.

Exit **0** measured-and-passed / **1** measured-a-violation / **2**
could-not-measure. `2` never collapses into `0` ("no data" must not read as
"passed") and never into `1` — a defect and a missing credential call for
different actions.

### Measured offline at this head

Against the newest **COMPLETE** archived scrape (`dynasty_export_20260818_230211.zip`)
rebuilt through `build_api_data_contract` → `build_league_roster_intelligence`:

| # | check | result | level | denominator |
|---|---|---|---|---|
| 02 | thresholds scale with `teamCount` | PASS | L1 | **216 rungs** |
| 03 | flex slots from actual config | PASS | L2 | **36 flex slots** |
| 04 | every player at most once | PASS | L2 | **374 members** |
| 05 | starters removed before reserves | PASS | L2 | **240 starters** |
| 06 | core ≤ starters + reserve demand | PASS | L2 | **12 teams** |
| 07 | unpriced reported, not coerced | PASS | L2 | **660 rostered** |
| 08 | unpriced excluded from aggregates | PASS | L2 | **83 unpriced (12.6%)** |
| 09 | strength groups re-sum to total | PASS | L2 | **12 teams** |
| 10 | no player credited to two rungs | PASS | L2 | **215 rung credits** |
| 11 | Young Core core-only + PRIOR | PASS | L2 | **12 portfolios** |
| 01/12/13 | both leagues · teamAssignment · latency | UNMEASURABLE | — | 0 |

**Offline exit code 2** — correct, and the point. The denominators matter more
than the verdicts: 240 starters is 12 × 20 live slots (the same figure C2-U1 §10a
reports); 83 of 660 matches `roster_intelligence.py`'s own docstring. Had the
join silently failed these would read 0 and every PASS would have been downgraded.

### Why the checks are trusted

63 tests in `tests/roster_intel/test_verification_pack.py`: each check passes a
clean payload **with a non-zero denominator**, each **FAILS** under a mutation of
the property it polices, and each reports `UNMEASURABLE` on absent input.

Mutation specificity is **measured and reported rather than engineered away**:
six of ten mutations flip exactly one check; the rest also trip check 11 or 04,
and in every case that collateral is a genuine second violation (check 11's
property is that the age portfolio's population *is* the core). The test asserts
"the intended check is among the red ones" with a bounded allowance — claiming
the stricter property would mean weakening a check to buy a tidier table.

Transport exercised by hand against a canned backend: healthy → exit 0, 13/13;
no URL → 2; connection refused → 2; **401 → exit 2 in 0 s, terminal not retried**
(`verify-sharp-production.yml` spent 40 minutes per run learning that one).

## Part 2 — V1-35

**Headline finding:**

> Six live production answers to "how good is this team" exist on six different
> units — and the module documented as *"THE canonical Team Strength owner"* is
> the one nobody renders.

`grep -rn "roster/intelligence" frontend/` → **0 hits**. Meanwhile
`nav-model.js:147` labels **`/rosters`** "Team Strength", and `/rosters` renders
`scoreTeamTiers` — `starterValue*0.7 + depthValue*0.2 − pickValue*0.1`, terciled
into Contender/Mid-Tier/Rebuilder, with **pick capital as a penalty** and no
server equivalent anywhere. That is the V1 contract's own false-green test
failing, and it is why V1-31 cannot claim EVIDENCE-L4.

Three boundaries that are **already correct** are recorded so nobody "fixes"
them: `rosValue` vs dynasty value, `/api/terminal`'s portfolio total vs core
strength, and `roster_intel/engine.py` refusing to invent championship odds the
simulator did not supply.

**No cross-lane file is edited.** Every duplicate outside this lane is a handoff
(H-1…H-5) with path, consumer, current quantity, desired owner and test —
`src/ros/`, `src/public_league/` and `frontend/` are untouched.

`tests/roster_intel/test_metric_separation.py` (10 tests) discharges V1-35's
**model** half at its required EVIDENCE-L1, including an AST guard that the
dynasty-value lane cannot import the ROS-production modules. Both structural
detectors are mutation-proven against code that really does violate them.

**V1-35 should read `IN PROGRESS` with the model half evidenced — not
`VERIFIED`.** Decision 69 says "in the model *and the UI*", and the UI half is
handoff H-1.

## Files (all new)

- `scripts/verify_roster_intelligence.py`
- `tests/roster_intel/test_verification_pack.py` · `test_metric_separation.py`
- `docs/roster-intelligence/V1_ROSTER_VERIFICATION_PACK.md` ·
  `V1_35_METRIC_SEPARATION_AUDIT.md` · `V1_ROSTER_EVIDENCE_MATRIX.md`

## Validation

- `ruff format --check` + `ruff check` — clean
- `pytest tests/roster_intel tests/lineup tests/test_livedata_policy.py` — **697 passed, 22 skipped**
- `check_decision_coercions.py` — **671 present, 671 accepted; clean** (no new coercions)
- `check_planning_integrity.py` — clean · `check_work_claims.py` — no overlapping claim
- Full `-m "not livedata"` suite — running; result posted before this is ready to merge
- Both new test files are pure-logic and stay in the **hard gate**; neither is in
  `_LIVEDATA_MODULES`

`check_release_candidate.py` reports 91 class-C changes on `origin/main` not in
this head — expected for a branch stacked off #922 while the 2-hourly refresh
runs; the strict gate at the merge moment is Claude 5's call.

## Limitations

- **No production evidence is produced here.** This unit produces the *means*;
  EVIDENCE-L3/L4 remains Claude 5's execution — command in the pack doc §2.
- **No API surface publishes the deployed commit.** `--expect-sha` is recorded as
  *operator-asserted* provenance and the artifact stamps `shaPublishedByApi: null`
  so the two cannot be confused. Take the SHA from the deploy run.
- `dynasty_new` has no local contract, so it reports `UNMEASURABLE` with a named
  reason rather than a silent skip — that is the designed behaviour, not a gap.
- `team-assignment.jsx` has no frontend test; check 12's L4 half is Claude 6's.

## Next Roster-only unit

**V1-29 — retire the five duplicate replacement-level implementations.** Required
level L2, entirely inside `src/roster_intel/` + `src/league_intel/replacement.py`,
no other lane, no deploy. The contract names it in its own words: #914
"designates the owner … but adds **no new implementation** — the retirements are
still owed, so this is begun, not done."

Deliberately **not** the Team Strength consumer gap: that repair is a frontend
change on `/rosters`, which is Claude 6's lane.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyqbZejxh7ytbfijL5pmdE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyqbZejxh7ytbfijL5pmdE)_