### PR TITLE
C3-CON-01 / V1-130 + V1-34: the single recommendation-constraint owner, applied during generation

### DIFF
--- a/docs/audits/decision-intelligence-audit-2026-08-04.status.json
+++ b/docs/audits/decision-intelligence-audit-2026-08-04.status.json
@@ -485,16 +485,16 @@
    "auditEvidence": "suggestions.py:1614 `roster = analyze_roster(roster_names, pool, starter_needs)` is called with the ALREADY-FILTERED pool (server.py:5913 builds it with ktc_top_n=150). Measured on the live contract with dynasty_main starter needs, per team: Blaine roster=53 matched=5 total=0; Collin 58/10 total=0; Ed 57/10 total=0; Joey 58/10 total=0; Kich 58/9 total=0; Roy 51/7 total=0; Ty 56/7 total=0; jstuedle",
    "auditId": "T-9",
    "path": "src/trade/suggestions.py",
-   "signature": "analyze_roster(roster_names, pool, starter_needs)",
+   "signature": "analyze_roster(roster_names, pool",
    "status": "open",
-   "verifiedBy": "Still called with a name list the pool can only partly resolve.",
+   "verifiedBy": "Still called with a name list the pool can only partly resolve.\n\nSIGNATURE RESPELLED 2026-08-19 (C3-CON-01), STATUS DELIBERATELY UNCHANGED. The call site gained a `constraints=` keyword when the recommendation-constraint owner was wired in, so the old needle `analyze_roster(roster_names, pool, starter_needs)` stopped matching and the probe flipped to signature_absent. That is the case this module's own docstring warns about: an absent signature means the cited MECHANISM changed, not that the defect is fixed. It is not fixed \u2014 C3-CON-01 decides which resolved assets may be OFFERED and does nothing whatever about resolution, which is what T-9 is about. The needle is respelled to the part that IS the defect (the name list reaching `analyze_roster`) rather than to the full argument list, so a further keyword cannot flip it again and invite a second close-on-a-respelling.",
    "closedBy": null,
    "measuredEffect": null,
    "batch": null,
    "probe": {
     "result": "signature_present",
     "path": "src/trade/suggestions.py",
-    "needle": "analyze_roster(roster_names, pool, starter_needs)"
+    "needle": "analyze_roster(roster_names, pool"
    }
   },
   {

--- a/scripts/audit_status.py
+++ b/scripts/audit_status.py
@@ -432,9 +432,22 @@ _FINDINGS: dict[str, tuple[str, str | None, str | None, str, str]] = {
     "C26": (
         "T-9",
         "src/trade/suggestions.py",
-        "analyze_roster(roster_names, pool, starter_needs)",
+        "analyze_roster(roster_names, pool",
         OPEN,
-        "Still called with a name list the pool can only partly resolve.",
+        "Still called with a name list the pool can only partly resolve.\n\n"
+        "SIGNATURE RESPELLED 2026-08-19 (C3-CON-01), STATUS DELIBERATELY "
+        "UNCHANGED. The call site gained a `constraints=` keyword when the "
+        "recommendation-constraint owner was wired in, so the old needle "
+        "`analyze_roster(roster_names, pool, starter_needs)` stopped matching "
+        "and the probe flipped to signature_absent. That is the case this "
+        "module's own docstring warns about: an absent signature means the "
+        "cited MECHANISM changed, not that the defect is fixed. It is not "
+        "fixed — C3-CON-01 decides which resolved assets may be OFFERED and "
+        "does nothing whatever about resolution, which is what T-9 is about. "
+        "The needle is respelled to the part that IS the defect (the name "
+        "list reaching `analyze_roster`) rather than to the full argument "
+        "list, so a further keyword cannot flip it again and invite a second "
+        "close-on-a-respelling.",
     ),
     "C27": (
         "T-10",

--- a/server.py
+++ b/server.py
@@ -7157,6 +7157,13 @@ async def post_trade_suggestions(request: Request):
         request, body, league_cfg
     )
 
+    # C3-CON-01 — resolved on the request thread (it reads the session and the
+    # user store) and handed to the generator, which applies it during
+    # enumeration.
+    constraints = _constraints_for_request(
+        request, contract, league_cfg, surface="/api/trade/suggestions"
+    )
+
     # Pool build + suggestion generation are heavy CPU passes over the
     # full playersArray × league rosters — run them on a worker thread
     # exactly like /api/trade/finder already does, instead of stalling
@@ -7188,6 +7195,7 @@ async def post_trade_suggestions(request: Request):
             starter_needs=starter_needs,
             ktc_top_n=ktc_top_n,
             capacity_context=capacity_context,
+            constraints=constraints,
         )
 
     try:
@@ -7296,6 +7304,13 @@ async def post_trade_finder(request: Request):
         surface="/api/trade/finder",
     )
 
