### PR TITLE
Lane 4 production verification package, and the next-unit audit

### DIFF
--- a/docs/lane4/LANE4_V1_NEXT_UNIT_AUDIT.md
+++ b/docs/lane4/LANE4_V1_NEXT_UNIT_AUDIT.md
@@ -1,0 +1,179 @@
+# Lane 4 — what is actually left, and what to do next
+
+**Audit date 2026-08-19, against `main` @ `d7b126d6d` (post-#920 reconciliation).
+No code changed from this document.** The proposal at the end is a proposal; it
+is not authorized and not implemented.
+
+---
+
+## 1. The shape of the problem
+
+Fourteen V1 REQUIRED rows carry lane **L4**:
+
+| status | count | rows |
+|---|---|---|
+| `VERIFIED` | 2 | V1-26, V1-55 |
+| `IMPLEMENTED_UNVERIFIED` | **9** | V1-56, 57, 58, 60, 61, 63, 64, 65, 129 |
+| `IN PROGRESS` | 2 | V1-59, V1-62 |
+| `BLOCKED` | 1 | V1-89 |
+
+**Nine of fourteen are `IMPLEMENTED_UNVERIFIED`.** That is the whole finding.
+The code exists and has been reviewed; what is missing is *evidence*, and for
+almost all of them the evidence is production-side.
+
+Sorting those nine by what is actually blocking them:
+
+| blocker | rows |
+|---|---|
+| an authenticated production read | V1-58, V1-60, V1-61, V1-129 (and half of V1-57, V1-59) |
+| a production **filesystem** read (gitignored `data/`) | V1-57, V1-129 |
+| a **UI consumer** proof (L4) | V1-56, V1-61, V1-62 |
+| nothing — deterministic, and satisfied at #927's head | V1-63, V1-64 |
+
+**Writing more Lane 4 code moves almost none of this.** The scarce resource is
+not implementation, it is admissible evidence.
+
+---
+
+## 2. The two `IN PROGRESS` rows, measured rather than assumed
+
+### V1-59 — "Sharp bootstrap stops failing" (L3)
+
+Contract note: *"FFPC timeouts + SQLite locking."*
+
+**The SQLite half looks already addressed, and the note appears stale.** Every
+sharp store reaches SQLite through one connection owner:
+`roster_store.ensure_roster_schema` → `platform_ledger.ensure_platform_schema` →
+`ledger.connect`, and that owner sets
+
+* `sqlite3.connect(..., timeout=30.0)` plus `PRAGMA busy_timeout=30000`
+  (`src/intel/ledger.py:467-468`), and
+* `PRAGMA journal_mode=WAL` + `synchronous=NORMAL` at schema application
+  (`_apply_schema`, `:290-291`) — and `journal_mode` is persistent in the
+  database file, so one application covers every later connection.
+
+`ledger.py` also already distinguishes a routine `database is locked`
+`OperationalError` from corruption (`:353-354`), which is the specific mistake
+that used to escalate a lock into a rebuild.
+
+The FFPC half has bounded HTTP (`timeoutSeconds: 20`, `retryLimit: 2`,
+`requestBudgetPerRun: 100` in `config/sharp/ffpc_sources.json`).
+
+**What this does NOT establish:** that the bootstrap now succeeds. Whether these
+protections are sufficient in production is a `journalctl` question about the
+04:20 → 04:50 → 05:50 chain, and that is L3 evidence, not code. **So V1-59's
+remaining work is evidence, not engineering** — it sits behind the same wall as
+V1-58, and shipping more code here would be guessing at a failure nobody has
+measured recently.
+
+### V1-62 — "Sharp Tracker" (L4)
+
+Contract note: *"live but W15-F017 no memoization."* Confirmed: the only
+`lru_cache` in `src/sharp/market.py` is on `_local_asset_catalog` (`:65`), a
+display-metadata helper. `market_payload` recomputes the cohort, re-queries the
+ledger for **every window**, and re-aggregates on each request.
+
+Real, and worth fixing — but it is a **performance** defect, and the row's level
+is **L4**, which needs a production-consumer proof. Memoizing would not move the
+row's status by itself.
+
+---
+
+## 3. Proposed next unit
+
+> ### A bearer-gated, read-only Lane 4 verification endpoint
+>
+> One change that converts **four rows directly and three partially** from
+> permanently unverifiable into measurable.
+
+### The problem it solves
+
+Every recorded attempt to verify the Sharp rows ends the same way:
+
+```
+data/ops/sharp-production-smoke.json
+  status: "unverifiable_unauthenticated"
+  errors: [ ..., "401 from https://chaseupside.com/api/sharp/cohort" ]
+```
+
+Measured in the workflow's own comment: **80/80 attempts 401 across 79 runs.**
+`/api/sharp/*` is session-gated, correctly, and
+`tests/sharp/test_public_api_allowlist.py` pins that it is not public. **That
+gate must not be relaxed.** So the rows cannot be verified by any automated
+caller, and they have sat at `IMPLEMENTED_UNVERIFIED` for as long as they have
+existed.
+
+### Why this is provisioning, not bypassing
+
+The repo already names the answer, in
+`.github/workflows/verify-sharp-production.yml`:
+
+> *"Provision a token for the smoke (see `_SELF_AUTHED_API_EXACT` in server.py
+> for the bearer pattern used by `/api/signal-alerts/run`) to turn this into an
+> enforcing gate."*
+
+That pattern is live on three endpoints (`/api/signal-alerts/run`,
+`/api/custom-alerts/run`, and the intel refresh): an env-configured shared
+secret, compared with `hmac.compare_digest`, **empty means disabled** so it fails
+closed with nothing configured. Adding a credential path is the opposite of
+removing a gate.
+
+### Scope, and the constraints that keep it small
+
+* **Verdicts only, never data.** The endpoint returns the counts, states and
+  booleans `scripts/verify_lane4_production.py` already computes — cohort size,
+  `cohortCoveragePct`, `crowdMarket` state and census, the person-consensus
+  semantic checks, timer artifact freshness. **No player, manager, roster or
+  league identity crosses it.** A bearer token is a weaker credential than an
+  admin session, so it must see strictly less; that is what makes the exposure
+  acceptable rather than merely convenient.
+* **Read-only.** No mutation, no trigger, no refresh.
+* **Fails closed.** No token configured → the endpoint is not authenticated →
+  401, the same answer as today. Nothing regresses if it is never provisioned.
+* **Reuses the existing owner.** `_SELF_AUTHED_API_EXACT` plus the
+  `hmac.compare_digest` check, not a fourth auth mechanism.
+* **The verifier is already written.** `scripts/verify_lane4_production.py`
+  computes every verdict; this unit exposes them, and adds no second definition
+  of what "verified" means.
+
+### What it unblocks
+
+| row | effect |
+|---|---|
+| V1-58 Sharp cohort populated | **directly** — cohort size becomes readable by an automated caller |
+| V1-60 FFPC lane honest | **directly** — `cohortCoveragePct` null-vs-zero measurable |
+| V1-129 crowd comparability | **directly** — `crowdMarket` state and census measurable |
+| V1-65 Insider / cross-league | **directly** — the L2 measured statement |
+| V1-57 FAAB history timer | partly — artifact presence and age |
+| V1-59 Sharp bootstrap | partly — crawl-coverage state; `journalctl` still needed |
+| V1-61 Roster Percentage | partly — L4 still needs the UI consumer proof |
+
+### Why not the alternatives
+
+* **V1-62 memoization** — self-contained and shippable, but performance rather
+  than correctness, and being L4 it cannot reach `VERIFIED` on a memoization
+  commit. **This is the fallback** if the owner does not want an auth-surface
+  change.
+* **More V1-129 hardening** — the comparability owner is already the single
+  owner and #927 closes the label defect. More code there measures nothing.
+* **V1-59 engineering** — per §2, its protections are already in place; without
+  a fresh production failure to point at, changes would be speculative.
+
+### The one thing that needs sign-off before it starts
+
+This touches the **authentication surface**, which is Lane 5/6 territory rather
+than mine. It should not begin without Claude 5 agreeing to the shape —
+specifically that a bearer credential may read verdicts, and that the
+verdicts-only boundary is where the line sits.
+
+---
+
+## 4. Explicitly not proposed
+
+* **Relaxing `/api/sharp/*`'s session gate**, or adding those paths to the public
+  allowlist. The gate is correct.
+* **Manufacturing a cohort, ledger, scoring card or crowd row** to close
+  V1-58/V1-59. A manufactured population verifies the manufacture.
+* **#804 / #921** — post-V1, flag **OFF**, cadence awaiting an owner decision
+  (`docs/lane4/LANE4_804_CAPTURE_CADENCE_DECISION.md`). Nothing here changes the
+  V1 percentage.

