### PR TITLE
Lane 7 dispatch records: de-authorise the derived V1 tally, three abandoned refs, Lane 2 idle on undelivered work

### DIFF
--- a/docs/claude-dispatch/ASSIGNMENTS.json
+++ b/docs/claude-dispatch/ASSIGNMENTS.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Durable dispatch ledger written by Claude 7 (Lane Dispatcher). One PRIMARY assignment per lane. An ACTIVE row is never overwritten and a second task is never piled onto an unread one. Claude 7 does not merge, does not implement, and does not change V1 status.",
-  "updatedAt": "2026-08-20T03:12:00Z",
+  "updatedAt": "2026-08-20T05:25:00Z",
   "cycle": 17,
   "writePolicy": "Written only on a material state transition. An unchanged heartbeat produces no commit and no CI run.",
   "_delivery": {
@@ -292,5 +292,6 @@
       "correction": "C11-1 said the constraint stack supports V1-130 only and that counting V1-34 too was 'wrong by one'. The observation (no writer for tradeConstraintsByLeague, so no operable user control) stands, but the conclusion was too strong: V1-34's contract level is L1, and L1 requires a deterministic RED->GREEN plus merge-tree green, NOT a production consumer. Claude 5 promoted it on three mutations performed at Integration with six named REDs. My warning was itself wrong by one.",
       "whatSurvives": "An argument that V1-34 ought to need a production consumer is an argument to RE-LEVEL the row to L4 — an owner decision — not an argument against the promotion."
     }
-  ]
+  ],
+  "_authorityNote": "This ledger owns dispatch assignments only. It does not own V1 status, integration sequencing or canonical ownership. Any V1 figure appearing in an assignment rationale is a derived reading of docs/VERSION_1_COMPLETION_CONTRACT.md §3 at the SHA named beside it."
 }

--- a/docs/claude-dispatch/ASSIGNMENTS.json
+++ b/docs/claude-dispatch/ASSIGNMENTS.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Durable dispatch ledger written by Claude 7 (Lane Dispatcher). One PRIMARY assignment per lane. An ACTIVE row is never overwritten and a second task is never piled onto an unread one. Claude 7 does not merge, does not implement, and does not change V1 status.",
-  "updatedAt": "2026-08-20T05:25:00Z",
-  "cycle": 17,
+  "updatedAt": "2026-08-20T12:05:00Z",
+  "cycle": 30,
   "writePolicy": "Written only on a material state transition. An unchanged heartbeat produces no commit and no CI run.",
   "_delivery": {
     "state": "DELIVERY_REQUIRED — one assignment released and awaiting delivery",
@@ -123,7 +123,7 @@
     }
   ],
   "currentAssignmentsManual": {
-    "_note": "Made by the owner directly, not by this dispatcher. Recorded so durable state matches reality. Claude 7 does not own or re-scope these; it monitors them and will not assign over them.",
+    "_note": "Made by the owner directly, not by this dispatcher. Recorded so durable state matches reality. Claude 7 does not own or re-scope these; it monitors them and will not assign over them. This block covers ONLY lanes 1-6 (the original V1 sprint assignments this dispatcher tracks in detail). Five more owner-authorized lanes exist — Claude 8 (Source Acquisition + Cross-Position Bridge, chartered 2026-08-20, V1-scoped) and Claude 9-13 (the POST-V1 C-Series mass-build campaign, chartered 2026-08-20, EXECUTION_PLAN.md §0). Those five are self-directed under their own charter and are tracked lightly in LANE_STATUS.json (lanes 8-13) for awareness, not assignment. There is no lane 7: Claude 7 is this dispatcher, per EXECUTION_PLAN.md's own text ('Lane 7 is not missing... nothing here creates one').",
     "1": {
       "task": "V1-29 (#933) + Roster verification pack (#925, now chain head)",
       "status": "ACTIVE",
@@ -293,5 +293,11 @@
       "whatSurvives": "An argument that V1-34 ought to need a production consumer is an argument to RE-LEVEL the row to L4 — an owner decision — not an argument against the promotion."
     }
   ],
-  "_authorityNote": "This ledger owns dispatch assignments only. It does not own V1 status, integration sequencing or canonical ownership. Any V1 figure appearing in an assignment rationale is a derived reading of docs/VERSION_1_COMPLETION_CONTRACT.md §3 at the SHA named beside it."
+  "_authorityNote": "This ledger owns dispatch assignments only. It does not own V1 status, integration sequencing or canonical ownership. Any V1 figure appearing in an assignment rationale is a derived reading of docs/VERSION_1_COMPLETION_CONTRACT.md §3 at the SHA named beside it.",
+  "governanceCorrection_C30": {
+    "trigger": "Issue #967 — dispatch registry missing lanes 8 and 9-13.",
+    "whatChanged": "currentAssignmentsManual._note rewritten to state the assignment ledger covers lanes 1-6 only and name the five additional owner-authorized lanes without claiming dispatch authority over them. No assignment rows added for 8-13 — this dispatcher does not originate their work.",
+    "companionEdit": "docs/claude-dispatch/LANE_STATUS.json — full detail, including dispatcherIdentity block and lanes 8-13 entries.",
+    "noV1Edit": "This correction touches no V1 status, denominator, or product/governance file outside the two dispatcher-owned records named above."
+  }
 }

