### PR TITLE
Lane 4 V1 correctness: absent evidence stops reporting as a confident answer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1116,6 +1116,30 @@ Rules for new code:
   nothing** — the owner spec makes tier weights evidence-gated and no
   outcome data exists to fit them.
 
+  **The TARGET league's TEP is a FACT, read from its scoring card**
+  (2026-08-19).  It used to be inferred from the ``scoringProfile``
+  LABEL — the thing §4.10 above says may never decide a factual
+  question — and the label is measurably wrong here: ``dynasty_main``
+  carries ``superflex_tep15_ppr1`` while its 2026 card grants TEs no
+  premium at all (``bonus_rec_te 0.0`` / ``bonus_fd_te 1.0``, measured
+  ×1.000 against WR by the golden-validated scorer; the LI-7 / ADR-009
+  correction).  So the crowd market matched this league against
+  external TE-premium leagues and excluded the ones that actually
+  match it.  The rule is now
+  ``te_premium.measure_te_demand(None, card).has_scoring_edge`` —
+  reusing the canonical TE-demand owner, roster half withheld because
+  ``is_2te`` already carries it as a separate soft signal — gated on
+  ``scoring_evidence_state(cfg) == "fresh"``.  Anything else is
+  **UNKNOWN**, which hard-excludes rather than becoming "no premium",
+  and ``crowd_refusal_reason`` answers
+  ``target_format_unverifiable:<fields>`` AHEAD of the freshness
+  checks so an unprovable target cannot read as an absent feed.
+  TEP **severity** stays dormant: ``tep_level`` is ``None`` by
+  construction, because KTC's 4-level vendor taxonomy and our
+  continuous per-key scoring edge have no measured crosswalk, and
+  inventing one to make the ``tep_severity_gap`` branch execute is
+  exactly the class of error this lane exists to prevent.
+
   **The population is offense-only, and that is enforced.**  Across
   all 200 rows the starting slots are exactly QB/RB/WR/TE/PK/Def —
   ``Def`` is a team D/ST and NO league in the feed starts an

--- a/docs/faab-external-market-comparability.md
+++ b/docs/faab-external-market-comparability.md
@@ -97,7 +97,7 @@ a match.
 | `superflex_mismatch` / `superflex_unknown` | `qBs ≥ 2` vs the target | the single biggest driver of QB waiver demand |
 | `tep_mismatch` / `tep_unknown` | `tep > 0` vs the target | TE premium on/off |
 | `team_count_mismatch` / `team_count_unknown` | outside ±`teamCountTolerance` | how many rivals split the same finite pool |
-| `target_format_unknown:<field>` | the **target** league's own registry entry does not state `superflex`, `tep` or `teams` | comparability is measured *against* the target — see below |
+| `target_format_unknown:<field>` | the target league could not prove `superflex`, `tep` or `teams` — for `tep` that means no **fresh** scoring card | comparability is measured *against* the target — see below |
 
 The gate is **symmetric about the target**: a 1QB target excludes superflex
 evidence, not the other way round. Comparator relevance is derived from the
@@ -122,10 +122,57 @@ demotes a tier (`two_te_unknown`) rather than excluding — unknown must not pas
 as a match, but a TE-starter count is not worth discarding an otherwise
 comparable league over.
 
-One nuance on TEP: it is a **scoring** property, so a scoring-profile label
-containing `tep` settles it on its own even when the starter block is missing.
-Without such a label, the 2-TE requirement is the only signal available, so an
-unknown starter block leaves TEP unknown rather than false.
+### TEP is a FACT, read from the scoring card — never from a label
+
+**Corrected 2026-08-19.** This section used to say a scoring-profile label
+containing `tep` "settles it on its own". It settles nothing. A label is a
+hand-authored string in `config/leagues/registry.json`; `MASTER_PRODUCT_PLAN`
+§4.10 is explicit that it may decide model/config identity and never a factual
+question. Both live leagues carry `superflex_tep15_ppr1` while differing on 35
+of 48 scoring keys.
+
+It was not a theoretical risk. `dynasty_main`'s 2026 scoring grants tight ends
+**no premium at all** — `bonus_rec_te 0.0`, `bonus_fd_te 1.0`, identical to WR
+— proven by running one receiving line through the golden-validated
+deterministic scorer (TE 21.55 vs WR 21.55, ×1.000; the LI-7 / ADR-009
+correction recorded in `src/api/data_contract.py`). The commissioner removed
+the premium; the label did not change. So the crowd market matched this league
+against external TE-premium leagues, and excluded the ones that actually match
+its scoring, on a premium it does not grant.
+
+The rule now:
+
+| evidence | `TargetFormat.tep` |
+|---|---|
+| a **fresh** scoring card whose TE keys beat their WR/RB counterparts | `True` |
+| a **fresh** card where they do not | `False` |
+| a `stale` / `missing` card, or none at all | `None` — UNKNOWN |
+
+Freshness is `league_registry.scoring_evidence_state`, unchanged and not a new
+budget: a card proves when it was taken, not that it is still true, and a card
+from a different NFL season is wrong however recently it was fetched.
+
+The measurement itself reuses the canonical owner,
+`league_intel.te_premium.measure_te_demand`, which compares each TE-specific
+bonus against its WR/RB counterpart — so a league paying *every* pass-catcher a
+first-down bonus is correctly not a TE-premium league. Reading `bonus_rec_te`
+alone here would be a second owner and would miss `bonus_fd_te`, which was half
+of this league's measured 2025 premium.
+
+The roster half is deliberately withheld from that call: `is_2te` already
+carries the mandatory-TE-starter requirement as its own **soft** signal, so
+feeding it in again would count one fact twice — once hard, once soft.
+
+**UNKNOWN does not become non-TEP.** `tep is None` hard-excludes on
+`target_format_unknown:tep`, so an unprovable target admits nothing rather than
+quietly comparing itself against offense-scoring leagues.
+
+**And an unprovable target says so.** `CrowdMarket` carries
+`targetFormatUnknown`, and `crowd_refusal_reason` answers
+`target_format_unverifiable:<fields>` **ahead of** the freshness checks. When
+the target cannot be described, no row is admissible whatever the ledger's age
+— so reporting `no_crowd_ledger` would send the reader to the feed when the fix
+is a registry entry or a scoring card nobody fetched.
 
 ### The parse-failure guard
 
@@ -143,14 +190,15 @@ Among the survivors, soft mismatches demote a tier and **change no number**:
 
 | tier | meaning |
 |---|---|
-| A | no soft mismatch — same 2-TE setting, same TEP severity band, exact team count |
+| A | no soft mismatch — same 2-TE setting, exact team count (severity is dormant, see §10.5) |
 | B | one soft mismatch |
 | C | two or more |
 | `unverified` | a row persisted before the format evidence was captured (see §7) |
 