--- a/docs/lane4/PRODUCTION_VERIFICATION_PACKAGE.md
+++ b/docs/lane4/PRODUCTION_VERIFICATION_PACKAGE.md
@@ -1,0 +1,246 @@
+# Lane 4 — production verification package
+
+**Status: this is an instrument, not evidence.** Nothing here claims any V1 row
+is verified. Running it produces evidence; writing it down does not.
+
+The runnable half is **`scripts/verify_lane4_production.py`**. This document is
+what each check proves, what it deliberately cannot prove, and how to read a
+result without over-claiming.
+
+---
+
+## Why a script rather than a checklist
+
+The prose checklist that shipped in `#927`
+(`docs/lane4/L2_L3_VERIFICATION_PROCEDURES.md`) named endpoints and fields that
+**do not exist** — `POST /api/faab/recommend` (the real route is
+`/api/waiver/faab-recommend`) and roster-percentage fields like
+`rostersObserved` that the payload never had. Several of its steps are
+unrunnable as written.
+
+That is not a typo problem, it is a *method* problem: a checklist's paths are
+checked by a reader's goodwill, a script's are checked by execution. Every path
+and field below is resolved against the deployed code at run time, so this class
+of error fails loudly instead of silently producing an unrunnable procedure.
+
+**Both defects are in `#927`, which is frozen.** They are flagged there for
+Integration; this package supersedes those endpoint and field references.
+
+---
+
+## The three rules, enforced in code
+
+1. **Production authentication is never bypassed.** `/api/sharp/*` and
+   `/api/waiver/*` are session-gated and correctly so. The script sends a cookie
+   only if the operator exports `RISKIT_SESSION_COOKIE`. There is no fallback
+   credential, no test-mode header, no allowlist edit — pinned by
+   `test_no_cookie_means_no_cookie_header`.
+
+   **A 401/403 is `UNVERIFIABLE_UNAUTHENTICATED`**: insufficient evidence,
+   deliberately neither a pass nor a failure. It raises a dedicated
+   `Unauthenticated` type so no generic handler can downgrade it to a transient
+   error. The vocabulary is the one
+   `.github/workflows/verify-sharp-production.yml` already uses.
+
+2. **Nothing is fabricated.** No cohort, ledger, scoring card, crowd row or
+   player is invented. `--add-player` must name a real free agent; without it the
+   crowd checks report `BLOCKED` rather than guessing one.
+
+3. **Read-only.** GETs, a POST that computes a recommendation without persisting
+   one, file reads, and `systemctl list-timers`. Nothing writes to production.
+
+### The status vocabulary is the point
+
+| status | meaning |
+|---|---|
+| `pass` | the case under test arose and behaved correctly |
+| `fail` | the case arose and behaved incorrectly |
+| `inapplicable` | the input was read and **did not contain the case**. Not a pass |
+| `blocked` | a required input does not exist here. Not a pass, not a failure |
+| `unverifiable_unauthenticated` | 401/403. Not a pass, not a failure |
+| `error` | the check did not run |
+
+Exit codes: `0` at least one real pass and no failures · `1` error · `2` failure
+· **`3` nothing was proven** — every check was blocked, unauthenticated or
+inapplicable.
+
+`3` exists because it is the whole risk. A run where nothing could be measured
+must not share an exit code with a run where everything passed, and
+`test_a_run_that_proves_nothing_does_not_exit_zero` pins it.
+
+---
+
+## Modes
+
+Neither subsumes the other; the package is both.
+
+| | `--mode remote` | `--mode onbox` |
+|---|---|---|
+| runs | anywhere, over HTTPS | in the deployed working directory |
+| needs | `RISKIT_SESSION_COOKIE` | filesystem + deployed source |
+| sees | what the API publishes | the scoring card, the crowd ledger, systemd |
+| covers | C1–C3, C8, C9 | C1–C9, V1-57/60/65 |
+
+The scoring card (`data/leagues/scoring_<id>.json`) and the crowd ledger
+(`data/faab/crowd_history_<league>.json`) are gitignored and prod-only, so
+**C4–C7 are structurally impossible over HTTP** and say so rather than
+approximating.
+
+```bash
+# on the box
+python scripts/verify_lane4_production.py --mode onbox \
+    --league dynasty_main --origin http://127.0.0.1:8000 \
+    --add-player '<a real free agent>' --out data/ops/lane4-verification.json
+
+# from anywhere
+export RISKIT_SESSION_COOKIE='session=...'
+python scripts/verify_lane4_production.py --mode remote \
+    --origin https://chaseupside.com --league dynasty_main \
+    --add-player '<a real free agent>'
+```
+
+---
+
+## The #927 checks
+
+`#927` is not deployed yet, so this package is a **before/after instrument**.
+Run it now to establish the baseline, and again after the deploy. Measured on
+the two trees today:
+
+| check | on `main` (pre-#927) | on `#927` |
+|---|---|---|
+| C4 TEP rule | **`fail`** — label rule detected | `inapplicable` — card rule detected, no fresh card here to compare |
+| C5 unproven scoring | **`fail`** — no `unprovable_target_fields` owner | **`pass`** |
+
+That discrimination is the package proving it can tell the builds apart, and it
+was obtained without fabricating anything.
+
+### C1 — zero-voter `personManagerQuality` is JSON `null`, never `1.0` *(V1-63)*
+
+Reachable whenever every person who touched an asset both added **and** dropped
+it inside the window: the row is still emitted, with `personVotes: 0`. `1.0` is
+the *highest* possible manager quality, so the pre-#927 build answered "how good
+is the evidence?" with a green light precisely when there was none.
+
+`pass` = every zero-voter row published `null`. `fail` = any published a number.
+`inapplicable` = rows exist but none had `personVotes == 0`. `blocked` = no row
+carried `personConsensus` at all (empty cohort or empty ledger).
+
+**#920 named this as the blocker to V1-63 `VERIFIED`**: *"`personManagerQuality`
+still returns `1.0` for zero voters."*
+
+### C2 — a measured `0.0` stays `0.0` *(V1-63)*
+
+The repair must not overshoot. UNKNOWN and WORST are different answers, and a
+cohort of voters all scored `0.0` **has** an answer: the floor. Any row with
+voters and a `null` quality means a real measurement was swallowed → `fail`.
+
+### C3 — `networkConcentration` is `null` with no weighted volume *(V1-63)*
+
+It is a *share* of weighted volume. With no weighted volume there is no share for
+any network to hold, and `0.0` is the one value that reads as its exact opposite:
+"no single network dominates".
+
+### C4 — target TEP comes from the card, not the profile label *(V1-129)*
+
+Reads **which rule the deployed build implements** from
+`TargetFormat.from_roster_settings`'s own signature (`scoring_settings` = card,
+`scoring_profile` = label), then checks that the served `tep` equals what the
+league's own fresh card measures via
+`league_intel.te_premium.measure_te_demand`.
+
+Signature-first on purpose: a behaviour-only check passes on a label-rule build
+whenever the label happens to agree with the card.
+
+### C5 — stale or missing scoring evidence leaves TEP UNKNOWN and fails closed *(V1-129)*
+
+A card proves when it was taken, not that it is still true. `pass` requires all
+three: evidence is not `fresh`, `tep is None`, and the target reports `tep` among
+its unprovable fields so classification hard-excludes rather than assuming a
+match.
+
+**UNKNOWN must not become "no TE premium"** — that would admit a whole population
+of offense-scoring leagues as comparable.
+
+When the card *is* fresh this is `inapplicable`, and the detail says explicitly:
+do **not** age or delete a card to manufacture the case.
+
+### C6 — `dynasty_main` behaves as non-TE-premium under its actual card *(V1-129)*
+
+The specific measured claim, kept separate from C4 because a build can read the
+card and still get this league wrong. Asserts the card's own numbers
+(`bonus_rec_te`, `bonus_fd_te` against their WR counterparts) and that the served
+value follows them.
+
+If the card *does* show a TE edge, this reports `inapplicable`, not `fail` — the
+commissioner may have restored the premium, and that is a finding about the
+league rather than about the code.
+
+### C7 — comparable crowd population, card-derived vs the retired label rule *(V1-129)*
+
+A counterfactual over **real stored rows**, not a simulation: the accumulated
+ledger is classified twice — once against the served target, once against the
+same target with `tep` forced to what the retired label rule would have said.
+The only thing that varies is the policy.
+
+Reports `rowsUsed`, `tierCounts` and `excludedCounts` for both. Where card and
+label disagree, every row in the difference was being compared on a TE premium
+this league does not grant.
+
+### C8 — the refusal is specific, and names the right side *(V1-129)*
+
+"We hold no crowd evidence" and "we cannot describe our own league well enough to
+judge any" are different failures with different fixes. A build with no
+`targetFormatUnknown` key `fail`s: the two states are indistinguishable to a
+consumer. An undescribable target must answer
+`target_format_unverifiable:<fields>` **ahead of** the freshness checks, because
+freshness is moot when no row is admissible.
+
+### C9 — the crowd moves the bid only when it was actually admitted *(V1-129)*
+
+The crowd feeds `rival_bid_cdf` at weight **0.6**, so what it admits moves real
+recommended bids. Two directions, both `fail`:
+
+* admitted and priced, but **no** `Cross-league market` factor row → the evidence
+  moved the bid invisibly;
+* refused, but the factor row is **still there** → the refusal is cosmetic.
+
+Matched on the factor's stable `label`, not its prose, so improving the wording
+does not break the check. `standard` / `conservative` / `aggressive` / `max` /
+`contention.clearing` are recorded so two runs measure the effect directly.
+
+---
+
+## The other Lane 4 rows
+
+**V1-57 (L3)** — `dynasty-faab-history` installed *and fired* (`systemctl
+list-timers`), plus the artifact it produces
+(`data/faab/bid_history_<league>.json`, fresh inside 25 h against a daily timer).
+A green manual run of the script does **not** satisfy this row: that the script
+works was never the open question.
+
+**V1-60 (L2)** — the FFPC lane is real or honestly unavailable.
+`CollectResult` must carry `status`/`unavailable()`, and `cohortCoveragePct` must
+be `null` — never `0` — when nothing was observed. With an empty cohort the check
+reports `blocked` and names V1-58 as the blocker, because the honest-degraded
+half is only half the row.
+
+**V1-65 (L2)** — exactly one `cohort_members` definition, in
+`src/sharp/cohort.py`. Deterministic, so it runs anywhere; a second definition is
+how this row regresses.
+
+**V1-58 / V1-59 — BLOCKED, and stated as such.** Both need production Sharp
+evidence and the recorded artifacts end at `401` /
+`unverifiable_unauthenticated`. `/api/sharp/*` is not in the public allowlist
+(`tests/sharp/test_public_api_allowlist.py` pins that) and **that gate must not be
+relaxed to make verification easier**.
+
+The single credential that unblocks both is an authenticated admin session for
+the deployed origin, held by the site owner. With it: V1-58 is
+`GET /api/sharp/cohort` returning a non-empty membership against the deployed
+SHA; V1-59 is a clean `journalctl` run of `dynasty-sharp-discovery` (04:20) →
+`dynasty-sharp-records` (04:50) → `dynasty-sharp-rosters` (05:50) with no FFPC
+timeout and no SQLite lock.
+
+Neither is to be closed by standing up a synthetic cohort. **A manufactured
+population would verify the manufacture.**