--- a/docs/claude-dispatch/LANE_STATUS.json
+++ b/docs/claude-dispatch/LANE_STATUS.json
@@ -1,16 +1,16 @@
 {
   "_comment": "Lane utilization state, owned by Claude 7 (Lane Dispatcher). NOT an authority on integration sequencing (Claude 5 / docs/EXECUTION_PLAN.md), on V1 status (docs/VERSION_1_COMPLETION_CONTRACT.md) or on canonical ownership (CLAUDE.md). Repository evidence outranks this file: where they disagree, this file is wrong and must be corrected.",
-  "updatedAt": "2026-08-20T03:57:00Z",
-  "dispatchCycle": 18,
+  "updatedAt": "2026-08-20T04:40:00Z",
+  "dispatchCycle": 19,
   "writePolicy": "This file and ASSIGNMENTS.json are written ONLY on a material state transition — new assignment, assignment accepted, completion, blocker, freeze/unfreeze, or a meaningful dependency change. A heartbeat that finds nothing changed produces no commit and no CI run.",
-  "evidenceBasis": "origin/main 21b4db386; V1 §3 diffed main-to-main (b8ca95f4f -> 21b4db386) per row; all refs resolved live",
+  "evidenceBasis": "origin/main c5a367266; §3 diffed row-by-row from cycle-18 main (21b4db386); all refs resolved live; dispatcher branch rotated after #928 merged",
   "assignmentSourceNote": "The six current assignments were made manually by the owner, not by this dispatcher. Recorded here so the durable state matches reality; Claude 7 did not originate them and does not own them.",
   "v1": {
     "requiredRows": 132,
-    "verified": 47,
-    "percent": 35.6,
-    "source": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 on origin/main 21b4db386",
-    "note": "45 -> 47 via #941. Row-diffed rather than assumed: V1-34 NOT STARTED -> VERIFIED (L1) and V1-130 NOT STARTED -> VERIFIED (L2), plus two corrections in the honest direction — V1-51 -> IN PROGRESS and V1-95 -> IMPLEMENTED_UNVERIFIED. Net since the session began: 40 -> 47."
+    "verified": 48,
+    "percent": 36.4,
+    "source": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 on origin/main c5a367266",
+    "note": "47 -> 48 via #942. EXACTLY ONE row changed and it was verified in the table: V1-95 IMPLEMENTED_UNVERIFIED -> VERIFIED at L2. Its note carries both halves the level demands — L1 with two mutations each confirmed APPLIED and the changed line quoted, plus a measured statement on the DEPLOYED build. Session net: 40 -> 48."
   },
   "lanes": {
     "1": {
@@ -50,7 +50,7 @@
       "pr": null,
       "implementationHead": "n/a — nothing in flight",
       "releaseCandidate": "n/a",
-      "evidence": "no V1-43 branch exists; last Lane 2 activity 00:18Z",
+      "evidence": "still no V1-43 branch at 04:38Z; last Lane 2 activity 00:18Z — ~4h20m",
       "blockedBy": "ASSIGNMENT DELIVERY. L2-2026-08-19-02 is DELIVERY_REQUIRED and no agent channel is reachable from this dispatcher.",
       "doNotTouch": [
         "src/roster_intel/**",
@@ -61,13 +61,13 @@
       "nextSafeWork": "V1-43 Analyze Trade V1, branching from PLAIN MAIN — the stacked base is gone because #913 and #929 both merged. Assignment L2-2026-08-19-02 amended.",
       "lastMeaningfulActivity": "2026-08-20T00:18:00Z",
       "assignedThisCycle": "L2-2026-08-19-02 re-amended (base = main) — still DELIVERY_REQUIRED",
-      "idleMinutes": 217,
+      "idleMinutes": 260,
       "openPrs": [],
       "mergedThisCycle": [
         929
       ],
       "policyState": "ACTIONABLE_IDLE — holds an unstarted dependency-ready unit",
-      "policyStateDetail": "No open PR, nothing frozen, V1-43 unstarted and unblocked on plain main. Rule 8's freeze does not apply because there is nothing handed off. This is the one lane the 10-minute rule covers, and it has been idle ~3h37m."
+      "policyStateDetail": "No open PR, nothing frozen, V1-43 unstarted and unblocked on plain main. Rule 8's freeze does not apply. Idle ~4h20m and the cause is delivery, not the lane."
     },
     "3": {
       "name": "Scoring / Season / Projections / Power",
@@ -130,25 +130,22 @@
       "assignmentSource": "n/a — sole integration authority, never tasked by this dispatcher",
       "branch": null,
       "mergedThisCycle": [
-        915,
-        925,
-        935,
-        941
+        928,
+        942
       ],
       "implementationHead": "n/a",
       "releaseCandidate": "NOT_YET_FROZEN",
-      "evidence": "main 47/132; Lane 5 branch live again at f8060ef1e (5 ahead, 3 behind)",
+      "evidence": "main 48/132; Lane 5 branch live at ddf42e271 (25 behind main)",
       "blockedBy": null,
       "doNotTouch": [],
       "nextSafeWork": "its own sequencing",
       "reportedToIntegration": [
-        "V1 is 47/132 (35.6%), row-verified. Net +7 since this session began.",
-        "RULE 7 IS NOW BEING BREACHED, not just strained: rc-937 is 79 behind main and rc-wave-a 76 behind. Retire both — their content merged individually and they are now exactly the second long-lived source of truth the rule forbids.",
-        "THE BIGGEST REMAINING LEVER IS STILL UNRUN: the Lane-4 on-box verification batch (V1-57, V1-129, V1-60). The verifier is on main, needs host access only, no HTTP auth. It is worth more numerator than any remaining implementation and nobody has run it.",
-        "Lane 2 is idle with V1-43 unstarted and unblocked. The blocker is assignment delivery, not the lane.",
-        "V1-42 still reads NOT STARTED although #913's W3 supplied the consumer it lacked.",
-        "V1-88 remains correctly unpromoted.",
-        "origin/v1/premium-ui duplicates #912's head SHA exactly — worth deleting so branch attribution stays unambiguous."
+        "V1 is 48/132 (36.4%), row-verified. Session net +8. V1-95's promotion is the cleanest of the night: L1 mutations each confirmed applied with the line quoted, plus an L2 measured statement on the DEPLOYED build.",
+        "THREE ABANDONED REFS now, and rule 7 names this failure exactly: rc-937 110 behind, rc-wave-a 107 behind, v1/premium-ui 275 behind and an exact duplicate of #912's head. Deleting them costs nothing and removes three wrong answers to 'what is the current state'.",
+        "STILL THE LARGEST UNPULLED LEVER: the Lane-4 on-box batch (V1-57, V1-129, V1-60). Verifier on main, host access only, no HTTP auth, unrun since #932 landed.",
+        "Lane 2 is idle ~4h20m with V1-43 unstarted and unblocked. Delivery is the blocker.",
+        "V1-42 still reads NOT STARTED although #913's W3 supplied its missing consumer.",
+        "V1-88 remains correctly unpromoted."
       ],
       "lastMeaningfulActivity": "2026-08-20T02:23:00Z",
       "policyState": "INTEGRATION_OWNER"
@@ -205,11 +202,11 @@
     "consequence": "My 'wrong by one' warning was itself wrong by one. The level the contract sets is the contract's to set, and it says L1.",
     "whatSurvives": "If anyone believes V1-34 should require a production consumer, that is an argument for RE-LEVELLING the row to L4 — an owner decision — not an argument against this promotion. Recorded that way rather than quietly dropped."
   },
-  "cycle18Transitions": [
-    "V1 = 47/132 (35.6%). #941 landed the promotions Lane 5 staged. Verified by diffing main against main per row: V1-34 -> VERIFIED (L1), V1-130 -> VERIFIED (L2), and NOT STARTED -> IN PROGRESS for V1-51, NOT STARTED -> IMPLEMENTED_UNVERIFIED for V1-95.",
-    "THREE more merges: #925 (Roster V1 verification pack + V1-35 audit), #935 (/rosters consumes canonical Team Strength), #915 (exact league scoring, #802). The open-PR queue has collapsed from fourteen to four: #912, #921 (paused POST-V1), #923, #928 (this dispatcher's).",
-    "LANE 2 IS GENUINELY ACTIONABLE_IDLE — the first time that classification is correct under the #940 policy. It holds no open PR, V1-43 is unstarted and unblocked on plain main, and it has been quiet since 00:18Z, about 3h37m. It is NOT frozen-at-handoff, so rule 8 does not cover it. The bottleneck is ASSIGNMENT DELIVERY, not the lane: L2-2026-08-19-02 has been DELIVERY_REQUIRED for hours and no channel exists to send it.",
-    "Both integration branches are now abandoned rather than merely stale: rc-937 is 79 behind main, rc-wave-a 76 behind. Rule 7 says an integration branch must stay small and refreshed and must never become a second long-lived source of truth. These are neither refreshed nor retired.",
-    "Branch hygiene: origin/v1/premium-ui points at EXACTLY the same SHA as origin/claude/premium-ui-migration-ltldy0 (c025e4f68). Not a second line of work — a duplicate ref for #912's head. Harmless today, but it breaks branch-based attribution, which the '— <title>' merge format already weakens."
+  "cycle19Transitions": [
+    "V1 = 48/132 (36.4%). #942 promoted V1-95 on the deployed build. Row-diffed: exactly one row moved, which is what the commit subject claimed — checked rather than trusted.",
+    "#928 MERGED (231468bb4), so these dispatch records are now canonical on main rather than living on a review branch. The dispatcher branch was rotated onto the latest main per the merged-PR rule: every prior commit was already contained in main (verified with merge-base --is-ancestor before touching anything) and the remote branch had been deleted. Nothing was lost, and no commit was spent marking the rotation — it rides along here.",
+    "LANE 2 STILL ACTIONABLE_IDLE, now about 4h20m. No V1-43 branch exists. The blocker has not changed and is not the lane's: L2-2026-08-19-02 is DELIVERY_REQUIRED and no channel reaches Lane 2. No second assignment written.",
+    "THE LANE-4 ON-BOX BATCH IS STILL UNRUN (V1-57, V1-129, V1-60). Available since #932 merged, host access only, no HTTP auth. It remains the largest identified lever on the numerator that nobody has pulled.",
+    "RULE 7 BREACH IS WORSENING, not holding: rc-937 is now 110 commits behind main, rc-wave-a 107 behind, and origin/v1/premium-ui — the exact-duplicate ref for #912's head — is 275 behind. None retired. Three abandoned refs is past the point where 'stale' describes it."
   ]
 }

--- a/docs/claude-dispatch/LANE_STATUS.json
+++ b/docs/claude-dispatch/LANE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Lane utilization state, owned by Claude 7 (Lane Dispatcher). NOT an authority on integration sequencing (Claude 5 / docs/EXECUTION_PLAN.md), on V1 status (docs/VERSION_1_COMPLETION_CONTRACT.md) or on canonical ownership (CLAUDE.md). Repository evidence outranks this file: where they disagree, this file is wrong and must be corrected.",
-  "updatedAt": "2026-08-20T06:40:00Z",
-  "dispatchCycle": 22,
+  "updatedAt": "2026-08-20T09:40:00Z",
+  "dispatchCycle": 23,
   "writePolicy": "This file and ASSIGNMENTS.json are written ONLY on a material state transition — new assignment, assignment accepted, completion, blocker, freeze/unfreeze, or a meaningful dependency change. A heartbeat that finds nothing changed produces no commit and no CI run.",
   "evidenceBasis": "origin/main 079fc9e4a; §3 diffed row-by-row from cycle-19 main (c5a367266); all refs resolved live; #945 CI green 04:57:35Z",
   "assignmentSourceNote": "The six current assignments were made manually by the owner, not by this dispatcher. Recorded here so the durable state matches reality; Claude 7 did not originate them and does not own them.",
@@ -206,34 +206,42 @@
     "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA"
   },
   "canonicalOwnerRule": "This dispatcher previously carried a `v1` block with verified/percent fields that read as authoritative, and it DRIFTED — PR #945 declared 48/132 while the contract on main said 55/132. That is a second owner of the numerator forming inside a coordination record, which is the exact defect class this dispatcher has spent the session flagging in other lanes. Corrected on integration review: the fields are renamed to name themselves derived, carry the SHA they were read at, and declare the contract the winner in any disagreement.",
-  "cycle22Transitions": {
-    "mainTip": "c4431ccba (was 64769555a)",
-    "merged": {
-      "pr": "#947 — Integration",
-      "mergeCommit": "ff2741305 (subject format 2: 'Merge pull request #N — <title>')",
-      "verifiedIndependently": "Row-diffed §3 64769555a -> c4431ccba. EXACTLY the three rows #947 claimed and no others: V1-107 IN PROGRESS -> VERIFIED (target L2), V1-113 IN PROGRESS -> VERIFIED (target L1), V1-108 IN PROGRESS -> IMPLEMENTED_UNVERIFIED (target L2).",
-      "contractSelfConsistent": "Counted the rows myself (57 / 21 / 23 / 29 / 2 = 132) and then read the contract's own status table and completion line: identical, 57 / 132 = 43.2%. The two agree, which is the check the contract's own history says has failed before.",
-      "branchHygiene": "claude/v1-integration-authority-xaqcv8 DELETED on merge. Second correct rule 7 cleanup in two cycles."
+  "cycle23Transitions": {
+    "mainTip": "cca488cd7 (was c4431ccba)",
+    "headlineFinding": {
+      "statement": "FOUR PRs MERGED THIS CYCLE AND THE CONTRACT MOVED BY ZERO ROWS.",
+      "merged": [
+        "#946 (015570741) — P1 BDVM ingestion off the request path",
+        "#948 (9e8350960) — CI reliability",
+        "#952 (b5f339d2d) — /waivers FAAB on mobile",
+        "#956 (4157adfe4) — V1-51 championship truthful sims"
+      ],
+      "rowDiff": "§3 row-diffed c4431ccba -> cca488cd7: NO row changed status. Still 57/132, and the contract's own table and completion line agree with my independent count.",
+      "thisIsCorrectBehaviour": "#956 landed the V1-51 IMPLEMENTATION and the row stayed `IN PROGRESS` with a named close condition (give playoff_odds :215 the `unsimulable` shape with n_simulations 0, a RED-without-it test, then re-measure three endpoints for the L2 statement). A merge is not verification, and the lanes are holding that line.",
+      "butTheUtilizationReadingIsTheOppositeOfIdleLanes": "Across cycles 21-23: FIVE merges, +2 VERIFIED rows, and BOTH of those came from ONE promotion PR (#947). The numerator moves only when Integration runs a dedicated verification pass. Implementation throughput and verification throughput have decoupled, and verification is the binding constraint — not lane idleness, which is what this dispatcher has been reporting for a dozen cycles."
     },
-    "watchItemResolved": {
-      "ref": "claude/ci-reliability-hardening",
-      "became": "PR #948 — 'CI reliability: the seven red ticks were mostly right — CI's own side effects were not'",
-      "head": "c20a1f1df",
-      "verdict": "NOT a #940 rule 7 breach. It acquired a PR within one cycle of being flagged.",
-      "relevance": "Directly in the false-green class this dispatcher audits: it adds tests named for the property, not the mechanism — no workflow exits green on missing secrets, production checks do not skip green, bootstrap reports the unit's real outcome. It also touches verify-sharp-production.yml and adds tests/deploy/test_sharp_smoke_commit_order.py, which is adjacent to blocker B8 (pr-validation concurrency and refresh commits). Not dispatcher-assigned; not dispatcher-reviewed."
+    "abandonedRefUpdate": {
+      "cleared": "v1/premium-ui is GONE from origin. One of the three cleared without anyone being told to.",
+      "stillPresent": [
+        "integration/rc-937 (80b7b948d)",
+        "integration/rc-wave-a (213f91513)"
+      ],
+      "alsoDeletedOnMerge": [
+        "claude/bdvm-nonblocking-ingestion-v2",
+        "claude/ci-reliability-hardening"
+      ],
+      "assessment": "Branch hygiene has gone from zero cleanups in twenty cycles to four in three. The two that remain are integration-owned release-candidate refs, not lane refs."
     },
-    "newFinding_stalOpenPRs": {
-      "finding": "TWO OPEN PRs REPRESENT WORK ALREADY ON MAIN.",
-      "evidence": "#912's commit list contains c3aec3a10 'Stop six non-data routes from downloading the player contract (#759)' and a9136e13e 'Window the rankings board ... (#760)'. Confirmed on main directly rather than from the subjects: AppShell.jsx defines isNoPlayerDataRoute at line 162 and gates on it at 198, and frontend/components/ds/useRowWindow.js + frontend/__tests__/components/ds/RowWindow.test.jsx both exist at c4431ccba.",
-      "consequence": "The open-PR queue overstates outstanding work by two, and a future integrator could review or re-merge landed code. This is the rule 7 concern — a ref that is no longer a source of truth — arriving as a PR rather than a branch.",
-      "dispatcherAction": "REPORTED ONLY. Closing a PR is not dispatcher authority."
+    "newObservation_laneEight": {
+      "evidence": "#954 is titled 'feat(sources): acquisition states, bridge layer, per-row archive preservation (Lane 8 PR A)', with companion #950 and branches claude/cross-position-bridge-v1 and -prb.",
+      "consequence": "This dispatcher's model covers Lanes 1-6 plus Integration. A Lane 8 is committing and is outside every doNotTouch set, collision watchlist and idle clock in these records.",
+      "dispatcherAction": "REPORTED. Extending the lane model is an owner decision, not a dispatcher one. Recording it because a coordination record that silently omits an active lane is the same defect class as a stale tally — it looks complete."
     },
-    "newFinding_V1_106": {
-      "row": "V1-106 — rankings board windowing",
-      "status": "`IN PROGRESS`, target L2, evidence pointer reads only 'PR #760'",
-      "problem": "#760's code is ON MAIN. #947's summary says V1-106 'stays open per the owner ruling on the FPS harness', which is a real and correct reason — but the ROW does not say it. Read alone, the row looks like unlanded work when what is actually missing is a credible instrument.",
-      "whyItMatters": "This is the exact structural sibling of V1-108, which #947 decomposed properly with a named close condition. V1-106 is the same shape and did not get one, so it will keep reading as unstarted implementation and keep attracting the wrong kind of work.",
-      "dispatcherAction": "REPORTED to L5/L6, who own row text. The dispatcher does not edit the contract."
+    "myOwnPr": {
+      "pr": "#945",
+      "head": "0085493ac",
+      "ci": "Validate PR SUCCESS — job 96338019518, completed 06:50:03Z",
+      "reviewComments": "none new"
     }
   }
 }

--- a/docs/claude-dispatch/LANE_STATUS.json
+++ b/docs/claude-dispatch/LANE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Lane utilization state, owned by Claude 7 (Lane Dispatcher). NOT an authority on integration sequencing (Claude 5 / docs/EXECUTION_PLAN.md), on V1 status (docs/VERSION_1_COMPLETION_CONTRACT.md) or on canonical ownership (CLAUDE.md). Repository evidence outranks this file: where they disagree, this file is wrong and must be corrected.",
-  "updatedAt": "2026-08-20T09:55:00Z",
-  "dispatchCycle": 24,
+  "updatedAt": "2026-08-20T10:10:00Z",
+  "dispatchCycle": 25,
   "writePolicy": "This file and ASSIGNMENTS.json are written ONLY on a material state transition — new assignment, assignment accepted, completion, blocker, freeze/unfreeze, or a meaningful dependency change. A heartbeat that finds nothing changed produces no commit and no CI run.",
   "evidenceBasis": "origin/main 079fc9e4a; §3 diffed row-by-row from cycle-19 main (c5a367266); all refs resolved live; #945 CI green 04:57:35Z",
   "assignmentSourceNote": "The six current assignments were made manually by the owner, not by this dispatcher. Recorded here so the durable state matches reality; Claude 7 did not originate them and does not own them.",
@@ -215,38 +215,40 @@
     "newMethodRule": "(j) ABSENCE FROM A TRUNCATED LIST IS NOT EVIDENCE OF DELETION. To claim a ref is gone, name it to git ls-remote or read the [deleted] line from the fetch. Never infer it from a ref falling off the bottom of a sorted head -N.",
     "alsoWorthNaming": "This is the third time this session I have reported a cleaner state than the evidence supported, and each time the mechanism was the same: a convenient reading of an instrument I had narrowed myself."
   },
-  "cycle24Transitions": {
-    "mainTip": "cca488cd7 — UNCHANGED. No merges this cycle.",
-    "contract": "57/132 on main, unchanged by construction (same SHA).",
-    "promotionPassIsRunning": {
-      "pr": "#963 — 'V1-51 VERIFIED at L2 (58/136), and the owner's source-program decision reconciled into the denominator'",
-      "head": "f262003a8",
-      "significance": "This is the cycle-23 reframe confirming itself in the direction predicted: the numerator moves when Integration runs a promotion pass, and one is running. V1-51's implementation merged last cycle via #956 and left the row IN PROGRESS; the pass promotes it on DEPLOYED evidence at L2."
+  "cycle25Transitions": {
+    "mainTip": "a1c6e6ea4 (was cca488cd7)",
+    "merged": "#960 (a1c6e6ea4) — '#958: the tracker stops betting on how gh spells a bot login'. Branch deleted on merge.",
+    "v1Effect": "NONE. Row-diffed §3 cca488cd7 -> a1c6e6ea4: NO row changed. Still 57 VERIFIED of 132, and the contract's own table and completion line agree with my independent count.",
+    "theCyclePatternHolds": "Six merges across cycles 21-25 have produced +2 VERIFIED rows, both from one promotion pass. Verification remains the binding constraint.",
+    "promotionPassStillOpen": {
+      "pr": "#963",
+      "headNow": "115e0c662 (was f262003a8)",
+      "contentUnchanged": "Still exactly V1-51 IN PROGRESS -> VERIFIED plus V1-133..V1-136 added as NOT STARTED. Re-counted on the live head: 58+21+22+33+2 = 136, its own table agrees.",
+      "denominatorWarningStands": "57/132 = 43.2% -> 58/136 = 42.6%. The percentage falls while a row is verified. Scope entering the denominator, not a regression."
     },
-    "THE_DENOMINATOR_IS_MOVING": {
-      "_flag": "FIRST DENOMINATOR CHANGE OF THE SESSION. It has been 132 for every cycle until now.",
-      "from": "132",
-      "to": "136",
-      "cause": "#963 commit f99a5bf2c, 'Reconcile the owner's source-acquisition/bridge decision into the V1 denominator' — four new rows V1-133, V1-134, V1-135, V1-136, all NOT STARTED. This is Lane 8's source-acquisition/bridge program entering V1 scope by owner decision.",
-      "verifiedIndependently": "Read the contract on the Integration branch and counted: 58 + 21 + 22 + 33 + 2 = 136, and its own table and completion line agree. Row-diffed against main: exactly V1-51 IN PROGRESS -> VERIFIED plus the four additions, nothing else.",
-      "THE_ARITHMETIC_THAT_WILL_BE_MISREAD": "57/132 = 43.2% -> 58/136 = 42.6%. THE PERCENTAGE FALLS WHILE A ROW IS VERIFIED. That is scope entering the denominator, not a regression, and nothing was un-verified. Naming it before it lands, because a percentage that drops on a promotion pass is precisely the number someone reads as a lane going backwards.",
-      "consequenceForThisRecord": "Cross-cycle PERCENTAGE comparisons are no longer apples-to-apples once this merges. Compare VERIFIED ROW COUNTS across cycles, and state the denominator with every percentage."
+    "MY_CYCLE_24_FRAMING_WAS_WRONG": {
+      "_severity": "Correction — a framing error, not a fact error.",
+      "whatISaid": "Cycle 24: 'The fleet has outgrown my model… Lane 8 and C-Series Claude 9 are committing, neither in any doNotTouch set, collision watchlist or idle clock here.' The tone implied unmanaged sprawl.",
+      "whatIsActuallyTrue": "#963 carries commit e1a676c95, 'Authorize the POST-V1 C-Series mass-build campaign — execution timing only', and 115e0c662, 'Close two merged claim rows and narrow the freeze row, so the new lanes are not falsely blocked'. The new lanes are an AUTHORIZED campaign with its work claims deliberately unblocked.",
+      "correctReading": "My model was not violated; it was superseded by an owner authorization my records did not yet know about. A coordination record that has not caught up is not evidence that the fleet is uncoordinated — and reporting it that way is the same error as reading a truncated list as deletion: treating the limits of my own instrument as a fact about the world.",
+      "standing": "The lane model here still covers L1-L6 plus Integration. Extending it remains an owner decision. But the collision language is withdrawn: #962's Value Adjustment consolidation is campaign work, not an unclaimed incursion into Lane 2's territory."
     },
-    "fleetHasOutgrownMyModel": {
-      "evidence": [
-        "#954 / #950 — 'Lane 8 PR A', cross-position bridge",
-        "#962 — 'C-Series Claude 9: C3 Trade Substrate — Value Adjustment consolidation (C3-VA-01)'",
-        "#961 — C4-WAIV-01 + C4-MTL-01, waiver ledger and own-league Market Trade Ledger",
-        "#960 — #958 CI tracker identity"
-      ],
-      "status": "Escalated from the cycle-23 note. There are now at least TWO lanes (8 and 9) outside this dispatcher's six-lane model, both committing, neither in any doNotTouch set, collision watchlist or idle clock here.",
-      "collisionRisk": "#962 consolidates the Value Adjustment ports — CLAUDE.md names src/trade/ktc_va.py as the canonical owner and records that a duplicate Python port was already retired once. That is Lane 2 territory by my model, and Lane 2 is idle. Reported, not adjudicated.",
-      "dispatcherAction": "REPORTED. Extending the lane model is an owner decision."
+    "uncappedSweepFinding": {
+      "observation": "Sweeping origin UNCAPPED for the first time (rule j's consequence) shows roughly 85 remote refs, with a long dormant tail reaching back to March. My 'three abandoned refs' framing was itself too narrow a window — the same defect one level up.",
+      "dispatcherAction": "REPORTED, and deliberately NOT turned into work. A mass ref cleanup is not dispatcher authority and nobody asked for one. The three named refs stay named because they are RECENT and integration-owned, which is what made them rule-7 relevant; the March tail is ordinary repository sediment."
+    },
+    "abandonedRefsVerifiedByName": {
+      "method": "git ls-remote origin refs/heads/<ref> — named, not inferred",
+      "v1/premium-ui": "PRESENT c025e4f68",
+      "integration/rc-937": "PRESENT 80b7b948d",
+      "integration/rc-wave-a": "PRESENT 213f91513",
+      "claude/no-player-data-routes (#759)": "PRESENT 82851974f",
+      "claude/rankings-board-windowing (#760)": "PRESENT 4f00f1599"
     },
     "myOwnPr": {
       "pr": "#945",
-      "head": "2cf74ad94",
-      "ci": "last verdict SUCCESS on 0085493ac; 2cf74ad94 pushed 09:37Z",
+      "head": "673fa6f6f",
+      "ci": "Validate PR in_progress, job 96385604645, started 09:53Z",
       "reviewComments": "none new"
     }
   }

--- a/docs/claude-dispatch/LANE_STATUS.json
+++ b/docs/claude-dispatch/LANE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Lane utilization state, owned by Claude 7 (Lane Dispatcher). NOT an authority on integration sequencing (Claude 5 / docs/EXECUTION_PLAN.md), on V1 status (docs/VERSION_1_COMPLETION_CONTRACT.md) or on canonical ownership (CLAUDE.md). Repository evidence outranks this file: where they disagree, this file is wrong and must be corrected.",
-  "updatedAt": "2026-08-20T12:05:00Z",
-  "dispatchCycle": 30,
+  "updatedAt": "2026-08-20T12:15:00Z",
+  "dispatchCycle": 31,
   "writePolicy": "This file and ASSIGNMENTS.json are written ONLY on a material state transition — new assignment, assignment accepted, completion, blocker, freeze/unfreeze, or a meaningful dependency change. A heartbeat that finds nothing changed produces no commit and no CI run.",
   "evidenceBasis": "origin/main 079fc9e4a; §3 diffed row-by-row from cycle-19 main (c5a367266); all refs resolved live; #945 CI green 04:57:35Z",
   "assignmentSourceNote": "Lanes 1-6 carry the owner's original six manual assignments, tracked in detail by this dispatcher. Lanes 8-13 are five additional owner-authorized campaign lanes (Claude 8 chartered 2026-08-20; Claude 9-13 chartered the same day under the POST-V1 C-Series mass-build campaign, EXECUTION_PLAN.md §0). This dispatcher did not originate any of these eleven assignments and does not own or re-scope them. Lanes 8-13 are tracked here only lightly — ownership boundaries and authorization citation — because they are self-directed under their own charter, unlike lanes 1-6 which this dispatcher actively monitors for idleness and dispatches follow-on work to. There is no lane 7: Claude 7 is the dispatcher identity, per dispatcherIdentity above.",
@@ -343,6 +343,17 @@
       "VERSION_1_COMPLETION_CONTRACT.md, EXECUTION_PLAN.md, product source, CE registry — none touched by this dispatcher, per its standing scope",
       "the v1DerivedObservation block, which still carries the last SHA-stamped independent reading (58/136 at 31724a8d4) and is still explicitly marked non-authoritative"
     ],
-    "selfCheck": "This is the second time this session a governance send-back has asked this dispatcher to correct its own coordination record for the same underlying class of defect: #945's send-back (cycle 20) was 'you formed a second owner of the V1 numerator'; this one is 'your lane model went stale against a canonical record that superseded it.' Both are the same root cause — a derived/cached reading that nobody forced to reconcile against its source. Recording it here rather than treating it as a one-off, because the fix in both cases was the same: mark the block as derived and dated, and don't let convenience make it read as authoritative."
+    "selfCheck": "This is the second time this session a governance send-back has asked this dispatcher to correct its own coordination record for the same underlying class of defect: #945's send-back (cycle 20) was 'you formed a second owner of the V1 numerator'; this one is 'your lane model went stale against a canonical record that superseded it.' Both are the same root cause — a derived/cached reading that nobody forced to reconcile against its source. Recording it here rather than treating it as a one-off, because the fix in both cases was the same: mark the block as derived and dated, and don't let convenience make it read as authoritative.",
+    "validated": {
+      "ci": "Validate PR SUCCESS on head 40509bc5a — job 96415462467, 11:52:57Z -> 12:10:01Z, 17m4s",
+      "check1_oneDispatcherIdentity": "CONFIRMED — dispatcherIdentity block present, states Claude 7 = dispatcher, not a product lane",
+      "check2_lanes8to13Present": "CONFIRMED — LANE_STATUS.json lanes keys = ['1','2','3','4','5','6','8','9','10','11','12','13']",
+      "check3_noProductLane7Invented": "CONFIRMED — no '7' key in lanes{}; no 'lane: 7' entry in ASSIGNMENTS.json",
+      "check4_noV1StatusChanged": "CONFIRMED — diffed the correction commit against its parent: only docs/claude-dispatch/ASSIGNMENTS.json and LANE_STATUS.json touched, zero product/source/governance files, no observedVerifiedRows/observedRequiredRows/denominator value altered",
+      "verdict": "FEATURE_GREEN",
+      "integrationState": "READY_FOR_INTEGRATION",
+      "freeze": "This slice is FROZEN at 40509bc5a per #940/EXECUTION_PLAN.md's anti-thrashing rule. No further edits to it, no chasing main for ordinary data-refresh movement. Handed to Claude 5 (Integration Authority) for freshness reconciliation and shipping-tree merge at Integration's discretion.",
+      "handoff": "exact head 40509bc5a on claude/lane-dispatcher-orchestrator-u5hpca (#945)"
+    }
   }
 }

--- a/docs/claude-dispatch/LANE_STATUS.json
+++ b/docs/claude-dispatch/LANE_STATUS.json
@@ -1,17 +1,10 @@
 {
   "_comment": "Lane utilization state, owned by Claude 7 (Lane Dispatcher). NOT an authority on integration sequencing (Claude 5 / docs/EXECUTION_PLAN.md), on V1 status (docs/VERSION_1_COMPLETION_CONTRACT.md) or on canonical ownership (CLAUDE.md). Repository evidence outranks this file: where they disagree, this file is wrong and must be corrected.",
-  "updatedAt": "2026-08-20T05:24:00Z",
+  "updatedAt": "2026-08-20T05:25:00Z",
   "dispatchCycle": 20,
   "writePolicy": "This file and ASSIGNMENTS.json are written ONLY on a material state transition — new assignment, assignment accepted, completion, blocker, freeze/unfreeze, or a meaningful dependency change. A heartbeat that finds nothing changed produces no commit and no CI run.",
   "evidenceBasis": "origin/main 079fc9e4a; §3 diffed row-by-row from cycle-19 main (c5a367266); all refs resolved live; #945 CI green 04:57:35Z",
   "assignmentSourceNote": "The six current assignments were made manually by the owner, not by this dispatcher. Recorded here so the durable state matches reality; Claude 7 did not originate them and does not own them.",
-  "v1": {
-    "requiredRows": 132,
-    "verified": 55,
-    "percent": 41.7,
-    "source": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 on origin/main 079fc9e4a",
-    "note": "48 -> 55 via #944, on mutation-proven evidence. Row-diffed: EXACTLY SEVEN newly VERIFIED, matching the commit subject's claim — V1-39 (L1), V1-44 (L1), V1-81 (L2), V1-114, V1-115, V1-116, V1-118 (L1). Zero other status changes. SESSION NET: 40 -> 55, and the denominator never moved."
-  },
   "lanes": {
     "1": {
       "name": "Roster Intelligence",
@@ -208,6 +201,19 @@
     "V1-42 IS STILL NOT STARTED, and this is the third cycle reporting it. #913's W3 supplied the consumer that simulate_roster_change lacked — the exact false-green the contract's §2 names as its first precedent — so the row is closer to closable than its status suggests. Escalated again rather than dropped.",
     "MY PR #945 IS GREEN (Validate PR success 04:57:35Z).",
     "THREE ABANDONED REFS STILL PRESENT and still drifting: rc-937 122 behind, rc-wave-a 119 behind, v1/premium-ui 287 behind. Reported for a third cycle.",
-    "LANE 2 STILL ACTIONABLE_IDLE — no V1-43 branch, now roughly 5h. Delivery remains the blocker, and no second assignment has been written."
-  ]
+    "LANE 2 STILL ACTIONABLE_IDLE — no V1-43 branch, now roughly 5h. Delivery remains the blocker, and no second assignment has been written.",
+    "INTEGRATION SENT #945 BACK, and the correction was right on both halves. First: the record declared 48/132 while main already said 55/132 — stale. Second, and sharper: the `v1` block's verified/denominator/percent fields looked authoritative, so they could drift at all. Restructured as `v1DerivedObservation` — explicitly non-authoritative, stamped with the SHA it was read at, stale by construction, and naming the contract as the winner. No product code and no V1 row status touched."
+  ],
+  "v1DerivedObservation": {
+    "_authority": "NOT AUTHORITATIVE. docs/VERSION_1_COMPLETION_CONTRACT.md §3 is the sole owner of the V1 numerator and denominator. This block is a DERIVED READING of that file, kept only so the dispatcher can rank work by effort-per-row.",
+    "_staleByConstruction": true,
+    "_ifTheyDisagree": "the contract wins, always, and this block is the thing that is wrong.",
+    "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
+    "observedVerifiedRows": 55,
+    "observedRequiredRows": 132,
+    "observedAtSha": "079fc9e4a",
+    "observedAt": "2026-08-20T05:25:00Z",
+    "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA"
+  },
+  "canonicalOwnerRule": "This dispatcher previously carried a `v1` block with verified/percent fields that read as authoritative, and it DRIFTED — PR #945 declared 48/132 while the contract on main said 55/132. That is a second owner of the numerator forming inside a coordination record, which is the exact defect class this dispatcher has spent the session flagging in other lanes. Corrected on integration review: the fields are renamed to name themselves derived, carry the SHA they were read at, and declare the contract the winner in any disagreement."
 }

--- a/docs/claude-dispatch/LANE_STATUS.json
+++ b/docs/claude-dispatch/LANE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Lane utilization state, owned by Claude 7 (Lane Dispatcher). NOT an authority on integration sequencing (Claude 5 / docs/EXECUTION_PLAN.md), on V1 status (docs/VERSION_1_COMPLETION_CONTRACT.md) or on canonical ownership (CLAUDE.md). Repository evidence outranks this file: where they disagree, this file is wrong and must be corrected.",
-  "updatedAt": "2026-08-20T11:05:00Z",
-  "dispatchCycle": 28,
+  "updatedAt": "2026-08-20T11:30:00Z",
+  "dispatchCycle": 29,
   "writePolicy": "This file and ASSIGNMENTS.json are written ONLY on a material state transition — new assignment, assignment accepted, completion, blocker, freeze/unfreeze, or a meaningful dependency change. A heartbeat that finds nothing changed produces no commit and no CI run.",
   "evidenceBasis": "origin/main 079fc9e4a; §3 diffed row-by-row from cycle-19 main (c5a367266); all refs resolved live; #945 CI green 04:57:35Z",
   "assignmentSourceNote": "The six current assignments were made manually by the owner, not by this dispatcher. Recorded here so the durable state matches reality; Claude 7 did not originate them and does not own them.",
@@ -246,20 +246,31 @@
     "standingChange": "Cycle interval stays at 20+ minutes. The dispatcher's own write rate is now bounded by the validation it depends on.",
     "theLessonAgainstMyself": "I was measuring a system I was perturbing, and the perturbation looked exactly like the system being slow. It took twenty-seven cycles to check whether the anomaly on my own PR was caused by me — and the same defect on someone else's PR took me one cycle to find at #922. Method rule (m) exists because proximity made it invisible."
   },
-  "cycle28Transitions": {
-    "mainTip": "daf3c981e — UNCHANGED since cycle 27. No merges, no promotion pass, contract untouched at 58 VERIFIED of 136.",
+  "laneNumberingResolved_C29": {
+    "_closes": "The thread I opened at cycle 24 ('the fleet has outgrown my model') and half-corrected at cycle 25 ('it was superseded by an owner authorization'). It is now fully resolved in the canonical record, not in mine.",
+    "what": "#954 merged (main 31724a8d4) carrying commit 6f1556e86, 'docs(governance): Lane 8, not Lane 7'. docs/EXECUTION_PLAN.md §0 now charters the source-acquisition / cross-position-bridge lane as LANE 8 and states why 7 is not a gap.",
+    "theTextThatMattersToThisRecord": "EXECUTION_PLAN.md:55-59 — 'Lane 7 is **not** missing from this list: `docs/claude-dispatch/LANE_STATUS.json` and `ASSIGNMENTS.json` already assign **Claude 7 the Lane Dispatcher role** (\"owned by Claude 7 (Lane Dispatcher)\"; \"Claude 7 does not merge, does not implement\"). This lane was briefly mislabelled Lane 7 on 2026-08-20 and the owner corrected it the same day.'",
+    "consequence": "These dispatch records are now CITED BY the canonical execution record as the definition of Lane 7. That raises the cost of drift in this file: it is no longer only my own bookkeeping. The v1DerivedObservation guard rails matter more, not less — and the same discipline now applies to lane identity, which is a thing I do own here.",
+    "laneModelNow": "Lanes 1-6 product, Lane 7 dispatcher (this record), Lane 8 source acquisition / cross-position bridge. C-Series campaign lanes (Claude 9 and the C5 branches) run under the #963 authorization. My six-lane model was not wrong; it was incomplete, and the gap is now closed by the owner rather than by me."
+  },
+  "cycle29Transitions": {
+    "mainTip": "31724a8d4 (was daf3c981e)",
+    "merged": "#954 — Lane 8 PR A, merge 31724a8d4. Branch claude/cross-position-bridge-v1 deleted on merge.",
+    "v1Effect": "NONE. Row-diffed §3: no row changed. 58 VERIFIED of 136, and the contract's own table and completion line agree with my independent count.",
+    "andThatIsBYCHARTER": "Lane 8's charter states it 'does not add rows to VERSION_1_COMPLETION_CONTRACT.md §3' and 'marks nothing VERIFIED'. A merge that moves no row is this lane behaving exactly as chartered — the first time this session a zero-row merge has been the DESIGNED outcome rather than verification lagging implementation.",
+    "promotionPassRan": "NO. None since #963.",
     "myOwnPr": {
       "pr": "#945",
-      "head": "01cdc43ed",
-      "verdict": "Validate PR SUCCESS, job 96393703573, completed 10:38:35Z",
-      "note": "First completed verdict since cycle 22."
+      "head": "c270806dc",
+      "verdict": "Validate PR SUCCESS, job 96403117027, 11:03:16Z -> 11:20:27Z",
+      "runDuration": "17 minutes 11 seconds — LONGER than the 13m53s measured last cycle.",
+      "whyThatMatters": "The 20+ minute interval is not comfortably clear of the validation time; it is barely clear of it. An 11-minute cadence would have cancelled this run with six minutes to spare. Rule (m) holds, and the margin is thinner than the first measurement suggested."
     },
-    "newIntegrationBranch": {
-      "ref": "claude/integration-sweep-1048",
-      "head": "09a9322ef",
-      "subject": "'#958 closed by production evidence; #948 suppression holds at 3h'",
-      "readingForThisQueue": "Integration is doing PRODUCTION-EVIDENCE closure work again — the same instrument class that the Lane 4 on-box batch (V1-57 / V1-129 / V1-60) has been waiting on for eighteen hours. Reported, not assigned."
-    },
-    "campaignLaneActivity": "claude/cross-position-bridge-v1 -> 8fba3a9a5 and claude/cseries-seasonal-intelligence-efz837 -> 283ddef16. Authorized lanes, moving normally."
+    "newBranches": [
+      "claude/c5-proj-a-source-census",
+      "claude/c5-war-01-deterministic-core",
+      "claude/cseries-premium-public-closure",
+      "claude/cseries-trade-decision-mrwj7r moved to 08c89e1f3"
+    ]
   }
 }

--- a/docs/claude-dispatch/LANE_STATUS.json
+++ b/docs/claude-dispatch/LANE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Lane utilization state, owned by Claude 7 (Lane Dispatcher). NOT an authority on integration sequencing (Claude 5 / docs/EXECUTION_PLAN.md), on V1 status (docs/VERSION_1_COMPLETION_CONTRACT.md) or on canonical ownership (CLAUDE.md). Repository evidence outranks this file: where they disagree, this file is wrong and must be corrected.",
-  "updatedAt": "2026-08-20T05:25:00Z",
-  "dispatchCycle": 20,
+  "updatedAt": "2026-08-20T06:15:00Z",
+  "dispatchCycle": 21,
   "writePolicy": "This file and ASSIGNMENTS.json are written ONLY on a material state transition — new assignment, assignment accepted, completion, blocker, freeze/unfreeze, or a meaningful dependency change. A heartbeat that finds nothing changed produces no commit and no CI run.",
   "evidenceBasis": "origin/main 079fc9e4a; §3 diffed row-by-row from cycle-19 main (c5a367266); all refs resolved live; #945 CI green 04:57:35Z",
   "assignmentSourceNote": "The six current assignments were made manually by the owner, not by this dispatcher. Recorded here so the durable state matches reality; Claude 7 did not originate them and does not own them.",
@@ -194,16 +194,6 @@
     "consequence": "My 'wrong by one' warning was itself wrong by one. The level the contract sets is the contract's to set, and it says L1.",
     "whatSurvives": "If anyone believes V1-34 should require a production consumer, that is an argument for RE-LEVELLING the row to L4 — an owner decision — not an argument against this promotion. Recorded that way rather than quietly dropped."
   },
-  "cycle20Transitions": [
-    "V1 = 55/132 (41.7%). #944 promoted seven rows on mutation-proven evidence. Row-diffed rather than credited: exactly seven newly VERIFIED and zero other changes, so the subject's stated count was accurate. Session net 40 -> 55 with the denominator untouched throughout — no row was reclassified out of the required list to make the percentage rise.",
-    "V1-81 was one of the closability queue's four L2 IMPLEMENTED_UNVERIFIED rows and is now closed. V1-39 and V1-44 were Lane 2's Trade rows, verified at L1 after #913 landed.",
-    "V1-88 IS STILL IMPLEMENTED_UNVERIFIED after a THIRD promotion pass. The refusal has now survived three separate rounds of Claude 5's own review, which is stronger evidence than the original refusal.",
-    "V1-42 IS STILL NOT STARTED, and this is the third cycle reporting it. #913's W3 supplied the consumer that simulate_roster_change lacked — the exact false-green the contract's §2 names as its first precedent — so the row is closer to closable than its status suggests. Escalated again rather than dropped.",
-    "MY PR #945 IS GREEN (Validate PR success 04:57:35Z).",
-    "THREE ABANDONED REFS STILL PRESENT and still drifting: rc-937 122 behind, rc-wave-a 119 behind, v1/premium-ui 287 behind. Reported for a third cycle.",
-    "LANE 2 STILL ACTIONABLE_IDLE — no V1-43 branch, now roughly 5h. Delivery remains the blocker, and no second assignment has been written.",
-    "INTEGRATION SENT #945 BACK, and the correction was right on both halves. First: the record declared 48/132 while main already said 55/132 — stale. Second, and sharper: the `v1` block's verified/denominator/percent fields looked authoritative, so they could drift at all. Restructured as `v1DerivedObservation` — explicitly non-authoritative, stamped with the SHA it was read at, stale by construction, and naming the contract as the winner. No product code and no V1 row status touched."
-  ],
   "v1DerivedObservation": {
     "_authority": "NOT AUTHORITATIVE. docs/VERSION_1_COMPLETION_CONTRACT.md §3 is the sole owner of the V1 numerator and denominator. This block is a DERIVED READING of that file, kept only so the dispatcher can rank work by effort-per-row.",
     "_staleByConstruction": true,
@@ -215,5 +205,48 @@
     "observedAt": "2026-08-20T05:25:00Z",
     "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA"
   },
-  "canonicalOwnerRule": "This dispatcher previously carried a `v1` block with verified/percent fields that read as authoritative, and it DRIFTED — PR #945 declared 48/132 while the contract on main said 55/132. That is a second owner of the numerator forming inside a coordination record, which is the exact defect class this dispatcher has spent the session flagging in other lanes. Corrected on integration review: the fields are renamed to name themselves derived, carry the SHA they were read at, and declare the contract the winner in any disagreement."
+  "canonicalOwnerRule": "This dispatcher previously carried a `v1` block with verified/percent fields that read as authoritative, and it DRIFTED — PR #945 declared 48/132 while the contract on main said 55/132. That is a second owner of the numerator forming inside a coordination record, which is the exact defect class this dispatcher has spent the session flagging in other lanes. Corrected on integration review: the fields are renamed to name themselves derived, carry the SHA they were read at, and declare the contract the winner in any disagreement.",
+  "cycle21Transitions": {
+    "mainTip": "64769555a (was 079fc9e4a)",
+    "merged": {
+      "pr": "#912 — Lane 6 V1 frontend repair queue",
+      "mergeCommit": "b3ea4cf5a",
+      "reconciledHead": "677442ea5",
+      "v1EffectAtMerge": "NONE. Row-diffed the contract 079fc9e4a -> 64769555a: byte-identical, still 55/132. The largest Lane 6 landing of the session promoted zero rows on merge, which is the contract working as designed — a merge is not verification.",
+      "branchHygiene": "origin/claude/premium-ui-migration-ltldy0 was DELETED after merge. Correct #940 rule 7 behaviour, and the first branch cleanup observed this session."
+    },
+    "opened": [
+      {
+        "pr": "#947",
+        "lane": "L5 Integration",
+        "head": "b8ff3a29d",
+        "claim": "V1-107 + V1-113 VERIFIED from merged #912; V1-108 REFUSED. 55 -> 57 / 132",
+        "ci": "Validate PR in_progress at 06:09Z (run 32338403905)",
+        "dispatcherAudit": "Arithmetic internally consistent: 57+21+23+29+2 = 132, and the three row transitions account for every delta (VERIFIED 55->57, IMPLEMENTED_UNVERIFIED 20->21, IN PROGRESS 26->23). V1-107's L2 was re-measured AT INTEGRATION from an archive rather than read off the PR (compact 492.9 KB vs array 635.2 KB, -22.4%), with two named mutations each producing named REDs. The REFUSAL of V1-108 with a specific missing instrument is the part that makes the pass credible.",
+        "dispatcherObservation": "V1-113 is level L1, and its RED is the row's OWN history — 84 real violations before the ratchet, baseline now empty — rather than a mutation induced at the exact head. That is weaker than V1-107's proof, but the instrument is committed, confirmed non-skipping from the run log (20 axe checks, 20 passed, 0 skipped), and its RED was measured rather than manufactured. Recorded as an observation for Integration, not a refusal; the dispatcher does not adjudicate row status."
+      },
+      {
+        "pr": "#946",
+        "lane": "L3/L4 area — BDVM",
+        "head": "b101b1189",
+        "claim": "P1: remove heavyweight nflverse ingestion from the BDVM request path",
+        "note": "Matches the P1 class this queue tracks (work done inside a request that should be a pipeline artifact). Not dispatcher-assigned."
+      }
+    ],
+    "myOwnPr": {
+      "pr": "#945",
+      "head": "ff716614c",
+      "ci": "Validate PR SUCCESS (job 96324352820, 05:40Z)",
+      "correctionThisCycle": "The send-back's fix had been applied to the BODY and the JSON but NOT to the PR TITLE, which still declared 'V1 48/132'. Retitled. A stale number in a title is the same second-owner defect as one in a field — it just sits somewhere I forgot to look.",
+      "reviewComments": "none new since my reply 5351742519"
+    },
+    "newOrphanRef": {
+      "ref": "origin/claude/ci-reliability-hardening",
+      "head": "d07bd5cf7",
+      "age": "~4h",
+      "content": "docs/CI_RELIABILITY_LANE.md only, +84 lines, one commit",
+      "pr": "NONE",
+      "assessment": "WATCH, not yet a #940 rule 7 breach — it is fresh and single-commit. It becomes one if it accumulates work without a PR. Flagged because a docs-only lane definition with no PR is how a second coordination owner starts, which is the defect I shipped myself this session."
+    }
+  }
 }

--- a/docs/claude-dispatch/LANE_STATUS.json
+++ b/docs/claude-dispatch/LANE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Lane utilization state, owned by Claude 7 (Lane Dispatcher). NOT an authority on integration sequencing (Claude 5 / docs/EXECUTION_PLAN.md), on V1 status (docs/VERSION_1_COMPLETION_CONTRACT.md) or on canonical ownership (CLAUDE.md). Repository evidence outranks this file: where they disagree, this file is wrong and must be corrected.",
-  "updatedAt": "2026-08-20T14:50:00Z",
-  "dispatchCycle": 36,
+  "updatedAt": "2026-08-20T15:45:00Z",
+  "dispatchCycle": 38,
   "writePolicy": "This file and ASSIGNMENTS.json are written ONLY on a material state transition — new assignment, assignment accepted, completion, blocker, freeze/unfreeze, or a meaningful dependency change. A heartbeat that finds nothing changed produces no commit and no CI run.",
   "evidenceBasis": "origin/main 079fc9e4a; §3 diffed row-by-row from cycle-19 main (c5a367266); all refs resolved live; #945 CI green 04:57:35Z",
   "assignmentSourceNote": "Lanes 1-6 carry the owner's original six manual assignments, tracked in detail by this dispatcher. Lanes 8-13 are five additional owner-authorized campaign lanes (Claude 8 chartered 2026-08-20; Claude 9-13 chartered the same day under the POST-V1 C-Series mass-build campaign, EXECUTION_PLAN.md §0). This dispatcher did not originate any of these eleven assignments and does not own or re-scope them. Lanes 8-13 are tracked here only lightly — ownership boundaries and authorization citation — because they are self-directed under their own charter, unlike lanes 1-6 which this dispatcher actively monitors for idleness and dispatches follow-on work to. There is no lane 7: Claude 7 is the dispatcher identity, per dispatcherIdentity above.",
@@ -253,11 +253,11 @@
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
     "observedVerifiedRows": 60,
     "observedRequiredRows": 136,
-    "observedAtSha": "a9799ef93",
-    "observedAt": "2026-08-20T14:47:00Z",
+    "observedAtSha": "0c6f1fdcd",
+    "observedAt": "2026-08-20T15:42:00Z",
     "howObserved": "counted VERIFIED in the §3 table at that exact SHA; independently summed all statuses to 136 and confirmed the contract’s own table and completion line agree",
     "denominatorChangedAtThisSha": "YES — 132 -> 136. See cycle26Transitions.",
-    "note": "V1-63 promoted VERIFIED via #988 (fourth promotion pass this session, after #947/#963/#972). V1-108's close condition merged via #989 but the row correctly stayed IMPLEMENTED_UNVERIFIED pending a separate promotion."
+    "note": "VERIFIED unchanged at 60/136. V1-52 corrected NOT STARTED -> IN PROGRESS via #994, an accuracy correction, not a promotion."
   },
   "canonicalOwnerRule": "This dispatcher previously carried a `v1` block with verified/percent fields that read as authoritative, and it DRIFTED — PR #945 declared 48/132 while the contract on main said 55/132. That is a second owner of the numerator forming inside a coordination record, which is the exact defect class this dispatcher has spent the session flagging in other lanes. Corrected on integration review: the fields are renamed to name themselves derived, carry the SHA they were read at, and declare the contract the winner in any disagreement.",
   "correction_C24": {
@@ -357,26 +357,24 @@
       "handoff": "exact head 40509bc5a on claude/lane-dispatcher-orchestrator-u5hpca (#945)"
     }
   },
-  "cycle36Transitions": {
-    "mainTip": "a9799ef93 (was 7901b4733)",
-    "myOwnPr_ciAnomaly": {
+  "cycle38Transitions": {
+    "mainTip": "0c6f1fdcd (was 7a6af1027)",
+    "myOwnPr": {
       "pr": "#945",
-      "head": "b9731eb50 — UNCHANGED, no new commit landed on this branch this cycle",
-      "verdict": "Validate PR CANCELLED, job 96457874629, started 14:16:57Z, completed 14:38:06Z",
-      "investigated": "Confirmed via `git log` that b9731eb50 is still the branch tip — no push of mine caused this cancellation, unlike the earlier rule-(m) pattern where my own cadence cancelled prior runs. The concurrency group is keyed on PR NUMBER alone (`pr-${{ github.event.pull_request.number }}`), so cancellation requires a second pull_request event on #945 specifically; none is visible from this side (no new commits, no force-push). Recorded as an unexplained anomaly rather than attributed to my own cadence, since the evidence does not support that attribution this time.",
-      "resolution": "This cycle's write (a genuine material transition below) will push a new commit and trigger a fresh run naturally — no separate re-run action needed."
+      "head": "61004e586 — unchanged, no push this cycle since nothing material required one",
+      "verdict": "Validate PR SUCCESS, job 96467482637, 14:45:48Z -> 15:04:33Z (same run reported last cycle; re-confirmed rather than re-reported blind)"
     },
     "merged": [
-      "#979 — V1-52: isolate the canonical power engine, thread the results-only lens through HTTP",
-      "#989 — V1-108: transitive import-graph guard for the no-player-data routes (the close condition this dispatcher named since cycle 24)",
-      "#988 — Integration promotion: V1-63 VERIFIED (60/136)"
+      "#987 — V1-29: close the discovery gap in the replacement-level single-owner guard",
+      "#971 — Lane 8 PR C: Dynasty Nerds IDP Top-275 acquisition",
+      "#994 — Integration: 'Ledger truth: V1-52 IN PROGRESS, P1-BDVM claim closed, smoke churn root-caused'"
     ],
     "rowDiff": {
-      "method": "§3 row-diffed 7901b4733 -> a9799ef93",
-      "result": "EXACTLY ONE status change: V1-63 IMPLEMENTED_UNVERIFIED -> VERIFIED. Denominator held at 136.",
-      "selfConsistency": "Independent count 60+20+21+33+2=136; contract's own table and completion line read 60/136=44.1%, agreeing.",
-      "v1_108_didNotMoveDespiteMerging": "#989 merged — the exact close condition this record has named since cycle 24 — but V1-108's row correctly stayed IMPLEMENTED_UNVERIFIED. Same separation as V1-63 last cycle: implementation lands, a distinct Integration act promotes. Confirming rather than assuming: read the live row text directly."
+      "method": "§3 row-diffed a9799ef93 -> 0c6f1fdcd (spanning cycles 37-38, since cycle 37 was a no-commit cycle with no row movement)",
+      "result": "ONE change: V1-52 NOT STARTED -> IN PROGRESS. VERIFIED unchanged at 60.",
+      "contractFileTouch": "#994 touched the file (3 insertions/3 deletions) — read the diff per rule (o) rather than assuming: it is a STATUS CORRECTION, the row's own text reads 'Status corrected 2026-08-20 from NOT STARTED', matching the commit title exactly. Not a promotion, not a denominator change — independent count confirms 60+20+22+32+2=136, contract's own table agrees."
     },
-    "v1_88_stillOpen": "#991 (V1-88's close condition) is OPEN, UNMERGED — checked its body directly: 'READY FOR INTEGRATION — Claude 5 promotes/merges. I do not.' Structurally identical shape to #989: a caller-graph reachability guard, mutation-tested against the real F-26 defect (RED confirmed on reintroduction, GREEN restored). Not yet landed."
+    "v1_108_and_v1_88_stillPending": "Both still IMPLEMENTED_UNVERIFIED on main. Neither #989 (V1-108, merged 2 cycles ago) nor #991 (V1-88, still open at last check) has been promoted yet.",
+    "branchHygiene": "claude/lane8-dynasty-nerds-acquisition and claude/v1-29-replacement-discovery-guard deleted on merge — both landed and cleaned up in the same cycle their PRs merged."
   }
 }

--- a/docs/claude-dispatch/LANE_STATUS.json
+++ b/docs/claude-dispatch/LANE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Lane utilization state, owned by Claude 7 (Lane Dispatcher). NOT an authority on integration sequencing (Claude 5 / docs/EXECUTION_PLAN.md), on V1 status (docs/VERSION_1_COMPLETION_CONTRACT.md) or on canonical ownership (CLAUDE.md). Repository evidence outranks this file: where they disagree, this file is wrong and must be corrected.",
-  "updatedAt": "2026-08-20T09:40:00Z",
-  "dispatchCycle": 23,
+  "updatedAt": "2026-08-20T09:55:00Z",
+  "dispatchCycle": 24,
   "writePolicy": "This file and ASSIGNMENTS.json are written ONLY on a material state transition — new assignment, assignment accepted, completion, blocker, freeze/unfreeze, or a meaningful dependency change. A heartbeat that finds nothing changed produces no commit and no CI run.",
   "evidenceBasis": "origin/main 079fc9e4a; §3 diffed row-by-row from cycle-19 main (c5a367266); all refs resolved live; #945 CI green 04:57:35Z",
   "assignmentSourceNote": "The six current assignments were made manually by the owner, not by this dispatcher. Recorded here so the durable state matches reality; Claude 7 did not originate them and does not own them.",
@@ -206,41 +206,47 @@
     "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA"
   },
   "canonicalOwnerRule": "This dispatcher previously carried a `v1` block with verified/percent fields that read as authoritative, and it DRIFTED — PR #945 declared 48/132 while the contract on main said 55/132. That is a second owner of the numerator forming inside a coordination record, which is the exact defect class this dispatcher has spent the session flagging in other lanes. Corrected on integration review: the fields are renamed to name themselves derived, carry the SHA they were read at, and declare the contract the winner in any disagreement.",
-  "cycle23Transitions": {
-    "mainTip": "cca488cd7 (was c4431ccba)",
-    "headlineFinding": {
-      "statement": "FOUR PRs MERGED THIS CYCLE AND THE CONTRACT MOVED BY ZERO ROWS.",
-      "merged": [
-        "#946 (015570741) — P1 BDVM ingestion off the request path",
-        "#948 (9e8350960) — CI reliability",
-        "#952 (b5f339d2d) — /waivers FAAB on mobile",
-        "#956 (4157adfe4) — V1-51 championship truthful sims"
-      ],
-      "rowDiff": "§3 row-diffed c4431ccba -> cca488cd7: NO row changed status. Still 57/132, and the contract's own table and completion line agree with my independent count.",
-      "thisIsCorrectBehaviour": "#956 landed the V1-51 IMPLEMENTATION and the row stayed `IN PROGRESS` with a named close condition (give playoff_odds :215 the `unsimulable` shape with n_simulations 0, a RED-without-it test, then re-measure three endpoints for the L2 statement). A merge is not verification, and the lanes are holding that line.",
-      "butTheUtilizationReadingIsTheOppositeOfIdleLanes": "Across cycles 21-23: FIVE merges, +2 VERIFIED rows, and BOTH of those came from ONE promotion PR (#947). The numerator moves only when Integration runs a dedicated verification pass. Implementation throughput and verification throughput have decoupled, and verification is the binding constraint — not lane idleness, which is what this dispatcher has been reporting for a dozen cycles."
+  "correction_C24": {
+    "_severity": "CORRECTION AGAINST MYSELF — a verdict error, not a citation error.",
+    "whatIClaimed": "Cycle 23 reported: 'v1/premium-ui is GONE from origin. One of the three cleared without anyone being told to.' I repeated it in the cycle-23 report and in the cycle-24 prompt as 'v1/premium-ui is CLEARED'.",
+    "theTruth": "git ls-remote origin shows refs/heads/v1/premium-ui STILL PRESENT at c025e4f68. All THREE abandoned refs remain: v1/premium-ui, integration/rc-937, integration/rc-wave-a.",
+    "howIGotItWrong": "My ref sweep is sorted by committerdate and truncated with `head -12`. Three new branches were pushed between cycles, which pushed v1/premium-ui below the cut. I read its absence from a TRUNCATED list as deletion. No fetch line ever said it was deleted — I never checked for one.",
+    "theRuleThisBreaks": "Method rule (a) says sweep ALL remote refs, never a fixed tip list. I obeyed the letter — I did sweep by committerdate — and broke it in spirit by capping the output, which recreates exactly the fixed-window blindness the rule exists to prevent. A truncated sweep is a fixed list that moves.",
+    "newMethodRule": "(j) ABSENCE FROM A TRUNCATED LIST IS NOT EVIDENCE OF DELETION. To claim a ref is gone, name it to git ls-remote or read the [deleted] line from the fetch. Never infer it from a ref falling off the bottom of a sorted head -N.",
+    "alsoWorthNaming": "This is the third time this session I have reported a cleaner state than the evidence supported, and each time the mechanism was the same: a convenient reading of an instrument I had narrowed myself."
+  },
+  "cycle24Transitions": {
+    "mainTip": "cca488cd7 — UNCHANGED. No merges this cycle.",
+    "contract": "57/132 on main, unchanged by construction (same SHA).",
+    "promotionPassIsRunning": {
+      "pr": "#963 — 'V1-51 VERIFIED at L2 (58/136), and the owner's source-program decision reconciled into the denominator'",
+      "head": "f262003a8",
+      "significance": "This is the cycle-23 reframe confirming itself in the direction predicted: the numerator moves when Integration runs a promotion pass, and one is running. V1-51's implementation merged last cycle via #956 and left the row IN PROGRESS; the pass promotes it on DEPLOYED evidence at L2."
     },
-    "abandonedRefUpdate": {
-      "cleared": "v1/premium-ui is GONE from origin. One of the three cleared without anyone being told to.",
-      "stillPresent": [
-        "integration/rc-937 (80b7b948d)",
-        "integration/rc-wave-a (213f91513)"
-      ],
-      "alsoDeletedOnMerge": [
-        "claude/bdvm-nonblocking-ingestion-v2",
-        "claude/ci-reliability-hardening"
-      ],
-      "assessment": "Branch hygiene has gone from zero cleanups in twenty cycles to four in three. The two that remain are integration-owned release-candidate refs, not lane refs."
+    "THE_DENOMINATOR_IS_MOVING": {
+      "_flag": "FIRST DENOMINATOR CHANGE OF THE SESSION. It has been 132 for every cycle until now.",
+      "from": "132",
+      "to": "136",
+      "cause": "#963 commit f99a5bf2c, 'Reconcile the owner's source-acquisition/bridge decision into the V1 denominator' — four new rows V1-133, V1-134, V1-135, V1-136, all NOT STARTED. This is Lane 8's source-acquisition/bridge program entering V1 scope by owner decision.",
+      "verifiedIndependently": "Read the contract on the Integration branch and counted: 58 + 21 + 22 + 33 + 2 = 136, and its own table and completion line agree. Row-diffed against main: exactly V1-51 IN PROGRESS -> VERIFIED plus the four additions, nothing else.",
+      "THE_ARITHMETIC_THAT_WILL_BE_MISREAD": "57/132 = 43.2% -> 58/136 = 42.6%. THE PERCENTAGE FALLS WHILE A ROW IS VERIFIED. That is scope entering the denominator, not a regression, and nothing was un-verified. Naming it before it lands, because a percentage that drops on a promotion pass is precisely the number someone reads as a lane going backwards.",
+      "consequenceForThisRecord": "Cross-cycle PERCENTAGE comparisons are no longer apples-to-apples once this merges. Compare VERIFIED ROW COUNTS across cycles, and state the denominator with every percentage."
     },
-    "newObservation_laneEight": {
-      "evidence": "#954 is titled 'feat(sources): acquisition states, bridge layer, per-row archive preservation (Lane 8 PR A)', with companion #950 and branches claude/cross-position-bridge-v1 and -prb.",
-      "consequence": "This dispatcher's model covers Lanes 1-6 plus Integration. A Lane 8 is committing and is outside every doNotTouch set, collision watchlist and idle clock in these records.",
-      "dispatcherAction": "REPORTED. Extending the lane model is an owner decision, not a dispatcher one. Recording it because a coordination record that silently omits an active lane is the same defect class as a stale tally — it looks complete."
+    "fleetHasOutgrownMyModel": {
+      "evidence": [
+        "#954 / #950 — 'Lane 8 PR A', cross-position bridge",
+        "#962 — 'C-Series Claude 9: C3 Trade Substrate — Value Adjustment consolidation (C3-VA-01)'",
+        "#961 — C4-WAIV-01 + C4-MTL-01, waiver ledger and own-league Market Trade Ledger",
+        "#960 — #958 CI tracker identity"
+      ],
+      "status": "Escalated from the cycle-23 note. There are now at least TWO lanes (8 and 9) outside this dispatcher's six-lane model, both committing, neither in any doNotTouch set, collision watchlist or idle clock here.",
+      "collisionRisk": "#962 consolidates the Value Adjustment ports — CLAUDE.md names src/trade/ktc_va.py as the canonical owner and records that a duplicate Python port was already retired once. That is Lane 2 territory by my model, and Lane 2 is idle. Reported, not adjudicated.",
+      "dispatcherAction": "REPORTED. Extending the lane model is an owner decision."
     },
     "myOwnPr": {
       "pr": "#945",
-      "head": "0085493ac",
-      "ci": "Validate PR SUCCESS — job 96338019518, completed 06:50:03Z",
+      "head": "2cf74ad94",
+      "ci": "last verdict SUCCESS on 0085493ac; 2cf74ad94 pushed 09:37Z",
       "reviewComments": "none new"
     }
   }

--- a/docs/claude-dispatch/LANE_STATUS.json
+++ b/docs/claude-dispatch/LANE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Lane utilization state, owned by Claude 7 (Lane Dispatcher). NOT an authority on integration sequencing (Claude 5 / docs/EXECUTION_PLAN.md), on V1 status (docs/VERSION_1_COMPLETION_CONTRACT.md) or on canonical ownership (CLAUDE.md). Repository evidence outranks this file: where they disagree, this file is wrong and must be corrected.",
-  "updatedAt": "2026-08-20T13:45:00Z",
-  "dispatchCycle": 34,
+  "updatedAt": "2026-08-20T14:15:00Z",
+  "dispatchCycle": 35,
   "writePolicy": "This file and ASSIGNMENTS.json are written ONLY on a material state transition — new assignment, assignment accepted, completion, blocker, freeze/unfreeze, or a meaningful dependency change. A heartbeat that finds nothing changed produces no commit and no CI run.",
   "evidenceBasis": "origin/main 079fc9e4a; §3 diffed row-by-row from cycle-19 main (c5a367266); all refs resolved live; #945 CI green 04:57:35Z",
   "assignmentSourceNote": "Lanes 1-6 carry the owner's original six manual assignments, tracked in detail by this dispatcher. Lanes 8-13 are five additional owner-authorized campaign lanes (Claude 8 chartered 2026-08-20; Claude 9-13 chartered the same day under the POST-V1 C-Series mass-build campaign, EXECUTION_PLAN.md §0). This dispatcher did not originate any of these eleven assignments and does not own or re-scope them. Lanes 8-13 are tracked here only lightly — ownership boundaries and authorization citation — because they are self-directed under their own charter, unlike lanes 1-6 which this dispatcher actively monitors for idleness and dispatches follow-on work to. There is no lane 7: Claude 7 is the dispatcher identity, per dispatcherIdentity above.",
@@ -253,11 +253,11 @@
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
     "observedVerifiedRows": 59,
     "observedRequiredRows": 136,
-    "observedAtSha": "892df5686",
-    "observedAt": "2026-08-20T13:42:00Z",
+    "observedAtSha": "7901b4733",
+    "observedAt": "2026-08-20T14:12:00Z",
     "howObserved": "counted VERIFIED in the §3 table at that exact SHA; independently summed all statuses to 136 and confirmed the contract’s own table and completion line agree",
     "denominatorChangedAtThisSha": "YES — 132 -> 136. See cycle26Transitions.",
-    "note": "Unchanged at 59/136. One merge this cycle (#961, Claude 10 / Lane 10) — did not touch the contract file at all; zero rows by role."
+    "note": "Unchanged at 59/136. #977 implemented V1-63 but the row correctly stayed IMPLEMENTED_UNVERIFIED (own text: \"NOT promoted 2026-08-20\"); #988 (open, unmerged) is Integration's actual promotion PR for it."
   },
   "canonicalOwnerRule": "This dispatcher previously carried a `v1` block with verified/percent fields that read as authoritative, and it DRIFTED — PR #945 declared 48/132 while the contract on main said 55/132. That is a second owner of the numerator forming inside a coordination record, which is the exact defect class this dispatcher has spent the session flagging in other lanes. Corrected on integration review: the fields are renamed to name themselves derived, carry the SHA they were read at, and declare the contract the winner in any disagreement.",
   "correction_C24": {
@@ -357,22 +357,31 @@
       "handoff": "exact head 40509bc5a on claude/lane-dispatcher-orchestrator-u5hpca (#945)"
     }
   },
-  "cycle34Transitions": {
-    "mainTip": "892df5686 (was 7c826f9c2)",
+  "cycle35Transitions": {
+    "mainTip": "7901b4733 (was 892df5686)",
     "myOwnPr": {
       "pr": "#945",
-      "head": "b89fe75f5",
-      "verdict": "Validate PR SUCCESS, job 96439186866, 13:18:02Z -> 13:35:54Z",
-      "runDuration": "17m52s — inside the 13m29s-18m6s band observed so far, comfortably under the 24-minute interval."
+      "head": "ce66b5374",
+      "verdict": "Validate PR SUCCESS, job 96447771036, 13:45:43Z -> 14:03:25Z",
+      "runDuration": "17m42s — inside the observed band, comfortably under the 24-minute interval."
     },
     "merged": [
-      "#961 — Claude 10 (C4 + waiver/draft-related C7): waiver ledger, own-league Market Trade Ledger, comparable-trade matching (C4-WAIV-01, C4-MTL-01, C4-MTL-03)"
+      "#965 — Claude 13 (PSI/premium public closure): elevate the Chase Upside Market Ticker (C8-PSI-01/C8-A11Y-01)",
+      "#977 — Lane 4 implementation: publish per-player manager concentration on Sharp Roster Percentage (V1-63)"
     ],
     "rowDiff": {
-      "method": "§3 row-diffed 7c826f9c2 -> 892df5686",
+      "method": "§3 row-diffed 892df5686 -> 7901b4733",
       "result": "NO ROW CHANGED. 59 VERIFIED of 136, independent count and contract's own table agree.",
-      "contractFileTouch": "NONE — git diff --stat on VERSION_1_COMPLETION_CONTRACT.md for this range is empty, so rule (o) doesn't even need to activate here; the clean case."
+      "whyV163DidNotMoveDespiteTheMerge": "V1-63's row text reads its own history: 'NOT promoted 2026-08-20, and the previously-named blocker is NOT the real one.' #977 is the IMPLEMENTATION (Lane 4); promotion is a separate Integration act. Confirmed a promotion PR exists and is open, unmerged: #988 'V1-63 VERIFIED (60/136); PSI PR A browser verification and its one blocker'."
     },
-    "rule_n_appliedAgain": "#961 is a Claude 9-13 mass-build lane (Claude 10 / C4), which per EXECUTION_PLAN.md may not mark a §3 row VERIFIED. Zero rows is the designed outcome, fifth consecutive cycle confirming this before drawing any conclusion."
+    "rule_n_generalizes": "This is the first cycle where the zero-row merge came from a PRODUCT lane (Lane 4) rather than a mass-build lane, and the same rule held: only Integration promotes, so implementation from ANY lane is expected to leave the row unpromoted until Integration acts separately. Not limited to lanes 9-13.",
+    "promotionPassInFlightNotLanded": "#988 is open, unmerged, proposing V1-63 -> 60/136. Six cycles without a LANDED promotion pass since #972 (cycle 32), but not six cycles of stall — one is actively queued.",
+    "directResponseToStandingFindings": {
+      "_significance": "Three branches appeared this cycle that implement the EXACT close conditions this dispatcher has named in every cycle report since they were first identified — not similar work, the literal named fix.",
+      "V1-108": "branch claude/v1-108-no-player-data-import-graph-guard, commit 1d62b8682: 'V1-108: commit a transitive import-graph guard for the six no-player-data routes' — this dispatcher's stated close condition verbatim since cycle 24 (eleven cycles). PR #989 open.",
+      "V1-88": "branch claude/v1-88-flag-reachability-guard, commit df925de73: 'test(api): non-vacuous flag-to-route reachability guard (V1-88 / F-26)' — the structured-gates-field fix this dispatcher has named since cycle 26 (nine cycles) as the reason V1-88 stays unpromotable. PR #991 open.",
+      "V1-29 bonus": "branch claude/v1-29-replacement-discovery-guard also appeared, closing a discovery gap on a row this dispatcher has not been tracking directly but which shares the same guard-test shape.",
+      "dispatcherRole": "Both are OPEN PRs, not yet merged or promoted. Reported as movement toward the standing Tier B items, not claimed as closed — the row-diff already confirms neither V1-108 nor V1-88 changed status yet."
+    }
   }
 }

--- a/docs/claude-dispatch/LANE_STATUS.json
+++ b/docs/claude-dispatch/LANE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Lane utilization state, owned by Claude 7 (Lane Dispatcher). NOT an authority on integration sequencing (Claude 5 / docs/EXECUTION_PLAN.md), on V1 status (docs/VERSION_1_COMPLETION_CONTRACT.md) or on canonical ownership (CLAUDE.md). Repository evidence outranks this file: where they disagree, this file is wrong and must be corrected.",
-  "updatedAt": "2026-08-20T06:15:00Z",
-  "dispatchCycle": 21,
+  "updatedAt": "2026-08-20T06:40:00Z",
+  "dispatchCycle": 22,
   "writePolicy": "This file and ASSIGNMENTS.json are written ONLY on a material state transition — new assignment, assignment accepted, completion, blocker, freeze/unfreeze, or a meaningful dependency change. A heartbeat that finds nothing changed produces no commit and no CI run.",
   "evidenceBasis": "origin/main 079fc9e4a; §3 diffed row-by-row from cycle-19 main (c5a367266); all refs resolved live; #945 CI green 04:57:35Z",
   "assignmentSourceNote": "The six current assignments were made manually by the owner, not by this dispatcher. Recorded here so the durable state matches reality; Claude 7 did not originate them and does not own them.",
@@ -206,47 +206,34 @@
     "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA"
   },
   "canonicalOwnerRule": "This dispatcher previously carried a `v1` block with verified/percent fields that read as authoritative, and it DRIFTED — PR #945 declared 48/132 while the contract on main said 55/132. That is a second owner of the numerator forming inside a coordination record, which is the exact defect class this dispatcher has spent the session flagging in other lanes. Corrected on integration review: the fields are renamed to name themselves derived, carry the SHA they were read at, and declare the contract the winner in any disagreement.",
-  "cycle21Transitions": {
-    "mainTip": "64769555a (was 079fc9e4a)",
+  "cycle22Transitions": {
+    "mainTip": "c4431ccba (was 64769555a)",
     "merged": {
-      "pr": "#912 — Lane 6 V1 frontend repair queue",
-      "mergeCommit": "b3ea4cf5a",
-      "reconciledHead": "677442ea5",
-      "v1EffectAtMerge": "NONE. Row-diffed the contract 079fc9e4a -> 64769555a: byte-identical, still 55/132. The largest Lane 6 landing of the session promoted zero rows on merge, which is the contract working as designed — a merge is not verification.",
-      "branchHygiene": "origin/claude/premium-ui-migration-ltldy0 was DELETED after merge. Correct #940 rule 7 behaviour, and the first branch cleanup observed this session."
+      "pr": "#947 — Integration",
+      "mergeCommit": "ff2741305 (subject format 2: 'Merge pull request #N — <title>')",
+      "verifiedIndependently": "Row-diffed §3 64769555a -> c4431ccba. EXACTLY the three rows #947 claimed and no others: V1-107 IN PROGRESS -> VERIFIED (target L2), V1-113 IN PROGRESS -> VERIFIED (target L1), V1-108 IN PROGRESS -> IMPLEMENTED_UNVERIFIED (target L2).",
+      "contractSelfConsistent": "Counted the rows myself (57 / 21 / 23 / 29 / 2 = 132) and then read the contract's own status table and completion line: identical, 57 / 132 = 43.2%. The two agree, which is the check the contract's own history says has failed before.",
+      "branchHygiene": "claude/v1-integration-authority-xaqcv8 DELETED on merge. Second correct rule 7 cleanup in two cycles."
     },
-    "opened": [
-      {
-        "pr": "#947",
-        "lane": "L5 Integration",
-        "head": "b8ff3a29d",
-        "claim": "V1-107 + V1-113 VERIFIED from merged #912; V1-108 REFUSED. 55 -> 57 / 132",
-        "ci": "Validate PR in_progress at 06:09Z (run 32338403905)",
-        "dispatcherAudit": "Arithmetic internally consistent: 57+21+23+29+2 = 132, and the three row transitions account for every delta (VERIFIED 55->57, IMPLEMENTED_UNVERIFIED 20->21, IN PROGRESS 26->23). V1-107's L2 was re-measured AT INTEGRATION from an archive rather than read off the PR (compact 492.9 KB vs array 635.2 KB, -22.4%), with two named mutations each producing named REDs. The REFUSAL of V1-108 with a specific missing instrument is the part that makes the pass credible.",
-        "dispatcherObservation": "V1-113 is level L1, and its RED is the row's OWN history — 84 real violations before the ratchet, baseline now empty — rather than a mutation induced at the exact head. That is weaker than V1-107's proof, but the instrument is committed, confirmed non-skipping from the run log (20 axe checks, 20 passed, 0 skipped), and its RED was measured rather than manufactured. Recorded as an observation for Integration, not a refusal; the dispatcher does not adjudicate row status."
-      },
-      {
-        "pr": "#946",
-        "lane": "L3/L4 area — BDVM",
-        "head": "b101b1189",
-        "claim": "P1: remove heavyweight nflverse ingestion from the BDVM request path",
-        "note": "Matches the P1 class this queue tracks (work done inside a request that should be a pipeline artifact). Not dispatcher-assigned."
-      }
-    ],
-    "myOwnPr": {
-      "pr": "#945",
-      "head": "ff716614c",
-      "ci": "Validate PR SUCCESS (job 96324352820, 05:40Z)",
-      "correctionThisCycle": "The send-back's fix had been applied to the BODY and the JSON but NOT to the PR TITLE, which still declared 'V1 48/132'. Retitled. A stale number in a title is the same second-owner defect as one in a field — it just sits somewhere I forgot to look.",
-      "reviewComments": "none new since my reply 5351742519"
+    "watchItemResolved": {
+      "ref": "claude/ci-reliability-hardening",
+      "became": "PR #948 — 'CI reliability: the seven red ticks were mostly right — CI's own side effects were not'",
+      "head": "c20a1f1df",
+      "verdict": "NOT a #940 rule 7 breach. It acquired a PR within one cycle of being flagged.",
+      "relevance": "Directly in the false-green class this dispatcher audits: it adds tests named for the property, not the mechanism — no workflow exits green on missing secrets, production checks do not skip green, bootstrap reports the unit's real outcome. It also touches verify-sharp-production.yml and adds tests/deploy/test_sharp_smoke_commit_order.py, which is adjacent to blocker B8 (pr-validation concurrency and refresh commits). Not dispatcher-assigned; not dispatcher-reviewed."
     },
-    "newOrphanRef": {
-      "ref": "origin/claude/ci-reliability-hardening",
-      "head": "d07bd5cf7",
-      "age": "~4h",
-      "content": "docs/CI_RELIABILITY_LANE.md only, +84 lines, one commit",
-      "pr": "NONE",
-      "assessment": "WATCH, not yet a #940 rule 7 breach — it is fresh and single-commit. It becomes one if it accumulates work without a PR. Flagged because a docs-only lane definition with no PR is how a second coordination owner starts, which is the defect I shipped myself this session."
+    "newFinding_stalOpenPRs": {
+      "finding": "TWO OPEN PRs REPRESENT WORK ALREADY ON MAIN.",
+      "evidence": "#912's commit list contains c3aec3a10 'Stop six non-data routes from downloading the player contract (#759)' and a9136e13e 'Window the rankings board ... (#760)'. Confirmed on main directly rather than from the subjects: AppShell.jsx defines isNoPlayerDataRoute at line 162 and gates on it at 198, and frontend/components/ds/useRowWindow.js + frontend/__tests__/components/ds/RowWindow.test.jsx both exist at c4431ccba.",
+      "consequence": "The open-PR queue overstates outstanding work by two, and a future integrator could review or re-merge landed code. This is the rule 7 concern — a ref that is no longer a source of truth — arriving as a PR rather than a branch.",
+      "dispatcherAction": "REPORTED ONLY. Closing a PR is not dispatcher authority."
+    },
+    "newFinding_V1_106": {
+      "row": "V1-106 — rankings board windowing",
+      "status": "`IN PROGRESS`, target L2, evidence pointer reads only 'PR #760'",
+      "problem": "#760's code is ON MAIN. #947's summary says V1-106 'stays open per the owner ruling on the FPS harness', which is a real and correct reason — but the ROW does not say it. Read alone, the row looks like unlanded work when what is actually missing is a credible instrument.",
+      "whyItMatters": "This is the exact structural sibling of V1-108, which #947 decomposed properly with a named close condition. V1-106 is the same shape and did not get one, so it will keep reading as unstarted implementation and keep attracting the wrong kind of work.",
+      "dispatcherAction": "REPORTED to L5/L6, who own row text. The dispatcher does not edit the contract."
     }
   }
 }

--- a/docs/claude-dispatch/LANE_STATUS.json
+++ b/docs/claude-dispatch/LANE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Lane utilization state, owned by Claude 7 (Lane Dispatcher). NOT an authority on integration sequencing (Claude 5 / docs/EXECUTION_PLAN.md), on V1 status (docs/VERSION_1_COMPLETION_CONTRACT.md) or on canonical ownership (CLAUDE.md). Repository evidence outranks this file: where they disagree, this file is wrong and must be corrected.",
-  "updatedAt": "2026-08-20T10:25:00Z",
-  "dispatchCycle": 26,
+  "updatedAt": "2026-08-20T11:05:00Z",
+  "dispatchCycle": 28,
   "writePolicy": "This file and ASSIGNMENTS.json are written ONLY on a material state transition — new assignment, assignment accepted, completion, blocker, freeze/unfreeze, or a meaningful dependency change. A heartbeat that finds nothing changed produces no commit and no CI run.",
   "evidenceBasis": "origin/main 079fc9e4a; §3 diffed row-by-row from cycle-19 main (c5a367266); all refs resolved live; #945 CI green 04:57:35Z",
   "assignmentSourceNote": "The six current assignments were made manually by the owner, not by this dispatcher. Recorded here so the durable state matches reality; Claude 7 did not originate them and does not own them.",
@@ -216,23 +216,6 @@
     "newMethodRule": "(j) ABSENCE FROM A TRUNCATED LIST IS NOT EVIDENCE OF DELETION. To claim a ref is gone, name it to git ls-remote or read the [deleted] line from the fetch. Never infer it from a ref falling off the bottom of a sorted head -N.",
     "alsoWorthNaming": "This is the third time this session I have reported a cleaner state than the evidence supported, and each time the mechanism was the same: a convenient reading of an instrument I had narrowed myself."
   },
-  "cycle26Transitions": {
-    "mainTip": "113a29311 (was a1c6e6ea4)",
-    "merged": "#963 — merge 113a29311, 'Merge pull request #963 from jasonleetucker-code/claude/v1-integration-authority-xaqcv8'. Branch deleted on merge.",
-    "promotionPassRan": "YES. This is the second promotion pass of the session and the second time the numerator moved at all.",
-    "rowDiff": {
-      "method": "§3 row-diffed a1c6e6ea4 -> 113a29311",
-      "changes": [
-        "V1-51: IN PROGRESS -> VERIFIED (target L2, promoted on DEPLOYED evidence)",
-        "V1-133: added, NOT STARTED",
-        "V1-134: added, NOT STARTED",
-        "V1-135: added, NOT STARTED",
-        "V1-136: added, NOT STARTED"
-      ],
-      "nothingElseMoved": "No other row changed status. Exactly what #963 claimed while open, landing unchanged."
-    },
-    "selfConsistency": "Counted independently: 58 + 21 + 22 + 33 + 2 = 136. The contract's own status table and its completion line both read 58 / 136 = 42.6%. My count and its count agree."
-  },
   "denominatorHistory": {
     "_why": "Recorded durably because a moving denominator silently breaks every percentage comparison in this record's history, and a floating note in one cycle block would be lost the next time a cycle block is rotated out.",
     "132": {
@@ -247,5 +230,36 @@
     },
     "THE_READING_THAT_IS_EASY_TO_GET_WRONG": "43.2% -> 42.6% ACROSS A PASS THAT VERIFIED A ROW. Nothing was un-verified and nothing regressed; four unstarted rows entered the denominator. The verified COUNT went 57 -> 58, which is the honest measure of the pass.",
     "rule": "Compare VERIFIED ROW COUNTS across cycles. Never compare bare percentages across this boundary, and never quote a percentage without its denominator."
+  },
+  "selfFinding_C27_RESOLVED": {
+    "_class": "A defect in this dispatcher's own operation, diagnosed at cycle 27 and closed at cycle 28 with a measurement.",
+    "theDefect": "My commit cadence was SHORTER THAN MY OWN CI. pr-validation.yml uses concurrency group `pr-<number>` with cancel-in-progress: true — the same mechanism I diagnosed as blocker B8 for #922 at cycle 8 — so each cycle's push cancelled the previous cycle's still-running validation.",
+    "theEvidence": {
+      "2cf74ad94 (cycle 23)": "cancelled",
+      "673fa6f6f (cycle 24)": "cancelled",
+      "2303d4d4d (cycle 25)": "cancelled",
+      "lastGreenBeforeTheFix": "0085493ac at 06:36Z, cycle 22",
+      "whatIReportedInstead": "'CI in_progress' for four consecutive cycles, as though in_progress were a state that resolves itself. It was not resolving; I was cancelling it."
+    },
+    "theFix": "Do nothing for longer. Cycle 27 was a no-commit cycle and cycle 28 was armed at 22 minutes instead of 11.",
+    "theMeasurement": "Run 32358703349 on 01cdc43ed: started 10:24:42Z, completed 10:38:35Z — 13 minutes 53 seconds, conclusion SUCCESS. Against an 11-minute cadence, a green verdict was structurally unreachable; the margin was about three minutes.",
+    "standingChange": "Cycle interval stays at 20+ minutes. The dispatcher's own write rate is now bounded by the validation it depends on.",
+    "theLessonAgainstMyself": "I was measuring a system I was perturbing, and the perturbation looked exactly like the system being slow. It took twenty-seven cycles to check whether the anomaly on my own PR was caused by me — and the same defect on someone else's PR took me one cycle to find at #922. Method rule (m) exists because proximity made it invisible."
+  },
+  "cycle28Transitions": {
+    "mainTip": "daf3c981e — UNCHANGED since cycle 27. No merges, no promotion pass, contract untouched at 58 VERIFIED of 136.",
+    "myOwnPr": {
+      "pr": "#945",
+      "head": "01cdc43ed",
+      "verdict": "Validate PR SUCCESS, job 96393703573, completed 10:38:35Z",
+      "note": "First completed verdict since cycle 22."
+    },
+    "newIntegrationBranch": {
+      "ref": "claude/integration-sweep-1048",
+      "head": "09a9322ef",
+      "subject": "'#958 closed by production evidence; #948 suppression holds at 3h'",
+      "readingForThisQueue": "Integration is doing PRODUCTION-EVIDENCE closure work again — the same instrument class that the Lane 4 on-box batch (V1-57 / V1-129 / V1-60) has been waiting on for eighteen hours. Reported, not assigned."
+    },
+    "campaignLaneActivity": "claude/cross-position-bridge-v1 -> 8fba3a9a5 and claude/cseries-seasonal-intelligence-efz837 -> 283ddef16. Authorized lanes, moving normally."
   }
 }

--- a/docs/claude-dispatch/LANE_STATUS.json
+++ b/docs/claude-dispatch/LANE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Lane utilization state, owned by Claude 7 (Lane Dispatcher). NOT an authority on integration sequencing (Claude 5 / docs/EXECUTION_PLAN.md), on V1 status (docs/VERSION_1_COMPLETION_CONTRACT.md) or on canonical ownership (CLAUDE.md). Repository evidence outranks this file: where they disagree, this file is wrong and must be corrected.",
-  "updatedAt": "2026-08-20T13:15:00Z",
-  "dispatchCycle": 33,
+  "updatedAt": "2026-08-20T13:45:00Z",
+  "dispatchCycle": 34,
   "writePolicy": "This file and ASSIGNMENTS.json are written ONLY on a material state transition — new assignment, assignment accepted, completion, blocker, freeze/unfreeze, or a meaningful dependency change. A heartbeat that finds nothing changed produces no commit and no CI run.",
   "evidenceBasis": "origin/main 079fc9e4a; §3 diffed row-by-row from cycle-19 main (c5a367266); all refs resolved live; #945 CI green 04:57:35Z",
   "assignmentSourceNote": "Lanes 1-6 carry the owner's original six manual assignments, tracked in detail by this dispatcher. Lanes 8-13 are five additional owner-authorized campaign lanes (Claude 8 chartered 2026-08-20; Claude 9-13 chartered the same day under the POST-V1 C-Series mass-build campaign, EXECUTION_PLAN.md §0). This dispatcher did not originate any of these eleven assignments and does not own or re-scope them. Lanes 8-13 are tracked here only lightly — ownership boundaries and authorization citation — because they are self-directed under their own charter, unlike lanes 1-6 which this dispatcher actively monitors for idleness and dispatches follow-on work to. There is no lane 7: Claude 7 is the dispatcher identity, per dispatcherIdentity above.",
@@ -253,11 +253,11 @@
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
     "observedVerifiedRows": 59,
     "observedRequiredRows": 136,
-    "observedAtSha": "7c826f9c2",
-    "observedAt": "2026-08-20T13:12:00Z",
+    "observedAtSha": "892df5686",
+    "observedAt": "2026-08-20T13:42:00Z",
     "howObserved": "counted VERIFIED in the §3 table at that exact SHA; independently summed all statuses to 136 and confirmed the contract’s own table and completion line agree",
     "denominatorChangedAtThisSha": "YES — 132 -> 136. See cycle26Transitions.",
-    "note": "Unchanged at 59/136. Two merges this cycle (#976, #974) touched EXECUTION_PLAN.md/WORK_CLAIMS.md and added one V1 contract CHANGE-LOG line recording a +0 authorization — verified it is a log entry, not a §3 row edit, by reading the diff directly."
+    "note": "Unchanged at 59/136. One merge this cycle (#961, Claude 10 / Lane 10) — did not touch the contract file at all; zero rows by role."
   },
   "canonicalOwnerRule": "This dispatcher previously carried a `v1` block with verified/percent fields that read as authoritative, and it DRIFTED — PR #945 declared 48/132 while the contract on main said 55/132. That is a second owner of the numerator forming inside a coordination record, which is the exact defect class this dispatcher has spent the session flagging in other lanes. Corrected on integration review: the fields are renamed to name themselves derived, carry the SHA they were read at, and declare the contract the winner in any disagreement.",
   "correction_C24": {
@@ -357,24 +357,22 @@
       "handoff": "exact head 40509bc5a on claude/lane-dispatcher-orchestrator-u5hpca (#945)"
     }
   },
