### PR TITLE
V1-29 — enforce the replacement-level split; retire the one genuinely dead duplicate

### DIFF
--- a/docs/roster-intelligence/C2_CANONICAL_ROSTER_CHAIN.md
+++ b/docs/roster-intelligence/C2_CANONICAL_ROSTER_CHAIN.md
@@ -66,7 +66,7 @@ merging across units would be the defect, not the fix:
 
 | Module | Unit | Question it answers | Disposition |
 |---|---|---|---|
-| `src/league_intel/replacement.py` | canonical dynasty value | "What is a startable/rosterable player worth in THIS league?" | **CANONICAL for this lane.** Everything built here consumes it |
+| `src/league_intel/replacement.py` | **`rosValue` — 0-100 log-rank ROS production index** (corrected; see below) | "What is a startable/rosterable player worth in THIS league?" | **CANONICAL for that unit.** |
 | `src/scoring/replacement_level.py` | fantasy points (VORP) | "Points above replacement" | Different quantity. Consumer: `public_league/awards.py` via a shim |
 | `src/bdvm/replacement.py` | projected PPG | BDVM's dynamic replacement | Different lane; bound by the frozen Appendix-C parity fixture. **Do not touch** |
 | `src/trade/faab_engine.py` (`V_repl`) | board value, *format line* | "What does the league's format make replacement-level?" | Different question, different lane |
@@ -76,6 +76,20 @@ merging across units would be the defect, not the fix:
 So the deliverable here is **no new implementation** and no merge — a
 designation plus this table, so the next session does not "consolidate" two
 different units into one wrong number.
+
+**UNIT CORRECTED 2026-08-19 (V1-29).** This table originally gave
+`src/league_intel/replacement.py`'s unit as *canonical dynasty value*. That was
+wrong. It reads `rosValue` at every value site (`:299`, `:375`, `:386`, `:567`,
+`:618`); its own docstring says so (`:22` — *"runs the optimizer over
+``rosValue``"*); and its production caller supplies ROS rows (`gameplan.py:357`
+loads `data/ros/team_strength/`, handed in at `:486-488`).
+
+The error mattered more than a slip. This table's stated purpose is to prevent a
+cross-unit merge, and that cell invited exactly one — it made the dynasty-value
+replacement questions (`faab_engine.V_repl`, `displacement.waiverValue`) look
+like they belonged to an engine answering in ROS production units. The row now
+says what the code does, and `scripts/replacement_census.py` **enforces** the
+split rather than asserting it.
 
 ---
 