--- a/scripts/verify_lane4_production.py
+++ b/scripts/verify_lane4_production.py
@@ -1,0 +1,1390 @@
+#!/usr/bin/env python3
+"""Lane 4 production verification — executable post-deploy checks.
+
+WHAT THIS IS
+------------
+The Lane 4 V1 rows (`docs/VERSION_1_COMPLETION_CONTRACT.md` §3.5) sit at
+`IMPLEMENTED_UNVERIFIED` because their evidence is **production-side**: the
+crowd-FAAB ledger, the own-league bid history, the Sharp cohort and the
+league scoring cards are all gitignored and prod-only. A repository cannot
+prove any of them. This script is what someone with access runs so that
+"verified" stops being an assertion.
+
+It is also the before/after instrument for **#927**. Several checks below
+describe behaviour that only exists once #927 deploys; run it before and
+after, and the difference is the evidence.
+
+THE THREE RULES, ENFORCED IN CODE AND NOT ONLY IN PROSE
+-------------------------------------------------------
+1. **Production authentication is never bypassed.** `/api/sharp/*` and
+   `/api/waiver/*` require a session; this script sends one only if the
+   operator supplies it. There is no fallback, no test-mode header and no
+   allowlist edit. A **401 is `UNVERIFIABLE_UNAUTHENTICATED`** — recorded as
+   insufficient evidence, and deliberately neither a pass nor a failure. The
+   vocabulary matches `.github/workflows/verify-sharp-production.yml`, which
+   already treats it that way.
+2. **Nothing is fabricated.** No cohort, ledger, scoring card, crowd row or
+   player is invented to make a check runnable. A check whose real input is
+   absent reports `BLOCKED` and names the input. A check whose input exists
+   but does not contain the case under test reports `INAPPLICABLE` — "we
+   looked and the situation did not arise" is a different statement from
+   "we looked and it was correct", and collapsing them is the exact defect
+   class Lane 4 exists to prevent.
+3. **Read-only.** Every operation is a GET, a POST that computes a
+   recommendation without persisting one, a file read, or a `systemctl`
+   query. Nothing writes to production.
+
+WHY A NEW SCRIPT
+----------------
+`scripts/audit_status.py` tracks audit findings by source-signature tripwire,
+which is a different question (has this mechanism changed?) from this one
+(does the deployed system behave correctly on real data?).
+`.github/workflows/verify-sharp-production.yml` polls exactly one endpoint
+for one row. Neither is the owner of per-row Lane 4 production evidence.
+
+MODES
+-----
+``--mode remote`` runs over HTTPS against a deployed origin and needs a
+session cookie. It can see what the API publishes.
+
+``--mode onbox`` runs **in the deployed working directory** and reads local
+`data/` plus the deployed source. It can see the scoring card, the crowd
+ledger and the systemd units, and it is the only mode that can compute the
+before/after counterfactuals, because those need the real stored rows
+re-classified under two policies.
+
+Neither mode subsumes the other; the package is both.
+
+USAGE
+-----
+    # on the box, in the deployed working directory
+    python scripts/verify_lane4_production.py --mode onbox \
+        --league dynasty_main --out data/ops/lane4-verification.json
+
+    # from anywhere, with an operator-supplied session
+    export RISKIT_SESSION_COOKIE='session=...'
+    python scripts/verify_lane4_production.py --mode remote \
+        --origin https://chaseupside.com --league dynasty_main \
+        --add-player 'Some Free Agent'
+
+EXIT CODES
+----------
+    0  every applicable check passed, and at least one was applicable
+    1  an unexpected error while running a check
+    2  at least one check FAILED
+    3  no failure, but the run proved nothing — every check was blocked,
+       unverifiable or inapplicable.  Distinct from 0 on purpose: an
+       evidence-free run must not read as a green one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+# ── Result vocabulary ──────────────────────────────────────────────
+
+PASS = "pass"
+FAIL = "fail"
+#: The input exists and was read, but it does not contain the case under
+#: test.  NOT a pass: nothing was proven.
+INAPPLICABLE = "inapplicable"
+#: A required input does not exist here.  NOT a pass and NOT a failure.
+BLOCKED = "blocked"
+#: The endpoint answered 401/403.  Insufficient evidence, by design.
+UNVERIFIABLE = "unverifiable_unauthenticated"
+ERROR = "error"
+
+_PROVES_NOTHING = {INAPPLICABLE, BLOCKED, UNVERIFIABLE}
+
+
+@dataclass
+class Check:
+    """One named assertion, with the evidence that produced it."""
+
+    id: str
+    row: str
+    title: str
+    status: str = BLOCKED
+    detail: str = ""
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "row": self.row,
+            "title": self.title,
+            "status": self.status,
+            "detail": self.detail,
+            "evidence": self.evidence,
+        }
+
+
+class Report:
+    def __init__(self, mode: str, league: str, origin: str | None) -> None:
+        self.mode = mode
+        self.league = league
+        self.origin = origin
+        self.checks: list[Check] = []
+        self.deployed: dict[str, Any] = {}
+
+    def add(self, check: Check) -> Check:
+        self.checks.append(check)
+        return check
+
+    def to_dict(self) -> dict[str, Any]:
+        counts: dict[str, int] = {}
+        for c in self.checks:
+            counts[c.status] = counts.get(c.status, 0) + 1
+        applicable = [c for c in self.checks if c.status not in _PROVES_NOTHING]
+        return {
+            "checkedAt": datetime.now(timezone.utc).isoformat(),
+            "mode": self.mode,
+            "league": self.league,
+            "origin": self.origin,
+            "deployed": self.deployed,
+            "counts": counts,
+            "applicableChecks": len(applicable),
+            "checks": [c.to_dict() for c in self.checks],
+        }
+
+    def exit_code(self) -> int:
+        statuses = {c.status for c in self.checks}
+        if ERROR in statuses:
+            return 1
+        if FAIL in statuses:
+            return 2
+        if not any(c.status == PASS for c in self.checks):
+            # Nothing failed, but nothing was proven either.
+            return 3
+        return 0
+
+
+# ── HTTP (remote mode) ─────────────────────────────────────────────
+
+
+class Unauthenticated(Exception):
+    """401/403 from a session-gated endpoint.
+
+    Its own type because it must never be swallowed by a generic handler
+    and reported as a transient failure: a 401 is a definitive answer to a
+    different question ("do we hold a credential?"), and the measured
+    history on this repo is 80/80 attempts across 79 runs.
+    """
+
+
+def _http(url: str, *, cookie: str | None, body: dict | None = None, timeout: float = 30.0):
+    """GET, or POST when ``body`` is supplied.  Returns ``(status, payload)``.
+
+    The cookie is sent ONLY when the operator supplied one.  There is no
+    other credential path in this script by design.
+    """
+    data = None
+    headers = {"Accept": "application/json"}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    if cookie:
+        headers["Cookie"] = cookie
+    request = urllib.request.Request(url, data=data, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read().decode("utf-8")
+            return response.status, (json.loads(raw) if raw.strip() else {})
+    except urllib.error.HTTPError as exc:
+        if exc.code in (401, 403):
+            raise Unauthenticated(f"{exc.code} from {url}") from exc
+        raw = exc.read().decode("utf-8", "replace")
+        try:
+            return exc.code, json.loads(raw)
+        except ValueError:
+            return exc.code, {"raw": raw[:500]}
+
+
+# ── Shared helpers ─────────────────────────────────────────────────
+
+
+def _repo_file(*parts: str) -> Path:
+    return REPO_ROOT.joinpath(*parts)
+
+
+def _load_json(path: Path) -> Any | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+# ── #927 group A: person-consensus semantic states (V1-63) ─────────
+#
+# Three states that must never read as one another.  All three are read
+# off ONE market payload, because they are properties of the same rows and
+# fetching three times would let the board move underneath the check.
+
+
+def _person_rows(payload: dict) -> list[tuple[str, dict]]:
+    """``(assetId, personConsensus)`` for every row that has one."""
+    out: list[tuple[str, dict]] = []
+    for row in payload.get("assets") or []:
+        if not isinstance(row, dict):
+            continue
+        person = row.get("personConsensus")
+        if isinstance(person, dict):
+            out.append((str(row.get("assetId") or ""), person))
+    return out
+
+
+def check_zero_voter_quality(report: Report, payload: dict, source: str) -> None:
+    """#927 check 1 — zero voters must publish ``null``, never ``1.0``.
+
+    Reachable whenever every person who touched an asset both added AND
+    dropped it inside the window: the row is still emitted, with
+    ``personVotes: 0``.  ``1.0`` is the HIGHEST possible manager quality, so
+    the pre-#927 behaviour answered "how good is the evidence?" with a
+    green light precisely when there was none.
+    """
+    check = report.add(
+        Check(
+            "C1",
+            "V1-63",
+            "zero-voter personManagerQuality is JSON null, never 1.0",
+        )
+    )
+    rows = _person_rows(payload)
+    if not rows:
+        check.status = BLOCKED
+        check.detail = (
+            f"{source} published no personConsensus block on any row. With an empty "
+            "cohort or an empty movement ledger there is nothing to measure — this "
+            "is not evidence that the field is correct."
+        )
+        return
+    zero = [(a, p) for a, p in rows if p.get("personVotes") == 0]
+    if not zero:
+        check.status = INAPPLICABLE
+        check.detail = (
+            f"{len(rows)} rows carried personConsensus and none had personVotes == 0, "
+            "so the zero-voter branch did not execute. Not a pass: the case under "
+            "test did not arise. Re-run when the board carries a mixed-signal asset "
+            "(mixedPersonSignals > 0 with personVotes == 0)."
+        )
+        check.evidence = {"rowsWithPersonConsensus": len(rows)}
+        return
+    offenders = [
+        {
+            "assetId": asset_id,
+            "personManagerQuality": person.get("personManagerQuality"),
+            "mixedPersonSignals": person.get("mixedPersonSignals"),
+        }
+        for asset_id, person in zero
+        if person.get("personManagerQuality") is not None
+    ]
+    check.evidence = {
+        "rowsWithPersonConsensus": len(rows),
+        "zeroVoterRows": len(zero),
+        "offenders": offenders[:20],
+        "offenderCount": len(offenders),
+    }
+    if offenders:
+        check.status = FAIL
+        check.detail = (
+            f"{len(offenders)} of {len(zero)} zero-voter rows published a non-null "
+            "personManagerQuality. Pre-#927 this is 1.0 on every one of them."
+        )
+    else:
+        check.status = PASS
+        check.detail = f"all {len(zero)} zero-voter rows published personManagerQuality: null."
+
+
+def check_measured_zero_quality(report: Report, payload: dict, source: str) -> None:
+    """#927 check 2 — a measured 0.0 must stay 0.0.
+
+    The repair must not overshoot.  UNKNOWN and WORST are different answers,
+    and a cohort of voters all scored 0.0 HAS an answer: the floor.  A row
+    with voters and a null quality would mean the fix swallowed a real
+    measurement.
+    """
+    check = report.add(Check("C2", "V1-63", "a measured personManagerQuality of 0.0 stays 0.0"))
+    rows = _person_rows(payload)
+    voted = [(a, p) for a, p in rows if (p.get("personVotes") or 0) > 0]
+    if not voted:
+        check.status = BLOCKED if not rows else INAPPLICABLE
+        check.detail = (
+            f"{source} published no row with personVotes > 0, so no measured quality "
+            "exists to check. Nothing proven either way."
+        )
+        check.evidence = {"rowsWithPersonConsensus": len(rows)}
+        return
+    nulled = [a for a, p in voted if p.get("personManagerQuality") is None]
+    zeros = [a for a, p in voted if p.get("personManagerQuality") == 0]
+    check.evidence = {
+        "rowsWithVoters": len(voted),
+        "nulledDespiteVoters": nulled[:20],
+        "nulledCount": len(nulled),
+        "measuredZeroRows": len(zeros),
+    }
+    if nulled:
+        check.status = FAIL
+        check.detail = (
+            f"{len(nulled)} rows have voters but published personManagerQuality: null. "
+            "A measurement was discarded — the repair overshot into treating a real "
+            "value as missing."
+        )
+        return
+    check.status = PASS
+    if zeros:
+        check.detail = (
+            f"every one of {len(voted)} rows with voters published a number, including "
+            f"{len(zeros)} at exactly 0.0 — measured worst, not unknown."
+        )
+    else:
+        check.detail = (
+            f"every one of {len(voted)} rows with voters published a number. No row "
+            "measured exactly 0.0 on this board, so the floor case is reported by the "
+            "absence of nulls rather than by an example."
+        )
+
+
+def check_undefined_concentration(report: Report, payload: dict, source: str) -> None:
+    """#927 check 3 — no weighted volume means the ratio does not exist.
+
+    ``networkConcentration`` is a SHARE of weighted volume.  With no weighted
+    volume there is no share for any network to hold, and ``0.0`` is the one
+    value that reads as its exact opposite: "no single network dominates".
+    """
+    check = report.add(
+        Check(
+            "C3",
+            "V1-63",
+            "networkConcentration is null when weighted volume is zero",
+        )
+    )
+    rows = _person_rows(payload)
+    if not rows:
+        check.status = BLOCKED
+        check.detail = f"{source} published no personConsensus block on any row."
+        return
+    novol = [(a, p) for a, p in rows if not (float(p.get("weightedPersonVolume") or 0.0) > 0.0)]
+    if not novol:
+        check.status = INAPPLICABLE
+        check.detail = (
+            f"every one of {len(rows)} rows carried weighted volume > 0, so the "
+            "undefined branch did not execute."
+        )
+        check.evidence = {"rowsWithPersonConsensus": len(rows)}
+        return
+    offenders = [
+        {"assetId": a, "networkConcentration": p.get("networkConcentration")}
+        for a, p in novol
+        if p.get("networkConcentration") is not None
+    ]
+    check.evidence = {
+        "rowsWithPersonConsensus": len(rows),
+        "zeroVolumeRows": len(novol),
+        "offenders": offenders[:20],
+        "offenderCount": len(offenders),
+    }
+    if offenders:
+        check.status = FAIL
+        check.detail = (
+            f"{len(offenders)} of {len(novol)} zero-volume rows published a "
+            "networkConcentration number for a ratio that does not exist."
+        )
+    else:
+        check.status = PASS
+        check.detail = f"all {len(novol)} zero-volume rows published null."
+
+
+# ── #927 group B: TEP is a fact, not a label (V1-129) ──────────────
+#
+# On-box only.  These need the league's real Sleeper scoring card, which
+# lives at ``data/leagues/scoring_<sleeperLeagueId>.json`` and is gitignored,
+# so no repository and no HTTP client can answer them.
+
+
+def _deployed_tep_rule() -> str:
+    """Which rule the DEPLOYED code implements: ``card`` or ``label``.
+
+    Read from the constructor's own signature rather than from behaviour, so
+    the answer is unambiguous on a board where both rules would agree.
+    """
+    import inspect
+
+    from src.trade.faab_comparability import TargetFormat
+
+    params = inspect.signature(TargetFormat.from_roster_settings).parameters
+    if "scoring_settings" in params:
+        return "card"
+    if "scoring_profile" in params:
+        return "label"
+    return "unknown"
+
+
+def check_tep_is_card_derived(report: Report, league: str) -> dict[str, Any]:
+    """#927 check 4 — target TEP comes from the actual card, not the label.
+
+    Returns a context dict the later checks reuse, so the card is read once.
+    """
+    check = report.add(
+        Check("C4", "V1-129", "target TEP is derived from the scoring card, not the profile label")
+    )
+    ctx: dict[str, Any] = {}
+    try:
+        from src.api import league_registry
+        from src.league_intel.te_premium import measure_te_demand
+        from src.trade.faab_comparability import TargetFormat
+    except Exception as exc:  # pragma: no cover - deployment shape
+        check.status = ERROR
+        check.detail = f"could not import the comparability owner: {exc!r}"
+        return ctx
+
+    cfg = league_registry.get_league_by_key(league)
+    if cfg is None:
+        check.status = BLOCKED
+        check.detail = f"league {league!r} is not in the deployed registry."
+        return ctx
+
+    rule = _deployed_tep_rule()
+    evidence_state = league_registry.scoring_evidence_state(cfg)
+    card = league_registry.scoring_settings_for_league(cfg)
+    profile = str(getattr(cfg, "scoring_profile", "") or "")
+    label_says_tep = "tep" in profile.lower()
+
+    ctx = {
+        "cfg": cfg,
+        "card": card,
+        "evidenceState": evidence_state,
+        "profile": profile,
+        "labelSaysTep": label_says_tep,
+        "rule": rule,
+    }
+
+    # The factual answer, computed here from the card the deployed process
+    # would read.  ``None`` when the card is absent — never False.
+    card_says_tep: bool | None = None
+    edges: dict[str, float] = {}
+    if isinstance(card, dict) and card:
+        demand = measure_te_demand(None, card)
+        card_says_tep = demand.has_scoring_edge
+        edges = dict(demand.scoring_edges)
+    ctx["cardSaysTep"] = card_says_tep
+    ctx["scoringEdges"] = edges
+
+    try:
+        target = TargetFormat.from_registry(league)
+    except Exception as exc:
+        check.status = ERROR
+        check.detail = f"TargetFormat.from_registry({league!r}) raised: {exc!r}"
+        return ctx
+    ctx["target"] = target
+
+    check.evidence = {
+        "deployedRule": rule,
+        "scoringProfileLabel": profile,
+        "labelSaysTep": label_says_tep,
+        "scoringEvidenceState": evidence_state,
+        "cardPresent": bool(card),
+        "scoringEdges": edges,
+        "cardSaysTep": card_says_tep,
+        "servedTep": target.tep,
+        "servedIs2te": target.is_2te,
+    }
+
+    if rule == "label":
+        check.status = FAIL
+        check.detail = (
+            "the deployed build derives TEP from the scoring-profile LABEL "
+            f"({profile!r} -> {label_says_tep}). MASTER_PRODUCT_PLAN 4.10 forbids a "
+            "label deciding a factual question. This is the pre-#927 build."
+        )
+        return ctx
+    if rule != "card":
+        check.status = ERROR
+        check.detail = "could not determine which TEP rule the deployed build implements."
+        return ctx
+    if evidence_state != "fresh":
+        check.status = INAPPLICABLE
+        check.detail = (
+            f"the deployed build reads the card (rule={rule}), but this league's "
+            f"scoring evidence is {evidence_state!r}, so no card-derived value was "
+            "produced to compare. C5 is the check that covers this state."
+        )
+        return ctx
+    if target.tep != card_says_tep:
+        check.status = FAIL
+        check.detail = (
+            f"served tep={target.tep!r} but the league's own fresh card measures "
+            f"{card_says_tep!r} (edges {edges}). The served value did not come from "
+            "the card."
+        )
+        return ctx
+    check.status = PASS
+    agreement = "agrees with" if bool(card_says_tep) == label_says_tep else "DISAGREES with"
+    check.detail = (
+        f"served tep={target.tep!r}, derived from the fresh card (edges {edges}); it "
+        f"{agreement} the {profile!r} label."
+    )
+    return ctx
+
+
+def check_unproven_scoring_fails_closed(report: Report, ctx: dict[str, Any]) -> None:
+    """#927 check 5 — stale/missing scoring evidence means UNKNOWN and excludes.
+
+    A card proves when it was taken, not that it is still true.  Only
+    ``fresh`` authorises the claim; and UNKNOWN must not quietly become "no
+    TE premium", which would admit a whole population of offense-scoring
+    leagues as comparable.
+    """
+    check = report.add(
+        Check(
+            "C5", "V1-129", "stale or missing scoring evidence leaves TEP UNKNOWN and fails closed"
+        )
+    )
+    if "target" not in ctx:
+        check.status = BLOCKED
+        check.detail = "C4 could not resolve a target, so there is nothing to check."
+        return
+    state = ctx["evidenceState"]
+    target = ctx["target"]
+    try:
+        from src.trade.faab_comparability import unprovable_target_fields
+    except ImportError:
+        check.status = FAIL
+        check.detail = (
+            "the deployed build has no unprovable_target_fields owner, so an "
+            "unprovable target cannot be reported. This is the pre-#927 build."
+        )
+        return
+
+    unprovable = list(unprovable_target_fields(target))
+    check.evidence = {
+        "scoringEvidenceState": state,
+        "servedTep": target.tep,
+        "unprovableTargetFields": unprovable,
+    }
+    if state == "fresh":
+        if target.tep is None:
+            check.status = FAIL
+            check.detail = "evidence is fresh but TEP resolved to None."
+            return
+        check.status = INAPPLICABLE
+        check.detail = (
+            "this league's scoring evidence is fresh, so the unproven branch did not "
+            "execute. Not a pass — to exercise it, run against a league whose card is "
+            "stale or absent. Do NOT age or delete a card to manufacture the case."
+        )
+        return
+    if target.tep is not None:
+        check.status = FAIL
+        check.detail = (
+            f"scoring evidence is {state!r} but TEP resolved to {target.tep!r}. Unproven "
+            "scoring became a positive claim."
+        )
+        return
+    if "tep" not in unprovable:
+        check.status = FAIL
+        check.detail = (
+            "TEP is None but the comparability owner does not report it as unprovable, "
+            "so every external row would be judged against an unstated setting."
+        )
+        return
+    check.status = PASS
+    check.detail = (
+        f"scoring evidence is {state!r}, TEP is None (UNKNOWN, not 'no premium'), and "
+        f"the target reports unprovable fields {unprovable} so classification "
+        "hard-excludes rather than assuming a match."
+    )
+
+
+def check_dynasty_main_is_not_te_premium(report: Report, ctx: dict[str, Any], league: str) -> None:
+    """#927 check 6 — the specific measured claim about this league's card.
+
+    `dynasty_main` carries a `superflex_tep15_ppr1` label while its 2026 card
+    grants tight ends nothing over WRs.  This check asserts the CARD, and
+    reports what the served value does with it.  It is deliberately specific:
+    a generic "the rule is card-derived" check passes on a build that reads
+    the card and still gets this league wrong.
+    """
+    check = report.add(
+        Check("C6", "V1-129", f"{league} behaves as non-TE-premium under its actual card")
+    )
+    card = ctx.get("card")
+    if not isinstance(card, dict) or not card:
+        check.status = BLOCKED
+        check.detail = (
+            f"no scoring card on disk for {league} "
+            "(data/leagues/scoring_<sleeperLeagueId>.json). Run "
+            "scripts/fetch_league_scoring.py on the box first — do not synthesise one."
+        )
+        return
+    edges = ctx.get("scoringEdges") or {}
+    card_says_tep = ctx.get("cardSaysTep")
+    served = ctx.get("target").tep if ctx.get("target") is not None else None
+    check.evidence = {
+        "bonus_rec_te": card.get("bonus_rec_te"),
+        "bonus_rec_wr": card.get("bonus_rec_wr"),
+        "bonus_fd_te": card.get("bonus_fd_te"),
+        "bonus_fd_wr": card.get("bonus_fd_wr"),
+        "scoringEdges": edges,
+        "cardSaysTep": card_says_tep,
+        "servedTep": served,
+        "scoringProfileLabel": ctx.get("profile"),
+        "scoringEvidenceState": ctx.get("evidenceState"),
+    }
+    if card_says_tep is True:
+        check.status = INAPPLICABLE
+        check.detail = (
+            f"this league's current card DOES advantage TE ({edges}), so the "
+            "non-premium claim does not describe it today. That is a real finding, not "
+            "a failure — the commissioner may have restored the premium. What matters "
+            "is that the served value follows the card, which is C4."
+        )
+        return
+    if ctx.get("evidenceState") != "fresh":
+        check.status = BLOCKED
+        check.detail = (
+            f"the card measures no TE edge ({edges}) but its evidence state is "
+            f"{ctx.get('evidenceState')!r}, so it may not authorise a served value. "
+            "Refresh it before reading this as the league's behaviour."
+        )
+        return
+    if served is not False:
+        check.status = FAIL
+        check.detail = (
+            f"the fresh card grants TE no edge ({edges}) but the served tep is "
+            f"{served!r}. The label is still deciding."
+        )
+        return
+    check.status = PASS
+    check.detail = (
+        f"the fresh card grants TE no edge over WR/RB ({edges}) and the served tep is "
+        f"False, against a {ctx.get('profile')!r} label that says otherwise."
+    )
+
+
+# ── #927 group C: what the population change actually did (V1-129) ──
+
+
+def check_comparable_population_before_after(
+    report: Report, ctx: dict[str, Any], league: str
+) -> None:
+    """#927 check 7 — before/after comparable crowd population.
+
+    A counterfactual over REAL stored rows, not a simulation: the accumulated
+    ledger is classified twice, once against the served (card-derived) target
+    and once against the same target with TEP forced to what the retired
+    LABEL rule would have said.  Nothing is invented; the only thing that
+    varies is the policy.
+    """
+    check = report.add(
+        Check("C7", "V1-129", "comparable crowd population, card-derived vs the retired label rule")
+    )
+    if "target" not in ctx:
+        check.status = BLOCKED
+        check.detail = "C4 could not resolve a target."
+        return
+    try:
+        import dataclasses
+
+        from src.trade import faab_comparability as FC
+        from src.trade.faab_history import build_crowd_market, load_crowd_history
+    except Exception as exc:  # pragma: no cover - deployment shape
+        check.status = ERROR
+        check.detail = f"could not import the crowd market: {exc!r}"
+        return
+
+    payload = load_crowd_history(league)
+    rows = (payload or {}).get("rows") if isinstance(payload, dict) else None
+    if not rows:
+        check.status = BLOCKED
+        check.detail = (
+            f"no crowd ledger for {league} at data/faab/crowd_history_{league}.json. "
+            "It is gitignored and prod-only. Run the dynasty-crowd-faab timer (or "
+            "scripts/fetch_crowd_faab.py) and re-check — do not synthesise rows."
+        )
+        return
+
+    served = ctx["target"]
+    label_tep = bool(ctx.get("labelSaysTep"))
+    counterfactual = dataclasses.replace(served, tep=label_tep)
+
+    try:
+        from src.trade.faab_engine import FaabConfig
+
+        policy = FC.ComparabilityPolicy.from_config(FaabConfig())
+    except Exception:
+        policy = FC.ComparabilityPolicy()
+
+    after = build_crowd_market(payload, target=served, policy=policy)
+    before = build_crowd_market(payload, target=counterfactual, policy=policy)
+
+    check.evidence = {
+        "rowsTotal": after.rows_total,
+        "servedTep": served.tep,
+        "retiredLabelRuleTep": label_tep,
+        "after": {
+            "rowsUsed": after.rows_used,
+            "state": after.state,
+            "tierCounts": dict(after.tier_counts),
+            "excludedCounts": dict(after.excluded_counts),
+        },
+        "before": {
+            "rowsUsed": before.rows_used,
+            "state": before.state,
+            "tierCounts": dict(before.tier_counts),
+            "excludedCounts": dict(before.excluded_counts),
+        },
+    }
+    if served.tep is None:
+        check.status = INAPPLICABLE
+        check.detail = (
+            "the served target cannot prove TEP, so it admits nothing and there is no "
+            "meaningful 'after' population to compare. Fix the scoring card first "
+            "(C5/C6), then re-run."
+        )
+        return
+    check.status = PASS
+    if bool(served.tep) == label_tep:
+        check.detail = (
+            f"card and label agree ({served.tep!r}), so the admitted population is "
+            f"unchanged at {after.rows_used}/{after.rows_total} rows. The measurement "
+            "still ran; it simply found no divergence for this league today."
+        )
+    else:
+        check.detail = (
+            f"card ({served.tep!r}) and label ({label_tep!r}) DISAGREE: the retired rule "
+            f"admitted {before.rows_used}/{before.rows_total} rows, the card-derived "
+            f"rule admits {after.rows_used}. Every row in the difference was being "
+            "compared on a TE premium this league does not grant."
+        )
+
+
+def check_crowd_refusal_reasons(report: Report, faab_payload: dict, source: str) -> None:
+    """#927 check 8 — the refusal is specific, and names the right side.
+
+    "We hold no crowd evidence" and "we cannot describe our own league well
+    enough to judge any" are different failures with different fixes.
+    Reporting them identically sends the reader to the feed when the answer
+    is in the registry or in a scoring card nobody fetched.
+    """
+    check = report.add(
+        Check("C8", "V1-129", "crowd-market refusal reasons are specific and honest")
+    )
+    block = faab_payload.get("crowdMarket")
+    if not isinstance(block, dict):
+        check.status = FAIL
+        check.detail = (
+            f"{source} published no crowdMarket block at all. A missing block and a "
+            "reported refusal read the same to a consumer, which is the defect."
+        )
+        return
+    state = block.get("state")
+    reason = block.get("refusalReason")
+    unknown = block.get("targetFormatUnknown")
+    check.evidence = {
+        "state": state,
+        "refusalReason": reason,
+        "targetFormatUnknown": unknown,
+        "rowsTotal": block.get("rowsTotal"),
+        "rowsUsed": block.get("rowsUsed"),
+        "excludedCounts": block.get("excludedCounts"),
+        "tierCounts": block.get("tierCounts"),
+        "playerHasEvidence": block.get("playerHasEvidence"),
+        "pricesIdp": block.get("pricesIdp"),
+    }
+    if unknown is None:
+        check.status = FAIL
+        check.detail = (
+            "crowdMarket carries no targetFormatUnknown key, so a run that admitted "
+            "nothing because OUR league is undescribable is indistinguishable from an "
+            "absent feed. This is the pre-#927 build."
+        )
+        return
+    if unknown:
+        if reason != "target_format_unverifiable:" + ",".join(unknown):
+            check.status = FAIL
+            check.detail = (
+                f"targetFormatUnknown is {unknown} but refusalReason is {reason!r}. The "
+                "refusal must name our side, ahead of the freshness checks — freshness "
+                "is moot when no row is admissible."
+            )
+            return
+        check.status = PASS
+        check.detail = (
+            f"the target cannot prove {unknown} and the refusal says exactly that "
+            f"({reason!r}) rather than blaming the feed."
+        )
+        return
+    if state == "fresh" and reason is None:
+        check.status = PASS
+        check.detail = "target fully described, ledger fresh, no refusal — the usable state."
+        return
+    if state in {"stale", "missing"} and reason in {"crowd_ledger_stale", "no_crowd_ledger"}:
+        check.status = PASS
+        check.detail = (
+            f"target fully described; the ledger itself is {state!r} and the refusal "
+            f"({reason!r}) correctly points at the feed."
+        )
+        return
+    check.status = FAIL
+    check.detail = f"state {state!r} and refusalReason {reason!r} do not correspond."
+
+
+def check_faab_recommendation_effect(report: Report, faab_payload: dict, source: str) -> None:
+    """#927 check 9 — a refused population must not still move the bid.
+
+    The crowd feeds ``rival_bid_cdf`` at weight 0.6, so what it admits moves
+    real recommended bids.  This asserts the two directions that matter:
+    when the crowd is USED it must be visible as a factor, and when it is
+    REFUSED it must not appear at all.  A refusal that still quietly
+    contributes would be cosmetic.
+
+    The absolute numbers are recorded so two runs of this script — one before
+    a deploy and one after — measure the effect directly.
+    """
+    check = report.add(
+        Check("C9", "V1-129", "the crowd moves the bid only when it was actually admitted")
+    )
+    block = faab_payload.get("crowdMarket")
+    if not isinstance(block, dict):
+        check.status = BLOCKED
+        check.detail = f"{source} published no crowdMarket block; C8 covers that."
+        return
+    factors = faab_payload.get("factors")
+    factors = factors if isinstance(factors, list) else []
+    # Matched on the LABEL, which is the engine's stable identifier for this
+    # row (``_FactorRow("Cross-league market", ...)``), not on its prose --
+    # a check that breaks when the wording is improved is a bad check.
+    crowd_factors = [
+        f for f in factors if isinstance(f, dict) and f.get("label") == "Cross-league market"
+    ]
+    used = bool(block.get("playerHasEvidence")) and block.get("state") == "fresh"
+    contention = faab_payload.get("contention") or {}
+    check.evidence = {
+        "crowdState": block.get("state"),
+        "playerHasEvidence": block.get("playerHasEvidence"),
+        "refusalReason": block.get("refusalReason"),
+        "rowsUsed": block.get("rowsUsed"),
+        "crowdFactorRows": len(crowd_factors),
+        "standard": faab_payload.get("standard"),
+        "conservative": faab_payload.get("conservative"),
+        "aggressive": faab_payload.get("aggressive"),
+        "max": faab_payload.get("max"),
+        "clearing": contention.get("clearing") if isinstance(contention, dict) else None,
+        "contentionSkipped": contention.get("skipped") if isinstance(contention, dict) else None,
+    }
+    if used and not crowd_factors:
+        check.status = FAIL
+        check.detail = (
+            "the crowd market is fresh and prices this player, but no crowd factor row "
+            "was published — the evidence moved the bid invisibly, or was dropped."
+        )
+        return
+    if not used and crowd_factors:
+        check.status = FAIL
+        check.detail = (
+            f"the crowd was refused ({block.get('refusalReason')!r}) yet a crowd factor "
+            "row is still present. The refusal is cosmetic."
+        )
+        return
+    check.status = PASS
+    if used:
+        check.detail = (
+            f"the crowd priced this player and is visible as {len(crowd_factors)} factor "
+            f"row(s); standard={faab_payload.get('standard')}, "
+            f"clearing={check.evidence['clearing']}. Record these and compare across "
+            "deploys to measure the population change's effect."
+        )
+    else:
+        check.detail = (
+            f"the crowd was refused ({block.get('refusalReason')!r}) and contributed no "
+            f"factor row. standard={faab_payload.get('standard')} is therefore free of "
+            "external-market influence, which is the point of the refusal."
+        )
+
+
+# ── Lane 4 V1 rows beyond #927 ─────────────────────────────────────
+
+
+def check_faab_history_timer(report: Report) -> None:
+    """V1-57 (L3) — the collection is SCHEDULED, not a manual step.
+
+    A green manual run of ``scripts/fetch_faab_history.py`` proves the script
+    works, which was never the open question.  What L3 needs is the unit
+    installed and firing.
+    """
+    check = report.add(Check("V57", "V1-57", "dynasty-faab-history timer is installed and firing"))
+    try:
+        listed = subprocess.run(
+            ["systemctl", "list-timers", "--all", "--no-pager", "--no-legend"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        check.status = BLOCKED
+        check.detail = f"systemctl is not available here ({exc!r}); run this on the box."
+        return
+    if listed.returncode != 0:
+        check.status = BLOCKED
+        check.detail = f"systemctl exited {listed.returncode}: {listed.stderr.strip()[:200]}"
+        return
+    lines = [ln for ln in listed.stdout.splitlines() if "faab-history" in ln]
+    check.evidence = {"timerLines": lines}
+    if not lines:
+        check.status = FAIL
+        check.detail = (
+            "no faab-history timer is installed. The templates exist in the repo "
+            "(deploy/systemd/dynasty-faab-history.{service,timer}.template) but "
+            "install-systemd-service.sh has not run with them on this host."
+        )
+        return
+    # NEXT/LEFT/LAST/PASSED/UNIT/ACTIVATES -- LAST is populated only once fired.
+    fired = any(" n/a " not in ln.replace("\t", " ") for ln in lines)
+    check.status = PASS if fired else FAIL
+    check.detail = (
+        "timer installed and has fired at least once."
+        if fired
+        else "timer is installed but has never fired (LAST is n/a)."
+    )
+
+
+def check_faab_history_artifact(report: Report, league: str) -> None:
+    """V1-57, second half — the run produced the artifact the engine reads."""
+    check = report.add(Check("V57b", "V1-57", "own-league bid history exists and is recent"))
+    path = _repo_file("data", "faab", f"bid_history_{league}.json")
+    if not path.exists():
+        check.status = FAIL if _repo_file("data", "faab").exists() else BLOCKED
+        check.detail = (
+            f"{path} is absent. With data/faab/ present this is a real failure (the "
+            "timer ran and produced nothing); without it, this is not the deployed "
+            "working directory."
+        )
+        return
+    age_h = (datetime.now(timezone.utc).timestamp() - path.stat().st_mtime) / 3600.0
+    payload = _load_json(path)
+    entries = payload.get("bids") if isinstance(payload, dict) else None
+    check.evidence = {
+        "path": str(path),
+        "ageHours": round(age_h, 2),
+        "entryCount": len(entries) if isinstance(entries, list) else None,
+    }
+    if age_h > 25.0:
+        check.status = FAIL
+        check.detail = f"history is {age_h:.1f}h old against a daily timer."
+        return
+    check.status = PASS
+    check.detail = f"history written {age_h:.1f}h ago."
+
+
+def check_ffpc_lane_is_honest(report: Report) -> None:
+    """V1-60 (L2) — zero rosters must never be silently zero.
+
+    "The lane ran and found nothing" and "the lane did not run" are different
+    facts.  ``cohortCoveragePct`` is the one that must be ``None`` rather than
+    ``0`` when nothing was observed.
+    """
+    check = report.add(
+        Check("V60", "V1-60", "the FFPC roster lane is real or honestly unavailable")
+    )
+    try:
+        from src.sharp.roster_collect import CollectResult
+    except Exception as exc:  # pragma: no cover - deployment shape
+        check.status = ERROR
+        check.detail = f"could not import roster_collect: {exc!r}"
+        return
+    has_status = hasattr(CollectResult, "unavailable") and "status" in getattr(
+        CollectResult, "__dataclass_fields__", {}
+    )
+    check.evidence = {"collectResultCarriesStatus": has_status}
+    if not has_status:
+        check.status = FAIL
+        check.detail = (
+            "CollectResult has no status/unavailable() constructor, so a skipped lane "
+            "and an empty-but-successful lane are indistinguishable."
+        )
+        return
+    try:
+        from src.sharp import roster_percentage
+
+        payload = roster_percentage.build_board()
+    except Exception as exc:
+        check.status = BLOCKED
+        check.detail = f"could not build the roster-percentage board here: {exc!r}"
+        return
+    cohort = payload.get("cohort") if isinstance(payload, dict) else {}
+    cohort = cohort if isinstance(cohort, dict) else {}
+    coverage = cohort.get("cohortCoveragePct")
+    check.evidence.update(
+        {
+            "cohortManagers": cohort.get("cohortManagers"),
+            "cohortManagersRepresented": cohort.get("cohortManagersRepresented"),
+            "cohortCoveragePct": coverage,
+            "eligibleRosters": cohort.get("eligibleRosters"),
+            "ffpcRosters": cohort.get("ffpcRosters"),
+            "sleeperRosters": cohort.get("sleeperRosters"),
+        }
+    )
+    if not cohort.get("cohortManagers"):
+        if coverage is not None:
+            check.status = FAIL
+            check.detail = (
+                f"no cohort managers, yet cohortCoveragePct is {coverage!r}. An "
+                "unmeasured coverage must be null, never a number."
+            )
+            return
+        check.status = BLOCKED
+        check.detail = (
+            "the cohort is empty here, so the lane's populated behaviour cannot be "
+            "measured. It correctly reports cohortCoveragePct: null rather than 0 — "
+            "which is the honest-degraded half of the row, but not the whole row. "
+            "V1-58 is the blocker."
+        )
+        return
+    check.status = PASS
+    check.detail = (
+        f"cohort of {cohort.get('cohortManagers')} managers, "
+        f"{cohort.get('eligibleRosters')} eligible rosters "
+        f"({cohort.get('ffpcRosters')} FFPC), coverage {coverage!r}."
+    )
+
+
+def check_single_cohort_owner(report: Report) -> None:
+    """V1-65 (L2) — one definition of who is a sharp, structurally.
+
+    Deterministic and runnable anywhere, so it is recorded here rather than
+    deferred to production: a second cohort definition is the way this row
+    regresses.
+    """
+    check = report.add(Check("V65", "V1-65", "cohort_members has exactly one definition"))
+    hits: list[str] = []
+    for path in sorted((REPO_ROOT / "src").rglob("*.py")):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for number, line in enumerate(text.splitlines(), start=1):
+            if line.lstrip().startswith("def cohort_members"):
+                hits.append(f"{path.relative_to(REPO_ROOT)}:{number}")
+    check.evidence = {"definitions": hits}
+    if len(hits) == 1 and hits[0].startswith("src/sharp/cohort.py"):
+        check.status = PASS
+        check.detail = f"single owner at {hits[0]}; every surface re-exports it."
+    else:
+        check.status = FAIL
+        check.detail = f"expected one definition in src/sharp/cohort.py, found {hits}."
+
+
+def record_blocked_rows(report: Report, unauth_detail: str | None) -> None:
+    """V1-58 / V1-59 — recorded as BLOCKED, with the credential named.
+
+    Never closed by standing up a synthetic cohort: a manufactured population
+    would verify the manufacture.
+    """
+    for row, title in (
+        ("V1-58", "Sharp cohort proven populated in production"),
+        ("V1-59", "Sharp bootstrap stops failing"),
+    ):
+        check = report.add(Check(f"B{row[-2:]}", row, title))
+        check.status = UNVERIFIABLE if unauth_detail else BLOCKED
+        check.detail = (
+            (
+                f"{unauth_detail} — /api/sharp/* is session-gated and correctly so. "
+                "Insufficient evidence, deliberately neither pass nor fail. The single "
+                "credential that unblocks both is an authenticated admin session for "
+                "the deployed origin, held by the site owner."
+            )
+            if unauth_detail
+            else (
+                "needs the deployed host: an authenticated /api/sharp/cohort read "
+                "(V1-58) and a clean journalctl run of dynasty-sharp-discovery -> "
+                "-records -> -rosters (V1-59). Not closable from a repository, and not "
+                "to be closed by manufacturing a cohort."
+            )
+        )
+
+
+# ── Modes ──────────────────────────────────────────────────────────
+
+
+def run_remote(report: Report, args: argparse.Namespace) -> None:
+    """Everything the deployed API publishes, over HTTPS, with a real session."""
+    origin = args.origin.rstrip("/")
+    cookie = os.environ.get("RISKIT_SESSION_COOKIE") or None
+
+    # /api/status is public, so the deployed SHA is always recordable even
+    # when every gated check comes back unauthenticated.  An L3 result is
+    # meaningless without knowing which commit produced it.
+    try:
+        _, status_payload = _http(f"{origin}/api/status", cookie=cookie)
+        report.deployed = {
+            k: status_payload.get(k)
+            for k in ("commit", "version", "startedAt", "contractVersion", "scrapedAt")
+            if isinstance(status_payload, dict) and k in status_payload
+        }
+        report.deployed["origin"] = origin
+    except Exception as exc:
+        report.deployed = {"origin": origin, "error": repr(exc)}
+
+    unauth: str | None = None
+
+    # --- Sharp person consensus (C1-C3) ---
+    market: dict | None = None
+    try:
+        code, market = _http(f"{origin}/api/sharp/market?window=30d&limit=250", cookie=cookie)
+        if code != 200:
+            market = None
+    except Unauthenticated as exc:
+        unauth = str(exc)
+    except Exception as exc:
+        report.add(
+            Check("C1", "V1-63", "zero-voter personManagerQuality", ERROR, f"market fetch: {exc!r}")
+        )
+        market = None
+
+    if market is not None:
+        source = f"{origin}/api/sharp/market"
+        check_zero_voter_quality(report, market, source)
+        check_measured_zero_quality(report, market, source)
+        check_undefined_concentration(report, market, source)
+    elif unauth:
+        for cid, title in (
+            ("C1", "zero-voter personManagerQuality is JSON null, never 1.0"),
+            ("C2", "a measured personManagerQuality of 0.0 stays 0.0"),
+            ("C3", "networkConcentration is null when weighted volume is zero"),
+        ):
+            report.add(
+                Check(
+                    cid,
+                    "V1-63",
+                    title,
+                    UNVERIFIABLE,
+                    f"{unauth} — no session was supplied, so nothing was measured. "
+                    "Set RISKIT_SESSION_COOKIE to an authenticated session; do not "
+                    "relax the endpoint's gate.",
+                )
+            )
+
+    # --- TEP + crowd, as the API reports them (C4-C9, partially) ---
+    for cid, row, title in (
+        ("C4", "V1-129", "target TEP is derived from the scoring card, not the profile label"),
+        ("C5", "V1-129", "stale or missing scoring evidence leaves TEP UNKNOWN and fails closed"),
+        ("C6", "V1-129", f"{args.league} behaves as non-TE-premium under its actual card"),
+        ("C7", "V1-129", "comparable crowd population, card-derived vs the retired label rule"),
+    ):
+        report.add(
+            Check(
+                cid,
+                row,
+                title,
+                BLOCKED,
+                "needs the league's scoring card and/or the crowd ledger, both "
+                "gitignored and prod-local. Run --mode onbox on the deployed host. "
+                "C8 below is the API-visible shadow of C4/C5.",
+            )
+        )
+
+    if not args.add_player:
+        for cid, row, title in (
+            ("C8", "V1-129", "crowd-market refusal reasons are specific and honest"),
+            ("C9", "V1-129", "the crowd moves the bid only when it was actually admitted"),
+        ):
+            report.add(
+                Check(
+                    cid,
+                    row,
+                    title,
+                    BLOCKED,
+                    "needs --add-player naming a REAL free agent on the deployed board. "
+                    "No player is invented for this check.",
+                )
+            )
+        return
+
+    try:
+        code, faab = _http(
+            f"{origin}/api/waiver/faab-recommend",
+            cookie=cookie,
+            body={"leagueKey": args.league, "addPlayerName": args.add_player},
+        )
+    except Unauthenticated as exc:
+        for cid, row, title in (
+            ("C8", "V1-129", "crowd-market refusal reasons are specific and honest"),
+            ("C9", "V1-129", "the crowd moves the bid only when it was actually admitted"),
+        ):
+            report.add(Check(cid, row, title, UNVERIFIABLE, f"{exc} — no session supplied."))
+        return
+    except Exception as exc:
+        report.add(Check("C8", "V1-129", "crowd-market refusal reasons", ERROR, repr(exc)))
+        return
+
+    if code != 200:
+        for cid, row, title in (
+            ("C8", "V1-129", "crowd-market refusal reasons are specific and honest"),
+            ("C9", "V1-129", "the crowd moves the bid only when it was actually admitted"),
+        ):
+            report.add(Check(cid, row, title, BLOCKED, f"faab-recommend returned {code}: {faab}"))
+        return
+
+    source = f"{origin}/api/waiver/faab-recommend"
+    check_crowd_refusal_reasons(report, faab, source)
+    check_faab_recommendation_effect(report, faab, source)
+
+    record_blocked_rows(report, unauth)
+
+
+def run_onbox(report: Report, args: argparse.Namespace) -> None:
+    """Everything that needs the deployed filesystem and the deployed source."""
+    report.deployed = {
+        "workingDirectory": str(REPO_ROOT),
+        "headSha": _git_head(),
+        "dataDirPresent": _repo_file("data").is_dir(),
+    }
+
+    # --- Sharp person consensus, built locally from the real ledger ---
+    try:
+        from src.sharp import market as sharp_market
+
+        payload = sharp_market.market_payload(window="30d", limit=250)
+    except Exception as exc:
+        payload = None
+        report.add(
+            Check("C1", "V1-63", "zero-voter personManagerQuality", ERROR, f"market build: {exc!r}")
+        )
+    if payload is not None:
+        source = "market_payload(window='30d')"
+        check_zero_voter_quality(report, payload, source)
+        check_measured_zero_quality(report, payload, source)
+        check_undefined_concentration(report, payload, source)
+
+    # --- TEP, the crowd population, and their effect ---
+    ctx = check_tep_is_card_derived(report, args.league)
+    check_unproven_scoring_fails_closed(report, ctx)
+    check_dynasty_main_is_not_te_premium(report, ctx, args.league)
+    check_comparable_population_before_after(report, ctx, args.league)
+
+    # C8/C9 still go through the real endpoint, because the refusal reason and
+    # the factor rows are assembled in server.py and not in the engine.
+    if args.origin and args.add_player:
+        cookie = os.environ.get("RISKIT_SESSION_COOKIE") or None
+        try:
+            code, faab = _http(
+                f"{args.origin.rstrip('/')}/api/waiver/faab-recommend",
+                cookie=cookie,
+                body={"leagueKey": args.league, "addPlayerName": args.add_player},
+            )
+            if code == 200:
+                source = "faab-recommend"
+                check_crowd_refusal_reasons(report, faab, source)
+                check_faab_recommendation_effect(report, faab, source)
+            else:
+                report.add(
+                    Check("C8", "V1-129", "crowd-market refusal reasons", BLOCKED, f"HTTP {code}")
+                )
+        except Unauthenticated as exc:
+            report.add(
+                Check("C8", "V1-129", "crowd-market refusal reasons", UNVERIFIABLE, str(exc))
+            )
+    else:
+        for cid, title in (
+            ("C8", "crowd-market refusal reasons are specific and honest"),
+            ("C9", "the crowd moves the bid only when it was actually admitted"),
+        ):
+            report.add(
+                Check(
+                    cid,
+                    "V1-129",
+                    title,
+                    BLOCKED,
+                    "these read server.py's assembled response, so they need --origin "
+                    "(the local one is fine: http://127.0.0.1:8000) and --add-player "
+                    "naming a real free agent.",
+                )
+            )
+
+    # --- Lane 4 rows beyond #927 ---
+    check_faab_history_timer(report)
+    check_faab_history_artifact(report, args.league)
+    check_ffpc_lane_is_honest(report)
+    check_single_cohort_owner(report)
+    record_blocked_rows(report, None)
+
+
+def _git_head() -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            cwd=REPO_ROOT,
+        )
+        return out.stdout.strip() or None
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--mode", choices=("remote", "onbox"), required=True)
+    parser.add_argument("--league", default="dynasty_main")
+    parser.add_argument(
+        "--origin",
+        default="",
+        help="deployed origin, e.g. https://chaseupside.com (required for --mode remote)",
+    )
+    parser.add_argument(
+        "--add-player",
+        default="",
+        help="display name of a REAL free agent to price. Never invented by this script.",
+    )
+    parser.add_argument("--out", default="", help="write the JSON report here as well as stdout")
+    args = parser.parse_args(argv)
+
+    if args.mode == "remote" and not args.origin:
+        parser.error("--mode remote needs --origin")
+
+    report = Report(args.mode, args.league, args.origin or None)
+    try:
+        if args.mode == "remote":
+            run_remote(report, args)
+        else:
+            run_onbox(report, args)
+    except Exception as exc:  # pragma: no cover - last-resort guard
+        report.add(Check("RUN", "-", "verification run", ERROR, repr(exc)))
+
+    payload = report.to_dict()
+    text = json.dumps(payload, indent=2, sort_keys=True, default=str)
+    print(text)
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(text + "\n", encoding="utf-8")
+
+    code = report.exit_code()
+    summary = " ".join(f"{k}={v}" for k, v in sorted(payload["counts"].items()))
+    print(f"\n[lane4-verify] {summary} -> exit {code}", file=sys.stderr)
+    if code == 3:
+        print(
+            "[lane4-verify] nothing was proven: every check was blocked, unauthenticated "
+            "or inapplicable. This is NOT a pass.",
+            file=sys.stderr,
+        )
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_lane4_verification.py
+++ b/tests/ops/test_lane4_verification.py
@@ -1,0 +1,308 @@
+"""The verifier's own semantics.
+
+A verification script is only worth what its vocabulary is worth. These pin
+the three distinctions the package exists to preserve, because each of them
+is a way a run could quietly read as green when it proved nothing:
+
+* a 401 is INSUFFICIENT EVIDENCE, not a pass and not a failure;
+* a missing input is BLOCKED, not a pass;
+* an input that exists but does not contain the case under test is
+  INAPPLICABLE, not a pass.
+
+The checks themselves are exercised against synthetic PAYLOADS, which is not
+the same as fabricating production evidence: these are unit inputs to the
+analyser, and every one of them lives here in the test file rather than in a
+`data/` path any production run would read.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_SPEC = importlib.util.spec_from_file_location(
+    "verify_lane4_production", REPO_ROOT / "scripts" / "verify_lane4_production.py"
+)
+verify = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+# Registered BEFORE execution: ``@dataclass`` resolves annotations through
+# ``sys.modules[cls.__module__]``, so a module loaded by path alone raises
+# while processing its own dataclasses.
+sys.modules[_SPEC.name] = verify
+_SPEC.loader.exec_module(verify)
+
+
+def _report():
+    return verify.Report("onbox", "dynasty_main", None)
+
+
+def _market(*people):
+    return {"assets": [{"assetId": f"p{i}", "personConsensus": p} for i, p in enumerate(people)]}
+
+
+def _person(**kw):
+    base = {
+        "personVotes": 1,
+        "mixedPersonSignals": 0,
+        "weightedPersonVolume": 1.0,
+        "personManagerQuality": 0.9,
+        "networkConcentration": 1.0,
+    }
+    base.update(kw)
+    return base
+
+
+# ── The vocabulary ─────────────────────────────────────────────────
+
+
+class TestStatusVocabulary:
+    def test_a_run_that_proves_nothing_does_not_exit_zero(self):
+        """The single most important property.
+
+        A run where every check was blocked or unauthenticated has measured
+        nothing. Exiting 0 would make "we could not check" indistinguishable
+        from "we checked and it was fine" — to a human reading a CI badge,
+        and to any automation keying on the code.
+        """
+        report = _report()
+        report.add(verify.Check("X", "V1-58", "t", verify.BLOCKED, ""))
+        report.add(verify.Check("Y", "V1-59", "t", verify.UNVERIFIABLE, ""))
+        assert report.exit_code() == 3
+
+    def test_a_failure_outranks_everything_else(self):
+        report = _report()
+        report.add(verify.Check("X", "V1-63", "t", verify.PASS, ""))
+        report.add(verify.Check("Y", "V1-129", "t", verify.FAIL, ""))
+        report.add(verify.Check("Z", "V1-57", "t", verify.BLOCKED, ""))
+        assert report.exit_code() == 2
+
+    def test_an_error_outranks_a_failure(self):
+        """An error means a check did not run. That is a different problem
+        from a check that ran and disagreed, and it must not be reported as
+        the latter."""
+        report = _report()
+        report.add(verify.Check("Y", "V1-129", "t", verify.FAIL, ""))
+        report.add(verify.Check("Z", "V1-57", "t", verify.ERROR, ""))
+        assert report.exit_code() == 1
+
+    def test_green_needs_at_least_one_real_pass(self):
+        report = _report()
+        report.add(verify.Check("X", "V1-63", "t", verify.PASS, ""))
+        report.add(verify.Check("Y", "V1-58", "t", verify.BLOCKED, ""))
+        assert report.exit_code() == 0
+
+    def test_the_three_non_proving_statuses_are_counted_apart_from_passes(self):
+        report = _report()
+        for status in (verify.INAPPLICABLE, verify.BLOCKED, verify.UNVERIFIABLE):
+            report.add(verify.Check(status, "-", "t", status, ""))
+        report.add(verify.Check("P", "-", "t", verify.PASS, ""))
+        assert report.to_dict()["applicableChecks"] == 1
+
+
+class TestUnauthenticatedIsItsOwnAnswer:
+    def test_401_and_403_raise_the_dedicated_type(self, monkeypatch):
+        """Never swallowed into a generic failure path.
+
+        The measured history on this repo is 80/80 attempts returning 401
+        across 79 runs — a definitive answer to "do we hold a credential?",
+        which is not the question the check is asking.
+        """
+        import urllib.error
+
+        def boom(*_args, **_kwargs):
+            raise urllib.error.HTTPError("u", 401, "Unauthorized", {}, None)
+
+        monkeypatch.setattr(verify.urllib.request, "urlopen", boom)
+        with pytest.raises(verify.Unauthenticated):
+            verify._http("https://example.invalid/api/sharp/market", cookie=None)
+
+    def test_no_cookie_means_no_cookie_header(self, monkeypatch):
+        """There is no fallback credential path, and this proves it
+        structurally rather than by reading the source."""
+        seen = {}
+
+        class _Resp:
+            status = 200
+
+            def read(self):
+                return b"{}"
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                return False
+
+        def capture(request, timeout=None):
+            seen["headers"] = dict(request.headers)
+            return _Resp()
+
+        monkeypatch.setattr(verify.urllib.request, "urlopen", capture)
+        verify._http("https://example.invalid/api/status", cookie=None)
+        assert not any(k.lower() == "cookie" for k in seen["headers"])
+
+
+# ── The #927 checks ────────────────────────────────────────────────
+
+
+class TestZeroVoterQuality:
+    def test_a_zero_voter_row_with_a_number_fails(self):
+        report = _report()
+        payload = _market(_person(personVotes=0, mixedPersonSignals=2, personManagerQuality=1.0))
+        verify.check_zero_voter_quality(report, payload, "test")
+        check = report.checks[0]
+        assert check.status == verify.FAIL
+        assert check.evidence["offenderCount"] == 1
+
+    def test_a_zero_voter_row_with_null_passes(self):
+        report = _report()
+        payload = _market(_person(personVotes=0, mixedPersonSignals=2, personManagerQuality=None))
+        verify.check_zero_voter_quality(report, payload, "test")
+        assert report.checks[0].status == verify.PASS
+
+    def test_a_board_with_no_zero_voter_row_is_inapplicable_not_pass(self):
+        """ "We looked and the situation did not arise" is not "we looked and
+        it was correct". Collapsing them is the defect class this package
+        exists to catch."""
+        report = _report()
+        verify.check_zero_voter_quality(report, _market(_person()), "test")
+        assert report.checks[0].status == verify.INAPPLICABLE
+
+    def test_an_empty_board_is_blocked_not_pass(self):
+        report = _report()
+        verify.check_zero_voter_quality(report, {"assets": []}, "test")
+        assert report.checks[0].status == verify.BLOCKED
+
+
+class TestMeasuredZeroSurvives:
+    def test_a_measured_zero_is_a_pass_not_a_missing_value(self):
+        report = _report()
+        payload = _market(_person(personVotes=2, personManagerQuality=0.0))
+        verify.check_measured_zero_quality(report, payload, "test")
+        check = report.checks[0]
+        assert check.status == verify.PASS
+        assert check.evidence["measuredZeroRows"] == 1
+
+    def test_nulling_a_row_that_has_voters_fails(self):
+        """The repair must not overshoot: UNKNOWN and WORST are different
+        answers, and a row with voters has an answer."""
+        report = _report()
+        payload = _market(_person(personVotes=3, personManagerQuality=None))
+        verify.check_measured_zero_quality(report, payload, "test")
+        assert report.checks[0].status == verify.FAIL
+
+
+class TestUndefinedConcentration:
+    def test_zero_volume_with_a_number_fails(self):
+        report = _report()
+        payload = _market(_person(weightedPersonVolume=0.0, networkConcentration=0.0))
+        verify.check_undefined_concentration(report, payload, "test")
+        assert report.checks[0].status == verify.FAIL
+
+    def test_zero_volume_with_null_passes(self):
+        report = _report()
+        payload = _market(_person(weightedPersonVolume=0.0, networkConcentration=None))
+        verify.check_undefined_concentration(report, payload, "test")
+        assert report.checks[0].status == verify.PASS
+
+
+class TestCrowdRefusalReasons:
+    def test_a_build_without_target_format_unknown_fails(self):
+        """Pre-#927: an undescribable target and an absent feed report the
+        same thing, so the reader is sent to the wrong place."""
+        report = _report()
+        verify.check_crowd_refusal_reasons(
+            report, {"crowdMarket": {"state": "missing", "refusalReason": "no_crowd_ledger"}}, "t"
+        )
+        assert report.checks[0].status == verify.FAIL
+
+    def test_an_undescribable_target_must_name_our_side(self):
+        report = _report()
+        verify.check_crowd_refusal_reasons(
+            report,
+            {
+                "crowdMarket": {
+                    "state": "missing",
+                    "targetFormatUnknown": ["tep"],
+                    "refusalReason": "no_crowd_ledger",
+                }
+            },
+            "t",
+        )
+        assert report.checks[0].status == verify.FAIL
+
+    def test_the_correct_refusal_passes(self):
+        report = _report()
+        verify.check_crowd_refusal_reasons(
+            report,
+            {
+                "crowdMarket": {
+                    "state": "missing",
+                    "targetFormatUnknown": ["tep"],
+                    "refusalReason": "target_format_unverifiable:tep",
+                }
+            },
+            "t",
+        )
+        assert report.checks[0].status == verify.PASS
+
+    def test_a_fresh_fully_described_market_passes(self):
+        report = _report()
+        verify.check_crowd_refusal_reasons(
+            report,
+            {"crowdMarket": {"state": "fresh", "targetFormatUnknown": [], "refusalReason": None}},
+            "t",
+        )
+        assert report.checks[0].status == verify.PASS
+
+
+class TestCrowdEffectOnTheBid:
+    def test_a_refused_crowd_that_still_contributes_a_factor_fails(self):
+        """A refusal that still moves the number is cosmetic."""
+        report = _report()
+        verify.check_faab_recommendation_effect(
+            report,
+            {
+                "crowdMarket": {
+                    "state": "missing",
+                    "playerHasEvidence": False,
+                    "refusalReason": "no_crowd_ledger",
+                },
+                "factors": [{"label": "Cross-league market", "contribution": "..."}],
+            },
+            "t",
+        )
+        assert report.checks[0].status == verify.FAIL
+
+    def test_an_admitted_crowd_with_no_visible_factor_fails(self):
+        report = _report()
+        verify.check_faab_recommendation_effect(
+            report,
+            {
+                "crowdMarket": {"state": "fresh", "playerHasEvidence": True},
+                "factors": [{"label": "Expected competition"}],
+            },
+            "t",
+        )
+        assert report.checks[0].status == verify.FAIL
+
+    def test_a_refused_crowd_with_no_factor_passes(self):
+        report = _report()
+        verify.check_faab_recommendation_effect(
+            report,
+            {
+                "crowdMarket": {
+                    "state": "stale",
+                    "playerHasEvidence": False,
+                    "refusalReason": "crowd_ledger_stale",
+                },
+                "factors": [{"label": "Expected competition"}],
+                "standard": 12,
+            },
+            "t",
+        )
+        assert report.checks[0].status == verify.PASS