-  "cycle33Transitions": {
-    "mainTip": "7c826f9c2 (was 45d5cdac1)",
+  "cycle34Transitions": {
+    "mainTip": "892df5686 (was 7c826f9c2)",
     "myOwnPr": {
       "pr": "#945",
-      "head": "c6ade23f7",
-      "verdict": "Validate PR SUCCESS, job 96429090356, 12:43:16Z -> 13:01:22Z",
-      "runDuration": "18m6s — a new maximum (prior: 17m11s, 17m4s, 13m29s), still under the 22-minute interval but the margin is narrowing again."
+      "head": "b89fe75f5",
+      "verdict": "Validate PR SUCCESS, job 96439186866, 13:18:02Z -> 13:35:54Z",
+      "runDuration": "17m52s — inside the 13m29s-18m6s band observed so far, comfortably under the 24-minute interval."
     },
     "merged": [
-      "#974 — Integration checkpoint ('#948 checkpoint at 4h29m: 0 commits, 13 runs; tracker repair is 1:1 over 8 runs')",
-      "#976 — Integration governance ('Authorize the first PSI production migration; release two stale claims')"
+      "#961 — Claude 10 (C4 + waiver/draft-related C7): waiver ledger, own-league Market Trade Ledger, comparable-trade matching (C4-WAIV-01, C4-MTL-01, C4-MTL-03)"
     ],
     "rowDiff": {
-      "method": "§3 row-diffed 45d5cdac1 -> 7c826f9c2",
+      "method": "§3 row-diffed 7c826f9c2 -> 892df5686",
       "result": "NO ROW CHANGED. 59 VERIFIED of 136, independent count and contract's own table agree.",
-      "theOneLineChangeInTheContractFile": "#976 added ONE line to VERSION_1_COMPLETION_CONTRACT.md's §10 change log: a '+0' entry recording the PSI production-migration authorization as execution-timing only. Read the diff directly rather than trusting the file-touched signal — confirmed it is a change-log addition, not a §3 status edit, consistent with the row-diff finding nothing moved."
+      "contractFileTouch": "NONE — git diff --stat on VERSION_1_COMPLETION_CONTRACT.md for this range is empty, so rule (o) doesn't even need to activate here; the clean case."
     },
-    "rule_n_appliedAgain": "Both merges are Integration governance/operational work (a checkpoint record and an authorization record), correctly zero-row. Fourth consecutive cycle where this dispatcher has verified a zero-row merge against the merging lane's role before treating it as anything other than the designed outcome.",
-    "noteworthy": "#976's own text names a defect this dispatcher's earlier framing could have caused: '#965 records avoiding globals.css because this row still read open' — a stale claim (claude/premium-ui-migration-ltldy0, done via #912) was costing another lane real avoidance behavior until Integration released it this cycle. Not this dispatcher's record, but the same failure shape as the lane-numbering and V1-tally corrections already logged here: a stale record outliving the event it described."
+    "rule_n_appliedAgain": "#961 is a Claude 9-13 mass-build lane (Claude 10 / C4), which per EXECUTION_PLAN.md may not mark a §3 row VERIFIED. Zero rows is the designed outcome, fifth consecutive cycle confirming this before drawing any conclusion."
   }
 }