-Soft mismatch reasons: `two_te_mismatch`, `two_te_unknown`, `tep_severity_gap`
-(|Δ`tep`| ≥ 2, only measurable when the target's own level is known), and
-`team_count_offset`.
+Soft mismatch reasons: `two_te_mismatch`, `two_te_unknown`, `team_count_offset`
+— and `tep_severity_gap` (|Δ`tep`| ≥ 2), which is **dormant and unreachable in
+production** because the target never states a level. §10.5 says why, and what
+evidence would change it.
 
 **Why no weights.** The owner spec is explicit: *"Do not invent final numeric
 weights merely from these labels. Validate them empirically against Brisket
@@ -262,12 +310,31 @@ No UI consumes this yet; that is the UI lane's call.
 3. **Dynasty is a source-level claim** (§8), not per-league verification.
 4. **Legacy rows stay `unverified`** until the 120-day retention window clears
    them.
-5. **TEP severity is carried but rarely actionable** — `TargetFormat.tep_level`
-   is `None` for our leagues because our registry records TEP through the
-   scoring-profile label rather than a KTC-style 0-3 level. The gap check is
-   therefore dormant for Brisket and only fires for a target whose level is
-   known. Recording the level anyway means the evidence is there when a
-   scoring-derived level lands.
+5. **TEP severity is DORMANT, and stays dormant.** `TargetFormat.tep_level` is
+   `None` *by construction*, so `tep_severity_gap` and its
+   `ComparabilityPolicy.tep_severity_gap` threshold cannot fire in production.
+   That is deliberate, not an omission waiting to be filled in.
+
+   The two sides speak different languages. KTC states a 4-level **vendor
+   taxonomy** (`tepLevel` 0-3 — its Off / TE+ / TE++ / TE+++ settings, which
+   `CLAUDE.md` records as "same-source calibration states of one provider").
+   Our side has a **continuous** per-key scoring edge in points. No published
+   crosswalk exists and this repo has measured none.
+
+   `te_premium._REQUIRED_TE_TO_BASIS` maps TE starters onto the same 4-level
+   vocabulary and is the obvious candidate — but it carries its own provenance
+   note saying it encodes an operator-supplied assumption this repo did **not**
+   measure. Promoting an assumption into a comparability gate so that a branch
+   executes would be inventing methodology to satisfy a table.
+
+   **What would authorize it:** external leagues observed with *both* a stated
+   `tepLevel` and a readable scoring card, in enough numbers to **fit** the
+   mapping rather than assume it. The feed states the level and never the card,
+   so that evidence does not exist today.
+
+   Until then severity is UNKNOWN, and unknown is silent: it does not become a
+   severity of zero, and it does not make a league non-TEP — `tep` is answered
+   independently and its own unknown hard-excludes.
 6. **Sample size per player stays small** (often 1-6 claims), which the
    `crowdBlendWeight` of 0.6 already accounts for; this change makes the sample
    *cleaner*, not larger.

--- a/docs/lane4/L2_L3_VERIFICATION_PROCEDURES.md
+++ b/docs/lane4/L2_L3_VERIFICATION_PROCEDURES.md
@@ -1,0 +1,297 @@
+# Lane 4 — executable verification procedures (L2 / L3)
+
+**What this is.** The exact checklist for each Lane 4 item that
+`docs/VERSION_1_COMPLETION_CONTRACT.md` requires at **L2** or **L3**, written so
+that whoever holds production credentials can execute it without re-deriving
+what counts as proof.
+
+**What this is not.** It is not evidence. Nothing here is a claim that any item
+has been verified. Running a procedure produces evidence; writing one down does
+not.
+
+Levels, quoted from the contract §2 so this file cannot drift from it:
+
+| level | what satisfies it |
+|---|---|
+| **L1 — deterministic** | RED→GREEN test at exact head, plus green CI on the merge tree |
+| **L2 — board/contract inert or measured** | L1 plus a measured statement of the effect on the live board or contract (0 rows, or the exact rows) |
+| **L3 — production** | L1 plus the named checklist executed against the **deployed SHA**, evidence recorded |
+| **L4 — production consumer** | L3 plus proof the intended user-facing surface consumes the canonical implementation with truthful semantics |
+
+**Two rules that bind every procedure below.**
+
+1. **No production authentication is bypassed.** Where a step needs a session
+   the environment does not have, the procedure says so and stops. An
+   unauthenticated `401` is recorded as `unverifiable_unauthenticated` — it is
+   never rewritten as a pass, and never worked around.
+2. **No cohort, ledger or roster is manufactured to make a check succeed.**
+   A step whose input does not exist yet is `BLOCKED` with the missing input
+   named. Synthesising the input would verify the synthesis.
+
+---
+
+## Deployed-SHA preamble (every L3 procedure)
+
+An L3 result is only meaningful against a known commit. Record this first; if
+the SHA does not match the head being claimed, stop — the run proves something
+about a different tree.
+
+```bash
+curl -s https://chaseupside.com/api/status | python -m json.tool | head -40
+```
+
+Record: `commit`/`version` field, `startedAt`, and the wall-clock time of the
+call. Every artifact below is filed under that SHA.
+
+---
+
+## V1-57 — FAAB bid-history collection is scheduled, not a manual step (L3)
+
+The unit is `dynasty-faab-history` (daily, 07:40 UTC, `RandomizedDelaySec=600`,
+`Persistent=true`), installed by `deploy/install-systemd-service.sh` via
+`install_simple_timer "faab-history"`.
+
+**Do not confuse it with `dynasty-crowd-faab`.** That one collects what OTHER
+leagues pay; this one collects what THIS league pays, and it is what the market
+priors are fitted from. Verifying one says nothing about the other.
+
+On the box:
+
+```bash
+systemctl list-timers 'dynasty*faab*' --all
+systemctl status  dynasty-faab-history.timer
+systemctl status  dynasty-faab-history.service
+journalctl -u dynasty-faab-history.service --since '-8 days' --no-pager | tail -60
+ls -la /opt/dynasty/data/faab/          # path per the deployed APP_DIR
+```
+
+| assertion | pass |
+|---|---|
+| the timer is installed and enabled | `LOAD=loaded`, `ACTIVE=active`, `UNIT=dynasty-faab-history.timer` in `list-timers` |
+| it has actually fired | `LAST` is populated and within ~25 h of now |
+| the run succeeded | the most recent journal entry exits **0** (1 = registry unreadable, 2 = nothing fetched) |
+| it produced the artifact | `data/faab/bid_history_<leagueKey>.json` exists per active league, `mtime` inside 25 h |
+| the artifact is used | `POST /api/faab/recommend` → `contention.notes` does **not** carry the configured-priors fallback note |
+
+**Exit 2 is not a pass and not a failure.** It means nothing was fetched and the
+previous file was left untouched. Record it as `DEGRADED` with the prior file's
+`mtime`, because stale own-league priors and no own-league priors are different
+states.
+
+**Scheduling is the requirement; a green manual run does not satisfy it.** A
+one-off `python scripts/fetch_faab_history.py` proves the script works, which
+was never the open question.
+
+---
+
+## V1-129 — external crowd-FAAB evidence is comparable, fresh and position-capable (L2)
+
+Four separately-refusable behaviours. Each needs its own recorded answer; a
+single "the endpoint returned 200" satisfies none of them.
+
+L2 wants a measured statement, so every row below is a count, not a yes/no.
+
+### 129a — new crowd rows carry comparability provenance
+
+```bash
+python - <<'PY'
+import json, pathlib, collections
+p = pathlib.Path("data/faab/crowd_history_dynasty_main.json")
+d = json.loads(p.read_text())
+rows = d["rows"]
+have = [r for r in rows if isinstance(r.get("comparability"), dict)]
+print("updatedAt:", d.get("updatedAt"))
+print(f"rows={len(rows)} with comparability={len(have)}")
+print("tiers:", collections.Counter(r["comparability"].get("tier") for r in have))
+print("settings present:", sum(1 for r in rows if isinstance(r.get("settings"), dict)))
+PY
+```
+
+PASS: every row written **since #911 deployed** carries a `comparability` block
+and a `settings` block. Rows older than that deploy legitimately carry neither.
+
+### 129b — legacy rows are honestly excluded, not silently counted
+
+The ledger is accumulated, so pre-#911 rows persist. They must classify as
+`unverified` — retained and readable, never passing as verified.
+
+PASS: `crowdMarket.tierCounts` contains an `unverified` bucket whose size equals
+the pre-deploy row count, and those rows appear in **no** A/B/C tier.
+
+FAIL, and this is the trap worth naming: `unverified` **absent** while
+`rowsUsed == rowsTotal`. That is legacy rows passing as verified, and it looks
+identical to a clean ledger.
+
+### 129c — an offense-only population refuses to price an IDP claim
+
+```bash
+curl -s -X POST https://chaseupside.com/api/faab/recommend \
+  -H 'content-type: application/json' -b "$SESSION_COOKIE" \
+  -d '{"leagueKey":"dynasty_main","addPlayerName":"<a rostered LB>"}' \
+| python -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps(d["crowdMarket"], indent=2))'
+```
+
+PASS: `pricesIdp: false` **and** `refusalReason: "population_cannot_price_idp"`
+**and** `playerHasEvidence: false`.
+
+The gate reads what the retained rows contain, so `pricesIdp: true` is not a
+failure — it means an IDP league entered the feed. Record which league.
+
+### 129d — a stale ledger refuses to price
+
+Do **not** age the file to test this. Read the state that exists:
+
+PASS: `state == "fresh"` with `ageDays <= maxFileAgeDays`, and
+`refusalReason: null`; **or** `state == "stale"` with
+`refusalReason: "crowd_ledger_stale"` and `playerHasEvidence: false`. Either is
+a pass — what fails is a stale ledger that still priced, or a `state` of `fresh`
+with `ageDays > maxFileAgeDays`.
+
+`ageDays: null` must read `stale`: unmeasurable freshness is not freshness.
+
+### 129e — the target league can describe itself *(added 2026-08-19)*
+
+New with the card-derived TEP repair, and the one most likely to be red on a
+cold deploy.
+
+PASS: `crowdMarket.targetFormatUnknown == []`.
+
+FAIL: it lists `tep`, and `refusalReason` is
+`target_format_unverifiable:tep`. That is not a feed problem and the fix is not
+in `data/faab/` — the league has no **fresh** scoring card. Remedy:
+
+```bash
+python scripts/fetch_league_scoring.py     # writes data/leagues/scoring_<id>.json
+```
+
+Then re-read. Record the before/after `rowsUsed`, because this is exactly where
+the TEP change moves the admitted population.
+
+**Expect the admitted set to change, and record it rather than treating it as a
+regression.** `dynasty_main`'s real 2026 card grants TEs no premium, while its
+`superflex_tep15_ppr1` label said it did — so the leagues previously admitted on
+a TEP match are now excluded and vice versa. On the shipped synthetic fixture
+(`tests/sources/fixtures/ktc_waiver_page.html`, 12 rows) the comparable count
+goes **3 → 1**; the production number must be read off the real ledger.
+
+---
+
+## V1-60 — FFPC roster lane real or honestly empty (L2)
+
+The requirement is a **truthful degraded state**. Zero rosters because FFPC is
+switched off and zero rosters because the collection broke must not render
+identically, and neither may read as "we looked and nobody owns him".
+
+```bash
+curl -s 'https://chaseupside.com/api/sharp/roster-percentage' -b "$SESSION_COOKIE" \
+| python -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps({k:v for k,v in d.items() if k!="assets"}, indent=2))'
+```
+
+| assertion | pass |
+|---|---|
+| the source block states FFPC's status | `sources.ffpc.status` ∈ `disabled` / `degraded` / `no_data` / `ok`, never absent |
+| a disabled lane says disabled | `enabled: false` when no roster-bearing URL is configured |
+| coverage is unavailable, not zero | `cohortCoveragePct` is `null` — never `0` — when no roster was observed |
+| a skipped collection names itself | `CollectResult.status == "unavailable"` with an `unavailable_reason` of `skipped` / `no_managers` |
+
+FAIL: a `0` or `0.0` anywhere a lane was not actually measured. That is the
+whole defect this row tracks.
+
+---
+
+## V1-63 — manager-level Sharp concentration (L1)
+
+L1 only: a RED→GREEN test at exact head plus green CI. **No production step is
+required and none should be invented** — inventing one would move the bar the
+contract set.
+
+Current head ships the person-level concentration safeguard
+(`src/sharp/consensus.py`) with `networkConcentration`, `networkCount`,
+`weightedPersonNet`/`Volume`, `personVotes`, `mixedPersonSignals`,
+`personAgreement` and `personManagerQuality`.
+
+```bash
+python -m pytest tests/sharp/test_person_consensus.py tests/sharp/test_curated_wiring.py -q
+```
+
+PASS: green, **and** the four undefined-state tests are present and were shown
+RED before the fix that made them green:
+
+- zero voters → `personManagerQuality is None`
+- a measured `0.0` → stays `0.0`
+- ≥ 1 voter → the actual mean
+- no weighted volume → `networkConcentration is None`
+
+plus the consumer guard (no module coerces an undefined person quantity back to
+a number) and its meta-test (the scanner matches the shapes it exists to catch).
+
+**Open against this row, and not closed by the above:** the contract's status is
+`NOT STARTED` against `W15-F009`, "missing field". Nothing here adds a field —
+this repairs the semantics of the fields that exist. Whether `inv 4.6` is
+satisfied by the person-level block or requires a *manager*-level concentration
+figure is an owner/Integration reading, not mine to declare.
+
+---
+
+## V1-64 — Sharp event ledger surfaces adds/drops (L1)
+
+L1 only.
+
+```bash
+python -m pytest tests/sharp/test_transactions.py tests/sharp/test_unified_market.py -q
+```
+
+PASS: green, and `/api/sharp/market` rows carry `buys`, `sells`, `net`,
+`volume`, `movementCount`, `tradeCount` as **raw counts** alongside the weighted
+view — the audit trail is not replaced by the capped weights.
+
+Also assert the phantom-row guard (`2026-08-19`): a movement whose action is
+neither `add` nor `drop` must produce **no** asset row, rather than a row with
+zero movements and `managerQuality: 1.0`.
+
+---
+
+## V1-65 — Insider Trading / cross-league ownership (L2)
+
+Contract note: *"complete, consolidation pending"*. The L2 statement is
+therefore about the **cohort definition**, which is where a duplicate would
+show up.
+
+```bash
+python -m pytest tests/sharp -q
+grep -rn "def cohort_members" src/ | grep -v __pycache__
+```
+
+PASS: exactly **one** definition of `cohort_members`
+(`src/sharp/cohort.py`); `market.py`, `roster_percentage.py`,
+`roster_collect.py` and `scripts/crawl_sharp_activity.py` all resolve through
+it, and none applies a qualification rule of its own.
+
+Measured statement required for L2: the number of cohort members and the number
+of roster observations behind the live board, from
+`/api/sharp/roster-percentage` (`cohort.selectedManagers`, `rostersObserved`).
+If both are `0`, that is the honest answer and V1-58 is the blocker — record it
+as such rather than as a V1-65 failure.
+
+---
+
+## V1-58 / V1-59 — BLOCKED, and why
+
+Both need production Sharp evidence. The recorded artifacts end at
+`401` / `502` / `unverifiable_unauthenticated` from
+`https://chaseupside.com/api/sharp/cohort`.
+
+`/api/sharp/*` is **not** in the public-API allowlist
+(`tests/sharp/test_public_api_allowlist.py` pins that), so the endpoint requires
+an authenticated admin session. That is correct behaviour and must not be
+relaxed to make verification easier.
+
+**The single credential that unblocks both:** an authenticated admin session
+cookie for `chaseupside.com`, held by the site owner. With it, V1-58 is
+`GET /api/sharp/cohort` returning a non-empty membership against the deployed
+SHA, and V1-59 is a clean `journalctl` run of the three-pass chain
+(`dynasty-sharp-discovery` 04:20 → `dynasty-sharp-records` 04:50 →
+`dynasty-sharp-rosters` 05:50) with no FFPC timeout and no SQLite lock.
+
+Without it both stay `BLOCKED`. They are **not** to be closed by standing up a
+synthetic cohort: a manufactured population would verify the manufacture.

--- a/docs/lane4/LANE4_804_CAPTURE_CADENCE_DECISION.md
+++ b/docs/lane4/LANE4_804_CAPTURE_CADENCE_DECISION.md
@@ -1,0 +1,97 @@
+# #804 rank-digest capture — the cadence decision (owner)
+
+**Status: awaiting an owner decision. Nothing is scheduled and nothing is on.**
+
+The capture unit shipped in **#921** and its feature flag is **OFF**. This
+document exists because the one thing left is not an engineering choice — it is
+a storage/fidelity trade the owner should make, and it should not be smuggled in
+as a default.
+
+**This changes the V1 percentage by zero.** #804 capture is post-V1
+infrastructure. No canonical value, ranking weight, source weight, confidence
+level, B10 family assignment or decision surface depends on it, and no consumer
+reads the series.
+
+---
+
+## What the capture is for
+
+#804 is about **correlated / shared-lineage source movement**: sources that move
+together are not independent votes, and correlated anomalies were measured
+moving the blend by as much as **~48%** with no existing defence catching them.
+
+Deciding a defensible correlation grouping needs **longitudinal per-source rank
+observations** — the same sources, the same assets, over many days. That
+evidence does not exist: 24 sources are live, 3 are archived, and 0 of 176
+committed bundles retain more. Every day not captured is a day that cannot be
+recovered later, which is the only reason this is time-sensitive at all.
+
+**Capture is not analysis.** Correlation methodology, family weighting,
+automatic downweighting and confidence changes all remain unauthorized.
+
+---
+
+## The measurement
+
+Per build, on the live board:
+
+| quantity | measured |
+|---|---|
+| observations | 7,245 |
+| sources contributing | 21 |
+| bytes per row (incl. index overhead) | 446 B |
+
+Denormalization accounts for only **4–7%** of the per-row cost; index overhead
+dominates. So schema tuning is not the lever — **cadence is**, and it is close
+to linear in the number of builds retained.
+
+| cadence | rows/day | bytes/day | 30 d | 90 d | 365 d |
+|---|---|---|---|---|---|
+| **every build** (12/day, the 2-hourly refresh) | ~87,000 | **38.8 MB** | 1.2 GB | 3.5 GB | **14.2 GB** |
+| **daily** (1/day) | ~7,245 | **3.2 MB** | 97 MB | 291 MB | **~1.2 GB** |
+
+---
+
+## The trade, stated honestly
+
+**Every build** captures intra-day co-movement. If two sources republish within
+the same day and move together, only build-level capture can see it.
+
+**Daily** costs ~8% of the storage and still answers the question #804 actually
+poses — *do these sources repeatedly move together over weeks?* — because a
+source's own publication cadence is daily at best for most of the pool.
+
+What I can measure says daily is sufficient for the stated purpose. What I
+cannot measure is whether a future analysis will want the intra-day resolution,
+and that is a real cost of choosing daily: the resolution is not recoverable
+afterwards.
+
+**Recommendation: daily.** ~1.2 GB/year is a cost worth paying to stop losing
+evidence, and it is small enough not to need a retention policy in the same
+breath. Every-build is defensible if intra-day co-movement is expected to
+matter, and it is the one that would need a retention decision alongside it.
+
+---
+
+## What is deliberately NOT proposed here
+
+**No retention or compaction policy.** Deleting perishable evidence is an owner
+decision, and inventing one unauthorized would be the same class of error the
+capture exists to correct. The 365-day figures above are what *accumulates*, not
+a claim that it must be kept.
+
+If every-build is chosen, retention becomes a question that needs its own
+decision — flagged, not answered.
+
+---
+
+## Turning it on
+
+The flag defaults OFF and flag reads are cached per process, so a change needs a
+restart. Whichever cadence is chosen, the switch is a scheduling decision plus
+the flag; no code change is required for either option.
+
+Confirm non-influence after enabling, the same way #921 proved it before
+shipping: `scripts/golden_board.py` before and after with code as the only
+variable, then `scripts/board_diff.py --expect-no-value-change`. #921's own
+capture was byte-identical.

--- a/scripts/fetch_crowd_faab.py
+++ b/scripts/fetch_crowd_faab.py
@@ -300,11 +300,9 @@ def main() -> int:
         # The comparator profile comes from the TARGET league's own canonical
         # settings, never a hardcoded Brisket shape — the product is expected
         # to serve other people's dynasty leagues later (owner spec section 7).
-        target = FC.TargetFormat.from_roster_settings(
-            league_registry.get_league_roster_settings(cfg.key) or {},
-            league_key=cfg.key,
-            scoring_profile=getattr(cfg, "scoring_profile", "") or "",
-            idp_enabled=getattr(cfg, "idp_enabled", None),
+        target = FC.TargetFormat.from_league_config(
+            cfg,
+            roster_settings=league_registry.get_league_roster_settings(cfg.key) or {},
             original_budget=league_budget_for(cfg.key),
         )
 

--- a/server.py
+++ b/server.py
@@ -6101,11 +6101,9 @@ async def post_waiver_faab_recommend(request: Request):
     crowd_for_player: dict | None = None
     crowd_market_block: dict | None = None
     try:
-        crowd_target = _faab_comparability.TargetFormat.from_roster_settings(
-            roster_settings,
-            league_key=league_cfg.key,
-            scoring_profile=getattr(league_cfg, "scoring_profile", "") or "",
-            idp_enabled=getattr(league_cfg, "idp_enabled", None),
+        crowd_target = _faab_comparability.TargetFormat.from_league_config(
+            league_cfg,
+            roster_settings=roster_settings,
             original_budget=float(league_budget),
         )
         crowd_policy = _faab_comparability.ComparabilityPolicy.from_config(

--- a/src/sharp/consensus.py
+++ b/src/sharp/consensus.py
@@ -108,7 +108,14 @@ def aggregate_person_consensus(
             "mixedPersonSignals": mixed,
             "weightedPersonNet": round(weighted_net, 6),
             "weightedPersonVolume": round(weighted_volume, 6),
-            "personManagerQuality": quality_total / voters if voters else 1.0,
+            # UNKNOWN, NOT PERFECT.  ``else 1.0`` answered "how good are the
+            # managers behind this signal?" with the HIGHEST possible score
+            # exactly when nobody qualified to answer it.  Reachable whenever
+            # every person who touched the asset both added and dropped it in
+            # the window: the row is still emitted, with ``personVotes: 0``
+            # and ``mixedPersonSignals > 0``.  A measured 0.0 is a different
+            # statement and still reports as 0.0.
+            "personManagerQuality": quality_total / voters if voters else None,
             "networkCount": len(network_vote_abs),
             "networkConcentration": (None if concentration is None else round(concentration, 4)),
             "personAgreement": (max(buys, sells) / voters if voters else None),

--- a/src/sharp/market.py
+++ b/src/sharp/market.py
@@ -187,6 +187,18 @@ def _aggregate_window(
         asset_id = str(row.get("canonicalAssetId") or "")
         if not asset_id:
             continue
+        action = row.get("action")
+        if action not in ("add", "drop"):
+            # A row we cannot count must not MINT a row either.  The
+            # ``setdefault`` used to run before this check, so an asset whose
+            # only movements in the window carried an uncountable action was
+            # emitted with zero buys, zero sells, zero movements — and
+            # ``managerQuality: 1.0`` from the ``qualityObservations == 0``
+            # branch below, which feeds ``signal_strength``.  Unreachable
+            # today because ``intel/ledger.py`` filters actions at ingest, so
+            # this changes no live value; it makes the guarantee structural
+            # instead of borrowed from a filter two modules away.
+            continue
         entry = grouped.setdefault(
             asset_id,
             {
@@ -212,13 +224,10 @@ def _aggregate_window(
                 "byLeague": {},
             },
         )
-        action = row.get("action")
         if action == "add":
             entry["buys"] += 1
-        elif action == "drop":
-            entry["sells"] += 1
         else:
-            continue
+            entry["sells"] += 1
         canonical_manager = str(row.get("canonicalManagerKey") or row.get("managerKey"))
         entry["managerKeys"].add(canonical_manager)
         entry["leagueKeys"].add(str(row.get("leagueKey")))

--- a/src/trade/faab_comparability.py
+++ b/src/trade/faab_comparability.py
@@ -260,6 +260,90 @@ def source_format_from_settings(settings: Any) -> SourceFormat:
     )
 
 
+#: Evidence states from ``league_registry.scoring_evidence_state`` that PROVE a
+#: league's current scoring.  Only ``fresh`` does: a card proves when it was
+#: taken, not that it is still true, and a card from a different NFL season is
+#: wrong however recently it was fetched.  Same rule the scoring-fingerprint
+#: gate already applies — not a second budget.
+_SCORING_EVIDENCE_PROVES_CURRENT = ("fresh",)
+
+
+def _tep_from_scoring(scoring: dict[str, Any] | None, evidence: str) -> bool | None:
+    """Does this league's ACTUAL scoring grant tight ends a premium?
+
+    ``None`` when it cannot be proven — and that is a real, common answer, not
+    a corner case.
+
+    Why not the scoring-profile label
+    ─────────────────────────────────
+    This used to be ``"tep" in scoring_profile``.  A label is a hand-authored
+    string in ``config/leagues/registry.json`` and settles nothing about
+    scoring; ``MASTER_PRODUCT_PLAN`` §4.10 is explicit that it may decide
+    model/config identity and never a factual question.  Both live leagues
+    carry ``superflex_tep15_ppr1`` while differing on 35 of 48 scoring keys.
+
+    It was not a theoretical risk here.  ``dynasty_main``'s 2026 card grants
+    TEs **no** premium — ``bonus_rec_te 0.0``, ``bonus_fd_te 1.0``, identical
+    to WR — proven by running one receiving line through the golden-validated
+    deterministic scorer (TE 21.55 vs WR 21.55, ×1.000; see the LI-7 / ADR-009
+    correction in ``src/api/data_contract.py``).  The label said TEP, so the
+    crowd market matched this league against external TE-premium leagues and
+    excluded non-premium ones, on a premium the commissioner had removed.
+
+    The measurement reuses the canonical owner
+    ──────────────────────────────────────────
+    ``league_intel.te_premium.measure_te_demand`` already answers "does scoring
+    advantage TE", comparing each TE-specific bonus against its WR/RB
+    counterparts — so a league that pays *everyone* a first-down bonus is
+    correctly not a TE-premium league.  Reading ``bonus_rec_te`` alone here
+    would be a second owner AND would miss ``bonus_fd_te``, which is half of
+    the measured 2025 premium.
+
+    The roster half is deliberately withheld from it (``roster=None``).
+    ``measure_te_demand`` lets mandatory TE starters raise the basis, which is
+    right for valuation and wrong here: ``TargetFormat.is_2te`` already carries
+    the roster requirement as its own soft signal, so feeding it in as well
+    would count one fact twice — once hard, once soft.
+    """
+    if evidence not in _SCORING_EVIDENCE_PROVES_CURRENT:
+        return None
+    if not isinstance(scoring, dict) or not scoring:
+        return None
+    from src.league_intel.te_premium import measure_te_demand  # noqa: PLC0415
+
+    return measure_te_demand(None, scoring).has_scoring_edge
+
+
+# ── TEP SEVERITY IS DORMANT, AND STAYS DORMANT ─────────────────────
+#
+# ``ComparabilityPolicy.tep_severity_gap`` and the ``tep_severity_gap`` soft
+# reason exist and are unreachable in production: ``TargetFormat.tep_level`` is
+# ``None`` by construction, so the branch that needs BOTH levels never fires.
+# That is deliberate, and this note is here so the next reader does not "fix"
+# it by making one up.
+#
+# The two sides speak different languages.  KTC's waiver rows carry a 4-level
+# VENDOR TAXONOMY (``tepLevel`` 0-3, its Off / TE+ / TE++ / TE+++ settings,
+# which CLAUDE.md records as "same-source calibration states of one provider").
+# Our side has a CONTINUOUS per-key scoring edge in points.  There is no
+# published crosswalk between them, and this repo has measured none.
+#
+# ``te_premium._REQUIRED_TE_TO_BASIS`` maps TE starters onto the same 4-level
+# vocabulary and is the obvious candidate — but it carries its own provenance
+# note saying it encodes an operator-supplied assumption this repo did not
+# measure.  Promoting an assumption into a comparability gate, so that a branch
+# executes, would be inventing methodology to satisfy a table.
+#
+# WHAT WOULD AUTHORIZE IT: external leagues observed with BOTH a stated
+# ``tepLevel`` and a readable scoring card, enough of them to FIT the mapping
+# rather than assume it.  The feed states the level and never the card, so the
+# evidence does not exist today.
+#
+# Until then: severity is UNKNOWN, and unknown is silent.  It does not become a
+# severity of zero, and it does not make a league non-TEP — ``tep`` above is
+# answered independently, and its own unknown hard-excludes.
+
+
 @dataclass(frozen=True)
 class TargetFormat:
     """The league we are trying to price a waiver claim FOR.
@@ -292,10 +376,19 @@ class TargetFormat:
         settings: dict[str, Any] | None,
         *,
         league_key: str = "",
-        scoring_profile: str = "",
+        scoring_settings: dict[str, Any] | None = None,
+        scoring_evidence: str = "missing",
         idp_enabled: bool | None = None,
         original_budget: float | None = None,
     ) -> "TargetFormat":
+        """Build the comparator from the league's own FACTS.
+
+        ``scoring_settings`` is the league's real Sleeper scoring card and
+        ``scoring_evidence`` is ``league_registry.scoring_evidence_state``'s
+        verdict on it.  Both default to "we were told nothing", so a caller
+        that forgets them gets ``tep=None`` and fails closed rather than a
+        confident guess.
+        """
         settings = settings or {}
         starters = settings.get("starters")
         starters = starters if isinstance(starters, dict) and starters else None
@@ -308,19 +401,7 @@ class TargetFormat:
         else:
             superflex = bool(starters.get("SFLEX") or starters.get("SUPER_FLEX"))
 
-        # TEP is a SCORING property, read from the scoring-profile label; the
-        # starter block only says how many TEs must START.  Both are kept
-        # because §7 names them separately ("TE premium AND two mandatory TE
-        # starters").  A profile label that says "tep" is positive evidence on
-        # its own; without one, the 2-TE requirement is the only signal, so an
-        # unknown starter block leaves TEP unknown rather than false.
-        profile_says_tep = "tep" in str(scoring_profile or "").lower()
-        if profile_says_tep:
-            tep = True
-        elif is_2te is None:
-            tep = None
-        else:
-            tep = is_2te
+        tep = _tep_from_scoring(scoring_settings, scoring_evidence)
 
         if idp_enabled is not None:
             idp: bool | None = bool(idp_enabled)
@@ -334,6 +415,7 @@ class TargetFormat:
             superflex=superflex,
             tep=tep,
             is_2te=is_2te,
+            # SEVERITY IS DORMANT BY CONSTRUCTION — see ``_tep_from_scoring``.
             tep_level=None,
             idp=idp,
             original_budget=original_budget,
@@ -341,17 +423,40 @@ class TargetFormat:
         )
 
     @classmethod
+    def from_league_config(
+        cls,
+        cfg: Any,
+        *,
+        roster_settings: dict[str, Any] | None = None,
+        original_budget: float | None = None,
+    ) -> "TargetFormat":
+        """Build from a ``LeagueConfig``, reading that league's real scoring.
+
+        The ONE place the registry lookups live, so no caller has to remember
+        that TEP comes from the card and not from the profile label.
+        """
+        from src.api import league_registry  # noqa: PLC0415 — optional at import time
+
+        if cfg is None:
+            return cls()
+        key = str(getattr(cfg, "key", "") or "")
+        if roster_settings is None:
+            roster_settings = league_registry.get_league_roster_settings(key)
+        return cls.from_roster_settings(
+            roster_settings or {},
+            league_key=key,
+            scoring_settings=league_registry.scoring_settings_for_league(cfg),
+            scoring_evidence=league_registry.scoring_evidence_state(cfg),
+            idp_enabled=getattr(cfg, "idp_enabled", None),
+            original_budget=original_budget,
+        )
+
+    @classmethod
     def from_registry(cls, league_key: str) -> "TargetFormat":
         """Read the target league out of the canonical registry."""
         from src.api import league_registry  # noqa: PLC0415 — optional at import time
 
-        cfg = league_registry.get_league_by_key(league_key)
-        return cls.from_roster_settings(
-            league_registry.get_league_roster_settings(league_key),
-            league_key=league_key,
-            scoring_profile=getattr(cfg, "scoring_profile", "") or "",
-            idp_enabled=getattr(cfg, "idp_enabled", None),
-        )
+        return cls.from_league_config(league_registry.get_league_by_key(league_key))
 
 
 # ── Policy ─────────────────────────────────────────────────────────
@@ -424,6 +529,27 @@ class Comparability:
         return {"tier": self.tier, "excluded": self.excluded, "reasons": list(self.reasons)}
 
 
+#: Target settings that MUST be proven before any external league can be
+#: matched against it.  One definition, so the census, the refusal reason and
+#: the gate itself cannot drift apart.
+REQUIRED_TARGET_FIELDS: tuple[str, ...] = ("superflex", "tep", "teams")
+
+
+def unprovable_target_fields(target: TargetFormat | None) -> tuple[str, ...]:
+    """Which required target settings this league could not prove.
+
+    Non-empty means EVERY external row is inadmissible — which a consumer must
+    be able to say out loud.  "We hold no crowd evidence" and "we cannot
+    describe our own league well enough to judge any" are different failures
+    with different fixes, and reporting them identically sends the reader
+    looking at the feed when the answer is in the registry or in a scoring card
+    that was never fetched.
+    """
+    if target is None:
+        return REQUIRED_TARGET_FIELDS
+    return tuple(name for name in REQUIRED_TARGET_FIELDS if getattr(target, name, None) is None)
+
+
 def classify(
     source: SourceFormat,
     target: TargetFormat,
@@ -446,9 +572,8 @@ def classify(
     # Excluding here rather than defaulting is the whole reason
     # ``TargetFormat`` has no defaults: judging real external evidence
     # against an invented comparator is worse than judging it against none.
-    for field_name in ("superflex", "tep", "teams"):
-        if getattr(target, field_name) is None:
-            hard.append(f"target_format_unknown:{field_name}")
+    for field_name in unprovable_target_fields(target):
+        hard.append(f"target_format_unknown:{field_name}")
 
     # Budget — the denominator of every normalized share.
     if source.original_budget is None or source.original_budget <= 0:

--- a/src/trade/faab_history.py
+++ b/src/trade/faab_history.py
@@ -467,6 +467,13 @@ class CrowdMarket:
     excluded_counts: dict[str, int] = field(default_factory=dict)
     prices_idp: bool = False
     target_budget: float | None = None
+    target_unknown: tuple[str, ...] = ()
+    """Required target settings this league could not prove.
+
+    Non-empty means every row was inadmissible for a reason on OUR side, not
+    the feed's — reported separately because "no crowd evidence" and "we cannot
+    describe our own league" have different fixes.
+    """
 
     @property
     def usable(self) -> bool:
@@ -483,6 +490,7 @@ class CrowdMarket:
             "excludedCounts": dict(sorted(self.excluded_counts.items())),
             "pricesIdp": self.prices_idp,
             "pricedPlayers": len(self.index),
+            "targetFormatUnknown": list(self.target_unknown),
             # Dynasty status of this feed is asserted by the SOURCE, not
             # verified per league — recorded so a consumer can see which kind
             # of evidence it holds (owner spec section 5).
@@ -514,6 +522,7 @@ def build_crowd_market(
     pol = policy or _comparability.ComparabilityPolicy()
     market = CrowdMarket(
         target_budget=(target.original_budget if target else None),
+        target_unknown=_comparability.unprovable_target_fields(target),
     )
     if not isinstance(payload, dict):
         return market
@@ -647,6 +656,13 @@ def crowd_refusal_reason(market: CrowdMarket, position: str | None = None) -> st
     """
     if not isinstance(market, CrowdMarket):
         return "market_unavailable"
+    if market.target_unknown:
+        # Ahead of the state checks on purpose.  When the target cannot be
+        # described, no row is admissible whatever the ledger's age, so
+        # freshness is moot and reporting "no ledger" would send the reader to
+        # the wrong place -- the fix is a registry entry or a scoring card
+        # nobody fetched, not the feed.
+        return "target_format_unverifiable:" + ",".join(market.target_unknown)
     if market.state == "missing":
         return "no_crowd_ledger"
     if market.state == "stale":

--- a/tests/api/test_faab_recommend_endpoint.py
+++ b/tests/api/test_faab_recommend_endpoint.py
@@ -757,17 +757,33 @@ def _with_crowd(monkeypatch, payload):
 #: the tests that exercise the crowd path have to state a real format.
 _FULL_FORMAT = {
     "teamCount": 12,
-    # 1QB, single TE, no TE premium — matching the crowd rows below, so the
-    # tests exercise the crowd path rather than the format gate.
+    # 1QB, single TE — matching the crowd rows below, so the tests exercise
+    # the crowd path rather than the format gate.
     "starters": {"QB": 1, "RB": 2, "WR": 3, "TE": 1, "FLEX": 2},
 }
 
+#: TEP is read from the league's REAL scoring card, never from the profile
+#: label, so stating a format now means stating scoring too.  This card grants
+#: TEs nothing over WRs, matching the non-TEP crowd rows below.
+_FULL_SCORING = {"rec": 1.0, "bonus_rec_te": 0.0, "bonus_fd_te": 1.0, "bonus_fd_wr": 1.0}
 
-def _with_stated_format(monkeypatch):
+
+def _with_stated_format(monkeypatch, *, scoring=None, evidence="fresh"):
     monkeypatch.setattr(
         server._league_registry,
         "get_league_roster_settings",
         lambda key: dict(_FULL_FORMAT),
+    )
+    card = dict(_FULL_SCORING) if scoring is None else scoring
+    monkeypatch.setattr(
+        server._league_registry,
+        "scoring_settings_for_league",
+        lambda cfg: (dict(card) if card else None),
+    )
+    monkeypatch.setattr(
+        server._league_registry,
+        "scoring_evidence_state",
+        lambda cfg: evidence,
     )
 
 
@@ -853,6 +869,7 @@ def test_an_idp_league_in_the_population_unlocks_idp_pricing(faab_env, monkeypat
 
 
 def test_no_ledger_reports_missing_rather_than_omitting_the_block(faab_env, monkeypatch):
+    _with_stated_format(monkeypatch)
     with TestClient(server.app) as c:
         _with_crowd(monkeypatch, None)
         res = _post(c, monkeypatch, {"addPlayerName": "Hot Pickup"})
@@ -881,3 +898,44 @@ def test_an_underspecified_target_league_admits_nothing(faab_env, monkeypatch):
         "target_format_unknown:superflex",
         "target_format_unknown:tep",
     }
+    # ...and the refusal names OUR side, not the feed's. A fresh ledger that
+    # admitted nothing because we cannot describe our own league must not
+    # read as "no crowd ledger" -- the fix is in the registry, not the feed.
+    assert block["refusalReason"] == "target_format_unverifiable:superflex,tep"
+    assert block["targetFormatUnknown"] == ["superflex", "tep"]
+
+
+def test_an_unproven_scoring_card_leaves_tep_unknown_and_says_so(faab_env, monkeypatch):
+    """A card proves when it was taken, not that it is still true.
+
+    Stale scoring is UNKNOWN TEP, and unknown must not quietly become "no TE
+    premium" -- that would silently admit a whole population of offense-scoring
+    leagues as comparable. It fails closed and reports which setting failed.
+    """
+    _with_stated_format(monkeypatch, evidence="stale")
+    with TestClient(server.app) as c:
+        _with_crowd(monkeypatch, _crowd_payload(_now()))
+        res = _post(c, monkeypatch, {"addPlayerName": "Hot Pickup"})
+    block = res.json()["crowdMarket"]
+    assert block["rowsTotal"] == 4 and block["rowsUsed"] == 0
+    assert block["targetFormatUnknown"] == ["tep"]
+    assert block["refusalReason"] == "target_format_unverifiable:tep"
+
+
+def test_a_proven_te_premium_is_read_from_the_card_not_the_label(faab_env, monkeypatch):
+    """The same league, same label, different card -> different market.
+
+    This is the whole point of the repair: ``dynasty_main`` carries a
+    ``superflex_tep15_ppr1`` label while its real 2026 card grants TEs no
+    premium at all, so the label admitted TE-premium leagues as comparable and
+    excluded the ones that actually match.
+    """
+    _with_stated_format(monkeypatch, scoring={"rec": 1.0, "bonus_rec_te": 0.5})
+    with TestClient(server.app) as c:
+        _with_crowd(monkeypatch, _crowd_payload(_now()))
+        res = _post(c, monkeypatch, {"addPlayerName": "Hot Pickup"})
+    block = res.json()["crowdMarket"]
+    # The crowd rows are non-TEP leagues; a proven TE premium now excludes them.
+    assert block["targetFormatUnknown"] == []
+    assert block["rowsUsed"] == 0
+    assert block["excludedCounts"] == {"tep_mismatch": 4}

--- a/tests/sharp/test_curated_wiring.py
+++ b/tests/sharp/test_curated_wiring.py
@@ -10,6 +10,7 @@ connections themselves.
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -169,3 +170,101 @@ def test_an_unbuilt_curated_store_degrades_instead_of_breaking_the_board(monkeyp
 
     monkeypatch.setattr(market.curated_model, "curated_cohort_members", explode)
     assert market.curated_industry_members("industry") == []
+
+
+def test_a_zero_voter_asset_reaches_the_api_as_unknown_not_perfect(monkeypatch):
+    """The repaired state must survive the whole path, not just the producer.
+
+    ``/api/sharp/market`` embeds the person view verbatim, so a producer
+    fix that a caller then coerced would publish the same false green. This
+    asserts the served row, and that the field serializes as JSON ``null``
+    rather than being dropped -- an absent key and a present ``1.0`` are
+    both readable as "no problem here", which is the failure mode.
+    """
+    movements = [
+        {
+            "canonicalAssetId": "player:1",
+            "displayName": "Churned Player",
+            "assetType": "player",
+            "managerKey": "sleeper:1",
+            "canonicalManagerKey": "person:a",
+            "action": action,
+            "leagueKey": f"sleeper:L{index}",
+            "transactionKey": f"tx{index}",
+            "movementKey": f"mv{index}",
+            "platform": "sleeper",
+            "timestampMs": 1_000 + index,
+        }
+        for index, action in enumerate(("add", "drop"))
+    ]
+    monkeypatch.setattr(
+        market.platform_ledger, "query_movements", lambda **_kwargs: list(movements)
+    )
+    monkeypatch.setattr(
+        market,
+        "cohort_members",
+        lambda **_kwargs: (
+            [
+                market.CohortMember(
+                    manager_key="sleeper:1",
+                    platform="sleeper",
+                    qualification_method="curated_industry",
+                    quality=0.9,
+                    person_id="person:a",
+                    network="Network A",
+                )
+            ],
+            {},
+        ),
+    )
+
+    payload = market.market_payload(window="30d", now_ms=10_000)
+    row = next(item for item in payload["assets"] if item["assetId"] == "player:1")
+
+    # The movement record is real and stays visible.
+    assert row["movementCount"] == 2
+    person = row["personConsensus"]
+    assert person["personVotes"] == 0
+    assert person["mixedPersonSignals"] == 1
+    # The three quantities that do not exist without a voter.
+    assert person["personManagerQuality"] is None
+    assert person["personAgreement"] is None
+    assert person["networkConcentration"] is None
+
+    encoded = json.loads(json.dumps(person))
+    assert "personManagerQuality" in encoded
+    assert encoded["personManagerQuality"] is None
+
+
+def test_an_uncountable_action_does_not_mint_a_phantom_asset_row(monkeypatch):
+    """A movement we cannot count must not create a row either.
+
+    ``_aggregate_window`` used to ``setdefault`` the asset entry BEFORE
+    checking the action, so an asset whose only movements in the window
+    carried an action that is neither ``add`` nor ``drop`` was emitted with
+    zero buys, zero sells and zero movements — and ``managerQuality: 1.0``
+    out of the ``qualityObservations == 0`` branch, which is an input to
+    ``signal_strength``. Same false-green shape as the zero-voter
+    ``personManagerQuality``, in a field that drives a decision.
+
+    Unreachable in production today: ``src/intel/ledger.py`` refuses any
+    action outside add/drop at ingest, so this changes no live value. The
+    point is that the guarantee is now local instead of borrowed from a
+    filter two modules away.
+    """
+    movements = [
+        {
+            "canonicalAssetId": "player:9",
+            "displayName": "Uncountable",
+            "assetType": "player",
+            "managerKey": "sleeper:1",
+            "canonicalManagerKey": "person:a",
+            "action": "trade_pending",
+            "leagueKey": "sleeper:L1",
+            "transactionKey": "tx0",
+            "movementKey": "mv0",
+            "platform": "sleeper",
+            "timestampMs": 1_000,
+        }
+    ]
+    assert market._aggregate_window(movements, {"sleeper:1": 0.9}) == {}

--- a/tests/sharp/test_person_consensus.py
+++ b/tests/sharp/test_person_consensus.py
@@ -1,3 +1,6 @@
+import re
+from pathlib import Path
+
 from src.sharp.consensus import aggregate_person_consensus
 
 
@@ -115,3 +118,185 @@ def test_a_manager_absent_from_the_quality_map_still_defaults_to_full():
     rows = [movement("p1", "sleeper:9", "person:a", "add", "l1")]
     result = aggregate_person_consensus(rows, {})["p1"]
     assert result["weightedPersonVolume"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# personManagerQuality: four states, none of which may read as another
+# ---------------------------------------------------------------------------
+
+
+def test_zero_voters_reports_unknown_manager_quality_not_maximum():
+    """NO QUALIFYING VOTERS IS UNKNOWN, NOT PERFECT.
+
+    ``quality_total / voters if voters else 1.0`` answered the question
+    "how good are the managers behind this signal?" with **1.0 — the
+    highest possible score** — precisely when nobody qualified to answer
+    it. That is the MISSING IS NEVER ZERO invariant inverted: missing
+    became the maximum rather than the minimum, which is the more
+    dangerous direction because it reads as a green light.
+
+    Reachability is exact, not theoretical. An asset enters the
+    aggregation on any add or drop, but ``voters`` only increments when a
+    person's net is non-zero. So an asset every person both added AND
+    dropped inside the window is emitted with ``mixedPersonSignals > 0``
+    and ``personVotes: 0`` — a row about which the cohort expressed no
+    net opinion at all, stamped with perfect manager quality.
+
+    ``None`` is not a new convention here: ``personAgreement`` three
+    lines below and ``networkConcentration`` above already answer the
+    identical ``voters == 0`` case with ``None``.
+    """
+    rows = [
+        movement("p1", "sleeper:1", "person:a", "add", "l1"),
+        movement("p1", "sleeper:1", "person:a", "drop", "l2"),
+        movement("p1", "sleeper:2", "person:b", "add", "l3"),
+        movement("p1", "sleeper:2", "person:b", "drop", "l4"),
+    ]
+    result = aggregate_person_consensus(rows, {"sleeper:1": 1.0, "sleeper:2": 1.0})["p1"]
+    assert result["personVotes"] == 0
+    assert result["mixedPersonSignals"] == 2
+    assert result["personManagerQuality"] is None
+    # The three undefined-on-no-voters quantities now agree with each other.
+    assert result["personAgreement"] is None
+    assert result["networkConcentration"] is None
+    # The raw evidence is untouched; only the derived ratios are withheld.
+    assert result["personBuys"] == 0
+    assert result["personSells"] == 0
+
+
+def test_a_measured_zero_manager_quality_stays_zero():
+    """UNKNOWN AND WORST ARE DIFFERENT ANSWERS.
+
+    The repair must not overshoot into treating a genuinely measured 0.0
+    as missing. A cohort of one manager scored 0.0 HAS an answer, and the
+    answer is the floor.
+    """
+    rows = [movement("p1", "sleeper:1", "person:a", "add", "l1")]
+    result = aggregate_person_consensus(rows, {"sleeper:1": 0.0})["p1"]
+    assert result["personVotes"] == 1
+    assert result["personManagerQuality"] == 0.0
+    assert result["personManagerQuality"] is not None
+
+
+def test_manager_quality_is_the_mean_over_qualifying_voters():
+    """With voters present the value is the plain mean, unchanged."""
+    rows = [
+        movement("p1", "sleeper:1", "person:a", "add", "l1"),
+        movement("p1", "sleeper:2", "person:b", "add", "l2"),
+    ]
+    result = aggregate_person_consensus(rows, {"sleeper:1": 1.0, "sleeper:2": 0.5})["p1"]
+    assert result["personVotes"] == 2
+    assert result["personManagerQuality"] == 0.75
+
+
+def test_mixed_only_asset_is_still_emitted_as_a_row():
+    """The row must not be deleted to dodge the question.
+
+    Suppressing zero-voter assets would trade a wrong number for missing
+    evidence of real churn. The row stays; its derived ratios are
+    honestly unavailable.
+    """
+    rows = [
+        movement("p1", "sleeper:1", "person:a", "add", "l1"),
+        movement("p1", "sleeper:1", "person:a", "drop", "l2"),
+    ]
+    result = aggregate_person_consensus(rows, {"sleeper:1": 1.0})
+    assert "p1" in result
+    assert result["p1"]["mixedPersonSignals"] == 1
+    assert result["p1"]["personManagerQuality"] is None
+
+
+# ---------------------------------------------------------------------------
+# Consumer guard
+# ---------------------------------------------------------------------------
+
+_UNDEFINED_WITHOUT_A_VOTER = (
+    "personManagerQuality",
+    "personAgreement",
+    "networkConcentration",
+)
+
+# ``x or 1``, ``x || 1``, ``x ?? 0``, ``float(x or 1.0)`` -- every shape that
+# turns a deliberate ``None`` back into a confident number.
+_COERCION = re.compile(r"(\|\||\bor\b|\?\?)\s*-?\d")
+
+_SEARCH_ROOTS = ("src", "scripts", "frontend/lib", "frontend/components", "frontend/app")
+_SEARCH_SUFFIXES = {".py", ".js", ".jsx", ".ts", ".tsx"}
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _source_files():
+    root = _repo_root()
+    for name in _SEARCH_ROOTS:
+        base = root / name
+        if not base.is_dir():
+            continue
+        for path in base.rglob("*"):
+            if path.suffix not in _SEARCH_SUFFIXES:
+                continue
+            if "node_modules" in path.parts or "__pycache__" in path.parts:
+                continue
+            yield path
+    for extra in ("server.py",):
+        path = root / extra
+        if path.is_file():
+            yield path
+
+
+def test_no_consumer_coerces_an_undefined_person_quantity_back_to_a_number():
+    """Fixing the producer is only half of it.
+
+    ``personManagerQuality`` now publishes ``None`` when no voter qualified.
+    A consumer writing ``quality || 1`` would restore the exact false green
+    the producer stopped emitting, one layer further from the evidence and
+    correspondingly harder to find. There is no such consumer today -- this
+    keeps it that way rather than trusting a grep taken once.
+
+    Deliberately scoped to a coercion to a NUMBER. Reading the field,
+    formatting it, or branching on ``is None`` are all fine; substituting a
+    value for the missing one is not.
+    """
+    offenders = []
+    for path in _source_files():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if not any(field in text for field in _UNDEFINED_WITHOUT_A_VOTER):
+            continue
+        for number, line in enumerate(text.splitlines(), start=1):
+            if not any(field in line for field in _UNDEFINED_WITHOUT_A_VOTER):
+                continue
+            if path.name == "consensus.py" and "if voters else" in line:
+                continue  # the producer's own definition
+            if _COERCION.search(line):
+                offenders.append(f"{path.relative_to(_repo_root())}:{number}: {line.strip()}")
+    assert offenders == [], "undefined person quantity coerced to a number:\n" + "\n".join(
+        offenders
+    )
+
+
+def test_the_consumer_guard_would_actually_catch_a_regression(tmp_path):
+    """A scanner nobody has seen fail is not evidence.
+
+    ``_COERCION`` must match the shapes it exists to catch, in both
+    languages, or the guard above passes for the wrong reason.
+    """
+    caught = [
+        'quality = person["personManagerQuality"] or 1.0',
+        "const q = person.personManagerQuality || 1;",
+        "const q = person.personManagerQuality ?? 0;",
+        'weight = float(row["personAgreement"] or 1)',
+    ]
+    for line in caught:
+        assert _COERCION.search(line), line
+    ignored = [
+        'if person["personManagerQuality"] is None:',
+        'label = fmt(person["personManagerQuality"])',
+        'quality = person.get("personManagerQuality")',
+    ]
+    for line in ignored:
+        assert not _COERCION.search(line), line

--- a/tests/trade/test_faab_comparability.py
+++ b/tests/trade/test_faab_comparability.py
@@ -279,7 +279,8 @@ class TestTargetFormat:
         target = FC.TargetFormat.from_roster_settings(
             {"teamCount": 10, "starters": {"QB": 1, "TE": 1, "SFLEX": 1}},
             league_key="other",
-            scoring_profile="superflex_ppr1",
+            scoring_settings={"rec": 1.0, "bonus_rec_te": 0.0},
+            scoring_evidence="fresh",
             idp_enabled=False,
         )
         assert (target.teams, target.superflex, target.is_2te, target.tep, target.idp) == (
@@ -305,16 +306,20 @@ class TestTargetFormat:
         target = FC.TargetFormat.from_roster_settings(
             entry["rosterSettings"],
             league_key=entry["key"],
-            scoring_profile=entry["scoringProfile"],
             idp_enabled=entry["idpEnabled"],
         )
-        assert (target.teams, target.superflex, target.is_2te, target.tep, target.idp) == (
+        # Roster facts come straight from the shipped JSON...
+        assert (target.teams, target.superflex, target.is_2te, target.idp) == (
             12,
             True,
             True,
             True,
-            True,
         )
+        # ...but TEP is a SCORING fact and the registry entry does not carry
+        # one, so it is unknown here.  It used to read ``True`` off the
+        # ``superflex_tep15_ppr1`` LABEL, which is measurably wrong for this
+        # league: its 2026 card grants TEs no premium at all.
+        assert target.tep is None
 
     def test_an_unresolvable_league_degrades_rather_than_raising(self):
         """A registry that cannot answer must not take the waiver page down —
@@ -336,16 +341,125 @@ class TestTargetFormat:
             None,
         )
 
-    def test_a_tep_profile_label_is_positive_evidence_on_its_own(self):
-        """TEP is a SCORING property.  A profile that says so settles it even
-        when the starter block is missing; without one, an unknown starter
-        block leaves TEP unknown rather than false."""
-        labelled = FC.TargetFormat.from_roster_settings(
-            {"teamCount": 12}, scoring_profile="superflex_tep15_ppr1"
+
+class TestTepIsAFactNotALabel:
+    """TEP is decided by the league's ACTUAL scoring card.
+
+    The scoring-profile label decides nothing here.  Both live leagues carry
+    ``superflex_tep15_ppr1`` while differing on 35 of 48 scoring keys, and
+    ``dynasty_main``'s 2026 card grants TEs no premium at all
+    (``bonus_rec_te 0.0`` / ``bonus_fd_te 1.0``, measured ×1.000 against WR by
+    the golden-validated scorer — the LI-7 / ADR-009 correction).  The label
+    said TEP anyway, so the crowd market matched this league against external
+    TE-premium leagues on a premium the commissioner had removed.
+    """
+
+    @staticmethod
+    def _target(scoring, evidence="fresh"):
+        return FC.TargetFormat.from_roster_settings(
+            {"teamCount": 12, "starters": {"QB": 1, "TE": 2, "SFLEX": 1}},
+            league_key="t",
+            scoring_settings=scoring,
+            scoring_evidence=evidence,
         )
-        assert labelled.tep is True and labelled.is_2te is None
-        unlabelled = FC.TargetFormat.from_roster_settings({"teamCount": 12})
-        assert unlabelled.tep is None
+
+    def test_a_real_te_bonus_proves_tep(self):
+        assert self._target({"rec": 1.0, "bonus_rec_te": 0.5}).tep is True
+
+    def test_a_first_down_te_bonus_also_proves_tep(self):
+        """``bonus_rec_te`` alone is not the rule.  ``bonus_fd_te`` was half of
+        this league's measured 2025 premium, so a rule reading only receptions
+        would call a first-down-premium league non-TEP."""
+        assert self._target({"bonus_fd_te": 1.35, "bonus_fd_wr": 1.0}).tep is True
+
+    def test_a_bonus_every_pass_catcher_receives_is_not_a_te_premium(self):
+        """Reusing ``te_premium.measure_te_demand`` buys this for free: each TE
+        key is compared against its WR/RB counterpart, so a league-wide
+        first-down bonus advantages nobody."""
+        assert self._target({"bonus_fd_te": 1.0, "bonus_fd_wr": 1.0}).tep is False
+
+    def test_a_card_with_no_te_premium_is_false_not_unknown(self):
+        """``dynasty_main``'s real 2026 shape.  A proven absence is an answer.
+
+        Both first-down bonuses are present and EQUAL, which is the measured
+        2026 card ("``bonus_fd_te 1.0`` ... identical to WR").  An absent WR
+        comparator would be a different league and a genuine TE edge.
+        """
+        card = {"rec": 1.0, "bonus_rec_te": 0.0, "bonus_fd_te": 1.0, "bonus_fd_wr": 1.0}
+        assert self._target(card).tep is False
+
+    def test_two_mandatory_te_starters_do_not_make_the_scoring_a_premium(self):
+        """The roster requirement is carried separately as ``is_2te``.
+
+        Letting it also decide ``tep`` would count one fact twice — once as a
+        hard gate and once as a soft demotion — which is why the roster half is
+        withheld from ``measure_te_demand`` here.
+        """
+        target = self._target({"rec": 1.0, "bonus_rec_te": 0.0})
+        assert target.is_2te is True
+        assert target.tep is False
+
+    @pytest.mark.parametrize("evidence", ["stale", "missing", "", "unknown"])
+    def test_unproven_scoring_is_unknown_never_non_tep(self, evidence):
+        """A card proves when it was taken, not that it is still true.  Only
+        ``fresh`` authorizes the claim; everything else is UNKNOWN — and
+        UNKNOWN must not silently become "no TE premium"."""
+        assert self._target({"bonus_rec_te": 0.5}, evidence=evidence).tep is None
+
+    def test_no_card_at_all_is_unknown(self):
+        assert self._target(None).tep is None
+        assert self._target({}).tep is None
+
+    def test_a_caller_that_supplies_nothing_fails_closed(self):
+        """The defaults are "we were told nothing", so a call site that forgets
+        to pass the card cannot accidentally assert a format."""
+        assert FC.TargetFormat.from_roster_settings({"teamCount": 12}).tep is None
+
+    def test_unknown_tep_excludes_every_external_league(self):
+        """UNKNOWN does not become non-TEP, and it does not pass as a match.
+
+        ``classify`` hard-excludes on ``target_format_unknown:tep``, so an
+        unprovable target admits nothing rather than quietly comparing itself
+        against offense-scoring leagues.
+        """
+        target = self._target({"bonus_rec_te": 0.5}, evidence="stale")
+        verdict = FC.classify(_fmt(tep_level=2), target)
+        assert verdict.excluded
+        assert "target_format_unknown:tep" in verdict.reasons
+
+
+class TestTepSeverityIsDormant:
+    """Severity is UNKNOWN, and unknown is silent.
+
+    KTC states a 4-level vendor taxonomy (``tepLevel`` 0-3); our side has a
+    continuous per-key scoring edge in points.  No published crosswalk exists
+    and this repo has measured none, so mapping one onto the other would be
+    invented methodology existing only to make a branch execute.
+    """
+
+    def test_the_target_never_claims_a_severity(self):
+        target = FC.TargetFormat.from_roster_settings(
+            {"teamCount": 12, "starters": {"TE": 3, "SFLEX": 1}},
+            scoring_settings={"bonus_rec_te": 2.0},
+            scoring_evidence="fresh",
+        )
+        # A big TE bonus and three mandatory TE starters still yields no level.
+        assert target.tep is True
+        assert target.tep_level is None
+
+    def test_the_severity_branch_cannot_fire_and_changes_no_tier(self):
+        """Dormant means the soft reason is never emitted, not that it is
+        emitted as zero."""
+        target = FC.TargetFormat.from_roster_settings(
+            {"teamCount": 12, "starters": {"TE": 2, "SFLEX": 1}},
+            scoring_settings={"bonus_rec_te": 0.5},
+            scoring_evidence="fresh",
+        )
+        # tepLevel 3 vs an unknown target level: the widest gap the feed can
+        # state, against a target that states none.
+        verdict = FC.classify(_fmt(tep_level=3, is_2te=True), target)
+        assert not verdict.excluded
+        assert "tep_severity_gap" not in verdict.reasons
 
 
 class TestAnUnknownTargetFailsClosed:


### PR DESCRIPTION
**READY FOR INTEGRATION — Claude 5 merges. I do not.**

Two live semantic defects, both the same failure: *absence of evidence* published as a maximally confident answer. Plus the L2/L3 verification procedures for the Lane 4 V1 rows, and the #804 cadence question written up as an owner decision.

Board proof up front: `golden_board` before/after with code as the only variable is **byte-identical** (sha256 `2c10f3c5163231…`), `board_diff --expect-no-value-change` reports **0 values moved, 0 ranks changed**.

---

## 1 — Zero-voter Sharp quality: `1.0` → `None`

`src/sharp/consensus.py`

```python
"personManagerQuality": quality_total / voters if voters else 1.0,
```

"How good are the managers behind this signal?" was answered with **the highest possible score** exactly when nobody qualified to answer it. That is MISSING IS NEVER ZERO inverted, in the more dangerous direction — missing became the maximum, which reads as a green light rather than as an absence.

**Reachable, not theoretical.** An asset enters the aggregation on any add or drop, but `voters` only increments when a person's net is non-zero. So an asset that every person both added *and* dropped inside the window is still emitted — `mixedPersonSignals > 0`, `personVotes: 0`, and perfect manager quality.

The file was already internally inconsistent about this, which is why it reads as a defect and not a choice: `personAgreement` three lines below and `networkConcentration` above both answer the identical `voters == 0` case with `None`.

RED proven first: the new tests fail on `393e14df1` before the one-line repair.

Four states, each separately pinned so none can read as another:

| state | value |
|---|---|
| zero voters | `None` (UNKNOWN) |
| a measured `0.0` | stays `0.0` |
| ≥ 1 voter | the actual mean |
| no weighted volume | `networkConcentration is None` |

**Consumer side, traced rather than assumed.** `personManagerQuality` has no reader: it reaches `/api/sharp/market` embedded verbatim as `personConsensus`, and nothing in `src/`, `scripts/`, `server.py` or `frontend/` consumes it. Fixing a producer and leaving a consumer doing `|| 1` would republish the same false green one layer further from the evidence, so the absence is now **enforced by a scanner** — with a meta-test proving the scanner actually matches the shapes it exists to catch, in both languages. An end-to-end test asserts the served row and that the field serializes as JSON `null` rather than being dropped (an absent key and a present `1.0` are both readable as "no problem here").

### Second finding, same shape, in a field that *does* drive a decision

`_aggregate_window` created the asset entry **before** checking the action, so an asset whose only movements carried an uncountable action was emitted with zero buys, zero sells, zero movements and `managerQuality: 1.0` out of the `qualityObservations == 0` branch — an input to `signal_strength`. Unreachable in production because `src/intel/ledger.py` refuses non-add/drop actions at ingest, so **this changes no live value**; the guarantee is now local instead of borrowed from a filter two modules away.

### Live impact — measured, not assumed

- **No Sharp decision changes**, because the repaired field has no decision consumer (established by the scanner above, not by a one-time grep).
- The **published field** changes from `1.0` to `null` on every `/api/sharp/market` row where `personVotes == 0`.
- **The exact row count is not measurable in this environment** and I am not reporting a zero: the local platform ledger holds no movements (only `meta`) and `cohort_members()` returns 0, so the local count of 0 is an artifact of an empty ledger, not a finding. It must be read off the deployed board — procedure in the new doc.

---

## 2 — TEP comparability is a fact, read from the scoring card

`src/trade/faab_comparability.py`

`TargetFormat.tep` was `"tep" in scoring_profile` — a hand-authored string in `config/leagues/registry.json`. `MASTER_PRODUCT_PLAN` §4.10 is explicit that a profile label may decide model/config identity and **never** a factual question.

**It was not a theoretical risk.** This repo has already *proven*, with the golden-validated deterministic scorer against 1,415 host-awarded player-weeks, that `dynasty_main`'s 2026 scoring grants tight ends **no premium at all** — `bonus_rec_te 0.0`, `bonus_fd_te 1.0`, TE 21.55 vs WR 21.55, ×1.000 (the LI-7 / ADR-009 correction in `src/api/data_contract.py`). The commissioner removed the premium; the label did not change. So the crowd market has been matching this league against external TE-premium leagues and excluding the ones that actually match its scoring — and the crowd pool feeds `rival_bid_cdf` at weight **0.6**, so that moves real recommended bids.

The rule now:

| evidence | `tep` |
|---|---|
| a **fresh** card whose TE keys beat their WR/RB counterparts | `True` |
| a **fresh** card where they do not | `False` |
| `stale` / `missing` / no card | `None` — UNKNOWN |

Freshness is `league_registry.scoring_evidence_state`, unchanged — not a new budget.

The measurement **reuses the canonical owner**, `league_intel.te_premium.measure_te_demand`, which compares each TE-specific bonus against its WR/RB counterpart, so a league paying *every* pass-catcher a first-down bonus is correctly not a TE-premium league. Reading `bonus_rec_te` alone would be a second owner **and** would miss `bonus_fd_te`, which was half of this league's measured 2025 premium.

The roster half is deliberately withheld from that call: `is_2te` already carries the mandatory-TE-starter requirement as its own **soft** signal, so feeding it in again would count one fact twice — once hard, once soft.

**UNKNOWN does not become non-TEP.** `tep is None` hard-excludes on `target_format_unknown:tep`.

**And an unprovable target now says so.** A fresh ledger that admitted nothing because we cannot describe our own league used to report `no_crowd_ledger` — sending the reader to the feed when the fix is a registry entry or a scoring card nobody fetched. `CrowdMarket` carries `targetFormatUnknown`, and `crowd_refusal_reason` answers `target_format_unverifiable:<fields>` **ahead of** the freshness checks, because freshness is moot when no row is admissible. `REQUIRED_TARGET_FIELDS` / `unprovable_target_fields` are one definition shared by the gate, the census and the refusal.

### Severity stays dormant, deliberately

`tep_level` is `None` **by construction**, so `tep_severity_gap` cannot fire. KTC states a 4-level *vendor taxonomy*; our side has a *continuous* per-key scoring edge; no published crosswalk exists and this repo has measured none. `te_premium._REQUIRED_TE_TO_BASIS` is the obvious candidate and carries its own note saying it encodes an unmeasured operator assumption — promoting it into a comparability gate so a branch executes would be inventing methodology to satisfy a table.

**What would authorize it:** external leagues observed with *both* a stated `tepLevel` and a readable scoring card, enough to **fit** the mapping rather than assume it. The feed states the level and never the card.

### Measured consequence — reported, not buried

The admitted population **inverts** wherever the card and the label disagree. On the shipped synthetic fixture (12 waiver rows, `dynasty_main` shape): comparable rows **3 → 1** under a proven no-premium card, and **0** with no card at all.

`data/faab/` and `data/leagues/` do not exist in this environment, so locally **both** leagues resolve `scoring_evidence_state == "missing"` and the crowd market excludes everything. On a cold deploy the remedy is `scripts/fetch_league_scoring.py`. The production numbers must be read off the deployed ledger — and 129e in the new doc is exactly that check.

---

## 3 — L2/L3 verification procedures (documentation only)

`docs/lane4/L2_L3_VERIFICATION_PROCEDURES.md` — the executable checklist per Lane 4 row: **V1-57** (timer firing, and why a green manual run does not satisfy it), **V1-129** (a–e: provenance on new rows, legacy rows honestly `unverified`, offense-only refuses IDP, stale ledger refuses pricing, and the new target-describability check), **V1-60** (truthful degraded FFPC state), **V1-63/64** (L1 only — no production step is invented), **V1-65**.

Levels are quoted from the contract §2 so the file cannot drift from it. Two rules bind every procedure: **no production authentication is bypassed** (a `401` is recorded as `unverifiable_unauthenticated`, never rewritten as a pass) and **no cohort, ledger or roster is manufactured**. **V1-58 / V1-59 stay `BLOCKED`**, with the single credential that unblocks them named.

Open and *not* closed by this PR, flagged rather than quietly claimed: V1-63's contract status is `NOT STARTED` against `W15-F009` "missing field". Nothing here adds a field — this repairs the semantics of fields that exist. Whether `inv 4.6` is satisfied by the person-level block is an Integration reading, not mine to declare.

---

## 4 — #804 capture cadence (report only, no code)

`docs/lane4/LANE4_804_CAPTURE_CADENCE_DECISION.md`. **#921 stays frozen and its flag stays OFF.** Every-build capture is 38.8 MB/day (~14.2 GB/yr); daily is ~3.2 MB/day (~1.2 GB/yr). Denormalization is only 4–7% of the cost, so cadence is the lever, not schema. Recommends daily and names when every-build would be right. **Proposes no retention or compaction policy** — deleting perishable evidence is an owner decision.

**This changes the V1 percentage by zero.**

---

## Verification

| check | result |
|---|---|
| RED before the fix | 2 failures on `393e14df1`, both `personManagerQuality is None` |
| `tests/sharp` | 295 → 299 passed |
| `tests/trade` | 539 passed |
| `tests/api/test_faab_recommend_endpoint.py` | 28 passed |
| `ruff check` / `format --check` (pinned `~=0.6.0`) | clean, 1167 files |
| `scripts/check_decision_coercions.py` | clean — no new coercions, no stale allowances |
| `scripts/check_release_candidate.py` | the validated tree IS the tree that will merge |
| `golden_board` + `board_diff --expect-no-value-change` | byte-identical, 0 values, 0 ranks |

Full-suite `-m "not livedata"` is running locally and is slow in this container; **CI on this exact head is the authority** and I will report the result here rather than in place of it. One transient `F` appeared in an early local run and did **not** reproduce in isolation or on re-run — reported because it happened, not because I believe it is real.

Files: `src/sharp/consensus.py`, `src/sharp/market.py`, `src/trade/faab_comparability.py`, `src/trade/faab_history.py`, `server.py`, `scripts/fetch_crowd_faab.py`, `CLAUDE.md`, `docs/faab-external-market-comparability.md`, `docs/lane4/*` + tests.

Not touched: #921's branch, `src/history/`, correlation methodology, weighting, UI, Central Buy/Sell.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqEBEngbUtzXsbHRYrPLkF)_