### PR DESCRIPTION
**READY FOR INTEGRATION — Claude 5 merges. I do not.** #927 and #921 are untouched and stay frozen.

Verification tooling and documentation only. No product code, no engine, no canonical value, no UI. `#804`/`#921` remain post-V1 with the flag **OFF**.

> **One assumption, stated plainly.** "No new feature branch" — this is not feature work, and the package has to be committed somewhere or it dies with the container. It is a docs-and-verification branch off `main`, carrying nothing else.

---

## The finding that shapes everything

Fourteen V1 rows carry lane **L4**. **Nine of them are `IMPLEMENTED_UNVERIFIED`.** The code exists and has been reviewed; what is missing is *evidence* — and the crowd ledger, the bid history, the Sharp cohort and the league scoring cards are all gitignored and prod-only, so no repository can prove any of them.

| blocker | rows |
|---|---|
| an authenticated production read | V1-58, V1-60, V1-61, V1-129 (+ half of V1-57, V1-59) |
| a production **filesystem** read | V1-57, V1-129 |
| a **UI consumer** proof (L4) | V1-56, V1-61, V1-62 |
| nothing — deterministic, satisfied at #927's head | V1-63, V1-64 |

**Writing more Lane 4 code moves almost none of this.** The scarce resource is admissible evidence, not implementation.