--- a/docs/claude-dispatch/LANE_STATUS.json
+++ b/docs/claude-dispatch/LANE_STATUS.json
@@ -1,16 +1,16 @@
 {
   "_comment": "Lane utilization state, owned by Claude 7 (Lane Dispatcher). NOT an authority on integration sequencing (Claude 5 / docs/EXECUTION_PLAN.md), on V1 status (docs/VERSION_1_COMPLETION_CONTRACT.md) or on canonical ownership (CLAUDE.md). Repository evidence outranks this file: where they disagree, this file is wrong and must be corrected.",
-  "updatedAt": "2026-08-20T04:40:00Z",
-  "dispatchCycle": 19,
+  "updatedAt": "2026-08-20T05:24:00Z",
+  "dispatchCycle": 20,
   "writePolicy": "This file and ASSIGNMENTS.json are written ONLY on a material state transition — new assignment, assignment accepted, completion, blocker, freeze/unfreeze, or a meaningful dependency change. A heartbeat that finds nothing changed produces no commit and no CI run.",
-  "evidenceBasis": "origin/main c5a367266; §3 diffed row-by-row from cycle-18 main (21b4db386); all refs resolved live; dispatcher branch rotated after #928 merged",
+  "evidenceBasis": "origin/main 079fc9e4a; §3 diffed row-by-row from cycle-19 main (c5a367266); all refs resolved live; #945 CI green 04:57:35Z",
   "assignmentSourceNote": "The six current assignments were made manually by the owner, not by this dispatcher. Recorded here so the durable state matches reality; Claude 7 did not originate them and does not own them.",
   "v1": {
     "requiredRows": 132,
-    "verified": 48,
-    "percent": 36.4,
-    "source": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 on origin/main c5a367266",
-    "note": "47 -> 48 via #942. EXACTLY ONE row changed and it was verified in the table: V1-95 IMPLEMENTED_UNVERIFIED -> VERIFIED at L2. Its note carries both halves the level demands — L1 with two mutations each confirmed APPLIED and the changed line quoted, plus a measured statement on the DEPLOYED build. Session net: 40 -> 48."
+    "verified": 55,
+    "percent": 41.7,
+    "source": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 on origin/main 079fc9e4a",
+    "note": "48 -> 55 via #944, on mutation-proven evidence. Row-diffed: EXACTLY SEVEN newly VERIFIED, matching the commit subject's claim — V1-39 (L1), V1-44 (L1), V1-81 (L2), V1-114, V1-115, V1-116, V1-118 (L1). Zero other status changes. SESSION NET: 40 -> 55, and the denominator never moved."
   },
   "lanes": {
     "1": {
@@ -50,7 +50,7 @@
       "pr": null,
       "implementationHead": "n/a — nothing in flight",
       "releaseCandidate": "n/a",
-      "evidence": "still no V1-43 branch at 04:38Z; last Lane 2 activity 00:18Z — ~4h20m",
+      "evidence": "still no V1-43 branch at 05:22Z; last Lane 2 activity 00:18Z — ~5h04m",
       "blockedBy": "ASSIGNMENT DELIVERY. L2-2026-08-19-02 is DELIVERY_REQUIRED and no agent channel is reachable from this dispatcher.",
       "doNotTouch": [
         "src/roster_intel/**",
@@ -61,13 +61,13 @@
       "nextSafeWork": "V1-43 Analyze Trade V1, branching from PLAIN MAIN — the stacked base is gone because #913 and #929 both merged. Assignment L2-2026-08-19-02 amended.",
       "lastMeaningfulActivity": "2026-08-20T00:18:00Z",
       "assignedThisCycle": "L2-2026-08-19-02 re-amended (base = main) — still DELIVERY_REQUIRED",
-      "idleMinutes": 260,
+      "idleMinutes": 302,
       "openPrs": [],
       "mergedThisCycle": [
         929
       ],
       "policyState": "ACTIONABLE_IDLE — holds an unstarted dependency-ready unit",
-      "policyStateDetail": "No open PR, nothing frozen, V1-43 unstarted and unblocked on plain main. Rule 8's freeze does not apply. Idle ~4h20m and the cause is delivery, not the lane."
+      "policyStateDetail": "No open PR, nothing frozen, V1-43 unstarted and unblocked on plain main. Idle ~5h; cause is delivery, not the lane. Two of its rows (V1-39, V1-44) were VERIFIED this cycle from work it already landed."
     },
     "3": {
       "name": "Scoring / Season / Projections / Power",
@@ -130,22 +130,21 @@
       "assignmentSource": "n/a — sole integration authority, never tasked by this dispatcher",
       "branch": null,
       "mergedThisCycle": [
-        928,
-        942
+        944
       ],
       "implementationHead": "n/a",
       "releaseCandidate": "NOT_YET_FROZEN",
-      "evidence": "main 48/132; Lane 5 branch live at ddf42e271 (25 behind main)",
+      "evidence": "main 55/132 after #944",
       "blockedBy": null,
       "doNotTouch": [],
       "nextSafeWork": "its own sequencing",
       "reportedToIntegration": [
-        "V1 is 48/132 (36.4%), row-verified. Session net +8. V1-95's promotion is the cleanest of the night: L1 mutations each confirmed applied with the line quoted, plus an L2 measured statement on the DEPLOYED build.",
-        "THREE ABANDONED REFS now, and rule 7 names this failure exactly: rc-937 110 behind, rc-wave-a 107 behind, v1/premium-ui 275 behind and an exact duplicate of #912's head. Deleting them costs nothing and removes three wrong answers to 'what is the current state'.",
-        "STILL THE LARGEST UNPULLED LEVER: the Lane-4 on-box batch (V1-57, V1-129, V1-60). Verifier on main, host access only, no HTTP auth, unrun since #932 landed.",
-        "Lane 2 is idle ~4h20m with V1-43 unstarted and unblocked. Delivery is the blocker.",
-        "V1-42 still reads NOT STARTED although #913's W3 supplied its missing consumer.",
-        "V1-88 remains correctly unpromoted."
+        "V1 is 55/132 (41.7%), row-verified. Session net +15, denominator never moved — worth stating because shrinking the denominator is the failure mode the contract's §0 names first.",
+        "V1-42 is the cheapest thing left that nobody is looking at: it reads NOT STARTED, but #913's W3 gave simulate_roster_change the consumer it was missing, which was the precise false-green blocking it. Third cycle reporting it.",
+        "V1-88 has now survived three promotion passes unpromoted. That is correct — and closing it still needs a structured `gates` field or a re-levelling ruling, not a proxy test.",
+        "THREE ABANDONED REFS, third cycle: rc-937 122 behind, rc-wave-a 119 behind, v1/premium-ui 287 behind and an exact duplicate of #912's head. Deleting them is free and removes three wrong answers about current state.",
+        "The Lane-4 on-box batch (V1-57, V1-129, V1-60) is STILL unrun and is still the cheapest remaining numerator conversion — host access only, no HTTP auth.",
+        "Lane 2 idle ~5h with V1-43 unstarted and unblocked; delivery is the blocker."
       ],
       "lastMeaningfulActivity": "2026-08-20T02:23:00Z",
       "policyState": "INTEGRATION_OWNER"
@@ -202,11 +201,13 @@
     "consequence": "My 'wrong by one' warning was itself wrong by one. The level the contract sets is the contract's to set, and it says L1.",
     "whatSurvives": "If anyone believes V1-34 should require a production consumer, that is an argument for RE-LEVELLING the row to L4 — an owner decision — not an argument against this promotion. Recorded that way rather than quietly dropped."
   },
-  "cycle19Transitions": [
-    "V1 = 48/132 (36.4%). #942 promoted V1-95 on the deployed build. Row-diffed: exactly one row moved, which is what the commit subject claimed — checked rather than trusted.",
-    "#928 MERGED (231468bb4), so these dispatch records are now canonical on main rather than living on a review branch. The dispatcher branch was rotated onto the latest main per the merged-PR rule: every prior commit was already contained in main (verified with merge-base --is-ancestor before touching anything) and the remote branch had been deleted. Nothing was lost, and no commit was spent marking the rotation — it rides along here.",
-    "LANE 2 STILL ACTIONABLE_IDLE, now about 4h20m. No V1-43 branch exists. The blocker has not changed and is not the lane's: L2-2026-08-19-02 is DELIVERY_REQUIRED and no channel reaches Lane 2. No second assignment written.",
-    "THE LANE-4 ON-BOX BATCH IS STILL UNRUN (V1-57, V1-129, V1-60). Available since #932 merged, host access only, no HTTP auth. It remains the largest identified lever on the numerator that nobody has pulled.",
-    "RULE 7 BREACH IS WORSENING, not holding: rc-937 is now 110 commits behind main, rc-wave-a 107 behind, and origin/v1/premium-ui — the exact-duplicate ref for #912's head — is 275 behind. None retired. Three abandoned refs is past the point where 'stale' describes it."
+  "cycle20Transitions": [
+    "V1 = 55/132 (41.7%). #944 promoted seven rows on mutation-proven evidence. Row-diffed rather than credited: exactly seven newly VERIFIED and zero other changes, so the subject's stated count was accurate. Session net 40 -> 55 with the denominator untouched throughout — no row was reclassified out of the required list to make the percentage rise.",
+    "V1-81 was one of the closability queue's four L2 IMPLEMENTED_UNVERIFIED rows and is now closed. V1-39 and V1-44 were Lane 2's Trade rows, verified at L1 after #913 landed.",
+    "V1-88 IS STILL IMPLEMENTED_UNVERIFIED after a THIRD promotion pass. The refusal has now survived three separate rounds of Claude 5's own review, which is stronger evidence than the original refusal.",
+    "V1-42 IS STILL NOT STARTED, and this is the third cycle reporting it. #913's W3 supplied the consumer that simulate_roster_change lacked — the exact false-green the contract's §2 names as its first precedent — so the row is closer to closable than its status suggests. Escalated again rather than dropped.",
+    "MY PR #945 IS GREEN (Validate PR success 04:57:35Z).",
+    "THREE ABANDONED REFS STILL PRESENT and still drifting: rc-937 122 behind, rc-wave-a 119 behind, v1/premium-ui 287 behind. Reported for a third cycle.",
+    "LANE 2 STILL ACTIONABLE_IDLE — no V1-43 branch, now roughly 5h. Delivery remains the blocker, and no second assignment has been written."
   ]
 }

--- a/docs/claude-dispatch/LANE_STATUS.json
+++ b/docs/claude-dispatch/LANE_STATUS.json
@@ -1,10 +1,10 @@
 {
   "_comment": "Lane utilization state, owned by Claude 7 (Lane Dispatcher). NOT an authority on integration sequencing (Claude 5 / docs/EXECUTION_PLAN.md), on V1 status (docs/VERSION_1_COMPLETION_CONTRACT.md) or on canonical ownership (CLAUDE.md). Repository evidence outranks this file: where they disagree, this file is wrong and must be corrected.",
-  "updatedAt": "2026-08-20T11:30:00Z",
-  "dispatchCycle": 29,
+  "updatedAt": "2026-08-20T12:05:00Z",
+  "dispatchCycle": 30,
   "writePolicy": "This file and ASSIGNMENTS.json are written ONLY on a material state transition — new assignment, assignment accepted, completion, blocker, freeze/unfreeze, or a meaningful dependency change. A heartbeat that finds nothing changed produces no commit and no CI run.",
   "evidenceBasis": "origin/main 079fc9e4a; §3 diffed row-by-row from cycle-19 main (c5a367266); all refs resolved live; #945 CI green 04:57:35Z",
-  "assignmentSourceNote": "The six current assignments were made manually by the owner, not by this dispatcher. Recorded here so the durable state matches reality; Claude 7 did not originate them and does not own them.",
+  "assignmentSourceNote": "Lanes 1-6 carry the owner's original six manual assignments, tracked in detail by this dispatcher. Lanes 8-13 are five additional owner-authorized campaign lanes (Claude 8 chartered 2026-08-20; Claude 9-13 chartered the same day under the POST-V1 C-Series mass-build campaign, EXECUTION_PLAN.md §0). This dispatcher did not originate any of these eleven assignments and does not own or re-scope them. Lanes 8-13 are tracked here only lightly — ownership boundaries and authorization citation — because they are self-directed under their own charter, unlike lanes 1-6 which this dispatcher actively monitors for idleness and dispatches follow-on work to. There is no lane 7: Claude 7 is the dispatcher identity, per dispatcherIdentity above.",
   "lanes": {
     "1": {
       "name": "Roster Intelligence",
@@ -167,6 +167,58 @@
       "mergedThisCycle": [
         935
       ]
+    },
+    "8": {
+      "name": "Source Acquisition + Cross-Position Bridge",
+      "chartered": "2026-08-20",
+      "priority": "top-priority V1 (per EXECUTION_PLAN.md — this lane IS V1-scoped, unlike 9-13)",
+      "owns": "new source acquisition; cross-position bridge architecture; Dynasty Nerds integration; Dynasty Dealer bridge qualification; Draft Sharks cross-position qualification; IDP Show / Footballguys acquisition",
+      "assignmentSource": "owner-authorized (EXECUTION_PLAN.md §0); not dispatcher-originated",
+      "dispatcherRole": "monitor only — reported neutrally in cycle notes since cycle 24; not assigned, not idle-clocked the way lanes 1-6 are",
+      "observedActivity": "#954 merged 2026-08-20 (Lane 8 PR A); #950 open; branch churn continuing as of cycle 29",
+      "mayNot": "introduce a second package/lineup/replacement/value engine; own global source-health semantics (lane 5) or source-health frontend surfaces (lane 6); add V1 §3 rows or mark anything VERIFIED"
+    },
+    "9": {
+      "name": "C3 + trade-related C7",
+      "chartered": "2026-08-20 (POST-V1 C-Series mass-build campaign)",
+      "owns": "C3 trade substrate; trade-related C7 decision products",
+      "oneWriter": "sole new mass-build writer for C3 — no other mass-build lane independently modifies the trade substrate",
+      "assignmentSource": "owner-authorized (EXECUTION_PLAN.md §0); not dispatcher-originated",
+      "dispatcherRole": "monitor only",
+      "observedActivity": "#962 (C3-VA-01, Value Adjustment consolidation) open as of cycle 24-29"
+    },
+    "10": {
+      "name": "C4 + waiver/draft-related C7",
+      "chartered": "2026-08-20 (POST-V1 C-Series mass-build campaign)",
+      "owns": "C4 Market / Sharp / FAAB; waiver- and draft-related C7",
+      "assignmentSource": "owner-authorized (EXECUTION_PLAN.md §0); not dispatcher-originated",
+      "dispatcherRole": "monitor only",
+      "observedActivity": "#961 (C4-WAIV-01 / C4-MTL-01 / C4-MTL-03) open as of cycle 24-29"
+    },
+    "11": {
+      "name": "C5 Seasonal Intelligence",
+      "chartered": "2026-08-20 (POST-V1 C-Series mass-build campaign)",
+      "owns": "C5 Seasonal Intelligence",
+      "assignmentSource": "owner-authorized (EXECUTION_PLAN.md §0); not dispatcher-originated",
+      "dispatcherRole": "monitor only",
+      "observedActivity": "claude/c5-proj-a-source-census, claude/c5-war-01-deterministic-core branches active as of cycle 29 (C5-PROJ-A, C5-WAR-01)"
+    },
+    "12": {
+      "name": "C6 + intelligence-related C7",
+      "chartered": "2026-08-20 (POST-V1 C-Series mass-build campaign)",
+      "owns": "C6 Analyst / Signal / Manager / AI intelligence; intelligence-driven C7",
+      "assignmentSource": "owner-authorized (EXECUTION_PLAN.md §0); not dispatcher-originated",
+      "dispatcherRole": "monitor only",
+      "observedActivity": "claude/cseries-seasonal-intelligence-efz837 / claude/cseries-intelligence-data-80btkq branches observed — not yet reconciled to a specific PR by this dispatcher"
+    },
+    "13": {
+      "name": "C8 + C9 + C10",
+      "chartered": "2026-08-20 (POST-V1 C-Series mass-build campaign)",
+      "owns": "C8 Premium/Performance; C9 Public/Storytelling; C10 closure",
+      "boundary": "the existing Claude 6 premium-UI claim is repair-only and protects only its named files/defect scope, not all of C8/C9/C10 — Claude 13 avoids those actively claimed files and continues elsewhere in scope",
+      "assignmentSource": "owner-authorized (EXECUTION_PLAN.md §0); not dispatcher-originated",
+      "dispatcherRole": "monitor only",
+      "observedActivity": "claude/cseries-premium-public-closure -> ada3b1471 (C10-CLOSE-02) observed as of cycle 29"
     }
   },
   "collisionWatch": [
@@ -272,5 +324,25 @@
       "claude/cseries-premium-public-closure",
       "claude/cseries-trade-decision-mrwj7r moved to 08c89e1f3"
     ]
+  },
+  "dispatcherIdentity": {
+    "_authority": "docs/EXECUTION_PLAN.md §0, lines 55-59 and the POST-V1 C-Series section: 'There is no Claude 7 lane. The number is not assigned, and nothing here creates one.'",
+    "statement": "Claude 7 IS the Lane Dispatcher — the author of this record — and is explicitly NOT a seventh product implementation lane. This file's own numbering (lanes 1-6 as product lanes) was briefly read elsewhere as leaving '7' open; EXECUTION_PLAN.md corrected that reading on 2026-08-20 by naming this file and ASSIGNMENTS.json directly as the reason 7 is not a gap.",
+    "doesNotChange": "Nothing about the dispatcher's own conduct rules changes: no merging, no implementing, no V1 status edits, no origination of work for other lanes."
+  },
+  "governanceCorrection_C30": {
+    "trigger": "Issue #967 — 'Dispatch registry is missing lanes 8 and 9-13' — a bounded dispatcher-owned governance correction requested directly, citing head d51910bf5.",
+    "whatWasStale": "LANE_STATUS.json materially listed only lanes 1-6, and assignmentSourceNote said 'The six current assignments were made manually by the owner,' which had been true and was now incomplete against EXECUTION_PLAN.md's Lane 8 charter (cycle 26-29) and the Claude 9-13 mass-build campaign (authorized at #963, cycle 26).",
+    "whatChanged": [
+      "added dispatcherIdentity, citing EXECUTION_PLAN.md's own text that Claude 7 is the dispatcher and no product lane 7 exists",
+      "added lanes 8-13 as lightly-tracked entries (owns/charter-date/citation/observed activity), explicitly NOT given the full assignment-tracking shape lanes 1-6 have, because this dispatcher does not originate or own their work",
+      "rewrote assignmentSourceNote to state eleven total owner-authorized assignments across 1-6 and 8-13, with no lane 7"
+    ],
+    "whatDidNotChange": [
+      "V1 status, denominator or any §3 row — untouched",
+      "VERSION_1_COMPLETION_CONTRACT.md, EXECUTION_PLAN.md, product source, CE registry — none touched by this dispatcher, per its standing scope",
+      "the v1DerivedObservation block, which still carries the last SHA-stamped independent reading (58/136 at 31724a8d4) and is still explicitly marked non-authoritative"
+    ],
+    "selfCheck": "This is the second time this session a governance send-back has asked this dispatcher to correct its own coordination record for the same underlying class of defect: #945's send-back (cycle 20) was 'you formed a second owner of the V1 numerator'; this one is 'your lane model went stale against a canonical record that superseded it.' Both are the same root cause — a derived/cached reading that nobody forced to reconcile against its source. Recording it here rather than treating it as a one-off, because the fix in both cases was the same: mark the block as derived and dated, and don't let convenience make it read as authoritative."
   }
 }

--- a/docs/claude-dispatch/LANE_STATUS.json
+++ b/docs/claude-dispatch/LANE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Lane utilization state, owned by Claude 7 (Lane Dispatcher). NOT an authority on integration sequencing (Claude 5 / docs/EXECUTION_PLAN.md), on V1 status (docs/VERSION_1_COMPLETION_CONTRACT.md) or on canonical ownership (CLAUDE.md). Repository evidence outranks this file: where they disagree, this file is wrong and must be corrected.",
-  "updatedAt": "2026-08-20T12:15:00Z",
-  "dispatchCycle": 31,
+  "updatedAt": "2026-08-20T12:45:00Z",
+  "dispatchCycle": 32,
   "writePolicy": "This file and ASSIGNMENTS.json are written ONLY on a material state transition — new assignment, assignment accepted, completion, blocker, freeze/unfreeze, or a meaningful dependency change. A heartbeat that finds nothing changed produces no commit and no CI run.",
   "evidenceBasis": "origin/main 079fc9e4a; §3 diffed row-by-row from cycle-19 main (c5a367266); all refs resolved live; #945 CI green 04:57:35Z",
   "assignmentSourceNote": "Lanes 1-6 carry the owner's original six manual assignments, tracked in detail by this dispatcher. Lanes 8-13 are five additional owner-authorized campaign lanes (Claude 8 chartered 2026-08-20; Claude 9-13 chartered the same day under the POST-V1 C-Series mass-build campaign, EXECUTION_PLAN.md §0). This dispatcher did not originate any of these eleven assignments and does not own or re-scope them. Lanes 8-13 are tracked here only lightly — ownership boundaries and authorization citation — because they are self-directed under their own charter, unlike lanes 1-6 which this dispatcher actively monitors for idleness and dispatches follow-on work to. There is no lane 7: Claude 7 is the dispatcher identity, per dispatcherIdentity above.",
@@ -251,11 +251,11 @@
     "_staleByConstruction": true,
     "_ifTheyDisagree": "the contract wins, always, and this block is the thing that is wrong.",
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
-    "observedVerifiedRows": 58,
+    "observedVerifiedRows": 59,
     "observedRequiredRows": 136,
-    "observedAtSha": "113a29311",
-    "observedAt": "2026-08-20T10:22:00Z",
-    "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA; independently summed all statuses to 136 and confirmed the contract’s own table and completion line agree",
+    "observedAtSha": "45d5cdac1",
+    "observedAt": "2026-08-20T12:42:00Z",
+    "howObserved": "counted VERIFIED in the §3 table at that exact SHA; independently summed all statuses to 136 and confirmed the contract’s own table and completion line agree",
     "denominatorChangedAtThisSha": "YES — 132 -> 136. See cycle26Transitions."
   },
   "canonicalOwnerRule": "This dispatcher previously carried a `v1` block with verified/percent fields that read as authoritative, and it DRIFTED — PR #945 declared 48/132 while the contract on main said 55/132. That is a second owner of the numerator forming inside a coordination record, which is the exact defect class this dispatcher has spent the session flagging in other lanes. Corrected on integration review: the fields are renamed to name themselves derived, carry the SHA they were read at, and declare the contract the winner in any disagreement.",
@@ -354,6 +354,31 @@
       "integrationState": "READY_FOR_INTEGRATION",
       "freeze": "This slice is FROZEN at 40509bc5a per #940/EXECUTION_PLAN.md's anti-thrashing rule. No further edits to it, no chasing main for ordinary data-refresh movement. Handed to Claude 5 (Integration Authority) for freshness reconciliation and shipping-tree merge at Integration's discretion.",
       "handoff": "exact head 40509bc5a on claude/lane-dispatcher-orchestrator-u5hpca (#945)"
+    }
+  },
+  "cycle32Transitions": {
+    "mainTip": "45d5cdac1 (was 31724a8d4)",
+    "myOwnPr": {
+      "pr": "#945",
+      "head": "493e1b014",
+      "verdict": "Validate PR SUCCESS, job 96421927245, 12:17:09Z -> 12:30:38Z",
+      "runDuration": "13m29s — shorter than the two prior 17m runs, comfortably inside the 22-minute interval."
+    },
+    "merged": [
+      "#950 — Lane 8 docs (cross-position bridge / IDP ceiling audit)",
+      "#964 — Lane 12 implementation (V1-53: widen canonical-alias write guard to cover the seasonal lane)",
+      "#968 — Integration's own closure work (#958 closed by production evidence; #948 suppression holds at 3h)",
+      "#972 — Integration promotion pass (V1-53 VERIFIED at L1 — 59/136)"
+    ],
+    "promotionPassRan": "YES — #972, the third promotion pass of the session (after #947, #963).",
+    "rowDiff": {
+      "method": "§3 row-diffed 113a29311 -> 45d5cdac1",
+      "result": "EXACTLY ONE row changed: V1-53 IN PROGRESS -> VERIFIED (L1). Denominator held at 136.",
+      "selfConsistency": "Independent count 59+21+21+33+2 = 136; contract's own table and completion line read 59/136 = 43.4%, agreeing."
+    },
+    "rule_n_appliedCorrectly": {
+      "observation": "Three of the four merges (#950, #964, #968) moved zero §3 rows. Checked each against its lane's charter before drawing any conclusion, per rule (n).",
+      "finding": "All three are non-promotion by charter or by role: #950 is Lane 8 (forbidden from touching §3), #964 is Lane 12's IMPLEMENTATION of V1-53 (mass-build lanes mark nothing VERIFIED), #968 is Integration's own operational closure work, not a §3 edit. The ONE row that moved came from #972, which IS Integration exercising its sole promotion authority. This is the pattern working exactly as chartered — implementation and promotion cleanly separated across four merges in one cycle, with the row-diff proving it rather than assuming it."
     }
   }
 }