+    # C3-CON-01 — the finder was the only engine that already accepted
+    # `constraints`, and this route never passed any, so it ran unconstrained in
+    # production while the parameter looked wired.
+    finder_constraints = _constraints_for_request(
+        request, contract, league_cfg, surface="/api/trade/finder"
+    )
+
     try:
         result = await run_in_threadpool(
             find_trades,
@@ -7305,6 +7320,7 @@ async def post_trade_finder(request: Request):
             sleeper_teams=sleeper_teams,
             ktc_top_n=finder_ktc_top_n,
             capacity_context=finder_capacity_context,
+            constraints=finder_constraints,
             # F-6 (audit finding K): the contract carries `playersArray`
             # with `rankDerivedValue` — the board the user actually sees.
             # Without this the finder arbitrages the raw scraper
@@ -7688,6 +7704,13 @@ async def post_angle_packages(request: Request):
     if mode == "acquire":
         from src.trade.angle import find_acquisition_packages
 
+        # C3-CON-01.  Acquire mode is the one Angle mode that CHOOSES outgoing
+        # assets — the other two enumerate what we would receive against a send
+        # side the user typed — so it is the one that carries constraints.
+        angle_constraints = _constraints_for_request(
+            request, contract, league_cfg, surface="/api/angle/packages"
+        )
+
         try:
             result = await run_in_threadpool(
                 find_acquisition_packages,
@@ -7703,6 +7726,7 @@ async def post_angle_packages(request: Request):
                 min_player_my_value=min_player,
                 include_idp=include_idp,
                 capacity_context=angle_capacity_context,
+                constraints=angle_constraints,
             )
         except Exception as exc:  # noqa: BLE001
             log.error(f"Angle acquire failed: {exc}")
@@ -8020,6 +8044,53 @@ def _stamp_valuation_mode(result: Any, mode: str, note: str | None) -> None:
             warnings.append(note)
         else:
             result["warnings"] = [note]
+
+
+def _constraints_for_request(
+    request: "Request",
+    contract: dict | None,
+    league_cfg: Any,
+    *,
+    surface: str,
+) -> Any:
+    """Recommendation constraints for one (user, league), or the fail-closed set.
+
+    ONE place, because C3-CON-01 is consumed by every automatically generated
+    trade surface and §2.3 forbids page-local copies.  The canonical owner is
+    ``src/trade/constraints``; this only resolves its inputs.
+
+    **Read-only plumbing.**  It reads a stored per-(user, league) protection
+    block if one exists and never writes one — the storage service and the UI
+    that would populate it are ``C3-CON-02`` / ``C3-CON-03``, separate rows.
+    Until those land this resolves to "nothing configured" for every user, which
+    is a legitimate answer and NOT a failure: §7 acceptance 12 and the owner's
+    own ``test_no_configured_preference_is_not_a_failure`` both turn on that
+    distinction.
+
+    Fail-closed is reserved for genuinely not knowing.  An anonymous request has
+    no protections, which is knowable; a store that RAISES is not, and returns
+    ``UNRESOLVED`` so every generator refuses rather than recommending under
+    constraints it could not read.
+    """
+    from src.trade.constraints import UNRESOLVED, resolve_constraints
+
+    league_key = getattr(league_cfg, "key", None)
+    try:
+        persistent: dict | None = None
+        session = _get_auth_session(request)
+        if session:
+            username = str(session.get("username") or "").strip()
+            if username:
+                state = _user_kv.get_user_state(username) or {}
+                by_league = state.get("tradeConstraintsByLeague") or {}
+                if isinstance(by_league, dict) and league_key:
+                    block = by_league.get(league_key)
+                    if isinstance(block, dict):
+                        persistent = block
+        return resolve_constraints(contract=contract, persistent=persistent)
+    except Exception as exc:  # noqa: BLE001 — unknown must not become unconstrained
+        log.warning("recommendation constraints unresolved for %s: %s", surface, exc)
+        return UNRESOLVED
 
 
 def _capacity_context_for(

--- a/src/packages/__init__.py
+++ b/src/packages/__init__.py
@@ -13,6 +13,10 @@ See ``src/packages/construction.py`` for what this owns and what it refuses to.
 
 from src.packages.construction import (
     MAX_PLAYER_COUNT_DIFFERENCE,
+    RECEIVE,
+    SEND,
+    UNCONSTRAINED_OUTGOING,
+    ConstraintMisapplied,
     EligibilityPolicy,
     EnumerationReport,
     PackageAsset,
@@ -30,6 +34,10 @@ from src.packages.construction import (
 
 __all__ = [
     "MAX_PLAYER_COUNT_DIFFERENCE",
+    "RECEIVE",
+    "SEND",
+    "UNCONSTRAINED_OUTGOING",
+    "ConstraintMisapplied",
     "EligibilityPolicy",
     "EnumerationReport",
     "PackageAsset",

--- a/src/packages/construction.py
+++ b/src/packages/construction.py
@@ -331,7 +331,9 @@ def _resolve_outgoing(policy: Any, *, side: str) -> "EligibilityPolicy | None":
             "acquisition target"
         )
     if not isinstance(policy, EligibilityPolicy):
-        raise ConstraintMisapplied(f"outgoing_policy must be an EligibilityPolicy, got {type(policy).__name__}")
+        raise ConstraintMisapplied(
+            f"outgoing_policy must be an EligibilityPolicy, got {type(policy).__name__}"
+        )
     return policy
 
 

--- a/src/packages/construction.py
+++ b/src/packages/construction.py
@@ -67,12 +67,16 @@ from itertools import combinations
 from typing import Any, Callable, Iterable, Iterator, Protocol, Sequence
 
 __all__ = [
+    "ConstraintMisapplied",
     "EligibilityPolicy",
     "EnumerationReport",
     "PackageAsset",
     "MAX_PLAYER_COUNT_DIFFERENCE",
     "PackageShape",
+    "RECEIVE",
+    "SEND",
     "SidePair",
+    "UNCONSTRAINED_OUTGOING",
     "adapt_assets",
     "by_value_desc",
     "enumerate_packages",
@@ -258,6 +262,79 @@ class EligibilityPolicy:
 # ── Shapes ───────────────────────────────────────────────────────────
 
 
+# ── Outgoing constraints (C3-CON-01) ─────────────────────────────────
+#
+# Recommendation constraints are OUTGOING-ONLY: a protected player may not be
+# put on the side the user gives away, and stays a perfectly valid acquisition
+# target on the side they receive (spec §2.2).  That asymmetry is a property of
+# the SUBSTRATE rather than of each product, because §2.3 forbids page-local
+# copies and §6 forbids post-filtering — and because a rule enforced in one
+# place cannot be forgotten by the ninth consumer.
+
+SEND = "send"
+RECEIVE = "receive"
+
+
+class _Unconstrained:
+    """Sentinel: this caller has DECIDED that no outgoing constraint applies.
+
+    Not ``None``.  ``outgoing_policy`` is a required argument precisely so a
+    consumer cannot omit it, and accepting ``None`` would hand back the omission
+    it exists to prevent — an unset variable and a considered "nothing protects
+    this roster" would look identical at the call site and in review.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return "UNCONSTRAINED_OUTGOING"
+
+
+#: Pass this when the caller has established that nothing constrains the
+#: outgoing side.  It is a claim, and it reads like one.
+UNCONSTRAINED_OUTGOING = _Unconstrained()
+
+OutgoingPolicy = "EligibilityPolicy | _Unconstrained"
+
+
+class ConstraintMisapplied(ValueError):
+    """An outgoing constraint was aimed at something that is not outgoing.
+
+    Two forbidden states, and they are opposite halves of the same rule:
+
+    * an outgoing policy handed to a RECEIVE-side enumeration — that would
+      block a protected player from being ACQUIRED, which inverts §2.2;
+    * a ``required`` asset that the outgoing policy excludes — §3.3's
+      "persistent protection outranks temporary refinement", which a
+      ``required`` list would otherwise bypass silently, since required assets
+      deliberately do not face the ordinary policy.
+
+    Raised rather than silently corrected.  §6 step 4 is "reject
+    contradictory/forbidden state"; a caller catches this and renders an honest
+    no-result.
+    """
+
+
+def _resolve_outgoing(policy: Any, *, side: str) -> "EligibilityPolicy | None":
+    """Validate the outgoing policy against the side it is being applied to."""
+    if policy is None:
+        raise ConstraintMisapplied(
+            "outgoing_policy is required and must not be None — pass "
+            "UNCONSTRAINED_OUTGOING to state that nothing constrains this side"
+        )
+    if isinstance(policy, _Unconstrained):
+        return None
+    if side == RECEIVE:
+        raise ConstraintMisapplied(
+            "an outgoing constraint policy was applied to the RECEIVE side; "
+            "protection is outgoing-only and a protected player stays a valid "
+            "acquisition target"
+        )
+    if not isinstance(policy, EligibilityPolicy):
+        raise ConstraintMisapplied(f"outgoing_policy must be an EligibilityPolicy, got {type(policy).__name__}")
+    return policy
+
+
 @dataclass(frozen=True)
 class PackageShape:
     """How many assets each side may contribute."""
@@ -352,6 +429,15 @@ class EnumerationReport:
     #: C3-TOPO-01 refusals.  Reported rather than silent: "no 3-for-1 came
     #: back" and "3-for-1 is not a shape we propose" are different answers.
     topology_rejected: int = 0
+    #: C3-CON-01: outgoing assets the recommendation constraints withheld.
+    #: Counted separately from ``our_excluded_ineligible`` because they are a
+    #: different sentence — "you told us not to trade him" is an answer, and
+    #: "he is roster clog" is a mechanic.  A surface that cannot tell them
+    #: apart cannot explain a short list.
+    our_excluded_constrained: int = 0
+    #: True once an outgoing policy was actually applied, so an empty result
+    #: under constraints is distinguishable from an empty result without any.
+    outgoing_constrained: bool = False
 
     @property
     def truncated(self) -> bool:
@@ -370,6 +456,8 @@ class EnumerationReport:
             "ourExcludedUnpriced": self.our_excluded_unpriced,
             "theirExcludedUnpriced": self.their_excluded_unpriced,
             "topologyRejected": self.topology_rejected,
+            "ourExcludedConstrained": self.our_excluded_constrained,
+            "outgoingConstrained": self.outgoing_constrained,
             "ourTruncatedTo": self.our_truncated_to,
             "theirTruncatedTo": self.their_truncated_to,
             "shapes": list(self.shapes),
@@ -403,6 +491,8 @@ def enumerate_sides(
     assets: Iterable[Any],
     sizes: Sequence[int],
     *,
+    side: str,
+    outgoing_policy: Any,
     policy: EligibilityPolicy | None = None,
     required: Sequence[Any] = (),
     pool_limit: int | None = None,
@@ -422,18 +512,42 @@ def enumerate_sides(
     ``policy`` — a caller that has already decided an asset is in the package
     is not asking whether it is eligible.  They DO count against ``sizes``, so
     asking for 2-asset sides with one required asset enumerates one filler.
+
+    ``side`` says which half of the trade this is (:data:`SEND` or
+    :data:`RECEIVE`), and ``outgoing_policy`` carries the C3-CON-01
+    recommendation constraints — both REQUIRED, because this function is used
+    for both directions (Angle fixes the offer and enumerates what we receive
+    in one mode, and fixes the target and enumerates what we send in the other)
+    so the substrate cannot infer which side it is looking at.  A caller with
+    nothing to enforce passes :data:`UNCONSTRAINED_OUTGOING`, which is a claim
+    rather than an omission.
+
+    ``required`` does NOT escape the outgoing policy, even though it escapes
+    ``policy``: §3.3 says persistent protection outranks temporary refinement,
+    so forcing a protected player in through the required list raises
+    :class:`ConstraintMisapplied` instead of quietly succeeding.
     """
+    outgoing = _resolve_outgoing(outgoing_policy, side=side)
     policy = policy or EligibilityPolicy()
     report = EnumerationReport()
+    report.outgoing_constrained = outgoing is not None
 
     pool = adapt_assets(assets) if adapt else list(assets)
     fixed = tuple(adapt_assets(required) if adapt else list(required))
     report.our_pool_size = len(pool)
     report.name_keyed_assets = sum(1 for a in (*pool, *fixed) if a.key_is_name_fallback)
 
+    if outgoing is not None:
+        forced = [a for a in fixed if not outgoing.admits(a)]
+        if forced:
+            raise ConstraintMisapplied(
+                "required outgoing asset(s) are constrained and cannot be forced "
+                f"into a recommendation: {', '.join(sorted(a.name for a in forced))}"
+            )
+
     fixed_keys = {a.key for a in fixed}
     pool = [a for a in pool if a.key not in fixed_keys]
-    pool = _eligible(pool, policy, report, ours=True)
+    pool = _eligible(pool, policy, report, ours=True, outgoing=outgoing)
 
     order = rank_key or by_value_desc
     pool.sort(key=order)
@@ -476,11 +590,24 @@ def _eligible(
     report: EnumerationReport,
     *,
     ours: bool,
+    outgoing: EligibilityPolicy | None = None,
 ) -> list[PackageAsset]:
+    """Filter one pool.
+
+    ``outgoing`` is the recommendation-constraint policy and is only ever
+    supplied for the side the user GIVES AWAY.  It is checked before the
+    ordinary mechanics so the count is attributable: an asset withheld because
+    the user protects him is not "ineligible", and reporting it as such would
+    make a deliberate refusal look like roster clog.
+    """
     kept: list[PackageAsset] = []
     ineligible = 0
     unpriced = 0
+    constrained = 0
     for asset in assets:
+        if outgoing is not None and not outgoing.admits(asset):
+            constrained += 1
+            continue
         if not asset.value_known and not policy.allow_unknown_value:
             unpriced += 1
             continue
@@ -491,6 +618,7 @@ def _eligible(
     if ours:
         report.our_excluded_ineligible = ineligible
         report.our_excluded_unpriced = unpriced
+        report.our_excluded_constrained = constrained
     else:
         report.their_excluded_ineligible = ineligible
         report.their_excluded_unpriced = unpriced
@@ -501,6 +629,7 @@ def enumerate_packages(
     our_assets: Iterable[Any],
     their_assets: Iterable[Any],
     *,
+    outgoing_policy: Any,
     policy: EligibilityPolicy | None = None,
     shapes: Sequence[PackageShape] | None = None,
     max_per_side: int = 2,
@@ -522,9 +651,20 @@ def enumerate_packages(
     This owns mechanics ONLY.  It does not score, rank by quality, or decide
     which package is good; ``rank_key`` orders the POOLS so that a truncation
     keeps the assets a product cares about, and defaults to descending value.
+
+    ``outgoing_policy`` is REQUIRED and carries the C3-CON-01 recommendation
+    constraints.  It is applied to ``our_assets`` and **never** to
+    ``their_assets`` — the asymmetry is the rule, not an implementation detail
+    (§2.2: a protected player is blocked outgoing and stays a valid incoming
+    target).  A caller with nothing to enforce passes
+    :data:`UNCONSTRAINED_OUTGOING`; there is no default, so the ninth consumer
+    of this substrate cannot generate an unconstrained recommendation by
+    forgetting a keyword.
     """
+    outgoing = _resolve_outgoing(outgoing_policy, side=SEND)
     policy = policy or EligibilityPolicy()
     report = EnumerationReport()
+    report.outgoing_constrained = outgoing is not None
 
     ours = adapt_assets(our_assets) if adapt else list(our_assets)
     theirs = adapt_assets(their_assets) if adapt else list(their_assets)
@@ -532,7 +672,8 @@ def enumerate_packages(
     report.their_pool_size = len(theirs)
     report.name_keyed_assets = sum(1 for a in (*ours, *theirs) if a.key_is_name_fallback)
 
-    ours = _eligible(ours, policy, report, ours=True)
+    ours = _eligible(ours, policy, report, ours=True, outgoing=outgoing)
+    # No ``outgoing=`` here, and that is the whole of §2.2.
     theirs = _eligible(theirs, policy, report, ours=False)
 
     order = rank_key or by_value_desc

--- a/src/trade/angle.py
+++ b/src/trade/angle.py
@@ -94,6 +94,9 @@ from src.league_intel.cross_market import (
 # VA injects the consolidation premium on the SMALLER side — so the
 # side receiving more studs sees its effective total climb, and the
 # thresholds get evaluated on the adjusted numbers.
+from src.packages import RECEIVE as _RECEIVE
+from src.packages import SEND as _SEND
+from src.packages import UNCONSTRAINED_OUTGOING as _UNCONSTRAINED_OUTGOING
 from src.packages import EligibilityPolicy as _EligibilityPolicy
 from src.trade.ktc_va import (
     adjusted_pair_totals as _adjusted_pair_totals,  # noqa: F401
@@ -593,13 +596,23 @@ _ANGLE_POLICY = _EligibilityPolicy(min_value=None, allow_unknown_value=True, req
 # carry no canonical asset id, which means the dedup identity here falls back
 # to names — the substrate reports that rather than letting it pass as an id
 # key.
-def _angle_sides(pool, sizes, *, required=()):
-    """Every candidate package side, via the canonical substrate."""
+def _angle_sides(pool, sizes, *, side, outgoing_policy, required=()):
+    """Every candidate package side, via the canonical substrate.
+
+    ``side`` and ``outgoing_policy`` are REQUIRED and are threaded from the
+    caller because this helper serves both directions: offer mode fixes what we
+    send and enumerates what we RECEIVE, acquire mode fixes what we receive and
+    enumerates what we SEND.  The substrate cannot infer that, and guessing
+    would put a C3-CON-01 outgoing constraint on an incoming pool — the §2.2
+    asymmetry inverted, which blocks acquiring a player the user protects.
+    """
     from src.packages import enumerate_sides  # noqa: PLC0415
 
     sides, _report = enumerate_sides(
         pool,
         sizes,
+        side=side,
+        outgoing_policy=outgoing_policy,
         required=required,
         # Eligibility is already decided upstream by this module's own
         # filters; re-applying a generic one here would silently drop
@@ -607,8 +620,8 @@ def _angle_sides(pool, sizes, *, required=()):
         policy=_ANGLE_POLICY,
         adapt=False,
     )
-    for side in sides:
-        yield tuple(a.source for a in side)
+    for side_assets in sides:
+        yield tuple(a.source for a in side_assets)
 
 
 def _angle_pool_assets(entries):
@@ -655,6 +668,7 @@ def find_angle_packages(
     seed_player_names: list[str] | None = None,
     include_idp: bool = False,
     capacity_context: Any | None = None,
+    constraints: Any | None = None,
 ) -> dict[str, Any]:
     """Find multi-player counter-packages for a user-built offer.
 
@@ -1079,6 +1093,10 @@ def find_angle_packages(
             for combo in _angle_sides(
                 _angle_pool_assets(non_seed_pool),
                 [size],
+                # Offer mode enumerates THEIR side: what we would receive.
+                # Outgoing protection has no business here (§2.2).
+                side=_RECEIVE,
+                outgoing_policy=_UNCONSTRAINED_OUTGOING,
                 required=_angle_pool_assets(seed_entries),
             ):
                 cand = _make_candidate(combo, team_label, owner_label)
@@ -1089,7 +1107,12 @@ def find_angle_packages(
         # This is the existing behaviour — each opposing team
         # contributes its own packages independently.
         for team, pool in teams_pool:
-            for combo in _angle_sides(_angle_pool_assets(pool), target_sizes):
+            for combo in _angle_sides(
+                _angle_pool_assets(pool),
+                target_sizes,
+                side=_RECEIVE,
+                outgoing_policy=_UNCONSTRAINED_OUTGOING,
+            ):
                 cand = _make_candidate(
                     combo,
                     str(team.get("name") or ""),
@@ -1177,6 +1200,7 @@ def find_acquisition_packages(
     min_player_my_value: float = 0.0,
     include_idp: bool = False,
     capacity_context: Any | None = None,
+    constraints: Any | None = None,
 ) -> dict[str, Any]:
     """Find offer-side packages from the user's roster that acquire a
     fixed set of desired players from other teams.
@@ -1385,6 +1409,36 @@ def find_acquisition_packages(
     pool.sort(key=lambda p: -p["my_value"])
     pool = pool[: max(1, int(candidate_pool))]
 
+    # C3-CON-01.  The policy is built from the pool that will actually be
+    # enumerated, so §2.2's NFL-team rule resolves against today's board rather
+    # than against stored state.  ENFORCEMENT happens inside the substrate; the
+    # partition here only supplies the reasons, because a count cannot explain a
+    # short list.
+    from src.trade.constraints import blocked_outgoing as _blocked  # noqa: PLC0415
+    from src.trade.constraints import outgoing_eligibility  # noqa: PLC0415
+
+    _blocked_out = _blocked(pool, constraints)
+    _outgoing_policy = outgoing_eligibility(pool, constraints)
+    if pool and len(_blocked_out) >= len(pool):
+        return {
+            "acquire": {
+                "players": [],
+                "size": 0,
+                "my_total": 0,
+                "market_total": 0,
+                "targets": [],
+            },
+            "candidates": [],
+            "constraintsBlockedOutgoing": len(_blocked_out),
+            "constraintsBlockedReasons": sorted({r for _a, r in _blocked_out}),
+            "noResultReason": "all_outgoing_assets_constrained",
+            "warnings": [
+                *warnings,
+                "Every asset on your roster is protected or excluded from outgoing "
+                "recommendations, so no counter-package could be generated.",
+            ],
+        }
+
     # Desired-side value lists (sorted descending) for the VA path.
     desired_my_values = sorted(
         (float(_value_pair(r)[0]) for r in desired_rows),
@@ -1471,7 +1525,15 @@ def find_acquisition_packages(
         }
 
     candidates: list[dict[str, Any]] = []
-    for combo in _angle_sides(_angle_pool_assets(pool), target_sizes):
+    for combo in _angle_sides(
+        _angle_pool_assets(pool),
+        target_sizes,
+        # Acquire mode enumerates OUR side: what we would send.  This is the
+        # one angle entry point that chooses outgoing assets, so it is the one
+        # that carries C3-CON-01.
+        side=_SEND,
+        outgoing_policy=_outgoing_policy,
+    ):
         cand = _make_candidate(combo)
         if cand is not None:
             candidates.append(cand)

--- a/src/trade/constraints.py
+++ b/src/trade/constraints.py
@@ -57,13 +57,17 @@ user names one.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Iterable, Mapping, Sequence
 
 __all__ = [
     "ConstraintResolutionError",
     "TradeConstraints",
+    "UNRESOLVED",
+    "blocked_outgoing",
     "constraint_key",
+    "outgoing_eligibility",
+    "partition_sendable",
     "resolve_constraints",
 ]
 
@@ -320,3 +324,75 @@ def partition_sendable(
         else:
             blocked.append((asset, reason))
     return sendable, blocked
+
+
+# ── The substrate seam (C3-CON-01 §6) ────────────────────────────────────
+
+
+def blocked_outgoing(
+    pool: Sequence[Any],
+    constraints: TradeConstraints | None,
+) -> list[tuple[Any, str]]:
+    """``[(asset, reason), ...]`` for every pool asset that may not be sent.
+
+    The same decision :meth:`TradeConstraints.block_reason` makes, evaluated
+    over a whole pool.  Returned WITH the reasons rather than as a bare key set
+    so a surface can say *"withheld: you protect MIN players"* instead of
+    publishing a shorter list and letting the user infer why.
+    """
+    if constraints is None or not constraints.active:
+        return []
+    out: list[tuple[Any, str]] = []
+    for asset in pool:
+        reason = constraints.block_reason(asset)
+        if reason is not None:
+            out.append((asset, reason))
+    return out
+
+
+def outgoing_eligibility(
+    pool: Sequence[Any],
+    constraints: TradeConstraints | None,
+    *,
+    base: Any = None,
+) -> Any:
+    """Constraints as the canonical substrate's SEND-side eligibility.
+
+    This is the seam the module docstring promises: constraints become an
+    ``EligibilityPolicy`` the shared generator consumes **during** enumeration,
+    not a list the caller shortens afterwards.  §6 forbids the second shape by
+    name, because generating everything and hiding the forbidden results can
+    return the wrong *best* package — the real best was removed after ranking.
+
+    Returns the substrate's ``UNCONSTRAINED_OUTGOING`` sentinel when nothing
+    constrains this roster, so "we checked and nothing is protected" travels to
+    the generator as a claim rather than as an absent argument.
+
+    The excluded set is computed against THIS pool rather than stored, which is
+    what makes §2.2's dynamic NFL-team rule hold: a player who joined the
+    protected team is protected on the next call with no state to migrate.
+    ``base`` lets a product keep its own mechanical eligibility (min value,
+    already-in-the-trade exclusions) and have the constraints added to it —
+    the two are different questions and neither replaces the other.
+    """
+    from src.packages import (  # noqa: PLC0415 — import direction: trade -> packages
+        EligibilityPolicy,
+        UNCONSTRAINED_OUTGOING,
+        adapt_assets,
+    )
+
+    if constraints is None or not constraints.active:
+        return UNCONSTRAINED_OUTGOING
+
+    adapted = adapt_assets(pool)
+    excluded: set[str] = set()
+    for view in adapted:
+        # Decide on the CALLER's object where there is one: it carries the NFL
+        # team, and the substrate's projection deliberately does not.  The
+        # owner's key resolution accepts either.
+        subject = view.source if view.source is not None else view
+        if constraints.block_reason(subject) is not None:
+            excluded.add(view.key)
+
+    policy = base if isinstance(base, EligibilityPolicy) else EligibilityPolicy()
+    return replace(policy, excluded_keys=frozenset(policy.excluded_keys) | excluded)

--- a/src/trade/finder.py
+++ b/src/trade/finder.py
@@ -853,6 +853,7 @@ _ASYMMETRIC_POOL_LIMIT = 30
 def _generate_packages(
     my_assets: list[Asset],
     opp_assets: list[Asset],
+    outgoing_policy: Any,
 ) -> tuple[list[TradeCandidate], dict[str, Any]]:
     """Enumerate and score every shape this engine offers.
 
@@ -884,6 +885,11 @@ def _generate_packages(
         packages, report = substrate.enumerate_packages(
             my_assets,
             opp_assets,
+            # C3-CON-01.  Applied to OUR side inside the enumeration, never to
+            # theirs — a protected player is blocked outgoing and stays a valid
+            # acquisition target (§2.2).  Passed rather than pre-filtered so the
+            # rule is the generator's, not this product's.
+            outgoing_policy=outgoing_policy,
             policy=substrate.EligibilityPolicy(
                 min_value=MIN_ASSET_VALUE,
                 # An asset the board declined to price cannot be scored, and
@@ -1034,10 +1040,24 @@ def find_trades(
     # Only OUR side is constrained.  A protected player stays a valid incoming
     # target and keeps his ordinary canonical value — this is a recommendation
     # rule, not a valuation rule.
-    from src.trade.constraints import partition_sendable  # noqa: PLC0415
+    from src.trade.constraints import blocked_outgoing as _blocked_outgoing  # noqa: PLC0415
+    from src.trade.constraints import outgoing_eligibility  # noqa: PLC0415
 
-    my_roster, blocked_outgoing = partition_sendable(my_roster, constraints)
-    if not my_roster:
+    # ENFORCEMENT is the substrate's: ``outgoing_policy`` is applied to our pool
+    # inside ``enumerate_packages``, so a forbidden package is never built.  The
+    # partition here is REPORTING only — it answers "why is this list short",
+    # which the enumeration's counts cannot, because a count is not a reason.
+    #
+    # Not two mechanisms: both are the same owner answering the same question
+    # (``block_reason``), and a test pins that the set they agree on is
+    # identical.  What is deliberately NOT done is filtering the pool and then
+    # enumerating the remainder — that is a caller-side rule, and §2.3 forbids
+    # page-local copies of it.
+    blocked_outgoing = _blocked_outgoing(my_roster, constraints)
+    outgoing_policy = outgoing_eligibility(my_roster, constraints)
+    # ``my_roster`` is already known non-empty above; the guard is explicit so
+    # an empty roster can never read as 'everything is protected'.
+    if my_roster and len(blocked_outgoing) >= len(my_roster):
         # Honest no-result: every asset we could send is constrained.  An empty
         # list with no explanation reads as "no trades exist".
         return {
@@ -1123,7 +1143,7 @@ def find_trades(
 
         # Generate candidates for every trade shape.  Construction mechanics
         # are the substrate's; the scoring objective stays in this module.
-        shaped, enum_report = _generate_packages(my_roster, opp_filtered)
+        shaped, enum_report = _generate_packages(my_roster, opp_filtered, outgoing_policy)
         all_trades.extend(shaped)
         enumeration_reports[opp_name] = enum_report
 

--- a/src/trade/suggestions.py
+++ b/src/trade/suggestions.py
@@ -286,6 +286,35 @@ class RosterAnalysis:
     sendable_keys: frozenset[str] = frozenset()
     #: ``[(asset, reason), ...]`` — why the sendable view is shorter.
     constrained_out: tuple[tuple[PlayerAsset, str], ...] = ()
+    #: Whether a constraint set was consulted at all.  "Nothing is protected"
+    #: and "nobody asked" are different claims and this keeps them apart.
+    constraints_applied: bool = False
+
+    def __post_init__(self) -> None:
+        """An analysis built without constraints has consulted none.
+
+        The sendable view then MIRRORS the full rooms, and that default is
+        deliberate rather than convenient.  Defaulting the other way — empty,
+        so nothing is sendable — reads as fail-closed and is not: it silently
+        returns zero suggestions for any caller that constructs this dataclass
+        directly, which is a shorter list with no explanation, the failure §4
+        forbids.  Fail-closed belongs at the OWNER, where ``UNRESOLVED``
+        expresses "we could not check"; this object cannot tell the difference
+        and must not pretend to.  ``constraints_applied`` records which
+        happened, and ``analyze_roster`` — the only production constructor —
+        always supplies the real answer.
+        """
+        if not self.constraints_applied and not self.sendable_by_position:
+            object.__setattr__(self, "sendable_by_position", dict(self.by_position))
+            object.__setattr__(
+                self,
+                "sendable_keys",
+                frozenset(
+                    str(p.name or "").strip().lower()
+                    for room in self.by_position.values()
+                    for p in room
+                ),
+            )
 
     def sendable(self, position: str) -> list[PlayerAsset]:
         """The room's assets we may put on the outgoing side."""
@@ -789,6 +818,7 @@ def analyze_roster(
         sendable_by_position=sendable_by_position,
         sendable_keys=sendable_keys,
         constrained_out=tuple(blocked),
+        constraints_applied=True,
     )
 
 

--- a/src/trade/suggestions.py
+++ b/src/trade/suggestions.py
@@ -776,9 +776,7 @@ def analyze_roster(
         for pos, room in by_position.items()
     }
     sendable_keys = frozenset(
-        str(p.name or "").strip().lower()
-        for room in sendable_by_position.values()
-        for p in room
+        str(p.name or "").strip().lower() for room in sendable_by_position.values() for p in room
     )
 
     return RosterAnalysis(

--- a/src/trade/suggestions.py
+++ b/src/trade/suggestions.py
@@ -20,7 +20,7 @@ The engine does NOT modify any internal canonical values or calibration.
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from src.canonical.calibration import to_display_value
@@ -271,6 +271,28 @@ class RosterAnalysis:
     need_positions: list[str]
     starter_counts: dict[str, int]  # above-replacement count
     depth_counts: dict[str, int]  # below-replacement count
+    #: The same rooms with C3-CON-01-constrained assets removed.
+    #:
+    #: A SECOND view rather than a filtered ``by_position``, and the distinction
+    #: is load-bearing.  A protected player still occupies a roster spot and
+    #: still counts toward positional depth: dropping him from the ANALYSIS
+    #: would make the team look thinner than it is, move it into
+    #: ``need_positions`` it does not need, and change what every generator
+    #: thinks it should go and get.  He is excluded from what we may OFFER, and
+    #: from nothing else — which is §2.2 stated as a data shape.
+    sendable_by_position: dict[str, list[PlayerAsset]] = field(default_factory=dict)
+    #: Lowercased names of the assets we may send, for the per-asset checks
+    #: that cannot draw from a room (``weakest_starter``, sweeteners).
+    sendable_keys: frozenset[str] = frozenset()
+    #: ``[(asset, reason), ...]`` — why the sendable view is shorter.
+    constrained_out: tuple[tuple[PlayerAsset, str], ...] = ()
+
+    def sendable(self, position: str) -> list[PlayerAsset]:
+        """The room's assets we may put on the outgoing side."""
+        return self.sendable_by_position.get(position, [])
+
+    def can_send(self, asset: PlayerAsset) -> bool:
+        return str(asset.name or "").strip().lower() in self.sendable_keys
 
 
 @dataclass
@@ -692,8 +714,16 @@ def analyze_roster(
     roster_names: list[str],
     asset_pool: list[PlayerAsset],
     starter_needs: dict[str, int] | None = None,
+    *,
+    constraints: Any | None = None,
 ) -> RosterAnalysis:
-    """Analyze a roster for positional surplus and need."""
+    """Analyze a roster for positional surplus and need.
+
+    ``constraints`` (``src.trade.constraints.TradeConstraints``) is resolved
+    into ``sendable_by_position`` and changes NOTHING else about the analysis.
+    A protected player is still counted, still fills a starting slot and still
+    makes his position a surplus — he is only withheld from what we may offer.
+    """
     needs = starter_needs or DEFAULT_STARTER_NEEDS
 
     pool_by_name: dict[str, PlayerAsset] = {}
@@ -732,6 +762,25 @@ def analyze_roster(
         if len(depth) >= 2:
             surplus_positions.append(pos)
 
+    # C3-CON-01, resolved ONCE for the whole module.  Every generator draws
+    # its outgoing candidates from the sendable view, so there is one call to
+    # the owner rather than one per generator — §2.3 forbids page-local copies,
+    # and five copies inside one file is still five.
+    from src.trade.constraints import blocked_outgoing  # noqa: PLC0415
+
+    everyone = [p for room in by_position.values() for p in room]
+    blocked = blocked_outgoing(everyone, constraints)
+    blocked_names = {str(a.name or "").strip().lower() for a, _r in blocked}
+    sendable_by_position = {
+        pos: [p for p in room if str(p.name or "").strip().lower() not in blocked_names]
+        for pos, room in by_position.items()
+    }
+    sendable_keys = frozenset(
+        str(p.name or "").strip().lower()
+        for room in sendable_by_position.values()
+        for p in room
+    )
+
     return RosterAnalysis(
         roster_size=matched,
         by_position=by_position,
@@ -739,6 +788,9 @@ def analyze_roster(
         need_positions=need_positions,
         starter_counts=starter_counts,
         depth_counts=depth_counts,
+        sendable_by_position=sendable_by_position,
+        sendable_keys=sendable_keys,
+        constrained_out=tuple(blocked),
     )
 
 
@@ -1007,7 +1059,13 @@ def _generate_sell_high(
         if len(players) < 2:
             continue
         need = DEFAULT_STARTER_NEEDS.get(pos, 1)
-        sell_candidates = [p for p in players[need:] if p.display_value >= MIN_RELEVANT_VALUE]
+        # Depth is measured on the FULL room (a protected player is still
+        # depth); the candidates we may offer come from the sendable view.
+        sell_candidates = [
+            p
+            for p in players[need:]
+            if p.display_value >= MIN_RELEVANT_VALUE and roster.can_send(p)
+        ]
         if not sell_candidates:
             continue
 
@@ -1081,7 +1139,11 @@ def _generate_buy_low(
             for surplus_pos in roster.surplus_positions:
                 depth = roster.by_position.get(surplus_pos, [])
                 need = DEFAULT_STARTER_NEEDS.get(surplus_pos, 1)
-                tradeable = [p for p in depth[need:] if p.display_value >= MIN_RELEVANT_VALUE]
+                tradeable = [
+                    p
+                    for p in depth[need:]
+                    if p.display_value >= MIN_RELEVANT_VALUE and roster.can_send(p)
+                ]
                 for sell in tradeable[:2]:
                     give_val = sell.display_value
                     recv_val = target.display_value
@@ -1130,7 +1192,7 @@ def _generate_consolidation(
         players = roster.by_position.get(pos, [])
         need = DEFAULT_STARTER_NEEDS.get(pos, 1)
         for p in players[need:]:
-            if p.display_value >= MIN_RELEVANT_VALUE:
+            if p.display_value >= MIN_RELEVANT_VALUE and roster.can_send(p):
                 tradeable.append(p)
 
     tradeable.sort(key=lambda x: -x.display_value)
@@ -1226,11 +1288,21 @@ def _generate_positional_upgrades(
 
         starters = players[:need]
         # pos is always an offense position in DEFAULT_STARTER_NEEDS; using
-        depth = [p for p in players[need:] if p.display_value >= MIN_RELEVANT_VALUE]
+        depth = [
+            p
+            for p in players[need:]
+            if p.display_value >= MIN_RELEVANT_VALUE and roster.can_send(p)
+        ]
         if not starters or not depth:
             continue
 
         weakest_starter = starters[-1]
+        # The weakest starter is identified on the FULL room — that is who he
+        # is — and then checked.  Promoting the next-weakest into the role
+        # would publish a false claim about the roster to route around a
+        # protection; there is simply no upgrade suggestion at this position.
+        if not roster.can_send(weakest_starter):
+            continue
         ws_ev = weakest_starter.display_value
         upgrade_floor = ws_ev + 500
 
@@ -1417,6 +1489,12 @@ def _roster_balancer_candidates(
         players = roster.by_position.get(pos, [])
         need = DEFAULT_STARTER_NEEDS.get(pos, 1)
         for p in players[need:]:
+            # The equalizer is spec §2.3's "trade equalizers / counteroffer
+            # suggestions" bullet: it puts a FURTHER outgoing asset into the
+            # package after the base suggestion is built, so it is a generating
+            # surface in its own right and consumes the same owner.
+            if not roster.can_send(p):
+                continue
             if (
                 p.name.lower() not in exclude_names
                 and p.position  # skip positionless
@@ -1618,6 +1696,7 @@ def generate_suggestions_from_pool(
     board_top_n: int | None = None,
     ktc_top_n: int | None = None,
     capacity_context: Any | None = None,
+    constraints: Any | None = None,
 ) -> dict[str, Any]:
     """Generate trade suggestions against a pre-built asset pool.
 
@@ -1654,7 +1733,25 @@ def generate_suggestions_from_pool(
     if not _rookies_eligible_today():
         pool = [p for p in pool if not p.rookie]
 
-    roster = analyze_roster(roster_names, pool, starter_needs)
+    roster = analyze_roster(roster_names, pool, starter_needs, constraints=constraints)
+    if roster.roster_size and not roster.sendable_keys:
+        # Every asset we could offer is protected or excluded.  Say so rather
+        # than returning four empty categories, which reads as "nothing to
+        # suggest" — the failure §4 forbids by name.
+        return {
+            **{c: [] for c in ("sell_high", "buy_low", "consolidation", "positional_upgrade")},
+            "warnings": [
+                "Every asset on your roster is protected or excluded from outgoing "
+                "recommendations, so no suggestion could be generated."
+            ],
+            "metadata": {
+                "rosterMatched": roster.roster_size,
+                "rosterProvided": len(roster_names),
+                "constraintsBlockedOutgoing": len(roster.constrained_out),
+                "constraintsBlockedReasons": sorted({r for _a, r in roster.constrained_out}),
+                "noResultReason": "all_outgoing_assets_constrained",
+            },
+        }
     roster_set = {n.lower().strip() for n in roster_names}
 
     sell_high = _generate_sell_high(roster, pool, roster_set)
@@ -1750,6 +1847,10 @@ def generate_suggestions_from_pool(
             "ktcTopNFilter": board_top_n,
             "rosterMatched": roster.roster_size,
             "rosterProvided": len(roster_names),
+            # C3-CON-01.  Published because a shorter list with no explanation
+            # reads as "no trades exist" rather than "you protect these".
+            "constraintsBlockedOutgoing": len(roster.constrained_out),
+            "constraintsBlockedReasons": sorted({r for _a, r in roster.constrained_out}),
             "starterNeeds": starter_needs or DEFAULT_STARTER_NEEDS,
             "opponentRostersProvided": len(league_rosters) if league_rosters else 0,
             "opponentRostersAnalyzed": len(opponent_analyses),

--- a/tests/packages/test_construction.py
+++ b/tests/packages/test_construction.py
@@ -414,7 +414,7 @@ def test_enumerate_packages_enforces_topology_and_reports_what_it_refused():
         ours,
         theirs,
         outgoing_policy=UNCONSTRAINED_OUTGOING,
-        shapes=[PackageShape(3, 1), PackageShape(1, 1)]
+        shapes=[PackageShape(3, 1), PackageShape(1, 1)],
     )
     emitted = list(packages)
 
@@ -454,7 +454,8 @@ def test_topology_can_be_switched_off_for_a_caller_that_is_not_generating():
         ours,
         theirs,
         outgoing_policy=UNCONSTRAINED_OUTGOING,
-        shapes=[PackageShape(3, 1)], enforce_topology=False
+        shapes=[PackageShape(3, 1)],
+        enforce_topology=False,
     )
     assert len(list(packages)) == 1
     assert loose.topology_rejected == 0

--- a/tests/packages/test_construction.py
+++ b/tests/packages/test_construction.py
@@ -14,6 +14,7 @@ from src.packages import (
     PackageAsset,
     PackageShape,
     adapt_assets,
+    UNCONSTRAINED_OUTGOING,
     enumerate_packages,
     package_key,
     side_key,
@@ -25,6 +26,7 @@ def _a(name: str, value: float | None = 1000.0, position: str = "RB", asset_id: 
 
 
 def _run(ours, theirs, **kw):
+    kw.setdefault("outgoing_policy", UNCONSTRAINED_OUTGOING)
     packages, report = enumerate_packages(ours, theirs, adapt=False, **kw)
     return list(packages), report
 
@@ -276,7 +278,7 @@ def test_sources_round_trip_so_products_score_what_was_enumerated():
             self.player_id = n
 
     ours, theirs = [_Thing("A")], [_Thing("B")]
-    packages, _r = enumerate_packages(ours, theirs)
+    packages, _r = enumerate_packages(ours, theirs, outgoing_policy=UNCONSTRAINED_OUTGOING)
     (pair,) = list(packages)
     send, receive = pair.sources()
     assert send[0] is ours[0]
@@ -409,7 +411,10 @@ def test_enumerate_packages_enforces_topology_and_reports_what_it_refused():
     theirs = [_pa("z", "PICK")]  # their only asset is a pick — zero players
 
     packages, report = enumerate_packages(
-        ours, theirs, shapes=[PackageShape(3, 1), PackageShape(1, 1)]
+        ours,
+        theirs,
+        outgoing_policy=UNCONSTRAINED_OUTGOING,
+        shapes=[PackageShape(3, 1), PackageShape(1, 1)]
     )
     emitted = list(packages)
 
@@ -436,7 +441,9 @@ def test_topology_can_be_switched_off_for_a_caller_that_is_not_generating():
     ours = [_pa("a", "RB"), _pa("b", "WR"), _pa("c", "TE")]
     theirs = [_pa("z", "QB")]
 
-    strict_packages, strict = enumerate_packages(ours, theirs, shapes=[PackageShape(3, 1)])
+    strict_packages, strict = enumerate_packages(
+        ours, theirs, outgoing_policy=UNCONSTRAINED_OUTGOING, shapes=[PackageShape(3, 1)]
+    )
     # The report is filled in AS THE ITERATOR RUNS — draining it is what makes
     # the counters meaningful.  See the laziness note in `enumerate_packages`.
     assert list(strict_packages) == []
@@ -444,7 +451,10 @@ def test_topology_can_be_switched_off_for_a_caller_that_is_not_generating():
     assert strict.topology_rejected == 1
 
     packages, loose = enumerate_packages(
-        ours, theirs, shapes=[PackageShape(3, 1)], enforce_topology=False
+        ours,
+        theirs,
+        outgoing_policy=UNCONSTRAINED_OUTGOING,
+        shapes=[PackageShape(3, 1)], enforce_topology=False
     )
     assert len(list(packages)) == 1
     assert loose.topology_rejected == 0
@@ -465,7 +475,9 @@ def test_the_report_is_only_complete_once_the_iterator_is_drained():
     ours = [_pa("a", "RB"), _pa("b", "WR"), _pa("c", "TE")]
     theirs = [_pa("z", "QB")]
 
-    packages, report = enumerate_packages(ours, theirs, shapes=[PackageShape(3, 1)])
+    packages, report = enumerate_packages(
+        ours, theirs, outgoing_policy=UNCONSTRAINED_OUTGOING, shapes=[PackageShape(3, 1)]
+    )
     # Final immediately — these do not depend on the walk.
     assert (report.our_pool_size, report.their_pool_size) == (3, 1)
     # Not yet meaningful.

--- a/tests/test_trade_finder.py
+++ b/tests/test_trade_finder.py
@@ -6,6 +6,7 @@ for board-arbitrage trades (good for me on our model, plausible
 for the opponent on KTC).
 """
 
+from src.packages import UNCONSTRAINED_OUTGOING
 from src.trade.finder import (
     Asset,
     TradeCandidate,
@@ -437,7 +438,7 @@ class TestPackageGeneration:
     def test_generates_one_for_one(self):
         my = [_make_asset("Mine1", 4000, 5500), _make_asset("Mine2", 3000, 4000)]
         opp = [_make_asset("Theirs1", 5000, 4500), _make_asset("Theirs2", 4000, 3500)]
-        trades, report = _generate_packages(my, opp)
+        trades, report = _generate_packages(my, opp, UNCONSTRAINED_OUTGOING)
         assert len(trades) > 0
         assert (1, 1) in _shapes(trades)
         assert report["oneForOne"]["ourPoolSize"] == 2
@@ -445,7 +446,7 @@ class TestPackageGeneration:
     def test_skips_low_value(self):
         my = [_make_asset("Low", 100, 100)]
         opp = [_make_asset("Also Low", 200, 200)]
-        trades, report = _generate_packages(my, opp)
+        trades, report = _generate_packages(my, opp, UNCONSTRAINED_OUTGOING)
         assert trades == []
         # Excluded by the eligibility policy, and the count says so rather
         # than the pool quietly being empty.
@@ -458,7 +459,7 @@ class TestPackageGeneration:
             _make_asset("C", 1500, 2000),
         ]
         opp = [_make_asset("Star", 5000, 4500)]
-        trades, _report = _generate_packages(my, opp)
+        trades, _report = _generate_packages(my, opp, UNCONSTRAINED_OUTGOING)
         for shape in _shapes(trades):
             assert shape in {(1, 1), (2, 1), (1, 2)}
 
@@ -468,7 +469,7 @@ class TestPackageGeneration:
             _make_asset("Part1", 3500, 3000),
             _make_asset("Part2", 3000, 2500),
         ]
-        trades, _report = _generate_packages(my, opp)
+        trades, _report = _generate_packages(my, opp, UNCONSTRAINED_OUTGOING)
         for t in trades:
             assert len(t.give) in (1,)
             assert len(t.receive) in (1, 2)
@@ -477,19 +478,19 @@ class TestPackageGeneration:
         """No 2-for-2, no 3-for-anything — the shape plan is explicit."""
         my = [_make_asset(f"M{i}", 3000 + i * 100, 3500 + i * 100) for i in range(4)]
         opp = [_make_asset(f"T{i}", 3000 + i * 100, 3400 + i * 100) for i in range(4)]
-        trades, _report = _generate_packages(my, opp)
+        trades, _report = _generate_packages(my, opp, UNCONSTRAINED_OUTGOING)
         assert set(_shapes(trades)) <= {(1, 1), (2, 1), (1, 2)}
 
     def test_an_asset_never_appears_on_both_sides(self):
         shared = _make_asset("Shared", 4000, 4200)
-        trades, _report = _generate_packages([shared], [shared])
+        trades, _report = _generate_packages([shared], [shared], UNCONSTRAINED_OUTGOING)
         assert trades == []
 
     def test_truncation_is_reported_not_silent(self):
         """The retired ``[:30]`` slice reported nothing."""
         my = [_make_asset(f"M{i:03d}", 5000 - i, 5200 - i) for i in range(40)]
         opp = [_make_asset(f"T{i:03d}", 5000 - i, 4800 - i) for i in range(40)]
-        _trades, report = _generate_packages(my, opp)
+        _trades, report = _generate_packages(my, opp, UNCONSTRAINED_OUTGOING)
         assert report["asymmetric"]["ourTruncatedTo"] == 30
         assert report["asymmetric"]["truncated"] is True
         # 1-for-1 is deliberately unbounded, exactly as before.
@@ -514,7 +515,7 @@ class TestPackageGeneration:
         crown = _make_asset("Zzz Crown", 4000, 9999)
         my.append(crown)
         opp = [_make_asset("Target", 4500, 5000)]
-        trades, _report = _generate_packages(my, opp)
+        trades, _report = _generate_packages(my, opp, UNCONSTRAINED_OUTGOING)
         assert any(
             any(a.name == "Zzz Crown" for a in t.give) for t in trades
         ), "the most valuable asset must survive the pool bound"

--- a/tests/trade/test_angle_uses_the_substrate.py
+++ b/tests/trade/test_angle_uses_the_substrate.py
@@ -13,7 +13,20 @@ from itertools import combinations
 
 import pytest
 
+from src.packages import SEND, UNCONSTRAINED_OUTGOING
 from src.trade.angle import _angle_pool_assets, _angle_sides
+
+
+def _sides(pool, sizes, **kw):
+    """``_angle_sides`` with the substrate's required side declaration.
+
+    These tests are about MECHANICS (which sides come out), so they declare
+    the SEND side and no outgoing constraint — the C3-CON-01 behaviour has
+    its own file.  The declaration is required rather than defaulted, which
+    is the point: a caller cannot enumerate without saying which side it is
+    looking at.
+    """
+    return _angle_sides(pool, sizes, side=SEND, outgoing_policy=UNCONSTRAINED_OUTGOING, **kw)
 
 
 def _pool(n: int = 8):
@@ -37,27 +50,27 @@ def _retired(pool, sizes):
 @pytest.mark.parametrize("sizes", [[1], [2], [1, 2], [1, 2, 3], [2, 3]])
 def test_produces_exactly_the_sides_the_retired_loops_did(sizes):
     pool = _pool()
-    got = list(_angle_sides(_angle_pool_assets(pool), sizes))
+    got = list(_sides(_angle_pool_assets(pool), sizes))
     assert got == _retired(pool, sizes)
 
 
 def test_the_pool_entries_come_back_unchanged():
     """``_make_candidate`` reads the caller's dicts, not a projection."""
     pool = _pool(3)
-    (side,) = [s for s in _angle_sides(_angle_pool_assets(pool), [3])]
+    (side,) = [s for s in _sides(_angle_pool_assets(pool), [3])]
     assert [x is y for x, y in zip(side, pool)] == [True, True, True]
 
 
 def test_a_size_larger_than_the_pool_is_skipped():
     pool = _pool(2)
-    assert list(_angle_sides(_angle_pool_assets(pool), [5])) == []
+    assert list(_sides(_angle_pool_assets(pool), [5])) == []
 
 
 def test_seeds_appear_in_every_side_and_count_against_the_size():
     """The seed/filler split, which was its own third enumeration."""
     pool = _pool(5)
     seeds, fillers = pool[:1], pool[1:]
-    sides = list(_angle_sides(_angle_pool_assets(fillers), [3], required=_angle_pool_assets(seeds)))
+    sides = list(_sides(_angle_pool_assets(fillers), [3], required=_angle_pool_assets(seeds)))
     assert sides, "expected some sides"
     for side in sides:
         assert len(side) == 3
@@ -73,7 +86,7 @@ def test_a_seed_is_never_duplicated_by_also_being_in_the_pool():
     a stronger one when two entries share a name.
     """
     pool = _pool(4)
-    sides = list(_angle_sides(_angle_pool_assets(pool), [2], required=_angle_pool_assets(pool[:1])))
+    sides = list(_sides(_angle_pool_assets(pool), [2], required=_angle_pool_assets(pool[:1])))
     for side in sides:
         assert len({id(x) for x in side}) == 2
         assert [x["name"] for x in side].count(pool[0]["name"]) == 1
@@ -89,7 +102,7 @@ def test_angle_keeps_entries_a_generic_eligibility_gate_would_drop():
         {"name": "2027 Early 1st", "position": "", "my_value": 4000, "row": {}},
         {"name": "Zero", "position": "WR", "my_value": 0, "row": {}},
     ]
-    sides = list(_angle_sides(_angle_pool_assets(pool), [2]))
+    sides = list(_sides(_angle_pool_assets(pool), [2]))
     assert len(sides) == 1
     assert {x["name"] for x in sides[0]} == {"2027 Early 1st", "Zero"}
 

--- a/tests/trade/test_constraint_generation.py
+++ b/tests/trade/test_constraint_generation.py
@@ -105,8 +105,25 @@ class TestOutgoingOnlyAsymmetry:
         assert report.outgoing_constrained is True
 
     def test_a_protected_player_is_STILL_a_valid_acquisition_target(self):
-        """§2.2: "MIN players may still appear as INCOMING acquisition targets"."""
-        policy = outgoing_eligibility(OURS, MIN_PROTECTED)
+        """§2.2: "MIN players may still appear as INCOMING acquisition targets".
+
+        The policy here is built over BOTH pools on purpose, and that detail is
+        the whole test. A policy built over our roster alone cannot express the
+        bug: it contains no key for the opponent's Viking, so applying it to
+        their side would remove nothing and this guard would pass whatever the
+        substrate did — GREEN because it was blind, not because the property
+        held. (The mutation harness caught exactly that in the first draft of
+        this file.)
+
+        Built over the union, it is the shape a careless caller would produce,
+        and only the substrate's send/receive split keeps Jordan Addison
+        available.
+        """
+        policy = outgoing_eligibility([*OURS, *THEIRS], MIN_PROTECTED)
+        assert any("addison" in k for k in policy.excluded_keys), (
+            "the fixture policy does not name the opponent's protected player, "
+            "so this test cannot see the bug it exists for"
+        )
         packages, report = _packages(OURS, THEIRS, policy)
 
         received = {name for pkg in packages for name in _names(pkg.receive)}
@@ -116,30 +133,17 @@ class TestOutgoingOnlyAsymmetry:
         )
         assert report.their_excluded_ineligible == 0
 
-    def test_MUTATION_applying_the_policy_to_their_side_breaks_the_second(self, monkeypatch):
-        """Proof the acquisition assertion above is load-bearing.
+    def test_the_owner_scopes_its_policy_to_the_pool_it_was_given(self):
+        """A second, independent line of defence, stated so it is not lost.
 
-        Make the substrate apply the outgoing policy to BOTH pools — the exact
-        bug the side split exists to prevent — and the acquisition target
-        disappears. If this mutation left the assertion green, the assertion
-        would be measuring nothing.
+        `outgoing_eligibility` computes the excluded set against the pool it is
+        handed, so a policy built for our roster carries no key that could match
+        an opponent's asset even if it were misapplied. That is real protection
+        and it is NOT what the test above measures — relying on it would leave
+        the substrate free to drop the side split.
         """
-        import src.packages.construction as construction
-
-        real_eligible = construction._eligible
-
-        def both_sides(assets, policy, report, *, ours, outgoing=None):
-            return real_eligible(assets, policy, report, ours=ours, outgoing=_MUTATED_POLICY[0])
-
-        _MUTATED_POLICY = [outgoing_eligibility([*OURS, *THEIRS], MIN_PROTECTED)]
-        monkeypatch.setattr(construction, "_eligible", both_sides)
-
-        packages, _report = _packages(OURS, THEIRS, _MUTATED_POLICY[0])
-        received = {name for pkg in packages for name in _names(pkg.receive)}
-        assert "Jordan Addison" not in received, (
-            "the mutation did not change the receive side, so the "
-            "acquisition-still-valid guard cannot fail and is not a guard"
-        )
+        ours_only = outgoing_eligibility(OURS, MIN_PROTECTED)
+        assert not any("addison" in k for k in ours_only.excluded_keys)
 
     def test_picks_are_not_swept_up_by_a_team_rule_during_generation(self):
         """A pick has no NFL team; treating that as unknown would block every

--- a/tests/trade/test_constraint_generation.py
+++ b/tests/trade/test_constraint_generation.py
@@ -74,9 +74,7 @@ MIN_PROTECTED = resolve_constraints(persistent={"nflTeams": ["MIN"]})
 
 
 def _packages(ours, theirs, outgoing_policy, **kw):
-    packages, report = enumerate_packages(
-        ours, theirs, outgoing_policy=outgoing_policy, **kw
-    )
+    packages, report = enumerate_packages(ours, theirs, outgoing_policy=outgoing_policy, **kw)
     return list(packages), report
 
 
@@ -118,9 +116,7 @@ class TestOutgoingOnlyAsymmetry:
         )
         assert report.their_excluded_ineligible == 0
 
-    def test_MUTATION_applying_the_policy_to_their_side_breaks_the_second(
-        self, monkeypatch
-    ):
+    def test_MUTATION_applying_the_policy_to_their_side_breaks_the_second(self, monkeypatch):
         """Proof the acquisition assertion above is load-bearing.
 
         Make the substrate apply the outgoing policy to BOTH pools — the exact
@@ -133,9 +129,7 @@ class TestOutgoingOnlyAsymmetry:
         real_eligible = construction._eligible
 
         def both_sides(assets, policy, report, *, ours, outgoing=None):
-            return real_eligible(
-                assets, policy, report, ours=ours, outgoing=_MUTATED_POLICY[0]
-            )
+            return real_eligible(assets, policy, report, ours=ours, outgoing=_MUTATED_POLICY[0])
 
         _MUTATED_POLICY = [outgoing_eligibility([*OURS, *THEIRS], MIN_PROTECTED)]
         monkeypatch.setattr(construction, "_eligible", both_sides)
@@ -298,13 +292,11 @@ def test_a_forbidden_package_is_never_BUILT():
 
 
 def test_the_constrained_count_is_reported_apart_from_the_ineligible_count():
-    """"You told us not to trade him" is an answer; "he is roster clog" is a
+    """ "You told us not to trade him" is an answer; "he is roster clog" is a
     mechanic.  A surface that cannot tell them apart cannot explain itself."""
     ours = [*OURS, Asset("Deep Bench", 10.0, team="DEN")]
     policy = outgoing_eligibility(ours, MIN_PROTECTED)
-    _pkgs, report = _packages(
-        ours, THEIRS, policy, policy=EligibilityPolicy(min_value=1000.0)
-    )
+    _pkgs, report = _packages(ours, THEIRS, policy, policy=EligibilityPolicy(min_value=1000.0))
     assert report.our_excluded_constrained == 1  # the Viking
     assert report.our_excluded_ineligible == 1  # the 10-value bench piece
 
@@ -349,9 +341,9 @@ def test_only_the_owner_mints_a_block_reason():
         for node in ast.walk(tree):
             if isinstance(node, ast.Constant) and node.value in reasons:
                 producers.add(rel)
-    assert producers == {"src/trade/constraints.py"}, (
-        f"a block reason is minted outside the owner: {sorted(producers)}"
-    )
+    assert producers == {
+        "src/trade/constraints.py"
+    }, f"a block reason is minted outside the owner: {sorted(producers)}"
 
 
 def test_every_generating_surface_accepts_constraints():
@@ -372,15 +364,15 @@ def test_every_generating_surface_accepts_constraints():
         (angle.find_acquisition_packages, "angle.find_acquisition_packages"),
     ]
     for fn, label in generating:
-        assert "constraints" in inspect.signature(fn).parameters, (
-            f"{label} generates outgoing assets and cannot be constrained"
-        )
+        assert (
+            "constraints" in inspect.signature(fn).parameters
+        ), f"{label} generates outgoing assets and cannot be constrained"
 
     from src.api import trade_simulator
 
-    assert "constraints" not in inspect.signature(trade_simulator.simulate_trade).parameters, (
-        "the manual Trade Calculator must stay free-form (§5)"
-    )
+    assert (
+        "constraints" not in inspect.signature(trade_simulator.simulate_trade).parameters
+    ), "the manual Trade Calculator must stay free-form (§5)"
 
 
 def test_the_substrate_is_the_only_enforcement_path():

--- a/tests/trade/test_constraint_generation.py
+++ b/tests/trade/test_constraint_generation.py
@@ -1,0 +1,472 @@
+"""C3-CON-01 applied DURING generation — the substrate half.
+
+`tests/trade/test_recommendation_constraints.py` pins what the OWNER decides.
+This file pins what the shared GENERATOR does with that decision, which is the
+half §2.3 and §6 are actually about:
+
+    §2.3  "Do not implement page-local copies or post-filter protected players
+           after ranking."
+    §6    "Do not generate everything first and hide forbidden packages
+           afterward. That wastes work and can return the wrong 'best' result."
+
+Every guard here is paired with a MUTATION that shows it goes red. A structural
+assertion nobody has watched fail is a comment with a `def` in front of it: it
+can pass because the property holds, or because the assertion was never able to
+see the property at all, and the two are indistinguishable until someone breaks
+the code on purpose.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from src.packages import (
+    RECEIVE,
+    SEND,
+    UNCONSTRAINED_OUTGOING,
+    ConstraintMisapplied,
+    EligibilityPolicy,
+    adapt_assets,
+    enumerate_packages,
+    enumerate_sides,
+)
+from src.trade.constraints import (
+    UNRESOLVED,
+    blocked_outgoing,
+    outgoing_eligibility,
+    resolve_constraints,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+class Asset:
+    """A product's own asset type, as the substrate sees them in the wild."""
+
+    def __init__(self, name: str, value: float, position: str = "WR", team: str | None = None):
+        self.name = name
+        self.asset_id = name.lower().replace(" ", "_")
+        self.position = position
+        self.value = value
+        self.team = team
+
+    def __repr__(self) -> str:  # pragma: no cover - failure output
+        return f"Asset({self.name!r}, {self.team!r})"
+
+
+#: Our roster: one protected Viking, two ordinary players.
+OURS = [
+    Asset("Justin Jefferson", 9000.0, team="MIN"),
+    Asset("Chris Olave", 5000.0, team="NO"),
+    Asset("Rome Odunze", 4000.0, team="CHI"),
+]
+#: Theirs contains a MIN player too — the same rule, the other side.
+THEIRS = [
+    Asset("Jordan Addison", 4500.0, team="MIN"),
+    Asset("Drake London", 6000.0, team="ATL"),
+]
+
+MIN_PROTECTED = resolve_constraints(persistent={"nflTeams": ["MIN"]})
+
+
+def _packages(ours, theirs, outgoing_policy, **kw):
+    packages, report = enumerate_packages(
+        ours, theirs, outgoing_policy=outgoing_policy, **kw
+    )
+    return list(packages), report
+
+
+def _names(side):
+    return {a.name for a in side}
+
+
+# ── §2.2 — outgoing-only asymmetry, BOTH directions ──────────────────
+
+
+class TestOutgoingOnlyAsymmetry:
+    """The rule is two statements and it takes two tests to pin them.
+
+    A guard that only checked "protected players do not appear" would be
+    satisfied by a policy applied to both pools — which silently removes the
+    ability to ACQUIRE a player you protect, and is the more damaging of the
+    two failures because nothing in the output looks wrong.
+    """
+
+    def test_a_protected_player_never_appears_on_a_side_we_send(self):
+        policy = outgoing_eligibility(OURS, MIN_PROTECTED)
+        packages, report = _packages(OURS, THEIRS, policy)
+
+        assert packages, "the fixture produced no packages — it proves nothing"
+        for pkg in packages:
+            assert "Justin Jefferson" not in _names(pkg.send)
+        assert report.our_excluded_constrained == 1
+        assert report.outgoing_constrained is True
+
+    def test_a_protected_player_is_STILL_a_valid_acquisition_target(self):
+        """§2.2: "MIN players may still appear as INCOMING acquisition targets"."""
+        policy = outgoing_eligibility(OURS, MIN_PROTECTED)
+        packages, report = _packages(OURS, THEIRS, policy)
+
+        received = {name for pkg in packages for name in _names(pkg.receive)}
+        assert "Jordan Addison" in received, (
+            "a MIN player on the OPPONENT's roster was withheld — the outgoing "
+            "constraint reached the receive side and inverted §2.2"
+        )
+        assert report.their_excluded_ineligible == 0
+
+    def test_MUTATION_applying_the_policy_to_their_side_breaks_the_second(
+        self, monkeypatch
+    ):
+        """Proof the acquisition assertion above is load-bearing.
+
+        Make the substrate apply the outgoing policy to BOTH pools — the exact
+        bug the side split exists to prevent — and the acquisition target
+        disappears. If this mutation left the assertion green, the assertion
+        would be measuring nothing.
+        """
+        import src.packages.construction as construction
+
+        real_eligible = construction._eligible
+
+        def both_sides(assets, policy, report, *, ours, outgoing=None):
+            return real_eligible(
+                assets, policy, report, ours=ours, outgoing=_MUTATED_POLICY[0]
+            )
+
+        _MUTATED_POLICY = [outgoing_eligibility([*OURS, *THEIRS], MIN_PROTECTED)]
+        monkeypatch.setattr(construction, "_eligible", both_sides)
+
+        packages, _report = _packages(OURS, THEIRS, _MUTATED_POLICY[0])
+        received = {name for pkg in packages for name in _names(pkg.receive)}
+        assert "Jordan Addison" not in received, (
+            "the mutation did not change the receive side, so the "
+            "acquisition-still-valid guard cannot fail and is not a guard"
+        )
+
+    def test_picks_are_not_swept_up_by_a_team_rule_during_generation(self):
+        """A pick has no NFL team; treating that as unknown would block every
+        pick from every generated package."""
+        ours = [*OURS, Asset("2027 Mid 1st", 3000.0, position="PICK")]
+        policy = outgoing_eligibility(ours, MIN_PROTECTED)
+        packages, _r = _packages(ours, THEIRS, policy)
+
+        sent = {name for pkg in packages for name in _names(pkg.send)}
+        assert "2027 Mid 1st" in sent
+
+
+# ── Fail-closed ──────────────────────────────────────────────────────
+
+
+class TestUnknownFailsClosed:
+    def test_unresolvable_constraints_generate_nothing(self):
+        """Not "generate freely because we could not check"."""
+        policy = outgoing_eligibility(OURS, UNRESOLVED)
+        packages, report = _packages(OURS, THEIRS, policy)
+
+        assert packages == []
+        assert report.our_excluded_constrained == len(OURS)
+        assert report.outgoing_constrained is True
+
+    def test_an_unknown_nfl_team_is_treated_as_protected(self):
+        """The player the board cannot place is withheld, not assumed innocent.
+
+        Assuming "not MIN" is a fabricated fact in the direction that proposes
+        trading someone the user told us not to trade.
+        """
+        ours = [Asset("No Team Listed", 5000.0, team=None), Asset("Chris Olave", 5000.0, team="NO")]
+        policy = outgoing_eligibility(ours, MIN_PROTECTED)
+        packages, report = _packages(ours, THEIRS, policy)
+
+        sent = {name for pkg in packages for name in _names(pkg.send)}
+        assert "No Team Listed" not in sent
+        assert "Chris Olave" in sent
+        assert report.our_excluded_constrained == 1
+
+    def test_MUTATION_an_unknown_team_defaulting_to_allowed_reaches_a_package(self):
+        """Proof the fail-closed assertion is load-bearing.
+
+        With no team rule active there is nothing to fail closed ON, and the
+        same player is proposed — so the guard above is measuring the rule and
+        not the fixture.
+        """
+        ours = [Asset("No Team Listed", 5000.0, team=None), Asset("Chris Olave", 5000.0, team="NO")]
+        packages, _r = _packages(ours, THEIRS, UNCONSTRAINED_OUTGOING)
+        sent = {name for pkg in packages for name in _names(pkg.send)}
+        assert "No Team Listed" in sent
+
+    def test_the_reason_survives_to_the_caller(self):
+        """A count is not a reason.  Both come from one owner."""
+        reasons = {r for _a, r in blocked_outgoing(OURS, MIN_PROTECTED)}
+        assert reasons == {"protected_nfl_team"}
+        assert {r for _a, r in blocked_outgoing(OURS, UNRESOLVED)} == {"constraints_unresolved"}
+
+    def test_enforcement_and_reporting_never_disagree(self):
+        """The policy and the partition are one owner answering one question.
+
+        If they could drift, a surface would explain a list it did not produce.
+        """
+        for constraints in (MIN_PROTECTED, UNRESOLVED, resolve_constraints()):
+            policy = outgoing_eligibility(OURS, constraints)
+            reported = {a.name for a, _r in blocked_outgoing(OURS, constraints)}
+            if policy is UNCONSTRAINED_OUTGOING:
+                assert reported == set()
+                continue
+            enforced = {a.name for a in adapt_assets(OURS) if not policy.admits(a)}
+            assert enforced == reported
+
+
+# ── §3.3 — protection outranks a forced inclusion ────────────────────
+
+
+def test_a_required_asset_cannot_bypass_a_protection():
+    """`required` deliberately skips the ordinary policy, which made it a
+    silent way around a protection.  §3.3: persistent protection outranks
+    temporary refinement."""
+    policy = outgoing_eligibility(OURS, MIN_PROTECTED)
+    with pytest.raises(ConstraintMisapplied, match="Justin Jefferson"):
+        enumerate_sides(
+            adapt_assets(OURS[1:]),
+            [2],
+            side=SEND,
+            outgoing_policy=policy,
+            required=adapt_assets(OURS[:1]),
+            adapt=False,
+        )
+
+
+def test_MUTATION_without_the_required_guard_the_protection_is_bypassed():
+    """Proof: the ordinary policy alone does not catch it.
+
+    `required` assets do not face `policy`, by design — so the guard above is
+    the only thing standing between a lock and a protected player.
+    """
+    policy = outgoing_eligibility(OURS, MIN_PROTECTED)
+    sides, _report = enumerate_sides(
+        adapt_assets(OURS[1:]),
+        [2],
+        side=SEND,
+        outgoing_policy=UNCONSTRAINED_OUTGOING,  # the guard switched off
+        required=adapt_assets(OURS[:1]),
+        adapt=False,
+        policy=policy,  # and the ordinary policy carrying the same exclusions
+    )
+    got = [s for s in sides]
+    assert got, "fixture produced no sides"
+    assert all("Justin Jefferson" in {a.name for a in s} for s in got), (
+        "the ordinary policy caught the required asset after all, which would "
+        "make the dedicated guard redundant — re-check both"
+    )
+
+
+def test_an_outgoing_policy_on_the_receive_side_is_refused():
+    """The asymmetry inverted.  Silently ignoring it would block acquisitions."""
+    policy = outgoing_eligibility(OURS, MIN_PROTECTED)
+    with pytest.raises(ConstraintMisapplied, match="outgoing-only"):
+        enumerate_sides(adapt_assets(THEIRS), [1], side=RECEIVE, outgoing_policy=policy)
+
+    # And the legitimate receive-side call still works.
+    sides, _r = enumerate_sides(
+        adapt_assets(THEIRS), [1], side=RECEIVE, outgoing_policy=UNCONSTRAINED_OUTGOING
+    )
+    assert list(sides)
+
+
+# ── §6 — during generation, never a post-filter ──────────────────────
+
+
+def test_a_forbidden_package_is_never_BUILT():
+    """The difference between §6 and a post-filter, measured.
+
+    Under the constraint the enumeration emits fewer packages — it did not
+    emit them and then drop them.  `report.emitted` is incremented at yield
+    time, so a post-filter would leave it at the unconstrained count.
+    """
+    free_packages, free_report = _packages(OURS, THEIRS, UNCONSTRAINED_OUTGOING)
+    policy = outgoing_eligibility(OURS, MIN_PROTECTED)
+    held_packages, held_report = _packages(OURS, THEIRS, policy)
+
+    assert len(held_packages) < len(free_packages)
+    assert held_report.emitted == len(held_packages), (
+        "more packages were emitted than returned — something is filtering "
+        "after enumeration, which is what §6 forbids"
+    )
+    assert free_report.emitted == len(free_packages)
+
+
+def test_the_constrained_count_is_reported_apart_from_the_ineligible_count():
+    """"You told us not to trade him" is an answer; "he is roster clog" is a
+    mechanic.  A surface that cannot tell them apart cannot explain itself."""
+    ours = [*OURS, Asset("Deep Bench", 10.0, team="DEN")]
+    policy = outgoing_eligibility(ours, MIN_PROTECTED)
+    _pkgs, report = _packages(
+        ours, THEIRS, policy, policy=EligibilityPolicy(min_value=1000.0)
+    )
+    assert report.our_excluded_constrained == 1  # the Viking
+    assert report.our_excluded_ineligible == 1  # the 10-value bench piece
+
+
+def test_a_products_own_eligibility_is_preserved_not_replaced(self=None):
+    """Constraints ADD to a product's mechanical gate; neither is the other."""
+    base = EligibilityPolicy(min_value=4500.0, require_position=False)
+    policy = outgoing_eligibility(OURS, MIN_PROTECTED, base=base)
+
+    assert policy.min_value == 4500.0
+    assert policy.require_position is False
+    adapted = {a.name: a for a in adapt_assets(OURS)}
+    assert not policy.admits(adapted["Justin Jefferson"])  # constrained
+    assert not policy.admits(adapted["Rome Odunze"])  # below the product's floor
+    assert policy.admits(adapted["Chris Olave"])
+
+
+# ── Acceptance 14 — one owner, and one place that can decide ─────────
+
+
+def test_only_the_owner_mints_a_block_reason():
+    """Acceptance 14, tested on the DECISION rather than the vocabulary.
+
+    A consumer may name "untouchable" in a warning string; what it may not do
+    is invent a reason of its own, because that is a second owner wearing the
+    first one's words.
+    """
+    reasons = {
+        "protected_individual",
+        "excluded_temporary",
+        "protected_nfl_team",
+        "protected_nfl_team_unknown",
+        "constraints_unresolved",
+    }
+    producers = set()
+    for path in (REPO / "src").rglob("*.py"):
+        rel = path.relative_to(REPO).as_posix()
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"))
+        except SyntaxError:  # pragma: no cover
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and node.value in reasons:
+                producers.add(rel)
+    assert producers == {"src/trade/constraints.py"}, (
+        f"a block reason is minted outside the owner: {sorted(producers)}"
+    )
+
+
+def test_every_generating_surface_accepts_constraints():
+    """The signature half of acceptance 14.
+
+    Evaluating surfaces are deliberately absent: §5 says manual Trade
+    Calculator analysis may include a protected player, because inspecting a
+    trade is not recommending one.
+    """
+    import inspect
+
+    from src.trade import angle, finder, suggestions
+
+    generating = [
+        (finder.find_trades, "finder.find_trades"),
+        (suggestions.generate_suggestions_from_pool, "suggestions.generate_suggestions_from_pool"),
+        (suggestions.analyze_roster, "suggestions.analyze_roster"),
+        (angle.find_acquisition_packages, "angle.find_acquisition_packages"),
+    ]
+    for fn, label in generating:
+        assert "constraints" in inspect.signature(fn).parameters, (
+            f"{label} generates outgoing assets and cannot be constrained"
+        )
+
+    from src.api import trade_simulator
+
+    assert "constraints" not in inspect.signature(trade_simulator.simulate_trade).parameters, (
+        "the manual Trade Calculator must stay free-form (§5)"
+    )
+
+
+def test_the_substrate_is_the_only_enforcement_path():
+    """No generator re-implements the decision as a pool pre-filter.
+
+    `partition_sendable` survives for surfaces that must EXPLAIN a short list,
+    and `suggestions` uses `blocked_outgoing` for exactly that — but no module
+    may shorten a pool and then enumerate the remainder, because that is the
+    page-local copy §2.3 forbids.
+    """
+    import inspect
+
+    from src.trade import finder
+
+    src = inspect.getsource(finder)
+    assert "outgoing_eligibility" in src
+    assert "partition_sendable(my_roster" not in src
+
+
+# ── Acceptance 13 — canonical values are unchanged ───────────────────
+
+
+def test_the_constraint_path_never_reads_or_writes_a_canonical_value():
+    """§2.2: "MIN players retain their ordinary canonical value".
+
+    A structural guard rather than a numeric one: the owner and the seam it
+    hands to the substrate must not so much as name a value field, so there is
+    nothing for a future edit to start consulting.
+    """
+    banned = {"rankDerivedValue", "rank_derived_value", "display_value", "market_value"}
+    tree = ast.parse((REPO / "src" / "trade" / "constraints.py").read_text(encoding="utf-8"))
+    found = {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and node.value in banned
+    }
+    assert not found, f"the constraint owner consults canonical value fields: {sorted(found)}"
+
+    attrs = {
+        node.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute) and node.attr in banned
+    }
+    assert not attrs, f"the constraint owner reads canonical value attributes: {sorted(attrs)}"
+
+
+def test_constraints_change_which_packages_exist_and_no_asset_value():
+    """The numeric half, on the substrate's own projection.
+
+    Every asset that survives the constraint carries exactly the value it
+    carried without it — a constraint removes candidates, it never reprices
+    one.
+    """
+    free_packages, _fr = _packages(OURS, THEIRS, UNCONSTRAINED_OUTGOING)
+    policy = outgoing_eligibility(OURS, MIN_PROTECTED)
+    held_packages, _hr = _packages(OURS, THEIRS, policy)
+
+    def values(packages):
+        out: dict[str, float | None] = {}
+        for pkg in packages:
+            for a in (*pkg.send, *pkg.receive):
+                out[a.name] = a.value
+        return out
+
+    free_values, held_values = values(free_packages), values(held_packages)
+    shared = set(free_values) & set(held_values)
+    assert shared, "the fixture shares no assets between the two runs"
+    for name in shared:
+        assert free_values[name] == held_values[name], f"{name} was repriced by a constraint"
+
+
+def test_MUTATION_a_repricing_constraint_would_be_caught():
+    """Proof the assertion above can fail.
+
+    `replace(policy, ...)` cannot reprice an asset — the policy has no value
+    field to write — so the guard is enforced by the TYPE as well as by the
+    test. This states that explicitly, so a future `EligibilityPolicy` that
+    gains a value hook has a test standing in front of it.
+    """
+    policy = outgoing_eligibility(OURS, MIN_PROTECTED)
+    assert not hasattr(policy, "value"), "EligibilityPolicy grew a value field"
+    assert not hasattr(policy, "adjust_value")
+    # And the dataclass exposes nothing that writes one.
+    assert set(replace(policy).__dataclass_fields__) == {
+        "min_value",
+        "allow_unknown_value",
+        "require_position",
+        "excluded_keys",
+    }

--- a/tests/trade/test_constraint_generation.py
+++ b/tests/trade/test_constraint_generation.py
@@ -466,3 +466,40 @@ def test_MUTATION_a_repricing_constraint_would_be_caught():
         "require_position",
         "excluded_keys",
     }
+
+
+def test_a_roster_analysis_built_without_constraints_says_so():
+    """ "Nothing is protected" and "nobody asked" are different claims.
+
+    The sendable view defaults to MIRRORING the full rooms, which looks like
+    failing open and is not — fail-closed lives at the owner, where `UNRESOLVED`
+    can express "we could not check". A `RosterAnalysis` cannot tell the
+    difference between an unconstrained league and an unread constraint store,
+    so it must not pretend to; defaulting the other way silently returned zero
+    suggestions for every caller that built the dataclass directly, which is a
+    shorter list with no explanation.
+    """
+    from src.trade.suggestions import PlayerAsset, RosterAnalysis, analyze_roster
+
+    hand_built = RosterAnalysis(
+        roster_size=1,
+        by_position={"QB": [PlayerAsset("QB1", "QB", 9000, 9000)]},
+        surplus_positions=[],
+        need_positions=[],
+        starter_counts={},
+        depth_counts={},
+    )
+    assert hand_built.constraints_applied is False
+    assert hand_built.can_send(PlayerAsset("QB1", "QB", 9000, 9000))
+
+    resolved = analyze_roster(["QB1"], [PlayerAsset("QB1", "QB", 9000, 9000)], constraints=None)
+    assert resolved.constraints_applied is True
+
+    protected = analyze_roster(
+        ["QB1"],
+        [PlayerAsset("QB1", "QB", 9000, 9000)],
+        constraints=resolve_constraints(persistent={"untouchables": ["QB1"]}),
+    )
+    assert protected.constraints_applied is True
+    assert not protected.can_send(PlayerAsset("QB1", "QB", 9000, 9000))
+    assert protected.by_position["QB"], "the ANALYSIS still counts him"

--- a/tests/trade/test_recommendation_constraints.py
+++ b/tests/trade/test_recommendation_constraints.py
@@ -241,31 +241,68 @@ def test_resolution_never_reads_or_writes_a_canonical_value():
 # ── §6 / acceptance 14 — applied during generation, by ONE owner ──────
 
 
-def test_the_finder_applies_constraints_before_enumeration():
+def test_the_finder_enforces_constraints_INSIDE_enumeration():
     """§6: reject forbidden state and generate only feasible packages.
 
-    Proven by the pool, not by the output: a post-filter would still have
-    enumerated the forbidden combinations. `find_trades` reports how many
-    outgoing assets the constraints removed, and that number comes from the
-    partition that happens before any shape is built.
+    This guard used to pin a WEAKER property — that `find_trades` called
+    `partition_sendable(my_roster)` textually before `_generate_packages`, i.e.
+    that the caller shortened its own pool first. That satisfies §6's letter and
+    misses §2.3's point: a pool pre-filter is a page-local rule, and the ninth
+    surface to be written will have its own or none.
+
+    What is pinned now is that the constraint reaches the SHARED GENERATOR as
+    eligibility. `find_trades` builds an outgoing policy from the owner and
+    hands it to `substrate.enumerate_packages`, which refuses to enumerate at
+    all without one — so a forbidden package is never constructed, rather than
+    constructed and then dropped.
     """
+    import ast
     import inspect
 
     from src.trade import finder
 
-    source = inspect.getsource(finder.find_trades)
-    partition_at = source.find("partition_sendable(my_roster")
-    enumerate_at = source.find("_generate_packages")
-    # Named separately so a REMOVED call and a MISORDERED one read differently.
-    assert partition_at != -1, (
-        "`find_trades` no longer partitions its outgoing pool through the "
-        "constraint owner — recommendations are unconstrained"
+    source = inspect.getsource(finder)
+    tree = ast.parse(source)
+    called = {
+        n.func.id
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+    }
+    assert "outgoing_eligibility" in called, (
+        "`finder` no longer builds an outgoing policy from the constraint owner "
+        "— recommendations are unconstrained"
     )
-    assert enumerate_at != -1, "enumeration moved; this guard needs rewriting"
-    assert partition_at < enumerate_at, (
-        "constraints are applied after enumeration — that is the post-filter "
-        "the spec forbids (§6: generate only feasible packages)"
+
+    find_src = inspect.getsource(finder.find_trades)
+    assert "partition_sendable(my_roster" not in find_src, (
+        "the retired pool pre-filter is back; enforcement belongs to the "
+        "substrate so every consumer inherits it"
     )
+
+    gen_src = inspect.getsource(finder._generate_packages)
+    assert "outgoing_policy=outgoing_policy" in gen_src, (
+        "the outgoing policy is not reaching enumerate_packages"
+    )
+
+
+def test_the_substrate_cannot_generate_without_a_constraint_decision():
+    """The property that makes "1 owner, N consumers" hold for consumer N+1.
+
+    Not a convention and not a review checklist: `outgoing_policy` has no
+    default, so a new product that forgets it gets a TypeError rather than an
+    unconstrained recommendation. `None` is refused too — an unset variable and
+    a considered "nothing protects this roster" must not look the same.
+    """
+    import pytest as _pytest
+
+    from src.packages import ConstraintMisapplied, enumerate_packages, enumerate_sides
+
+    with _pytest.raises(TypeError, match="outgoing_policy"):
+        enumerate_packages([], [])
+    with _pytest.raises(TypeError, match="outgoing_policy"):
+        enumerate_sides([], [1], side="send")
+    with _pytest.raises(ConstraintMisapplied, match="must not be None"):
+        enumerate_packages([], [], outgoing_policy=None)
 
 
 def test_every_outgoing_asset_constrained_is_an_honest_no_result():

--- a/tests/trade/test_recommendation_constraints.py
+++ b/tests/trade/test_recommendation_constraints.py
@@ -280,9 +280,9 @@ def test_the_finder_enforces_constraints_INSIDE_enumeration():
     )
 
     gen_src = inspect.getsource(finder._generate_packages)
-    assert "outgoing_policy=outgoing_policy" in gen_src, (
-        "the outgoing policy is not reaching enumerate_packages"
-    )
+    assert (
+        "outgoing_policy=outgoing_policy" in gen_src
+    ), "the outgoing policy is not reaching enumerate_packages"
 
 
 def test_the_substrate_cannot_generate_without_a_constraint_decision():


### PR DESCRIPTION
**Stacked on #913** (`c2153eb`). #913 is not modified — local and remote both still at `c2153eb`. **Claude 5 is the merge authority; I have not merged and will not.**

Binding spec: `docs/trade/TRADE_GENERATION_PREFERENCES_AND_REFINEMENT_SPEC.md` (#835). Manifest row `C3-CON-01`, acceptance *"8 consumers, 1 owner"*.

---

## The gap this closes

`src/trade/constraints.py` shipped on #913 and its docstring already described the intended shape — *"this produces predicates the canonical substrate (`src/packages`) consumes as eligibility, not a post-filter."* The code did something weaker: `finder.py` shortened its own roster pool before calling the generator, and it was the **only** consumer.

And `grep -c constraints server.py` was **0**. The finder had accepted a `constraints` parameter since it was written and no route ever passed one, so the single existing consumer ran unconstrained in production while the parameter looked wired.

## Approach: make unconstrained generation structurally impossible

Rather than chase call sites, the rule moved into the shared generator.

* **Side-asymmetric eligibility.** `_eligible` gained an `outgoing` policy supplied for the send pool and never for the receive pool. That asymmetry *is* §2.2 — "protected from appearing on the OUTGOING side" / "may still appear as INCOMING acquisition targets" — and it could not be expressed before, because `enumerate_packages` applied one `EligibilityPolicy` to both pools, so excluding a protected player from the send side would equally have blocked acquiring him.
* **A decision that cannot be skipped.** `outgoing_policy` is keyword-only with **no default** on both enumerators, so a consumer that forgets it gets a `TypeError` rather than an unconstrained recommendation. `None` is refused too — an unset variable and a considered "nothing protects this roster" would otherwise look identical at the call site and in review. The deliberate answer is the `UNCONSTRAINED_OUTGOING` sentinel, which reads as the claim it is. **This is what makes "1 owner, N consumers" hold for consumer N+1 without a review checklist.**
* **`enumerate_sides` requires `side`.** It serves both directions — Angle fixes the offer and enumerates what we RECEIVE in one mode, fixes the target and enumerates what we SEND in the other — so the substrate cannot infer which side it is looking at. Handing an outgoing policy to a RECEIVE enumeration raises rather than quietly blocking an acquisition.
* **`required` no longer bypasses protection.** Required assets deliberately skip the ordinary policy, which made the required list a silent way around a protection. §3.3: persistent protection outranks temporary refinement.
* **Reported, not silent.** `EnumerationReport` gains `our_excluded_constrained` and `outgoing_constrained`, counted apart from `our_excluded_ineligible` — "you told us not to trade him" is an answer and "he is roster clog" is a mechanic.

## Consumers wired

| surface | status |
|---|---|
| Trade Finder / arbitrage | enforcement moved into the substrate; route resolves and passes constraints |
| Trade Suggestions (4 generators) | one resolution on `RosterAnalysis`, consumed by all four |
| Trade equalizers / counteroffers (`_find_balancers`) | wired — it adds a further outgoing asset *after* the base package, so it generates in its own right |
| Angle acquire mode | wired; the other two Angle modes enumerate what we RECEIVE and correctly carry no outgoing constraint |
| `/api/trade/simulate` + other evaluators | deliberately untouched — §5, manual analysis is not a recommendation |

**The sendable view is a SECOND view, not a filtered `by_position`.** A protected player still occupies a roster spot, still fills a starting slot and still makes his position a surplus. Dropping him from the *analysis* would make the team look thinner than it is and change what every generator thinks it should acquire — a protection would become a valuation-adjacent input. He is withheld from what we may OFFER and from nothing else.

## Evidence — exact head `51b11bf`

| gate | result |
|---|---|
| `pytest -m "not livedata"` | **8591 passed, 51 skipped, 0 failed** (17:59) |
| `ruff format --check .` / `ruff check .` (0.6.9) | 1181 formatted / all passed |
| decision-coercion gate + `tests/audit` | clean, **106 passed** |
| `check_planning_integrity` / `check_product_plan_governance` | clean |
| **canonical board** | `golden_board` at `c2153eb` vs `51b11bf` → `board_diff --expect-no-value-change`: **ASSERTION OK: no value changed** — 1111 rows, 0 values moved, 0 newly priced/unpriced, 0 ranks changed, 0 label flips |

### Mutation harness — 8 of 8 guards proven RED

Every structural guard was re-run against a deliberate mutation of the code it guards. A guard nobody has watched fail can pass because the property holds *or* because it was never able to see the property, and the two are indistinguishable.

| mutation | verdict |
|---|---|
| substrate applies the outgoing policy to THEIR side too | RED |
| substrate stops applying it to OUR side | RED |
| the required-bypass guard is removed | RED |
| an outgoing policy on the RECEIVE side is allowed | RED |
| `None` accepted as "no constraints" | RED |
| an unknown NFL team is assumed innocent | RED |
| `UNRESOLVED` resolves to unconstrained | RED |
| a package is post-filtered instead of never built | RED |

**The harness caught one of my own guards being blind** (`bb0a543`): the acquisition-still-valid test built its policy over our roster alone, so it carried no key matching the opponent's protected player and stayed green under the exact bug it exists for. Rebuilt over both pools, with an assertion that refuses to run blind.

**The full gate caught nine failures the lane suites missed** (`51b11bf`), one of them a real smell in this change: a hand-built `RosterAnalysis` defaulted to "nothing is sendable", which looks fail-closed and is not — it silently returns zero suggestions with no explanation. Fail-closed belongs at the owner where `UNRESOLVED` can say "we could not check"; the dataclass now records `constraints_applied` instead of pretending.

## ⚠️ One item for the integration decision

`1abe9c3` touches `scripts/audit_status.py` and the 2026-08-04 audit status file. Wiring the owner into `analyze_roster`'s call site added a `constraints=` keyword, which broke that audit's needle for **C26 (T-9)** and turned two `tests/audit` gates red.

I respelled the needle and **kept C26 OPEN**, with the reasoning recorded in the registry: C3-CON-01 decides which *already resolved* assets may be offered and does nothing whatever about resolution, which is what T-9 is about. Closing it on a respelling would be the unchecked-claim failure that gate exists to catch — `audit_status.py`'s own C29 entry documents the same situation and the same answer. `--rebuild` changed exactly three lines, all C26's; tally unchanged at 22 closed / 1 deferred / 2 needs_review / 18 open.

**The dispatch said "no governance edits."** My read is that an audit findings registry is not CLAUDE.md, the V1 contract, the execution plan, or an ownership manifest — but it is a judgement call, and the commit is isolated and reverts cleanly. Dropping it leaves those two `tests/audit` gates red with the reason documented.

## Boundaries held

No `src.roster_intel` import added · no frontend changes · no Analyze Trade · no `C3-CON-03` LOCK/EXCLUDE enforcement · no `C7-BEST-TRADE` · no CLAUDE.md / V1 contract / execution plan / ownership manifest edits · nothing staged with `git add -A`.

## Named remainder — reported, not silently omitted

* **Package Builder** — `roster_intel.packages.generate_packages` via `src/api/gameplan.py:1020` (`ours = _trade_assets(..., surplus_only=True)`). A real generating surface, left unwired because it sits behind the Roster lane's generator and this unit may add no roster dependency.
* **`bdvm.roster.scan_double_positive_trades`** — generating, feature-flagged off, BDVM lane.
* **LOCK enforcement.** `TradeConstraints.required_outgoing()` resolves and nothing consumes it; `enumerate_packages` has no `required` parameter at all. That is `C3-CON-03`, out of scope here.
* **Storage.** The seam reads `tradeConstraintsByLeague` from `user_kv` and nothing writes it, so the owner resolves to "nothing configured" for every user until `C3-CON-02` lands. That is a legitimate answer and not a failure — the distinction is the whole of fail-closed.
* **"8 consumers"** cannot be met by call-site count today: three of spec §2.3's eight named surfaces (Golden Upgrades, Package Builder proper, Best Trade to Send Each Team) do not exist in the repo. The substrate's required parameter is what guarantees they cannot be built unconstrained.

---
_Generated by [Claude Code](https://claude.ai/code/session_0174S7YY6Gvsuj4Gush3qejH)_