---

## 1 — `scripts/verify_lane4_production.py`

### Why a script and not a checklist

The prose checklist shipped in #927 names **endpoints and fields that do not exist**: `POST /api/faab/recommend` (the real route is `/api/waiver/faab-recommend`) and roster-percentage fields like `rostersObserved` that the payload never had. Several of its steps are unrunnable as written.

That is a *method* problem, not a typo. A checklist's paths are checked by a reader's goodwill; a script's are checked by execution. **Both defects are flagged on #927** (frozen) and superseded here.

### The three rules, enforced in code

**Authentication is never bypassed.** A cookie is sent only if the operator exports `RISKIT_SESSION_COOKIE`. No fallback credential, no test-mode header, no allowlist edit — pinned structurally by `test_no_cookie_means_no_cookie_header`. A 401/403 raises a dedicated `Unauthenticated` type so no generic handler can quietly downgrade it, and is recorded as **`UNVERIFIABLE_UNAUTHENTICATED`**: insufficient evidence, deliberately neither pass nor failure. Same vocabulary `verify-sharp-production.yml` already uses.

**Nothing is fabricated.** No cohort, ledger, scoring card, crowd row or player is invented. `--add-player` must name a real free agent or the crowd checks report `BLOCKED`.

**Read-only.** GETs, a POST that computes a recommendation without persisting one, file reads, `systemctl list-timers`.