--- a/docs/claude-dispatch/LANE_STATUS.json
+++ b/docs/claude-dispatch/LANE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Lane utilization state, owned by Claude 7 (Lane Dispatcher). NOT an authority on integration sequencing (Claude 5 / docs/EXECUTION_PLAN.md), on V1 status (docs/VERSION_1_COMPLETION_CONTRACT.md) or on canonical ownership (CLAUDE.md). Repository evidence outranks this file: where they disagree, this file is wrong and must be corrected.",
-  "updatedAt": "2026-08-20T10:10:00Z",
-  "dispatchCycle": 25,
+  "updatedAt": "2026-08-20T10:25:00Z",
+  "dispatchCycle": 26,
   "writePolicy": "This file and ASSIGNMENTS.json are written ONLY on a material state transition — new assignment, assignment accepted, completion, blocker, freeze/unfreeze, or a meaningful dependency change. A heartbeat that finds nothing changed produces no commit and no CI run.",
   "evidenceBasis": "origin/main 079fc9e4a; §3 diffed row-by-row from cycle-19 main (c5a367266); all refs resolved live; #945 CI green 04:57:35Z",
   "assignmentSourceNote": "The six current assignments were made manually by the owner, not by this dispatcher. Recorded here so the durable state matches reality; Claude 7 did not originate them and does not own them.",
@@ -199,11 +199,12 @@
     "_staleByConstruction": true,
     "_ifTheyDisagree": "the contract wins, always, and this block is the thing that is wrong.",
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
-    "observedVerifiedRows": 55,
-    "observedRequiredRows": 132,
-    "observedAtSha": "079fc9e4a",
-    "observedAt": "2026-08-20T05:25:00Z",
-    "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA"
+    "observedVerifiedRows": 58,
+    "observedRequiredRows": 136,
+    "observedAtSha": "113a29311",
+    "observedAt": "2026-08-20T10:22:00Z",
+    "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA; independently summed all statuses to 136 and confirmed the contract’s own table and completion line agree",
+    "denominatorChangedAtThisSha": "YES — 132 -> 136. See cycle26Transitions."
   },
   "canonicalOwnerRule": "This dispatcher previously carried a `v1` block with verified/percent fields that read as authoritative, and it DRIFTED — PR #945 declared 48/132 while the contract on main said 55/132. That is a second owner of the numerator forming inside a coordination record, which is the exact defect class this dispatcher has spent the session flagging in other lanes. Corrected on integration review: the fields are renamed to name themselves derived, carry the SHA they were read at, and declare the contract the winner in any disagreement.",
   "correction_C24": {
@@ -215,41 +216,36 @@
     "newMethodRule": "(j) ABSENCE FROM A TRUNCATED LIST IS NOT EVIDENCE OF DELETION. To claim a ref is gone, name it to git ls-remote or read the [deleted] line from the fetch. Never infer it from a ref falling off the bottom of a sorted head -N.",
     "alsoWorthNaming": "This is the third time this session I have reported a cleaner state than the evidence supported, and each time the mechanism was the same: a convenient reading of an instrument I had narrowed myself."
   },
-  "cycle25Transitions": {
-    "mainTip": "a1c6e6ea4 (was cca488cd7)",
-    "merged": "#960 (a1c6e6ea4) — '#958: the tracker stops betting on how gh spells a bot login'. Branch deleted on merge.",
-    "v1Effect": "NONE. Row-diffed §3 cca488cd7 -> a1c6e6ea4: NO row changed. Still 57 VERIFIED of 132, and the contract's own table and completion line agree with my independent count.",
-    "theCyclePatternHolds": "Six merges across cycles 21-25 have produced +2 VERIFIED rows, both from one promotion pass. Verification remains the binding constraint.",
-    "promotionPassStillOpen": {
-      "pr": "#963",
-      "headNow": "115e0c662 (was f262003a8)",
-      "contentUnchanged": "Still exactly V1-51 IN PROGRESS -> VERIFIED plus V1-133..V1-136 added as NOT STARTED. Re-counted on the live head: 58+21+22+33+2 = 136, its own table agrees.",
-      "denominatorWarningStands": "57/132 = 43.2% -> 58/136 = 42.6%. The percentage falls while a row is verified. Scope entering the denominator, not a regression."
+  "cycle26Transitions": {
+    "mainTip": "113a29311 (was a1c6e6ea4)",
+    "merged": "#963 — merge 113a29311, 'Merge pull request #963 from jasonleetucker-code/claude/v1-integration-authority-xaqcv8'. Branch deleted on merge.",
+    "promotionPassRan": "YES. This is the second promotion pass of the session and the second time the numerator moved at all.",
+    "rowDiff": {
+      "method": "§3 row-diffed a1c6e6ea4 -> 113a29311",
+      "changes": [
+        "V1-51: IN PROGRESS -> VERIFIED (target L2, promoted on DEPLOYED evidence)",
+        "V1-133: added, NOT STARTED",
+        "V1-134: added, NOT STARTED",
+        "V1-135: added, NOT STARTED",
+        "V1-136: added, NOT STARTED"
+      ],
+      "nothingElseMoved": "No other row changed status. Exactly what #963 claimed while open, landing unchanged."
     },
-    "MY_CYCLE_24_FRAMING_WAS_WRONG": {
-      "_severity": "Correction — a framing error, not a fact error.",
-      "whatISaid": "Cycle 24: 'The fleet has outgrown my model… Lane 8 and C-Series Claude 9 are committing, neither in any doNotTouch set, collision watchlist or idle clock here.' The tone implied unmanaged sprawl.",
-      "whatIsActuallyTrue": "#963 carries commit e1a676c95, 'Authorize the POST-V1 C-Series mass-build campaign — execution timing only', and 115e0c662, 'Close two merged claim rows and narrow the freeze row, so the new lanes are not falsely blocked'. The new lanes are an AUTHORIZED campaign with its work claims deliberately unblocked.",
-      "correctReading": "My model was not violated; it was superseded by an owner authorization my records did not yet know about. A coordination record that has not caught up is not evidence that the fleet is uncoordinated — and reporting it that way is the same error as reading a truncated list as deletion: treating the limits of my own instrument as a fact about the world.",
-      "standing": "The lane model here still covers L1-L6 plus Integration. Extending it remains an owner decision. But the collision language is withdrawn: #962's Value Adjustment consolidation is campaign work, not an unclaimed incursion into Lane 2's territory."
+    "selfConsistency": "Counted independently: 58 + 21 + 22 + 33 + 2 = 136. The contract's own status table and its completion line both read 58 / 136 = 42.6%. My count and its count agree."
+  },
+  "denominatorHistory": {
+    "_why": "Recorded durably because a moving denominator silently breaks every percentage comparison in this record's history, and a floating note in one cycle block would be lost the next time a cycle block is rotated out.",
+    "132": {
+      "heldFrom": "the start of this dispatcher's involvement",
+      "heldUntil": "main a1c6e6ea4",
+      "finalReading": "57 VERIFIED of 132 = 43.2%"
     },
-    "uncappedSweepFinding": {
-      "observation": "Sweeping origin UNCAPPED for the first time (rule j's consequence) shows roughly 85 remote refs, with a long dormant tail reaching back to March. My 'three abandoned refs' framing was itself too narrow a window — the same defect one level up.",
-      "dispatcherAction": "REPORTED, and deliberately NOT turned into work. A mass ref cleanup is not dispatcher authority and nobody asked for one. The three named refs stay named because they are RECENT and integration-owned, which is what made them rule-7 relevant; the March tail is ordinary repository sediment."
+    "136": {
+      "beganAt": "main 113a29311 (#963, commit f99a5bf2c)",
+      "cause": "the owner's source-acquisition / bridge decision reconciled into V1 scope — V1-133..V1-136 added, all NOT STARTED",
+      "firstReading": "58 VERIFIED of 136 = 42.6%"
     },
-    "abandonedRefsVerifiedByName": {
-      "method": "git ls-remote origin refs/heads/<ref> — named, not inferred",
-      "v1/premium-ui": "PRESENT c025e4f68",
-      "integration/rc-937": "PRESENT 80b7b948d",
-      "integration/rc-wave-a": "PRESENT 213f91513",
-      "claude/no-player-data-routes (#759)": "PRESENT 82851974f",
-      "claude/rankings-board-windowing (#760)": "PRESENT 4f00f1599"
-    },
-    "myOwnPr": {
-      "pr": "#945",
-      "head": "673fa6f6f",
-      "ci": "Validate PR in_progress, job 96385604645, started 09:53Z",
-      "reviewComments": "none new"
-    }
+    "THE_READING_THAT_IS_EASY_TO_GET_WRONG": "43.2% -> 42.6% ACROSS A PASS THAT VERIFIED A ROW. Nothing was un-verified and nothing regressed; four unstarted rows entered the denominator. The verified COUNT went 57 -> 58, which is the honest measure of the pass.",
+    "rule": "Compare VERIFIED ROW COUNTS across cycles. Never compare bare percentages across this boundary, and never quote a percentage without its denominator."
   }
 }

--- a/docs/claude-dispatch/LANE_STATUS.json
+++ b/docs/claude-dispatch/LANE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Lane utilization state, owned by Claude 7 (Lane Dispatcher). NOT an authority on integration sequencing (Claude 5 / docs/EXECUTION_PLAN.md), on V1 status (docs/VERSION_1_COMPLETION_CONTRACT.md) or on canonical ownership (CLAUDE.md). Repository evidence outranks this file: where they disagree, this file is wrong and must be corrected.",
-  "updatedAt": "2026-08-20T12:45:00Z",
-  "dispatchCycle": 32,
+  "updatedAt": "2026-08-20T13:15:00Z",
+  "dispatchCycle": 33,
   "writePolicy": "This file and ASSIGNMENTS.json are written ONLY on a material state transition — new assignment, assignment accepted, completion, blocker, freeze/unfreeze, or a meaningful dependency change. A heartbeat that finds nothing changed produces no commit and no CI run.",
   "evidenceBasis": "origin/main 079fc9e4a; §3 diffed row-by-row from cycle-19 main (c5a367266); all refs resolved live; #945 CI green 04:57:35Z",
   "assignmentSourceNote": "Lanes 1-6 carry the owner's original six manual assignments, tracked in detail by this dispatcher. Lanes 8-13 are five additional owner-authorized campaign lanes (Claude 8 chartered 2026-08-20; Claude 9-13 chartered the same day under the POST-V1 C-Series mass-build campaign, EXECUTION_PLAN.md §0). This dispatcher did not originate any of these eleven assignments and does not own or re-scope them. Lanes 8-13 are tracked here only lightly — ownership boundaries and authorization citation — because they are self-directed under their own charter, unlike lanes 1-6 which this dispatcher actively monitors for idleness and dispatches follow-on work to. There is no lane 7: Claude 7 is the dispatcher identity, per dispatcherIdentity above.",
@@ -253,10 +253,11 @@
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
     "observedVerifiedRows": 59,
     "observedRequiredRows": 136,
-    "observedAtSha": "45d5cdac1",
-    "observedAt": "2026-08-20T12:42:00Z",
+    "observedAtSha": "7c826f9c2",
+    "observedAt": "2026-08-20T13:12:00Z",
     "howObserved": "counted VERIFIED in the §3 table at that exact SHA; independently summed all statuses to 136 and confirmed the contract’s own table and completion line agree",
-    "denominatorChangedAtThisSha": "YES — 132 -> 136. See cycle26Transitions."
+    "denominatorChangedAtThisSha": "YES — 132 -> 136. See cycle26Transitions.",
+    "note": "Unchanged at 59/136. Two merges this cycle (#976, #974) touched EXECUTION_PLAN.md/WORK_CLAIMS.md and added one V1 contract CHANGE-LOG line recording a +0 authorization — verified it is a log entry, not a §3 row edit, by reading the diff directly."
   },
   "canonicalOwnerRule": "This dispatcher previously carried a `v1` block with verified/percent fields that read as authoritative, and it DRIFTED — PR #945 declared 48/132 while the contract on main said 55/132. That is a second owner of the numerator forming inside a coordination record, which is the exact defect class this dispatcher has spent the session flagging in other lanes. Corrected on integration review: the fields are renamed to name themselves derived, carry the SHA they were read at, and declare the contract the winner in any disagreement.",
   "correction_C24": {
@@ -356,29 +357,24 @@
       "handoff": "exact head 40509bc5a on claude/lane-dispatcher-orchestrator-u5hpca (#945)"
     }
   },
-  "cycle32Transitions": {
-    "mainTip": "45d5cdac1 (was 31724a8d4)",
+  "cycle33Transitions": {
+    "mainTip": "7c826f9c2 (was 45d5cdac1)",
     "myOwnPr": {
       "pr": "#945",
-      "head": "493e1b014",
-      "verdict": "Validate PR SUCCESS, job 96421927245, 12:17:09Z -> 12:30:38Z",
-      "runDuration": "13m29s — shorter than the two prior 17m runs, comfortably inside the 22-minute interval."
+      "head": "c6ade23f7",
+      "verdict": "Validate PR SUCCESS, job 96429090356, 12:43:16Z -> 13:01:22Z",
+      "runDuration": "18m6s — a new maximum (prior: 17m11s, 17m4s, 13m29s), still under the 22-minute interval but the margin is narrowing again."
     },
     "merged": [
-      "#950 — Lane 8 docs (cross-position bridge / IDP ceiling audit)",
-      "#964 — Lane 12 implementation (V1-53: widen canonical-alias write guard to cover the seasonal lane)",
-      "#968 — Integration's own closure work (#958 closed by production evidence; #948 suppression holds at 3h)",
-      "#972 — Integration promotion pass (V1-53 VERIFIED at L1 — 59/136)"
+      "#974 — Integration checkpoint ('#948 checkpoint at 4h29m: 0 commits, 13 runs; tracker repair is 1:1 over 8 runs')",
+      "#976 — Integration governance ('Authorize the first PSI production migration; release two stale claims')"
     ],
-    "promotionPassRan": "YES — #972, the third promotion pass of the session (after #947, #963).",
     "rowDiff": {
-      "method": "§3 row-diffed 113a29311 -> 45d5cdac1",
-      "result": "EXACTLY ONE row changed: V1-53 IN PROGRESS -> VERIFIED (L1). Denominator held at 136.",
-      "selfConsistency": "Independent count 59+21+21+33+2 = 136; contract's own table and completion line read 59/136 = 43.4%, agreeing."
+      "method": "§3 row-diffed 45d5cdac1 -> 7c826f9c2",
+      "result": "NO ROW CHANGED. 59 VERIFIED of 136, independent count and contract's own table agree.",
+      "theOneLineChangeInTheContractFile": "#976 added ONE line to VERSION_1_COMPLETION_CONTRACT.md's §10 change log: a '+0' entry recording the PSI production-migration authorization as execution-timing only. Read the diff directly rather than trusting the file-touched signal — confirmed it is a change-log addition, not a §3 status edit, consistent with the row-diff finding nothing moved."
     },
-    "rule_n_appliedCorrectly": {
-      "observation": "Three of the four merges (#950, #964, #968) moved zero §3 rows. Checked each against its lane's charter before drawing any conclusion, per rule (n).",
-      "finding": "All three are non-promotion by charter or by role: #950 is Lane 8 (forbidden from touching §3), #964 is Lane 12's IMPLEMENTATION of V1-53 (mass-build lanes mark nothing VERIFIED), #968 is Integration's own operational closure work, not a §3 edit. The ONE row that moved came from #972, which IS Integration exercising its sole promotion authority. This is the pattern working exactly as chartered — implementation and promotion cleanly separated across four merges in one cycle, with the row-diff proving it rather than assuming it."
-    }
+    "rule_n_appliedAgain": "Both merges are Integration governance/operational work (a checkpoint record and an authorization record), correctly zero-row. Fourth consecutive cycle where this dispatcher has verified a zero-row merge against the merging lane's role before treating it as anything other than the designed outcome.",
+    "noteworthy": "#976's own text names a defect this dispatcher's earlier framing could have caused: '#965 records avoiding globals.css because this row still read open' — a stale claim (claude/premium-ui-migration-ltldy0, done via #912) was costing another lane real avoidance behavior until Integration released it this cycle. Not this dispatcher's record, but the same failure shape as the lane-numbering and V1-tally corrections already logged here: a stale record outliving the event it described."
   }
 }

--- a/docs/claude-dispatch/LANE_STATUS.json
+++ b/docs/claude-dispatch/LANE_STATUS.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Lane utilization state, owned by Claude 7 (Lane Dispatcher). NOT an authority on integration sequencing (Claude 5 / docs/EXECUTION_PLAN.md), on V1 status (docs/VERSION_1_COMPLETION_CONTRACT.md) or on canonical ownership (CLAUDE.md). Repository evidence outranks this file: where they disagree, this file is wrong and must be corrected.",
-  "updatedAt": "2026-08-20T14:15:00Z",
-  "dispatchCycle": 35,
+  "updatedAt": "2026-08-20T14:50:00Z",
+  "dispatchCycle": 36,
   "writePolicy": "This file and ASSIGNMENTS.json are written ONLY on a material state transition — new assignment, assignment accepted, completion, blocker, freeze/unfreeze, or a meaningful dependency change. A heartbeat that finds nothing changed produces no commit and no CI run.",
   "evidenceBasis": "origin/main 079fc9e4a; §3 diffed row-by-row from cycle-19 main (c5a367266); all refs resolved live; #945 CI green 04:57:35Z",
   "assignmentSourceNote": "Lanes 1-6 carry the owner's original six manual assignments, tracked in detail by this dispatcher. Lanes 8-13 are five additional owner-authorized campaign lanes (Claude 8 chartered 2026-08-20; Claude 9-13 chartered the same day under the POST-V1 C-Series mass-build campaign, EXECUTION_PLAN.md §0). This dispatcher did not originate any of these eleven assignments and does not own or re-scope them. Lanes 8-13 are tracked here only lightly — ownership boundaries and authorization citation — because they are self-directed under their own charter, unlike lanes 1-6 which this dispatcher actively monitors for idleness and dispatches follow-on work to. There is no lane 7: Claude 7 is the dispatcher identity, per dispatcherIdentity above.",
@@ -251,13 +251,13 @@
     "_staleByConstruction": true,
     "_ifTheyDisagree": "the contract wins, always, and this block is the thing that is wrong.",
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
-    "observedVerifiedRows": 59,
+    "observedVerifiedRows": 60,
     "observedRequiredRows": 136,
-    "observedAtSha": "7901b4733",
-    "observedAt": "2026-08-20T14:12:00Z",
+    "observedAtSha": "a9799ef93",
+    "observedAt": "2026-08-20T14:47:00Z",
     "howObserved": "counted VERIFIED in the §3 table at that exact SHA; independently summed all statuses to 136 and confirmed the contract’s own table and completion line agree",
     "denominatorChangedAtThisSha": "YES — 132 -> 136. See cycle26Transitions.",
-    "note": "Unchanged at 59/136. #977 implemented V1-63 but the row correctly stayed IMPLEMENTED_UNVERIFIED (own text: \"NOT promoted 2026-08-20\"); #988 (open, unmerged) is Integration's actual promotion PR for it."
+    "note": "V1-63 promoted VERIFIED via #988 (fourth promotion pass this session, after #947/#963/#972). V1-108's close condition merged via #989 but the row correctly stayed IMPLEMENTED_UNVERIFIED pending a separate promotion."
   },
   "canonicalOwnerRule": "This dispatcher previously carried a `v1` block with verified/percent fields that read as authoritative, and it DRIFTED — PR #945 declared 48/132 while the contract on main said 55/132. That is a second owner of the numerator forming inside a coordination record, which is the exact defect class this dispatcher has spent the session flagging in other lanes. Corrected on integration review: the fields are renamed to name themselves derived, carry the SHA they were read at, and declare the contract the winner in any disagreement.",
   "correction_C24": {
@@ -357,31 +357,26 @@
       "handoff": "exact head 40509bc5a on claude/lane-dispatcher-orchestrator-u5hpca (#945)"
     }
   },
