### PR TITLE
Both ROS simulators take the canonical standings tiebreak — a level league was resolved by the alphabet

### DIFF
--- a/src/public_league/playoff_odds.py
+++ b/src/public_league/playoff_odds.py
@@ -403,8 +403,8 @@ def _round_robin_schedule(
     return schedule
 
 
-def _standings_from_sim(
-    wins: dict[str, int],
+def standings_from_sim(
+    wins: dict[str, float],
     points: dict[str, float],
     owners: Iterable[str],
     *,
@@ -688,7 +688,7 @@ def compute_playoff_odds(
         # simulation (where it prevents the ownerId from becoming the answer)
         # and nowhere near a completed season. Passed explicitly so the choice
         # is visible at the call site rather than inherited from a default.
-        ordered = _standings_from_sim(
+        ordered = standings_from_sim(
             wins_snapshot, pf_snapshot, owners_in_league, ties=ties_snapshot, rng=None
         )
         made = set(ordered[:spots])
@@ -752,7 +752,7 @@ def compute_playoff_odds(
     # every owner made each matchup 100.0 vs 100.0, an exact tie, so every
     # simulation ended with identical wins, ties and points-for.
     #
-    # ``_standings_from_sim`` then broke that tie on its third key, the ownerId
+    # ``standings_from_sim`` then broke that tie on its third key, the ownerId
     # STRING.  Its docstring justifies that crude key on the grounds that
     # advanced tiebreakers "don't matter for probability at num_sims >= 10_000
     # when integrated over many draws" — true, but the placeholder destroys the
@@ -830,10 +830,10 @@ def compute_playoff_odds(
                     # Exact-tie simulation branch.  Both sides get a
                     # tie credited so downstream standings correctly
                     # rank (0-0-1) above (0-1-0) via the ``wins +
-                    # 0.5 * ties`` key in ``_standings_from_sim``.
+                    # 0.5 * ties`` key in ``standings_from_sim``.
                     sim_ties[a] = sim_ties.get(a, 0) + 1
                     sim_ties[b] = sim_ties.get(b, 0) + 1
-        ordered = _standings_from_sim(sim_wins, sim_pf, owners_in_league, ties=sim_ties, rng=rng)
+        ordered = standings_from_sim(sim_wins, sim_pf, owners_in_league, ties=sim_ties, rng=rng)
         for o in ordered[:spots]:
             made_counter[o] += 1
 

--- a/src/ros/championship.py
+++ b/src/ros/championship.py
@@ -37,7 +37,7 @@ import logging
 import random
 from typing import Any
 
-from src.public_league import metrics
+from src.public_league import metrics, playoff_odds
 from src.public_league.playoff_structure import resolve_playoff_structure
 from src.public_league.snapshot import PublicLeagueSnapshot
 from src.ros import ROS_DATA_DIR, playoff_sim
@@ -252,10 +252,12 @@ def simulate_championship_odds(
                 sim_wins[owner_a] = sim_wins.get(owner_a, 0.0) + 0.5
                 sim_wins[owner_b] = sim_wins.get(owner_b, 0.0) + 0.5
 
-        seeded = sorted(
-            owners,
-            key=lambda o: (-sim_wins.get(o, 0.0), -sim_pf.get(o, 0.0)),
-        )
+        # Seeding order comes from the CANONICAL owner — same rule the public
+        # engine and playoff_sim use, so three surfaces cannot disagree about
+        # who the 4-seed is.  The retired local sort resolved exact ties in
+        # alphabetical ownerId order (stable sort over a sorted owner list),
+        # which on a level league handed one owner 100% of championships.
+        seeded = playoff_odds.standings_from_sim(sim_wins, sim_pf, owners, rng=rng)
         finishes = _simulate_bracket(
             seeded,
             distributions,

--- a/src/ros/playoff_sim.py
+++ b/src/ros/playoff_sim.py
@@ -839,11 +839,14 @@ def simulate_playoff_odds(
                 sim_wins[owner_a] = sim_wins.get(owner_a, 0.0) + 0.5
                 sim_wins[owner_b] = sim_wins.get(owner_b, 0.0) + 0.5
 
-        # Sort: wins desc, PF tiebreak desc.
-        ranked = sorted(
-            owners,
-            key=lambda o: (-sim_wins.get(o, 0.0), -sim_pf.get(o, 0.0)),
-        )
+        # Standings order comes from the CANONICAL owner, not a local sort.
+        # This used to be a two-key ``sorted(owners, key=(-wins, -pf))``, and
+        # the third key was implicit: Python's sort is stable and ``owners``
+        # is ``sorted(distributions.keys())``, so exact ties resolved in
+        # ALPHABETICAL ownerId order.  Renaming an owner is not a football
+        # event.  ``rng`` is passed explicitly per W19-F008 — see the guard in
+        # tests/ros/test_standings_tiebreak.py.
+        ranked = playoff_odds.standings_from_sim(sim_wins, sim_pf, owners, rng=rng)
         for i, owner in enumerate(ranked):
             seed_counts[owner][i] += 1
             wins_total[owner] += sim_wins.get(owner, 0.0)

--- a/tests/public_league/test_playoff_odds.py
+++ b/tests/public_league/test_playoff_odds.py
@@ -311,14 +311,14 @@ class TieHandling(unittest.TestCase):
         wins = {"loser": 0, "tier": 0}
         points = {"loser": 1000.0, "tier": 500.0}
         ties = {"loser": 0, "tier": 1}
-        ordered = playoff_odds._standings_from_sim(wins, points, ["loser", "tier"], ties=ties)
+        ordered = playoff_odds.standings_from_sim(wins, points, ["loser", "tier"], ties=ties)
         self.assertEqual(ordered, ["tier", "loser"])
 
     def test_standings_uses_pf_tiebreak_when_record_matches(self) -> None:
         wins = {"a": 5, "b": 5}
         points = {"a": 1500.0, "b": 1200.0}
         ties = {"a": 1, "b": 1}
-        ordered = playoff_odds._standings_from_sim(wins, points, ["a", "b"], ties=ties)
+        ordered = playoff_odds.standings_from_sim(wins, points, ["a", "b"], ties=ties)
         self.assertEqual(ordered, ["a", "b"])
 
     def test_record_counts_tied_matchup(self) -> None:

--- a/tests/public_league/test_playoff_odds_no_fabricated_certainty.py
+++ b/tests/public_league/test_playoff_odds_no_fabricated_certainty.py
@@ -8,7 +8,7 @@ individually-defensible decisions then composed into a fabricated answer:
 
 1. every simulated matchup became ``100.0 vs 100.0`` — an exact tie, so every
    owner finished every simulation with identical wins, ties and points-for;
-2. ``_standings_from_sim`` breaks ties on ``(-(wins + 0.5*ties), -pointsFor,
+2. ``standings_from_sim`` breaks ties on ``(-(wins + 0.5*ties), -pointsFor,
    ownerId)`` — and its docstring justifies that crude third key on the
    grounds that advanced tiebreakers "don't matter for probability at
    num_sims >= 10_000 when integrated over many draws";
@@ -72,7 +72,7 @@ def test_identical_records_do_not_resolve_to_alphabetical_order():
     seen = set()
     rng = random.Random(11)
     for _ in range(50):
-        seen.add(tuple(_po._standings_from_sim(wins, points, owners, ties=ties, rng=rng)[:3]))
+        seen.add(tuple(_po.standings_from_sim(wins, points, owners, ties=ties, rng=rng)[:3]))
     assert len(seen) > 1, (
         "the top-3 was identical across 50 draws of an exactly-level league — "
         "the tiebreak is deterministic and has become the answer"
@@ -96,8 +96,8 @@ def test_relabelling_owners_does_not_change_who_qualifies():
     # Same seed, same records: reversing the ITERATION ORDER of the ids must
     # not change which of them qualifies. Renaming or reordering owners is not
     # a football event.
-    a = _po._standings_from_sim(wins, pts, list(ids), ties=ties, rng=random.Random(7))
-    b = _po._standings_from_sim(wins, pts, list(reversed(ids)), ties=ties, rng=random.Random(7))
+    a = _po.standings_from_sim(wins, pts, list(ids), ties=ties, rng=random.Random(7))
+    b = _po.standings_from_sim(wins, pts, list(reversed(ids)), ties=ties, rng=random.Random(7))
     assert sorted(a) == sorted(b), "the owner set itself changed"
     # Non-vacuity: an exactly-level league must not resolve to the id order.
     assert (
@@ -214,7 +214,7 @@ def test_the_recorded_production_output_is_the_alphabet():
 def test_the_simulation_loop_passes_an_rng_to_the_tiebreak():
     """Structural guard, in the repo's own idiom.
 
-    ``_standings_from_sim`` keeps an ownerId fallback for callers that pass no
+    ``standings_from_sim`` keeps an ownerId fallback for callers that pass no
     rng, so a future edit could silently drop the argument at the ONE call
     site that matters and reinstate the defect with every test still green.
     An AST check is how this repo pins that class of regression elsewhere
@@ -228,13 +228,13 @@ def test_the_simulation_loop_passes_an_rng_to_the_tiebreak():
     calls = [
         n
         for n in ast.walk(tree)
-        if isinstance(n, ast.Call) and getattr(n.func, "id", None) == "_standings_from_sim"
+        if isinstance(n, ast.Call) and getattr(n.func, "id", None) == "standings_from_sim"
     ]
-    assert calls, "no call to _standings_from_sim found — did it get renamed?"
+    assert calls, "no call to standings_from_sim found — did it get renamed?"
     for call in calls:
         kwargs = {k.arg for k in call.keywords}
         assert "rng" in kwargs, (
-            f"_standings_from_sim called without an explicit rng= at line "
+            f"standings_from_sim called without an explicit rng= at line "
             f"{call.lineno}. Every call site must STATE its tiebreak choice: a "
             "simulation passes the rng so the ownerId cannot become the "
             "answer; the final-standings path passes None because a completed "

--- a/tests/ros/test_standings_tiebreak.py
+++ b/tests/ros/test_standings_tiebreak.py
@@ -1,0 +1,278 @@
+"""Both private ROS simulators order standings through the CANONICAL tiebreak.
+
+THE DEFECT, reproduced before it was repaired.
+
+``ros/playoff_sim.py`` and ``ros/championship.py`` each sorted their
+simulated standings locally::
+
+    ranked = sorted(owners, key=lambda o: (-sim_wins.get(o, 0.0),
+                                           -sim_pf.get(o, 0.0)))
+
+Two keys — and the third was *implicit*.  Python's sort is stable and
+``owners`` is ``sorted(distributions.keys())``, so any pair the simulation
+could not separate resolved in **alphabetical ownerId order**.
+
+Measured on the fixture below (four owners the engine genuinely cannot
+separate: identical deterministic distributions, so every game is an exact
+tie and everyone finishes on equal wins AND equal points-for):
+
+===================  =========================  ==========================
+engine               before                     after
+===================  =========================  ==========================
+playoff odds (top 2) 1.00 / 1.00 / 0.00 / 0.00  ~0.50 each
+championship         1.00 / 0.00 / 0.00 / 0.00  ~0.25 each
+===================  =========================  ==========================
+
+and renaming the owners so alphabetical order reversed flipped the result
+exactly.  **Renaming an owner is not a football event.**
+
+THE REPAIR IS NOT A NEW RULE.  ``public_league.playoff_odds`` already owned
+this decision — W19-F008, 2026-08-18 — after the same defect was found in the
+public engine: the third key is a per-simulation RNG draw, so two teams the
+season could not separate split the outcome ~50/50 instead of 100/0 to
+whoever sorts first.  This unit routes the two ROS engines through that owner
+rather than adding a third opinion.  ``standings_from_sim`` was promoted from
+``_standings_from_sim`` to a public name because it now genuinely has three
+consumers; a private function borrowed across modules is not a shared owner.
+
+WHAT IS DELIBERATELY *NOT* ASSERTED: exact equality of per-owner odds under a
+fixed seed when the ids are permuted.  The jitter is drawn per owner in
+iteration order, so permuting the ids permutes which draw each owner gets.
+That is RNG stream position, not identifier semantics.  The property that
+matters — and that the defect violated — is that no owner's result is decided
+by where their id sorts.
+"""
+
+from __future__ import annotations
+
+import random
+import unittest.mock as mock
+from types import SimpleNamespace
+
+import pytest
+
+from src.public_league import playoff_odds
+from src.ros import championship, playoff_sim
+
+# ── the discriminating fixture ────────────────────────────────────────
+
+#: Four owners the simulator CANNOT separate.  ``sd=0.0`` makes every draw
+#: identical, so every matchup is an exact tie: equal wins (0.5 each, every
+#: week) and equal points-for.  Only the tiebreak can order them, which is
+#: what makes this fixture discriminating rather than merely realistic.
+_BASE_IDS = ["alice", "bob", "carol", "dave"]
+
+#: A permutation chosen so alphabetical order REVERSES.  If identifiers decide
+#: anything, this inverts the answer.
+_RENAMED = {"alice": "zeta", "bob": "yank", "carol": "xray", "dave": "west"}
+
+
+def _snapshot(playoff_teams: int):
+    return SimpleNamespace(
+        managers=SimpleNamespace(by_owner_id={}),
+        current_season=SimpleNamespace(
+            season="2026",
+            league_id="L1",
+            league={"settings": {"playoff_teams": playoff_teams, "playoff_week_start": 15}},
+            rosters=[],
+            matchups_by_week={},
+            regular_season_weeks=[],
+        ),
+    )
+
+
+def _level_league(names: list[str]):
+    """Distributions + a full round robin. Every game is an exact tie."""
+    dists = {
+        o: playoff_sim._TeamDist(owner_id=o, mean=100.0, sd=0.0, pf_to_date=0.0) for o in names
+    }
+    schedule = [
+        (1, names[i], names[j]) for i in range(len(names)) for j in range(i + 1, len(names))
+    ]
+    return dists, schedule
+
+
+def _run(engine: str, names: list[str], *, playoff_teams: int = 2, sims: int = 2000):
+    dists, schedule = _level_league(names)
+    with (
+        mock.patch.object(playoff_sim, "_current_record", lambda *a, **k: {o: {} for o in names}),
+        mock.patch.object(playoff_sim, "_remaining_schedule", lambda *a, **k: schedule),
+        mock.patch.object(playoff_sim, "_load_ros_strength_map", lambda: {}),
+        mock.patch.object(playoff_sim, "_league_best_ball", lambda: False),
+        mock.patch.object(
+            playoff_sim,
+            "_build_team_distributions",
+            lambda *a, **k: (dists, {o: 0.0 for o in names}),
+        ),
+    ):
+        if engine == "playoff":
+            out = playoff_sim.simulate_playoff_odds(
+                _snapshot(playoff_teams), n_simulations=sims, rng=random.Random(11)
+            )
+            return {r["ownerId"]: r["playoffOdds"] for r in out["playoffOdds"]}
+        out = championship.simulate_championship_odds(
+            _snapshot(playoff_teams), n_simulations=sims, rng=random.Random(11)
+        )
+        return {r["ownerId"]: r["championshipOdds"] for r in out["championshipOdds"]}
+
+
+# ── behavioural: the alphabet is not the answer ───────────────────────
+
+
+@pytest.mark.parametrize(
+    "engine,expected",
+    [("playoff", 0.50), ("champ", 0.25)],
+)
+def test_a_level_league_is_not_resolved_by_the_alphabet(engine, expected):
+    """Four owners nothing can separate must SHARE the outcome.
+
+    Under the defect this returned 1.00/1.00/0.00/0.00 (playoff) and
+    1.00/0.00/0.00/0.00 (championship) — certainty and impossibility
+    manufactured out of the id order.
+    """
+    odds = _run(engine, _BASE_IDS)
+
+    assert set(odds) == set(_BASE_IDS)
+    for owner, value in odds.items():
+        assert 0.0 < value < 1.0, (
+            f"{owner} got a structurally certain/impossible {value} on a league "
+            f"where every team is identical: {odds}"
+        )
+        assert abs(value - expected) < 0.08, f"{owner}={value}, expected ≈{expected}: {odds}"
+
+
+@pytest.mark.parametrize("engine", ["playoff", "champ"])
+def test_renaming_the_owners_does_not_move_the_odds(engine):
+    """The invariance that names the defect.
+
+    Same teams, same seed, same schedule — only the identifiers change, and
+    they change so that alphabetical order REVERSES.  Under the defect this
+    inverted the result completely.
+    """
+    before = _run(engine, _BASE_IDS)
+    after = _run(engine, [_RENAMED[o] for o in _BASE_IDS])
+
+    for owner in _BASE_IDS:
+        a, b = before[owner], after[_RENAMED[owner]]
+        assert abs(a - b) < 0.10, (
+            f"renaming {owner} -> {_RENAMED[owner]} moved its odds {a} -> {b}. "
+            "A rename is not a football event."
+        )
+
+
+# ── the canonical owner is actually consumed ──────────────────────────
+
+
+@pytest.mark.parametrize("engine", ["playoff", "champ"])
+def test_both_engines_consume_the_canonical_tiebreak(engine):
+    """Consumption proof, not a shape assertion.
+
+    Spies on the canonical function itself, so a future edit that
+    reintroduces a local sort fails here even if the numbers happen to
+    look plausible.
+    """
+    calls: list[dict] = []
+    real = playoff_odds.standings_from_sim
+
+    def _spy(wins, points, owners, **kwargs):
+        calls.append({"owners": list(owners), "kwargs": set(kwargs)})
+        return real(wins, points, owners, **kwargs)
+
+    with mock.patch.object(playoff_odds, "standings_from_sim", _spy):
+        _run(engine, _BASE_IDS, sims=25)
+
+    assert calls, "the engine ordered its standings without the canonical owner"
+    for call in calls:
+        assert "rng" in call["kwargs"], (
+            "the canonical tiebreak was called WITHOUT an rng, which falls back "
+            "to the ownerId — the exact defect this unit removes"
+        )
+
+
+def test_the_canonical_owner_has_one_name():
+    """``standings_from_sim`` is public because it has three consumers now.
+
+    A private ``_``-prefixed function imported across module boundaries is a
+    borrowed implementation, not a shared owner — and an alias for the old
+    name would be a second name for one concept.
+    """
+    assert hasattr(playoff_odds, "standings_from_sim")
+    assert not hasattr(
+        playoff_odds, "_standings_from_sim"
+    ), "the old private name survives as an alias — one owner, one name"
+
+
+# ── structural guard ──────────────────────────────────────────────────
+
+_ROS_ENGINES = ("src/ros/playoff_sim.py", "src/ros/championship.py")
+
+
+def _bracket_modules():
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    return [(rel, (root / rel).read_text(encoding="utf-8")) for rel in _ROS_ENGINES]
+
+
+def test_no_ros_engine_sorts_its_own_standings():
+    """Structural guard, in the repo's idiom (cf. the lineup no-greedy test).
+
+    The behavioural tests above can be satisfied by a local sort that happens
+    to include a jitter key — which would be a SECOND owner of the tiebreak,
+    free to drift from the public engine's. This asserts the absence of the
+    local sort itself.
+
+    Scoped to sorting the OWNER list: these modules legitimately sort seasons
+    and other collections.
+    """
+    import ast
+
+    offenders = []
+    for rel, src in _bracket_modules():
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call) and getattr(node.func, "id", None) == "sorted"):
+                continue
+            if not node.args:
+                continue
+            first = node.args[0]
+            names = {n.id for n in ast.walk(first) if isinstance(n, ast.Name)}
+            if names & {"owners", "seeded_owners", "ranked", "seeded"}:
+                offenders.append(f"{rel}:{node.lineno}: local sort of the owner list")
+    assert not offenders, (
+        "a ROS engine is ordering owners itself again. Standings order has one "
+        "owner — playoff_odds.standings_from_sim:\n" + "\n".join(offenders)
+    )
+
+
+def test_ros_engines_state_their_tiebreak_choice():
+    """Every call site must pass ``rng=`` EXPLICITLY.
+
+    The canonical function keeps an ownerId fallback for callers that pass no
+    rng (a completed season needs no coin flip). A simulation that silently
+    dropped the argument would reinstate the defect with the behavioural tests
+    still green if they ever weakened, so the argument is pinned structurally
+    — the same posture the public engine's own guard takes.
+    """
+    import ast
+
+    total = 0
+    for rel, src in _bracket_modules():
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = getattr(func, "attr", None) or getattr(func, "id", None)
+            if name != "standings_from_sim":
+                continue
+            total += 1
+            assert "rng" in {k.arg for k in node.keywords}, (
+                f"{rel}:{node.lineno}: standings_from_sim called without an "
+                "explicit rng= — that path falls back to the ownerId"
+            )
+    assert total == len(_ROS_ENGINES), (
+        f"expected one canonical standings call per ROS engine, found {total}. "
+        "If an engine stopped ordering standings, say so here; if it was "
+        "renamed, this guard is now blind."
+    )


### PR DESCRIPTION
## What this is

The second defect the #930 audit named, as its own unit. #930 is merged and untouched by this PR.

**Reproduced first, not taken on trust from the note — and it is worse than the note claimed.**

## The defect

`ros/playoff_sim.py` and `ros/championship.py` each ordered their simulated standings with a **local two-key sort**:

```python
sorted(owners, key=lambda o: (-sim_wins.get(o, 0.0), -sim_pf.get(o, 0.0)))
```

The third key was never written down. Python's sort is stable and `owners` is `sorted(distributions.keys())`, so any pair the simulation could not separate resolved in **alphabetical ownerId order**.

## Measured, on a fixture built to discriminate

Four owners with **identical deterministic distributions** (`sd=0.0`) and a full round robin — so every game is an exact tie and everyone finishes on equal wins **and** equal points-for. Nothing but the tiebreak can order them.

| engine | before | after |
|---|---|---|
| playoff odds (top 2 of 4) | `1.00 / 1.00 / 0.00 / 0.00` | **~0.50 each** |
| championship (top-2 bracket) | `1.00 / 0.00 / 0.00 / 0.00` | **~0.25 each** |

Then renaming the owners so alphabetical order **reverses** inverted both results exactly. A rename is not a football event.

Note what that means on the championship side: on a league the model considers level, **one owner was taking 100% of championships**, selected by their id.

## No new rule was invented, and none needed to be

`public_league.playoff_odds` **already owned this decision** — **W19-F008, 2026-08-18** — recorded after the identical defect was found in the *public* engine. Its policy: the third key is a per-simulation RNG draw, so two teams the season could not separate split the outcome ~50/50 rather than 100/0 to whoever sorts first. Its docstring states the reasoning, and it already carries its own AST guard.

This PR routes the two ROS engines through that owner instead of adding a third opinion.

`_standings_from_sim` is promoted to **`standings_from_sim`**. It has three consumers now, and a private function imported across module boundaries is a borrowed implementation rather than a shared owner. **Deliberately no back-compat alias** — an alias is a second name for one concept, and the public engine's existing *"no call found — did it get renamed?"* assertion is what makes the rename safe to do mechanically. The `wins` annotation widens to `float` because the ROS engines fold ties in as 0.5 before the call.

`playoff_odds` imports nothing from `ros`, so there is no circularity; `playoff_sim` already imported it.

## What was deliberately NOT added

**The league publishes no tiebreak setting at all.** Checked against the committed capture `data/sleeper_last_good.json`: `playoff_teams: 7`, `playoff_seed_type: 1`, and nothing bearing on ties. Sleeper exposes none.

The **observed**-standings ladder (`metrics.season_standings`) continues past PF to points-against and then `sleeperRank` — but `sleeperRank` cannot exist for a season that has not been played, and the ROS sim tracks no points-against. Extending the **simulated** ladder is a methodology change requiring evidence, so **the gap is named rather than closed by guesswork**. This PR adds no key.

## Tests — 9 in `tests/ros/test_standings_tiebreak.py`

| kind | test |
|---|---|
| behavioural | a level league is not resolved by the alphabet (both engines) — asserts no owner is structurally certain *or* impossible |
| behavioural | renaming the owners does not move the odds |
| consumption | a **spy on the canonical function** proves both engines actually call it, so a plausible-looking local sort cannot pass |
| one name | the old private name must not survive as an alias |
| structural | neither ROS engine sorts the owner list itself |
| structural | every call site states `rng=` **explicitly** |

That last guard matters because the canonical function keeps an ownerId fallback for the completed-season caller that legitimately needs no coin flip — so a silently dropped argument would reinstate the defect while still calling the right owner.

### Mutations — each turns tests RED

| mutation | result |
|---|---|
| revert `playoff_sim` to the local lexical sort | **5 red** |
| revert `championship` to the local lexical sort | **5 red** |
| drop `rng=` (still calls the owner; re-enables its lexical fallback) | **4 red** |
| re-add the old private name as an alias | **1 red** |

### What is *not* asserted, and why

Exact per-owner equality under a fixed seed when ids are permuted. The jitter is drawn per owner in **iteration order**, so permuting ids permutes which draw each owner gets — that is RNG stream position, not identifier semantics. The tests assert the property the defect actually violated, and the canonical owner's own test takes the same posture.

## #930 preserved

Its 37 bracket tests pass unchanged, including the live **7-team fix** and the legacy **6-team control**. This branch was cut from #930's head, so that work arrives via `main`.

**Not broadened:** the `>8`-team bracket collapse recorded on #930 is untouched (it needs more than two rounds; this league plays 7 → 4 → 2). No Power work is included. **V1-52 remains IN PROGRESS** — Step 5 is not started.

## Verification

| gate | result |
|---|---|
| `pytest tests/ -m "not livedata"` | **8,422 passed · 51 skipped · 0 failed** |
| `pytest tests/api -m "not livedata"` | 2,005 passed, 0 failed |
| `pytest tests/ros tests/public_league` | 580 passed, 1 skipped |
| `python -m ruff format --check .` / `check .` | clean (1,172 files) |
| `scripts/check_decision_coercions.py` | clean — run **post-commit** |
| `scripts/validate_api_contract.py --lane structural` | `ok=True`, `structuralErrors=0` |
| `scripts/check_planning_integrity.py` | clean |

A wider run that omitted the marker showed 13 failures; all were **livedata** (the advisory lane) and none reproduce under the hard gate's own marker — confirmed both by the full run above and by `tests/api -m "not livedata"` passing clean.

**Not deployed, and production verification has not been done.** This moves live playoff and championship numbers for any exactly-level pair — that is the point of it, and it should be observed rather than assumed.

Not self-merging, per the integration-authority rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnuUUPc6Xx2QCjtkqRsa3k)_