### The status vocabulary *is* the deliverable

| status | meaning |
|---|---|
| `pass` | the case arose and behaved correctly |
| `fail` | the case arose and behaved incorrectly |
| `inapplicable` | the input was read and **did not contain the case**. Not a pass |
| `blocked` | a required input does not exist here. Not a pass, not a failure |
| `unverifiable_unauthenticated` | 401/403 |
| `error` | the check did not run |

Exit `0` real pass and no failures · `1` error · `2` failure · **`3` nothing was proven**. `3` exists because it is the entire risk: a run that measured nothing must not share an exit code with a run where everything passed. Pinned by `test_a_run_that_proves_nothing_does_not_exit_zero`.

### It discriminates the two builds — measured, not asserted

| check | on `main` (pre-#927) | on #927's tree |
|---|---|---|
| C4 TEP rule | **`fail`** — label rule detected | `inapplicable` — card rule detected, no fresh card here |
| C5 unproven scoring | **`fail`** — no `unprovable_target_fields` owner | **`pass`** |

Obtained by running it against both trees, fabricating nothing. Run it before and after the deploy and the difference is the evidence.

### The nine #927 checks

1. **C1** zero-voter `personManagerQuality` is `null`, never `1.0` — the defect #920 named as V1-63's blocker to `VERIFIED`.
2. **C2** a measured `0.0` stays `0.0` — the repair must not overshoot; UNKNOWN and WORST are different answers.
3. **C3** `networkConcentration` is `null` with no weighted volume — `0.0` reads as its exact opposite.
4. **C4** TEP read from the card, detected from `from_roster_settings`' own **signature**. Signature-first on purpose: a behaviour-only check passes on a label build whenever label and card happen to agree.
5. **C5** stale/missing scoring evidence → TEP UNKNOWN **and** hard-excludes. When the card *is* fresh this is `inapplicable`, and the detail says explicitly: do not age or delete a card to manufacture the case.
6. **C6** `dynasty_main`'s actual card grants TE no edge. Separate from C4 because a build can read the card and still get this league wrong. If the card *does* show an edge → `inapplicable`, not `fail`: the commissioner may have restored the premium.
7. **C7** comparable population, card rule vs the retired label rule — a counterfactual over **real stored rows** where the only thing that varies is the policy.
8. **C8** refusal reasons name our side (`target_format_unverifiable:…`) rather than blaming the feed.
9. **C9** the crowd moves the bid only when admitted — fails **both** when an admitted crowd is invisible and when a refused one still contributes a factor row. Matched on the factor's stable `label`, not its prose.

### The other rows

**V1-57** timer installed *and fired*, plus the artifact — a green manual run does not satisfy the row. **V1-60** `cohortCoveragePct` null rather than `0` when nothing was observed. **V1-65** one `cohort_members` definition. **V1-58/V1-59** recorded `BLOCKED` with the single credential that unblocks them named, and never to be closed by standing up a synthetic cohort.

---

## 2 — The proposed next unit (proposal only, not implemented)

> **A bearer-gated, read-only Lane 4 verification endpoint.**

Every recorded verification attempt ends `status: "unverifiable_unauthenticated"` — **80/80 attempts 401 across 79 runs**, per the workflow's own comment. `/api/sharp/*` is session-gated, correctly, and `test_public_api_allowlist.py` pins that. **That gate must not be relaxed.**

The repo already names the answer, in `verify-sharp-production.yml`:

> *"Provision a token for the smoke (see `_SELF_AUTHED_API_EXACT` … for the bearer pattern used by `/api/signal-alerts/run`) to turn this into an enforcing gate."*

That pattern is live on three endpoints: env-configured secret, `hmac.compare_digest`, **empty means disabled** so it fails closed. Adding a credential path is the opposite of removing a gate.

**Verdicts only, never data** — counts, states and booleans; no player, manager, roster or league identity crosses it. A bearer token is a weaker credential than an admin session, so it must see strictly less; that is what makes the exposure acceptable rather than merely convenient. Read-only, fails closed, reuses the existing owner, and the verifier is already written so it adds no second definition of "verified".

Unblocks **V1-58, V1-60, V1-65, V1-129 directly** and V1-57, V1-59, V1-61 partially.

**Needs Claude 5's sign-off before it starts** — it touches the authentication surface, which is not my lane. Fallback if the owner would rather not: **V1-62 memoization** (self-contained, but performance rather than correctness, and being L4 it cannot reach `VERIFIED` on a memoization commit).

### Measured along the way, reported rather than buried

**V1-59's contract note looks stale on its SQLite half.** Every sharp store reaches SQLite through one owner (`roster_store` → `platform_ledger` → `ledger.connect`), which already sets `timeout=30.0` + `busy_timeout=30000`, applies `journal_mode=WAL` + `synchronous=NORMAL` at schema time (persistent in the file), and already distinguishes a routine `database is locked` from corruption. This does **not** establish that the bootstrap succeeds — that is a `journalctl` question — but it does mean V1-59's remaining work is evidence, not engineering.

---

## Verification

| check | result |
|---|---|
| `tests/ops` (new, 22 tests) | passed — status vocabulary, 401 handling, no-cookie-means-no-cookie, and each check's pass/fail/inapplicable/blocked boundaries |
| `tests/ops` + `tests/sharp` + `tests/trade` | **836 passed** |
| the script, run for real | `--mode onbox` on both `main` and #927's tree; results in the table above |
| `ruff check` / `format --check` | clean, 1195 files |
| `check_decision_coercions.py` | clean |
| `check_release_candidate.py` | base `d7b126d6d`, head `66fb1a053` — the validated tree IS the tree that will merge |

Board impact: none — no product code is touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqEBEngbUtzXsbHRYrPLkF)_