--- a/scripts/replacement_census.py
+++ b/scripts/replacement_census.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""V1-29 — census of every replacement-level implementation, and the guard.
+
+**Read this before reading the output.** Six things in this tree use the word
+"replacement". They are not six copies of one quantity: they split by UNIT and
+by POPULATION, and merging across either would be the defect rather than the
+fix. This script exists to make that split *checkable* instead of a table in a
+document that nothing enforces.
+
+Each row below declares what its implementation computes — quantity, unit,
+population, and its disposition — and the script derives the CALLERS from the
+tree at run time by AST. So the declared half is reviewable and the measured
+half cannot go stale.
+
+Dispositions:
+
+    OWNER     the canonical implementation for its (unit, population)
+    ADAPTER   reshapes a caller's data and delegates to an OWNER
+    DISTINCT  answers a materially different question; must NOT be merged
+    DEAD      no production caller; retire
+    RETIRED   deleted by V1-29; the guard fails if it comes back
+
+Exit codes follow the repo convention (``scripts/backtest_perfect_draft.py``):
+0 clean · 1 a violation was measured · 2 could not measure. ``2`` is never
+collapsed into ``0`` — "no data" must not read as "passed".
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+TAG = "[replacement-census]"
+
+EXIT_OK, EXIT_VIOLATION, EXIT_UNMEASURED = 0, 1, 2
+
+OWNER, ADAPTER, DISTINCT, DEAD, RETIRED = "OWNER", "ADAPTER", "DISTINCT", "DEAD", "RETIRED"
+
+#: Files scanned for call sites. Tests are excluded deliberately: a symbol kept
+#: alive only by its own unit test is DEAD for production purposes, and that is
+#: the distinction this census is for.
+SCAN_ROOTS = ("src", "scripts")
+SCAN_FILES = ("server.py",)
+
+
+@dataclass(frozen=True)
+class Impl:
+    key: str
+    path: str
+    symbol: str
+    quantity: str
+    unit: str
+    population: str
+    disposition: str
+    note: str
+    #: Names that count as a call site for this row.
+    call_names: tuple[str, ...] = ()
+    callers: list[str] = field(default_factory=list)
+    intra: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "key": self.key,
+            "path": self.path,
+            "symbol": self.symbol,
+            "quantity": self.quantity,
+            "unit": self.unit,
+            "population": self.population,
+            "disposition": self.disposition,
+            "note": self.note,
+            "crossModuleCallers": sorted(set(self.callers)),
+            "crossModuleCallerCount": len(set(self.callers)),
+            "intraModuleCallSites": sorted(set(self.intra)),
+            "intraModuleCallCount": len(set(self.intra)),
+        }
+
+
+#: The declared census. Every unit/population claim here was read off the code
+#: or its docstring at HEAD, not inherited from an earlier audit.
+CENSUS: tuple[Impl, ...] = (
+    Impl(
+        key="A",
+        path="src/league_intel/replacement.py",
+        symbol="compute_replacement_levels / measure_endogenous_starters / compute_scarcity",
+        quantity="four replacement tiers (starter / bestBallStarter / roster / waiver)",
+        unit="rosValue — 0-100 log-rank ROS production index",
+        population="every rostered player in the league, plus free agents",
+        disposition=OWNER,
+        note=(
+            "Canonical for the ROS-production unit. Reads rosValue at :299/:375/"
+            ":386/:567/:618; its own docstring :22 says 'runs the optimizer over "
+            "rosValue'. Its production caller supplies ROS rows "
+            "(gameplan.py:357 loads data/ros/team_strength/)."
+        ),
+        call_names=(
+            "compute_replacement_levels",
+            "measure_endogenous_starters",
+            "compute_scarcity",
+        ),
+    ),
+    Impl(
+        key="A-demand",
+        path="src/league_intel/replacement.py",
+        symbol="measure_revealed_demand",
+        quantity="rostership counts vs supply",
+        unit="counts (unit-agnostic value floor)",
+        population="league rosters",
+        disposition=DISTINCT,
+        note=(
+            "NOT a replacement level. Its own docstring: 'Evidence about DEMAND, "
+            "not about value.' No production caller yet, but it is exported, "
+            "unit-agnostic by design and covered by tests/league_intel/"
+            "test_replacement.py. Deleting it would remove tested behaviour for "
+            "no V1-29 reason — out of scope, not dead."
+        ),
+        call_names=("measure_revealed_demand",),
+    ),
+    Impl(
+        key="B",
+        path="src/scoring/replacement_level.py",
+        symbol="replacement_per_game",
+        quantity="replacement-level points per game at one position",
+        unit="fantasy points per game",
+        population="players supplied by the caller, ranked by per-game pace",
+        disposition=OWNER,
+        note="Canonical for the fantasy-points unit. Consumed via the awards adapter.",
+        call_names=("replacement_per_game",),
+    ),
+    Impl(
+        key="B-dead",
+        path="src/scoring/replacement_level.py",
+        symbol="vorp_table",
+        quantity="per-player VORP",
+        unit="fantasy points",
+        population="ALL points (rows.points / rows.games)",
+        disposition=RETIRED,
+        note=(
+            "DELETED by V1-29. Had no production caller and no test, and its "
+            "stated purpose — reuse by the IDP scoring-fit pipeline — never "
+            "landed. It was NOT a duplicate of the awards VORP: different "
+            "population (all points vs starter-only). It was simply a plausible "
+            "second VORP sitting beside the live one."
+        ),
+        call_names=("vorp_table",),
+    ),
+    Impl(
+        key="B-slots",
+        path="src/scoring/replacement_level.py",
+        symbol="starter_slot_counts",
+        quantity="starter slots per position from a Sleeper roster_positions list",
+        unit="slot counts",
+        population="league roster_positions",
+        disposition=ADAPTER,
+        note=(
+            "ALREADY CONSOLIDATED, and currently unconsumed. It routes through the "
+            "canonical lineup owner — slot_demand(...).even_split from src/ros/"
+            "lineup.py (C2-U1) — and its docstring records that this was one of four "
+            "independent copies and that routing through the owner fixed a REC_FLEX "
+            "split bug. It is also the only reason this module imports the owner, so "
+            "deleting it would break tests/lineup/test_single_owner.py::"
+            "test_every_consumer_imports_the_owner_rather_than_reimplementing. "
+            "Retiring a correct consolidation is not a consolidation."
+        ),
+        call_names=("starter_slot_counts",),
+    ),
+    Impl(
+        key="C",
+        path="src/public_league/awards.py",
+        symbol="_replacement_per_game_for_position / _vorp_rows / _vorp_starter_slots",
+        quantity="award VORP per player",
+        unit="fantasy season points",
+        population=(
+            "STARTER-ONLY points (_player_starter_totals: 'Aggregate starter-only "
+            "points per player across the season')"
+        ),
+        disposition=ADAPTER,
+        note=(
+            "Already delegates the baseline: _replacement_per_game_for_position is "
+            "a 'thin shim around src.scoring.replacement_level.replacement_per_game'. "
+            "What remains local is DISTINCT and must stay: a starter-only population, "
+            "an award-convention slot table with a dynamic RB/WR split from the top-84 "
+            "flex pool, and a zero-floor that is a presentation rule."
+        ),
+        call_names=("_vorp_rows", "_replacement_per_game_for_position", "_vorp_starter_slots"),
+    ),
+    Impl(
+        key="D",
+        path="src/bdvm/replacement.py",
+        symbol="ReplacementEngine.R",
+        quantity="dynamic replacement baseline",
+        unit="projected fantasy points per game",
+        population="BDVM projection pools, flex-allocated + waiver buffer",
+        disposition=DISTINCT,
+        note="Different lane and unit; bound by the frozen Appendix-C parity fixture.",
+        call_names=("ReplacementEngine", "has_replacement", "startable"),
+    ),
+    Impl(
+        key="E",
+        path="src/trade/faab_engine.py",
+        symbol="resolve_anchors -> Anchors.v_repl",
+        quantity="format replacement line, blended with the live pool",
+        unit="rankDerivedValue (1-9999 dynasty)",
+        population="league format line + Nth-best genuinely available player",
+        disposition=DISTINCT,
+        note=(
+            "Answers 'what does the format make replacement', not 'what can I sign'. "
+            "Explicitly rejects the single-best anchor. FAAB lane."
+        ),
+        call_names=("resolve_anchors", "surplus_over_replacement"),
+    ),
+    Impl(
+        key="G",
+        path="src/draft/displacement.py",
+        symbol="waiver_values_by_position",
+        quantity="best available (unrostered) value at each position",
+        unit="rankDerivedValue (1-9999 dynasty)",
+        population="unrostered players on the canonical board",
+        disposition=DISTINCT,
+        note=(
+            "Answers 'what can I sign instead' — the opportunity cost of a roster "
+            "spot. Different question from E even though the unit matches."
+        ),
+        call_names=("waiver_values_by_position", "free_agent_ladder"),
+    ),
+    Impl(
+        key="I",
+        path="src/league_comparison/metrics.py",
+        symbol="position_metrics -> replacement_level",
+        quantity="the Nth player's points at a position",
+        unit="blended season points (volume+pace composite)",
+        population="one league-season's players",
+        disposition=DISTINCT,
+        note="Display-only cross-league comparison.",
+        call_names=("position_metrics",),
+    ),
+)
+
+#: Symbols V1-29 deleted. The guard fails if any reappears as a call site.
+#: Kept separate from CENSUS so a deletion cannot be undone by editing a row.
+RETIRED_SYMBOLS: tuple[str, ...] = ("vorp_table",)
+
+
+def _python_files(extra: Path | None = None) -> list[Path]:
+    files = [p for root in SCAN_ROOTS for p in (REPO / root).rglob("*.py")]
+    files += [REPO / f for f in SCAN_FILES]
+    if extra is not None:
+        files.append(extra)
+    return [p for p in files if p.exists()]
+
+
+def called_names(tree: ast.AST) -> set[str]:
+    """Every name appearing in CALL position.
+
+    AST rather than a substring scan, because a docstring explaining a
+    retirement contains the retired name — the trap that made two earlier
+    guards in this repo decorative — and because a text match would equally
+    miss a call written through an alias.
+    """
+    out: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        if isinstance(fn, ast.Name):
+            out.add(fn.id)
+        elif isinstance(fn, ast.Attribute):
+            out.add(fn.attr)
+    return out
+
+
+def call_sites(names: set[str], extra: Path | None = None) -> dict[str, list[str]]:
+    hits: dict[str, list[str]] = {}
+    for path in _python_files(extra):
+        rel = str(path.relative_to(REPO)) if REPO in path.parents else str(path)
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for name in called_names(tree) & names:
+            # A function calling itself, or a module defining it, is not a
+            # consumer. Definition site is excluded by comparing paths below.
+            hits.setdefault(name, []).append(rel)
+    return hits
+
+
+def build_census(extra: Path | None = None) -> list[Impl]:
+    wanted = {n for impl in CENSUS for n in impl.call_names}
+    hits = call_sites(wanted, extra=extra)
+    out: list[Impl] = []
+    for impl in CENSUS:
+        callers: list[str] = []
+        intra: list[str] = []
+        for name in impl.call_names:
+            for rel in hits.get(name, []):
+                # Cross-module use is what "is this owner consumed" asks. An
+                # intra-module call is real too (a private helper is called by
+                # its own module) and is reported separately rather than
+                # dropped, which would under-report an ADAPTER to zero.
+                (intra if rel == impl.path else callers).append(f"{rel}::{name}")
+        out.append(
+            Impl(
+                key=impl.key,
+                path=impl.path,
+                symbol=impl.symbol,
+                quantity=impl.quantity,
+                unit=impl.unit,
+                population=impl.population,
+                disposition=impl.disposition,
+                note=impl.note,
+                call_names=impl.call_names,
+                callers=callers,
+                intra=intra,
+            )
+        )
+    return out
+
+
+def retired_reachable(extra: Path | None = None) -> dict[str, list[str]]:
+    """Any production call site for a symbol V1-29 deleted."""
+    return call_sites(set(RETIRED_SYMBOLS), extra=extra)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--json-out", type=Path, default=None)
+    args = ap.parse_args(argv)
+
+    rows = build_census()
+    if not rows:
+        print(f"{TAG} census is empty — nothing was measured. exit 2.")
+        return EXIT_UNMEASURED
+
+    print(
+        f"{TAG} {len(rows)} implementations declared; callers derived by AST over {len(_python_files())} files"
+    )
+    print("")
+    for r in rows:
+        print(f"  {r.disposition:<9} {r.key:<8} {r.path}::{r.symbol.split(' /')[0]}")
+        print(f"            unit={r.unit}")
+        print(f"            population={r.population}")
+        print(
+            f"            cross-module callers: {len(set(r.callers))}   "
+            f"intra-module call sites: {len(set(r.intra))}"
+        )
+        for c in sorted(set(r.callers)):
+            print(f"              - {c}")
+    print("")
+
+    failures: list[str] = []
+    unconsumed: list[str] = []
+
+    reachable = retired_reachable()
+    if reachable:
+        failures.append(f"retired symbols are reachable again: {reachable}")
+
+    for r in rows:
+        if r.disposition in (DEAD, RETIRED) and (r.callers or r.intra):
+            failures.append(
+                f"{r.key} is declared DEAD but has callers: "
+                f"{sorted(set(r.callers)) or sorted(set(r.intra))}"
+            )
+        if r.disposition == OWNER and not (r.callers or r.intra):
+            failures.append(
+                f"{r.key} is declared OWNER but has NO production caller — "
+                "either the declaration is stale or the owner is unconsumed"
+            )
+        if r.disposition == ADAPTER and not (r.callers or r.intra):
+            # Not a failure: an adapter can be correct and simply unused. Said
+            # out loud so "nobody calls it" cannot be mistaken for "it is wrong".
+            unconsumed.append(r.key)
+
+    print(f"{TAG} ── verdict ──")
+    if failures:
+        for f in failures:
+            print(f"{TAG} ::error title=Replacement census::{f}")
+        return EXIT_VIOLATION
+
+    if unconsumed:
+        print(
+            f"{TAG} note: adapters with no current caller (correct, just unused): "
+            f"{', '.join(unconsumed)}"
+        )
+    dead = [r.key for r in rows if r.disposition == DEAD]
+    print(
+        f"{TAG} clean: {len(RETIRED_SYMBOLS)} retired symbol(s) deleted and unreachable; "
+        f"{len(dead)} DEAD row(s); every OWNER consumed; every OWNER unit distinct."
+    )
+
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(
+            json.dumps(
+                {
+                    "implementations": [r.to_dict() for r in rows],
+                    "retiredSymbols": list(RETIRED_SYMBOLS),
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        print(f"{TAG} census written to {args.json_out}")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/scoring/replacement_level.py
+++ b/src/scoring/replacement_level.py
@@ -12,23 +12,27 @@ scoring-fit path, future projection sources in Phase 2+).
 
 What this module owns
 ─────────────────────
-1. ``starter_slot_counts`` — maps a Sleeper ``roster_positions`` list
-   plus team count to ``{position: int}``.  Splits FLEX (RB/WR/TE
-   1/3 each), SUPER_FLEX (QB/RB/WR/TE 1/4 each), REC_FLEX (WR/TE/RB
-   1/3 each), IDP_FLEX (DL/LB/DB 1/3 each).
-2. ``replacement_per_game`` — per-position replacement-level
+1. ``replacement_per_game`` — per-position replacement-level
    points-per-game.  Defined as the average per-game pace of the
    five players ranked just *below* the league's starter cutoff
-   (so injured starters don't anchor the baseline).
-3. ``vorp_table`` — for each player: ``vorp = points - replacement
-   * games``.  Returns sorted descending.
+   (so injured starters don't anchor the baseline).  **This is the
+   canonical owner of the fantasy-points replacement baseline**, and
+   ``public_league/awards.py`` consumes it through a shim.
+2. ``starter_slot_counts`` — maps a Sleeper ``roster_positions`` list
+   plus team count to ``{position: int}``.  The flex split comes from
+   the canonical lineup owner (``src/ros/lineup.slot_demand``), not
+   from a table here; see the function for the REC_FLEX correction
+   that came with it.  Currently unconsumed.
 
 What this module does NOT own
 ─────────────────────────────
 * No Sleeper roster fetch — caller passes already-built rows.
-* No team / owner attribution — the input row is intentionally
-  flat.  ``awards.py`` decorates with team / owner after calling
-  ``vorp_table``.
+* No per-player VORP table.  ``vorp_table`` was retired by V1-29 —
+  it had no production caller and no test, and its stated purpose
+  (reuse by the IDP scoring-fit pipeline) never landed.  The live
+  VORP is ``public_league/awards.py::_vorp_rows``, which is NOT a
+  copy of it: it runs on STARTER-ONLY points and an award-convention
+  slot table, and delegates only the baseline to this module.
 * No fantasy-points computation — caller pre-computes
   ``points`` (e.g. via ``realized_points.compute_cumulative_points``).
 
@@ -64,17 +68,6 @@ class PlayerSeasonRow:
     # Optional metadata — kept here so callers don't have to maintain
     # a parallel lookup; the VORP functions ignore it.
     player_name: str = ""
-
-
-@dataclass(frozen=True)
-class VorpRow:
-    player_id: str
-    position: str
-    player_name: str
-    points: float
-    games: int
-    vorp: float
-    replacement_per_game: float
 
 
 # ── Slot-counting (flex-aware) ────────────────────────────────────
@@ -175,61 +168,3 @@ def replacement_per_game(
     if not band:
         return per_game[-1]
     return sum(band) / len(band)
-
-
-# ── Top-level VORP table ──────────────────────────────────────────
-def vorp_table(
-    rows: Iterable[PlayerSeasonRow],
-    starter_slots_by_pos: dict[str, int],
-    *,
-    band_size: int = 5,
-) -> list[VorpRow]:
-    """Compute VORP per player, grouped by position.
-
-    For each position present in ``rows``:
-
-      * Look up the position's ``starter_slots`` from
-        ``starter_slots_by_pos``.  Positions with no slot
-        configured fall back to ``max(1, len(group)//2)`` so a
-        single-game cameo doesn't outshine real full-season
-        starters.
-      * Compute the per-game replacement baseline via
-        ``replacement_per_game``.
-      * Per player: ``vorp = points - (replacement_per_game * games)``.
-
-    Returns a single flat list of ``VorpRow``s sorted by ``vorp``
-    descending.  Callers that want per-position views can group by
-    ``row.position`` after the fact.
-    """
-    grouped: dict[str, list[PlayerSeasonRow]] = defaultdict(list)
-    for r in rows or []:
-        if not isinstance(r, PlayerSeasonRow):
-            continue
-        if not r.position:
-            continue
-        if r.games <= 0:
-            continue
-        grouped[r.position].append(r)
-
-    out: list[VorpRow] = []
-    for pos, group in grouped.items():
-        slots = starter_slots_by_pos.get(pos, 0)
-        if slots <= 0:
-            slots = max(1, len(group) // 2)
-        rpg = replacement_per_game(group, slots, band_size=band_size)
-        for r in group:
-            replacement_total = rpg * r.games
-            vorp = r.points - replacement_total
-            out.append(
-                VorpRow(
-                    player_id=r.player_id,
-                    position=pos,
-                    player_name=r.player_name,
-                    points=round(r.points, 2),
-                    games=r.games,
-                    vorp=round(vorp, 2),
-                    replacement_per_game=round(rpg, 2),
-                )
-            )
-    out.sort(key=lambda v: -v.vorp)
-    return out

--- a/tests/roster_intel/test_replacement_owner.py
+++ b/tests/roster_intel/test_replacement_owner.py
@@ -1,0 +1,137 @@
+"""V1-29 — one replacement-level owner per (unit, population).
+
+The rule this file enforces is NOT "there is one replacement level". Six
+things in this tree use the word and they answer different questions in
+different units; collapsing them would be the defect. What it enforces is:
+
+* a retired implementation stays retired;
+* every declared OWNER is actually consumed;
+* anything declared DEAD really has no caller;
+* and the census that asserts all of the above can be made to fail.
+
+The last point is the load-bearing one. A scanner nobody has watched go red
+is not evidence, so ``test_the_census_detects_a_reintroduced_duplicate``
+writes a real call site and asserts the census catches it.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+from scripts.replacement_census import (
+    ADAPTER,
+    RETIRED,
+    CENSUS,
+    DEAD,
+    DISTINCT,
+    EXIT_OK,
+    EXIT_VIOLATION,
+    OWNER,
+    RETIRED_SYMBOLS,
+    build_census,
+    main,
+    retired_reachable,
+)
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+
+def test_the_census_runs_clean_at_head():
+    assert main(["--json-out", "/dev/null"]) == EXIT_OK
+
+
+def test_retired_implementations_are_not_reachable():
+    assert (
+        not retired_reachable()
+    ), "a replacement implementation retired by V1-29 has a production call site again"
+
+
+def test_retired_implementations_are_gone_not_renamed():
+    """Retirement means deletion, not a wrapper kept 'for fallback'.
+
+    Checked against the module NAMESPACE rather than its text: the
+    docstring deliberately records what was retired and why, and a text
+    scan would force that explanation out of the code — the trap that
+    made two earlier guards in this repo decorative.
+    """
+    src = (REPO / "src" / "scoring" / "replacement_level.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    defined = {n.name for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.ClassDef))}
+    for symbol in RETIRED_SYMBOLS:
+        assert symbol not in defined, f"{symbol} was reintroduced as a definition"
+
+
+def test_every_declared_owner_is_consumed():
+    """An owner nobody calls is either mis-declared or dead.
+
+    This is what stops the census degrading into a wish list.
+    """
+    rows = {r.key: r for r in build_census()}
+    assert rows, "the census produced no rows — it measured nothing"
+    for row in rows.values():
+        if row.disposition == OWNER:
+            assert row.callers or row.intra, f"{row.key} is declared OWNER but nothing calls it"
+
+
+def test_dead_rows_really_have_no_callers():
+    for row in build_census():
+        if row.disposition == DEAD:
+            assert not (
+                row.callers or row.intra
+            ), f"{row.key} is declared DEAD but has callers: {row.callers or row.intra}"
+
+
+def test_the_census_detects_a_reintroduced_duplicate(tmp_path):
+    """Non-vacuity. The census must be able to fail.
+
+    Writes a module that calls a retired symbol and asserts the scan sees
+    it. Without this the "zero duplicates remain" verdict is unfalsifiable.
+    """
+    probe = REPO / "src" / "_v129_census_probe.py"
+    probe.write_text(
+        "from src.scoring.replacement_level import vorp_table\n"
+        "def f(rows, slots):\n"
+        "    return vorp_table(rows, slots)\n",
+        encoding="utf-8",
+    )
+    try:
+        assert retired_reachable(), "the census did NOT detect a reintroduced retired symbol"
+        assert main([]) == EXIT_VIOLATION, "the census exited clean with a duplicate present"
+    finally:
+        probe.unlink(missing_ok=True)
+
+
+def test_a_docstring_mention_does_not_trip_the_census():
+    """The complementary half: history notes are not call sites.
+
+    ``replacement_level.py``'s own docstring names ``vorp_table`` while
+    explaining the retirement, and that must stay legal.
+    """
+    src = (REPO / "src" / "scoring" / "replacement_level.py").read_text(encoding="utf-8")
+    assert "vorp_table" in src, "the fixture is stale — the docstring no longer names it"
+    assert not retired_reachable(), "a docstring mention was mistaken for a call site"
+
+
+def test_units_are_declared_and_distinct_rows_are_not_merged():
+    """The census must keep the units apart, because that is the whole point.
+
+    Every row declares a unit; no two rows with DIFFERENT units may claim
+    the same owner. This is the executable form of the boundary table.
+    """
+    rows = build_census()
+    for row in rows:
+        assert row.unit.strip(), f"{row.key} declares no unit"
+        assert row.population.strip(), f"{row.key} declares no population"
+    owners = [r for r in rows if r.disposition == OWNER]
+    units = [r.unit for r in owners]
+    assert len(units) == len(
+        set(units)
+    ), f"two OWNER rows claim the same unit, which means one of them is a duplicate: {units}"
+
+
+@pytest.mark.parametrize("row", CENSUS, ids=lambda r: r.key)
+def test_every_row_declares_a_known_disposition(row):
+    assert row.disposition in {OWNER, ADAPTER, DISTINCT, DEAD, RETIRED}


### PR DESCRIPTION
> Branched from current `main` (`c400fecb9`), after #914 merged. **#922 (`a03d17532`) and #925 (`991280ad4`) are untouched** — verified at their original SHAs. Claude 5 remains merge authority; I am not merging this.

## The headline: the contract's "5 implementations to retire" is stale in both directions

A fresh census at HEAD — re-derived, not inherited from the earlier audit — finds **ten** things in this tree that use the word "replacement", and only **one** worth deleting. Most of what V1-29 asks for **already happened**, in #914 / C2-U1 and in the awards shim.

## Canonical owner — there are **two**, on deliberately different units

That is not a hedge; it is the finding. The ten split by **unit** and by **population**, and merging across either would be the defect:

| unit | owner |
|---|---|
| `rosValue` — 0–100 log-rank ROS production index | `src/league_intel/replacement.py` |
| fantasy points per game | `src/scoring/replacement_level.py::replacement_per_game` |

The census **fails** if two OWNER rows ever claim the same unit.

## Census (machine-derived by AST at run time)

| disposition | key | module · symbol | unit | cross-module callers |
|---|---|---|---|---|
| OWNER | A | `league_intel/replacement.py` · `compute_replacement_levels` + 2 | rosValue 0–100 | 3 (`api/gameplan.py`) |
| DISTINCT | A-demand | `league_intel/replacement.py` · `measure_revealed_demand` | counts | 0 |
| OWNER | B | `scoring/replacement_level.py` · `replacement_per_game` | fantasy PPG | 1 (`public_league/awards.py`) |
| **RETIRED** | B-dead | `scoring/replacement_level.py` · `vorp_table` | fantasy points | 0 |
| ADAPTER | B-slots | `scoring/replacement_level.py` · `starter_slot_counts` | slot counts | 0 |
| ADAPTER | C | `public_league/awards.py` · `_vorp_rows` + 2 | fantasy season points, **starter-only** | 3 intra |
| DISTINCT | D | `bdvm/replacement.py` · `ReplacementEngine.R` | projected FPG | 2 |
| DISTINCT | E | `trade/faab_engine.py` · `Anchors.v_repl` | rankDerivedValue, format line | 4 |
| DISTINCT | G | `draft/displacement.py` · `waiver_values_by_position` | rankDerivedValue, best unrostered | 3 |
| DISTINCT | I | `league_comparison/metrics.py` · `position_metrics` | blended season points | 1 |

`scripts/replacement_census.py` **declares** quantity/unit/population/disposition and **derives** callers from the tree, so the reviewable half is reviewable and the measured half cannot go stale.

## Retired: exactly one

**`scoring.replacement_level.vorp_table`** plus its orphaned `VorpRow`. Zero production callers, **zero tests**, and its stated purpose — reuse by the IDP scoring-fit pipeline — never landed. Precisely the "plausible fallback copy" the brief says to delete rather than leave sitting beside the live implementation.

## Intentionally NOT retired, and why

Two things I expected to be duplicates are not. Both were checked **before** anything was deleted:

- **`awards.py` is an ADAPTER, not a copy.** `_replacement_per_game_for_position` is explicitly *"a thin shim around `src.scoring.replacement_level.replacement_per_game`"* — the baseline is **already** consolidated onto the owner. What remains local is genuinely a different question: a **starter-only** population (`_player_starter_totals` — *"Aggregate starter-only points per player across the season"*, vs `vorp_table`'s all-points), an award-convention slot table with a dynamic RB/WR split from the top-84 flex pool, and a zero-floor that is a presentation rule.
- **`starter_slot_counts` is already consolidated.** It routes through the canonical lineup owner (`ros/lineup.slot_demand(...).even_split`), and its docstring records that doing so *fixed* a REC_FLEX split bug. It is currently unconsumed — but deleting it would remove a correct consolidation **and** break `test_single_owner::test_every_consumer_imports_the_owner_rather_than_reimplementing`, which pins that module as importing the owner. Retiring a correct consolidation is not a consolidation.
- **`measure_revealed_demand`** is kept: its own docstring says it is *"Evidence about DEMAND, not about value"*, it is unit-agnostic by design, and it has tests. Deleting tested behaviour for no V1-29 reason would be manufacturing work.
- **D / E / G / I** stay: four different units, four different questions. E and G share a unit but not a question — *"what does the format make replacement"* vs *"what can I sign instead"* — and E explicitly rejects G's single-best anchor.

## A boundary-table unit was wrong — my own error, shipped in #914

`C2_CANONICAL_ROSTER_CHAIN.md` §3 gave `league_intel/replacement.py`'s unit as **"canonical dynasty value"**. It is `rosValue`:

| evidence | where |
|---|---|
| every value read is `rosValue` | `:299`, `:375`, `:386`, `:567`, `:618` |
| its own docstring | `:22` — *"runs the optimizer over ``rosValue``"* |
| its production caller supplies ROS rows | `gameplan.py:357` loads `data/ros/team_strength/`, handed in at `:486-488` |

That cell mattered more than a slip: the table exists **to prevent a cross-unit merge**, and it invited exactly one — making the dynasty-value questions look like they belonged to an ROS-production engine. Corrected, with the reasoning recorded in place.

## Production consumers — before / after

**Unchanged for every surviving implementation.** The only delta is `vorp_table`: 0 → deleted.

## Did any published number move? No.

| proof | result |
|---|---|
| `replacement_per_game` (the only consumed function in the touched module) across 7 cutoffs, before vs after | **byte-identical**, sha256 `8048eea510c354ef` both sides |
| canonical board | **structurally cannot move** — importing `src.api.data_contract` pulls in 96 modules and **none** is `scoring.replacement_level` |
| `public_league` / awards suites | pass unchanged |

## RED-before-GREEN / mutation evidence

The non-vacuity requirement, discharged in **both** directions:

| mutation | result |
|---|---|
| write a module calling `vorp_table` | census exits **1**; retired-symbol guard **and** DEAD-disposition check both fire |
| docstring *mentions* `vorp_table` (the module's own retirement note does) | census stays **clean** — the trap that made two earlier guards in this repo decorative |

The guard is an **AST call-site scan**, not a substring match, for exactly that reason.

## Tests and gates

| gate | result |
|---|---|
| `tests/roster_intel/test_replacement_owner.py` (new) | **18 passed** |
| roster_intel · lineup · scoring · league_intel · public_league · draft | **1616 passed**, 22 skipped |
| full `pytest -m "not livedata"` | **8651 passed**, 5 failed — see below |
| `ruff format --check` / `ruff check` | clean |
| decision-coercion | **670 present / 670 accepted**, clean on changed files |
| planning-integrity · product-plan-governance | clean |
| `check_release_candidate.py` | **0 class-A/B/C outstanding** — *"the validated tree IS the tree that will merge"* |

**The 5 failures are a linked-worktree artifact, not this change.** All five are `tests/consensus_edge/test_panel.py`. `src/consensus_edge/panel.py::is_shallow()` tests `(REPO/".git"/"shallow").exists()`, and in a linked worktree `.git` is a *file*, so it answers `False` while `git rev-parse --is-shallow-repository` answers `true` — the deep-only skip does not fire and the tests run against history the clone lacks. Proven independent of this diff: `src/consensus_edge/` and `tests/consensus_edge/` are **byte-identical to `main`**, and neither imports anything this PR touches. Same signature as documented on #925 (primary copy: 51 skipped / 0 failed; worktree: 38 skipped / 5 failed). CI does a normal checkout and is unaffected.

## What remains for V1-29

**Nothing in this lane.** Every remaining implementation is either DISTINCT by unit and population, or an adapter already consuming an owner. Integration should reconcile the contract's "5 implementations to retire" against this census — the row's premise is stale, and I have not edited the V1 denominator or marked anything `VERIFIED`.

One process note: the census initially under-reported the awards adapter to **zero** callers because I excluded same-file calls — wrong for module-private helpers. It now reports intra- and cross-module callers separately. The guard caught my own rule, not a reviewer.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyqbZejxh7ytbfijL5pmdE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyqbZejxh7ytbfijL5pmdE)_