### PR TITLE
The championship bracket takes the league's field size too — #919 left three of seven qualifiers on a structurally impossible 0.00%

### DIFF
--- a/src/ros/championship.py
+++ b/src/ros/championship.py
@@ -66,6 +66,7 @@ def _simulate_bracket(
     distributions: dict[str, playoff_sim._TeamDist],
     *,
     bye_seeds: int,
+    playoff_seeds: int,
     rng: random.Random,
 ) -> dict[str, int]:
     """Simulate one playoff bracket.  Returns finish placement per
@@ -78,7 +79,7 @@ def _simulate_bracket(
 
     # Mark anyone outside the playoff field with a finish equal to
     # their seed (they're "out" in seeding order).
-    playoff_field_size = len([s for s in seeded_owners if seeded_owners.index(s) < 6]) or 6
+    playoff_field_size = min(playoff_seeds, len(seeded_owners))
     for i, owner in enumerate(seeded_owners):
         if i >= playoff_field_size:
             finishes[owner] = i + 1
@@ -259,6 +260,7 @@ def simulate_championship_odds(
             seeded,
             distributions,
             bye_seeds=bye_seeds,
+            playoff_seeds=playoff_seeds,
             rng=rng,
         )
         for owner, finish in finishes.items():

--- a/tests/public_league/test_playoff_structure.py
+++ b/tests/public_league/test_playoff_structure.py
@@ -372,9 +372,9 @@ def test_the_bracket_plays_every_game_it_owes(monkeypatch, seeds, byes):
     championship._simulate_bracket(
         list(owners), dists, bye_seeds=byes, playoff_seeds=seeds, rng=random.Random(7)
     )
-    assert len(played) == seeds - 1, (
-        f"a {seeds}-team bracket played {len(played)} games, not {seeds - 1}: {played}"
-    )
+    assert (
+        len(played) == seeds - 1
+    ), f"a {seeds}-team bracket played {len(played)} games, not {seeds - 1}: {played}"
 
 
 def test_the_top_seed_does_not_absorb_the_stranded_teams_odds():

--- a/tests/public_league/test_playoff_structure.py
+++ b/tests/public_league/test_playoff_structure.py
@@ -270,3 +270,196 @@ def test_no_production_module_still_hardcodes_a_six_team_bracket():
     assert not offenders, (
         "a default bracket is back — resolve it from the league instead:\n" + "\n".join(offenders)
     )
+
+
+# ── The bracket the championship engine actually PLAYS ───────────────
+#
+# V1-51 unified where the bracket comes FROM. It did not check that the
+# championship simulator uses it, and the two tests above could not: one
+# asserts the *stamped* pair ``(7, 1)``, the other walks kwarg defaults,
+# and the defect was an integer literal in a function body.
+#
+# ``_simulate_bracket`` capped the field at six while ``bye_seeds`` came
+# through as the league's real 1, which leaves five wildcard teams. The
+# pairing loop runs ``while len(wildcard) >= 2``, so one is stranded,
+# three reach the semis, one survives, and ``if len(semis_advance) >= 2``
+# is False — **the final is never played**. The champion then falls out
+# of the defensive placement block in seed order.
+#
+# Measured on 12 identical teams before the repair: seed 1 took 49.86% of
+# championships and seeds 5, 6 and 7 took 0.00% — not a low probability,
+# a structurally impossible one, published beside a payload stamping
+# ``playoffSeeds: 7``.
+
+
+def _identical_field(n_owners: int):
+    """N owners the simulator cannot tell apart. Any asymmetry in the
+    result is therefore the bracket's, not the teams'."""
+    owners = [f"o{i:02d}" for i in range(1, n_owners + 1)]
+    dists = {
+        o: playoff_sim._TeamDist(owner_id=o, mean=100.0, sd=15.0, pf_to_date=0.0) for o in owners
+    }
+    return owners, dists
+
+
+def _championship_counts(
+    *, playoff_seeds: int, bye_seeds: int, n_owners: int = 12, runs: int = 600
+):
+    from src.ros import championship
+
+    owners, dists = _identical_field(n_owners)
+    rng = random.Random(7)
+    champions: dict[str, int] = {o: 0 for o in owners}
+    runners_up = 0
+    for _ in range(runs):
+        finishes = championship._simulate_bracket(
+            list(owners),
+            dists,
+            bye_seeds=bye_seeds,
+            playoff_seeds=playoff_seeds,
+            rng=rng,
+        )
+        won = [o for o, place in finishes.items() if place == 1]
+        assert len(won) == 1, f"a bracket produced {len(won)} champions: {finishes}"
+        champions[won[0]] += 1
+        runners_up += sum(1 for place in finishes.values() if place == 2)
+    return owners, champions, runners_up, runs
+
+
+def test_every_qualifier_can_win_the_live_seven_team_bracket():
+    """The defect, stated as the property it broke. Seven teams qualify,
+    so all seven must be able to win it — and only those seven."""
+    owners, champions, _, _ = _championship_counts(playoff_seeds=7, bye_seeds=1)
+
+    qualifiers = owners[:7]
+    impossible = [o for o in qualifiers if champions[o] == 0]
+    assert not impossible, (
+        "seeds with a structurally impossible championship: "
+        f"{impossible} — counts {[champions[o] for o in qualifiers]}"
+    )
+
+    eliminated = [o for o in owners[7:] if champions[o]]
+    assert not eliminated, f"a non-qualifier won the bracket: {eliminated}"
+
+
+@pytest.mark.parametrize("seeds,byes", [(4, 0), (6, 2), (7, 1), (8, 0)])
+def test_the_bracket_plays_every_game_it_owes(monkeypatch, seeds, byes):
+    """The mechanism, pinned separately from its consequence — and pinned
+    on the games PLAYED, not on the finishes emitted.
+
+    My first version of this test asserted that exactly one owner is
+    stamped runner-up, and it passed under the defect: when the final is
+    never played, the defensive placement block at the end of
+    ``_simulate_bracket`` still hands out finishes 1 and 2 in seed order,
+    so the payload looks identical. Counting games is what actually
+    distinguishes them.
+
+    A single-elimination bracket of N qualifiers plays exactly N-1
+    games, whatever the bye count. Under the defect the live 7/1 bracket
+    played 3 of its 6: an odd wildcard round strands a team, three reach
+    the semis, one survives, and ``len(semis_advance) >= 2`` is False."""
+    from src.ros import championship
+
+    played = []
+    real = championship._simulate_matchup
+    monkeypatch.setattr(
+        championship,
+        "_simulate_matchup",
+        lambda a, b, d, r: played.append((a, b)) or real(a, b, d, r),
+    )
+
+    owners, dists = _identical_field(12)
+    championship._simulate_bracket(
+        list(owners), dists, bye_seeds=byes, playoff_seeds=seeds, rng=random.Random(7)
+    )
+    assert len(played) == seeds - 1, (
+        f"a {seeds}-team bracket played {len(played)} games, not {seeds - 1}: {played}"
+    )
+
+
+def test_the_top_seed_does_not_absorb_the_stranded_teams_odds():
+    """One bye among seven teams is worth roughly a doubled share, not a
+    quadrupled one. Under the defect the top seed took 49.86% because it
+    inherited every bracket that failed to reach a final."""
+    owners, champions, _, runs = _championship_counts(playoff_seeds=7, bye_seeds=1)
+    top_seed_share = champions[owners[0]] / runs
+    assert 0.18 <= top_seed_share <= 0.34, f"top seed took {top_seed_share:.2%} of championships"
+
+
+def test_the_six_seed_bracket_is_unchanged():
+    """Non-vacuity in the other direction: this repair generalises the
+    bracket the code already played rather than changing it. Six seeds
+    and two byes must still produce two bye-sized shares and four equal
+    ones, exactly as before."""
+    owners, champions, _, runs = _championship_counts(playoff_seeds=6, bye_seeds=2)
+
+    assert all(champions[o] == 0 for o in owners[6:])
+    byes = sorted(champions[o] / runs for o in owners[:2])
+    rest = sorted(champions[o] / runs for o in owners[2:6])
+    assert all(0.18 <= s <= 0.34 for s in byes), byes
+    assert all(0.06 <= s <= 0.20 for s in rest), rest
+    assert min(byes) > max(rest), f"a bye stopped being worth more: {byes} vs {rest}"
+
+
+def test_the_championship_engine_receives_the_leagues_field_size(monkeypatch):
+    """The wiring, not the arithmetic. ``playoff_seeds`` was in scope at
+    the call site — used two lines later — and simply was not passed."""
+    from src.ros import championship
+
+    seen: dict[str, int] = {}
+    real = championship._simulate_bracket
+
+    def _spy(seeded_owners, distributions, **kwargs):
+        seen.update(playoff_seeds=kwargs["playoff_seeds"], bye_seeds=kwargs["bye_seeds"])
+        return real(seeded_owners, distributions, **kwargs)
+
+    monkeypatch.setattr(championship, "_simulate_bracket", _spy)
+    monkeypatch.setattr(playoff_sim, "_load_ros_strength_map", lambda: {})
+    monkeypatch.setattr(playoff_sim, "_league_best_ball", lambda: False)
+
+    owners, dists = _identical_field(12)
+    monkeypatch.setattr(playoff_sim, "_build_team_distributions", lambda *a, **k: (dists, {}))
+    monkeypatch.setattr(playoff_sim, "_current_record", lambda *a, **k: {})
+    monkeypatch.setattr(playoff_sim, "_remaining_schedule", lambda *a, **k: [])
+
+    out = championship.simulate_championship_odds(_snapshot(playoff_teams=7), n_simulations=5)
+    assert seen == {"playoff_seeds": 7, "bye_seeds": 1}
+    assert (out["playoffSeeds"], out["byeSeeds"]) == (7, 1)
+
+
+def test_no_bracket_function_sizes_its_field_from_a_literal():
+    """The guard above walks kwarg DEFAULTS, so it could not see an
+    integer literal inside a function BODY — which is where this defect
+    lived.
+
+    Scoped to assignments that name a field size rather than to every
+    integer in the function. The first version of this test flagged
+    ``for _ in range(8)`` in ``playoff_sim._simulate_bracket``, which is
+    the tie re-draw cap and has nothing to do with the bracket — a guard
+    that cries wolf gets its assertion loosened, which is how the
+    original one ended up unable to see anything."""
+    import ast
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    watched_files = ("src/ros/championship.py", "src/ros/playoff_sim.py")
+    sizing = ("field_size", "playoff_seeds", "bye_seeds", "field", "seeds")
+    offenders = []
+    for rel in watched_files:
+        path = root / rel
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            if not any(any(k in n for k in sizing) for n in names):
+                continue
+            for sub in ast.walk(node.value):
+                if isinstance(sub, ast.Constant) and isinstance(sub.value, int):
+                    offenders.append(
+                        f"{rel}:{node.lineno}: {'/'.join(names)} sized from literal {sub.value}"
+                    )
+    assert not offenders, (
+        "a bracket field size is hardcoded again — take it from the "
+        "resolved structure instead:\n" + "\n".join(offenders)
+    )

--- a/tests/ros/test_playoff_sim.py
+++ b/tests/ros/test_playoff_sim.py
@@ -101,6 +101,13 @@ class TestSimulateBracket(unittest.TestCase):
                 list(distributions.keys()),
                 distributions,
                 bye_seeds=2,
+                # V1-51 follow-up: the field size is no longer a literal
+                # inside the function, and ``playoff_seeds`` has no
+                # default — a plausible default is how the six-team
+                # bracket survived for a seven-team league. All six of
+                # these owners qualify, which is what the bye_seeds=2
+                # above already assumed.
+                playoff_seeds=6,
                 rng=rng,
             )
             if out.get("o0") == 1:


### PR DESCRIPTION
## What this is

A **P1 regression fix**, not a feature. #919 (V1-51) unified where the playoff bracket comes **from**. It did not check that the championship simulator **uses** it — and merging it made that engine worse rather than better.

I flagged this on #919 before the merge and offered to push it; the merge landed first, so it goes here. #919 is merged and closed, so it cannot be amended.

## The defect

`src/ros/championship.py` sized its playoff field with a literal:

```python
playoff_field_size = len([s for s in seeded_owners if seeded_owners.index(s) < 6]) or 6
```

and the call site passed `bye_seeds` only — **`playoff_seeds` never reached it**, though it is in scope and read two lines later (`if finish <= playoff_seeds`). `src/ros/scrape.py:372` is the only production caller and passes no bracket, so after #919 the league's real bye count (**1**) came through while the field stayed **6**.

That leaves **five** wildcard teams. The pairing loop runs `while len(wildcard) >= 2`, so one is **stranded**, three reach the semis, one survives, and `if len(semis_advance) >= 2` is False — **the final is never played**. The champion then falls out of the defensive placement block at the end of the function, in seed order.

Before #919 the same literal was *harmless*: 6 seeds and 2 byes leave four wildcard teams, which pairs evenly. The bracket was wrong for the league but internally coherent. Supplying the correct bye count to a hardcoded field is what broke it.

## Measured

20,000 simulations over **12 identical teams** — same mean, same sd — so any asymmetry in the result is the bracket's, not the teams'.

| seed | pre-#919 (6 seeds / 2 byes) | **on `main` today (7 / 1)** | this PR (7 / 1) |
|---|---|---|---|
| 1 | 24.77% | **49.86%** | 24.99% |
| 2 | 25.55% | 24.80% | 12.43% |
| 3 | 12.29% | 12.67% | 12.30% |
| 4 | 12.12% | 12.67% | 12.85% |
| 5 | 12.86% | **0.00%** | 12.57% |
| 6 | 12.43% | **0.00%** | 12.67% |
| 7 | — (not a qualifier) | **0.00%** | 12.20% |

Three of the seven teams this league qualifies had a **structurally impossible** championship — 0.00%, not a low number — published beside a payload stamping `playoffSeeds: 7`, `byeSeeds: 1`. Missing is never zero, and here zero was being served as certainty. The top seed meanwhile absorbed every bracket that failed to reach a final, roughly doubling its odds.

## The fix

`playoff_field_size = min(playoff_seeds, len(seeded_owners))`, and the call site passes the value that was already in scope.

`playoff_seeds` is keyword-only with **no default**. A plausible default is exactly how the six-team bracket survived unnoticed, which is why #919 *deleted* `DEFAULT_PLAYOFF_SPOTS` rather than deprecating it. One existing test called `_simulate_bracket` without it and now passes `playoff_seeds=6` explicitly — that break is the parameter doing its job.

**It generalises rather than changes.** Run at 6 seeds / 2 byes the fixed function reproduces the pre-#919 distribution *digit for digit* (24.77 / 25.55 / 12.29 / 12.12 / 12.86 / 12.43), and every bracket now plays exactly **N−1** games — 6 for 7/1, 5 for 6/2 — where the defect played **3 of 6**. Same evidence standard #919 used for `byes_for_teams`: 6 → 2 reproduced, 7 → 1 newly correct.

### The correct implementation was ten lines away

`playoff_sim._simulate_bracket` slices `ranked[:playoff_seeds]`, handles an odd round explicitly (`survivors.extend(contenders)  # odd bracket: the middle team advances`) and re-seeds down to one survivor. `championship.py` is the deficient **second copy** of one concept.

Merging them is a larger unit — they return different things (a champion vs finish placements) — so it is named here rather than attempted.

## Why the existing tests missed it

Both are #919's own, and both are aimed one inch off:

- `test_the_championship_engine_takes_the_leagues_bracket_too` asserts the **stamped pair** `(7, 1)` and never that a 7-seed can win.
- the AST guard walks kwarg **defaults**, so an integer literal in a function *body* is invisible to it.

## Tests — six, each mutation-checked RED against the pre-fix code

| test | property |
|---|---|
| `test_every_qualifier_can_win_the_live_seven_team_bracket` | all seven qualifiers reach finish 1 at least once; no non-qualifier ever does |
| `test_the_bracket_plays_every_game_it_owes` | an N-team bracket plays exactly N−1 games, parameterised over 4 / 6 / 7 / 8 seeds |
| `test_the_top_seed_does_not_absorb_the_stranded_teams_odds` | one bye among seven is worth a doubled share, not a quadrupled one |
| `test_the_six_seed_bracket_is_unchanged` | non-vacuity in the other direction — the control must not move |
| `test_the_championship_engine_receives_the_leagues_field_size` | the wiring, spied at the call site |
| `test_no_bracket_function_sizes_its_field_from_a_literal` | structural guard over field-size assignments in **both** ROS bracket modules |

Two of these needed a second pass, recorded because the failure mode is the point:

- **The first game-count test was vacuous.** It asserted that exactly one owner is stamped runner-up, and that **passes under the defect** — when the final is never played, the defensive block still hands out finishes 1 and 2 in seed order, so the payload looks identical. Counting the games actually played is what distinguishes them.
- **The first structural guard cried wolf.** It flagged `for _ in range(8)` in `playoff_sim._simulate_bracket` — the tie re-draw cap, nothing to do with brackets. It is now scoped to assignments naming a field size. A guard with false positives gets its assertion loosened, which is how the original one ended up unable to see anything.

## Not fixed here — recorded, not carried silently

- **The lexical `ownerId` tiebreak survives in both ROS engines.** `playoff_sim.py:838-841` and `championship.py:254-257` sort on `(-wins, -pf)` over `owners = sorted(distributions.keys())`, so Python's stable sort resolves ties in alphabetical ownerId order. Same defect class #919 fixed in the *public* engine; the AST guard covers only `playoff_odds.py`.
- **A latent collapse for brackets needing more than two rounds.** At 9 seeds / 7 byes — which `byes_for_teams(9)` will happily return — seeds 3-6 score **0.00%** even with this fix, because the `wildcard → semis → final` structure only handles a field that collapses to ≤ 4 after round one. **Not live for this league** (7 → 4 → 2 is fine).

Both are separate units. Mixing them in makes a regression fix unreviewable.

## Verification

| gate | result |
|---|---|
| `pytest tests/ -m "not livedata"` | **8,413 passed · 51 skipped · 0 failed** |
| `pytest tests/ros tests/public_league` | 571 passed, 1 skipped |
| `ruff format --check` / `ruff check` on the changed files | clean |
| `scripts/check_decision_coercions.py` | clean — run **post-commit**, since it scopes "new" to git-changed files |
| `scripts/validate_api_contract.py --lane structural` | `ok=True`, `structuralErrors=0`, 1,107 players |
| `scripts/check_planning_integrity.py` | clean |

Every number in the table above was reproduced on this tree in this session, not quoted from an earlier run.

### Post-deploy — UNVERIFIED HERE, command supplied

```bash
curl -s "$HOST/api/public/league/rosChampionship" \
  | jq '{seeds: .data.playoffSeeds, byes: .data.byeSeeds, cached: .data.cached,
         zeroOdds: [.data.championshipOdds[] | select(.championshipOdds == 0)] | length}'
```

Assert `seeds == 7`, `byes == 1`, and **`cached == false`** — `data/ros/sims/latest_championship.json` is a committed **pre-V1-51** artifact served under a 6h TTL, so without the `cached` check the verification proves nothing. Then assert the count of exactly-zero championship odds is 5 (the non-qualifiers), not 8.

**Not deployed, and production verification has not been done.** This moves live championship numbers for this league the moment it ships — that is the point of it, and it should be observed rather than assumed.

Not self-merging, per the integration-authority rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnuUUPc6Xx2QCjtkqRsa3k)_