### PR TITLE
V1-64 micro-unit: deterministic L1 pin for oldestCrawlMs

### DIFF
--- a/tests/sharp/test_record_queue.py
+++ b/tests/sharp/test_record_queue.py
@@ -1,3 +1,8 @@
+import json
+
+import pytest
+
+from src.sharp import record_queue
 from src.sharp.record_queue import prioritize_league_ids
 
 
@@ -28,3 +33,98 @@ def test_invalid_crawl_timestamp_is_treated_as_uncrawled() -> None:
             "league-c": None,
         },
     ) == ["league-a", "league-c", "league-b"]
+
+
+# ── queue_stats: the staleness figure operators actually read ───────
+#
+# ``oldestCrawlMs`` had no deterministic coverage on either producer
+# (`record_queue.queue_stats` and `transactions.crawl_coverage`), so the
+# property was confirmed by reading the source. These pin it.
+
+
+@pytest.fixture()
+def ledger_db(tmp_path, monkeypatch):
+    from src.intel import ledger, store
+
+    monkeypatch.setattr(store, "DATA_DIR", tmp_path / "intel")
+    ledger.reset_setup_cache()
+    yield tmp_path / "intel" / ledger.LEDGER_FILENAME
+    ledger.reset_setup_cache()
+
+
+def _seed(path, leagues, crawls):
+    """``leagues``: {league_id: sharp_eligible}.  ``crawls``: {league_id: ms}."""
+    from src.intel import ledger
+
+    conn = ledger.connect(path)
+    try:
+        for league_id, eligible in leagues.items():
+            conn.execute(
+                "INSERT OR REPLACE INTO leagues(league_id, settings_json) VALUES (?, ?)",
+                (league_id, json.dumps({"sharpEligible": bool(eligible)})),
+            )
+        for index, (league_id, crawled_ms) in enumerate(crawls.items()):
+            conn.execute(
+                "INSERT OR REPLACE INTO manager_seasons"
+                "(league_id, season, user_id, crawled_ms) VALUES (?, ?, ?, ?)",
+                (league_id, "2026", f"u{index}", crawled_ms),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_oldest_crawl_is_the_minimum_not_the_most_recent(ledger_db) -> None:
+    """The figure answers "how stale is the STALEST league".
+
+    Publishing the newest instead would make a badly-lagging queue look
+    current — the reassuring direction, and therefore the one that goes
+    unnoticed. ``newestCrawlMs`` is published beside it precisely so the two
+    questions stay separate, and this asserts they are not the same number.
+    """
+    _seed(
+        ledger_db,
+        {"L1": True, "L2": True, "L3": True},
+        {"L1": 300, "L2": 100, "L3": 200},
+    )
+    stats = record_queue.queue_stats(ledger_path=ledger_db)
+    assert stats["crawledLeagues"] == 3, "fixture must crawl three leagues or it proves nothing"
+    assert stats["oldestCrawlMs"] == 100
+    assert stats["newestCrawlMs"] == 300
+    assert stats["oldestCrawlMs"] != stats["newestCrawlMs"]
+
+
+def test_no_crawled_league_publishes_none_never_zero(ledger_db) -> None:
+    """MISSING IS NEVER ZERO, on the axis where zero is the worst value.
+
+    These are epoch milliseconds, so ``0`` is 1970 — the oldest timestamp
+    expressible. "We have never crawled anything" would render as "our crawl
+    is 56 years stale", and any consumer comparing against a staleness budget
+    would read an absence as a maximal alarm.
+    """
+    _seed(ledger_db, {"L1": True, "L2": True}, {})
+    stats = record_queue.queue_stats(ledger_path=ledger_db)
+    assert stats["crawledLeagues"] == 0
+    assert stats["oldestCrawlMs"] is None
+    assert stats["newestCrawlMs"] is None
+    assert stats["oldestCrawlMs"] != 0
+    # The denominator survives, so "nothing crawled" keeps its own scale and
+    # cannot read as "nothing eligible".
+    assert stats["eligibleLeagues"] == 2
+    assert stats["uncrawledLeagues"] == 2
+
+
+def test_a_crawl_for_an_ineligible_league_does_not_move_the_oldest(ledger_db) -> None:
+    """The figure is scoped to the SHARP-ELIGIBLE set.
+
+    An older crawl of a league outside that set must not drag the number
+    down, or the queue would report staleness it is not responsible for.
+    """
+    _seed(
+        ledger_db,
+        {"L1": True, "L2": False},
+        {"L1": 500, "L2": 1},
+    )
+    stats = record_queue.queue_stats(ledger_path=ledger_db)
+    assert stats["eligibleLeagues"] == 1
+    assert stats["oldestCrawlMs"] == 500

--- a/tests/sharp/test_transactions.py
+++ b/tests/sharp/test_transactions.py
@@ -99,6 +99,26 @@ def _crawl(responses, league_ids=("L1",), ledger_path=None, budget=100, now_ms=N
     return result, http
 
 
+def _fetch_stamps(ledger_path):
+    """The ``last_fetched_ms`` values actually stored, read back from the DB.
+
+    Deliberately read from the ledger rather than assumed from the ``now_ms``
+    the fixture passed in: the assertion is about what ``crawl_coverage``
+    summarises, so its comparison set has to be the same rows it reads.
+    """
+    conn = ledger.connect(ledger_path)
+    try:
+        return [
+            int(row["last_fetched_ms"])
+            for row in conn.execute(
+                "SELECT last_fetched_ms FROM sharp_league_fetch WHERE backfilled = 1"
+            ).fetchall()
+            if row["last_fetched_ms"] is not None
+        ]
+    finally:
+        conn.close()
+
+
 class TestItActuallyIngests:
     def test_a_trade_lands_in_the_ledger(self, db):
         result, _ = _crawl(responses_for(), ledger_path=db)
@@ -254,6 +274,59 @@ class TestCoverageHonesty:
         assert cov["sharpEligibleLeagues"] == 2
         assert cov["leaguesCrawled"] == 1
         assert cov["leaguesUncrawled"] == 1
+
+    def test_oldest_crawl_is_the_minimum_not_the_most_recent(self, db, monkeypatch):
+        """``oldestCrawlMs`` answers "how stale is the STALEST league".
+
+        It is the number an operator reads to decide whether the crawl is
+        keeping up, so publishing the newest timestamp instead would make a
+        badly-lagging crawl look current — the reassuring direction, which is
+        the one that goes unnoticed.
+
+        Three leagues crawled a day apart: the answer must be the oldest of
+        the three, and must not equal the newest.
+        """
+        monkeypatch.setattr(
+            transactions.discovery,
+            "sharp_eligible_league_ids",
+            lambda *, ledger_path=None: ["L1", "L2", "L3"],
+        )
+        for league, when in (("L1", NOW), ("L2", NOW - DAY_MS), ("L3", NOW - 2 * DAY_MS)):
+            _crawl(responses_for(league), league_ids=[league], ledger_path=db, now_ms=when)
+
+        cov = transactions.crawl_coverage(ledger_path=db)
+        stamps = _fetch_stamps(db)
+        assert len(stamps) == 3, "the fixture must crawl three leagues or it proves nothing"
+        assert cov["oldestCrawlMs"] == min(stamps)
+        assert cov["oldestCrawlMs"] != max(
+            stamps
+        ), "min and max coincide, so this fixture cannot tell them apart"
+        # ...and the denominator behaviour already pinned above is untouched.
+        assert cov["sharpEligibleLeagues"] == 3
+        assert cov["leaguesCrawled"] == 3
+
+    def test_no_crawled_league_publishes_none_never_zero(self, db, monkeypatch):
+        """MISSING IS NEVER ZERO, on the axis where zero is worst.
+
+        ``oldestCrawlMs`` is an epoch millisecond, so ``0`` is 1970 — the
+        oldest timestamp expressible. "We have never crawled anything" would
+        therefore render as "our crawl is 56 years stale", and any consumer
+        comparing against a staleness budget would read the empty state as a
+        maximal alarm rather than as an absence.
+        """
+        monkeypatch.setattr(
+            transactions.discovery,
+            "sharp_eligible_league_ids",
+            lambda *, ledger_path=None: ["L1", "L2"],
+        )
+        cov = transactions.crawl_coverage(ledger_path=db)
+        assert cov["leaguesCrawled"] == 0
+        assert cov["oldestCrawlMs"] is None
+        assert cov["oldestCrawlMs"] != 0
+        # The denominator is still stated, so "nothing crawled" keeps its
+        # own denominator and cannot read as "nothing eligible".
+        assert cov["sharpEligibleLeagues"] == 2
+        assert cov["leaguesUncrawled"] == 2
 
 
 class TestWaiverSeparation:


### PR DESCRIPTION
**READY FOR INTEGRATION — Claude 5 merges. I do not.** Off current `main`, independent of #927/#932, which stay **frozen** at `07482b9b8` / `c795381ba`.

**Tests only.** `git diff origin/main --name-only` is two files:

```
tests/sharp/test_record_queue.py
tests/sharp/test_transactions.py
```

No product source, no methodology, no cohort, no auth, no verifier expansion, no V1 contract edit, no #927/#932 edit.

---

## Why the row was half-open

V1-64's contract note says the property was *"confirmed rather than changed"* — `oldestCrawlMs` is `min(timestamps) if timestamps else None`, "`None`, never `0`". That was confirmed **by reading the source**: an audit found **zero** references to `oldestCrawlMs` anywhere in `tests/`. L1 asks for a RED→GREEN test at exact head, so half the row's evidence did not exist.

`sharpEligibleLeagues` was already pinned (`test_coverage_separates_crawled_from_eligible`) and is left intact.

## Both producers, because they are separate implementations of one published field

| module | implementation |
|---|---|
| `record_queue.queue_stats` | `min(timestamps) if timestamps else None` |
| `transactions.crawl_coverage` | SQL `MIN(last_fetched_ms)`, guarded to `None` |

## Three properties, each with why it matters

**The minimum, not the most recent.** The figure answers *"how stale is the **stalest** league"* — it is what an operator reads to decide whether the crawl is keeping up. Publishing the newest instead would make a badly-lagging crawl look **current**: the reassuring direction, and therefore the one that goes unnoticed. Both tests assert the value equals the minimum **and differs from the maximum**, so a fixture where the two coincide cannot pass by accident.

**`None`, never `0` — on the axis where zero is the *worst* value.** These are epoch milliseconds, so `0` is 1970. "We have never crawled anything" would render as *"our crawl is 56 years stale"*, and any consumer comparing against a staleness budget would read an **absence** as a **maximal alarm**.

**The denominator survives the empty state.** `sharpEligibleLeagues` / `leaguesCrawled` / `leaguesUncrawled` (and `eligibleLeagues` / `uncrawledLeagues` on the queue side) are re-asserted alongside, so "nothing crawled" keeps its own scale and cannot read as "nothing eligible".

Plus scoping: a crawl of a league **outside** the sharp-eligible set must not drag the figure down, or the queue reports staleness it does not own.

## Mutation proof — all four, both producers, restored after each

| mutation | module | result |
|---|---|---|
| `min(...)` → `max(...)` | `record_queue` | **1 failed** |
| empty-state `None` → `0` | `record_queue` | **1 failed** |
| SQL `MIN(...)` → `MAX(...)` | `transactions` | **1 failed** |
| empty-state `None` → `0` | `transactions` | **1 failed** |
| baseline / restored | both | **27 passed** |

`git diff src/` is empty after the sweep — production code was restored each time.

One detail worth knowing: the coverage assertion reads the stored `last_fetched_ms` rows **back out of the ledger** rather than assuming the `now_ms` the fixture passed in. The claim is about what `crawl_coverage` summarises, so its comparison set has to be the same rows it reads.

## Why this fully satisfies V1-64's L1 requirement

L1 is *"RED→GREEN test at exact head, plus green CI on the merge tree."* The row's two published properties are `sharpEligibleLeagues` (already pinned) and `oldestCrawlMs` (pinned here, on both producers, with the empty state and the ordering direction each proven to be able to go red). No production, auth or on-box step is required for this row and none is invented here.

**I am not marking V1-64 `VERIFIED`** — that is Integration's call once this is on the green merge tree.

## Production code unchanged — no defect found

Nothing was rewritten. One edge observed and deliberately left alone, named rather than silently passed over: a genuine `last_fetched_ms == 0` is reported as `None` by the transactions guard. `0` ms is 1970 and not a plausible crawl timestamp, and treating it as *unknown* is the fail-safe direction — changing it would be a product change this unit is not authorised to make.

## Verification

| check | result |
|---|---|
| `tests/sharp` | **293 passed** |
| new pins, mutation sweep | 4/4 detected, both directions, both producers |
| `ruff check` / `format --check` | clean, 1193 files |
| `check_decision_coercions.py` | clean |
| `check_release_candidate.py` | the validated tree IS the tree that will merge |
| diff scope | two test files; no product source |

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqEBEngbUtzXsbHRYrPLkF)_