-  "cycle35Transitions": {
-    "mainTip": "7901b4733 (was 892df5686)",
-    "myOwnPr": {
+  "cycle36Transitions": {
+    "mainTip": "a9799ef93 (was 7901b4733)",
+    "myOwnPr_ciAnomaly": {
       "pr": "#945",
-      "head": "ce66b5374",
-      "verdict": "Validate PR SUCCESS, job 96447771036, 13:45:43Z -> 14:03:25Z",
-      "runDuration": "17m42s — inside the observed band, comfortably under the 24-minute interval."
+      "head": "b9731eb50 — UNCHANGED, no new commit landed on this branch this cycle",
+      "verdict": "Validate PR CANCELLED, job 96457874629, started 14:16:57Z, completed 14:38:06Z",
+      "investigated": "Confirmed via `git log` that b9731eb50 is still the branch tip — no push of mine caused this cancellation, unlike the earlier rule-(m) pattern where my own cadence cancelled prior runs. The concurrency group is keyed on PR NUMBER alone (`pr-${{ github.event.pull_request.number }}`), so cancellation requires a second pull_request event on #945 specifically; none is visible from this side (no new commits, no force-push). Recorded as an unexplained anomaly rather than attributed to my own cadence, since the evidence does not support that attribution this time.",
+      "resolution": "This cycle's write (a genuine material transition below) will push a new commit and trigger a fresh run naturally — no separate re-run action needed."
     },
     "merged": [
-      "#965 — Claude 13 (PSI/premium public closure): elevate the Chase Upside Market Ticker (C8-PSI-01/C8-A11Y-01)",
-      "#977 — Lane 4 implementation: publish per-player manager concentration on Sharp Roster Percentage (V1-63)"
+      "#979 — V1-52: isolate the canonical power engine, thread the results-only lens through HTTP",
+      "#989 — V1-108: transitive import-graph guard for the no-player-data routes (the close condition this dispatcher named since cycle 24)",
+      "#988 — Integration promotion: V1-63 VERIFIED (60/136)"
     ],
     "rowDiff": {
-      "method": "§3 row-diffed 892df5686 -> 7901b4733",
-      "result": "NO ROW CHANGED. 59 VERIFIED of 136, independent count and contract's own table agree.",
-      "whyV163DidNotMoveDespiteTheMerge": "V1-63's row text reads its own history: 'NOT promoted 2026-08-20, and the previously-named blocker is NOT the real one.' #977 is the IMPLEMENTATION (Lane 4); promotion is a separate Integration act. Confirmed a promotion PR exists and is open, unmerged: #988 'V1-63 VERIFIED (60/136); PSI PR A browser verification and its one blocker'."
+      "method": "§3 row-diffed 7901b4733 -> a9799ef93",
+      "result": "EXACTLY ONE status change: V1-63 IMPLEMENTED_UNVERIFIED -> VERIFIED. Denominator held at 136.",
+      "selfConsistency": "Independent count 60+20+21+33+2=136; contract's own table and completion line read 60/136=44.1%, agreeing.",
+      "v1_108_didNotMoveDespiteMerging": "#989 merged — the exact close condition this record has named since cycle 24 — but V1-108's row correctly stayed IMPLEMENTED_UNVERIFIED. Same separation as V1-63 last cycle: implementation lands, a distinct Integration act promotes. Confirming rather than assuming: read the live row text directly."
     },
-    "rule_n_generalizes": "This is the first cycle where the zero-row merge came from a PRODUCT lane (Lane 4) rather than a mass-build lane, and the same rule held: only Integration promotes, so implementation from ANY lane is expected to leave the row unpromoted until Integration acts separately. Not limited to lanes 9-13.",
-    "promotionPassInFlightNotLanded": "#988 is open, unmerged, proposing V1-63 -> 60/136. Six cycles without a LANDED promotion pass since #972 (cycle 32), but not six cycles of stall — one is actively queued.",
-    "directResponseToStandingFindings": {
-      "_significance": "Three branches appeared this cycle that implement the EXACT close conditions this dispatcher has named in every cycle report since they were first identified — not similar work, the literal named fix.",
-      "V1-108": "branch claude/v1-108-no-player-data-import-graph-guard, commit 1d62b8682: 'V1-108: commit a transitive import-graph guard for the six no-player-data routes' — this dispatcher's stated close condition verbatim since cycle 24 (eleven cycles). PR #989 open.",
-      "V1-88": "branch claude/v1-88-flag-reachability-guard, commit df925de73: 'test(api): non-vacuous flag-to-route reachability guard (V1-88 / F-26)' — the structured-gates-field fix this dispatcher has named since cycle 26 (nine cycles) as the reason V1-88 stays unpromotable. PR #991 open.",
-      "V1-29 bonus": "branch claude/v1-29-replacement-discovery-guard also appeared, closing a discovery gap on a row this dispatcher has not been tracking directly but which shares the same guard-test shape.",
-      "dispatcherRole": "Both are OPEN PRs, not yet merged or promoted. Reported as movement toward the standing Tier B items, not claimed as closed — the row-diff already confirms neither V1-108 nor V1-88 changed status yet."
-    }
+    "v1_88_stillOpen": "#991 (V1-88's close condition) is OPEN, UNMERGED — checked its body directly: 'READY FOR INTEGRATION — Claude 5 promotes/merges. I do not.' Structurally identical shape to #989: a caller-graph reachability guard, mutation-tested against the real F-26 defect (RED confirmed on reintroduction, GREEN restored). Not yet landed."
   }
 }

--- a/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
+++ b/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Live V1 Closability Queue, owned by Claude 7 as independent V1 traffic controller / adversarial auditor. Ranks IMPLEMENTED_UNVERIFIED rows by verification effort per row gained. NOT an authority on V1 status — only Claude 5 promotes a row, and no percentage here is claimed as achieved.",
-  "updatedAt": "2026-08-20T05:25:00Z",
-  "auditCycle": 2,
+  "updatedAt": "2026-08-20T06:15:00Z",
+  "auditCycle": 21,
   "evidenceBasis": {
     "contract": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 read on origin/main e3b387ca5",
     "deployedSha": "e3b387ca5",
@@ -401,9 +401,44 @@
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
     "observedVerifiedRows": 55,
     "observedRequiredRows": 132,
-    "observedAtSha": "079fc9e4a",
-    "observedAt": "2026-08-20T05:25:00Z",
-    "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA"
+    "observedAtSha": "64769555a",
+    "observedAt": "2026-08-20T06:12:00Z",
+    "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA",
+    "note": "Unchanged across the #912 merge. #947 (open) proposes 57; a proposal is not the contract."
   },
-  "_authorityNote": "This queue RANKS work by verification effort. It does not own, publish or restate V1 status. docs/VERSION_1_COMPLETION_CONTRACT.md §3 owns that, and every count in this file is a derived reading stamped with the SHA it came from."
+  "_authorityNote": "This queue RANKS work by verification effort. It does not own, publish or restate V1 status. docs/VERSION_1_COMPLETION_CONTRACT.md §3 owns that, and every count in this file is a derived reading stamped with the SHA it came from.",
+  "cycle21": {
+    "standingItemsUnchanged": [
+      {
+        "item": "Lane 2 ACTIONABLE_IDLE",
+        "elapsed": "~9h since 9e9d8e8ec (2026-08-19 21:46Z)",
+        "row": "V1-43 still `NOT STARTED`, level L1, unblocked on plain main, no branch",
+        "blocker": "ASSIGNMENT DELIVERY. L2-2026-08-19-02 remains DELIVERY_REQUIRED — no reachable channel from this session.",
+        "dispatcherAction": "NONE beyond surfacing. No second assignment written, per the standing instruction not to pile onto an unread one."
+      },
+      {
+        "item": "Lane 4 on-box verification batch",
+        "rows": "V1-57 (L3), V1-129, V1-60 (L2) — all still `IMPLEMENTED_UNVERIFIED` at 64769555a",
+        "elapsed": "~12h since 66fb1a053",
+        "whyItMatters": "Still the cheapest remaining numerator conversion: host access only, no HTTP auth, verifier already on main.",
+        "dispatcherAction": "NONE. Cannot execute on-box verification from this session."
+      },
+      {
+        "item": "Abandoned refs, #940 rule 7",
+        "stillPresent": [
+          "integration/rc-937 (80b7b948d)",
+          "integration/rc-wave-a (213f91513)",
+          "v1/premium-ui (c025e4f68)"
+        ],
+        "changeThisCycle": "v1/premium-ui is now DEFINITIVELY dead: c025e4f68 is an ancestor of merge b3ea4cf5a, so the ref holds nothing main lacks. claude/premium-ui-migration-ltldy0, its live twin, was correctly deleted on merge — this one was not.",
+        "dispatcherAction": "NONE. Ref deletion is not dispatcher authority."
+      }
+    ],
+    "rowsStillOpenAndReported": {
+      "V1-42": "`NOT STARTED` for a fifth consecutive cycle, though #913's W3 supplied the consumer simulate_roster_change lacked.",
+      "V1-88": "`IMPLEMENTED_UNVERIFIED`, unpromotable absent a structured `gates` field on the flag registry or an owner re-levelling ruling. Fourth promotion pass survived.",
+      "V1-108": "Newly decomposed by Integration in #947 with an exact close condition — commit the transitive import-graph scan as a guard. That is a Tier B item now rather than an unanalysed IN PROGRESS row.",
+      "pr930PostDeployScrape": "Still unconfirmed."
+    }
+  }
 }

--- a/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
+++ b/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Live V1 Closability Queue, owned by Claude 7 as independent V1 traffic controller / adversarial auditor. Ranks IMPLEMENTED_UNVERIFIED rows by verification effort per row gained. NOT an authority on V1 status — only Claude 5 promotes a row, and no percentage here is claimed as achieved.",
-  "updatedAt": "2026-08-20T03:57:00Z",
+  "updatedAt": "2026-08-20T04:40:00Z",
   "auditCycle": 2,
   "evidenceBasis": {
     "contract": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 read on origin/main e3b387ca5",
@@ -9,11 +9,11 @@
     "method": "per-PR exact-head check runs, git merge-tree mergeability, git grep against origin/main for the claimed properties"
   },
   "v1Status": {
-    "verified": 47,
+    "verified": 48,
     "denominator": 132,
-    "percent": 35.6,
-    "note": "47/132 (35.6%) on main, row-diffed. Session net: 40 -> 47. V1-34 (L1) and V1-130 (L2) promoted via #941; V1-51 and V1-95 corrected upward in status without being promoted.",
-    "implementedUnverified": 22,
+    "percent": 36.4,
+    "note": "48/132 (36.4%). V1-95 promoted at L2 on the deployed build via #942 — exactly one row moved, row-diffed. Session net 40 -> 48.",
+    "implementedUnverified": 21,
     "inProgress": 32,
     "notStarted": 29
   },
@@ -387,6 +387,7 @@
       "constraint": "the session gate must not be relaxed to achieve this"
     },
     "notAssignable": "Claude 7 cannot dispatch either batch: both need production access this dispatcher does not have and must not fabricate.",
-    "statusAtCycle18": "STILL UNRUN. This is now the single largest identified lever on the numerator and it has been available since #932 merged. It needs an operator on the box; no lane and no dispatcher can supply that."
+    "statusAtCycle18": "STILL UNRUN. This is now the single largest identified lever on the numerator and it has been available since #932 merged. It needs an operator on the box; no lane and no dispatcher can supply that.",
+    "statusAtCycle19": "STILL UNRUN, ~2.5h after becoming executable. Nothing else on the board converts as cheaply."
   }
 }

--- a/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
+++ b/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Live V1 Closability Queue, owned by Claude 7 as independent V1 traffic controller / adversarial auditor. Ranks IMPLEMENTED_UNVERIFIED rows by verification effort per row gained. NOT an authority on V1 status — only Claude 5 promotes a row, and no percentage here is claimed as achieved.",
-  "updatedAt": "2026-08-20T10:10:00Z",
-  "auditCycle": 25,
+  "updatedAt": "2026-08-20T10:25:00Z",
+  "auditCycle": 26,
   "evidenceBasis": {
     "contract": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 read on origin/main e3b387ca5",
     "deployedSha": "e3b387ca5",
@@ -399,41 +399,46 @@
     "_staleByConstruction": true,
     "_ifTheyDisagree": "the contract wins, always, and this block is the thing that is wrong.",
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
-    "observedVerifiedRows": 57,
-    "observedRequiredRows": 132,
-    "observedAtSha": "a1c6e6ea4",
-    "observedAt": "2026-08-20T10:05:00Z",
+    "observedVerifiedRows": 58,
+    "observedRequiredRows": 136,
+    "observedAtSha": "113a29311",
+    "observedAt": "2026-08-20T10:22:00Z",
     "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA",
-    "note": "#960 merged and changed no row. #963 (open, head 115e0c662) still proposes 58/136."
+    "note": "#963 MERGED. Denominator moved 132 -> 136 by owner decision; V1-51 promoted. See LANE_STATUS denominatorHistory."
   },
   "_authorityNote": "This queue RANKS work by verification effort. It does not own, publish or restate V1 status. docs/VERSION_1_COMPLETION_CONTRACT.md §3 owns that, and every count in this file is a derived reading stamped with the SHA it came from.",
-  "cycle25": {
-    "reportingRule": "From #963 onward, report VERIFIED ROW COUNT and state the denominator with every percentage. 57 of 132 and 58 of 136 are not comparable as percentages.",
-    "bottleneck": "Unchanged and now measured over five cycles: six merges, +2 VERIFIED rows, both from one promotion pass. Implementation lands honestly and waits.",
+  "cycle26": {
+    "landed": "#963 merged as 113a29311. V1-51 VERIFIED at L2 on deployed evidence; V1-133..V1-136 added NOT STARTED. Verified row count 57 -> 58; denominator 132 -> 136.",
+    "bottleneckMeasuredOverSixCycles": "Cycles 21-26: SEVEN merges, +3 VERIFIED rows, and ALL THREE came from the TWO promotion passes (#947, #963). Every other merge landed implementation that is waiting. The drain works when it runs; it runs rarely.",
+    "newlyOpenedV1Work": "#964 'V1-53: widen canonical-alias write guard to cover the seasonal lane' — a C-Series campaign lane taking a V1 row. Reported neutrally: the authorized campaign is not confined to post-V1 work, which is a fact about where V1 throughput may now come from.",
     "tierB": {
-      "V1-108": "Close: commit the transitive import-graph scan as a guard. Unactioned, third cycle.",
-      "V1-106": "STILL no named close condition; still cites only PR #760 while that code is on main. FIFTH cycle reporting it. This is now the longest-standing unactioned finding in this record."
+      "V1-106": "SIXTH cycle. Still IN PROGRESS, still citing only PR #760 while that code is on main, still no named close condition. Longest-standing unactioned finding in this record.",
+      "V1-108": "Close: commit the transitive import-graph scan as a guard. Fourth cycle unactioned."
     },
     "standingItems": [
       {
         "item": "Lane 2 ACTIONABLE_IDLE",
-        "elapsed": "~16.5h",
+        "elapsed": "~17h; branch still at 9e9d8e8ec",
         "row": "V1-43 NOT STARTED, target L1, unblocked on plain main",
         "blocker": "ASSIGNMENT DELIVERY of L2-2026-08-19-02",
-        "cycle24ComplicationWithdrawn": "#962 is authorized C-Series campaign work, not an incursion. See LANE_STATUS MY_CYCLE_24_FRAMING_WAS_WRONG.",
         "dispatcherAction": "Surfaced only. No second assignment written."
       },
       {
         "item": "Lane 4 on-box verification batch",
-        "rows": "V1-57, V1-129, V1-60 — all IMPLEMENTED_UNVERIFIED at a1c6e6ea4",
-        "elapsed": "~18h"
+        "rows": "V1-57, V1-129, V1-60 — all IMPLEMENTED_UNVERIFIED at 113a29311",
+        "elapsed": "~18.5h; branch still at 66fb1a053",
+        "instrumentExists": "#963 promoted V1-51 on DEPLOYED evidence, which is the same class of instrument this batch needs."
       },
       {
-        "item": "Abandoned refs",
-        "verifiedByName": "All five present — see LANE_STATUS abandonedRefsVerifiedByName.",
-        "scopeNote": "An uncapped sweep shows ~85 refs with a dormant tail to March. The three named refs stay named because they are recent and integration-owned; the tail is sediment, not a work item."
+        "item": "Abandoned refs, verified by name",
+        "present": [
+          "v1/premium-ui c025e4f68",
+          "integration/rc-937 80b7b948d",
+          "integration/rc-wave-a 213f91513"
+        ],
+        "hygieneNote": "claude/v1-integration-authority-xaqcv8 was deleted on merge — the fourth lane branch cleaned up in six cycles."
       }
     ],
-    "stalePRsUnacted": "#759 and #760 open against landed code, branches present. Fifth cycle."
+    "stalePRsUnacted": "#759 (82851974f) and #760 (4f00f1599) still open against landed code, branches present. Sixth cycle."
   }
 }

--- a/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
+++ b/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Live V1 Closability Queue, owned by Claude 7 as independent V1 traffic controller / adversarial auditor. Ranks IMPLEMENTED_UNVERIFIED rows by verification effort per row gained. NOT an authority on V1 status — only Claude 5 promotes a row, and no percentage here is claimed as achieved.",
-  "updatedAt": "2026-08-20T14:50:00Z",
-  "auditCycle": 36,
+  "updatedAt": "2026-08-20T15:45:00Z",
+  "auditCycle": 38,
   "evidenceBasis": {
     "contract": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 read on origin/main e3b387ca5",
     "deployedSha": "e3b387ca5",
@@ -401,24 +401,23 @@
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
     "observedVerifiedRows": 60,
     "observedRequiredRows": 136,
-    "observedAtSha": "a9799ef93",
-    "observedAt": "2026-08-20T14:47:00Z",
+    "observedAtSha": "0c6f1fdcd",
+    "observedAt": "2026-08-20T15:42:00Z",
     "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA",
-    "note": "V1-63 VERIFIED via #988. Fourth promotion pass this session."
+    "note": "VERIFIED unchanged at 60/136. No promotion pass since #988 (cycle 36)."
   },
   "_authorityNote": "This queue RANKS work by verification effort. It does not own, publish or restate V1 status. docs/VERSION_1_COMPLETION_CONTRACT.md §3 owns that, and every count in this file is a derived reading stamped with the SHA it came from.",
-  "cycle36": {
-    "promotionPassRan": "YES — #988. V1-63 VERIFIED, 59 -> 60/136.",
-    "bottleneckUpdated": "Cycles 21-36: eleven merges total across promotion+implementation, +5 VERIFIED rows (V1-107, V1-113, V1-51, V1-53, V1-63), all five from FOUR dedicated Integration promotion passes (#947, #963, #972, #988). Implementation volume across many lanes stays high; the numerator moves only in discrete Integration acts, and this cycle both halves of that pattern were visible in one sweep: V1-108's implementation merged (#989) while its promotion did NOT, in the same window V1-63's promotion DID land.",
+  "cycle38": {
+    "promotionPassRan": "NO. V1-52 moved NOT STARTED -> IN PROGRESS as a status correction (#994), not a promotion.",
     "tierB": {
-      "V1-106": "SIXTEENTH cycle. Still IN PROGRESS, still citing only PR #760, still the ONLY standing item with no PR or fix in flight anywhere.",
-      "V1-108": "Implementation MERGED via #989 — this dispatcher's own named close condition, verbatim. Row still IMPLEMENTED_UNVERIFIED pending Integration's separate promotion. Watch for a dedicated promotion PR next.",
-      "V1-88": "Implementation OPEN, unmerged, in #991 — 'READY FOR INTEGRATION'. Same shape as V1-108: mutation-tested, RED-confirmed, awaiting Integration to merge and promote separately."
+      "V1-106": "EIGHTEENTH cycle. Still IN PROGRESS, still citing only PR #760, still the ONLY standing item with no PR or fix in flight anywhere.",
+      "V1-108": "Implementation merged (#989, cycle 36). Promotion still pending, two cycles later.",
+      "V1-88": "Implementation open (#991). Still unmerged."
     },
     "standingItems": [
       {
         "item": "Lane 2 ACTIONABLE_IDLE",
-        "elapsed": "~22h; branch still 9e9d8e8ec",
+        "elapsed": "~23h; branch still 9e9d8e8ec",
         "row": "V1-43 NOT STARTED, target L1, unblocked on plain main",
         "blocker": "ASSIGNMENT DELIVERY of L2-2026-08-19-02",
         "dispatcherAction": "Surfaced only. No second assignment written."
@@ -426,7 +425,7 @@
       {
         "item": "Lane 4 on-box verification batch",
         "rows": "V1-57, V1-129, V1-60 — IMPLEMENTED_UNVERIFIED",
-        "elapsed": "~22.5h; branch still 66fb1a053"
+        "elapsed": "~23.5h; branch still 66fb1a053"
       },
       {
         "item": "Abandoned refs, verified by name",
@@ -434,10 +433,9 @@
           "v1/premium-ui c025e4f68",
           "integration/rc-937 80b7b948d",
           "integration/rc-wave-a 213f91513"
-        ],
-        "hygiene": "claude/v1-108-no-player-data-import-graph-guard, claude/v1-52-canonical-power, claude/v1-integration-authority-xaqcv8 all deleted on merge this cycle."
+        ]
       }
     ],
-    "stalePRsUnacted": "#759 and #760 still open against landed code. Thirteenth cycle."
+    "stalePRsUnacted": "#759 and #760 still open against landed code. Fourteenth cycle."
   }
 }

--- a/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
+++ b/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Live V1 Closability Queue, owned by Claude 7 as independent V1 traffic controller / adversarial auditor. Ranks IMPLEMENTED_UNVERIFIED rows by verification effort per row gained. NOT an authority on V1 status — only Claude 5 promotes a row, and no percentage here is claimed as achieved.",
-  "updatedAt": "2026-08-20T04:40:00Z",
+  "updatedAt": "2026-08-20T05:24:00Z",
   "auditCycle": 2,
   "evidenceBasis": {
     "contract": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 read on origin/main e3b387ca5",
@@ -9,12 +9,12 @@
     "method": "per-PR exact-head check runs, git merge-tree mergeability, git grep against origin/main for the claimed properties"
   },
   "v1Status": {
-    "verified": 48,
+    "verified": 55,
     "denominator": 132,
-    "percent": 36.4,
-    "note": "48/132 (36.4%). V1-95 promoted at L2 on the deployed build via #942 — exactly one row moved, row-diffed. Session net 40 -> 48.",
-    "implementedUnverified": 21,
-    "inProgress": 32,
+    "percent": 41.7,
+    "note": "55/132 (41.7%). #944 promoted seven on mutation-proven evidence, row-diffed and matching its stated count. Session net 40 -> 55 with the denominator constant.",
+    "implementedUnverified": 20,
+    "inProgress": 26,
     "notStarted": 29
   },
   "deployState": {
@@ -389,5 +389,17 @@
     "notAssignable": "Claude 7 cannot dispatch either batch: both need production access this dispatcher does not have and must not fabricate.",
     "statusAtCycle18": "STILL UNRUN. This is now the single largest identified lever on the numerator and it has been available since #932 merged. It needs an operator on the box; no lane and no dispatcher can supply that.",
     "statusAtCycle19": "STILL UNRUN, ~2.5h after becoming executable. Nothing else on the board converts as cheaply."
+  },
+  "queueScorecard": {
+    "rowsThisQueueRankedThatAreNowVERIFIED": [
+      "V1-119 (its sole Tier A)",
+      "V1-64 (its Tier B micro-PR)",
+      "V1-81 (one of its four L2 rows)"
+    ],
+    "rowsThisQueueRefusedThatRemainUnpromoted": [
+      "V1-88 — refused for want of an exact endpoint-naming proof; has now survived THREE promotion passes unpromoted"
+    ],
+    "coverageGapAcknowledged": "Rows that go IN PROGRESS -> VERIFIED in one motion (V1-28, V1-30, V1-33, V1-39, V1-44, V1-114..V1-118) were never ranked here, because the queue ranked IMPLEMENTED_UNVERIFIED rows. That is most of the +15.",
+    "standingRecommendationStillUnactioned": "the on-box batch (V1-57, V1-129, V1-60)"
   }
 }

--- a/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
+++ b/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Live V1 Closability Queue, owned by Claude 7 as independent V1 traffic controller / adversarial auditor. Ranks IMPLEMENTED_UNVERIFIED rows by verification effort per row gained. NOT an authority on V1 status — only Claude 5 promotes a row, and no percentage here is claimed as achieved.",
-  "updatedAt": "2026-08-20T12:45:00Z",
-  "auditCycle": 32,
+  "updatedAt": "2026-08-20T13:15:00Z",
+  "auditCycle": 33,
   "evidenceBasis": {
     "contract": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 read on origin/main e3b387ca5",
     "deployedSha": "e3b387ca5",
@@ -401,23 +401,22 @@
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
     "observedVerifiedRows": 59,
     "observedRequiredRows": 136,
-    "observedAtSha": "45d5cdac1",
-    "observedAt": "2026-08-20T12:42:00Z",
+    "observedAtSha": "7c826f9c2",
+    "observedAt": "2026-08-20T13:12:00Z",
     "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA",
-    "note": "#972 merged: V1-53 promoted VERIFIED at L1. Third promotion pass of the session (after #947, #963)."
+    "note": "Unchanged at 59/136. No promotion pass this cycle."
   },
   "_authorityNote": "This queue RANKS work by verification effort. It does not own, publish or restate V1 status. docs/VERSION_1_COMPLETION_CONTRACT.md §3 owns that, and every count in this file is a derived reading stamped with the SHA it came from.",
-  "cycle32": {
-    "promotionPassRan": "YES — #972. V1-53 VERIFIED at L1, denominator unchanged at 136.",
-    "bottleneckUpdated": "Cycles 21-32: nine merges, +4 VERIFIED rows total, all four from three dedicated promotion passes (#947, #963, #972). Every other merge — now including three more this cycle (#950, #964, #968) — landed implementation or operational work that did not touch §3, correctly by charter. The pattern holds: implementation volume is high across many lanes; promotion happens in discrete, attributable passes.",
+  "cycle33": {
+    "promotionPassRan": "NO — two Integration merges, both governance/checkpoint, zero rows by role.",
     "tierB": {
-      "V1-106": "ELEVENTH cycle. Still IN PROGRESS, still citing only PR #760 while that code is on main, still no named close condition.",
-      "V1-108": "Close: commit the transitive import-graph scan as a guard. Ninth cycle unactioned."
+      "V1-106": "TWELFTH cycle. Still IN PROGRESS, still citing only PR #760, still no named close condition.",
+      "V1-108": "Close: commit the transitive import-graph scan as a guard. Tenth cycle unactioned."
     },
     "standingItems": [
       {
         "item": "Lane 2 ACTIONABLE_IDLE",
-        "elapsed": "~20h; branch still 9e9d8e8ec",
+        "elapsed": "~20.5h; branch still 9e9d8e8ec",
         "row": "V1-43 NOT STARTED, target L1, unblocked on plain main",
         "blocker": "ASSIGNMENT DELIVERY of L2-2026-08-19-02",
         "dispatcherAction": "Surfaced only. No second assignment written."
@@ -425,8 +424,7 @@
       {
         "item": "Lane 4 on-box verification batch",
         "rows": "V1-57, V1-129, V1-60 — IMPLEMENTED_UNVERIFIED",
-        "elapsed": "~20.5h; branch still 66fb1a053",
-        "note": "#968 (this cycle) is Integration running the same production-evidence closure instrument on a different item while this batch continues to wait."
+        "elapsed": "~21h; branch still 66fb1a053"
       },
       {
         "item": "Abandoned refs, verified by name",
@@ -435,9 +433,10 @@
           "integration/rc-937 80b7b948d",
           "integration/rc-wave-a 213f91513"
         ],
-        "hygiene": "claude/cseries-seasonal-intelligence-efz837, claude/idp-ceiling-bridge-audit-zr28tj and claude/integration-sweep-1048 all deleted on merge this cycle — three more lane branches cleaned up."
+        "hygiene": "claude/obs-checkpoint-1210 and claude/psi-migration-authorization both deleted on merge this cycle."
       }
     ],
-    "stalePRsUnacted": "#759 and #760 still open against landed code. Ninth cycle."
+    "newAuthorization": "PSI first production migration authorized (#976) — execution-timing only, V1 denominator unchanged (verified: change-log line reads '+0'). Claude 13 implements, Claude 5 integrates/deploys. Not a V1-scoped item; reported for awareness only.",
+    "stalePRsUnacted": "#759 and #760 still open against landed code. Tenth cycle."
   }
 }

