### PR TITLE
Verification-only (stacked on #927): correct the Lane 4 procedures in place, and make them executable

### DIFF
--- a/docs/lane4/L2_L3_VERIFICATION_PROCEDURES.md
+++ b/docs/lane4/L2_L3_VERIFICATION_PROCEDURES.md
@@ -30,18 +30,88 @@ Levels, quoted from the contract §2 so this file cannot drift from it:
 
 ---
 
+## Corrected 2026-08-19, and now executable
+
+This document shipped with **four wrong references**, found by deriving every
+endpoint and field from the actual route registrations and response producers
+rather than from memory. Each is corrected in place below and called out where
+it occurs, because a superseding document leaves the wrong one in circulation.
+
+| # | this document said | reality |
+|---|---|---|
+| 1 | `POST /api/faab/recommend` (×2) | **`POST /api/waiver/faab-recommend`** — there is no `/api/faab/*` prefix at all, so **every crowd-market step was unrunnable** |
+| 2 | roster-percentage → `sources.ffpc.status` | **`coverage.platforms.ffpc.status`**, and it is on **`/api/sharp/market`** — wrong field *and* wrong endpoint |
+| 3 | `cohortCoveragePct` (under `cohort`) | **`transparency.cohortCoveragePct`** |
+| 4 | roster-percentage → `rostersObserved` | **does not exist**; the count is `transparency.eligibleRosters` (also `sample.eligibleRosters`) |
+
+Correct and left alone: `cohort.selectedManagers` (present on **both** boards),
+`crowdMarket.{state,refusalReason,excludedCounts,tierCounts,pricesIdp,rowsUsed,rowsTotal,targetFormatUnknown,playerHasEvidence}`,
+`contention.notes`, and `CollectResult.status`. Two further values were wrong
+and are fixed at their rows: the `/api/status` SHA fields (next section) and the
+`unavailable_reason` literals (V1-60).
+
+**The reason this happened is worth keeping.** A prose checklist's paths are
+checked by a reader's goodwill; nothing fails when one is wrong, and an
+unrunnable procedure reads exactly like a runnable one until someone with
+production credentials wastes an evening on it.
+
+So the checklist is no longer the only artifact. **`scripts/verify_lane4_production.py`**
+resolves every route and field against the deployed code at run time, and
+`tests/ops/test_lane4_verification.py` asserts — against the real producers, at
+every CI run — that each route this package names is registered and each field
+path exists. One of those tests scans **this document** and fails if it names a
+route that does not exist. That is what would have caught all four.
+
+The verifier reports five states, and three of them are not passes:
+
+| status | meaning |
+|---|---|
+| `pass` | the case arose and behaved correctly |
+| `fail` | the case arose and behaved incorrectly |
+| `unmeasurable` | the input was read; the case did not arise |
+| `blocked` | a required input does not exist here |
+| `unverifiable_unauthenticated` | 401/403 — insufficient evidence |
+
+**Exit `0` is reserved for a COMPLETE run.** Any blocked, unmeasurable or
+unauthenticated check caps the run at exit `3`, however many others passed, and
+a `pass` whose denominator is `0` is downgraded automatically — a check that
+inspected nothing cannot report success.
+
+---
+
 ## Deployed-SHA preamble (every L3 procedure)
 
-An L3 result is only meaningful against a known commit. Record this first; if
-the SHA does not match the head being claimed, stop — the run proves something
-about a different tree.
+An L3 result is only meaningful against a known commit.
+
+> **CORRECTED 2026-08-19 — the deployed SHA is NOT observable over HTTP.**
+> This section previously said to record a `commit` field and a `startedAt`
+> field from `/api/status`. **Neither exists.** Verified against the producer
+> (`server.py::get_status` + `_scrape_status_payload`): the payload carries
+> `contract`, `data_runtime`, `health`, `sources`, `source_failures` and the
+> payload-size block, and its `contract.version` is the **API data-contract**
+> version (e.g. `2026-03-10.v2`) — the payload's shape, not the commit that
+> produced it. **No endpoint publishes a git SHA or build identifier.**
+
+So an L3 run's tree identity must come from the box, not the API:
 
 ```bash
+# ON THE BOX — the only place the SHA is knowable
+git -C "$APP_DIR" rev-parse HEAD
+git -C "$APP_DIR" log -1 --format='%H %ci %s'
+
+# from anywhere — useful context, but NOT a tree identity
 curl -s https://chaseupside.com/api/status | python -m json.tool | head -40
 ```
 
-Record: `commit`/`version` field, `startedAt`, and the wall-clock time of the
-call. Every artifact below is filed under that SHA.
+Record: the `git rev-parse HEAD` output, `contract.version`,
+`data_runtime.last_data_refresh_at`, and the wall-clock time of the call. Every
+artifact below is filed under that SHA.
+
+**`scripts/verify_lane4_production.py` encodes this gap rather than papering
+over it:** in `--mode remote` it stamps `headSha: null` with
+`headShaSource: "unavailable_over_http"`, and only `--mode onbox` can answer it.
+Closing the gap properly means publishing a build identifier, which is a Lane 5
+change and is not proposed here.
 
 ---
 
@@ -72,11 +142,11 @@ ls -la /opt/dynasty/data/faab/          # path per the deployed APP_DIR
 
 | assertion | pass |
 |---|---|
-| the timer is installed and enabled | `LOAD=loaded`, `ACTIVE=active`, `UNIT=dynasty-faab-history.timer` in `list-timers` |
+| the timer is installed and enabled | `LOAD=loaded`, `ACTIVE=active`, and a `list-timers` row whose `UNIT` ends `-faab-history.timer`. The prefix is `$SERVICE_NAME` from `install-systemd-service.sh` (`install_simple_timer` builds `${SERVICE_NAME}-${stem}`), so match on the **suffix** rather than assuming `dynasty-` |
 | it has actually fired | `LAST` is populated and within ~25 h of now |
 | the run succeeded | the most recent journal entry exits **0** (1 = registry unreadable, 2 = nothing fetched) |
 | it produced the artifact | `data/faab/bid_history_<leagueKey>.json` exists per active league, `mtime` inside 25 h |
-| the artifact is used | `POST /api/faab/recommend` → `contention.notes` does **not** carry the configured-priors fallback note |
+| the artifact is used | `POST /api/waiver/faab-recommend` → `contention.notes` does **not** carry the configured-priors fallback note |
 
 **Exit 2 is not a pass and not a failure.** It means nothing was fetched and the
 previous file was left untouched. Record it as `DEGRADED` with the prior file's
@@ -145,11 +215,17 @@ ledger.
 ### 129c — an offense-only population refuses to price an IDP claim
 
 ```bash
-curl -s -X POST https://chaseupside.com/api/faab/recommend \
+curl -s -X POST https://chaseupside.com/api/waiver/faab-recommend \
   -H 'content-type: application/json' -b "$SESSION_COOKIE" \
   -d '{"leagueKey":"dynasty_main","addPlayerName":"<a rostered LB>"}' \
 | python -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps(d["crowdMarket"], indent=2))'
 ```
+
+> **CORRECTED 2026-08-19.** This block said `POST /api/faab/recommend`, which is
+> not a route — there is no `/api/faab/*` prefix at all. The real registration
+> is `@app.post("/api/waiver/faab-recommend")` in `server.py`. Both occurrences
+> in this document were wrong, so **every crowd-market step here was
+> unrunnable**.
 
 PASS: `pricesIdp: false` **and** `refusalReason: "population_cannot_price_idp"`
 **and** `playerHasEvidence: false`.
@@ -202,17 +278,32 @@ The requirement is a **truthful degraded state**. Zero rosters because FFPC is
 switched off and zero rosters because the collection broke must not render
 identically, and neither may read as "we looked and nobody owns him".
 
+> **CORRECTED 2026-08-19 — three field paths here were wrong, and one field
+> did not exist.** Verified by building both real payloads and walking them:
+> the FFPC status block is on **`/api/sharp/market`**, not this board; the
+> population counts live under **`transparency`**, not `cohort`; and
+> `rostersObserved` (named elsewhere in this file's V1-65 step) exists nowhere.
+> `cohort.selectedManagers` is correct and is present on **both** boards.
+
+Two payloads, because the two facts live on different endpoints:
+
 ```bash
+# population counts + coverage
 curl -s 'https://chaseupside.com/api/sharp/roster-percentage' -b "$SESSION_COOKIE" \
-| python -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps({k:v for k,v in d.items() if k!="assets"}, indent=2))'
+| python -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps({"status": d.get("status"), "cohort": d.get("cohort"), "transparency": d.get("transparency"), "sample": d.get("sample")}, indent=2))'
+
+# per-platform lane status
+curl -s 'https://chaseupside.com/api/sharp/market?window=30d&limit=1' -b "$SESSION_COOKIE" \
+| python -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps(d["coverage"]["platforms"], indent=2))'
 ```
 
 | assertion | pass |
 |---|---|
-| the source block states FFPC's status | `sources.ffpc.status` ∈ `disabled` / `degraded` / `no_data` / `ok`, never absent |
-| a disabled lane says disabled | `enabled: false` when no roster-bearing URL is configured |
-| coverage is unavailable, not zero | `cohortCoveragePct` is `null` — never `0` — when no roster was observed |
-| a skipped collection names itself | `CollectResult.status == "unavailable"` with an `unavailable_reason` of `skipped` / `no_managers` |
+| the platform block states FFPC's status | **`coverage.platforms.ffpc.status`** (on `/api/sharp/market`) ∈ `disabled` / `degraded` / `no_data` / `ok`, never absent. **Not** `sources.ffpc.status`, and **not** on the roster-percentage board |
+| a disabled lane says disabled | `coverage.platforms.ffpc.enabled: false` when no roster-bearing URL is configured |
+| coverage is unavailable, not zero | **`transparency.cohortCoveragePct`** is `null` — never `0` — when no roster was observed. It is **not** under `cohort` |
+| the population is stated beside it | `transparency.cohortManagers`, `transparency.cohortManagersRepresented`, `transparency.eligibleRosters`, `transparency.ffpcRosters`, `transparency.sleeperRosters` |
+| a skipped collection names itself | `CollectResult.status == "unavailable"` (the constant is `roster_collect.STATUS_UNAVAILABLE`) with an `unavailable_reason` of **`skipped_by_caller`** or **`no_cohort_managers_on_platform`** — the literal values of `UNAVAILABLE_SKIPPED` / `UNAVAILABLE_NO_MANAGERS`. This row previously named them `skipped` / `no_managers`, which match nothing |
 
 FAIL: a `0` or `0.0` anywhere a lane was not actually measured. That is the
 whole defect this row tracks.
@@ -293,7 +384,10 @@ it, and none applies a qualification rule of its own.
 
 Measured statement required for L2: the number of cohort members and the number
 of roster observations behind the live board, from
-`/api/sharp/roster-percentage` (`cohort.selectedManagers`, `rostersObserved`).
+`/api/sharp/roster-percentage` — **`cohort.selectedManagers`** and
+**`transparency.eligibleRosters`**. (`rostersObserved`, which this line used to
+name, does not exist in the payload; `sample.eligibleRosters` carries the same
+count beside the 8-roster ranking minimum.)
 If both are `0`, that is the honest answer and V1-58 is the blocker — record it
 as such rather than as a V1-65 failure.
 

--- a/scripts/verify_lane4_production.py
+++ b/scripts/verify_lane4_production.py
@@ -854,6 +854,29 @@ def check_tep_is_card_derived(report: Report, league: str) -> dict[str, Any]:
             "produced to compare. C5 is the check that covers this state."
         )
         return ctx
+    if not isinstance(card, dict) or not card:
+        # FRESH EVIDENCE IS NOT THE SAME AS A READABLE CARD, and conflating
+        # them was a false green found in adversarial review.
+        # ``scoring_evidence_state`` decides freshness from the snapshot's
+        # fetch timestamp and season -- it never reads ``scoringSettings`` --
+        # so a snapshot written by a partial fetch is ``fresh`` while carrying
+        # no card at all.  In that state ``_tep_from_scoring`` correctly
+        # returns ``None`` (fail-closed, so the PRODUCT is fine), and the
+        # served value then equalled the derived value trivially: both
+        # ``None``.  This check reported PASS with the detail "derived from
+        # the fresh card" having observed no card.
+        #
+        # BLOCKED rather than FAIL because nothing is broken -- the evidence
+        # is absent.  C6 already handled this case; C4 did not, which is what
+        # marks it an oversight rather than a decision.
+        check.status = BLOCKED
+        check.detail = (
+            f"scoring evidence is {evidence_state!r} but the snapshot carries no "
+            "scoringSettings, so there is no card to derive from and nothing to "
+            "compare against. Refetch with scripts/fetch_league_scoring.py; do not "
+            "read this as the rule being verified."
+        )
+        return ctx
     if target.tep != card_says_tep:
         check.status = FAIL
         check.detail = (

--- a/scripts/verify_lane4_production.py
+++ b/scripts/verify_lane4_production.py
@@ -1,0 +1,1800 @@
+#!/usr/bin/env python3
+"""Lane 4 production verification — executable post-deploy checks.
+
+WHAT THIS IS
+------------
+The Lane 4 V1 rows (`docs/VERSION_1_COMPLETION_CONTRACT.md` §3.5) sit at
+`IMPLEMENTED_UNVERIFIED` because their evidence is **production-side**: the
+crowd-FAAB ledger, the own-league bid history, the Sharp cohort and the
+league scoring cards are all gitignored and prod-only. A repository cannot
+prove any of them. This script is what someone with access runs so that
+"verified" stops being an assertion.
+
+It is also the before/after instrument for **#927**. Several checks below
+describe behaviour that only exists once #927 deploys; run it before and
+after, and the difference is the evidence.
+
+THE THREE RULES, ENFORCED IN CODE AND NOT ONLY IN PROSE
+-------------------------------------------------------
+1. **Production authentication is never bypassed.** `/api/sharp/*` and
+   `/api/waiver/*` require a session; this script sends one only if the
+   operator supplies it. There is no fallback, no test-mode header and no
+   allowlist edit. A **401 is `UNVERIFIABLE_UNAUTHENTICATED`** — recorded as
+   insufficient evidence, and deliberately neither a pass nor a failure. The
+   vocabulary matches `.github/workflows/verify-sharp-production.yml`, which
+   already treats it that way.
+2. **Nothing is fabricated.** No cohort, ledger, scoring card, crowd row or
+   player is invented to make a check runnable. A check whose real input is
+   absent reports `BLOCKED` and names the input. A check whose input exists
+   but does not contain the case under test reports `UNMEASURABLE` — "we
+   looked and the situation did not arise" is a different statement from
+   "we looked and it was correct", and collapsing them is the exact defect
+   class Lane 4 exists to prevent.
+3. **Read-only.** Every operation is a GET, a POST that computes a
+   recommendation without persisting one, a file read, or a `systemctl`
+   query. Nothing writes to production.
+
+WHY A NEW SCRIPT
+----------------
+`scripts/audit_status.py` tracks audit findings by source-signature tripwire,
+which is a different question (has this mechanism changed?) from this one
+(does the deployed system behave correctly on real data?).
+`.github/workflows/verify-sharp-production.yml` polls exactly one endpoint
+for one row. Neither is the owner of per-row Lane 4 production evidence.
+
+MODES
+-----
+``--mode remote`` runs over HTTPS against a deployed origin and needs a
+session cookie. It can see what the API publishes.
+
+``--mode onbox`` runs **in the deployed working directory** and reads local
+`data/` plus the deployed source. It can see the scoring card, the crowd
+ledger and the systemd units, and it is the only mode that can compute the
+before/after counterfactuals, because those need the real stored rows
+re-classified under two policies.
+
+Neither mode subsumes the other; the package is both.
+
+USAGE
+-----
+    # on the box, in the deployed working directory
+    python scripts/verify_lane4_production.py --mode onbox \
+        --league dynasty_main --out data/ops/lane4-verification.json
+
+    # from anywhere, with an operator-supplied session
+    export RISKIT_SESSION_COOKIE='session=...'
+    python scripts/verify_lane4_production.py --mode remote \
+        --origin https://chaseupside.com --league dynasty_main \
+        --add-player 'Some Free Agent'
+
+EXIT CODES
+----------
+    0  every applicable check passed, and at least one was applicable
+    1  an unexpected error while running a check
+    2  at least one check FAILED
+    3  no failure, but the run proved nothing — every check was blocked,
+       unverifiable or inapplicable.  Distinct from 0 on purpose: an
+       evidence-free run must not read as a green one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+# ── Result vocabulary ──────────────────────────────────────────────
+
+PASS = "pass"
+FAIL = "fail"
+#: The input was read but the case under test could not be measured from
+#: it -- the situation did not arise, or the population was empty.  NOT a
+#: pass: "we looked and it did not happen" is not "we looked and it was
+#: correct", and collapsing them is the defect class this lane exists to
+#: catch.
+UNMEASURABLE = "unmeasurable"
+#: A required input does not exist here.  NOT a pass and NOT a failure.
+BLOCKED = "blocked"
+#: The endpoint answered 401/403.  Insufficient evidence, by design.
+UNVERIFIABLE = "unverifiable_unauthenticated"
+ERROR = "error"
+
+#: Statuses that answer no question.  Each one caps the run's exit code at
+#: 3, so an incomplete run can never read as green.
+_PROVES_NOTHING = {UNMEASURABLE, BLOCKED, UNVERIFIABLE}
+
+
+@dataclass
+class Check:
+    """One named assertion, with the evidence that produced it.
+
+    ``denominator`` is what the check actually inspected -- rows examined,
+    files read, units listed.  It exists because the failure mode of any
+    verification tool is being GREEN WHILE INSPECTING NOTHING: a check that
+    iterates an empty list and finds no offenders is indistinguishable, in
+    its output, from one that examined a thousand rows and found none.
+
+    A check that has a denominator concept sets it.  ``None`` means the
+    check is not a population check (a route registration, a signature, a
+    file's presence), and those are exempt.
+    """
+
+    id: str
+    row: str
+    title: str
+    status: str = BLOCKED
+    detail: str = ""
+    evidence: dict[str, Any] = field(default_factory=dict)
+    denominator: int | None = None
+
+    def finalize(self) -> "Check":
+        """Downgrade a vacuous pass, structurally rather than by discipline.
+
+        ``PASS`` with a denominator of ``0`` means nothing was inspected, so
+        nothing was proven.  It becomes ``UNMEASURABLE`` here rather than at
+        every call site, because one forgotten guard is all it takes for a
+        verification run to report success over an empty population.
+        """
+        if self.status == PASS and self.denominator == 0:
+            self.status = UNMEASURABLE
+            self.detail = (
+                "downgraded from pass: the check inspected 0 items, so it proved "
+                "nothing. " + self.detail
+            )
+        return self
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "row": self.row,
+            "title": self.title,
+            "status": self.status,
+            "detail": self.detail,
+            "denominator": self.denominator,
+            "evidence": self.evidence,
+        }
+
+
+class Report:
+    def __init__(self, mode: str, league: str, origin: str | None) -> None:
+        self.mode = mode
+        self.league = league
+        self.origin = origin
+        self.checks: list[Check] = []
+        self.deployed: dict[str, Any] = {}
+
+    def add(self, check: Check) -> Check:
+        self.checks.append(check)
+        return check
+
+    def finalize(self) -> None:
+        """Apply the vacuous-pass guard to every check, once, at the end.
+
+        Deliberately here and not in ``add``: a check is mutated after it is
+        added (its status and denominator are set by the analyser that owns
+        it), so finalising on insert would run before the numbers exist.
+        """
+        for check in self.checks:
+            check.finalize()
+
+    def to_dict(self) -> dict[str, Any]:
+        counts: dict[str, int] = {}
+        for c in self.checks:
+            counts[c.status] = counts.get(c.status, 0) + 1
+        applicable = [c for c in self.checks if c.status not in _PROVES_NOTHING]
+        return {
+            "checkedAt": datetime.now(timezone.utc).isoformat(),
+            "mode": self.mode,
+            "league": self.league,
+            "origin": self.origin,
+            "deployed": self.deployed,
+            "counts": counts,
+            "applicableChecks": len(applicable),
+            "checks": [c.to_dict() for c in self.checks],
+        }
+
+    def exit_code(self) -> int:
+        """``0`` is reserved for a COMPLETE run.
+
+        The strict reading, and the safe one: a 401, an absent credential, an
+        empty population, a missing scoring card or a missing ledger must
+        never reach exit ``0``.  Each of those leaves a question unanswered,
+        and an unanswered question is not a pass -- so any check that did not
+        actually measure its case caps the run at ``3``, however many other
+        checks passed.
+
+        Consequence, stated rather than hidden: until production evidence
+        exists this exits ``3`` on every host, which is the accurate report.
+        A green ``0`` means every check ran and every one passed.
+        """
+        statuses = {c.status for c in self.checks}
+        if ERROR in statuses:
+            return 1
+        if FAIL in statuses:
+            return 2
+        if statuses & _PROVES_NOTHING:
+            return 3
+        if not any(c.status == PASS for c in self.checks):
+            return 3
+        return 0
+
+
+# ── HTTP (remote mode) ─────────────────────────────────────────────
+
+
+class Unauthenticated(Exception):
+    """401/403 from a session-gated endpoint.
+
+    Its own type because it must never be swallowed by a generic handler
+    and reported as a transient failure: a 401 is a definitive answer to a
+    different question ("do we hold a credential?"), and the measured
+    history on this repo is 80/80 attempts across 79 runs.
+    """
+
+
+def _http(url: str, *, cookie: str | None, body: dict | None = None, timeout: float = 30.0):
+    """GET, or POST when ``body`` is supplied.  Returns ``(status, payload)``.
+
+    The cookie is sent ONLY when the operator supplied one.  There is no
+    other credential path in this script by design.
+    """
+    data = None
+    headers = {"Accept": "application/json"}
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    if cookie:
+        headers["Cookie"] = cookie
+    request = urllib.request.Request(url, data=data, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read().decode("utf-8")
+            return response.status, (json.loads(raw) if raw.strip() else {})
+    except urllib.error.HTTPError as exc:
+        if exc.code in (401, 403):
+            raise Unauthenticated(f"{exc.code} from {url}") from exc
+        raw = exc.read().decode("utf-8", "replace")
+        try:
+            return exc.code, json.loads(raw)
+        except ValueError:
+            return exc.code, {"raw": raw[:500]}
+
+
+# ── Shared helpers ─────────────────────────────────────────────────
+
+
+def _repo_file(*parts: str) -> Path:
+    return REPO_ROOT.joinpath(*parts)
+
+
+def _load_json(path: Path) -> Any | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+# ── Route and field existence ──────────────────────────────────────
+#
+# A verification step that names a route or a field which does not exist is
+# WORSE than no step: an unrunnable procedure reads identically to a runnable
+# one until someone with production credentials wastes an evening on it.  The
+# first draft of the Lane 4 procedures shipped four such references.  These
+# two helpers make that class of error a FAIL rather than a silent skip.
+
+
+#: Routes this package's steps depend on, each with the module that registers
+#: it.  Derived by enumerating the real decorators and ``add_api_route`` calls,
+#: not from documentation.
+REQUIRED_ROUTES: tuple[tuple[str, str], ...] = (
+    ("/api/status", "GET"),
+    ("/api/sharp/market", "GET"),
+    ("/api/sharp/cohort", "GET"),
+    ("/api/sharp/roster-percentage", "GET"),
+    ("/api/waiver/faab-recommend", "POST"),
+)
+
+#: Field paths this package reads, as ``(producer, dotted path)``.  A rename
+#: upstream must break this rather than silently produce ``None`` at a caller.
+REQUIRED_FIELDS: tuple[tuple[str, str], ...] = (
+    ("roster-percentage", "transparency.cohortCoveragePct"),
+    ("roster-percentage", "transparency.cohortManagers"),
+    ("roster-percentage", "transparency.eligibleRosters"),
+    ("roster-percentage", "cohort.selectedManagers"),
+    ("roster-percentage", "status"),
+    ("sharp-market", "cohort.selectedManagers"),
+    ("sharp-market", "coverage.platforms"),
+    ("sharp-market", "status"),
+    ("crowd-market", "state"),
+    ("crowd-market", "targetFormatUnknown"),
+    ("crowd-market", "excludedCounts"),
+    ("crowd-market", "tierCounts"),
+    ("crowd-market", "pricesIdp"),
+    ("crowd-market", "rowsUsed"),
+    ("crowd-market", "rowsTotal"),
+)
+
+
+def _dotted(obj: Any, path: str) -> tuple[bool, Any]:
+    """``(present, value)`` for a dotted path.  Presence, not truthiness.
+
+    A field that exists and holds ``None`` is PRESENT -- that is the whole
+    point of ``cohortCoveragePct`` being null rather than zero, and a
+    truthiness test here would report the correct behaviour as a missing
+    field.
+    """
+    cur = obj
+    for part in path.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return False, None
+        cur = cur[part]
+    return True, cur
+
+
+def _registered_routes_static() -> set[tuple[str, str]]:
+    """Every route the SOURCE registers, by AST rather than by import.
+
+    ``import server`` refuses without ``JASON_LOGIN_PASSWORD`` -- correctly,
+    it is a fail-closed auth requirement -- so an import-only check reports
+    BLOCKED on every machine that is not the deployed box, which is exactly
+    where a stale route name in a document needs catching.  Route
+    registration is a source-level fact, so it is read from the source.
+    """
+    import ast
+
+    found: set[tuple[str, str]] = set()
+    targets = [REPO_ROOT / "server.py", *sorted((REPO_ROOT / "src").rglob("*.py"))]
+    for path in targets:
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            # @app.get("/api/...") and friends
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                for dec in node.decorator_list:
+                    if not isinstance(dec, ast.Call) or not isinstance(dec.func, ast.Attribute):
+                        continue
+                    verb = dec.func.attr.upper()
+                    if verb not in {"GET", "POST", "PUT", "DELETE", "PATCH"}:
+                        continue
+                    if dec.args and isinstance(dec.args[0], ast.Constant):
+                        value = dec.args[0].value
+                        if isinstance(value, str):
+                            found.add((value, verb))
+            # app.add_api_route("/api/...", handler, methods=["GET"])
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "add_api_route"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+            ):
+                path_value = node.args[0].value
+                for kw in node.keywords:
+                    if kw.arg == "methods" and isinstance(kw.value, (ast.List, ast.Tuple)):
+                        for element in kw.value.elts:
+                            if isinstance(element, ast.Constant) and isinstance(element.value, str):
+                                found.add((path_value, element.value.upper()))
+    return found
+
+
+def check_required_routes_exist(report: Report) -> None:
+    """Every route these steps name is actually registered.
+
+    Static by design (see :func:`_registered_routes_static`), with the live
+    app used as a confirmation when it can be imported.
+    """
+    check = report.add(Check("R0", "-", "every route this package names is registered"))
+    try:
+        registered = _registered_routes_static()
+    except Exception as exc:  # pragma: no cover - defensive
+        check.status = ERROR
+        check.detail = f"route scan failed: {exc!r}"
+        return
+    source = "source scan"
+    try:
+        import server
+
+        live = {
+            (getattr(route, "path", ""), method)
+            for route in getattr(server.app, "routes", [])
+            for method in (getattr(route, "methods", None) or ())
+        }
+        if live:
+            registered = live
+            source = "live app"
+    except Exception:
+        pass
+
+    missing = [f"{m} {p}" for p, m in REQUIRED_ROUTES if (p, m) not in registered]
+    check.denominator = len(REQUIRED_ROUTES)
+    check.evidence = {
+        "source": source,
+        "routesDiscovered": len(registered),
+        "required": [f"{m} {p}" for p, m in REQUIRED_ROUTES],
+        "missing": missing,
+    }
+    if not registered:
+        check.status = BLOCKED
+        check.detail = "no routes discovered at all, so nothing was verified."
+        return
+    if missing:
+        check.status = FAIL
+        check.detail = (
+            f"{len(missing)} of {len(REQUIRED_ROUTES)} routes are not registered "
+            f"({source}): {missing}. Any step naming one of them is unrunnable."
+        )
+        return
+    check.status = PASS
+    check.detail = (
+        f"all {len(REQUIRED_ROUTES)} routes registered, confirmed by {source} "
+        f"({len(registered)} routes discovered)."
+    )
+
+
+def check_required_fields_exist(report: Report, producers: dict[str, Any]) -> None:
+    """Every field path these steps read is present in its real producer.
+
+    ``producers`` maps the names used in :data:`REQUIRED_FIELDS` to a real
+    payload.  A producer that could not be built is reported as such rather
+    than counted as passing.
+    """
+    check = report.add(Check("R1", "-", "every field this package reads exists in its producer"))
+    missing: list[str] = []
+    unchecked: list[str] = []
+    checked = 0
+    for producer, path in REQUIRED_FIELDS:
+        payload = producers.get(producer)
+        if payload is None:
+            unchecked.append(f"{producer}.{path}")
+            continue
+        checked += 1
+        present, _ = _dotted(payload, path)
+        if not present:
+            missing.append(f"{producer}.{path}")
+    check.denominator = checked
+    check.evidence = {
+        "checked": checked,
+        "missing": missing,
+        "uncheckedBecauseProducerUnavailable": unchecked,
+    }
+    if missing:
+        check.status = FAIL
+        check.detail = (
+            f"{len(missing)} field path(s) absent from their producer: {missing}. Either "
+            "the producer renamed them -- so every consumer is now reading nothing -- or "
+            "this package is pointed at the wrong names."
+        )
+        return
+    if checked == 0:
+        check.status = BLOCKED
+        check.detail = (
+            "no producer could be built here, so no field path was verified: " f"{unchecked}"
+        )
+        return
+    check.status = PASS
+    check.detail = (
+        f"all {checked} field paths present"
+        + (f"; {len(unchecked)} unchecked (producer unavailable)" if unchecked else "")
+        + "."
+    )
+
+
+def check_idp_population_refusal(report: Report, crowd_market: Any) -> None:
+    """The offense-only population must REFUSE to price an IDP claim.
+
+    Measured on the live feed: zero of 86 external leagues start an individual
+    defender, so a median drawn from that population is offense-only evidence.
+    The gate reads what the retained rows actually contain, so it self-corrects
+    the day an IDP league appears -- which is why ``pricesIdp: true`` is a
+    finding to record, not a failure.
+    """
+    check = report.add(Check("C10", "V1-129", "an offense-only population refuses to price IDP"))
+    try:
+        from src.trade.faab_comparability import is_idp_position, population_prices_position
+    except Exception as exc:  # pragma: no cover - deployment shape
+        check.status = ERROR
+        check.detail = f"could not import the population gate: {exc!r}"
+        return
+    if crowd_market is None:
+        check.status = BLOCKED
+        check.detail = (
+            "no crowd ledger here, so the retained population cannot be inspected. "
+            "Do not synthesise rows."
+        )
+        return
+    prices_idp = bool(getattr(crowd_market, "prices_idp", False))
+    idp_positions = ["DL", "LB", "DB"]
+    offense_positions = ["QB", "RB", "WR", "TE"]
+    refused = [
+        p for p in idp_positions if not population_prices_position(p, any_idp_source=prices_idp)
+    ]
+    allowed = [
+        p for p in offense_positions if population_prices_position(p, any_idp_source=prices_idp)
+    ]
+    check.denominator = len(idp_positions) + len(offense_positions)
+    check.evidence = {
+        "pricesIdp": prices_idp,
+        "rowsUsed": getattr(crowd_market, "rows_used", None),
+        "idpPositionsRefused": refused,
+        "offensePositionsAllowed": allowed,
+        "isIdpPositionSane": [p for p in idp_positions if is_idp_position(p)],
+    }
+    if prices_idp:
+        check.status = UNMEASURABLE
+        check.detail = (
+            "the retained population contains at least one IDP league, so the refusal "
+            "branch does not apply today. That is a finding about the feed, not a "
+            "failure -- record which league, and note that the gate self-corrected."
+        )
+        return
+    if refused != idp_positions or allowed != offense_positions:
+        check.status = FAIL
+        check.detail = (
+            f"offense-only population: expected DL/LB/DB refused and QB/RB/WR/TE "
+            f"allowed, got refused={refused} allowed={allowed}."
+        )
+        return
+    check.status = PASS
+    check.detail = (
+        "the retained population starts no individual defender, and the gate refuses "
+        "DL/LB/DB while still pricing QB/RB/WR/TE."
+    )
+
+
+# ── #927 group A: person-consensus semantic states (V1-63) ─────────
+#
+# Three states that must never read as one another.  All three are read
+# off ONE market payload, because they are properties of the same rows and
+# fetching three times would let the board move underneath the check.
+
+
+def _person_rows(payload: dict) -> list[tuple[str, dict]]:
+    """``(assetId, personConsensus)`` for every row that has one."""
+    out: list[tuple[str, dict]] = []
+    for row in payload.get("assets") or []:
+        if not isinstance(row, dict):
+            continue
+        person = row.get("personConsensus")
+        if isinstance(person, dict):
+            out.append((str(row.get("assetId") or ""), person))
+    return out
+
+
+def check_zero_voter_quality(report: Report, payload: dict, source: str) -> None:
+    """#927 check 1 — zero voters must publish ``null``, never ``1.0``.
+
+    Reachable whenever every person who touched an asset both added AND
+    dropped it inside the window: the row is still emitted, with
+    ``personVotes: 0``.  ``1.0`` is the HIGHEST possible manager quality, so
+    the pre-#927 behaviour answered "how good is the evidence?" with a
+    green light precisely when there was none.
+    """
+    check = report.add(
+        Check(
+            "C1",
+            "V1-63",
+            "zero-voter personManagerQuality is JSON null, never 1.0",
+        )
+    )
+    rows = _person_rows(payload)
+    if not rows:
+        check.status = BLOCKED
+        check.detail = (
+            f"{source} published no personConsensus block on any row. With an empty "
+            "cohort or an empty movement ledger there is nothing to measure — this "
+            "is not evidence that the field is correct."
+        )
+        return
+    zero = [(a, p) for a, p in rows if p.get("personVotes") == 0]
+    if not zero:
+        check.status = UNMEASURABLE
+        check.detail = (
+            f"{len(rows)} rows carried personConsensus and none had personVotes == 0, "
+            "so the zero-voter branch did not execute. Not a pass: the case under "
+            "test did not arise. Re-run when the board carries a mixed-signal asset "
+            "(mixedPersonSignals > 0 with personVotes == 0)."
+        )
+        check.evidence = {"rowsWithPersonConsensus": len(rows)}
+        return
+    offenders = [
+        {
+            "assetId": asset_id,
+            "personManagerQuality": person.get("personManagerQuality"),
+            "mixedPersonSignals": person.get("mixedPersonSignals"),
+        }
+        for asset_id, person in zero
+        if person.get("personManagerQuality") is not None
+    ]
+    check.denominator = len(zero)
+    check.evidence = {
+        "rowsWithPersonConsensus": len(rows),
+        "zeroVoterRows": len(zero),
+        "offenders": offenders[:20],
+        "offenderCount": len(offenders),
+    }
+    if offenders:
+        check.status = FAIL
+        check.detail = (
+            f"{len(offenders)} of {len(zero)} zero-voter rows published a non-null "
+            "personManagerQuality. Pre-#927 this is 1.0 on every one of them."
+        )
+    else:
+        check.status = PASS
+        check.detail = f"all {len(zero)} zero-voter rows published personManagerQuality: null."
+
+
+def check_measured_zero_quality(report: Report, payload: dict, source: str) -> None:
+    """#927 check 2 — a measured 0.0 must stay 0.0.
+
+    The repair must not overshoot.  UNKNOWN and WORST are different answers,
+    and a cohort of voters all scored 0.0 HAS an answer: the floor.  A row
+    with voters and a null quality would mean the fix swallowed a real
+    measurement.
+    """
+    check = report.add(Check("C2", "V1-63", "a measured personManagerQuality of 0.0 stays 0.0"))
+    rows = _person_rows(payload)
+    voted = [(a, p) for a, p in rows if (p.get("personVotes") or 0) > 0]
+    if not voted:
+        check.status = BLOCKED if not rows else UNMEASURABLE
+        check.detail = (
+            f"{source} published no row with personVotes > 0, so no measured quality "
+            "exists to check. Nothing proven either way."
+        )
+        check.evidence = {"rowsWithPersonConsensus": len(rows)}
+        return
+    nulled = [a for a, p in voted if p.get("personManagerQuality") is None]
+    zeros = [a for a, p in voted if p.get("personManagerQuality") == 0]
+    check.denominator = len(voted)
+    check.evidence = {
+        "rowsWithVoters": len(voted),
+        "nulledDespiteVoters": nulled[:20],
+        "nulledCount": len(nulled),
+        "measuredZeroRows": len(zeros),
+    }
+    if nulled:
+        check.status = FAIL
+        check.detail = (
+            f"{len(nulled)} rows have voters but published personManagerQuality: null. "
+            "A measurement was discarded — the repair overshot into treating a real "
+            "value as missing."
+        )
+        return
+    check.status = PASS
+    if zeros:
+        check.detail = (
+            f"every one of {len(voted)} rows with voters published a number, including "
+            f"{len(zeros)} at exactly 0.0 — measured worst, not unknown."
+        )
+    else:
+        check.detail = (
+            f"every one of {len(voted)} rows with voters published a number. No row "
+            "measured exactly 0.0 on this board, so the floor case is reported by the "
+            "absence of nulls rather than by an example."
+        )
+
+
+def check_undefined_concentration(report: Report, payload: dict, source: str) -> None:
+    """#927 check 3 — no weighted volume means the ratio does not exist.
+
+    ``networkConcentration`` is a SHARE of weighted volume.  With no weighted
+    volume there is no share for any network to hold, and ``0.0`` is the one
+    value that reads as its exact opposite: "no single network dominates".
+    """
+    check = report.add(
+        Check(
+            "C3",
+            "V1-63",
+            "networkConcentration is null when weighted volume is zero",
+        )
+    )
+    rows = _person_rows(payload)
+    if not rows:
+        check.status = BLOCKED
+        check.detail = f"{source} published no personConsensus block on any row."
+        return
+    novol = [(a, p) for a, p in rows if not (float(p.get("weightedPersonVolume") or 0.0) > 0.0)]
+    if not novol:
+        check.status = UNMEASURABLE
+        check.detail = (
+            f"every one of {len(rows)} rows carried weighted volume > 0, so the "
+            "undefined branch did not execute."
+        )
+        check.evidence = {"rowsWithPersonConsensus": len(rows)}
+        return
+    offenders = [
+        {"assetId": a, "networkConcentration": p.get("networkConcentration")}
+        for a, p in novol
+        if p.get("networkConcentration") is not None
+    ]
+    check.denominator = len(novol)
+    check.evidence = {
+        "rowsWithPersonConsensus": len(rows),
+        "zeroVolumeRows": len(novol),
+        "offenders": offenders[:20],
+        "offenderCount": len(offenders),
+    }
+    if offenders:
+        check.status = FAIL
+        check.detail = (
+            f"{len(offenders)} of {len(novol)} zero-volume rows published a "
+            "networkConcentration number for a ratio that does not exist."
+        )
+    else:
+        check.status = PASS
+        check.detail = f"all {len(novol)} zero-volume rows published null."
+
+
+# ── #927 group B: TEP is a fact, not a label (V1-129) ──────────────
+#
+# On-box only.  These need the league's real Sleeper scoring card, which
+# lives at ``data/leagues/scoring_<sleeperLeagueId>.json`` and is gitignored,
+# so no repository and no HTTP client can answer them.
+
+
+def _deployed_tep_rule() -> str:
+    """Which rule the DEPLOYED code implements: ``card`` or ``label``.
+
+    Read from the constructor's own signature rather than from behaviour, so
+    the answer is unambiguous on a board where both rules would agree.
+    """
+    import inspect
+
+    from src.trade.faab_comparability import TargetFormat
+
+    params = inspect.signature(TargetFormat.from_roster_settings).parameters
+    if "scoring_settings" in params:
+        return "card"
+    if "scoring_profile" in params:
+        return "label"
+    return "unknown"
+
+
+def check_tep_is_card_derived(report: Report, league: str) -> dict[str, Any]:
+    """#927 check 4 — target TEP comes from the actual card, not the label.
+
+    Returns a context dict the later checks reuse, so the card is read once.
+    """
+    check = report.add(
+        Check("C4", "V1-129", "target TEP is derived from the scoring card, not the profile label")
+    )
+    ctx: dict[str, Any] = {}
+    try:
+        from src.api import league_registry
+        from src.league_intel.te_premium import measure_te_demand
+        from src.trade.faab_comparability import TargetFormat
+    except Exception as exc:  # pragma: no cover - deployment shape
+        check.status = ERROR
+        check.detail = f"could not import the comparability owner: {exc!r}"
+        return ctx
+
+    cfg = league_registry.get_league_by_key(league)
+    if cfg is None:
+        check.status = BLOCKED
+        check.detail = f"league {league!r} is not in the deployed registry."
+        return ctx
+
+    rule = _deployed_tep_rule()
+    evidence_state = league_registry.scoring_evidence_state(cfg)
+    card = league_registry.scoring_settings_for_league(cfg)
+    profile = str(getattr(cfg, "scoring_profile", "") or "")
+    label_says_tep = "tep" in profile.lower()
+
+    ctx = {
+        "cfg": cfg,
+        "card": card,
+        "evidenceState": evidence_state,
+        "profile": profile,
+        "labelSaysTep": label_says_tep,
+        "rule": rule,
+    }
+
+    # The factual answer, computed here from the card the deployed process
+    # would read.  ``None`` when the card is absent — never False.
+    card_says_tep: bool | None = None
+    edges: dict[str, float] = {}
+    if isinstance(card, dict) and card:
+        demand = measure_te_demand(None, card)
+        card_says_tep = demand.has_scoring_edge
+        edges = dict(demand.scoring_edges)
+    ctx["cardSaysTep"] = card_says_tep
+    ctx["scoringEdges"] = edges
+
+    try:
+        target = TargetFormat.from_registry(league)
+    except Exception as exc:
+        check.status = ERROR
+        check.detail = f"TargetFormat.from_registry({league!r}) raised: {exc!r}"
+        return ctx
+    ctx["target"] = target
+
+    check.evidence = {
+        "deployedRule": rule,
+        "scoringProfileLabel": profile,
+        "labelSaysTep": label_says_tep,
+        "scoringEvidenceState": evidence_state,
+        "cardPresent": bool(card),
+        "scoringEdges": edges,
+        "cardSaysTep": card_says_tep,
+        "servedTep": target.tep,
+        "servedIs2te": target.is_2te,
+    }
+
+    if rule == "label":
+        check.status = FAIL
+        check.detail = (
+            "the deployed build derives TEP from the scoring-profile LABEL "
+            f"({profile!r} -> {label_says_tep}). MASTER_PRODUCT_PLAN 4.10 forbids a "
+            "label deciding a factual question. This is the pre-#927 build."
+        )
+        return ctx
+    if rule != "card":
+        check.status = ERROR
+        check.detail = "could not determine which TEP rule the deployed build implements."
+        return ctx
+    if evidence_state != "fresh":
+        check.status = UNMEASURABLE
+        check.detail = (
+            f"the deployed build reads the card (rule={rule}), but this league's "
+            f"scoring evidence is {evidence_state!r}, so no card-derived value was "
+            "produced to compare. C5 is the check that covers this state."
+        )
+        return ctx
+    if target.tep != card_says_tep:
+        check.status = FAIL
+        check.detail = (
+            f"served tep={target.tep!r} but the league's own fresh card measures "
+            f"{card_says_tep!r} (edges {edges}). The served value did not come from "
+            "the card."
+        )
+        return ctx
+    check.status = PASS
+    agreement = "agrees with" if bool(card_says_tep) == label_says_tep else "DISAGREES with"
+    check.detail = (
+        f"served tep={target.tep!r}, derived from the fresh card (edges {edges}); it "
+        f"{agreement} the {profile!r} label."
+    )
+    return ctx
+
+
+def check_unproven_scoring_fails_closed(report: Report, ctx: dict[str, Any]) -> None:
+    """#927 check 5 — stale/missing scoring evidence means UNKNOWN and excludes.
+
+    A card proves when it was taken, not that it is still true.  Only
+    ``fresh`` authorises the claim; and UNKNOWN must not quietly become "no
+    TE premium", which would admit a whole population of offense-scoring
+    leagues as comparable.
+    """
+    check = report.add(
+        Check(
+            "C5", "V1-129", "stale or missing scoring evidence leaves TEP UNKNOWN and fails closed"
+        )
+    )
+    if "target" not in ctx:
+        check.status = BLOCKED
+        check.detail = "C4 could not resolve a target, so there is nothing to check."
+        return
+    state = ctx["evidenceState"]
+    target = ctx["target"]
+    try:
+        from src.trade.faab_comparability import unprovable_target_fields
+    except ImportError:
+        check.status = FAIL
+        check.detail = (
+            "the deployed build has no unprovable_target_fields owner, so an "
+            "unprovable target cannot be reported. This is the pre-#927 build."
+        )
+        return
+
+    unprovable = list(unprovable_target_fields(target))
+    check.evidence = {
+        "scoringEvidenceState": state,
+        "servedTep": target.tep,
+        "unprovableTargetFields": unprovable,
+    }
+    if state == "fresh":
+        if target.tep is None:
+            check.status = FAIL
+            check.detail = "evidence is fresh but TEP resolved to None."
+            return
+        check.status = UNMEASURABLE
+        check.detail = (
+            "this league's scoring evidence is fresh, so the unproven branch did not "
+            "execute. Not a pass — to exercise it, run against a league whose card is "
+            "stale or absent. Do NOT age or delete a card to manufacture the case."
+        )
+        return
+    if target.tep is not None:
+        check.status = FAIL
+        check.detail = (
+            f"scoring evidence is {state!r} but TEP resolved to {target.tep!r}. Unproven "
+            "scoring became a positive claim."
+        )
+        return
+    if "tep" not in unprovable:
+        check.status = FAIL
+        check.detail = (
+            "TEP is None but the comparability owner does not report it as unprovable, "
+            "so every external row would be judged against an unstated setting."
+        )
+        return
+    check.status = PASS
+    check.detail = (
+        f"scoring evidence is {state!r}, TEP is None (UNKNOWN, not 'no premium'), and "
+        f"the target reports unprovable fields {unprovable} so classification "
+        "hard-excludes rather than assuming a match."
+    )
+
+
+def check_dynasty_main_is_not_te_premium(report: Report, ctx: dict[str, Any], league: str) -> None:
+    """#927 check 6 — the specific measured claim about this league's card.
+
+    `dynasty_main` carries a `superflex_tep15_ppr1` label while its 2026 card
+    grants tight ends nothing over WRs.  This check asserts the CARD, and
+    reports what the served value does with it.  It is deliberately specific:
+    a generic "the rule is card-derived" check passes on a build that reads
+    the card and still gets this league wrong.
+    """
+    check = report.add(
+        Check("C6", "V1-129", f"{league} behaves as non-TE-premium under its actual card")
+    )
+    card = ctx.get("card")
+    if not isinstance(card, dict) or not card:
+        check.status = BLOCKED
+        check.detail = (
+            f"no scoring card on disk for {league} "
+            "(data/leagues/scoring_<sleeperLeagueId>.json). Run "
+            "scripts/fetch_league_scoring.py on the box first — do not synthesise one."
+        )
+        return
+    edges = ctx.get("scoringEdges") or {}
+    card_says_tep = ctx.get("cardSaysTep")
+    served = ctx.get("target").tep if ctx.get("target") is not None else None
+    check.evidence = {
+        "bonus_rec_te": card.get("bonus_rec_te"),
+        "bonus_rec_wr": card.get("bonus_rec_wr"),
+        "bonus_fd_te": card.get("bonus_fd_te"),
+        "bonus_fd_wr": card.get("bonus_fd_wr"),
+        "scoringEdges": edges,
+        "cardSaysTep": card_says_tep,
+        "servedTep": served,
+        "scoringProfileLabel": ctx.get("profile"),
+        "scoringEvidenceState": ctx.get("evidenceState"),
+    }
+    if card_says_tep is True:
+        check.status = UNMEASURABLE
+        check.detail = (
+            f"this league's current card DOES advantage TE ({edges}), so the "
+            "non-premium claim does not describe it today. That is a real finding, not "
+            "a failure — the commissioner may have restored the premium. What matters "
+            "is that the served value follows the card, which is C4."
+        )
+        return
+    if ctx.get("evidenceState") != "fresh":
+        check.status = BLOCKED
+        check.detail = (
+            f"the card measures no TE edge ({edges}) but its evidence state is "
+            f"{ctx.get('evidenceState')!r}, so it may not authorise a served value. "
+            "Refresh it before reading this as the league's behaviour."
+        )
+        return
+    if served is not False:
+        check.status = FAIL
+        check.detail = (
+            f"the fresh card grants TE no edge ({edges}) but the served tep is "
+            f"{served!r}. The label is still deciding."
+        )
+        return
+    check.status = PASS
+    check.detail = (
+        f"the fresh card grants TE no edge over WR/RB ({edges}) and the served tep is "
+        f"False, against a {ctx.get('profile')!r} label that says otherwise."
+    )
+
+
+# ── #927 group C: what the population change actually did (V1-129) ──
+
+
+def check_comparable_population_before_after(
+    report: Report, ctx: dict[str, Any], league: str
+) -> None:
+    """#927 check 7 — before/after comparable crowd population.
+
+    A counterfactual over REAL stored rows, not a simulation: the accumulated
+    ledger is classified twice, once against the served (card-derived) target
+    and once against the same target with TEP forced to what the retired
+    LABEL rule would have said.  Nothing is invented; the only thing that
+    varies is the policy.
+    """
+    check = report.add(
+        Check("C7", "V1-129", "comparable crowd population, card-derived vs the retired label rule")
+    )
+    if "target" not in ctx:
+        check.status = BLOCKED
+        check.detail = "C4 could not resolve a target."
+        return
+    try:
+        import dataclasses
+
+        from src.trade import faab_comparability as FC
+        from src.trade.faab_history import build_crowd_market, load_crowd_history
+    except Exception as exc:  # pragma: no cover - deployment shape
+        check.status = ERROR
+        check.detail = f"could not import the crowd market: {exc!r}"
+        return
+
+    payload = load_crowd_history(league)
+    rows = (payload or {}).get("rows") if isinstance(payload, dict) else None
+    if not rows:
+        check.status = BLOCKED
+        check.detail = (
+            f"no crowd ledger for {league} at data/faab/crowd_history_{league}.json. "
+            "It is gitignored and prod-only. Run the dynasty-crowd-faab timer (or "
+            "scripts/fetch_crowd_faab.py) and re-check — do not synthesise rows."
+        )
+        return
+
+    served = ctx["target"]
+    label_tep = bool(ctx.get("labelSaysTep"))
+    counterfactual = dataclasses.replace(served, tep=label_tep)
+
+    try:
+        from src.trade.faab_engine import FaabConfig
+
+        policy = FC.ComparabilityPolicy.from_config(FaabConfig())
+    except Exception:
+        policy = FC.ComparabilityPolicy()
+
+    after = build_crowd_market(payload, target=served, policy=policy)
+    before = build_crowd_market(payload, target=counterfactual, policy=policy)
+
+    check.evidence = {
+        "rowsTotal": after.rows_total,
+        "servedTep": served.tep,
+        "retiredLabelRuleTep": label_tep,
+        "after": {
+            "rowsUsed": after.rows_used,
+            "state": after.state,
+            "tierCounts": dict(after.tier_counts),
+            "excludedCounts": dict(after.excluded_counts),
+        },
+        "before": {
+            "rowsUsed": before.rows_used,
+            "state": before.state,
+            "tierCounts": dict(before.tier_counts),
+            "excludedCounts": dict(before.excluded_counts),
+        },
+    }
+    if served.tep is None:
+        check.status = UNMEASURABLE
+        check.detail = (
+            "the served target cannot prove TEP, so it admits nothing and there is no "
+            "meaningful 'after' population to compare. Fix the scoring card first "
+            "(C5/C6), then re-run."
+        )
+        return
+    check.status = PASS
+    if bool(served.tep) == label_tep:
+        check.detail = (
+            f"card and label agree ({served.tep!r}), so the admitted population is "
+            f"unchanged at {after.rows_used}/{after.rows_total} rows. The measurement "
+            "still ran; it simply found no divergence for this league today."
+        )
+    else:
+        check.detail = (
+            f"card ({served.tep!r}) and label ({label_tep!r}) DISAGREE: the retired rule "
+            f"admitted {before.rows_used}/{before.rows_total} rows, the card-derived "
+            f"rule admits {after.rows_used}. Every row in the difference was being "
+            "compared on a TE premium this league does not grant."
+        )
+
+
+def check_crowd_refusal_reasons(report: Report, faab_payload: dict, source: str) -> None:
+    """#927 check 8 — the refusal is specific, and names the right side.
+
+    "We hold no crowd evidence" and "we cannot describe our own league well
+    enough to judge any" are different failures with different fixes.
+    Reporting them identically sends the reader to the feed when the answer
+    is in the registry or in a scoring card nobody fetched.
+    """
+    check = report.add(
+        Check("C8", "V1-129", "crowd-market refusal reasons are specific and honest")
+    )
+    block = faab_payload.get("crowdMarket")
+    if not isinstance(block, dict):
+        check.status = FAIL
+        check.detail = (
+            f"{source} published no crowdMarket block at all. A missing block and a "
+            "reported refusal read the same to a consumer, which is the defect."
+        )
+        return
+    state = block.get("state")
+    reason = block.get("refusalReason")
+    unknown = block.get("targetFormatUnknown")
+    check.evidence = {
+        "state": state,
+        "refusalReason": reason,
+        "targetFormatUnknown": unknown,
+        "rowsTotal": block.get("rowsTotal"),
+        "rowsUsed": block.get("rowsUsed"),
+        "excludedCounts": block.get("excludedCounts"),
+        "tierCounts": block.get("tierCounts"),
+        "playerHasEvidence": block.get("playerHasEvidence"),
+        "pricesIdp": block.get("pricesIdp"),
+    }
+    if unknown is None:
+        check.status = FAIL
+        check.detail = (
+            "crowdMarket carries no targetFormatUnknown key, so a run that admitted "
+            "nothing because OUR league is undescribable is indistinguishable from an "
+            "absent feed. This is the pre-#927 build."
+        )
+        return
+    if unknown:
+        if reason != "target_format_unverifiable:" + ",".join(unknown):
+            check.status = FAIL
+            check.detail = (
+                f"targetFormatUnknown is {unknown} but refusalReason is {reason!r}. The "
+                "refusal must name our side, ahead of the freshness checks — freshness "
+                "is moot when no row is admissible."
+            )
+            return
+        check.status = PASS
+        check.detail = (
+            f"the target cannot prove {unknown} and the refusal says exactly that "
+            f"({reason!r}) rather than blaming the feed."
+        )
+        return
+    if state == "fresh" and reason is None:
+        check.status = PASS
+        check.detail = "target fully described, ledger fresh, no refusal — the usable state."
+        return
+    if state in {"stale", "missing"} and reason in {"crowd_ledger_stale", "no_crowd_ledger"}:
+        check.status = PASS
+        check.detail = (
+            f"target fully described; the ledger itself is {state!r} and the refusal "
+            f"({reason!r}) correctly points at the feed."
+        )
+        return
+    check.status = FAIL
+    check.detail = f"state {state!r} and refusalReason {reason!r} do not correspond."
+
+
+def check_faab_recommendation_effect(report: Report, faab_payload: dict, source: str) -> None:
+    """#927 check 9 — a refused population must not still move the bid.
+
+    The crowd feeds ``rival_bid_cdf`` at weight 0.6, so what it admits moves
+    real recommended bids.  This asserts the two directions that matter:
+    when the crowd is USED it must be visible as a factor, and when it is
+    REFUSED it must not appear at all.  A refusal that still quietly
+    contributes would be cosmetic.
+
+    The absolute numbers are recorded so two runs of this script — one before
+    a deploy and one after — measure the effect directly.
+    """
+    check = report.add(
+        Check("C9", "V1-129", "the crowd moves the bid only when it was actually admitted")
+    )
+    block = faab_payload.get("crowdMarket")
+    if not isinstance(block, dict):
+        check.status = BLOCKED
+        check.detail = f"{source} published no crowdMarket block; C8 covers that."
+        return
+    factors = faab_payload.get("factors")
+    factors = factors if isinstance(factors, list) else []
+    # Matched on the LABEL, which is the engine's stable identifier for this
+    # row (``_FactorRow("Cross-league market", ...)``), not on its prose --
+    # a check that breaks when the wording is improved is a bad check.
+    crowd_factors = [
+        f for f in factors if isinstance(f, dict) and f.get("label") == "Cross-league market"
+    ]
+    used = bool(block.get("playerHasEvidence")) and block.get("state") == "fresh"
+    contention = faab_payload.get("contention") or {}
+    check.evidence = {
+        "crowdState": block.get("state"),
+        "playerHasEvidence": block.get("playerHasEvidence"),
+        "refusalReason": block.get("refusalReason"),
+        "rowsUsed": block.get("rowsUsed"),
+        "crowdFactorRows": len(crowd_factors),
+        "standard": faab_payload.get("standard"),
+        "conservative": faab_payload.get("conservative"),
+        "aggressive": faab_payload.get("aggressive"),
+        "max": faab_payload.get("max"),
+        "clearing": contention.get("clearing") if isinstance(contention, dict) else None,
+        "contentionSkipped": contention.get("skipped") if isinstance(contention, dict) else None,
+    }
+    if used and not crowd_factors:
+        check.status = FAIL
+        check.detail = (
+            "the crowd market is fresh and prices this player, but no crowd factor row "
+            "was published — the evidence moved the bid invisibly, or was dropped."
+        )
+        return
+    if not used and crowd_factors:
+        check.status = FAIL
+        check.detail = (
+            f"the crowd was refused ({block.get('refusalReason')!r}) yet a crowd factor "
+            "row is still present. The refusal is cosmetic."
+        )
+        return
+    check.status = PASS
+    if used:
+        check.detail = (
+            f"the crowd priced this player and is visible as {len(crowd_factors)} factor "
+            f"row(s); standard={faab_payload.get('standard')}, "
+            f"clearing={check.evidence['clearing']}. Record these and compare across "
+            "deploys to measure the population change's effect."
+        )
+    else:
+        check.detail = (
+            f"the crowd was refused ({block.get('refusalReason')!r}) and contributed no "
+            f"factor row. standard={faab_payload.get('standard')} is therefore free of "
+            "external-market influence, which is the point of the refusal."
+        )
+
+
+# ── Lane 4 V1 rows beyond #927 ─────────────────────────────────────
+
+
+def check_faab_history_timer(report: Report) -> None:
+    """V1-57 (L3) — the collection is SCHEDULED, not a manual step.
+
+    A green manual run of ``scripts/fetch_faab_history.py`` proves the script
+    works, which was never the open question.  What L3 needs is the unit
+    installed and firing.
+    """
+    check = report.add(Check("V57", "V1-57", "dynasty-faab-history timer is installed and firing"))
+    try:
+        listed = subprocess.run(
+            ["systemctl", "list-timers", "--all", "--no-pager", "--no-legend"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        check.status = BLOCKED
+        check.detail = f"systemctl is not available here ({exc!r}); run this on the box."
+        return
+    if listed.returncode != 0:
+        check.status = BLOCKED
+        check.detail = f"systemctl exited {listed.returncode}: {listed.stderr.strip()[:200]}"
+        return
+    lines = [ln for ln in listed.stdout.splitlines() if "faab-history" in ln]
+    check.evidence = {"timerLines": lines}
+    if not lines:
+        check.status = FAIL
+        check.detail = (
+            "no faab-history timer is installed. The templates exist in the repo "
+            "(deploy/systemd/dynasty-faab-history.{service,timer}.template) but "
+            "install-systemd-service.sh has not run with them on this host."
+        )
+        return
+    # NEXT/LEFT/LAST/PASSED/UNIT/ACTIVATES -- LAST is populated only once fired.
+    fired = any(" n/a " not in ln.replace("\t", " ") for ln in lines)
+    check.status = PASS if fired else FAIL
+    check.detail = (
+        "timer installed and has fired at least once."
+        if fired
+        else "timer is installed but has never fired (LAST is n/a)."
+    )
+
+
+def check_faab_history_artifact(report: Report, league: str) -> None:
+    """V1-57, second half — the run produced the artifact the engine reads."""
+    check = report.add(Check("V57b", "V1-57", "own-league bid history exists and is recent"))
+    path = _repo_file("data", "faab", f"bid_history_{league}.json")
+    if not path.exists():
+        check.status = FAIL if _repo_file("data", "faab").exists() else BLOCKED
+        check.detail = (
+            f"{path} is absent. With data/faab/ present this is a real failure (the "
+            "timer ran and produced nothing); without it, this is not the deployed "
+            "working directory."
+        )
+        return
+    age_h = (datetime.now(timezone.utc).timestamp() - path.stat().st_mtime) / 3600.0
+    payload = _load_json(path)
+    entries = payload.get("bids") if isinstance(payload, dict) else None
+    check.evidence = {
+        "path": str(path),
+        "ageHours": round(age_h, 2),
+        "entryCount": len(entries) if isinstance(entries, list) else None,
+    }
+    if age_h > 25.0:
+        check.status = FAIL
+        check.detail = f"history is {age_h:.1f}h old against a daily timer."
+        return
+    check.status = PASS
+    check.detail = f"history written {age_h:.1f}h ago."
+
+
+def check_ffpc_lane_is_honest(report: Report) -> None:
+    """V1-60 (L2) — zero rosters must never be silently zero.
+
+    "The lane ran and found nothing" and "the lane did not run" are different
+    facts.  ``cohortCoveragePct`` is the one that must be ``None`` rather than
+    ``0`` when nothing was observed.
+    """
+    check = report.add(
+        Check("V60", "V1-60", "the FFPC roster lane is real or honestly unavailable")
+    )
+    try:
+        from src.sharp.roster_collect import CollectResult
+    except Exception as exc:  # pragma: no cover - deployment shape
+        check.status = ERROR
+        check.detail = f"could not import roster_collect: {exc!r}"
+        return
+    has_status = hasattr(CollectResult, "unavailable") and "status" in getattr(
+        CollectResult, "__dataclass_fields__", {}
+    )
+    check.evidence = {"collectResultCarriesStatus": has_status}
+    if not has_status:
+        check.status = FAIL
+        check.detail = (
+            "CollectResult has no status/unavailable() constructor, so a skipped lane "
+            "and an empty-but-successful lane are indistinguishable."
+        )
+        return
+    try:
+        from src.sharp import roster_percentage
+
+        payload = roster_percentage.build_board()
+    except Exception as exc:
+        check.status = BLOCKED
+        check.detail = f"could not build the roster-percentage board here: {exc!r}"
+        return
+    # FIELD PATHS VERIFIED AGAINST THE PRODUCER, not remembered.  The
+    # roster-percentage board puts the population counts under
+    # ``transparency`` and only ``selectedManagers`` under ``cohort``; an
+    # earlier draft of this check read ``cohort.cohortCoveragePct``, which is
+    # always absent and would have reported BLOCKED for the wrong reason on a
+    # perfectly healthy board.
+    payload = payload if isinstance(payload, dict) else {}
+    transparency = payload.get("transparency")
+    transparency = transparency if isinstance(transparency, dict) else {}
+    cohort = payload.get("cohort")
+    cohort = cohort if isinstance(cohort, dict) else {}
+    if "cohortCoveragePct" not in transparency:
+        check.status = FAIL
+        check.detail = (
+            "the roster-percentage payload has no transparency.cohortCoveragePct. "
+            "Either the producer renamed it -- in which case every consumer reading "
+            "coverage is now reading nothing -- or this check is pointed at the wrong "
+            "field. Both are failures; neither is a pass."
+        )
+        return
+    coverage = transparency.get("cohortCoveragePct")
+    check.evidence.update(
+        {
+            "cohortManagers": transparency.get("cohortManagers"),
+            "cohortManagersRepresented": transparency.get("cohortManagersRepresented"),
+            "cohortCoveragePct": coverage,
+            "eligibleRosters": transparency.get("eligibleRosters"),
+            "ffpcRosters": transparency.get("ffpcRosters"),
+            "sleeperRosters": transparency.get("sleeperRosters"),
+            "selectedManagers": cohort.get("selectedManagers"),
+            "boardStatus": payload.get("status"),
+        }
+    )
+    if not transparency.get("cohortManagers"):
+        if coverage is not None:
+            check.status = FAIL
+            check.detail = (
+                f"no cohort managers, yet cohortCoveragePct is {coverage!r}. An "
+                "unmeasured coverage must be null, never a number."
+            )
+            return
+        check.status = BLOCKED
+        check.detail = (
+            "the cohort is empty here, so the lane's populated behaviour cannot be "
+            "measured. It correctly reports cohortCoveragePct: null rather than 0 — "
+            "which is the honest-degraded half of the row, but not the whole row. "
+            "V1-58 is the blocker."
+        )
+        return
+    check.status = PASS
+    check.denominator = int(transparency.get("cohortManagers") or 0)
+    check.detail = (
+        f"cohort of {transparency.get('cohortManagers')} managers, "
+        f"{transparency.get('eligibleRosters')} eligible rosters "
+        f"({transparency.get('ffpcRosters')} FFPC), coverage {coverage!r}."
+    )
+
+
+def check_single_cohort_owner(report: Report) -> None:
+    """V1-65 (L2) — one definition of who is a sharp, structurally.
+
+    Deterministic and runnable anywhere, so it is recorded here rather than
+    deferred to production: a second cohort definition is the way this row
+    regresses.
+    """
+    check = report.add(Check("V65", "V1-65", "cohort_members has exactly one definition"))
+    hits: list[str] = []
+    for path in sorted((REPO_ROOT / "src").rglob("*.py")):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for number, line in enumerate(text.splitlines(), start=1):
+            if line.lstrip().startswith("def cohort_members"):
+                hits.append(f"{path.relative_to(REPO_ROOT)}:{number}")
+    check.evidence = {"definitions": hits}
+    if len(hits) == 1 and hits[0].startswith("src/sharp/cohort.py"):
+        check.status = PASS
+        check.detail = f"single owner at {hits[0]}; every surface re-exports it."
+    else:
+        check.status = FAIL
+        check.detail = f"expected one definition in src/sharp/cohort.py, found {hits}."
+
+
+def record_blocked_rows(report: Report, unauth_detail: str | None) -> None:
+    """V1-58 / V1-59 — recorded as BLOCKED, with the credential named.
+
+    Never closed by standing up a synthetic cohort: a manufactured population
+    would verify the manufacture.
+    """
+    for row, title in (
+        ("V1-58", "Sharp cohort proven populated in production"),
+        ("V1-59", "Sharp bootstrap stops failing"),
+    ):
+        check = report.add(Check(f"B{row[-2:]}", row, title))
+        check.status = UNVERIFIABLE if unauth_detail else BLOCKED
+        check.detail = (
+            (
+                f"{unauth_detail} — /api/sharp/* is session-gated and correctly so. "
+                "Insufficient evidence, deliberately neither pass nor fail. The single "
+                "credential that unblocks both is an authenticated admin session for "
+                "the deployed origin, held by the site owner."
+            )
+            if unauth_detail
+            else (
+                "needs the deployed host: an authenticated /api/sharp/cohort read "
+                "(V1-58) and a clean journalctl run of dynasty-sharp-discovery -> "
+                "-records -> -rosters (V1-59). Not closable from a repository, and not "
+                "to be closed by manufacturing a cohort."
+            )
+        )
+
+
+# ── Modes ──────────────────────────────────────────────────────────
+
+
+def run_remote(report: Report, args: argparse.Namespace) -> None:
+    """Everything the deployed API publishes, over HTTPS, with a real session."""
+    origin = args.origin.rstrip("/")
+    cookie = os.environ.get("RISKIT_SESSION_COOKIE") or None
+
+    # /api/status is public, so the deployed SHA is always recordable even
+    # when every gated check comes back unauthenticated.  An L3 result is
+    # meaningless without knowing which commit produced it.
+    # THE DEPLOYED SHA IS NOT OBSERVABLE OVER HTTP, and pretending otherwise
+    # was a real defect in the first draft of this package.  ``/api/status``
+    # publishes no ``commit``, no ``startedAt`` and no build identifier of any
+    # kind -- its ``contract.version`` is the API DATA-CONTRACT version
+    # (e.g. "2026-03-10.v2"), which identifies the payload shape and not the
+    # commit that produced it.  Verified against the producer, not assumed.
+    #
+    # The contract's L3 definition says "executed against the deployed SHA",
+    # so this is recorded as a NAMED GAP rather than papered over with a
+    # field that happens to exist.  Only --mode onbox can answer it, via
+    # ``git rev-parse HEAD`` in the deployed working directory.
+    try:
+        _, status_payload = _http(f"{origin}/api/status", cookie=cookie)
+        status_payload = status_payload if isinstance(status_payload, dict) else {}
+        contract = status_payload.get("contract")
+        contract = contract if isinstance(contract, dict) else {}
+        runtime = status_payload.get("data_runtime")
+        runtime = runtime if isinstance(runtime, dict) else {}
+        report.deployed = {
+            "origin": origin,
+            "headSha": None,
+            "headShaSource": "unavailable_over_http",
+            "contractVersion": contract.get("version"),
+            "contractHealthy": (contract.get("health") or {}).get("ok")
+            if isinstance(contract.get("health"), dict)
+            else None,
+            "lastDataRefreshAt": runtime.get("last_data_refresh_at"),
+            "lastPayloadLoadedAt": runtime.get("last_payload_loaded_at"),
+        }
+    except Exception as exc:
+        report.deployed = {"origin": origin, "error": repr(exc)}
+
+    check_required_routes_exist(report)
+
+    unauth: str | None = None
+
+    # --- Sharp person consensus (C1-C3) ---
+    market: dict | None = None
+    try:
+        code, market = _http(f"{origin}/api/sharp/market?window=30d&limit=250", cookie=cookie)
+        if code != 200:
+            market = None
+    except Unauthenticated as exc:
+        unauth = str(exc)
+    except Exception as exc:
+        report.add(
+            Check("C1", "V1-63", "zero-voter personManagerQuality", ERROR, f"market fetch: {exc!r}")
+        )
+        market = None
+
+    if market is not None:
+        source = f"{origin}/api/sharp/market"
+        check_zero_voter_quality(report, market, source)
+        check_measured_zero_quality(report, market, source)
+        check_undefined_concentration(report, market, source)
+    elif unauth:
+        for cid, title in (
+            ("C1", "zero-voter personManagerQuality is JSON null, never 1.0"),
+            ("C2", "a measured personManagerQuality of 0.0 stays 0.0"),
+            ("C3", "networkConcentration is null when weighted volume is zero"),
+        ):
+            report.add(
+                Check(
+                    cid,
+                    "V1-63",
+                    title,
+                    UNVERIFIABLE,
+                    f"{unauth} — no session was supplied, so nothing was measured. "
+                    "Set RISKIT_SESSION_COOKIE to an authenticated session; do not "
+                    "relax the endpoint's gate.",
+                )
+            )
+
+    # --- TEP + crowd, as the API reports them (C4-C9, partially) ---
+    for cid, row, title in (
+        ("C4", "V1-129", "target TEP is derived from the scoring card, not the profile label"),
+        ("C5", "V1-129", "stale or missing scoring evidence leaves TEP UNKNOWN and fails closed"),
+        ("C6", "V1-129", f"{args.league} behaves as non-TE-premium under its actual card"),
+        ("C7", "V1-129", "comparable crowd population, card-derived vs the retired label rule"),
+    ):
+        report.add(
+            Check(
+                cid,
+                row,
+                title,
+                BLOCKED,
+                "needs the league's scoring card and/or the crowd ledger, both "
+                "gitignored and prod-local. Run --mode onbox on the deployed host. "
+                "C8 below is the API-visible shadow of C4/C5.",
+            )
+        )
+
+    if not args.add_player:
+        for cid, row, title in (
+            ("C8", "V1-129", "crowd-market refusal reasons are specific and honest"),
+            ("C9", "V1-129", "the crowd moves the bid only when it was actually admitted"),
+        ):
+            report.add(
+                Check(
+                    cid,
+                    row,
+                    title,
+                    BLOCKED,
+                    "needs --add-player naming a REAL free agent on the deployed board. "
+                    "No player is invented for this check.",
+                )
+            )
+        return
+
+    try:
+        code, faab = _http(
+            f"{origin}/api/waiver/faab-recommend",
+            cookie=cookie,
+            body={"leagueKey": args.league, "addPlayerName": args.add_player},
+        )
+    except Unauthenticated as exc:
+        for cid, row, title in (
+            ("C8", "V1-129", "crowd-market refusal reasons are specific and honest"),
+            ("C9", "V1-129", "the crowd moves the bid only when it was actually admitted"),
+        ):
+            report.add(Check(cid, row, title, UNVERIFIABLE, f"{exc} — no session supplied."))
+        return
+    except Exception as exc:
+        report.add(Check("C8", "V1-129", "crowd-market refusal reasons", ERROR, repr(exc)))
+        return
+
+    if code != 200:
+        for cid, row, title in (
+            ("C8", "V1-129", "crowd-market refusal reasons are specific and honest"),
+            ("C9", "V1-129", "the crowd moves the bid only when it was actually admitted"),
+        ):
+            report.add(Check(cid, row, title, BLOCKED, f"faab-recommend returned {code}: {faab}"))
+        return
+
+    source = f"{origin}/api/waiver/faab-recommend"
+    check_crowd_refusal_reasons(report, faab, source)
+    check_faab_recommendation_effect(report, faab, source)
+
+    record_blocked_rows(report, unauth)
+
+
+def run_onbox(report: Report, args: argparse.Namespace) -> None:
+    """Everything that needs the deployed filesystem and the deployed source."""
+    report.deployed = {
+        "workingDirectory": str(REPO_ROOT),
+        "headSha": _git_head(),
+        "dataDirPresent": _repo_file("data").is_dir(),
+    }
+
+    # --- Do the routes and fields this package names actually exist? ---
+    check_required_routes_exist(report)
+
+    # --- Sharp person consensus, built locally from the real ledger ---
+    try:
+        from src.sharp import market as sharp_market
+
+        payload = sharp_market.market_payload(window="30d", limit=250)
+    except Exception as exc:
+        payload = None
+        report.add(
+            Check("C1", "V1-63", "zero-voter personManagerQuality", ERROR, f"market build: {exc!r}")
+        )
+    if payload is not None:
+        source = "market_payload(window='30d')"
+        check_zero_voter_quality(report, payload, source)
+        check_measured_zero_quality(report, payload, source)
+        check_undefined_concentration(report, payload, source)
+
+    try:
+        from src.sharp import roster_percentage as _rp
+
+        rp_payload = _rp.build_board()
+    except Exception:
+        rp_payload = None
+
+    # --- TEP, the crowd population, and their effect ---
+    ctx = check_tep_is_card_derived(report, args.league)
+    check_unproven_scoring_fails_closed(report, ctx)
+    check_dynasty_main_is_not_te_premium(report, ctx, args.league)
+    check_comparable_population_before_after(report, ctx, args.league)
+
+    crowd_market = None
+    try:
+        from src.trade.faab_history import build_crowd_market, load_crowd_history
+
+        raw = load_crowd_history(args.league)
+        if raw:
+            crowd_market = build_crowd_market(raw, target=ctx.get("target"))
+    except Exception:
+        crowd_market = None
+    check_idp_population_refusal(report, crowd_market)
+
+    check_required_fields_exist(
+        report,
+        {
+            "roster-percentage": rp_payload,
+            "sharp-market": payload,
+            "crowd-market": crowd_market.to_dict() if crowd_market is not None else None,
+        },
+    )
+
+    # C8/C9 still go through the real endpoint, because the refusal reason and
+    # the factor rows are assembled in server.py and not in the engine.
+    if args.origin and args.add_player:
+        cookie = os.environ.get("RISKIT_SESSION_COOKIE") or None
+        try:
+            code, faab = _http(
+                f"{args.origin.rstrip('/')}/api/waiver/faab-recommend",
+                cookie=cookie,
+                body={"leagueKey": args.league, "addPlayerName": args.add_player},
+            )
+            if code == 200:
+                source = "faab-recommend"
+                check_crowd_refusal_reasons(report, faab, source)
+                check_faab_recommendation_effect(report, faab, source)
+            else:
+                report.add(
+                    Check("C8", "V1-129", "crowd-market refusal reasons", BLOCKED, f"HTTP {code}")
+                )
+        except Unauthenticated as exc:
+            report.add(
+                Check("C8", "V1-129", "crowd-market refusal reasons", UNVERIFIABLE, str(exc))
+            )
+    else:
+        for cid, title in (
+            ("C8", "crowd-market refusal reasons are specific and honest"),
+            ("C9", "the crowd moves the bid only when it was actually admitted"),
+        ):
+            report.add(
+                Check(
+                    cid,
+                    "V1-129",
+                    title,
+                    BLOCKED,
+                    "these read server.py's assembled response, so they need --origin "
+                    "(the local one is fine: http://127.0.0.1:8000) and --add-player "
+                    "naming a real free agent.",
+                )
+            )
+
+    # --- Lane 4 rows beyond #927 ---
+    check_faab_history_timer(report)
+    check_faab_history_artifact(report, args.league)
+    check_ffpc_lane_is_honest(report)
+    check_single_cohort_owner(report)
+    record_blocked_rows(report, None)
+
+
+def _git_head() -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            cwd=REPO_ROOT,
+        )
+        return out.stdout.strip() or None
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--mode", choices=("remote", "onbox"), required=True)
+    parser.add_argument("--league", default="dynasty_main")
+    parser.add_argument(
+        "--origin",
+        default="",
+        help="deployed origin, e.g. https://chaseupside.com (required for --mode remote)",
+    )
+    parser.add_argument(
+        "--add-player",
+        default="",
+        help="display name of a REAL free agent to price. Never invented by this script.",
+    )
+    parser.add_argument("--out", default="", help="write the JSON report here as well as stdout")
+    args = parser.parse_args(argv)
+
+    if args.mode == "remote" and not args.origin:
+        parser.error("--mode remote needs --origin")
+
+    report = Report(args.mode, args.league, args.origin or None)
+    try:
+        if args.mode == "remote":
+            run_remote(report, args)
+        else:
+            run_onbox(report, args)
+    except Exception as exc:  # pragma: no cover - last-resort guard
+        report.add(Check("RUN", "-", "verification run", ERROR, repr(exc)))
+
+    report.finalize()
+    payload = report.to_dict()
+    text = json.dumps(payload, indent=2, sort_keys=True, default=str)
+    print(text)
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(text + "\n", encoding="utf-8")
+
+    code = report.exit_code()
+    summary = " ".join(f"{k}={v}" for k, v in sorted(payload["counts"].items()))
+    print(f"\n[lane4-verify] {summary} -> exit {code}", file=sys.stderr)
+    if code == 3:
+        incomplete = sorted({c.status for c in report.checks} & _PROVES_NOTHING) or [
+            "no passing check"
+        ]
+        print(
+            f"[lane4-verify] INCOMPLETE ({', '.join(incomplete)}): at least one question "
+            "went unanswered, so this run is NOT a pass. Exit 0 is reserved for a run in "
+            "which every check measured its case and passed.",
+            file=sys.stderr,
+        )
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_lane4_verification.py
+++ b/tests/ops/test_lane4_verification.py
@@ -608,3 +608,119 @@ class TestTheDocumentItselfNamesRealRoutes:
             n for n in missing if not any(r.startswith(n.rstrip("/") + "/") for r in registered)
         ]
         assert missing == [], f"procedures doc names unregistered routes: {missing}"
+
+
+# ── Adversarial review findings, pinned ────────────────────────────
+
+
+class TestFreshEvidenceIsNotTheSameAsAReadableCard:
+    """C4 could report PASS having observed no card at all.
+
+    `scoring_evidence_state` decides freshness from the snapshot's fetch
+    timestamp and season — it never reads `scoringSettings` — so a snapshot
+    written by a partial fetch is `fresh` while carrying no card. In that
+    state `_tep_from_scoring` correctly returns `None` (fail-closed, so the
+    product is fine), the served value then equalled the derived value
+    trivially (both `None`), and the check reported **pass** with the detail
+    "derived from the fresh card".
+
+    That is a false green in the check whose whole job is to prove TEP is
+    card-derived: Integration could have recorded the capability as observed
+    without a card ever existing.
+    """
+
+    @staticmethod
+    def _run(card, evidence="fresh"):
+        import types
+        from unittest import mock
+
+        from src.api import league_registry
+
+        report = _report()
+        cfg = types.SimpleNamespace(
+            key="dynasty_main", scoring_profile="superflex_tep15_ppr1", idp_enabled=True
+        )
+        with (
+            mock.patch.object(league_registry, "get_league_by_key", return_value=cfg),
+            mock.patch.object(league_registry, "scoring_evidence_state", return_value=evidence),
+            mock.patch.object(league_registry, "scoring_settings_for_league", return_value=card),
+            mock.patch.object(
+                league_registry,
+                "get_league_roster_settings",
+                return_value={"teamCount": 12, "starters": {"QB": 1, "TE": 2, "SFLEX": 1}},
+            ),
+        ):
+            verify.check_tep_is_card_derived(report, "dynasty_main")
+        report.finalize()
+        return report.checks[0]
+
+    @pytest.mark.parametrize("card", [{}, None])
+    def test_a_fresh_snapshot_with_no_card_is_blocked_not_passed(self, card):
+        check = self._run(card)
+        assert check.status == verify.BLOCKED
+        assert check.evidence["cardPresent"] is False
+        assert "no scoringSettings" in check.detail
+
+    def test_a_fresh_snapshot_with_a_real_card_still_passes(self):
+        """The converse, so the repair cannot pass by refusing everything."""
+        check = self._run({"rec": 1.0, "bonus_rec_te": 0.0, "bonus_fd_te": 1.0, "bonus_fd_wr": 1.0})
+        assert check.status == verify.PASS
+        assert check.evidence["cardPresent"] is True
+        assert check.evidence["servedTep"] is False
+
+    def test_c6_already_handled_this_and_still_does(self):
+        """C6 blocked on an absent card from the start. That asymmetry is why
+        C4's omission reads as an oversight rather than a decision, and this
+        keeps the two consistent."""
+        report = _report()
+        verify.check_dynasty_main_is_not_te_premium(report, {"card": None}, "dynasty_main")
+        assert report.checks[0].status == verify.BLOCKED
+
+
+class TestTheRequiredListsCannotBeSilentlyEmptied:
+    """Emptying `REQUIRED_ROUTES` disarmed the route guard with **zero** test
+    failures — the "a verifier test that itself matches nothing" case.
+
+    At runtime `Check.finalize` downgrades the resulting zero-denominator pass
+    to `unmeasurable`, so the verifier itself stays honest. What was missing is
+    that **CI would not tell anyone the guard had been disarmed**: a refactor,
+    a bad merge, or a well-meaning cleanup could empty the list and every test
+    would stay green. `REQUIRED_FIELDS` was already covered by two tests; this
+    closes the asymmetry.
+    """
+
+    def test_the_route_list_is_not_empty(self):
+        assert verify.REQUIRED_ROUTES, "the route guard has been disarmed"
+
+    def test_the_field_list_is_not_empty(self):
+        assert verify.REQUIRED_FIELDS, "the field guard has been disarmed"
+
+    @pytest.mark.parametrize(
+        "route",
+        [
+            ("/api/waiver/faab-recommend", "POST"),
+            ("/api/sharp/market", "GET"),
+            ("/api/sharp/roster-percentage", "GET"),
+            ("/api/sharp/cohort", "GET"),
+            ("/api/status", "GET"),
+        ],
+    )
+    def test_each_route_the_procedures_depend_on_is_still_guarded(self, route):
+        """Named individually, so dropping ONE — which an empty-list check
+        would not catch — fails here."""
+        assert route in verify.REQUIRED_ROUTES
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            ("roster-percentage", "transparency.cohortCoveragePct"),
+            ("crowd-market", "targetFormatUnknown"),
+            ("crowd-market", "pricesIdp"),
+            ("sharp-market", "coverage.platforms"),
+        ],
+    )
+    def test_each_field_a_correction_depends_on_is_still_guarded(self, field):
+        """These four are precisely the paths the six documented corrections
+        turned on. If one stops being guarded, the correction it protects can
+        silently rot back."""
+        assert field in verify.REQUIRED_FIELDS

--- a/tests/ops/test_lane4_verification.py
+++ b/tests/ops/test_lane4_verification.py
@@ -1,0 +1,610 @@
+"""The verifier's own semantics.
+
+A verification script is only worth what its vocabulary is worth. These pin
+the three distinctions the package exists to preserve, because each of them
+is a way a run could quietly read as green when it proved nothing:
+
+* a 401 is INSUFFICIENT EVIDENCE, not a pass and not a failure;
+* a missing input is BLOCKED, not a pass;
+* an input that exists but does not contain the case under test is
+  UNMEASURABLE, not a pass.
+
+The checks themselves are exercised against synthetic PAYLOADS, which is not
+the same as fabricating production evidence: these are unit inputs to the
+analyser, and every one of them lives here in the test file rather than in a
+`data/` path any production run would read.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_SPEC = importlib.util.spec_from_file_location(
+    "verify_lane4_production", REPO_ROOT / "scripts" / "verify_lane4_production.py"
+)
+verify = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+# Registered BEFORE execution: ``@dataclass`` resolves annotations through
+# ``sys.modules[cls.__module__]``, so a module loaded by path alone raises
+# while processing its own dataclasses.
+sys.modules[_SPEC.name] = verify
+_SPEC.loader.exec_module(verify)
+
+
+def _report():
+    return verify.Report("onbox", "dynasty_main", None)
+
+
+def _market(*people):
+    return {"assets": [{"assetId": f"p{i}", "personConsensus": p} for i, p in enumerate(people)]}
+
+
+def _person(**kw):
+    base = {
+        "personVotes": 1,
+        "mixedPersonSignals": 0,
+        "weightedPersonVolume": 1.0,
+        "personManagerQuality": 0.9,
+        "networkConcentration": 1.0,
+    }
+    base.update(kw)
+    return base
+
+
+# ── The vocabulary ─────────────────────────────────────────────────
+
+
+class TestStatusVocabulary:
+    def test_a_run_that_proves_nothing_does_not_exit_zero(self):
+        """The single most important property.
+
+        A run where every check was blocked or unauthenticated has measured
+        nothing. Exiting 0 would make "we could not check" indistinguishable
+        from "we checked and it was fine" — to a human reading a CI badge,
+        and to any automation keying on the code.
+        """
+        report = _report()
+        report.add(verify.Check("X", "V1-58", "t", verify.BLOCKED, ""))
+        report.add(verify.Check("Y", "V1-59", "t", verify.UNVERIFIABLE, ""))
+        assert report.exit_code() == 3
+
+    def test_a_failure_outranks_everything_else(self):
+        report = _report()
+        report.add(verify.Check("X", "V1-63", "t", verify.PASS, ""))
+        report.add(verify.Check("Y", "V1-129", "t", verify.FAIL, ""))
+        report.add(verify.Check("Z", "V1-57", "t", verify.BLOCKED, ""))
+        assert report.exit_code() == 2
+
+    def test_an_error_outranks_a_failure(self):
+        """An error means a check did not run. That is a different problem
+        from a check that ran and disagreed, and it must not be reported as
+        the latter."""
+        report = _report()
+        report.add(verify.Check("Y", "V1-129", "t", verify.FAIL, ""))
+        report.add(verify.Check("Z", "V1-57", "t", verify.ERROR, ""))
+        assert report.exit_code() == 1
+
+    def test_green_needs_at_least_one_real_pass(self):
+        report = _report()
+        report.add(verify.Check("X", "V1-63", "t", verify.PASS, ""))
+        assert report.exit_code() == 0
+
+    def test_a_single_blocked_check_caps_the_run_at_incomplete(self):
+        """Exit 0 is reserved for a COMPLETE run.
+
+        A 401, an absent credential, an empty population, a missing scoring
+        card or a missing ledger each leave a question unanswered, and an
+        unanswered question is not a pass -- however many other checks passed
+        alongside it.
+        """
+        report = _report()
+        report.add(verify.Check("X", "V1-63", "t", verify.PASS, "", denominator=9))
+        report.add(verify.Check("Y", "V1-58", "t", verify.BLOCKED, ""))
+        assert report.exit_code() == 3
+
+    @pytest.mark.parametrize("status", [verify.BLOCKED, verify.UNVERIFIABLE, verify.UNMEASURABLE])
+    def test_every_non_proving_status_caps_the_run(self, status):
+        report = _report()
+        report.add(verify.Check("X", "V1-63", "t", verify.PASS, "", denominator=9))
+        report.add(verify.Check("Y", "-", "t", status, ""))
+        assert report.exit_code() == 3
+
+    def test_the_three_non_proving_statuses_are_counted_apart_from_passes(self):
+        report = _report()
+        for status in (verify.UNMEASURABLE, verify.BLOCKED, verify.UNVERIFIABLE):
+            report.add(verify.Check(status, "-", "t", status, ""))
+        report.add(verify.Check("P", "-", "t", verify.PASS, ""))
+        assert report.to_dict()["applicableChecks"] == 1
+
+
+class TestUnauthenticatedIsItsOwnAnswer:
+    def test_401_and_403_raise_the_dedicated_type(self, monkeypatch):
+        """Never swallowed into a generic failure path.
+
+        The measured history on this repo is 80/80 attempts returning 401
+        across 79 runs — a definitive answer to "do we hold a credential?",
+        which is not the question the check is asking.
+        """
+        import urllib.error
+
+        def boom(*_args, **_kwargs):
+            raise urllib.error.HTTPError("u", 401, "Unauthorized", {}, None)
+
+        monkeypatch.setattr(verify.urllib.request, "urlopen", boom)
+        with pytest.raises(verify.Unauthenticated):
+            verify._http("https://example.invalid/api/sharp/market", cookie=None)
+
+    def test_no_cookie_means_no_cookie_header(self, monkeypatch):
+        """There is no fallback credential path, and this proves it
+        structurally rather than by reading the source."""
+        seen = {}
+
+        class _Resp:
+            status = 200
+
+            def read(self):
+                return b"{}"
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                return False
+
+        def capture(request, timeout=None):
+            seen["headers"] = dict(request.headers)
+            return _Resp()
+
+        monkeypatch.setattr(verify.urllib.request, "urlopen", capture)
+        verify._http("https://example.invalid/api/status", cookie=None)
+        assert not any(k.lower() == "cookie" for k in seen["headers"])
+
+
+# ── The #927 checks ────────────────────────────────────────────────
+
+
+class TestZeroVoterQuality:
+    def test_a_zero_voter_row_with_a_number_fails(self):
+        report = _report()
+        payload = _market(_person(personVotes=0, mixedPersonSignals=2, personManagerQuality=1.0))
+        verify.check_zero_voter_quality(report, payload, "test")
+        check = report.checks[0]
+        assert check.status == verify.FAIL
+        assert check.evidence["offenderCount"] == 1
+
+    def test_a_zero_voter_row_with_null_passes(self):
+        report = _report()
+        payload = _market(_person(personVotes=0, mixedPersonSignals=2, personManagerQuality=None))
+        verify.check_zero_voter_quality(report, payload, "test")
+        assert report.checks[0].status == verify.PASS
+
+    def test_a_board_with_no_zero_voter_row_is_inapplicable_not_pass(self):
+        """ "We looked and the situation did not arise" is not "we looked and
+        it was correct". Collapsing them is the defect class this package
+        exists to catch."""
+        report = _report()
+        verify.check_zero_voter_quality(report, _market(_person()), "test")
+        assert report.checks[0].status == verify.UNMEASURABLE
+
+    def test_an_empty_board_is_blocked_not_pass(self):
+        report = _report()
+        verify.check_zero_voter_quality(report, {"assets": []}, "test")
+        assert report.checks[0].status == verify.BLOCKED
+
+
+class TestMeasuredZeroSurvives:
+    def test_a_measured_zero_is_a_pass_not_a_missing_value(self):
+        report = _report()
+        payload = _market(_person(personVotes=2, personManagerQuality=0.0))
+        verify.check_measured_zero_quality(report, payload, "test")
+        check = report.checks[0]
+        assert check.status == verify.PASS
+        assert check.evidence["measuredZeroRows"] == 1
+
+    def test_nulling_a_row_that_has_voters_fails(self):
+        """The repair must not overshoot: UNKNOWN and WORST are different
+        answers, and a row with voters has an answer."""
+        report = _report()
+        payload = _market(_person(personVotes=3, personManagerQuality=None))
+        verify.check_measured_zero_quality(report, payload, "test")
+        assert report.checks[0].status == verify.FAIL
+
+
+class TestUndefinedConcentration:
+    def test_zero_volume_with_a_number_fails(self):
+        report = _report()
+        payload = _market(_person(weightedPersonVolume=0.0, networkConcentration=0.0))
+        verify.check_undefined_concentration(report, payload, "test")
+        assert report.checks[0].status == verify.FAIL
+
+    def test_zero_volume_with_null_passes(self):
+        report = _report()
+        payload = _market(_person(weightedPersonVolume=0.0, networkConcentration=None))
+        verify.check_undefined_concentration(report, payload, "test")
+        assert report.checks[0].status == verify.PASS
+
+
+class TestCrowdRefusalReasons:
+    def test_a_build_without_target_format_unknown_fails(self):
+        """Pre-#927: an undescribable target and an absent feed report the
+        same thing, so the reader is sent to the wrong place."""
+        report = _report()
+        verify.check_crowd_refusal_reasons(
+            report, {"crowdMarket": {"state": "missing", "refusalReason": "no_crowd_ledger"}}, "t"
+        )
+        assert report.checks[0].status == verify.FAIL
+
+    def test_an_undescribable_target_must_name_our_side(self):
+        report = _report()
+        verify.check_crowd_refusal_reasons(
+            report,
+            {
+                "crowdMarket": {
+                    "state": "missing",
+                    "targetFormatUnknown": ["tep"],
+                    "refusalReason": "no_crowd_ledger",
+                }
+            },
+            "t",
+        )
+        assert report.checks[0].status == verify.FAIL
+
+    def test_the_correct_refusal_passes(self):
+        report = _report()
+        verify.check_crowd_refusal_reasons(
+            report,
+            {
+                "crowdMarket": {
+                    "state": "missing",
+                    "targetFormatUnknown": ["tep"],
+                    "refusalReason": "target_format_unverifiable:tep",
+                }
+            },
+            "t",
+        )
+        assert report.checks[0].status == verify.PASS
+
+    def test_a_fresh_fully_described_market_passes(self):
+        report = _report()
+        verify.check_crowd_refusal_reasons(
+            report,
+            {"crowdMarket": {"state": "fresh", "targetFormatUnknown": [], "refusalReason": None}},
+            "t",
+        )
+        assert report.checks[0].status == verify.PASS
+
+
+class TestCrowdEffectOnTheBid:
+    def test_a_refused_crowd_that_still_contributes_a_factor_fails(self):
+        """A refusal that still moves the number is cosmetic."""
+        report = _report()
+        verify.check_faab_recommendation_effect(
+            report,
+            {
+                "crowdMarket": {
+                    "state": "missing",
+                    "playerHasEvidence": False,
+                    "refusalReason": "no_crowd_ledger",
+                },
+                "factors": [{"label": "Cross-league market", "contribution": "..."}],
+            },
+            "t",
+        )
+        assert report.checks[0].status == verify.FAIL
+
+    def test_an_admitted_crowd_with_no_visible_factor_fails(self):
+        report = _report()
+        verify.check_faab_recommendation_effect(
+            report,
+            {
+                "crowdMarket": {"state": "fresh", "playerHasEvidence": True},
+                "factors": [{"label": "Expected competition"}],
+            },
+            "t",
+        )
+        assert report.checks[0].status == verify.FAIL
+
+    def test_a_refused_crowd_with_no_factor_passes(self):
+        report = _report()
+        verify.check_faab_recommendation_effect(
+            report,
+            {
+                "crowdMarket": {
+                    "state": "stale",
+                    "playerHasEvidence": False,
+                    "refusalReason": "crowd_ledger_stale",
+                },
+                "factors": [{"label": "Expected competition"}],
+                "standard": 12,
+            },
+            "t",
+        )
+        assert report.checks[0].status == verify.PASS
+
+
+# ── Mutation proofs: the guards must be able to go red ─────────────
+#
+# A verification tool that has never been observed failing is an
+# unfalsifiable claim of exactly the kind it exists to prevent. Each test
+# below breaks one thing and asserts the verifier notices.
+
+
+class TestItDetectsAWrongEndpoint:
+    def test_a_route_that_does_not_exist_fails(self, monkeypatch):
+        """The defect that motivated this package.
+
+        `POST /api/faab/recommend` was named in the shipped procedures and is
+        not a route — there is no `/api/faab/*` prefix at all.
+        """
+        monkeypatch.setattr(
+            verify, "REQUIRED_ROUTES", (("/api/faab/recommend", "POST"),), raising=True
+        )
+        report = _report()
+        verify.check_required_routes_exist(report)
+        check = report.checks[0]
+        assert check.status == verify.FAIL
+        assert check.evidence["missing"] == ["POST /api/faab/recommend"]
+
+    def test_the_real_route_passes(self, monkeypatch):
+        """The converse, so the check cannot pass by matching nothing."""
+        monkeypatch.setattr(
+            verify, "REQUIRED_ROUTES", (("/api/waiver/faab-recommend", "POST"),), raising=True
+        )
+        report = _report()
+        verify.check_required_routes_exist(report)
+        check = report.checks[0]
+        assert check.status == verify.PASS
+        assert check.denominator == 1
+        assert check.evidence["routesDiscovered"] > 50
+
+    def test_the_shipped_routes_all_exist_right_now(self):
+        """The live assertion, not a fixture: every route this package names
+        is registered at HEAD. This is what fails if someone renames one."""
+        report = _report()
+        verify.check_required_routes_exist(report)
+        assert report.checks[0].status == verify.PASS, report.checks[0].detail
+
+    def test_the_wrong_method_is_also_caught(self, monkeypatch):
+        """A route registered only for POST must not pass a GET step."""
+        monkeypatch.setattr(
+            verify, "REQUIRED_ROUTES", (("/api/waiver/faab-recommend", "GET"),), raising=True
+        )
+        report = _report()
+        verify.check_required_routes_exist(report)
+        assert report.checks[0].status == verify.FAIL
+
+
+class TestItDetectsARenamedField:
+    def test_a_missing_field_path_fails(self):
+        report = _report()
+        verify.check_required_fields_exist(report, {"crowd-market": {"state": "fresh"}})
+        check = report.checks[0]
+        assert check.status == verify.FAIL
+        assert any("targetFormatUnknown" in m for m in check.evidence["missing"])
+
+    def test_a_field_present_but_null_is_present(self):
+        """Presence, not truthiness.
+
+        `cohortCoveragePct: null` is the CORRECT unmeasured state, so a
+        truthiness test here would report right behaviour as a missing field —
+        inverting the very invariant the field exists to express.
+        """
+        present, value = verify._dotted(
+            {"transparency": {"cohortCoveragePct": None}}, "transparency.cohortCoveragePct"
+        )
+        assert present is True and value is None
+
+    def test_a_field_nested_under_the_wrong_parent_is_absent(self):
+        """The exact defect found in the shipped doc: `cohortCoveragePct` was
+        read from `cohort`, where it has never lived."""
+        board = {"cohort": {"selectedManagers": 0}, "transparency": {"cohortCoveragePct": None}}
+        assert verify._dotted(board, "cohort.cohortCoveragePct")[0] is False
+        assert verify._dotted(board, "transparency.cohortCoveragePct")[0] is True
+
+    def test_no_producer_available_is_blocked_not_pass(self):
+        report = _report()
+        verify.check_required_fields_exist(report, {})
+        check = report.checks[0]
+        assert check.status == verify.BLOCKED
+        assert check.denominator == 0
+
+    def test_the_shipped_field_paths_all_exist_right_now(self):
+        """Live, against the real producers. Fails if a payload is reshaped."""
+        from src.sharp import market as sharp_market
+        from src.sharp import roster_percentage
+        from src.trade.faab_history import CrowdMarket
+
+        report = _report()
+        verify.check_required_fields_exist(
+            report,
+            {
+                "roster-percentage": roster_percentage.build_board(),
+                "sharp-market": sharp_market.market_payload(window="30d", limit=1),
+                "crowd-market": CrowdMarket().to_dict(),
+            },
+        )
+        check = report.checks[0]
+        assert check.status == verify.PASS, check.detail
+        assert check.denominator == len(verify.REQUIRED_FIELDS)
+
+
+class TestItCannotBeGreenWhileInspectingNothing:
+    def test_a_pass_over_an_empty_population_is_downgraded(self):
+        """The structural anti-vacuous-green guard.
+
+        A check that iterates an empty list and finds no offenders looks
+        exactly like one that examined a thousand rows and found none. The
+        denominator is what tells them apart, and the downgrade happens in
+        `Check.finalize` rather than at each call site so one forgotten guard
+        cannot produce a false green.
+        """
+        check = verify.Check("X", "-", "t", verify.PASS, "all good", denominator=0)
+        check.finalize()
+        assert check.status == verify.UNMEASURABLE
+        assert "proved nothing" in check.detail
+
+    def test_a_pass_over_a_real_population_survives(self):
+        check = verify.Check("X", "-", "t", verify.PASS, "all good", denominator=7)
+        check.finalize()
+        assert check.status == verify.PASS
+
+    def test_a_denominator_of_none_is_exempt(self):
+        """Structural checks — a route registration, a file's presence — have
+        no population, and must not be downgraded for lacking one."""
+        check = verify.Check("X", "-", "t", verify.PASS, "registered", denominator=None)
+        check.finalize()
+        assert check.status == verify.PASS
+
+    def test_a_failure_is_never_downgraded(self):
+        check = verify.Check("X", "-", "t", verify.FAIL, "broken", denominator=0)
+        check.finalize()
+        assert check.status == verify.FAIL
+
+    def test_the_report_finalises_every_check(self):
+        report = _report()
+        report.add(verify.Check("A", "-", "t", verify.PASS, "", denominator=0))
+        report.add(verify.Check("B", "-", "t", verify.PASS, "", denominator=3))
+        report.finalize()
+        assert [c.status for c in report.checks] == [verify.UNMEASURABLE, verify.PASS]
+        # ...and with the only "pass" downgraded, a run of just A proves nothing.
+        solo = _report()
+        solo.add(verify.Check("A", "-", "t", verify.PASS, "", denominator=0))
+        solo.finalize()
+        assert solo.exit_code() == 3
+
+
+class TestItDetectsAnEmptyPopulation:
+    def test_an_empty_market_blocks_rather_than_passing(self):
+        report = _report()
+        verify.check_zero_voter_quality(report, {"assets": []}, "test")
+        assert report.checks[0].status == verify.BLOCKED
+
+    def test_rows_without_the_case_are_unmeasurable_and_carry_a_zero_denominator(self):
+        report = _report()
+        verify.check_zero_voter_quality(report, _market(_person()), "test")
+        check = report.checks[0]
+        assert check.status == verify.UNMEASURABLE
+        assert check.evidence["rowsWithPersonConsensus"] == 1
+
+
+class TestItDetectsStaleEvidence:
+    @pytest.mark.parametrize("state", ["stale", "missing", "", "unknown"])
+    def test_unproven_scoring_with_a_positive_tep_claim_fails(self, state):
+        """Stale evidence that still yields a TEP answer is unproven scoring
+        promoted to a positive claim."""
+        from src.trade.faab_comparability import TargetFormat
+
+        report = _report()
+        ctx = {
+            "evidenceState": state,
+            "target": TargetFormat(teams=12, superflex=True, tep=True),
+        }
+        verify.check_unproven_scoring_fails_closed(report, ctx)
+        assert report.checks[0].status == verify.FAIL
+
+    def test_unproven_scoring_that_fails_closed_passes(self):
+        from src.trade.faab_comparability import TargetFormat
+
+        report = _report()
+        ctx = {"evidenceState": "stale", "target": TargetFormat(teams=12, superflex=True, tep=None)}
+        verify.check_unproven_scoring_fails_closed(report, ctx)
+        check = report.checks[0]
+        assert check.status == verify.PASS
+        assert "tep" in check.evidence["unprovableTargetFields"]
+
+    def test_fresh_evidence_makes_the_stale_branch_unmeasurable_not_passed(self):
+        from src.trade.faab_comparability import TargetFormat
+
+        report = _report()
+        ctx = {
+            "evidenceState": "fresh",
+            "target": TargetFormat(teams=12, superflex=True, tep=False),
+        }
+        verify.check_unproven_scoring_fails_closed(report, ctx)
+        assert report.checks[0].status == verify.UNMEASURABLE
+
+
+class TestItDetectsTheTepRule:
+    def test_the_deployed_rule_is_read_from_the_signature(self):
+        """Signature-first, because a behaviour-only check passes on a
+        label-rule build whenever the label happens to agree with the card."""
+        assert verify._deployed_tep_rule() == "card"
+
+    def test_a_card_with_no_te_edge_yields_a_false_tep(self):
+        """The measured `dynasty_main` shape, asserted through the same owner
+        the verifier uses rather than a reimplementation."""
+        from src.league_intel.te_premium import measure_te_demand
+
+        card = {"rec": 1.0, "bonus_rec_te": 0.0, "bonus_fd_te": 1.0, "bonus_fd_wr": 1.0}
+        assert measure_te_demand(None, card).has_scoring_edge is False
+
+    def test_a_card_with_a_te_edge_yields_a_true_tep(self):
+        from src.league_intel.te_premium import measure_te_demand
+
+        assert measure_te_demand(None, {"bonus_rec_te": 0.5}).has_scoring_edge is True
+
+
+class TestItDetectsIdpRefusal:
+    class _Market:
+        def __init__(self, prices_idp, rows_used=40):
+            self.prices_idp = prices_idp
+            self.rows_used = rows_used
+
+    def test_an_offense_only_population_refuses_idp_and_still_prices_offense(self):
+        report = _report()
+        verify.check_idp_population_refusal(report, self._Market(prices_idp=False))
+        check = report.checks[0]
+        assert check.status == verify.PASS
+        assert check.evidence["idpPositionsRefused"] == ["DL", "LB", "DB"]
+        assert check.evidence["offensePositionsAllowed"] == ["QB", "RB", "WR", "TE"]
+
+    def test_a_population_containing_an_idp_league_is_unmeasurable_not_failed(self):
+        """The gate reads what the retained rows contain, so it self-corrects
+        the day an IDP league appears. That is a finding about the feed."""
+        report = _report()
+        verify.check_idp_population_refusal(report, self._Market(prices_idp=True))
+        assert report.checks[0].status == verify.UNMEASURABLE
+
+    def test_no_ledger_is_blocked_never_passed(self):
+        report = _report()
+        verify.check_idp_population_refusal(report, None)
+        assert report.checks[0].status == verify.BLOCKED
+
+
+class TestTheDocumentItselfNamesRealRoutes:
+    """The regression guard on the corrected procedures document.
+
+    Every `/api/...` path the document names must be registered. This is what
+    would have caught `POST /api/faab/recommend` before it shipped, and it is
+    the reason a correction is worth more than a superseding document.
+    """
+
+    def test_every_api_path_in_the_procedures_doc_is_a_real_route(self):
+        import re
+
+        doc = REPO_ROOT / "docs" / "lane4" / "L2_L3_VERIFICATION_PROCEDURES.md"
+        text = doc.read_text(encoding="utf-8")
+        registered = {path for path, _method in verify._registered_routes_static()}
+        # The corrections quote the retired names in order to say they are
+        # wrong. Quoting a wrong name must stay legal, or the document cannot
+        # record its own history -- so the whole retired prefix is exempt, and
+        # naming it is the point rather than an oversight.
+        retired_prefix = "/api/faab"
+        named = {
+            m.rstrip("/.,`*")
+            for m in re.findall(r"/api/[a-zA-Z0-9/_{}-]+", text)
+            if not m.startswith(retired_prefix)
+        }
+        assert named, "the guard must not pass by matching nothing"
+        missing = sorted(n for n in named if n not in registered and not n.endswith("/*"))
+        # `/api/sharp/` appears as a prefix in prose; allow bare prefixes that
+        # are the parent of a real route.
+        missing = [
+            n for n in missing if not any(r.startswith(n.rstrip("/") + "/") for r in registered)
+        ]
+        assert missing == [], f"procedures doc names unregistered routes: {missing}"


### PR DESCRIPTION
**READY FOR INTEGRATION — Claude 5 merges. I do not.** Stacked on **#927**'s frozen head `07482b9b8`; **#927 and #921 are untouched.**

**Integration order:** #927 → this. Or absorb this correction into the same bounded release candidate if that produces the identical final tree.

**Verification tooling and documentation only.** No product source, methodology, weights, canonical values, V1 statuses, denominator, #921 capture behaviour, or #927 implementation code. The whole diff is four files:

```
docs/lane4/L2_L3_VERIFICATION_PROCEDURES.md   122 +-      (corrected in place)
scripts/verify_lane4_production.py           1800 +
tests/ops/test_lane4_verification.py          610 +
tests/ops/__init__.py                            0
```

---

## Why a correction, not another document

Superseding a wrong document leaves it in circulation for whoever opens it first. So it is **fixed where the errors occur**, each annotated at its row.

**Every endpoint and field was re-derived from the actual route registrations and response producers** — by enumerating the real decorators and `add_api_route` calls, and by *building* both Sharp payloads and walking them — not from old docs, comments, or remembered shapes.

## The six corrections

| # | the document said | reality |
|---|---|---|
| 1 | `POST /api/faab/recommend` (**×2**) | **`POST /api/waiver/faab-recommend`**. There is no `/api/faab/*` prefix *at all* — so **every crowd-market step was unrunnable** |
| 2 | roster-percentage → `sources.ffpc.status` | **`coverage.platforms.ffpc.status`**, and it lives on **`/api/sharp/market`**. Wrong field *and* wrong endpoint; the roster-percentage board has no `sources` block |
| 3 | `cohortCoveragePct` under `cohort` | **`transparency.cohortCoveragePct`**. `cohort` carries only `selectedManagers` + qualification counts |
| 4 | roster-percentage → `rostersObserved` | **exists nowhere**. The count is `transparency.eligibleRosters` (also `sample.eligibleRosters`) |
| 5 | record `commit` / `startedAt` from `/api/status` | **neither exists** — see below |
| 6 | `unavailable_reason` of `skipped` / `no_managers` | **`skipped_by_caller`** / **`no_cohort_managers_on_platform`**. The documented values matched nothing |

**Verified correct and left alone:** `cohort.selectedManagers` (present on **both** boards — my earlier comment on #927 said otherwise and was wrong), the whole `crowdMarket` block (`state`, `refusalReason`, `excludedCounts`, `tierCounts`, `pricesIdp`, `rowsUsed`, `rowsTotal`, `targetFormatUnknown`, `playerHasEvidence`), `contention.notes`, `CollectResult.status`.

### #5 is a real gap, not a typo

**No endpoint publishes a git SHA or build identifier of any kind.** `/api/status` carries `contract`, `data_runtime`, `health`, `sources`, the payload-size block — and its `contract.version` is the **API data-contract** version (`2026-03-10.v2`), which identifies the payload *shape*, not the commit that produced it.

The contract defines L3 as *"executed against the deployed SHA"*, so this is recorded as a named gap rather than papered over: the preamble now reads the SHA on the box via `git rev-parse HEAD`, and `--mode remote` stamps `headSha: null` with `headShaSource: "unavailable_over_http"`. Publishing a build identifier is a Lane 5 change and is **not** proposed here.

---

## The verifier — and the two bugs the audit found *in it*

It had itself been reading `cohort.cohortCoveragePct` (always absent → would have reported `BLOCKED` for the wrong reason on a perfectly healthy board) and the nonexistent `/api/status` SHA fields. Both fixed.

Five states, three of which are **not** passes:

| status | meaning |
|---|---|
| `pass` | the case arose and behaved correctly |
| `fail` | the case arose and behaved incorrectly |
| `unmeasurable` | the input was read; the case did not arise |
| `blocked` | a required input does not exist here |
| `unverifiable_unauthenticated` | 401/403 |

### Two structural guards against being green while inspecting nothing

**Denominators.** Every population check publishes what it actually inspected, and `Check.finalize` downgrades a `pass` whose denominator is `0` to `unmeasurable` — centrally, so one forgotten guard at a call site cannot produce a false green.

**Exit `0` is reserved for a COMPLETE run.** Any blocked, unmeasurable or unauthenticated check caps the run at exit `3`, however many others passed. Consequence stated rather than hidden: **until production evidence exists this exits `3` on every host**, which is the accurate report.

Route discovery is a source-level **AST scan**, not an app import — `import server` refuses without `JASON_LOGIN_PASSWORD` (correctly; it is fail-closed auth), so an import-only check reports `BLOCKED` on every machine that is *not* the deployed box, which is exactly where a stale route name needs catching. The live app is used as confirmation when importable.

---

## Tests — 55 deterministic, mutation-proven where it matters

Proving the verifier detects each thing you named:

| detects | test |
|---|---|
| a wrong endpoint | the real `/api/faab/recommend` → `FAIL`; plus the **converse** so it cannot pass by matching nothing, and a wrong-**method** case |
| a renamed/missing field | missing path → `FAIL`; and a field nested under the **wrong parent** (the exact `cohort` vs `transparency` defect) |
| HTTP 401 | raises the dedicated `Unauthenticated` type; plus **no-cookie-means-no-cookie-header**, structurally |
| an empty population | `BLOCKED`, never `pass` |
| a measured zero vs missing | `0.0` with voters passes; `null` with voters **fails** (the repair overshooting) |
| stale evidence | parametrised over `stale`/`missing`/`""`/`unknown`; a positive TEP claim under any of them fails |
| zero-voter Sharp quality | `1.0` → `FAIL`, `null` → `PASS` |
| card-derived TEP state | rule read from the **signature**; plus the measured no-edge and edge cards through the canonical owner |
| IDP population refusal | offense-only refuses DL/LB/DB while still pricing QB/RB/WR/TE; an IDP league present → `unmeasurable`, not `fail` |

**Three assert against the REAL producers at HEAD**, so a payload reshape breaks CI rather than the operator's evening.

**Mutation-proven, not merely written:** the vacuous-pass downgrade, the parametrised exit-code caps, and a scanner over **this document** that fails if it names an unregistered route — verified to go red by appending a bogus route to the real file and green again on restore. **That guard is what would have caught all four defects before they shipped.**

Presence is tested, never truthiness: `cohortCoveragePct: null` is the *correct* unmeasured state, so a truthiness test would report right behaviour as a missing field.

---

## Still impossible without production authentication

Recorded as `unverifiable_unauthenticated` — **not pass, not failure**. A live `--mode remote` run against `chaseupside.com` returned **3 × 401** just now, which is the wall itself, measured.

* **V1-58** Sharp cohort populated · **V1-59** Sharp bootstrap — need an authenticated `/api/sharp/cohort` read and `journalctl` on the 04:20 → 04:50 → 05:50 chain.
* **C1–C3** person-consensus states, **C8/C9** crowd refusal + bid effect — need a session.
* **C4–C7, C10** — need the scoring card and crowd ledger, both gitignored and prod-only; `--mode onbox` only.
* **V1-57** timer — needs `systemctl` on the box.

`/api/sharp/*` is not in the public allowlist and **that gate must not be relaxed to make verification easier**. No cohort, ledger, scoring card or crowd row is fabricated anywhere in this PR.

## Verification

| check | result |
|---|---|
| `tests/ops` | 55 passed |
| `tests/ops` + `tests/sharp` + `tests/trade` | **890 passed** |
| `ruff check` / `format --check` | clean, 1170 files |
| `check_decision_coercions.py` | clean |
| diff scope | nothing outside `scripts/verify_lane4_production.py`, `tests/ops/`, `docs/lane4/` |

**Supersedes #931**, which targeted `main` and is being closed in favour of this stacked one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqEBEngbUtzXsbHRYrPLkF)_