--- a/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
+++ b/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Live V1 Closability Queue, owned by Claude 7 as independent V1 traffic controller / adversarial auditor. Ranks IMPLEMENTED_UNVERIFIED rows by verification effort per row gained. NOT an authority on V1 status — only Claude 5 promotes a row, and no percentage here is claimed as achieved.",
-  "updatedAt": "2026-08-20T06:40:00Z",
-  "auditCycle": 22,
+  "updatedAt": "2026-08-20T09:40:00Z",
+  "auditCycle": 23,
   "evidenceBasis": {
     "contract": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 read on origin/main e3b387ca5",
     "deployedSha": "e3b387ca5",
@@ -401,52 +401,50 @@
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
     "observedVerifiedRows": 57,
     "observedRequiredRows": 132,
-    "observedAtSha": "c4431ccba",
-    "observedAt": "2026-08-20T06:38:00Z",
+    "observedAtSha": "cca488cd7",
+    "observedAt": "2026-08-20T09:38:00Z",
     "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA",
-    "note": "#947 merged as ff2741305. Row-diffed and independently counted; the contract's own table agrees."
+    "note": "Unchanged across four merges (#946, #948, #952, #956). Counted independently; the contract table agrees."
   },
   "_authorityNote": "This queue RANKS work by verification effort. It does not own, publish or restate V1 status. docs/VERSION_1_COMPLETION_CONTRACT.md §3 owns that, and every count in this file is a derived reading stamped with the SHA it came from.",
-  "cycle22": {
-    "promotedThisCycle": {
-      "V1-107": "VERIFIED, target L2 — payload re-measured at Integration from an archive, plus two mutations each producing named REDs.",
-      "V1-113": "VERIFIED, target L1 — 20 axe checks confirmed passing and non-skipping from the CI run log.",
-      "V1-108": "DEMOTED IN PLACE to IMPLEMENTED_UNVERIFIED with an exact close condition: commit the transitive import-graph scan as a guard. Now a Tier B item rather than an unanalysed IN PROGRESS row."
+  "cycle23": {
+    "bottleneckRestated": "VERIFICATION PASSES, NOT IMPLEMENTATION. Five merges over cycles 21-23 produced +2 VERIFIED rows, both from the single promotion PR #947. Rows now routinely land implemented-and-honest with a named close condition and then wait. The queue's Tier B population is growing faster than anything is draining it.",
+    "rowsWithNamedCloseConditions": {
+      "V1-51": "Implementation merged via #956; row stays IN PROGRESS. Close: give playoff_odds.py:215 the `unsimulable` shape with n_simulations 0 and a sibling-consistent `simulated` flag, a test RED without it, then re-measure the three endpoints for the L2 statement.",
+      "V1-108": "Close: commit the transitive import-graph scan as a guard.",
+      "V1-106": "NO named close condition — see the cycle-22 finding. Still IN PROGRESS citing only PR #760 while that code is on main."
     },
-    "tierB_newlyIdentified": {
-      "V1-106": "Code on main via #912; blocker is instrument credibility (the FPS harness owner ruling), not implementation. The row does not say so. Needs the same decomposition #947 gave V1-108.",
-      "V1-108": "Named close condition exists. Cheapest of the L6 rows now."
+    "cycle22FindingsRecheck": {
+      "stalePRs": "#759 and #760 STILL OPEN against landed code. Unacted. Note #949 (open) does exactly this class of cleanup for two work-claim rows in docs/WORK_CLAIMS.md, so someone is working the stale-bookkeeping seam — just not these two PRs.",
+      "V1_106_rowText": "Unchanged. Still the structural sibling of V1-108 without V1-108's decomposition."
     },
     "standingItemsUnchanged": [
       {
         "item": "Lane 2 ACTIONABLE_IDLE",
-        "elapsed": "~10.5h since 9e9d8e8ec; no new branch, no new PR",
-        "row": "V1-43 still `NOT STARTED`, target L1, unblocked on plain main",
-        "blocker": "ASSIGNMENT DELIVERY of L2-2026-08-19-02 — still DELIVERY_REQUIRED, still no reachable channel",
+        "elapsed": "~13.5h since 9e9d8e8ec; no new branch, no new PR",
+        "row": "V1-43 still NOT STARTED, target L1, unblocked on plain main",
+        "blocker": "ASSIGNMENT DELIVERY of L2-2026-08-19-02 — DELIVERY_REQUIRED, no reachable channel",
         "dispatcherAction": "Surfaced only. No second assignment written."
       },
       {
         "item": "Lane 4 on-box verification batch",
-        "rows": "V1-57, V1-129, V1-60 — all still IMPLEMENTED_UNVERIFIED at c4431ccba",
-        "elapsed": "~12.5h since 66fb1a053",
-        "dispatcherAction": "Cannot execute on-box verification from this session."
+        "rows": "V1-57, V1-129, V1-60 — all still IMPLEMENTED_UNVERIFIED at cca488cd7",
+        "elapsed": "~15h since 66fb1a053",
+        "sharpened": "Given the cycle-23 bottleneck reading, this batch is no longer merely 'cheap' — it is one of the few conversions available that needs NO new implementation and NO new PR from an implementation lane. Host access only."
       },
       {
-        "item": "Abandoned refs, #940 rule 7",
-        "stillPresent": [
-          "integration/rc-937 (80b7b948d)",
-          "integration/rc-wave-a (213f91513)",
-          "v1/premium-ui (c025e4f68 — provably dead, ancestor of b3ea4cf5a)"
-        ],
-        "counterObservation": "Two lanes DID delete their branches on merge this cycle and last. The three that remain are integration-owned or orphaned, not lane-owned.",
-        "dispatcherAction": "Ref deletion is not dispatcher authority."
+        "item": "Abandoned refs",
+        "resolved": "v1/premium-ui DELETED",
+        "remaining": [
+          "integration/rc-937",
+          "integration/rc-wave-a"
+        ]
       }
     ],
     "stillOpenAndReported": {
-      "V1-42": "NOT STARTED for a sixth consecutive cycle, though #913's W3 supplied the consumer simulate_roster_change lacked.",
-      "V1-88": "IMPLEMENTED_UNVERIFIED; unpromotable absent a structured `gates` field on the flag registry or an owner re-levelling ruling.",
-      "pr930PostDeployScrape": "Still unconfirmed.",
-      "stalePRs": "#759 and #760 open against landed code — see LANE_STATUS newFinding_stalOpenPRs."
+      "V1-42": "NOT STARTED for a seventh consecutive cycle despite #913's W3.",
+      "V1-88": "Unpromotable absent a structured `gates` field or an owner re-levelling ruling.",
+      "pr930PostDeployScrape": "Still unconfirmed."
     }
   }
 }

--- a/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
+++ b/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Live V1 Closability Queue, owned by Claude 7 as independent V1 traffic controller / adversarial auditor. Ranks IMPLEMENTED_UNVERIFIED rows by verification effort per row gained. NOT an authority on V1 status — only Claude 5 promotes a row, and no percentage here is claimed as achieved.",
-  "updatedAt": "2026-08-20T09:40:00Z",
-  "auditCycle": 23,
+  "updatedAt": "2026-08-20T09:55:00Z",
+  "auditCycle": 24,
   "evidenceBasis": {
     "contract": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 read on origin/main e3b387ca5",
     "deployedSha": "e3b387ca5",
@@ -402,49 +402,39 @@
     "observedVerifiedRows": 57,
     "observedRequiredRows": 132,
     "observedAtSha": "cca488cd7",
-    "observedAt": "2026-08-20T09:38:00Z",
+    "observedAt": "2026-08-20T09:50:00Z",
     "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA",
-    "note": "Unchanged across four merges (#946, #948, #952, #956). Counted independently; the contract table agrees."
+    "note": "Main did not move this cycle. NOTE: #963 (open) reconciles the denominator to 136 by owner decision and promotes V1-51 -> 58/136. Once it lands, this block must record 136 and cross-cycle percentage comparisons break."
   },
   "_authorityNote": "This queue RANKS work by verification effort. It does not own, publish or restate V1 status. docs/VERSION_1_COMPLETION_CONTRACT.md §3 owns that, and every count in this file is a derived reading stamped with the SHA it came from.",
-  "cycle23": {
-    "bottleneckRestated": "VERIFICATION PASSES, NOT IMPLEMENTATION. Five merges over cycles 21-23 produced +2 VERIFIED rows, both from the single promotion PR #947. Rows now routinely land implemented-and-honest with a named close condition and then wait. The queue's Tier B population is growing faster than anything is draining it.",
-    "rowsWithNamedCloseConditions": {
-      "V1-51": "Implementation merged via #956; row stays IN PROGRESS. Close: give playoff_odds.py:215 the `unsimulable` shape with n_simulations 0 and a sibling-consistent `simulated` flag, a test RED without it, then re-measure the three endpoints for the L2 statement.",
-      "V1-108": "Close: commit the transitive import-graph scan as a guard.",
-      "V1-106": "NO named close condition — see the cycle-22 finding. Still IN PROGRESS citing only PR #760 while that code is on main."
+  "cycle24": {
+    "denominatorWarning": "#963 adds V1-133..V1-136 (all NOT STARTED) per the owner's source-acquisition/bridge decision. 57/132 = 43.2% becomes 58/136 = 42.6%: the percentage FALLS while a row is VERIFIED. Compare row counts, not percentages, across cycles from here.",
+    "bottleneckUpdate": "The cycle-23 reading holds and is now visibly self-correcting: a promotion pass (#963) is running, and it is again the only thing moving the numerator. V1-51 went implementation-merged (#956) -> promoted-on-deployed-evidence (#963) in one cycle, which is the drain working.",
+    "tierB_remaining": {
+      "V1-108": "Close: commit the transitive import-graph scan as a guard. Unactioned.",
+      "V1-106": "STILL no named close condition; still cites only PR #760 while that code is on main. Third cycle reporting it."
     },
-    "cycle22FindingsRecheck": {
-      "stalePRs": "#759 and #760 STILL OPEN against landed code. Unacted. Note #949 (open) does exactly this class of cleanup for two work-claim rows in docs/WORK_CLAIMS.md, so someone is working the stale-bookkeeping seam — just not these two PRs.",
-      "V1_106_rowText": "Unchanged. Still the structural sibling of V1-108 without V1-108's decomposition."
-    },
-    "standingItemsUnchanged": [
+    "standingItems": [
       {
         "item": "Lane 2 ACTIONABLE_IDLE",
-        "elapsed": "~13.5h since 9e9d8e8ec; no new branch, no new PR",
+        "elapsed": "~16h since 9e9d8e8ec",
         "row": "V1-43 still NOT STARTED, target L1, unblocked on plain main",
-        "blocker": "ASSIGNMENT DELIVERY of L2-2026-08-19-02 — DELIVERY_REQUIRED, no reachable channel",
+        "blocker": "ASSIGNMENT DELIVERY of L2-2026-08-19-02 — DELIVERY_REQUIRED",
+        "newComplication": "#962 (Claude 9) is doing Value Adjustment consolidation, which is Lane 2's domain under my model. Idle lane, active outsider, same territory.",
         "dispatcherAction": "Surfaced only. No second assignment written."
       },
       {
         "item": "Lane 4 on-box verification batch",
-        "rows": "V1-57, V1-129, V1-60 — all still IMPLEMENTED_UNVERIFIED at cca488cd7",
-        "elapsed": "~15h since 66fb1a053",
-        "sharpened": "Given the cycle-23 bottleneck reading, this batch is no longer merely 'cheap' — it is one of the few conversions available that needs NO new implementation and NO new PR from an implementation lane. Host access only."
+        "rows": "V1-57, V1-129, V1-60 — all still IMPLEMENTED_UNVERIFIED",
+        "elapsed": "~17.5h",
+        "note": "#963 proves deployed-evidence verification is available and being run. This batch needs the same instrument."
       },
       {
-        "item": "Abandoned refs",
-        "resolved": "v1/premium-ui DELETED",
-        "remaining": [
-          "integration/rc-937",
-          "integration/rc-wave-a"
-        ]
+        "item": "Abandoned refs — CORRECTED",
+        "truth": "ALL THREE STILL EXIST on origin, confirmed by git ls-remote: v1/premium-ui (c025e4f68), integration/rc-937 (80b7b948d), integration/rc-wave-a (213f91513).",
+        "retraction": "Cycle 23 wrongly reported v1/premium-ui as cleared. See LANE_STATUS correction_C24."
       }
     ],
-    "stillOpenAndReported": {
-      "V1-42": "NOT STARTED for a seventh consecutive cycle despite #913's W3.",
-      "V1-88": "Unpromotable absent a structured `gates` field or an owner re-levelling ruling.",
-      "pr930PostDeployScrape": "Still unconfirmed."
-    }
+    "stalePRsUnacted": "#759 (82851974f) and #760 (4f00f1599) both still open with their branches present, against code that is on main. Fourth cycle unactioned."
   }
 }

--- a/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
+++ b/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Live V1 Closability Queue, owned by Claude 7 as independent V1 traffic controller / adversarial auditor. Ranks IMPLEMENTED_UNVERIFIED rows by verification effort per row gained. NOT an authority on V1 status — only Claude 5 promotes a row, and no percentage here is claimed as achieved.",
-  "updatedAt": "2026-08-20T11:05:00Z",
-  "auditCycle": 28,
+  "updatedAt": "2026-08-20T11:30:00Z",
+  "auditCycle": 29,
   "evidenceBasis": {
     "contract": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 read on origin/main e3b387ca5",
     "deployedSha": "e3b387ca5",
@@ -401,22 +401,23 @@
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
     "observedVerifiedRows": 58,
     "observedRequiredRows": 136,
-    "observedAtSha": "daf3c981e",
-    "observedAt": "2026-08-20T11:00:00Z",
+    "observedAtSha": "31724a8d4",
+    "observedAt": "2026-08-20T11:27:00Z",
     "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA",
-    "note": "Unchanged. Main has not moved since cycle 27 apart from automated data refreshes; no promotion pass since #963."
+    "note": "#954 merged and changed no row, by Lane 8 charter. No promotion pass since #963."
   },
   "_authorityNote": "This queue RANKS work by verification effort. It does not own, publish or restate V1 status. docs/VERSION_1_COMPLETION_CONTRACT.md §3 owns that, and every count in this file is a derived reading stamped with the SHA it came from.",
-  "cycle28": {
-    "promotionPassRan": "NO. None since #963 (cycle 26).",
+  "cycle29": {
+    "promotionPassRan": "NO — none since #963 at cycle 26.",
+    "zeroRowMergeWasByDesign": "#954 is Lane 8, whose charter forbids it from adding §3 rows or marking anything VERIFIED. Distinguish this from the cycles 21-25 pattern: there, zero-row merges meant verification lagging implementation. Here it is the intended shape.",
     "tierB": {
-      "V1-106": "EIGHTH cycle. Still IN PROGRESS, still citing only PR #760 while that code is on main, still no named close condition.",
-      "V1-108": "Close: commit the transitive import-graph scan as a guard. Sixth cycle unactioned."
+      "V1-106": "NINTH cycle. Still IN PROGRESS, still citing only PR #760 while that code is on main, still no named close condition.",
+      "V1-108": "Close: commit the transitive import-graph scan as a guard. Seventh cycle unactioned."
     },
     "standingItems": [
       {
         "item": "Lane 2 ACTIONABLE_IDLE",
-        "elapsed": "~18h; branch still 9e9d8e8ec",
+        "elapsed": "~18.5h; branch still 9e9d8e8ec",
         "row": "V1-43 NOT STARTED, target L1, unblocked on plain main",
         "blocker": "ASSIGNMENT DELIVERY of L2-2026-08-19-02",
         "dispatcherAction": "Surfaced only. No second assignment written."
@@ -424,8 +425,8 @@
       {
         "item": "Lane 4 on-box verification batch",
         "rows": "V1-57, V1-129, V1-60 — IMPLEMENTED_UNVERIFIED",
-        "elapsed": "~18.5h; branch still 66fb1a053",
-        "sharpenedAgain": "claude/integration-sweep-1048 shows Integration closing #958 on PRODUCTION EVIDENCE this hour. The instrument is not merely available in principle — it is in active use on other work while this batch waits."
+        "elapsed": "~19h; branch still 66fb1a053",
+        "note": "claude/integration-sweep-1048 still shows production-evidence closure running on other work."
       },
       {
         "item": "Abandoned refs, verified by name",
@@ -433,9 +434,10 @@
           "v1/premium-ui c025e4f68",
           "integration/rc-937 80b7b948d",
           "integration/rc-wave-a 213f91513"
-        ]
+        ],
+        "hygiene": "claude/cross-position-bridge-v1 deleted on merge — fifth lane branch cleaned up."
       }
     ],
-    "stalePRsUnacted": "#759 (82851974f) and #760 (4f00f1599) still open against landed code. Seventh cycle."
+    "stalePRsUnacted": "#759 and #760 still open against landed code. Eighth cycle."
   }
 }

--- a/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
+++ b/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Live V1 Closability Queue, owned by Claude 7 as independent V1 traffic controller / adversarial auditor. Ranks IMPLEMENTED_UNVERIFIED rows by verification effort per row gained. NOT an authority on V1 status — only Claude 5 promotes a row, and no percentage here is claimed as achieved.",
-  "updatedAt": "2026-08-20T14:15:00Z",
-  "auditCycle": 35,
+  "updatedAt": "2026-08-20T14:50:00Z",
+  "auditCycle": 36,
   "evidenceBasis": {
     "contract": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 read on origin/main e3b387ca5",
     "deployedSha": "e3b387ca5",
@@ -399,25 +399,26 @@
     "_staleByConstruction": true,
     "_ifTheyDisagree": "the contract wins, always, and this block is the thing that is wrong.",
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
-    "observedVerifiedRows": 59,
+    "observedVerifiedRows": 60,
     "observedRequiredRows": 136,
-    "observedAtSha": "7901b4733",
-    "observedAt": "2026-08-20T14:12:00Z",
+    "observedAtSha": "a9799ef93",
+    "observedAt": "2026-08-20T14:47:00Z",
     "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA",
-    "note": "Unchanged at 59/136. Promotion PR #988 (V1-63) open, unmerged."
+    "note": "V1-63 VERIFIED via #988. Fourth promotion pass this session."
   },
   "_authorityNote": "This queue RANKS work by verification effort. It does not own, publish or restate V1 status. docs/VERSION_1_COMPLETION_CONTRACT.md §3 owns that, and every count in this file is a derived reading stamped with the SHA it came from.",
-  "cycle35": {
-    "promotionPassRan": "NOT YET LANDED. #988 open, unmerged, proposes V1-63 -> VERIFIED (60/136).",
-    "tierB_movementAtLast": {
-      "V1-108": "OPEN PR #989 implements the exact close condition named since cycle 24: 'commit a transitive import-graph guard for the six no-player-data routes'. Row still IMPLEMENTED_UNVERIFIED on main pending merge+promotion.",
-      "V1-106": "STILL untouched. Fourteenth cycle, no PR, no close condition named by anyone but this dispatcher.",
-      "V1-88": "OPEN PR #991 implements the structured reachability-guard fix named since cycle 26: 'non-vacuous flag-to-route reachability guard (V1-88 / F-26)'. Row still IMPLEMENTED_UNVERIFIED on main pending merge+promotion."
+  "cycle36": {
+    "promotionPassRan": "YES — #988. V1-63 VERIFIED, 59 -> 60/136.",
+    "bottleneckUpdated": "Cycles 21-36: eleven merges total across promotion+implementation, +5 VERIFIED rows (V1-107, V1-113, V1-51, V1-53, V1-63), all five from FOUR dedicated Integration promotion passes (#947, #963, #972, #988). Implementation volume across many lanes stays high; the numerator moves only in discrete Integration acts, and this cycle both halves of that pattern were visible in one sweep: V1-108's implementation merged (#989) while its promotion did NOT, in the same window V1-63's promotion DID land.",
+    "tierB": {
+      "V1-106": "SIXTEENTH cycle. Still IN PROGRESS, still citing only PR #760, still the ONLY standing item with no PR or fix in flight anywhere.",
+      "V1-108": "Implementation MERGED via #989 — this dispatcher's own named close condition, verbatim. Row still IMPLEMENTED_UNVERIFIED pending Integration's separate promotion. Watch for a dedicated promotion PR next.",
+      "V1-88": "Implementation OPEN, unmerged, in #991 — 'READY FOR INTEGRATION'. Same shape as V1-108: mutation-tested, RED-confirmed, awaiting Integration to merge and promote separately."
     },
     "standingItems": [
       {
         "item": "Lane 2 ACTIONABLE_IDLE",
-        "elapsed": "~21.5h; branch still 9e9d8e8ec",
+        "elapsed": "~22h; branch still 9e9d8e8ec",
         "row": "V1-43 NOT STARTED, target L1, unblocked on plain main",
         "blocker": "ASSIGNMENT DELIVERY of L2-2026-08-19-02",
         "dispatcherAction": "Surfaced only. No second assignment written."
@@ -425,8 +426,7 @@
       {
         "item": "Lane 4 on-box verification batch",
         "rows": "V1-57, V1-129, V1-60 — IMPLEMENTED_UNVERIFIED",
-        "elapsed": "~22h; branch still 66fb1a053",
-        "note": "Lane 4 was NOT idle this cycle — it shipped #977 (V1-63 implementation) — but this specific batch remains untouched."
+        "elapsed": "~22.5h; branch still 66fb1a053"
       },
       {
         "item": "Abandoned refs, verified by name",
@@ -435,9 +435,9 @@
           "integration/rc-937 80b7b948d",
           "integration/rc-wave-a 213f91513"
         ],
-        "hygiene": "claude/cseries-premium-public-closure and claude/v1-63-manager-concentration deleted on merge this cycle."
+        "hygiene": "claude/v1-108-no-player-data-import-graph-guard, claude/v1-52-canonical-power, claude/v1-integration-authority-xaqcv8 all deleted on merge this cycle."
       }
     ],
-    "stalePRsUnacted": "#759 and #760 still open against landed code. Twelfth cycle."
+    "stalePRsUnacted": "#759 and #760 still open against landed code. Thirteenth cycle."
   }
 }

--- a/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
+++ b/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Live V1 Closability Queue, owned by Claude 7 as independent V1 traffic controller / adversarial auditor. Ranks IMPLEMENTED_UNVERIFIED rows by verification effort per row gained. NOT an authority on V1 status — only Claude 5 promotes a row, and no percentage here is claimed as achieved.",
-  "updatedAt": "2026-08-20T09:55:00Z",
-  "auditCycle": 24,
+  "updatedAt": "2026-08-20T10:10:00Z",
+  "auditCycle": 25,
   "evidenceBasis": {
     "contract": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 read on origin/main e3b387ca5",
     "deployedSha": "e3b387ca5",
@@ -401,40 +401,39 @@
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
     "observedVerifiedRows": 57,
     "observedRequiredRows": 132,
-    "observedAtSha": "cca488cd7",
-    "observedAt": "2026-08-20T09:50:00Z",
+    "observedAtSha": "a1c6e6ea4",
+    "observedAt": "2026-08-20T10:05:00Z",
     "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA",
-    "note": "Main did not move this cycle. NOTE: #963 (open) reconciles the denominator to 136 by owner decision and promotes V1-51 -> 58/136. Once it lands, this block must record 136 and cross-cycle percentage comparisons break."
+    "note": "#960 merged and changed no row. #963 (open, head 115e0c662) still proposes 58/136."
   },
   "_authorityNote": "This queue RANKS work by verification effort. It does not own, publish or restate V1 status. docs/VERSION_1_COMPLETION_CONTRACT.md §3 owns that, and every count in this file is a derived reading stamped with the SHA it came from.",
-  "cycle24": {
-    "denominatorWarning": "#963 adds V1-133..V1-136 (all NOT STARTED) per the owner's source-acquisition/bridge decision. 57/132 = 43.2% becomes 58/136 = 42.6%: the percentage FALLS while a row is VERIFIED. Compare row counts, not percentages, across cycles from here.",
-    "bottleneckUpdate": "The cycle-23 reading holds and is now visibly self-correcting: a promotion pass (#963) is running, and it is again the only thing moving the numerator. V1-51 went implementation-merged (#956) -> promoted-on-deployed-evidence (#963) in one cycle, which is the drain working.",
-    "tierB_remaining": {
-      "V1-108": "Close: commit the transitive import-graph scan as a guard. Unactioned.",
-      "V1-106": "STILL no named close condition; still cites only PR #760 while that code is on main. Third cycle reporting it."
+  "cycle25": {
+    "reportingRule": "From #963 onward, report VERIFIED ROW COUNT and state the denominator with every percentage. 57 of 132 and 58 of 136 are not comparable as percentages.",
+    "bottleneck": "Unchanged and now measured over five cycles: six merges, +2 VERIFIED rows, both from one promotion pass. Implementation lands honestly and waits.",
+    "tierB": {
+      "V1-108": "Close: commit the transitive import-graph scan as a guard. Unactioned, third cycle.",
+      "V1-106": "STILL no named close condition; still cites only PR #760 while that code is on main. FIFTH cycle reporting it. This is now the longest-standing unactioned finding in this record."
     },
     "standingItems": [
       {
         "item": "Lane 2 ACTIONABLE_IDLE",
-        "elapsed": "~16h since 9e9d8e8ec",
-        "row": "V1-43 still NOT STARTED, target L1, unblocked on plain main",
-        "blocker": "ASSIGNMENT DELIVERY of L2-2026-08-19-02 — DELIVERY_REQUIRED",
-        "newComplication": "#962 (Claude 9) is doing Value Adjustment consolidation, which is Lane 2's domain under my model. Idle lane, active outsider, same territory.",
+        "elapsed": "~16.5h",
+        "row": "V1-43 NOT STARTED, target L1, unblocked on plain main",
+        "blocker": "ASSIGNMENT DELIVERY of L2-2026-08-19-02",
+        "cycle24ComplicationWithdrawn": "#962 is authorized C-Series campaign work, not an incursion. See LANE_STATUS MY_CYCLE_24_FRAMING_WAS_WRONG.",
         "dispatcherAction": "Surfaced only. No second assignment written."
       },
       {
         "item": "Lane 4 on-box verification batch",
-        "rows": "V1-57, V1-129, V1-60 — all still IMPLEMENTED_UNVERIFIED",
-        "elapsed": "~17.5h",
-        "note": "#963 proves deployed-evidence verification is available and being run. This batch needs the same instrument."
+        "rows": "V1-57, V1-129, V1-60 — all IMPLEMENTED_UNVERIFIED at a1c6e6ea4",
+        "elapsed": "~18h"
       },
       {
-        "item": "Abandoned refs — CORRECTED",
-        "truth": "ALL THREE STILL EXIST on origin, confirmed by git ls-remote: v1/premium-ui (c025e4f68), integration/rc-937 (80b7b948d), integration/rc-wave-a (213f91513).",
-        "retraction": "Cycle 23 wrongly reported v1/premium-ui as cleared. See LANE_STATUS correction_C24."
+        "item": "Abandoned refs",
+        "verifiedByName": "All five present — see LANE_STATUS abandonedRefsVerifiedByName.",
+        "scopeNote": "An uncapped sweep shows ~85 refs with a dormant tail to March. The three named refs stay named because they are recent and integration-owned; the tail is sediment, not a work item."
       }
     ],
-    "stalePRsUnacted": "#759 (82851974f) and #760 (4f00f1599) both still open with their branches present, against code that is on main. Fourth cycle unactioned."
+    "stalePRsUnacted": "#759 and #760 open against landed code, branches present. Fifth cycle."
   }
 }

--- a/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
+++ b/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Live V1 Closability Queue, owned by Claude 7 as independent V1 traffic controller / adversarial auditor. Ranks IMPLEMENTED_UNVERIFIED rows by verification effort per row gained. NOT an authority on V1 status — only Claude 5 promotes a row, and no percentage here is claimed as achieved.",
-  "updatedAt": "2026-08-20T11:30:00Z",
-  "auditCycle": 29,
+  "updatedAt": "2026-08-20T12:45:00Z",
+  "auditCycle": 32,
   "evidenceBasis": {
     "contract": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 read on origin/main e3b387ca5",
     "deployedSha": "e3b387ca5",
@@ -399,25 +399,25 @@
     "_staleByConstruction": true,
     "_ifTheyDisagree": "the contract wins, always, and this block is the thing that is wrong.",
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
-    "observedVerifiedRows": 58,
+    "observedVerifiedRows": 59,
     "observedRequiredRows": 136,
-    "observedAtSha": "31724a8d4",
-    "observedAt": "2026-08-20T11:27:00Z",
+    "observedAtSha": "45d5cdac1",
+    "observedAt": "2026-08-20T12:42:00Z",
     "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA",
-    "note": "#954 merged and changed no row, by Lane 8 charter. No promotion pass since #963."
+    "note": "#972 merged: V1-53 promoted VERIFIED at L1. Third promotion pass of the session (after #947, #963)."
   },
   "_authorityNote": "This queue RANKS work by verification effort. It does not own, publish or restate V1 status. docs/VERSION_1_COMPLETION_CONTRACT.md §3 owns that, and every count in this file is a derived reading stamped with the SHA it came from.",
-  "cycle29": {
-    "promotionPassRan": "NO — none since #963 at cycle 26.",
-    "zeroRowMergeWasByDesign": "#954 is Lane 8, whose charter forbids it from adding §3 rows or marking anything VERIFIED. Distinguish this from the cycles 21-25 pattern: there, zero-row merges meant verification lagging implementation. Here it is the intended shape.",
+  "cycle32": {
+    "promotionPassRan": "YES — #972. V1-53 VERIFIED at L1, denominator unchanged at 136.",
+    "bottleneckUpdated": "Cycles 21-32: nine merges, +4 VERIFIED rows total, all four from three dedicated promotion passes (#947, #963, #972). Every other merge — now including three more this cycle (#950, #964, #968) — landed implementation or operational work that did not touch §3, correctly by charter. The pattern holds: implementation volume is high across many lanes; promotion happens in discrete, attributable passes.",
     "tierB": {
-      "V1-106": "NINTH cycle. Still IN PROGRESS, still citing only PR #760 while that code is on main, still no named close condition.",
-      "V1-108": "Close: commit the transitive import-graph scan as a guard. Seventh cycle unactioned."
+      "V1-106": "ELEVENTH cycle. Still IN PROGRESS, still citing only PR #760 while that code is on main, still no named close condition.",
+      "V1-108": "Close: commit the transitive import-graph scan as a guard. Ninth cycle unactioned."
     },
     "standingItems": [
       {
         "item": "Lane 2 ACTIONABLE_IDLE",
-        "elapsed": "~18.5h; branch still 9e9d8e8ec",
+        "elapsed": "~20h; branch still 9e9d8e8ec",
         "row": "V1-43 NOT STARTED, target L1, unblocked on plain main",
         "blocker": "ASSIGNMENT DELIVERY of L2-2026-08-19-02",
         "dispatcherAction": "Surfaced only. No second assignment written."
@@ -425,8 +425,8 @@
       {
         "item": "Lane 4 on-box verification batch",
         "rows": "V1-57, V1-129, V1-60 — IMPLEMENTED_UNVERIFIED",
-        "elapsed": "~19h; branch still 66fb1a053",
-        "note": "claude/integration-sweep-1048 still shows production-evidence closure running on other work."
+        "elapsed": "~20.5h; branch still 66fb1a053",
+        "note": "#968 (this cycle) is Integration running the same production-evidence closure instrument on a different item while this batch continues to wait."
       },
       {
         "item": "Abandoned refs, verified by name",
@@ -435,9 +435,9 @@
           "integration/rc-937 80b7b948d",
           "integration/rc-wave-a 213f91513"
         ],
-        "hygiene": "claude/cross-position-bridge-v1 deleted on merge — fifth lane branch cleaned up."
+        "hygiene": "claude/cseries-seasonal-intelligence-efz837, claude/idp-ceiling-bridge-audit-zr28tj and claude/integration-sweep-1048 all deleted on merge this cycle — three more lane branches cleaned up."
       }
     ],
-    "stalePRsUnacted": "#759 and #760 still open against landed code. Eighth cycle."
+    "stalePRsUnacted": "#759 and #760 still open against landed code. Ninth cycle."
   }
 }

--- a/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
+++ b/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Live V1 Closability Queue, owned by Claude 7 as independent V1 traffic controller / adversarial auditor. Ranks IMPLEMENTED_UNVERIFIED rows by verification effort per row gained. NOT an authority on V1 status — only Claude 5 promotes a row, and no percentage here is claimed as achieved.",
-  "updatedAt": "2026-08-20T13:45:00Z",
-  "auditCycle": 34,
+  "updatedAt": "2026-08-20T14:15:00Z",
+  "auditCycle": 35,
   "evidenceBasis": {
     "contract": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 read on origin/main e3b387ca5",
     "deployedSha": "e3b387ca5",
@@ -401,22 +401,23 @@
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
     "observedVerifiedRows": 59,
     "observedRequiredRows": 136,
-    "observedAtSha": "892df5686",
-    "observedAt": "2026-08-20T13:42:00Z",
+    "observedAtSha": "7901b4733",
+    "observedAt": "2026-08-20T14:12:00Z",
     "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA",
-    "note": "Unchanged at 59/136. No promotion pass this cycle."
+    "note": "Unchanged at 59/136. Promotion PR #988 (V1-63) open, unmerged."
   },
   "_authorityNote": "This queue RANKS work by verification effort. It does not own, publish or restate V1 status. docs/VERSION_1_COMPLETION_CONTRACT.md §3 owns that, and every count in this file is a derived reading stamped with the SHA it came from.",
-  "cycle34": {
-    "promotionPassRan": "NO — #961 is Claude 10 mass-build work, correctly zero-row.",
-    "tierB": {
-      "V1-106": "THIRTEENTH cycle. Still IN PROGRESS, still citing only PR #760, still no named close condition.",
-      "V1-108": "Close: commit the transitive import-graph scan as a guard. Eleventh cycle unactioned."
+  "cycle35": {
+    "promotionPassRan": "NOT YET LANDED. #988 open, unmerged, proposes V1-63 -> VERIFIED (60/136).",
+    "tierB_movementAtLast": {
+      "V1-108": "OPEN PR #989 implements the exact close condition named since cycle 24: 'commit a transitive import-graph guard for the six no-player-data routes'. Row still IMPLEMENTED_UNVERIFIED on main pending merge+promotion.",
+      "V1-106": "STILL untouched. Fourteenth cycle, no PR, no close condition named by anyone but this dispatcher.",
+      "V1-88": "OPEN PR #991 implements the structured reachability-guard fix named since cycle 26: 'non-vacuous flag-to-route reachability guard (V1-88 / F-26)'. Row still IMPLEMENTED_UNVERIFIED on main pending merge+promotion."
     },
     "standingItems": [
       {
         "item": "Lane 2 ACTIONABLE_IDLE",
-        "elapsed": "~21h; branch still 9e9d8e8ec",
+        "elapsed": "~21.5h; branch still 9e9d8e8ec",
         "row": "V1-43 NOT STARTED, target L1, unblocked on plain main",
         "blocker": "ASSIGNMENT DELIVERY of L2-2026-08-19-02",
         "dispatcherAction": "Surfaced only. No second assignment written."
@@ -424,7 +425,8 @@
       {
         "item": "Lane 4 on-box verification batch",
         "rows": "V1-57, V1-129, V1-60 — IMPLEMENTED_UNVERIFIED",
-        "elapsed": "~21.5h; branch still 66fb1a053"
+        "elapsed": "~22h; branch still 66fb1a053",
+        "note": "Lane 4 was NOT idle this cycle — it shipped #977 (V1-63 implementation) — but this specific batch remains untouched."
       },
       {
         "item": "Abandoned refs, verified by name",
@@ -433,10 +435,9 @@
           "integration/rc-937 80b7b948d",
           "integration/rc-wave-a 213f91513"
         ],
-        "hygiene": "claude/cseries-market-waiver-draft-2njtem deleted on merge (#961) — its work landed and the branch was cleaned up in the same cycle, textbook."
+        "hygiene": "claude/cseries-premium-public-closure and claude/v1-63-manager-concentration deleted on merge this cycle."
       }
     ],
-    "newCampaignBranches": "Eight new branches observed this cycle across C5/C6/PSI reference-routes/V1-52/V1-63/pending-does-not-vote/prod-e2e-smoke work. Reported neutrally; none dispatcher-assigned.",
-    "stalePRsUnacted": "#759 and #760 still open against landed code. Eleventh cycle."
+    "stalePRsUnacted": "#759 and #760 still open against landed code. Twelfth cycle."
   }
 }

--- a/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
+++ b/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Live V1 Closability Queue, owned by Claude 7 as independent V1 traffic controller / adversarial auditor. Ranks IMPLEMENTED_UNVERIFIED rows by verification effort per row gained. NOT an authority on V1 status — only Claude 5 promotes a row, and no percentage here is claimed as achieved.",
-  "updatedAt": "2026-08-20T13:15:00Z",
-  "auditCycle": 33,
+  "updatedAt": "2026-08-20T13:45:00Z",
+  "auditCycle": 34,
   "evidenceBasis": {
     "contract": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 read on origin/main e3b387ca5",
     "deployedSha": "e3b387ca5",
@@ -401,22 +401,22 @@
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
     "observedVerifiedRows": 59,
     "observedRequiredRows": 136,
-    "observedAtSha": "7c826f9c2",
-    "observedAt": "2026-08-20T13:12:00Z",
+    "observedAtSha": "892df5686",
+    "observedAt": "2026-08-20T13:42:00Z",
     "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA",
     "note": "Unchanged at 59/136. No promotion pass this cycle."
   },
   "_authorityNote": "This queue RANKS work by verification effort. It does not own, publish or restate V1 status. docs/VERSION_1_COMPLETION_CONTRACT.md §3 owns that, and every count in this file is a derived reading stamped with the SHA it came from.",
-  "cycle33": {
-    "promotionPassRan": "NO — two Integration merges, both governance/checkpoint, zero rows by role.",
+  "cycle34": {
+    "promotionPassRan": "NO — #961 is Claude 10 mass-build work, correctly zero-row.",
     "tierB": {
-      "V1-106": "TWELFTH cycle. Still IN PROGRESS, still citing only PR #760, still no named close condition.",
-      "V1-108": "Close: commit the transitive import-graph scan as a guard. Tenth cycle unactioned."
+      "V1-106": "THIRTEENTH cycle. Still IN PROGRESS, still citing only PR #760, still no named close condition.",
+      "V1-108": "Close: commit the transitive import-graph scan as a guard. Eleventh cycle unactioned."
     },
     "standingItems": [
       {
         "item": "Lane 2 ACTIONABLE_IDLE",
-        "elapsed": "~20.5h; branch still 9e9d8e8ec",
+        "elapsed": "~21h; branch still 9e9d8e8ec",
         "row": "V1-43 NOT STARTED, target L1, unblocked on plain main",
         "blocker": "ASSIGNMENT DELIVERY of L2-2026-08-19-02",
         "dispatcherAction": "Surfaced only. No second assignment written."
@@ -424,7 +424,7 @@
       {
         "item": "Lane 4 on-box verification batch",
         "rows": "V1-57, V1-129, V1-60 — IMPLEMENTED_UNVERIFIED",
-        "elapsed": "~21h; branch still 66fb1a053"
+        "elapsed": "~21.5h; branch still 66fb1a053"
       },
       {
         "item": "Abandoned refs, verified by name",
@@ -433,10 +433,10 @@
           "integration/rc-937 80b7b948d",
           "integration/rc-wave-a 213f91513"
         ],
-        "hygiene": "claude/obs-checkpoint-1210 and claude/psi-migration-authorization both deleted on merge this cycle."
+        "hygiene": "claude/cseries-market-waiver-draft-2njtem deleted on merge (#961) — its work landed and the branch was cleaned up in the same cycle, textbook."
       }
     ],
-    "newAuthorization": "PSI first production migration authorized (#976) — execution-timing only, V1 denominator unchanged (verified: change-log line reads '+0'). Claude 13 implements, Claude 5 integrates/deploys. Not a V1-scoped item; reported for awareness only.",
-    "stalePRsUnacted": "#759 and #760 still open against landed code. Tenth cycle."
+    "newCampaignBranches": "Eight new branches observed this cycle across C5/C6/PSI reference-routes/V1-52/V1-63/pending-does-not-vote/prod-e2e-smoke work. Reported neutrally; none dispatcher-assigned.",
+    "stalePRsUnacted": "#759 and #760 still open against landed code. Eleventh cycle."
   }
 }

--- a/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
+++ b/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
@@ -1,21 +1,12 @@
 {
   "_comment": "Live V1 Closability Queue, owned by Claude 7 as independent V1 traffic controller / adversarial auditor. Ranks IMPLEMENTED_UNVERIFIED rows by verification effort per row gained. NOT an authority on V1 status — only Claude 5 promotes a row, and no percentage here is claimed as achieved.",
-  "updatedAt": "2026-08-20T05:24:00Z",
+  "updatedAt": "2026-08-20T05:25:00Z",
   "auditCycle": 2,
   "evidenceBasis": {
     "contract": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 read on origin/main e3b387ca5",
     "deployedSha": "e3b387ca5",
     "deployProof": "Deploy Production run completed SUCCESS 2026-08-19T21:07:35Z on head e3b387ca5 — identical to current main",
     "method": "per-PR exact-head check runs, git merge-tree mergeability, git grep against origin/main for the claimed properties"
-  },
-  "v1Status": {
-    "verified": 55,
-    "denominator": 132,
-    "percent": 41.7,
-    "note": "55/132 (41.7%). #944 promoted seven on mutation-proven evidence, row-diffed and matching its stated count. Session net 40 -> 55 with the denominator constant.",
-    "implementedUnverified": 20,
-    "inProgress": 26,
-    "notStarted": 29
   },
   "deployState": {
     "correctionAccepted": "Cycle 1 collapsed four distinct facts into 'main is deployed'. Separated below.",
@@ -224,7 +215,8 @@
       "V1-19 — item 3 needs an irrecoverable artifact; owner ruling only"
     ],
     "deltaVsCycle1": "cycle 1 projected 43 at the Tier A step and 53 at the end. Corrected: 41 and 52. The Tier A over-count was the substantive error.",
-    "honestTail": "33 rows NOT STARTED and 34 IN PROGRESS. Verification batching converts an already-earned 30.3% into a truthful ~39%; it does not build the remaining half."
+    "honestTail": "33 rows NOT STARTED and 34 IN PROGRESS. Verification batching converts an already-earned 30.3% into a truthful ~39%; it does not build the remaining half.",
+    "_authority": "Projections are conditional arithmetic over the DERIVED observation above, not statements of V1 status. Only Claude 5 promotes a row, and no figure here counts until the contract on main changes."
   },
   "continue": [
     "Lane 4 — #932 is the verification instrument and has the highest V1 leverage of any open work",
@@ -401,5 +393,17 @@
     ],
     "coverageGapAcknowledged": "Rows that go IN PROGRESS -> VERIFIED in one motion (V1-28, V1-30, V1-33, V1-39, V1-44, V1-114..V1-118) were never ranked here, because the queue ranked IMPLEMENTED_UNVERIFIED rows. That is most of the +15.",
     "standingRecommendationStillUnactioned": "the on-box batch (V1-57, V1-129, V1-60)"
-  }
+  },
+  "v1DerivedObservation": {
+    "_authority": "NOT AUTHORITATIVE. docs/VERSION_1_COMPLETION_CONTRACT.md §3 is the sole owner of the V1 numerator and denominator. This block is a DERIVED READING of that file, kept only so the dispatcher can rank work by effort-per-row.",
+    "_staleByConstruction": true,
+    "_ifTheyDisagree": "the contract wins, always, and this block is the thing that is wrong.",
+    "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
+    "observedVerifiedRows": 55,
+    "observedRequiredRows": 132,
+    "observedAtSha": "079fc9e4a",
+    "observedAt": "2026-08-20T05:25:00Z",
+    "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA"
+  },
+  "_authorityNote": "This queue RANKS work by verification effort. It does not own, publish or restate V1 status. docs/VERSION_1_COMPLETION_CONTRACT.md §3 owns that, and every count in this file is a derived reading stamped with the SHA it came from."
 }

--- a/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
+++ b/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Live V1 Closability Queue, owned by Claude 7 as independent V1 traffic controller / adversarial auditor. Ranks IMPLEMENTED_UNVERIFIED rows by verification effort per row gained. NOT an authority on V1 status — only Claude 5 promotes a row, and no percentage here is claimed as achieved.",
-  "updatedAt": "2026-08-20T10:25:00Z",
-  "auditCycle": 26,
+  "updatedAt": "2026-08-20T11:05:00Z",
+  "auditCycle": 28,
   "evidenceBasis": {
     "contract": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 read on origin/main e3b387ca5",
     "deployedSha": "e3b387ca5",
@@ -401,33 +401,31 @@
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
     "observedVerifiedRows": 58,
     "observedRequiredRows": 136,
-    "observedAtSha": "113a29311",
-    "observedAt": "2026-08-20T10:22:00Z",
+    "observedAtSha": "daf3c981e",
+    "observedAt": "2026-08-20T11:00:00Z",
     "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA",
-    "note": "#963 MERGED. Denominator moved 132 -> 136 by owner decision; V1-51 promoted. See LANE_STATUS denominatorHistory."
+    "note": "Unchanged. Main has not moved since cycle 27 apart from automated data refreshes; no promotion pass since #963."
   },
   "_authorityNote": "This queue RANKS work by verification effort. It does not own, publish or restate V1 status. docs/VERSION_1_COMPLETION_CONTRACT.md §3 owns that, and every count in this file is a derived reading stamped with the SHA it came from.",
-  "cycle26": {
-    "landed": "#963 merged as 113a29311. V1-51 VERIFIED at L2 on deployed evidence; V1-133..V1-136 added NOT STARTED. Verified row count 57 -> 58; denominator 132 -> 136.",
-    "bottleneckMeasuredOverSixCycles": "Cycles 21-26: SEVEN merges, +3 VERIFIED rows, and ALL THREE came from the TWO promotion passes (#947, #963). Every other merge landed implementation that is waiting. The drain works when it runs; it runs rarely.",
-    "newlyOpenedV1Work": "#964 'V1-53: widen canonical-alias write guard to cover the seasonal lane' — a C-Series campaign lane taking a V1 row. Reported neutrally: the authorized campaign is not confined to post-V1 work, which is a fact about where V1 throughput may now come from.",
+  "cycle28": {
+    "promotionPassRan": "NO. None since #963 (cycle 26).",
     "tierB": {
-      "V1-106": "SIXTH cycle. Still IN PROGRESS, still citing only PR #760 while that code is on main, still no named close condition. Longest-standing unactioned finding in this record.",
-      "V1-108": "Close: commit the transitive import-graph scan as a guard. Fourth cycle unactioned."
+      "V1-106": "EIGHTH cycle. Still IN PROGRESS, still citing only PR #760 while that code is on main, still no named close condition.",
+      "V1-108": "Close: commit the transitive import-graph scan as a guard. Sixth cycle unactioned."
     },
     "standingItems": [
       {
         "item": "Lane 2 ACTIONABLE_IDLE",
-        "elapsed": "~17h; branch still at 9e9d8e8ec",
+        "elapsed": "~18h; branch still 9e9d8e8ec",
         "row": "V1-43 NOT STARTED, target L1, unblocked on plain main",
         "blocker": "ASSIGNMENT DELIVERY of L2-2026-08-19-02",
         "dispatcherAction": "Surfaced only. No second assignment written."
       },
       {
         "item": "Lane 4 on-box verification batch",
-        "rows": "V1-57, V1-129, V1-60 — all IMPLEMENTED_UNVERIFIED at 113a29311",
-        "elapsed": "~18.5h; branch still at 66fb1a053",
-        "instrumentExists": "#963 promoted V1-51 on DEPLOYED evidence, which is the same class of instrument this batch needs."
+        "rows": "V1-57, V1-129, V1-60 — IMPLEMENTED_UNVERIFIED",
+        "elapsed": "~18.5h; branch still 66fb1a053",
+        "sharpenedAgain": "claude/integration-sweep-1048 shows Integration closing #958 on PRODUCTION EVIDENCE this hour. The instrument is not merely available in principle — it is in active use on other work while this batch waits."
       },
       {
         "item": "Abandoned refs, verified by name",
@@ -435,10 +433,9 @@
           "v1/premium-ui c025e4f68",
           "integration/rc-937 80b7b948d",
           "integration/rc-wave-a 213f91513"
-        ],
-        "hygieneNote": "claude/v1-integration-authority-xaqcv8 was deleted on merge — the fourth lane branch cleaned up in six cycles."
+        ]
       }
     ],
-    "stalePRsUnacted": "#759 (82851974f) and #760 (4f00f1599) still open against landed code, branches present. Sixth cycle."
+    "stalePRsUnacted": "#759 (82851974f) and #760 (4f00f1599) still open against landed code. Seventh cycle."
   }
 }

--- a/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
+++ b/docs/claude-dispatch/V1_CLOSABILITY_QUEUE.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Live V1 Closability Queue, owned by Claude 7 as independent V1 traffic controller / adversarial auditor. Ranks IMPLEMENTED_UNVERIFIED rows by verification effort per row gained. NOT an authority on V1 status — only Claude 5 promotes a row, and no percentage here is claimed as achieved.",
-  "updatedAt": "2026-08-20T06:15:00Z",
-  "auditCycle": 21,
+  "updatedAt": "2026-08-20T06:40:00Z",
+  "auditCycle": 22,
   "evidenceBasis": {
     "contract": "docs/VERSION_1_COMPLETION_CONTRACT.md §3 read on origin/main e3b387ca5",
     "deployedSha": "e3b387ca5",
@@ -399,46 +399,54 @@
     "_staleByConstruction": true,
     "_ifTheyDisagree": "the contract wins, always, and this block is the thing that is wrong.",
     "_doNotQuote": "Do not cite this block as the V1 status. Read the contract on current main instead.",
-    "observedVerifiedRows": 55,
+    "observedVerifiedRows": 57,
     "observedRequiredRows": 132,
-    "observedAtSha": "64769555a",
-    "observedAt": "2026-08-20T06:12:00Z",
+    "observedAtSha": "c4431ccba",
+    "observedAt": "2026-08-20T06:38:00Z",
     "howObserved": "counted `VERIFIED` in the §3 table of the contract as it exists at that exact SHA",
-    "note": "Unchanged across the #912 merge. #947 (open) proposes 57; a proposal is not the contract."
+    "note": "#947 merged as ff2741305. Row-diffed and independently counted; the contract's own table agrees."
   },
   "_authorityNote": "This queue RANKS work by verification effort. It does not own, publish or restate V1 status. docs/VERSION_1_COMPLETION_CONTRACT.md §3 owns that, and every count in this file is a derived reading stamped with the SHA it came from.",
-  "cycle21": {
+  "cycle22": {
+    "promotedThisCycle": {
+      "V1-107": "VERIFIED, target L2 — payload re-measured at Integration from an archive, plus two mutations each producing named REDs.",
+      "V1-113": "VERIFIED, target L1 — 20 axe checks confirmed passing and non-skipping from the CI run log.",
+      "V1-108": "DEMOTED IN PLACE to IMPLEMENTED_UNVERIFIED with an exact close condition: commit the transitive import-graph scan as a guard. Now a Tier B item rather than an unanalysed IN PROGRESS row."
+    },
+    "tierB_newlyIdentified": {
+      "V1-106": "Code on main via #912; blocker is instrument credibility (the FPS harness owner ruling), not implementation. The row does not say so. Needs the same decomposition #947 gave V1-108.",
+      "V1-108": "Named close condition exists. Cheapest of the L6 rows now."
+    },
     "standingItemsUnchanged": [
       {
         "item": "Lane 2 ACTIONABLE_IDLE",
-        "elapsed": "~9h since 9e9d8e8ec (2026-08-19 21:46Z)",
-        "row": "V1-43 still `NOT STARTED`, level L1, unblocked on plain main, no branch",
-        "blocker": "ASSIGNMENT DELIVERY. L2-2026-08-19-02 remains DELIVERY_REQUIRED — no reachable channel from this session.",
-        "dispatcherAction": "NONE beyond surfacing. No second assignment written, per the standing instruction not to pile onto an unread one."
+        "elapsed": "~10.5h since 9e9d8e8ec; no new branch, no new PR",
+        "row": "V1-43 still `NOT STARTED`, target L1, unblocked on plain main",
+        "blocker": "ASSIGNMENT DELIVERY of L2-2026-08-19-02 — still DELIVERY_REQUIRED, still no reachable channel",
+        "dispatcherAction": "Surfaced only. No second assignment written."
       },
       {
         "item": "Lane 4 on-box verification batch",
-        "rows": "V1-57 (L3), V1-129, V1-60 (L2) — all still `IMPLEMENTED_UNVERIFIED` at 64769555a",
-        "elapsed": "~12h since 66fb1a053",
-        "whyItMatters": "Still the cheapest remaining numerator conversion: host access only, no HTTP auth, verifier already on main.",
-        "dispatcherAction": "NONE. Cannot execute on-box verification from this session."
+        "rows": "V1-57, V1-129, V1-60 — all still IMPLEMENTED_UNVERIFIED at c4431ccba",
+        "elapsed": "~12.5h since 66fb1a053",
+        "dispatcherAction": "Cannot execute on-box verification from this session."
       },
       {
         "item": "Abandoned refs, #940 rule 7",
         "stillPresent": [
           "integration/rc-937 (80b7b948d)",
           "integration/rc-wave-a (213f91513)",
-          "v1/premium-ui (c025e4f68)"
+          "v1/premium-ui (c025e4f68 — provably dead, ancestor of b3ea4cf5a)"
         ],
-        "changeThisCycle": "v1/premium-ui is now DEFINITIVELY dead: c025e4f68 is an ancestor of merge b3ea4cf5a, so the ref holds nothing main lacks. claude/premium-ui-migration-ltldy0, its live twin, was correctly deleted on merge — this one was not.",
-        "dispatcherAction": "NONE. Ref deletion is not dispatcher authority."
+        "counterObservation": "Two lanes DID delete their branches on merge this cycle and last. The three that remain are integration-owned or orphaned, not lane-owned.",
+        "dispatcherAction": "Ref deletion is not dispatcher authority."
       }
     ],
-    "rowsStillOpenAndReported": {
-      "V1-42": "`NOT STARTED` for a fifth consecutive cycle, though #913's W3 supplied the consumer simulate_roster_change lacked.",
-      "V1-88": "`IMPLEMENTED_UNVERIFIED`, unpromotable absent a structured `gates` field on the flag registry or an owner re-levelling ruling. Fourth promotion pass survived.",
-      "V1-108": "Newly decomposed by Integration in #947 with an exact close condition — commit the transitive import-graph scan as a guard. That is a Tier B item now rather than an unanalysed IN PROGRESS row.",
-      "pr930PostDeployScrape": "Still unconfirmed."
+    "stillOpenAndReported": {
+      "V1-42": "NOT STARTED for a sixth consecutive cycle, though #913's W3 supplied the consumer simulate_roster_change lacked.",
+      "V1-88": "IMPLEMENTED_UNVERIFIED; unpromotable absent a structured `gates` field on the flag registry or an owner re-levelling ruling.",
+      "pr930PostDeployScrape": "Still unconfirmed.",
+      "stalePRs": "#759 and #760 open against landed code — see LANE_STATUS newFinding_stalOpenPRs."
     }
   }
 }


### PR DESCRIPTION
**Successor to #928** (merged `231468bb4`). Docs only — the three JSON records under `docs/claude-dispatch/`. No source, no behaviour, **no V1 contract edit, no V1 row status change**, no merge.

## Corrected on integration send-back

Integration returned this PR with a bounded correction, right on both halves.

**Staleness (fixed).** The record declared 48/132 while the contract on main already said 55/132 — #944 merged between my read and the push. Re-read at `079fc9e4a`.

**The structural half (fixed properly).** The records carried a `v1` block with `verified` / `denominator` / `percent` fields that *read as authoritative* — which is why they could drift at all. That is a second owner of the V1 numerator forming inside a coordination record: precisely the defect class this dispatcher has spent the session flagging in other lanes. Being the one who warns about it is no protection against doing it.

So the fields are **gone rather than refreshed**. Both records now carry `v1DerivedObservation`, which:

- names `docs/VERSION_1_COMPLETION_CONTRACT.md` §3 as the **sole owner**;
- states it is **NOT AUTHORITATIVE** and **stale by construction**;
- stamps the exact SHA the count was read at;
- says outright that if the two disagree, **the contract wins and this block is what's wrong**;
- tells a reader **not to quote it**.

Projections in the closability queue carry the same label — conditional arithmetic over a derived reading, not statements of status. `ASSIGNMENTS.json` gets the matching note, since assignment rationales cite V1 rows too.

The queue keeps a count because it must rank work by effort-per-row. What it must not do is *look like the answer*, and now it doesn't.

## What the records actually contain

Nineteen dispatch cycles of lane state, plus the V1 closability queue and the assignment ledger. Highlights that outlived their cycle:

- **Method rules earned from my own errors**, each recorded against myself: a hardcoded SHA once reported a cleared blocker as still open; a remembered head SHA was cited after the ref had moved; a merge-detection grep missed a squash merge; and citing test *file names* rather than assertions produced two wrong Tier A calls.
- **`V1-88` refused three times.** It has now survived three of Claude 5's own promotion passes unpromoted. Closing it needs a structured `gates` field on the flag registry or a re-levelling ruling — **not a proxy test**.
- **Correction C17-1 against my own C11-1**: V1-34's level is L1, which does not require a production consumer, so my "wrong by one" warning was itself wrong by one.
- **Three standing items I cannot act on**: Lane 2 idle with V1-43 unstarted because the assignment cannot be delivered; the Lane-4 on-box verification batch (V1-57, V1-129, V1-60) unrun and needing host access only; and three abandoned refs (`rc-937`, `rc-wave-a`, `v1/premium-ui`) drifting further from main each cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)