### PR TITLE
docs(sources): cross-position bridge and IDP ceiling audit

### DIFF
--- a/docs/sources/CROSS_POSITION_SOURCE_AND_IDP_CEILING_AUDIT_2026-08-20.md
+++ b/docs/sources/CROSS_POSITION_SOURCE_AND_IDP_CEILING_AUDIT_2026-08-20.md
@@ -15,6 +15,7 @@
 > unchanged — both acquisition paths tried here really do return zero IDP rows
 > — but the conclusion drawn from it was wrong. Dynasty Dealer exposes cardinal
 > IDP values behind an undocumented parameter this audit did not try. See §15a.
+> The implementation lane that carries this forward is **Claude 8 / Lane 8**.
 > Bridge eligibility is now **PENDING** a same-basis and freshness
 > qualification against the offensive `current_value` basis. **No production
 > weighting or voting is authorized by this correction.**
@@ -765,7 +766,9 @@ exactly the disagreement §10 identified as the hardest:
 Note also `min = 0` on the offense side: under MISSING IS NEVER ZERO those rows
 must be treated as unpriced at the adapter, never as zero-valued.
 
-Full working record: `docs/sources/C7_PR_A_BRIDGE_FOUNDATION.md` §7a.
+Full working record: `docs/sources/C8_PR_A_BRIDGE_FOUNDATION.md` §7a
+(implementation lane **Claude 8 / Lane 8**, per the owner's designation of
+2026-08-20).
 
 ---
 

--- a/docs/sources/CROSS_POSITION_SOURCE_AND_IDP_CEILING_AUDIT_2026-08-20.md
+++ b/docs/sources/CROSS_POSITION_SOURCE_AND_IDP_CEILING_AUDIT_2026-08-20.md
@@ -8,6 +8,17 @@
 **Harness:** `scripts/simulate_idp_bridge_policies.py`
 **Evidence:** `docs/sources/evidence/IDP_BRIDGE_2026-08-20/policy_simulation.json`
 
+> **CORRECTION, 2026-08-20 (owner traffic-control on #950).** One verdict in
+> this document is stale **in interpretation**: §15's conclusion that Dynasty
+> Dealer "cannot serve as a cross-position bridge, because it publishes no IDP
+> players at all." The measurement behind it reproduces and is preserved
+> unchanged — both acquisition paths tried here really do return zero IDP rows
+> — but the conclusion drawn from it was wrong. Dynasty Dealer exposes cardinal
+> IDP values behind an undocumented parameter this audit did not try. See §15a.
+> Bridge eligibility is now **PENDING** a same-basis and freshness
+> qualification against the offensive `current_value` basis. **No production
+> weighting or voting is authorized by this correction.**
+
 Every number below was produced by rebuilding the real contract (1,109 rows,
 all 21 registered sources) in-process. Nothing is quoted from prior documents
 without re-verification; where a canonical document is stale, that is recorded
@@ -64,8 +75,10 @@ against IDPTC's 5,667 — Draft Sharks already exceeds the proposed IDPTC ceilin
 by 0.6%, which is precisely the case a naive ceiling must never touch.
 
 **Acquisition verdicts:** Draft Sharks is already acquired and league-specific.
-Dynasty Dealer needs no paid tier but publishes **zero IDP players**, so it
-cannot be a bridge. Dynasty Nerds' public IDP Top-275 is freely available but
+Dynasty Dealer needs no paid tier; the acquisition paths tried here returned
+**zero IDP players**, but that was a limitation of those paths, not of the
+source — see the correction in §15a, where it becomes a **PENDING** bridge
+candidate. Dynasty Nerds' public IDP Top-275 is freely available but
 carries ranks only, so it is a specialist, not a bridge, and Premium is not
 justified. The IDP Show Combined board is paywalled and unproven from here.
 
@@ -659,8 +672,10 @@ years_exp, updated_at, created_at, rating, votes, previous_rating`.
 Probes for `idp_players`, `idp_values`, `rankings` and `player_values` all
 return **404** — no IDP table exists.
 
-**Verdict on usefulness: Dynasty Dealer cannot serve as a cross-position
-bridge, because it publishes no IDP players at all.** The access question is
+**Verdict on usefulness** — ~~Dynasty Dealer cannot serve as a cross-position
+bridge, because it publishes no IDP players at all.~~ **SUPERSEDED by §15a:
+that conclusion was drawn from the acquisition paths tried above, and a third
+path does publish cardinal IDP values.** The access question is
 moot. It is a viable *offense + pick* source on one native 0–10,000 scale with
 excellent Sleeper-ID coverage, and `rating` / `votes` / `previous_rating` show
 it is a crowd-voted market (a distinct population from KTC's crowd, so plausibly
@@ -673,6 +688,84 @@ Two cautions if it is ever ingested:
   those must be treated as unpriced, not as zero-valued, at the fetcher.
 - Attribution and terms of use were not reviewed and must be settled before any
   scheduled ingestion.
+
+
+---
+
+## 15a. Dynasty Dealer — CORRECTION (2026-08-20)
+
+**The measurement in §15 stands. Its interpretation does not.**
+
+§15 tried two acquisition paths and both genuinely return zero IDP rows: the
+Supabase `/rest/v1/players` table (723 rows) and the default
+`/api/player-values` (1,000 rows). Neither was wrong. What was wrong was
+concluding from them that the *source* lacks defensive cardinal values.
+
+The IDP data sits behind an **undocumented query parameter**, recovered from
+the vendor's own JavaScript bundle:
+
+```
+GET /api/player-values?includeIdp=true&limit=5000   →  1,338 rows
+WR 414 · RB 241 · TE 181 · QB 128 · DB 126 · LB 117 · DL 95 · PICK 36
+```
+
+**338 IDP rows**, carrying `current_value` on the same field as offense. The
+top four match the owner-supplied figures exactly: **Myles Garrett 5,121 ·
+Will Anderson 4,601 · Jack Campbell 4,599 · Aidan Hutchinson 4,584.**
+
+The durable record is therefore:
+
+> The previously inspected Dynasty Dealer acquisition paths returned zero IDP
+> rows because they omitted `includeIdp=true`. That was an **acquisition-path
+> limitation, not proof that the source lacks defensive cardinal values.**
+> Bridge eligibility now depends on demonstrating that those defensive values
+> share the same valuation basis as the offensive `current_value` API.
+
+### The same-basis gate does NOT pass — two measured blockers
+
+**(a) The format flags are echo-only.** `scoringSettings` in the response
+reflects the *request*, not the data. `isSuperflex=true&isTePremium=true`
+changes **0 of 1,338 values**. An adapter trusting that field would believe it
+held a Superflex/TE-premium board while holding one unlabelled board — the same
+class of error as W18-F001, a label deciding a factual question. Corroborating
+evidence that the board is 1QB basis: QB1 Josh Allen 9,495 sits *below* RB1
+Bijan Robinson 10,000. This league is Superflex + TEP.
+
+**(b) Offense and IDP are not the same quantity in time.**
+
+| | offense | IDP |
+|---|---|---|
+| distinct `updated_at` | **33**, through 2026-08-20 | **1** — all 2026-07-15 |
+| rows carrying votes | 445 / 964 (46.2%) | **0 / 338 (0.0%)** |
+| `base_value` vs `current_value` | diverge | identical on every row |
+| range | max 10,000 · p50 16 · **min 0** | max 5,121 · p50 1,476 · min 73 |
+
+Live, crowd-vote-adjusted offense against a static 36-day-old un-voted IDP
+snapshot. The vendor's IDP page also offers tackle-heavy / balanced / big-play
+variants and the payload declares none, so the scoring variant is **UNKNOWN**.
+
+**Bridge status: `PENDING`. It does not vote.** Qualification needs the format
+basis proven independently of the echoed flags, the IDP scoring variant
+identified, and an owner decision on whether a static IDP snapshot may bridge
+against live offense values.
+
+### Why it is worth qualifying
+
+Dynasty Dealer is the most consensus-central of the three candidate bridges.
+Joined to 290 board IDP rows by normalized name: Spearman **IDPTC↔DD 0.773**,
+against IDPTC↔DS 0.609 and DS↔DD 0.597. It sits *between* the incumbent pair on
+exactly the disagreement §10 identified as the hardest:
+
+| player | IDPTC | Draft Sharks | Dynasty Dealer |
+|---|---|---|---|
+| Aidan Hutchinson (DL) | 6,444 | 2,116 | **4,584** |
+| Myles Garrett (DL) | 5,414 | 1,924 | **5,121** |
+| Carson Schwesinger (LB) | 5,667 | 6,485 | **4,062** |
+
+Note also `min = 0` on the offense side: under MISSING IS NEVER ZERO those rows
+must be treated as unpriced at the adapter, never as zero-valued.
+
+Full working record: `docs/sources/C7_PR_A_BRIDGE_FOUNDATION.md` §7a.
 
 ---
 
@@ -777,7 +870,7 @@ the rendered string was not.
 |---|---|---|---|---|
 | IDP Show Combined | **`fantasyPros`** (offense half is FantasyPros ECR) | 2 | **No** | authenticated access |
 | `dynastyNerdsIdp` | **`dynastyNerds`** (with the existing offense feed) | 4 | **No** | none — public today |
-| Dynasty Dealer | new singleton `dynastyDealer` | 1 (offense+picks only) | Yes | **fails the bridge test — 0 IDP rows** |
+| Dynasty Dealer | new singleton `dynastyDealer` | 1 (offense + IDP + picks) | Yes | **PENDING same-basis qualification** (§15a) |
 | Footballguys 2026 | new singleton `footballguys` | 1 or 2, unproven | Yes | authenticated access |
 | Draft Sharks **cardinal** reading | `draftSharks` (existing) | 1 | **No — same family** | none; reads a column we already fetch |
 
@@ -1159,7 +1252,7 @@ Reported, not fixed.
 | 8 | Can genuine combined sources remain unconstrained? | **Yes, structurally** — Type 1/2 sources never enter the translation seam. Live proof: `draftSharksIdp` contributes 6,485, above the proposed ceiling |
 | 9 | Can IDP Show Combined be acquired? | **Unproven** — paywalled, no repo evidence it exists. Owner action |
 | 10 | Can synced Draft Sharks 3D+ be acquired? | **Already acquired**, league 995704, and proven cross-position (ratio 0.9976) |
-| 11 | Are Dynasty Dealer IDP values available without Pro? | **No Pro needed, but there are no IDP values at all** — 0 IDP rows of 723 |
+| 11 | Are Dynasty Dealer IDP values available without Pro? | **Yes — no Pro needed.** Corrected in §15a: `?includeIdp=true` returns 338 cardinal IDP rows. Bridge status **PENDING** on two measured same-basis blockers |
 | 12 | Is Dynasty Nerds Premium necessary? | **No.** Public IDP Top-275 is ranks/tiers only; Premium unproven and unjustified |
 | 13 | How should specialists and bridges interact? | §20 — specialists order within domain, bridges price the domain, bridge layer aggregates and never selects |
 | 14 | What is the exact implementation plan? | §24 order, §25 files, §28 prompt. **Nothing authorized by this document** |

--- a/docs/sources/CROSS_POSITION_SOURCE_AND_IDP_CEILING_AUDIT_2026-08-20.md
+++ b/docs/sources/CROSS_POSITION_SOURCE_AND_IDP_CEILING_AUDIT_2026-08-20.md
@@ -1,0 +1,1165 @@
+# Cross-Position Source, Bridge Architecture & IDP Ceiling Audit
+
+**Date:** 2026-08-20
+**Status:** RESEARCH ONLY — no production ranking behaviour was changed.
+**Code pin:** `c4431ccba3bedc2f4b511f7ca93fad03e4b6286f`
+**Board pin:** `exports/latest/dynasty_data_2026-08-20.json`
+(sha256 `4dcf3ed04a121288…`, 972,624 B) + 24 hashed `CSVs/site_raw/*.csv`
+**Harness:** `scripts/simulate_idp_bridge_policies.py`
+**Evidence:** `docs/sources/evidence/IDP_BRIDGE_2026-08-20/policy_simulation.json`
+
+Every number below was produced by rebuilding the real contract (1,109 rows,
+all 21 registered sources) in-process. Nothing is quoted from prior documents
+without re-verification; where a canonical document is stale, that is recorded
+in §27 rather than repeated.
+
+---
+
+## 1. Executive Summary
+
+**The question was: can an IDP-only source turn its rank #1 into something
+approaching the overall market maximum, having no offense comparison?**
+
+**On the live board, no.** The repository already contains a cross-position
+bridge, and it works. An IDP-only source's #1 contributes **5,943** — 59.6% of
+the board maximum and 92.2% of the highest IDP Trade Calculator IDP. Nothing is
+near 9,999.
+
+**Under one specific failure, yes — completely.** If `idpTradeCalc` leaves the
+blend, the shared-market ladder empties, `translate_position_rank` falls back to
+the untranslated rank, and IDP #1 votes as asset #1. Measured: **661 votes cast
+on untranslated ranks**, 310 rows flagged, 19 IDP-only votes at or above 9,000,
+and the top IDP published at **9,999 — the entire market maximum**. Aidan
+Hutchinson receives 9,999 from all three IDP-only sources simultaneously.
+
+That is the real defect, and it is a **single-source dependency**, not a
+scaling-policy defect. `is_backbone` is a label; only `idpTradeCalc` can
+actually seed a ladder.
+
+**The owner's candidate ceiling does not solve it.** An IDP Trade Calculator
+top-IDP ceiling changes **0 values, 0 ranks** on the live board — it is inert.
+Under backbone loss it caps the peak number but leaves the board's composition
+untouched: IDPs in the top 100 stay at **29** against a healthy **8**. It also
+moves 12 rows *upward*, because capping a wild vote makes it survive the Hampel
+outlier filter that had been discarding it.
+
+**A bridge-derived monotonic mapping does solve it.** Candidate D restores the
+board almost exactly: IDPs in the top 100 go **24 → 8**, matching the healthy
+value, and the top IDP lands at 6,375 rather than 9,999. It is also nearly a
+no-op when the backbone is healthy (median absolute change 3 points).
+
+**Draft Sharks is a genuine cardinal bridge that the pipeline currently
+discards.** Its offense and IDP boards come from one league-scored session
+(league 995704, "Risk It To Get The Brisket") and share one `3D Value +` scale —
+proven, not assumed: the rate at which projection surplus converts into
+`3D Value +` is **0.09610 on offense and 0.09586 on IDP, a ratio of 0.998**,
+with the spread *within* each pool larger than the difference *between* them.
+Draft Sharks is therefore making a cross-position statement we already possess
+and throw away by converting it to an ordinal.
+
+**The two bridges disagree substantially, and that disagreement is real
+signal.** On DL1 Aidan Hutchinson, IDPTC contributes 6,444 while Draft Sharks
+contributes 2,116. On LB1 Carson Schwesinger, Draft Sharks contributes 6,485
+against IDPTC's 5,667 — Draft Sharks already exceeds the proposed IDPTC ceiling
+by 0.6%, which is precisely the case a naive ceiling must never touch.
+
+**Acquisition verdicts:** Draft Sharks is already acquired and league-specific.
+Dynasty Dealer needs no paid tier but publishes **zero IDP players**, so it
+cannot be a bridge. Dynasty Nerds' public IDP Top-275 is freely available but
+carries ranks only, so it is a specialist, not a bridge, and Premium is not
+justified. The IDP Show Combined board is paywalled and unproven from here.
+
+---
+
+## 2. Current Production Clamp Inventory
+
+Every guardrail that can touch a published player value. **Recommendations
+only — nothing here was changed.**
+
+| # | Guardrail | File : symbol | Stage | Purpose | Current value | IDP-specific | Rows affected | Recommendation |
+|---|---|---|---|---|---|---|---|---|
+| 1 | Tail saturation | `canonical/tail_policy.py:130` `TAIL_SATURATION_RANK` | rank→percentile | Bound extrapolation past the observed rank domain | `904` | **No** (no position/scope branch) | 245 values / 402 ranks at activation; 254 rows, 233 of them DL/LB/DB *by incidence* | **KEEP.** Out of scope — see §4 |
+| 2 | Percentile reference | `player_valuation.py:150` `PERCENTILE_REFERENCE_N` | rank→percentile | One coordinate universe for fit, holdout and serve | `500` | No | all rank-signal votes | KEEP |
+| 3 | Curve routing refusal | `rank_coordinates.py:138` `curve_for_pool` | percentile→value | Raises rather than defaulting on an unknown pool | n/a | No | 0 (never fires) | KEEP |
+| 4 | Hampel outlier filter | `data_contract.py:7767` | pre-blend | Drop contributions > K·MAD from the median | `K=2.75`, `min_n=4`, floor `1000.0` | No | varies | KEEP — but see §7, it interacts with any ceiling |
+| 5 | Count-aware mean-median blend | `data_contract.py:7828` | blend | Trim one extreme per side at n≥5 | structural | No | all | KEEP |
+| 6 | α-shrinkage to cross-market anchor | `data_contract.py:6087` `_ALPHA_SHRINKAGE` | blend | IDP/pick rows keep 10% of their subgroup's deviation | `0.10` | **Yes** (IDP + picks take the hierarchical path) | 383 IDP rows stamped `0.1` | **KEEP — this is already a bridge.** See §9 |
+| 7 | MAD volatility penalty | `data_contract.py:6121` | post-blend | Retired | `λ = 0.0`, strict no-op | No | 0 | KEEP retired |
+| 8 | Single-source haircut | `data_contract.py:6135` | post-blend | Uncorroborated rows keep 30% | `0.30` (picks exempt) | No | varies | KEEP |
+| 9 | Blend-hull integrity detector | `data_contract.py:5411` | post-blend | Flags a value outside its own contributions' range; **abstains, alters nothing** | `ε = 1e-9` | No | **0 under every candidate measured** | KEEP |
+| 10 | Quarantine flags | `data_contract.py:333` | validation | Row present but not consumable | 5 flags | No | 1 pre-existing | KEEP |
+| 11 | Near-name collision guard | `data_contract.py:304` | identity | Entity-resolution confusion | ratio `3.0` | No | — | KEEP |
+| 12 | Two-way player boost | `data_contract.py:5731` | post-blend override | Recovers IDP coverage for single-class players | `{"Travis Hunter": "DB"}` | **Yes** | 1 | KEEP |
+| 13 | TE lift soft knee | `data_contract.py:6845` | TE basis | Strictly-increasing bound preserving vote distinctness | knee `9900` | No | TEs | KEEP |
+| 14 | TE basis conversion refusal | `league_intel/te_premium.py:355` | TE basis | Refuses unmeasured basis pairs | base↔tepp only | No | — | KEEP |
+| 15 | TEP derived multiplier clamp | `data_contract.py:6696` | TEP derivation | Bounds a misconfigured league bonus | `[1.0, 2.0]` | No | — | KEEP |
+| 16 | Blanket TE multipliers | `data_contract.py:6791` | blend | Align non-KTC TEs to the TE++ baseline | `1.15` / `1.10` | No | TEs | KEEP |
+| 17 | Declared-range value check (D-1) | `data_contract.py:6235` | value ingest | Drops out-of-range rows; suppresses a rescaled source | `ktcSfTep`/`idpTradeCalc` = 9999; 2% / 50 rows | No | 0 today | KEEP |
+| 18 | Pick year discount | `data_contract.py:7197` | Phase 5, picks | Measured vendor year-step | per-cell `0.714`–`0.895` | No (picks only) | future picks | KEEP |
+| 19 | `OVERALL_RANK_LIMIT` | `data_contract.py:127` | board cut | Publishes 800 ranks | `800` | No | tail | KEEP |
+| 20 | Confidence gate | `api/confidence.py` + `config/confidence/gate_v1.json` | labelling | Five-axis bucket, weakest axis wins | 5/3 families, 0.75/0.5, 0.15 | No | all | KEEP |
+| 21 | Display scale clamp | `player_valuation.py:393, :500` | curve output | Hard 1–9999 | `1` / `9999` | No | all | KEEP — but see §5, it is the mechanism that produces the 9,999 |
+| 22 | Tier-gap detection | `player_valuation.py:285` | tiering | Rank-gap tier breaks | 7 / 2.0 / 3 | No | — | KEEP (not valuation) |
+| 23 | Normalization validator | `canonical/normalization_validator.py` | contract check | Invariant reporting; touches no value | — | No | — | KEEP |
+| 24 | Legacy calibration knees | `canonical/calibration.py` | **not on the live path** | Retired offline pipeline | IDP knee `0.80`, `idp_vet` scale `5500` | **Yes** | **0 — fenced** | **RECONSIDER for deletion.** Zero production callers for `calibrate_canonical_values`; it raises on canonical-pipeline assets and refuses picks. Only `to_display_value` is imported live (`trade/suggestions.py:26`), so removal means splitting that helper out — not a straight delete |
+
+**No guardrail in this table is a cross-position IDP value ceiling.** Number 6
+is the closest thing that exists, and it is an *anchor*, not a cap.
+
+---
+
+## 3. Historical Market-Corridor Status
+
+**GONE. Confirmed absent from executable production code.**
+
+A token-level scan of every `.py` under `src/`, `scripts/` and `server.py` —
+tokenizing and discarding `COMMENT` tokens and leading-position docstrings, then
+matching identifiers against surviving executable tokens — returns:
+
+```
+_apply_market_corridor_clamp:    0
+_market_anchor_for_row:          0
+_market_anchor_value_for_row:    0
+_MARKET_ANCHOR_BY_ASSET_CLASS:   0
+_MARKET_ANCHOR_FALLBACKS:        0
+_MARKET_CORRIDOR (any suffix):   0
+```
+
+Seven `corridor` tokens survive in executable code and **none is the
+mechanism**: the kwarg `suppress_market_corridor_clamp`
+(`data_contract.py:7965`, `:9893`, `:10579`, `:10829`, and its single caller
+`consensus_edge/fair_value.py:186`), which now gates only the *diagnostic stamp*
+of the blend-integrity detector; plus two string literals in the offline
+`scripts/measure_engine_value_divergence.py`.
+
+The historical measurement the owner recalled is confirmed by
+`docs/master-site-audit/evidence/W02/B3_MARKET_CORRIDOR_EVIDENCE.md`: 183 of 329
+ranked IDP rows clamped (**55.6%**), 160 down / 23 up, `idpTradeCalc` the anchor
+on **183 of 183** and also a voter in **183 of 183** of those same blends. Its
+safety ordering was inverted (high-confidence rows clamped at 63.9% against
+medium's 45.8%), and its stated purpose — containing the IDP calibration
+post-pass — had been dead since #251 on 2026-04-23, two days after the corridor
+was built.
+
+**The IDP calibration post-pass is also fully retired**: no function, no
+`config/idp_calibration.json`, no `src/idp_calibration/`, pinned absent by
+`tests/api/test_valuation_pipeline_stages.py:612` and
+`tests/docs/test_pipeline_trace_matches_tree.py:196`.
+
+**Nothing in this audit recommends restoring either.**
+
+---
+
+## 4. The Tail Policy Is Not an IDP Value Ceiling
+
+Stated explicitly because the two are easy to conflate and the owner asked for
+the distinction to be kept.
+
+`TAIL_SATURATION_RANK = 904` (`canonical/tail_policy.py:130`) answers **"how far
+into rank space are we willing to extrapolate?"**. `max_percentile` and
+`clamp_percentile` take exactly one argument, `reference_n`. There is no
+position branch, no scope branch, no source branch, and no asset-class branch
+anywhere in the module. It is IDP-*concentrated* only by incidence — deep ranks
+are where IDP lives, so 233 of the 254 rows it touches are DL/LB/DB — and every
+value-direct source contributes zero rows to it.
+
+The question this audit asks is different: **"what is IDP1 worth against QB1?"**
+That is a cross-position *value* question and the tail policy cannot answer it,
+because saturating rank 904 says nothing about what rank 34 is worth.
+
+**The tail policy was not modified and no recommendation here touches it.**
+
+---
+
+## 5. Current IDP-Only Scaling Behaviour
+
+There are six IDP-bearing feeds. They reach the common 1–9999 scale by four
+different routes.
+
+| Source | Signal | Route to the common scale | Coordinate pool → curve | Family |
+|---|---|---|---|---|
+| `idpTradeCalc` | **value** | value-direct, `raw / site_max × 9999`, where `site_max` is the max over its own **combined offense+IDP** board | GLOBAL (fallback only) | `idpTradeCalc` |
+| `draftSharksIdp` | value (exempt from `_VALUE_BASED_SOURCES` via `ds_combined_rank_partner`) | Phase 1b merges both DS CSVs into **one combined ordinal** on raw `3D Value +`, then rank→Hill | GLOBAL | `draftSharks` |
+| `idpShow` | rank | shared-market crosswalk via the IDP backbone ladder, then rank→Hill | GLOBAL | `idpShow` |
+| `dlfIdp` | rank | shared-market crosswalk | GLOBAL | `dlf` |
+| `fantasyProsIdp` | rank | shared-market crosswalk | GLOBAL | `fantasyPros` |
+| `dlfRookieIdp` | rank | rookie ladder against `idpTradeCalc`'s own ranks for *its* best IDP rookies | GLOBAL | `dlf` |
+
+### How the crosswalk works
+
+Sources flagged `needs_shared_market_translation` rank within the IDP class
+only. `idp_backbone.build_backbone_from_rows` builds a *shared-market ladder*
+whose i-th entry is the combined-pool rank of the (i+1)-th best IDP in the
+backbone source. `translate_position_rank` then lifts the within-IDP ordinal
+into combined rank space, the coordinate pool becomes `RANK_POOL_SHARED_MARKET`,
+and the GLOBAL master prices it.
+
+Only `idpTradeCalc` can seed that ladder, because
+`build_backbone_from_rows` needs a source whose own value column spans both
+pools. `draftSharksIdp` is registered `is_cross_market` but carries 0 positive
+offense values under its own key (its offense half lives under `draftSharks`),
+so flagging it `is_backbone` produces the identity ladder `[1,2,3,…]` — which
+is exactly the fallback.
+
+Measured on today's board: **ladder[0] = 34**. The first IDP in
+`idpTradeCalc`'s combined pool sits at combined rank 34, behind 33 offensive
+assets.
+
+### A note on `fantasyProsIdp.csv`
+
+That CSV ships a `normalizedValue` column whose rank-1 value is literally
+**9999** (rank 2 = 9849). It is stored on the row as the diagnostic
+`fantasyProsIdpNormalizedValue` and lands in `sourceNativeValues`. **It does not
+feed the blend** — the vote travels rank → translated rank → Hill, confirmed by
+the measured contribution of 5,943 rather than 9,999. The column is nonetheless
+a loaded gun: a future consumer reading it as a value would reproduce the exact
+defect this audit was commissioned to find. Recommend it be renamed or dropped
+at the fetcher.
+
+---
+
+## 6. The IDP1 Problem — Explicit Answer
+
+> **Can an IDP-only source currently turn its rank #1 into something
+> approaching the overall market maximum, despite having no offense
+> comparison?**
+
+### Steady state (backbone healthy): **NO**
+
+| Source | raw rank | effective rank | method | contribution | % of board max (9,979) | % of IDPTC ceiling (6,444) |
+|---|---|---|---|---|---|---|
+| `dlfIdp` | 1 | 34 | `exact` | **5,943** | 59.6% | 92.2% |
+| `idpShow` | 1 | 34 | `exact` | **5,943** | 59.6% | 92.2% |
+| `fantasyProsIdp` | 1 | 34 | `exact` | **5,943** | 59.6% | 92.2% |
+| `draftSharksIdp` | 1 | 25 | `ds_combined_cross_market` | 6,485 | 65.0% | 100.6% |
+| `dlfRookieIdp` | 1 | 69 | `rookie_ladder_translation_via_idpTradeCalc` | 4,645 | 46.5% | 72.1% |
+| `idpTradeCalc` | 1 | 1 | `direct` | 9,999 | 100.2% | — (rank 1 is Bijan Robinson, an RB) |
+
+Deeper probes for the IDP-only sources: rank 2 → 5,603 · rank 3 → 5,352 ·
+rank 5 → 4,783 · rank 10 → 3,766 · rank 20 → 3,283.
+
+Corroborating whole-board measurements:
+`shared_market_crosswalk_failed(rows)` = `{}`; `idpBackboneFallback` on **0**
+rows; IDP-only votes at or above 9,000 = **0**; highest published IDP value
+**6,393**; IDPs in the top 50/100/200/400 = **3 / 8 / 42 / 118**.
+
+### Backbone lost (`idpTradeCalc` excluded): **YES, completely**
+
+| measurement | healthy | backbone lost |
+|---|---|---|
+| votes on untranslated ranks | 0 | **661** (`idpShow` 308, `fantasyProsIdp` 185, `dlfIdp` 168) |
+| rows flagged `idpBackboneFallback` | 0 | **310** |
+| IDP-only votes ≥ 9,000 | 0 | **19** |
+| highest published IDP value | 6,393 | **9,999** |
+| IDPs in top 50 / 100 | 3 / 8 | **13 / 29** |
+
+Aidan Hutchinson receives a contribution of **9,999 from `dlfIdp`, `idpShow`
+and `fantasyProsIdp` simultaneously**; Will Anderson receives 9,841 from two of
+them. The mechanism is exact and structural: with an empty ladder
+`translate_position_rank` returns the raw rank stamped `TRANSLATION_FALLBACK`,
+the coordinate pool stays `RANK_POOL_IDP`, `p = 0`, and
+`percentile_to_value` short-circuits to `DISPLAY_SCALE_MAX`
+(`player_valuation.py:497-498`).
+
+### Classification
+
+This is **not** a source-domain scaling defect in the steady state — the
+translation layer already does the right thing. It is a **single-point-of-
+failure defect**: one source is load-bearing for the meaning of every IDP
+number on the board, and its loss is not a degradation but a silent
+re-denomination. The board still looks like an ordinary board.
+
+---
+
+## 7. IDP Trade Calculator Ceiling Test
+
+> **Would using the current highest IDP Trade Calculator IDP value as the
+> ceiling for IDP-only source contributions improve the architecture?**
+
+# **VERDICT: BETTER ALTERNATIVE EXISTS.**
+
+Ceiling under test: **6,444** (Aidan Hutchinson, native IDPTC). Applied at the
+translation layer to the three `needs_shared_market_translation` sources only;
+`idpTradeCalc`, `draftSharks` and `draftSharksIdp` exempt by construction.
+
+### Measured effect
+
+| scenario | values changed | ranks changed | IDP top-50 | IDP top-100 | max IDP value |
+|---|---|---|---|---|---|
+| live — control | — | — | 3 | 8 | 6,393 |
+| live — **candidate B** | **0** | **0** | 3 | 8 | 6,393 |
+| backbone lost — control | — | — | 13 | 29 | 9,999 |
+| backbone lost — **candidate B** | 67 (40 IDP) | — | **13** | **29** | 6,473 |
+
+**Three findings against it.**
+
+1. **It is inert when the board is healthy.** Zero values, zero ranks. The
+   crosswalk already places every IDP-only vote below the ceiling — the binding
+   constraint would be 6,444 and the actual contribution is 5,943.
+2. **It caps the number without repairing the board.** Under backbone loss it
+   pulls the peak from 9,999 to 6,473, but the top-50 and top-100 IDP counts do
+   not move at all (13 and 29, against a healthy 3 and 8). The board is still
+   wrong; only its largest number looks right.
+3. **It moves 12 rows *upward*, and the mechanism is instructive.** Micah
+   Parsons goes 2,327 → 6,215; Nik Bonitto 2,422 → 6,177; Laiatu Latu 2,310 →
+   5,955. Under the uncapped fallback their IDP-only votes were so extreme that
+   the **Hampel filter discarded them**, leaving the rows resting on thin
+   surviving evidence. Capping the votes makes them plausible, so they survive
+   the filter and the rows rise. A ceiling therefore interacts with the outlier
+   filter in a way that is not visible from the policy statement alone — "a
+   ceiling only lowers values" is false here, measured.
+
+### What it does get right
+
+Applying it at the **translation layer** rather than post-consensus is correct
+and must be preserved by whatever replaces it. It constrains what an IDP-only
+source may *claim*, never what the consensus may *conclude*, so it cannot
+recreate the retired corridor's vote-then-veto structure.
+
+---
+
+## 8. Bridge-Derived Ceiling Test
+
+Candidate C derives the ceiling from all bridge families rather than one
+provider. Three bridge readings exist today:
+
+| bridge | reading | top-IDP value on the canonical scale |
+|---|---|---|
+| `idpTradeCalc` | native cardinal, combined board | **6,444** (Aidan Hutchinson) |
+| `draftSharksIdp` | combined **ordinal** — what production derives today | **6,485** (Carson Schwesinger) |
+| `draftSharksIdp` | native **cardinal** — 53/100 ratio × board max | **5,289** |
+
+Estimators: median **6,444** · mean/trimmed mean **6,073** · min 5,289 ·
+max 6,485 · **spread 19.7%**.
+
+With the median estimator, candidate C is **numerically identical to candidate
+B** on this board (6,444 either way) and therefore shares every one of B's
+measured outcomes: 0 changes live, 67 changes and unchanged board composition
+under backbone loss.
+
+**C is nonetheless architecturally better than B even at an identical number**,
+for a reason that does not show up in the diff: it removes the single-provider
+arbiter. Under B, `idpTradeCalc` would set the bound on the very sources it
+already outvotes. Under C, losing one bridge degrades the estimate instead of
+destroying it — which is the exact failure this audit found.
+
+**The 19.7% spread is the important result, not the median.** The bridges
+genuinely disagree, and §11 requires that disagreement be preserved rather than
+averaged into a single authority. Any ceiling collapses it to one number by
+construction.
+
+---
+
+## 9. Full Bridge Mapping and the Hybrid
+
+### Candidate D — monotonic bridge mapping
+
+A specialist source says where a player sits **among IDPs**; the bridges say
+what that position is **worth against offense**. D learns a monotone
+within-IDP-quantile → cross-position-value map from the bridge families
+(median across bridges at each of 21 knots, forced non-increasing) and replaces
+the ladder translation with it.
+
+| scenario | values changed | up / down | median abs | max abs | IDP top-50 | IDP top-100 | max IDP |
+|---|---|---|---|---|---|---|---|
+| live — control | — | — | — | — | 3 | 8 | 6,393 |
+| live — **D** | 295 (273 IDP, 1 offense, 21 pick) | 154 / 141 | **3.0** | 1,756 | 4 | 10 | 6,441 |
+| backbone lost — control | — | — | — | — | 13 | 29 | 9,999 |
+| backbone lost — **D** | 350 (278 IDP, 1 offense, 71 pick) | 0 / 350 | 151.5 | 6,425 | **4** | **8** | **6,375** |
+
+**This is the result that decides the audit.** Under backbone loss D returns the
+top-100 IDP count to **8** — the healthy board's value — and the top-50 count to
+4 against a healthy 3. The ceiling policies leave those at 13 and 29. D repairs
+the board; a ceiling repairs one number.
+
+D is also close to a no-op when the backbone is healthy: median absolute change
+**3 points**, and its changes are symmetric (154 up, 141 down) rather than a
+systematic deflation. By IDP band, live:
+
+| band | n | changed | mean change | max abs |
+|---|---|---|---|---|
+| IDP 1–10 | 10 | 10 | +135.3 | 657 |
+| IDP 10–25 | 15 | 15 | −3.5 | 1,756 |
+| IDP 25–75 | 50 | 50 | +34.3 | 989 |
+| IDP 75+ | 221 | 198 | +2.7 | 703 |
+
+Under backbone loss the same bands show the scale of the repair: IDP 1–10 mean
+**−4,602**, IDP 10–25 mean −3,048, IDP 25–75 mean −1,038, IDP 75+ mean −132 —
+i.e. the correction is concentrated exactly where the fabricated cross-position
+claim was largest, and is nearly absent in the deep tail.
+
+Second-order effects are real and expected: 21 pick rows move live, 71 under
+backbone loss, via the rookie-pool tether. Offense moves 1 row in both. Contract
+health stays `ok: True` and **blend-integrity violations remain 0** under every
+candidate and both scenarios.
+
+### Candidate E — mapping plus bridge-derived ceiling
+
+**E is byte-identical to D in every scenario measured.** The mapping never
+produces a value above the bridge-derived ceiling, so the bound never binds.
+That is a meaningful negative result: once a bridge mapping is in place, a
+ceiling is redundant rather than defensive.
+
+### The bridge that already exists
+
+Two mechanisms already perform bridge duty and should be recognised as such
+before anything new is designed:
+
+1. **α-shrinkage** (`_ALPHA_SHRINKAGE = 0.10`). IDP and pick rows blend as
+   `anchor + 0.10 × (subgroup − anchor)`, so every IDP-only board together can
+   move an IDP value only 10% off the cross-market anchor.
+2. **The anchor set is already multi-bridge.** Measured over 297 anchored IDP
+   rows: the anchor set is `{draftSharksIdp, idpTradeCalc}` on **273** rows,
+   `idpTradeCalc` alone on **23**, `draftSharksIdp` alone on **1**.
+
+This is why the live board is healthy despite having no explicit ceiling, and
+it is why a ceiling adds nothing: the containment is already there, in a better
+form. What is missing is that both mechanisms depend on the *ladder*, and the
+ladder depends on one source.
+
+---
+
+## 10. Critical Rule Check — Genuine Combined Evidence Is Not Clamped
+
+The audit's own measurements produced a live instance of the case §11 of the
+brief warns about.
+
+**On LB1 Carson Schwesinger, `draftSharksIdp` contributes 6,485 — 100.6% of the
+proposed IDPTC ceiling of 6,444.** Draft Sharks is expressing genuine
+cross-position information and it lands *above* the bound. Under candidates B, C
+and E it is exempt by construction, and that exemption is load-bearing rather
+than cosmetic.
+
+The bridges disagree far more than the top-of-board number suggests:
+
+| player | pos | canonical | `idpTradeCalc` | `draftSharksIdp` | ratio |
+|---|---|---|---|---|---|
+| Aidan Hutchinson | DL | 6,393 | **6,444** | **2,116** | 3.05× |
+| Micah Parsons | DL | 5,318 | 5,409 | 1,643 | 3.29× |
+| Carson Schwesinger | LB | 5,954 | 5,667 | **6,485** | 0.87× |
+| Jihaad Campbell | LB | 3,417 | 3,458 | 4,309 | 0.80× |
+| Nick Emmanwori | DB | 3,550 | 3,598 | 4,671 | 0.77× |
+
+The two bridges do not merely differ in magnitude — they disagree about **which
+position family is valuable**. IDPTC prices elite DL far above elite LB; Draft
+Sharks does the reverse. That is a substantive market disagreement about IDP
+scoring structure, and any architecture that resolves it by appointing one
+bridge as the arbiter is discarding evidence.
+
+**Consequence for the recommendation:** the bridge layer must aggregate bridges
+and publish their dispersion, never select one.
+
+---
+
+## 11. Source-Type Taxonomy
+
+Mapped onto the flags the registry **already** carries, rather than inventing a
+parallel vocabulary.
+
+| Type | Definition | Existing flags | Members today | Candidates |
+|---|---|---|---|---|
+| **1 — native combined CARDINAL** | Values offense and IDP together on one numeric scale | `is_cross_market` + native value + `extra_scopes` spanning both pools | `idpTradeCalc` (backbone-capable); `draftSharks` + `draftSharksIdp` (**cardinal, but consumed as ordinal**) | Footballguys combined (unproven) |
+| **2 — combined overall RANK** | Ranks offense and IDP together, no values | `is_cross_market`, rank signal | *none today* | IDP Show Combined |
+| **3 — IDP-only numeric** | Publishes numbers, but the scale is internal to IDP | — | *none today* | — |
+| **4 — IDP-only RANK (specialist)** | Orders IDPs only; cannot place them against offense | `needs_shared_market_translation`, `scope: overall_idp` | `dlfIdp`, `idpShow`, `fantasyProsIdp` | Dynasty Nerds IDP (public Top-275) |
+
+Two gaps the current flags cannot express, and both matter:
+
+- **`is_backbone` is a label, not a capability.** Setting it on any of the five
+  other IDP sources empties the `scale_integrity_lost` guard while leaving the
+  board exactly as broken. Only "the source's own value column spans both
+  pools" is a real test, and only `idpTradeCalc` passes it. Measured on the
+  pinned board:
+
+  | source | positive offense values | positive IDP values | can seed a ladder |
+  |---|---|---|---|
+  | `idpTradeCalc` | **434** | **370** | **yes** |
+  | `ktcSfTep` | 463 | 0 | no |
+  | `draftSharks` | 389 | 0 | no |
+  | `draftSharksIdp` | **0** | 143 | no |
+
+  The registry should carry a *derived* capability, not a hand-set flag.
+- **Nothing distinguishes cardinal from ordinal cross-position evidence.**
+  `draftSharksIdp` and a future IDP Show Combined would both be
+  `is_cross_market`, but one states a ratio and the other states an order. The
+  first can seed a value mapping; the second can only seed a ladder.
+
+---
+
+## 12. Draft Sharks — Cardinal Bridge Analysis
+
+### Acquisition status: **already acquired, and league-specific**
+
+`scripts/fetch_draftsharks.py` drives a real browser against
+`draftsharks.com/dynasty-rankings/te-premium-superflex`, selects
+**`LEAGUE_ID = "995704"` ("Risk It To Get The Brisket")** through the page's
+Alpine.js dropdown (`_activate_league:506`), waits for the WebAssembly scoring
+worker to settle, and reads the `3D Value +` column. Draft Sharks applies league
+scoring **client-side**, so the server never returns a league-scored board — the
+browser drive is not an implementation preference, it is the only access path.
+
+Offense and IDP come from **one session and one pass**, split only by the
+vendor page's own `fantasyPosition` filter across QB/RB/WR/TE/DL/LB/DB. League
+match is by ID with an exact normalized-name fallback (never substring, to avoid
+a cloned league). The board is refreshed on the `scheduled-refresh.yml` cron
+every 2 hours.
+
+### Is `3D Value +` one scale across offense and IDP? **YES — proven**
+
+Reading the top of each board is not sufficient evidence; a vendor could publish
+two separately normalised boards of identical shape. The test uses `3yr. Proj`,
+which both boards carry.
+
+`3D Value +` behaves as value-over-replacement — each position family crosses
+zero at its own projection level, which is correct VOR behaviour and *not*
+evidence of separate scales. What must be shared for cross-position validity is
+the **conversion rate**: one point of projection surplus must be worth the same
+amount of `3D Value +` regardless of position.
+
+Regressing `3D Value +` on `3yr. Proj` within each family:
+
+| pos | n | slope (3D per proj point) | R² | implied replacement proj | top |
+|---|---|---|---|---|---|
+| QB | 51 | 0.07404 | 0.825 | 193 | Josh Allen **100** |
+| RB | 115 | 0.09061 | 0.984 | 37 | Bijan Robinson 72 |
+| WR | 185 | 0.09344 | 0.983 | 59 | Ja'Marr Chase 64 |
+| TE | 88 | 0.12630 | 0.973 | 108 | Brock Bowers 59 |
+| DL | 159 | 0.05799 | 0.862 | 219 | Aidan Hutchinson **11** |
+| LB | 89 | 0.09915 | 0.987 | 247 | Carson Schwesinger **53** |
+| DB | 162 | 0.13044 | 0.993 | 282 | Nick Emmanwori 36 |
+
+**Offense slope mean 0.09610 · IDP slope mean 0.09586 · ratio 0.9976.**
+
+The spread *within* offense (0.074 QB → 0.126 TE) and *within* IDP (0.058 DL →
+0.130 DB) both exceed the difference *between* the pools. There is no systematic
+offense-versus-IDP conversion gap. **The two boards are one scale.**
+
+### What that means, and what the pipeline does with it
+
+Draft Sharks is stating that the best IDP is worth **53% of the best offensive
+player** in surplus terms. Phase 1b (`data_contract.py:8544-8597`) merges both
+CSVs into a single combined **ordinal** and prices that through the Hill curve —
+so the pipeline learns "DS's best IDP is the 25th-best asset" (contribution
+6,485) and discards "DS's best IDP is worth 53% of DS's best QB" (which projects
+to **5,289** against today's board max).
+
+Those two readings differ by **19.7%** on the same source, in the same build.
+The ordinal reading is the one that ships.
+
+**Recommendation: preserve the cardinal reading as a second bridge input.** Not
+as a replacement — the ordinal path feeds the anchor set correctly today, and DS
+is one of only two anchors on 273 IDP rows. The gain is that the cardinal
+reading is available to the bridge mapping without a second scrape, and it is a
+genuinely independent statement of the offense↔IDP relationship.
+
+### On the current two-key split
+
+`draftSharks` / `draftSharksIdp` are two registry keys in **one** family, and
+the split is correct for family accounting. It does **not** destroy the native
+relationship — Phase 1b reunites them on the raw `3D Value +` before
+ordinalizing. What loses the relationship is the ordinalization, not the split.
+
+One player (`Justin Jefferson`) appears on both CSVs; the union is keyed on the
+vendor's own `data-key`, and the repair record reports 660 overlaps with 0
+conflicts.
+
+---
+
+## 13. The IDP Show — Verdict
+
+**Combined board acquisition: PENDING AUTHENTICATED ACCESS.**
+
+- **What we ingest today.** `scripts/fetch_idpshow.py` pulls the **IDP-only**
+  dynasty board from `theidpshow.com/p/idp-dynasty-rankings` via Datawrapper's
+  CDN (`dwcdn.net/{chart_id}/{version}/dataset.csv`, resolved by walking up to
+  20 version redirects). Output is `name,position,rank` — 350 ranked players.
+  Registered `scope: overall_idp`, family `idpShow` (singleton), 24h freshness
+  budget, and the **only** source flagged `soft` in
+  `config/source_staleness.json` because its session is hand-minted.
+- **Auth.** A cookie jar at `<repo>/idpshow_session.json` (`connect.sid`,
+  `AWSALBTG`, `AWSALBTGCORS`), pasted manually from DevTools, ~90-day rolling
+  expiry, plus `curl_cffi` chrome131 impersonation for Cloudflare. In CI the
+  same JSON is the `IDPSHOW_SESSION_JSON` secret; without it CI skips and the
+  prod `dynasty-idpshow-fetch` timer is the only producer.
+- **Is there a Combined board?** **No evidence in the repository, and none
+  visible anonymously.** Every `combined` match in the tree is *combined
+  tackles* (`src/bdvm/idpshow_projections.py:38, :74-75, :252`), a defensive
+  stat split, unrelated. An anonymous fetch of the dynasty-rankings page
+  returns 200 with paywall/subscriber markers present and **no Datawrapper
+  chart ids exposed**. The Combined board's existence, size and shape cannot be
+  established from here.
+- **Lineage warning that must travel with any acquisition.** The IDP Show's
+  offense component is FantasyPros ECR. A Combined board must therefore join
+  the **`fantasyPros` family**, not vote as an independent source — otherwise
+  the same FantasyPros opinion reaches the consensus three times
+  (`fantasyProsSf`, `fantasyProsIdp`, `fantasyProsFitzmaurice` are already one
+  family) and the confidence gate's independence axis is inflated.
+- **Its real value to this project is Type 2 cross-position placement**, not
+  its offense half. If the Combined board publishes overall ranks spanning both
+  pools, it becomes the **second ladder-capable source** — which is precisely
+  the single-point-of-failure identified in §6.
+
+**Future role of the existing IDP-only `idpShow` feed — recommendation:**
+**retain as a specialist**, do not replace. It is a distinct family from
+FantasyPros, so retiring it in favour of a FantasyPros-derived Combined board
+would *reduce* independent evidence while appearing to add a source. If the
+Combined board is acquired, it should be registered as a new key in the
+`fantasyPros` family alongside the retained `idpShow`.
+
+---
+
+## 14. Draft Sharks — Verdict
+
+**Is the Risk It To Get The Brisket-specific 3D+ board accessible? YES — it is
+already being ingested.**
+
+**Is it genuinely cross-position? YES — proven by measurement**, ratio 0.9976
+(§12).
+
+**Is the current split destroying the native relationship?** Partly. The two-key
+split is fine; the **ordinalization** discards a cardinal cross-position claim
+worth 19.7% against the ordinal reading.
+
+Remaining limitation, recorded rather than resolved: the `Team` column has been
+blank since 2026-07-26, and the vendor `data-key` is used for the in-memory
+union but **not persisted** to the CSV, so a downstream identity join cannot use
+it.
+
+---
+
+## 15. Dynasty Dealer — Verdict
+
+# **DYNASTY DEALER PRO REQUIRED: NO**
+
+But the access question is not the deciding one.
+
+**Evidence.** Dynasty Dealer is a React SPA backed by Supabase
+(`wjdntulndyhgjwfpommx.supabase.co`) with an `anon`-role JWT published in
+`static/js/main.501ffcea.js`. The values live in a `players` table, queried by
+the app as
+`select("player_id, name, position, team, current_value, sleeper_id, age")`.
+A public read of that endpoint returns HTTP 200 with no account of any kind.
+
+Full schema: `player_id, name, team, position, current_value, sleeper_id,
+mfl_id, espn_id, is_rookie, image_url, age, birthday, height, weight, college,
+years_exp, updated_at, created_at, rating, votes, previous_rating`.
+
+**Measured contents (2026-08-20):**
+
+| metric | value |
+|---|---|
+| rows returned | **723** |
+| positions | RB 161 · WR 264 · QB 103 · TE 126 · **PICK 69** |
+| **IDP rows (DL/LB/DB/DE/DT/CB/S/EDGE)** | **0** |
+| top of board | Bijan Robinson 10,000 · Jahmyr Gibbs 9,781 · Ja'Marr Chase 9,730 · Josh Allen 9,495 |
+| rows carrying `sleeper_id` | 709 of 723 (98.1%) |
+| freshest `updated_at` | 2026-08-20T02:08:07Z |
+| rows with `current_value == 0` | **158** |
+
+Probes for `idp_players`, `idp_values`, `rankings` and `player_values` all
+return **404** — no IDP table exists.
+
+**Verdict on usefulness: Dynasty Dealer cannot serve as a cross-position
+bridge, because it publishes no IDP players at all.** The access question is
+moot. It is a viable *offense + pick* source on one native 0–10,000 scale with
+excellent Sleeper-ID coverage, and `rating` / `votes` / `previous_rating` show
+it is a crowd-voted market (a distinct population from KTC's crowd, so plausibly
+an independent family) — but that is a different proposal from the one this
+audit was asked about.
+
+Two cautions if it is ever ingested:
+
+- **158 of 723 rows carry `current_value == 0`.** Under MISSING IS NEVER ZERO
+  those must be treated as unpriced, not as zero-valued, at the fetcher.
+- Attribution and terms of use were not reviewed and must be settled before any
+  scheduled ingestion.
+
+---
+
+## 16. Dynasty Nerds — Verdict
+
+# **DYNASTY NERDS PREMIUM REQUIRED: NO**
+
+**For the IDP board that exists, Premium buys nothing this project needs.**
+
+**The offense feed we already ingest is fully public.**
+`scripts/fetch_dynasty_nerds.py` reads `window.DR_DATA.SFLEXTEP` out of static
+HTML at `dynastynerds.com/dynasty-rankings/sf-tep/` — no JS execution, no auth,
+no paywall bypass. `DR_DATA` carries four keys (`PPR`, `SFLEX`, `STD`,
+`SFLEXTEP`), **all offense**, and **no IDP key**.
+
+**The public IDP board.** `dynastynerds.com/idp/dynasty-idp-rankings-tiers/`
+returns 200 anonymously and renders the board as 10 tiered HTML tables:
+
+| metric | value |
+|---|---|
+| ranked rows | **275** |
+| by position | DL 100 · LB 100 · DB 75 |
+| columns | Rank · Player · Position · Age · Team · 2026 IDP Rank (positional) |
+| **numeric value column** | **none** |
+| tiers | yes — 10 tables = 10 tiers |
+| top | 1 Aidan Hutchinson (DL1) · 2 Travis Hunter (DB1) · 3 Will Anderson Jr. (DL2) · 4 Carson Schwesinger (LB1) |
+
+**So the public IDP board is a TYPE 4 specialist**: ranks, positional ranks,
+tiers and age, with no cross-position information whatsoever.
+
+**Does Premium change that? UNPROVEN, and the burden is not met.** `app.dynasty
+nerds.com` is gated and was not probed. But the decision does not turn on it:
+Premium would only be worth buying if it supplied a genuine **offense↔IDP
+bridge**, and nothing in the public surface suggests one exists — the public
+rankings host publishes eight offense format paths and no IDP path, and the IDP
+product is delivered as editorial tiers rather than as a valued board.
+
+> **DO NOT BUY DYNASTY NERDS PREMIUM FOR THIS PURPOSE.**
+
+**If the public IDP board is ingested**, propose it as `dynastyNerdsIdp` in the
+**same `dynastyNerds` family** as the offense feed. It is **not** new
+independent family evidence, and registering it as a singleton would inflate the
+confidence gate's independence axis on exactly the rows that need it most.
+
+---
+
+## 17. Footballguys — Status
+
+# **PENDING AUTHENTICATED ACCESS**
+
+The prior integration (`footballGuys` / `footballGuysSf` / `footballGuysIdp`) is
+**RETIRED**: no registry entry, no CSV, no fetcher, no consumer, and the
+orphaned `_last_success` stamps were removed under census item S-5. It formerly
+served as a cross-market combined-rank anchor alongside DraftSharks SF+IDP —
+i.e. it was a **Type 1/2 bridge**, which is exactly what this audit finds the
+platform short of.
+
+**Do not revive it blindly.** Treat any future work as a fresh 2026 adapter.
+Pending research slot, to be filled once authenticated access exists:
+
+- dynasty overall board; IDP board; mixed offense/IDP expert boards
+- league-specific rankings (does it support a league sync like Draft Sharks?)
+- **numerical values, and whether one scale spans offense and IDP** — the
+  deciding question for bridge eligibility
+- delivery mechanism: export, API, or app payload
+- family assignment and any derivative relationship to existing sources
+
+**One live defect found in passing, reported not fixed:**
+`frontend/app/edge/page.jsx:401` still renders user-facing copy reading
+`"Consensus = DLF IDP, IDP Show, FantasyPros IDP, FootballGuys IDP, DraftSharks
+IDP."` — naming a source that has not existed for roughly 85 days.
+`frontend/lib/display-helpers.js:392` and
+`frontend/__tests__/idp-consensus-keys-parity.test.js:18` both already document
+that the name is not a key in either registry, so the comment was corrected and
+the rendered string was not.
+
+---
+
+## 18. Provider-Family Map
+
+### Current — 21 sources, 13 families (census `SOURCE_CENSUS_2026-08-18.md` re-verified member-for-member)
+
+| Family | Members | Bridge? |
+|---|---|---|
+| `ktc` | `ktcSfTep`, `fantasyNavigatorSf` | offense anchor |
+| `dlf` | `dlfSf`, `dlfRookieSf`, `dlfIdp`, `dlfRookieIdp` | no |
+| `fantasyPros` | `fantasyProsSf`, `fantasyProsIdp`, `fantasyProsFitzmaurice` | no |
+| `flockFantasy` | `flockFantasySf`, `flockFantasySfRookies` | no |
+| `draftSharks` | `draftSharks`, `draftSharksIdp` | **YES — cardinal (consumed as ordinal)** |
+| `idpTradeCalc` | `idpTradeCalc` | **YES — cardinal, and the only ladder-capable source** |
+| `idpShow` | `idpShow` | no (specialist) |
+| `dynastyNerdsSfTep` | `dynastyNerdsSfTep` | no |
+| `fantasyCalc` | `fantasyCalc` | no |
+| `otcffbSf` | `otcffbSf` | no |
+| `pfkDynasty` | `pfkDynasty` | no |
+| `dynastyDaddySf` | `dynastyDaddySf` | no |
+| `yahooBoone` | `yahooBoone` | no |
+
+### Proposed
+
+| Proposed source | Family | Type | Independent family? | Gate |
+|---|---|---|---|---|
+| IDP Show Combined | **`fantasyPros`** (offense half is FantasyPros ECR) | 2 | **No** | authenticated access |
+| `dynastyNerdsIdp` | **`dynastyNerds`** (with the existing offense feed) | 4 | **No** | none — public today |
+| Dynasty Dealer | new singleton `dynastyDealer` | 1 (offense+picks only) | Yes | **fails the bridge test — 0 IDP rows** |
+| Footballguys 2026 | new singleton `footballguys` | 1 or 2, unproven | Yes | authenticated access |
+| Draft Sharks **cardinal** reading | `draftSharks` (existing) | 1 | **No — same family** | none; reads a column we already fetch |
+
+Only **two** of these would add independent family evidence, and only one of
+those (Footballguys) could add a *bridge*.
+
+---
+
+## 19. Candidate Policy Comparison
+
+All figures against the same pinned board. Contract health `ok: True` and
+**0 blend-integrity violations under every candidate and both scenarios.**
+
+### Live board (backbone healthy)
+
+| candidate | values changed | up/down | median abs | P90 abs | max abs | IDP top-50/100/200/400 | max IDP |
+|---|---|---|---|---|---|---|---|
+| **A** control | — | — | — | — | — | 3 / 8 / 42 / 118 | 6,393 |
+| **B** IDPTC ceiling | **0** | 0/0 | 0 | 0 | 0 | 3 / 8 / 42 / 118 | 6,393 |
+| **C** bridge ceiling | **0** | 0/0 | 0 | 0 | 0 | 3 / 8 / 42 / 118 | 6,393 |
+| **D** bridge mapping | 295 | 154/141 | 3.0 | — | 1,756 | 4 / 10 / 42 / 118 | 6,441 |
+| **E** hybrid | 295 | 154/141 | 3.0 | — | 1,756 | 4 / 10 / 42 / 118 | 6,441 |
+
+### Backbone lost (`idpTradeCalc` excluded)
+
+| candidate | values changed | up/down | median abs | max abs | IDP top-50/100/200/400 | max IDP | untranslated votes |
+|---|---|---|---|---|---|---|---|
+| **A** control | — | — | — | — | 13 / 29 / 54 / 129 | **9,999** | **661** |
+| **B** IDPTC ceiling | 67 | 12/55 | 173 | 4,225 | 13 / 29 / 54 / 129 | 6,473 | 661 |
+| **C** bridge ceiling | 67 | 12/55 | 173 | 4,225 | 13 / 29 / 54 / 129 | 6,473 | 661 |
+| **D** bridge mapping | 350 | **0/350** | 151.5 | 6,425 | **4 / 8 / 22 / 97** | **6,375** | 661 |
+| **E** hybrid | 350 | 0/350 | 151.5 | 6,425 | 4 / 8 / 22 / 97 | 6,375 | 661 |
+
+**Reading the table.** Healthy top-50/100 is 3/8. Backbone loss inflates it to
+13/29. B and C leave it at 13/29. **D and E return it to 4/8.**
+
+Note that D and E do not reduce the *untranslated vote count* — they do not
+repair the ladder, they make the vote sane despite it. Repairing the ladder is a
+separate and complementary fix (§20).
+
+---
+
+## 20. Cross-Position Bridge Recommendation
+
+The architecture should separate two questions that are currently entangled in
+one ladder:
+
+> **Specialist information** answers *who is better within this domain?*
+> **Bridge information** answers *what is that domain position worth against
+> the overall dynasty market?*
+
+### Recommended future architecture
+
+1. **A named bridge layer with an explicit, multi-source population.** Bridge
+   families are those that publish cross-position evidence — today
+   `idpTradeCalc` (cardinal) and `draftSharks` (cardinal, currently read as
+   ordinal); tomorrow potentially IDP Show Combined (ordinal) and Footballguys.
+   The layer **aggregates and publishes dispersion; it never selects an
+   arbiter.** The measured 19.7% bridge spread, and the 3× disagreement on
+   elite DL, are the reason.
+
+2. **`is_backbone` replaced by a derived capability.** "This source's own value
+   column spans both pools" is testable and is the property that actually
+   matters. A hand-set label that can be moved to a source which cannot seed a
+   ladder is a guard that reports success while the board is broken.
+
+3. **A monotone quantile→value bridge mapping replaces the ladder as the
+   translation for Type 4 sources** (candidate D). It restores the board under
+   backbone loss (top-100 IDP 24 → 8) and is near-inert when the backbone is
+   healthy (median change 3). Crucially it degrades gracefully: losing one
+   bridge changes the median at each knot rather than emptying the mechanism.
+
+4. **No ceiling.** Candidate E proved the bound never binds once the mapping is
+   in place, and candidates B and C proved a ceiling is inert when healthy and
+   insufficient when not. Adding one would be a mechanism with no measured
+   effect and a demonstrated interaction with the Hampel filter.
+
+5. **Placement stays at the translation layer, never post-consensus.** This is
+   the one thing the retired corridor got wrong and it must not be repeated: a
+   bridge constrains what an IDP-only source may *claim*, never what the
+   consensus may *conclude*. Type 1 and Type 2 sources bypass the layer
+   entirely, by construction rather than by an editable exemption list.
+
+6. **Preserve Draft Sharks' cardinal reading** as a bridge input alongside its
+   existing ordinal contribution — it is a genuinely independent statement of
+   the offense↔IDP relationship, already in the repository, currently discarded.
+
+7. **Fail-closed reporting.** A row whose bridge evidence is missing or whose
+   bridges disagree beyond a declared threshold should be stamped and its
+   confidence degraded — not silently priced. The existing quarantine and
+   confidence machinery already supports this; nothing new is needed.
+
+### What this does NOT do
+
+It does not stop IDPs being valuable. Under D the healthy board's top-50 IDP
+count goes 3 → 4 and the top IDP rises 6,393 → 6,441. The mechanism is a
+*translation*, not a deflation, and its live effect is symmetric (154 up, 141
+down).
+
+---
+
+## 21. Representative Cross-Source Table
+
+Live board. Slots chosen by positional rank on the canonical board (reproducible
+rather than hand-picked). Figures are the **contribution that enters
+aggregation** for rank-signal sources and the native value for value sources.
+`—` means the source does not cover that asset.
+
+| slot | player | pos | canonical | `ktcSfTep` | `idpTradeCalc` | `draftSharks` | `draftSharksIdp` | `idpShow` | `dlfIdp` | `fantasyProsIdp` | `dynastyNerdsSfTep` |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| QB1 | Josh Allen | QB | 9,979 | 9,985 | 9,983 | 9,999 | — | — | — | — | 9,999 |
+| QB12 | Bo Nix | QB | 6,537 | 5,977 | 6,034 | 5,891 | — | — | — | — | 6,077 |
+| QB24 | Bryce Young | QB | 3,778 | 3,809 | 4,366 | 4,050 | — | — | — | — | 3,369 |
+| RB1 | Bijan Robinson | RB | 9,805 | 9,998 | 9,999 | 8,184 | — | — | — | — | 9,883 |
+| RB12 | Quinshon Judkins | RB | 5,329 | 5,325 | 5,501 | 5,391 | — | — | — | — | 5,802 |
+| RB24 | Bhayshul Tuten | RB | 3,859 | 4,278 | 4,032 | 3,541 | — | — | — | — | 3,809 |
+| WR1 | Ja'Marr Chase | WR | 9,620 | 9,954 | 9,978 | 7,898 | — | — | — | — | 9,481 |
+| WR12 | Nico Collins | WR | 6,027 | 5,653 | 5,595 | 6,052 | — | — | — | — | 5,737 |
+| WR24 | Makai Lemon | WR | 4,771 | 4,939 | 5,056 | 4,754 | — | — | — | — | 4,753 |
+| WR36 | Alec Pierce | WR | 3,565 | 3,676 | 4,032 | 3,706 | — | — | — | — | 3,719 |
+| TE1 | Brock Bowers | TE | 9,970 | 9,999 | 9,872 | 7,940 | — | — | — | — | 9,989 |
+| TE12 | Oronde Gadsden | TE | 4,086 | 3,968 | 4,511 | 4,558 | — | — | — | — | 3,935 |
+| **DL1 / IDP1** | Aidan Hutchinson | DL | 6,393 | — | **6,444** | — | **2,116** | 5,943 | 5,943 | 5,943 | — |
+| DL2 | Will Anderson | DL | 5,926 | — | 5,963 | — | 2,013 | 5,603 | 5,603 | 5,603 | — |
+| DL5 | Myles Garrett | DL | 5,317 | — | 5,414 | — | 1,924 | 4,726 | 4,726 | 3,077 | — |
+| DL10 | Nik Bonitto | DL | 3,558 | — | 3,593 | — | 1,962 | 3,231 | 3,751 | 2,826 | — |
+| **LB1** | Carson Schwesinger | LB | 5,954 | — | 5,667 | — | **6,485** | 5,352 | 4,783 | 4,698 | — |
+| LB2 | Sonny Styles | LB | 5,252 | — | 5,399 | — | 5,238 | 4,645 | 4,671 | 2,603 | — |
+| LB5 | Arvell Reese | LB | 3,946 | — | 4,173 | — | 3,812 | 3,766 | 3,294 | 2,557 | — |
+| LB10 | Jihaad Campbell | LB | 3,417 | — | 3,458 | — | 4,309 | 3,104 | 3,181 | 2,749 | — |
+| **DB1** | Nick Emmanwori | DB | 3,550 | — | 3,598 | — | 4,671 | 3,262 | 3,050 | 3,104 | — |
+| DB2 | Kevin Winston | DB | 3,272 | — | 2,971 | — | 3,860 | 2,585 | 1,753 | 1,892 | — |
+| DB5 | Dillon Thieneman | DB | 3,129 | — | 3,111 | — | 3,383 | 2,749 | 1,950 | 1,889 | — |
+| DB10 | Xavier Watts | DB | 2,046 | — | 1,970 | — | 2,163 | 1,908 | 1,585 | 2,007 | — |
+| IDP5 | Micah Parsons | DL | 5,318 | — | 5,409 | — | 1,643 | 4,698 | 5,352 | 2,878 | — |
+| IDP25 | Rueben Bain | DL | 3,336 | — | 3,396 | — | 1,755 | 3,050 | 2,557 | — | — |
+| IDP50 | Alex Highsmith | DL | 2,477 | — | 3,264 | — | 1,660 | 2,901 | 2,742 | 1,813 | — |
+| IDP100 | Jalyx Hunt | DL | 1,838 | — | 1,923 | — | 1,766 | 1,820 | 1,751 | — | — |
+
+**Candidate-mapped contributions** are not reproduced per-player here because
+candidates B and C change **nothing** on this board (§7) and D's live median
+change is 3 points (§9). The full per-candidate row-level diff, including the
+25 largest movers per scenario, is in the evidence JSON.
+
+Two things the table makes visible at a glance: no IDP-only source's
+contribution is anywhere near the 9,979 board maximum, and `draftSharksIdp`
+disagrees with `idpTradeCalc` about DL by roughly 3× while agreeing closely
+about deep DB.
+
+---
+
+## 22. Raw Data Preservation — Gap Analysis
+
+Any future ingestion must preserve source-native information before
+transformation. **Today it largely does not.**
+
+`src/source_archive/store.py` exists and is well designed — append-only SQLite,
+identity `(provider, endpoint, format_key, run_id, captured_date)`, native units
+kept verbatim, identical re-ingest a no-op, conflicting re-ingest surfaced never
+applied, fail-closed on non-`DYNASTY` game type. **It is inert**:
+`archive_board` has zero production callers, `data/source_archive/` does not
+exist, and `PRODUCTION_ELIGIBLE` is deliberately empty.
+
+In practice `CSVs/site_raw/*.csv` is overwritten in place on every fetch and no
+per-run version of any board survives.
+
+| Required field | live `site_raw` | `source_archive` | `RawAssetRecord` |
+|---|---|---|---|
+| provider | filename only | yes | yes |
+| product / feed | filename only | `format_key` | yes |
+| source URL / endpoint | **missing** | yes | yes |
+| fetch time | mtime + `_last_success` proxy | yes | yes |
+| source update time | **missing** | `source_as_of` (unused) | **missing** |
+| player source id | **missing** (DS `data-key` not persisted) | **missing** | field exists, hardcoded `""` |
+| Sleeper id | 2 of 24 CSVs | **missing** | **missing** |
+| name | yes | yes | yes |
+| NFL team | some CSVs (DS blank since 2026-07-26) | **missing** | yes |
+| position | some CSVs | **missing** | yes |
+| overall rank | rank-signal CSVs | collapses to one float | yes |
+| **positional rank** | **missing** | **missing** | **missing** |
+| **tier** | **missing** | **missing** | field exists, never populated |
+| native value | value-signal CSVs | yes (never normalized) | yes |
+| scoring format | **missing** | `format_key` | yes |
+| **league configuration** | **missing** (DS league is a hardcoded constant) | **missing** | free text only |
+| source type | **missing** | **missing** | `ingest_type` |
+| **auth class** | **missing** | **missing** | **missing** |
+| provenance / hash | **missing** | `content_hash`, `run_id` | yes |
+| game type | **missing** | yes (fail-closed) | **missing** |
+
+**Structural blocker:** `ArchivedBoard.rows` is typed `dict[str, float]` — a
+name→number map. It **cannot** express sleeper id, team, position, positional
+rank or tier. Wiring the archive is therefore a schema extension, not a
+call-site change. This matters immediately: the Dynasty Nerds IDP board's value
+is entirely in its positional ranks and tiers, and the archive cannot hold
+either.
+
+**Rule to carry forward:** native values must never be overwritten with our
+mapped values in raw storage. The one live violation of that spirit found in
+this audit is `pickAnchorsRaw`, already repaired under C1-U6-D1.
+
+---
+
+## 23. Player Identity QA — Capability and Gap
+
+For each proposed feed the brief requires ten metrics. **Seven are available
+today; three are not.**
+
+| Metric | Available | Where |
+|---|---|---|
+| total records | yes | `audit_sources` → `csvRows` / `parsedRows`; `record_count` |
+| unique players | yes | `matchedKeys`; `master_player_count` |
+| Sleeper-ID matches | yes | `idOnlyMatchedRows` |
+| exact-name matches | **partial** | split exists as `v2Method` in `resolution.py` but is not surfaced per feed |
+| normalized-name matches | **partial** | same |
+| unresolved | yes | `unmatchedRows`; `unresolved_count` |
+| ambiguous | **partial** | `v2Reason: "ambiguous"` in the dual-read tally only |
+| duplicates | yes | `alias_collision_delta`; `duplicate_alias_count` |
+| **team conflicts** | **NOT IMPLEMENTED** | `identity/matcher.py:70` sets `team` first-write-wins and never compares |
+| position conflicts | yes | `build_master_players:84-86` |
+
+Reusable owners: `scripts/audit_identity_matches.py::audit_sources` (per-feed
+join audit, wired to a daily workflow) and
+`src/identity/matcher.py::build_identity_resolution` (corpus-level).
+
+**Team conflicts must be reported as not-implemented, never as zero.** Adding
+them is a natural extension — `seen_positions` already demonstrates the pattern.
+
+Identity readiness of the two feeds that could actually be ingested from public
+surfaces today:
+
+| feed | records | Sleeper id | notes |
+|---|---|---|---|
+| Dynasty Dealer `players` | 723 | **709 (98.1%)** | also `mfl_id`, `espn_id`; excellent join quality |
+| Dynasty Nerds IDP Top-275 | 275 | **none** | name + team + position only; join is name-based, and 275 IDP names across DL/LB/DB is exactly the population where first-name variants bite |
+
+---
+
+## 24. Recommended Implementation Order
+
+**Nothing below was implemented.** Ordered by measured value per unit of risk.
+
+1. **Register a second ladder-capable bridge.** This is the highest-value item
+   and it is not a policy change at all — it removes the single-source
+   dependency that makes §6's answer "yes". Requires either the IDP Show
+   Combined board or a Footballguys combined board.
+2. **Replace `is_backbone` with a derived capability test.** Small, purely
+   defensive, and prevents a future edit from silently satisfying the guard
+   while leaving the board broken.
+3. **Preserve Draft Sharks' cardinal reading** as bridge evidence. No new
+   scrape — the column is already fetched. Publishes a second independent
+   offense↔IDP statement.
+4. **Build the bridge layer as reporting only**, publishing per-bridge top-IDP
+   equivalents and their dispersion on the contract, changing no value. Lets the
+   19.7% spread be monitored before anything consumes it.
+5. **Adopt candidate D as the Type 4 translation**, behind a feature flag, with
+   the harness re-run before and after. Only after 1–4.
+6. **Do not implement a ceiling** (candidates B, C, E) — measured inert.
+7. Separately and independently of the above: fix the `frontend/app/edge`
+   FootballGuys string, rename or drop `fantasyProsIdp.csv::normalizedValue`,
+   and correct the stale documentation in §27.
+
+---
+
+## 25. Exact Files a Future Implementation Would Touch
+
+| File | Change |
+|---|---|
+| `src/canonical/idp_backbone.py` | the bridge mapping alongside `translate_position_rank`; ladder-capability test in `build_backbone_from_rows` |
+| `src/api/data_contract.py` | `_RANKING_SOURCES` (new keys, derived capability); Phase 1 translation call site `:8467-8504`; Phase 1b DS merge `:8544-8597` for the cardinal reading; `scale_integrity_lost:2744` |
+| `src/canonical/rank_coordinates.py` | only if a new coordinate pool is introduced (not expected) |
+| `src/api/confidence.py` + `config/confidence/gate_v1.json` | bridge-dispersion as a confidence input, if adopted |
+| `frontend/lib/dynasty-data.js` | `RANKING_SOURCES` mirror, `SOURCE_VENDORS`, `SOURCE_VENDOR_LABELS` |
+| `tests/api/test_source_registry_parity.py` | parity for any new key |
+| `tests/api/test_curve_routing_coordinate_pool.py`, `tests/consensus_edge/test_fair_value.py` | translation/scale-integrity invariants |
+| `scripts/fetch_idpshow.py` (or a new `fetch_idpshow_combined.py`) | Combined board acquisition |
+| `scripts/fetch_dynasty_nerds_idp.py` (new) | public IDP Top-275 |
+| `config/source_staleness.json`, `.github/workflows/scheduled-refresh.yml`, `scripts/validate_scrape_sanity.py` | freshness + row floors for any new feed |
+| `src/source_archive/store.py`, `src/data_models/contracts.py` | row schema extension (§22) |
+| `src/identity/matcher.py` | team-conflict detection (§23) |
+| `frontend/app/edge/page.jsx:401` | stale FootballGuys string |
+
+---
+
+## 26. Owner Actions Required
+
+Only actions that cannot be performed from this session.
+
+1. **Paste a current IDP Show session** into `idpshow_session.json` (or update
+   the `IDPSHOW_SESSION_JSON` secret) **and confirm whether a Combined
+   offense+IDP dynasty board exists** on the subscriber side. This is the single
+   highest-value unknown in the audit — it is the likeliest second ladder-capable
+   bridge.
+2. **Confirm Footballguys reactivation** and supply credentials, then say
+   whether its dynasty product publishes numeric values spanning offense and
+   IDP.
+3. **Decide on Dynasty Dealer.** It is publicly readable and needs no paid tier,
+   but publishes **no IDP**. Confirm whether an offense+picks crowd source is
+   wanted on its own merits — that is a different proposal from this audit's.
+   Attribution / terms of use need a decision before any scheduled fetch.
+4. **Confirm Dynasty Nerds Premium is not to be purchased** for this purpose,
+   and whether the public IDP Top-275 should be ingested as a `dynastyNerds`
+   family member.
+5. **Authorize (or not) any implementation.** Nothing in §24 is authorized by
+   this document; `docs/EXECUTION_PLAN.md` remains the record of what may be
+   built.
+
+---
+
+## 27. Stale Documentation Found In Passing
+
+Reported, not fixed.
+
+| Location | Problem |
+|---|---|
+| `docs/master-site-audit/VALUE_FLOW_MAP.md:46`, `:128` | lists the market corridor clamp as live pipeline **stage 8** |
+| `docs/master-site-audit/FORMULA_INVENTORY.md:144` | `F-026` market corridor clamp, status **OK** |
+| `src/canonical/player_valuation.py:69`, `:440` | list "the corridor clamp" among live post-blend stages |
+| `src/canonical/player_valuation.py:465-467` | `percentile_to_value` docstring says ranks past 500 clamp to `p=1.0`, contradicting the `clamp_percentile` call at `:496` |
+| `src/api/compact_view.py:39` | retains contract field `marketCorridorClamp`, which nothing in `src/` writes |
+| `src/api/data_contract.py:1191-1200` | registry weight-policy comment says "All six sources"; there are 21 |
+| `frontend/app/edge/page.jsx:401` | user-facing copy names "FootballGuys IDP", retired ~85 days |
+| `_SOURCE_MAX_AGE_HOURS` (`data_contract.py:745-800`) | `fantasyProsSf`, `dlfRookieSf`, `dlfRookieIdp` fall to the 6h default by omission while their DLF siblings carry 24h — likely unintended |
+
+---
+
+## 28. Proposed Follow-Up Implementation Prompt
+
+**Not executed.** Provided for the owner to issue if and when §24 is authorized.
+
+> **CLAUDE — SECOND BRIDGE REGISTRATION & TYPE-4 TRANSLATION HARDENING**
+>
+> Repo: `jasonleetucker-code/riskittogetthebrisket`.
+>
+> Authorized scope is items 1–4 of §24 in
+> `docs/sources/CROSS_POSITION_SOURCE_AND_IDP_CEILING_AUDIT_2026-08-20.md`
+> **only**. Item 5 (adopting candidate D) is **not** authorized by this prompt
+> and must not be implemented.
+>
+> 1. Replace the `is_backbone` label with a **derived ladder capability**: a
+>    source can seed a shared-market ladder iff its own value column carries
+>    positive values in both the offense and IDP pools. `scale_integrity_lost`
+>    and `build_backbone_from_rows` must both consult the derived test.
+>    A test must fail if setting `is_backbone=True` on a source that cannot
+>    seed a ladder lifts the guard.
+> 2. Add the Draft Sharks **cardinal** reading as bridge evidence alongside its
+>    existing ordinal contribution. Do not change any published value. Prove
+>    with `scripts/board_diff.py --expect-no-value-change`.
+> 3. Add a **bridge layer that reports only**: per-bridge top-IDP equivalents,
+>    the aggregate estimators, and the dispersion between them, stamped on the
+>    contract. It must aggregate, never select an arbiter, and must change no
+>    value.
+> 4. If and only if the owner has supplied IDP Show Combined or Footballguys
+>    access: register it, assigning IDP Show Combined to the **`fantasyPros`**
+>    family (its offense half is FantasyPros ECR), with `game_type_evidence`
+>    proven per endpoint. Full registration checklist: registry entry, family,
+>    frontend mirror, parity test, row floors (both), workflow cadence,
+>    staleness config, identity audit.
+>
+> Constraints: do not implement any ceiling; do not modify
+> `TAIL_SATURATION_RANK`, `_ALPHA_SHRINKAGE`, any Hill constant, or any source
+> weight; do not re-thread `valuation_mode`. Re-run
+> `scripts/simulate_idp_bridge_policies.py` before and after and attach the
+> diff. Any change to a published value must be justified against the audit's
+> pinned board and stated explicitly.
+
+---
+
+## 29. Success Criteria — Answers
+
+| # | Question | Answer |
+|---|---|---|
+| 1 | Does any legacy IDP clamp still affect production? | **No.** The corridor and the IDP calibration post-pass are both gone; `calibration.py`'s IDP knees are fenced with zero production callers |
+| 2 | Is the market-corridor clamp completely removed? | **Yes** — 0 executable references to all six identifiers |
+| 3 | Which safety boundaries are unrelated to IDP cross-position valuation? | All 24 in §2. The tail policy (§4) is a rank-domain bound, not a value ceiling |
+| 4 | Can IDP-only rank #1 be mapped near market maximum? | **No in steady state** (5,943 = 59.6% of max). **Yes under backbone loss** (9,999) |
+| 5 | How is every IDP-only source translated? | §5 — shared-market crosswalk via a ladder seeded only by `idpTradeCalc`; rookie ladder for `dlfRookieIdp`; DS on its own combined ordinal |
+| 6 | Would an IDPTC-top-IDP ceiling solve it? | **No.** 0 changes live; caps the number but not the board under backbone loss; moves 12 rows up via the Hampel interaction |
+| 7 | Is a multi-bridge ceiling/mapping superior? | **The mapping is; the ceiling is not.** D returns top-100 IDP to the healthy 8; C is numerically identical to B today |
+| 8 | Can genuine combined sources remain unconstrained? | **Yes, structurally** — Type 1/2 sources never enter the translation seam. Live proof: `draftSharksIdp` contributes 6,485, above the proposed ceiling |
+| 9 | Can IDP Show Combined be acquired? | **Unproven** — paywalled, no repo evidence it exists. Owner action |
+| 10 | Can synced Draft Sharks 3D+ be acquired? | **Already acquired**, league 995704, and proven cross-position (ratio 0.9976) |
+| 11 | Are Dynasty Dealer IDP values available without Pro? | **No Pro needed, but there are no IDP values at all** — 0 IDP rows of 723 |
+| 12 | Is Dynasty Nerds Premium necessary? | **No.** Public IDP Top-275 is ranks/tiers only; Premium unproven and unjustified |
+| 13 | How should specialists and bridges interact? | §20 — specialists order within domain, bridges price the domain, bridge layer aggregates and never selects |
+| 14 | What is the exact implementation plan? | §24 order, §25 files, §28 prompt. **Nothing authorized by this document** |

--- a/docs/sources/CROSS_POSITION_SOURCE_AND_IDP_CEILING_AUDIT_2026-08-20.md
+++ b/docs/sources/CROSS_POSITION_SOURCE_AND_IDP_CEILING_AUDIT_2026-08-20.md
@@ -20,6 +20,18 @@
 > qualification against the offensive `current_value` basis. **No production
 > weighting or voting is authorized by this correction.**
 
+> **SECOND CORRECTION, 2026-08-20 (Integration review on #950).** §15a(a) as
+> first written over-generalized a negative result on one untried API
+> parameter into a claim about the vendor's dynasty board. Owner-observed live
+> UI evidence shows Dynasty Dealer's dynasty rankings materially respond to
+> Superflex and TE-premium toggles. §15a(a) is now retitled and rewritten to
+> scope the finding to the tested acquisition path only; the "1QB basis"
+> inference is withdrawn as corroboration. Net effect: the same-basis gate now
+> has **one** remaining blocker (temporal — a static IDP snapshot vs. live
+> offense), not two, and the IDP scoring-variant question is answered (all
+> three declared in-payload). Bridge status is unchanged: **`PENDING`, does
+> not vote.**
+
 Every number below was produced by rebuilding the real contract (1,109 rows,
 all 21 registered sources) in-process. Nothing is quoted from prior documents
 without re-verification; where a canonical document is stale, that is recorded
@@ -722,17 +734,58 @@ The durable record is therefore:
 > Bridge eligibility now depends on demonstrating that those defensive values
 > share the same valuation basis as the offensive `current_value` API.
 
-### The same-basis gate does NOT pass — two measured blockers
+### The same-basis gate does NOT pass — one remaining measured blocker
+(originally two; see the 2026-08-20 correction to (a) below)
 
-**(a) The format flags are echo-only.** `scoringSettings` in the response
-reflects the *request*, not the data. `isSuperflex=true&isTePremium=true`
-changes **0 of 1,338 values**. An adapter trusting that field would believe it
-held a Superflex/TE-premium board while holding one unlabelled board — the same
-class of error as W18-F001, a label deciding a factual question. Corroborating
-evidence that the board is 1QB basis: QB1 Josh Allen 9,495 sits *below* RB1
-Bijan Robinson 10,000. This league is Superflex + TEP.
+**(a) CORRECTED, 2026-08-20 — the tested API parameters did not change the
+returned values.** This is a finding about the one acquisition-path
+experiment that was tried, not a finding about Dynasty Dealer's dynasty
+board. `isSuperflex=true&isTePremium=true` against `/api/player-values`
+changes **0 of 1,338 values**, and `scoringSettings` in the response reflects
+the *request*, not the data — so those two query parameters are inert on this
+endpoint. That is all the experiment showed.
 
-**(b) Offense and IDP are not the same quantity in time.**
+It does **not** show that Dynasty Dealer lacks dynasty Superflex/TE-premium
+support. The owner independently observed the *live UI* materially responding
+to Superflex and Tight End Premium toggles, and that observation is what
+resolves the question the failed parameters could not: the **default**
+`/api/player-values` payload (no parameters at all) already *is* the
+Superflex + TE-premium board. Measured against the owner's live-UI figures:
+
+| player | owner-observed (live UI, SF+TEP) | default API payload |
+|---|---|---|
+| Josh Allen | ~#4 overall, ~9,495 | **#4 overall, 9,495** |
+| Brock Bowers | ~#8, high 8,000s | **#8 overall, 8,611** |
+
+Exact on both rank and value. `sf` is a real parameter, but on the
+`?format=redraft` endpoint, not the dynasty one — there it changes 623 of
+1,000 values. The withdrawn inference below rested on treating a negative
+result on the wrong endpoint as evidence about the vendor's board; that was a
+label (or in this case an absent one) deciding a factual question, the same
+class of error as W18-F001 in the direction this lane exists to prevent.
+
+The live-UI format adjustment is applied **client-side**, not via a
+documented query parameter: every IDP row already carries
+`idp_formats: {tackle, balanced, bigplay}` with per-variant values in the
+payload (mechanism C), and the site's own bundle recomputes offense values in
+a `useEffect` keyed on `[isSuperflex, isTePremium]`, cached per format key
+(mechanism D). This does not block acquisition — our league *is* SF+TEP, so
+the unparameterized default payload already is the basis this lane needs; the
+transform is only the path to formats we do not use. The exact transform
+coefficients were not extracted (static analysis reached the call site, not
+the minified definition; the live UI itself could not be driven from this
+environment — see the acquisition-verdicts note below). No access control was
+bypassed or attempted in reaching either conclusion.
+
+**Withdrawn, not corroboration:** the earlier "QB1 sits below RB1, therefore
+1QB" inference. Restated as what it actually shows — the *default endpoint's*
+Josh Allen/Bijan Robinson ordering is now understood to be measurements of the
+Superflex + TE-premium board itself (see the table above), not evidence of a
+1QB basis.
+
+**(b) Offense and IDP are not the same quantity in time.** This blocker is
+**unaffected** by the (a) correction above and is, on its own, sufficient to
+keep the bridge `PENDING`.
 
 | | offense | IDP |
 |---|---|---|
@@ -742,13 +795,34 @@ Bijan Robinson 10,000. This league is Superflex + TEP.
 | range | max 10,000 · p50 16 · **min 0** | max 5,121 · p50 1,476 · min 73 |
 
 Live, crowd-vote-adjusted offense against a static 36-day-old un-voted IDP
-snapshot. The vendor's IDP page also offers tackle-heavy / balanced / big-play
-variants and the payload declares none, so the scoring variant is **UNKNOWN**.
+snapshot.
 
-**Bridge status: `PENDING`. It does not vote.** Qualification needs the format
-basis proven independently of the echoed flags, the IDP scoring variant
-identified, and an owner decision on whether a static IDP snapshot may bridge
-against live offense values.
+**IDP same-basis, re-measured after the (a) correction:**
+
+| question | answer |
+|---|---|
+| Cardinal IDP values? | **YES** — 338 rows, same `current_value` field as offense |
+| Same 0–10,000 axis as offense? | **YES** — offense max 10,000, IDP max 5,121, one scale |
+| Do SF/TE-premium alter IDP? | **NO** — 0 of 1,338 (correct: those are offense-format axes; IDP has no positional analogue to Superflex or TE premium) |
+| Does `includeIdp=true` alter offense? | **NO** — purely additive to the payload |
+| tackle-heavy / balanced / big-play variants declared? | **YES — all three ship in the payload**, keyed `idp_formats: {tackle, balanced, bigplay}`; the served default is `balanced` |
+| Variant provenance | uneven, and it travels with any future ingestion: `balanced` is `market`-sourced on 327/338 rows, but `bigplay` is `derived` on 230/338 and `tackle` on 194/338; `idp_confidence` is high on 134, medium 59, low 145 |
+| Does qualifying this bridge require syncing a Sleeper league? | **NO** — `/api/player-values` is a plain public GET, no authentication |
+
+So the scoring-variant question from the original blocker (b) is now
+answered — all three variants are present and labelled — and the format
+half of same-basis is resolved. **What remains is temporal, not
+format-related or scoring-related**: a live, crowd-adjusted offense book
+against an IDP snapshot frozen five weeks earlier with zero votes recorded.
+Also unanswered by the payload: whether the IDP trades backing those values
+come from Superflex/TEP leagues specifically, or a mixed-format crowd.
+
+**Bridge status: `PENDING` on one blocker, not two. It does not vote.**
+Qualification now needs only an owner decision on whether a static,
+un-voted IDP snapshot may bridge against live-adjusted offense values, and
+(if so) which of the three declared IDP variants this league's scoring
+should select. No production weighting or voting is authorized by this
+correction.
 
 ### Why it is worth qualifying
 
@@ -766,7 +840,7 @@ exactly the disagreement §10 identified as the hardest:
 Note also `min = 0` on the offense side: under MISSING IS NEVER ZERO those rows
 must be treated as unpriced at the adapter, never as zero-valued.
 
-Full working record: `docs/sources/C8_PR_A_BRIDGE_FOUNDATION.md` §7a
+Full working record: `docs/sources/LANE8_PR_A_BRIDGE_FOUNDATION.md` §7a
 (implementation lane **Claude 8 / Lane 8**, per the owner's designation of
 2026-08-20).
 
@@ -1255,7 +1329,7 @@ Reported, not fixed.
 | 8 | Can genuine combined sources remain unconstrained? | **Yes, structurally** — Type 1/2 sources never enter the translation seam. Live proof: `draftSharksIdp` contributes 6,485, above the proposed ceiling |
 | 9 | Can IDP Show Combined be acquired? | **Unproven** — paywalled, no repo evidence it exists. Owner action |
 | 10 | Can synced Draft Sharks 3D+ be acquired? | **Already acquired**, league 995704, and proven cross-position (ratio 0.9976) |
-| 11 | Are Dynasty Dealer IDP values available without Pro? | **Yes — no Pro needed.** Corrected in §15a: `?includeIdp=true` returns 338 cardinal IDP rows. Bridge status **PENDING** on two measured same-basis blockers |
+| 11 | Are Dynasty Dealer IDP values available without Pro? | **Yes — no Pro needed.** Corrected in §15a: `?includeIdp=true` returns 338 cardinal IDP rows, all three scoring variants declared. Bridge status **PENDING** on one remaining same-basis blocker (temporal: static IDP snapshot vs. live offense) |
 | 12 | Is Dynasty Nerds Premium necessary? | **No.** Public IDP Top-275 is ranks/tiers only; Premium unproven and unjustified |
 | 13 | How should specialists and bridges interact? | §20 — specialists order within domain, bridges price the domain, bridge layer aggregates and never selects |
 | 14 | What is the exact implementation plan? | §24 order, §25 files, §28 prompt. **Nothing authorized by this document** |

--- a/docs/sources/evidence/IDP_BRIDGE_2026-08-20/policy_simulation.json
+++ b/docs/sources/evidence/IDP_BRIDGE_2026-08-20/policy_simulation.json
@@ -1,0 +1,5844 @@
+{
+  "provenance": {
+    "branch": "claude/idp-ceiling-bridge-audit-zr28tj",
+    "codeSha": "c4431ccba3bedc2f4b511f7ca93fad03e4b6286f",
+    "codeShaShort": "c4431ccb",
+    "csvCount": 24,
+    "csvSha256": {
+      "dlfIdp.csv": "0b985c2daebd3aeba0e574491161cc2ff98c8f8afae81e11c433385efd71b545",
+      "dlfRookieIdp.csv": "c82b1f29b0f93a9b16a1ae85dc40b8ac05edfe5b2efe83943545c0643e52d4b4",
+      "dlfRookieSf.csv": "83e433be3637e64a2b1840c0d69ed167eb9181f823561080538de83d3fe0f97c",
+      "dlfSf.csv": "9e9fff6e6ad4436d1cb39d576944af63464ce19b5bd16d8de345af429fcac5c2",
+      "draftSharksIdp.csv": "71424707f0c9846405ae959438e45991449edc28e9b6ff65219ad7f529f71a98",
+      "draftSharksRosIdp.csv": "bdbcc2c44d378fa1a24484c52aeff3e7c8f11bc999e276dbaa3ee1c68f0eb490",
+      "draftSharksRosSf.csv": "59fe893e771e24d0632eb54c1a2025329e8d5cf6946f062c6abb45bf93fc7065",
+      "draftSharksSf.csv": "d706839ad5c971b2a66d2f41ea73ee436047d658b971a045687246799122824d",
+      "dynastyDaddySf.csv": "e402c192cc9e5e8bd452831a99122981f20e481a54e3f01a073f937d121bdcb2",
+      "dynastyNerdsSfTep.csv": "66d296ec10f4db10a717b07972dd111273038192498b7fc9ec59f763f5738b06",
+      "fantasyCalc.csv": "a0b763d05a1a157819ad44e9fada3900dac1e4519a94710c8a69514edcad901b",
+      "fantasyNavigatorSf.csv": "45208ef97e0e016d3c8320268856229ebd9c8107f34ef2b972791da1a5ebf445",
+      "fantasyProsFitzmaurice.csv": "a834e5f371c4997034849975309af6cfa2d5bac0f7c22378bb8b76575c345aa2",
+      "fantasyProsIdp.csv": "c9715669c80a6e7f313c164fd988ab5a04706e7b2b0976540412a3134765ae17",
+      "fantasyProsSf.csv": "6fe984b2883e6013cb09dcbefe080dccca9c1d88162d1e301f502a60a0c84291",
+      "flockFantasySf.csv": "433c3a13b16f849d71b92e49afe8575eb7156f97924669deec48b1203dd07053",
+      "flockFantasySfRookies.csv": "b29bf3eeb6ce202b44ec20d368b0d781aa59dc1946922e77826e60f8ed160067",
+      "idpShow.csv": "8f93b30f9dd515ef3f6e6f269c752f86d4170a51fd720ffc39667e09b4517b28",
+      "idpTradeCalc.csv": "89351a0a1b1d1a36a377203336ac1945d7babb532ab6dc615beea4536982d87d",
+      "ktc.csv": "5e71d137d3d420f56f769f444c7c39df4865e5af38141d6908b17f0284816fd8",
+      "ktcSfTep.csv": "f84984f144a7dbd7a38975235d09524dddd5339442d2439e7be68276f29f99ae",
+      "otcffbSf.csv": "7072df49f19569551ff853a579f0a0551bbfcb703cdda7824225e1144c15fecb",
+      "pfkDynasty.csv": "857319bb502b0dd8542bf37be897e361bd38a9e1332b5c98ee74338552843a35",
+      "yahooBoone.csv": "27cdfd58e4f4e7db13765590974da1724c6860d7b40916e5ec252ff948b316a3"
+    },
+    "generatedAt": "2026-08-20T07:30:12.140171+00:00",
+    "payloadBytes": 972624,
+    "payloadPath": "exports/latest/dynasty_data_2026-08-20.json",
+    "payloadSha256": "4dcf3ed04a121288f23ebd991351c69c311f5683d9565d6f8ca37196ea16fafb",
+    "treeDirty": true
+  },
+  "scenarios": {
+    "backbone-lost": {
+      "bridgeEvidence": {
+        "draftSharksIdp_cardinal": {
+          "boardMaxValue": 9999.0,
+          "idpToOffenseRatio": 0.53,
+          "kind": "native_cardinal_combined",
+          "note": "ratio x board max; assumes both halves share one replacement baseline, which the audit tests separately",
+          "topIdpName": "Carson Schwesinger",
+          "topIdpNative": 53.0,
+          "topIdpPosition": "LB",
+          "topIdpValue": 5299.47,
+          "topOffenseName": "Josh Allen",
+          "topOffenseNative": 100.0,
+          "topOffensePosition": "QB"
+        },
+        "draftSharksIdp_ordinal": {
+          "idpCount": 295,
+          "kind": "combined_ordinal",
+          "topIdpCombinedRank": 25,
+          "topIdpName": "Carson Schwesinger",
+          "topIdpValue": 6485.0
+        },
+        "idpTradeCalc": {
+          "idpCount": 370,
+          "kind": "native_cardinal_combined",
+          "top10Mean": 5494.3,
+          "top25Mean": 4404.04,
+          "top5Mean": 5828.8,
+          "topIdpName": "Aidan Hutchinson",
+          "topIdpValue": 6444.0
+        }
+      },
+      "bridgeQuantileMap": [
+        {
+          "q": 0.0,
+          "value": 6464.5
+        },
+        {
+          "q": 0.05,
+          "value": 3464.0
+        },
+        {
+          "q": 0.1,
+          "value": 2793.0
+        },
+        {
+          "q": 0.15,
+          "value": 2492.5
+        },
+        {
+          "q": 0.2,
+          "value": 1984.0
+        },
+        {
+          "q": 0.25,
+          "value": 1909.0
+        },
+        {
+          "q": 0.3,
+          "value": 1856.5
+        },
+        {
+          "q": 0.35,
+          "value": 1819.5
+        },
+        {
+          "q": 0.4,
+          "value": 1541.0
+        },
+        {
+          "q": 0.45,
+          "value": 1471.0
+        },
+        {
+          "q": 0.5,
+          "value": 1430.5
+        },
+        {
+          "q": 0.55,
+          "value": 1404.0
+        },
+        {
+          "q": 0.6,
+          "value": 1388.0
+        },
+        {
+          "q": 0.65,
+          "value": 1375.0
+        },
+        {
+          "q": 0.7,
+          "value": 1361.5
+        },
+        {
+          "q": 0.75,
+          "value": 1169.0
+        },
+        {
+          "q": 0.8,
+          "value": 1133.0
+        },
+        {
+          "q": 0.85,
+          "value": 1105.0
+        },
+        {
+          "q": 0.9,
+          "value": 1086.5
+        },
+        {
+          "q": 0.95,
+          "value": 1070.5
+        },
+        {
+          "q": 1.0,
+          "value": 1055.5
+        }
+      ],
+      "candidates": {
+        "A": {
+          "ceilingApplied": null,
+          "crosswalkHealth": {
+            "backboneFallbackRows": 310,
+            "blendIntegrityViolations": 0,
+            "contractOk": true,
+            "fallbackVotes": {
+              "dlfIdp": 168,
+              "fantasyProsIdp": 185,
+              "idpShow": 308
+            },
+            "idpOnlyVotesAtOrAbove9000": 19,
+            "idpOnlyVotesAtOrAbove9000Examples": [
+              {
+                "effectiveRank": 1,
+                "method": "fallback",
+                "name": "Aidan Hutchinson",
+                "rawRank": 1,
+                "source": "dlfIdp",
+                "valueContribution": 9999
+              },
+              {
+                "effectiveRank": 1,
+                "method": "fallback",
+                "name": "Aidan Hutchinson",
+                "rawRank": 1,
+                "source": "idpShow",
+                "valueContribution": 9999
+              },
+              {
+                "effectiveRank": 1,
+                "method": "fallback",
+                "name": "Aidan Hutchinson",
+                "rawRank": 1,
+                "source": "fantasyProsIdp",
+                "valueContribution": 9999
+              },
+              {
+                "effectiveRank": 2,
+                "method": "fallback",
+                "name": "Will Anderson",
+                "rawRank": 2,
+                "source": "dlfIdp",
+                "valueContribution": 9841
+              },
+              {
+                "effectiveRank": 2,
+                "method": "fallback",
+                "name": "Will Anderson",
+                "rawRank": 2,
+                "source": "idpShow",
+                "valueContribution": 9841
+              },
+              {
+                "effectiveRank": 2,
+                "method": "fallback",
+                "name": "Will Anderson",
+                "rawRank": 2,
+                "source": "fantasyProsIdp",
+                "valueContribution": 9841
+              },
+              {
+                "effectiveRank": 3,
+                "method": "fallback",
+                "name": "Carson Schwesinger",
+                "rawRank": 3,
+                "source": "idpShow",
+                "valueContribution": 9665
+              },
+              {
+                "effectiveRank": 3,
+                "method": "fallback",
+                "name": "Micah Parsons",
+                "rawRank": 3,
+                "source": "dlfIdp",
+                "valueContribution": 9665
+              },
+              {
+                "effectiveRank": 3,
+                "method": "fallback",
+                "name": "Roquan Smith",
+                "rawRank": 3,
+                "source": "fantasyProsIdp",
+                "valueContribution": 9665
+              },
+              {
+                "effectiveRank": 4,
+                "method": "fallback",
+                "name": "Jack Campbell",
+                "rawRank": 4,
+                "source": "dlfIdp",
+                "valueContribution": 9484
+              },
+              {
+                "effectiveRank": 4,
+                "method": "fallback",
+                "name": "Jack Campbell",
+                "rawRank": 4,
+                "source": "idpShow",
+                "valueContribution": 9484
+              },
+              {
+                "effectiveRank": 4,
+                "method": "fallback",
+                "name": "Jack Campbell",
+                "rawRank": 4,
+                "source": "fantasyProsIdp",
+                "valueContribution": 9484
+              },
+              {
+                "effectiveRank": 5,
+                "method": "fallback",
+                "name": "Abdul Carter",
+                "rawRank": 5,
+                "source": "idpShow",
+                "valueContribution": 9304
+              },
+              {
+                "effectiveRank": 5,
+                "method": "fallback",
+                "name": "Carson Schwesinger",
+                "rawRank": 5,
+                "source": "dlfIdp",
+                "valueContribution": 9304
+              },
+              {
+                "effectiveRank": 5,
+                "method": "fallback",
+                "name": "Jordyn Brooks",
+                "rawRank": 5,
+                "source": "fantasyProsIdp",
+                "valueContribution": 9304
+              }
+            ],
+            "maxBoardValue": 9999.0,
+            "maxIdpValue": 9999.0
+          },
+          "diffVsControl": {
+            "idpInTop100": 24,
+            "idpInTop200": 51,
+            "idpInTop400": 129,
+            "idpInTop50": 13,
+            "idpRowsChanged": 0,
+            "largestMovers": [],
+            "maxAbsChange": 0.0,
+            "maxRelChangePct": 0.0,
+            "meanAbsChange": 0.0,
+            "medianAbsChange": 0.0,
+            "medianRelChangePct": 0.0,
+            "movedDown": 0,
+            "movedUp": 0,
+            "offenseRowsChanged": 0,
+            "p90AbsChange": 0.0,
+            "p90RelChangePct": 0.0,
+            "pickOrOtherRowsChanged": 0,
+            "ranksChanged": 0,
+            "rowsCompared": 1109,
+            "servedChurn": 0,
+            "servedCount": 788,
+            "valuesChanged": 0
+          },
+          "idpBands": {
+            "idp10_25": {
+              "changed": 0,
+              "maxAbsChange": 0.0,
+              "meanChange": 0.0,
+              "n": 15
+            },
+            "idp1_10": {
+              "changed": 0,
+              "maxAbsChange": 0.0,
+              "meanChange": 0.0,
+              "n": 10
+            },
+            "idp25_75": {
+              "changed": 0,
+              "maxAbsChange": 0.0,
+              "meanChange": 0.0,
+              "n": 50
+            },
+            "idp75_plus": {
+              "changed": 0,
+              "maxAbsChange": 0.0,
+              "meanChange": 0.0,
+              "n": 236
+            }
+          },
+          "label": "control (current production)"
+        },
+        "B": {
+          "ceilingApplied": 6444.0,
+          "crosswalkHealth": {
+            "backboneFallbackRows": 310,
+            "blendIntegrityViolations": 0,
+            "contractOk": true,
+            "fallbackVotes": {
+              "dlfIdp": 168,
+              "fantasyProsIdp": 185,
+              "idpShow": 308
+            },
+            "idpOnlyVotesAtOrAbove9000": 0,
+            "idpOnlyVotesAtOrAbove9000Examples": [],
+            "maxBoardValue": 9978.0,
+            "maxIdpValue": 6473.0
+          },
+          "diffVsControl": {
+            "idpInTop100": 29,
+            "idpInTop200": 54,
+            "idpInTop400": 129,
+            "idpInTop50": 13,
+            "idpRowsChanged": 40,
+            "largestMovers": [
+              {
+                "after": 2873.0,
+                "before": 7098.0,
+                "delta": -4225.0,
+                "name": "David Bailey",
+                "position": "DL"
+              },
+              {
+                "after": 6215.0,
+                "before": 2327.0,
+                "delta": 3888.0,
+                "name": "Micah Parsons",
+                "position": "DL"
+              },
+              {
+                "after": 6177.0,
+                "before": 2422.0,
+                "delta": 3755.0,
+                "name": "Nik Bonitto",
+                "position": "DL"
+              },
+              {
+                "after": 5955.0,
+                "before": 2310.0,
+                "delta": 3645.0,
+                "name": "Laiatu Latu",
+                "position": "DL"
+              },
+              {
+                "after": 6365.0,
+                "before": 9999.0,
+                "delta": -3634.0,
+                "name": "Aidan Hutchinson",
+                "position": "DL"
+              },
+              {
+                "after": 6365.0,
+                "before": 9841.0,
+                "delta": -3476.0,
+                "name": "Will Anderson",
+                "position": "DL"
+              },
+              {
+                "after": 6365.0,
+                "before": 9484.0,
+                "delta": -3119.0,
+                "name": "Jack Campbell",
+                "position": "LB"
+              },
+              {
+                "after": 6365.0,
+                "before": 3447.0,
+                "delta": 2918.0,
+                "name": "Jordyn Brooks",
+                "position": "LB"
+              },
+              {
+                "after": 5187.0,
+                "before": 2310.0,
+                "delta": 2877.0,
+                "name": "Nate Landman",
+                "position": "LB"
+              },
+              {
+                "after": 6473.0,
+                "before": 9305.0,
+                "delta": -2832.0,
+                "name": "Carson Schwesinger",
+                "position": "LB"
+              },
+              {
+                "after": 5942.0,
+                "before": 3607.0,
+                "delta": 2335.0,
+                "name": "Quay Walker",
+                "position": "LB"
+              },
+              {
+                "after": 6315.0,
+                "before": 8616.0,
+                "delta": -2301.0,
+                "name": "Myles Garrett",
+                "position": "DL"
+              },
+              {
+                "after": 6242.0,
+                "before": 4053.0,
+                "delta": 2189.0,
+                "name": "Ernest Jones",
+                "position": "LB"
+              },
+              {
+                "after": 6365.0,
+                "before": 4275.0,
+                "delta": 2090.0,
+                "name": "Nick Bolton",
+                "position": "LB"
+              },
+              {
+                "after": 6365.0,
+                "before": 8201.0,
+                "delta": -1836.0,
+                "name": "Fred Warner",
+                "position": "LB"
+              },
+              {
+                "after": 6365.0,
+                "before": 7952.0,
+                "delta": -1587.0,
+                "name": "Roquan Smith",
+                "position": "LB"
+              },
+              {
+                "after": 6365.0,
+                "before": 7874.0,
+                "delta": -1509.0,
+                "name": "Edgerrin Cooper",
+                "position": "LB"
+              },
+              {
+                "after": 6242.0,
+                "before": 7408.0,
+                "delta": -1166.0,
+                "name": "Nick Bosa",
+                "position": "DL"
+              },
+              {
+                "after": 6003.0,
+                "before": 7098.0,
+                "delta": -1095.0,
+                "name": "2026 Pick 1.02",
+                "position": "PICK"
+              },
+              {
+                "after": 6300.0,
+                "before": 7271.0,
+                "delta": -971.0,
+                "name": "Maxx Crosby",
+                "position": "DL"
+              },
+              {
+                "after": 6202.0,
+                "before": 7037.0,
+                "delta": -835.0,
+                "name": "Brian Burns",
+                "position": "DL"
+              },
+              {
+                "after": 4856.0,
+                "before": 5566.0,
+                "delta": -710.0,
+                "name": "Travis Hunter",
+                "position": "WR"
+              },
+              {
+                "after": 5548.0,
+                "before": 6003.0,
+                "delta": -455.0,
+                "name": "2026 Pick 1.03",
+                "position": "PICK"
+              },
+              {
+                "after": 4888.0,
+                "before": 5299.0,
+                "delta": -411.0,
+                "name": "2026 Pick 1.06",
+                "position": "PICK"
+              },
+              {
+                "after": 4279.0,
+                "before": 4662.0,
+                "delta": -383.0,
+                "name": "2026 Pick 1.10",
+                "position": "PICK"
+              }
+            ],
+            "maxAbsChange": 4225.0,
+            "maxRelChangePct": 167.08207993124194,
+            "meanAbsChange": 867.955223880597,
+            "medianAbsChange": 173.0,
+            "medianRelChangePct": 4.279600570613409,
+            "movedDown": 55,
+            "movedUp": 12,
+            "offenseRowsChanged": 1,
+            "p90AbsChange": 2918.0,
+            "p90RelChangePct": 54.00937577103381,
+            "pickOrOtherRowsChanged": 26,
+            "ranksChanged": 301,
+            "rowsCompared": 1109,
+            "servedChurn": 0,
+            "servedCount": 788,
+            "valuesChanged": 67
+          },
+          "idpBands": {
+            "idp10_25": {
+              "changed": 8,
+              "maxAbsChange": 4225.0,
+              "meanChange": -706.0,
+              "n": 15
+            },
+            "idp1_10": {
+              "changed": 10,
+              "maxAbsChange": 3634.0,
+              "meanChange": -2243.1,
+              "n": 10
+            },
+            "idp25_75": {
+              "changed": 18,
+              "maxAbsChange": 3888.0,
+              "meanChange": 1284.7222222222222,
+              "n": 50
+            },
+            "idp75_plus": {
+              "changed": 4,
+              "maxAbsChange": 90.0,
+              "meanChange": 15.75,
+              "n": 236
+            }
+          },
+          "label": "IDPTC top-IDP ceiling"
+        },
+        "C": {
+          "ceilingApplied": 6444.0,
+          "crosswalkHealth": {
+            "backboneFallbackRows": 310,
+            "blendIntegrityViolations": 0,
+            "contractOk": true,
+            "fallbackVotes": {
+              "dlfIdp": 168,
+              "fantasyProsIdp": 185,
+              "idpShow": 308
+            },
+            "idpOnlyVotesAtOrAbove9000": 0,
+            "idpOnlyVotesAtOrAbove9000Examples": [],
+            "maxBoardValue": 9978.0,
+            "maxIdpValue": 6473.0
+          },
+          "diffVsControl": {
+            "idpInTop100": 29,
+            "idpInTop200": 54,
+            "idpInTop400": 129,
+            "idpInTop50": 13,
+            "idpRowsChanged": 40,
+            "largestMovers": [
+              {
+                "after": 2873.0,
+                "before": 7098.0,
+                "delta": -4225.0,
+                "name": "David Bailey",
+                "position": "DL"
+              },
+              {
+                "after": 6215.0,
+                "before": 2327.0,
+                "delta": 3888.0,
+                "name": "Micah Parsons",
+                "position": "DL"
+              },
+              {
+                "after": 6177.0,
+                "before": 2422.0,
+                "delta": 3755.0,
+                "name": "Nik Bonitto",
+                "position": "DL"
+              },
+              {
+                "after": 5955.0,
+                "before": 2310.0,
+                "delta": 3645.0,
+                "name": "Laiatu Latu",
+                "position": "DL"
+              },
+              {
+                "after": 6365.0,
+                "before": 9999.0,
+                "delta": -3634.0,
+                "name": "Aidan Hutchinson",
+                "position": "DL"
+              },
+              {
+                "after": 6365.0,
+                "before": 9841.0,
+                "delta": -3476.0,
+                "name": "Will Anderson",
+                "position": "DL"
+              },
+              {
+                "after": 6365.0,
+                "before": 9484.0,
+                "delta": -3119.0,
+                "name": "Jack Campbell",
+                "position": "LB"
+              },
+              {
+                "after": 6365.0,
+                "before": 3447.0,
+                "delta": 2918.0,
+                "name": "Jordyn Brooks",
+                "position": "LB"
+              },
+              {
+                "after": 5187.0,
+                "before": 2310.0,
+                "delta": 2877.0,
+                "name": "Nate Landman",
+                "position": "LB"
+              },
+              {
+                "after": 6473.0,
+                "before": 9305.0,
+                "delta": -2832.0,
+                "name": "Carson Schwesinger",
+                "position": "LB"
+              },
+              {
+                "after": 5942.0,
+                "before": 3607.0,
+                "delta": 2335.0,
+                "name": "Quay Walker",
+                "position": "LB"
+              },
+              {
+                "after": 6315.0,
+                "before": 8616.0,
+                "delta": -2301.0,
+                "name": "Myles Garrett",
+                "position": "DL"
+              },
+              {
+                "after": 6242.0,
+                "before": 4053.0,
+                "delta": 2189.0,
+                "name": "Ernest Jones",
+                "position": "LB"
+              },
+              {
+                "after": 6365.0,
+                "before": 4275.0,
+                "delta": 2090.0,
+                "name": "Nick Bolton",
+                "position": "LB"
+              },
+              {
+                "after": 6365.0,
+                "before": 8201.0,
+                "delta": -1836.0,
+                "name": "Fred Warner",
+                "position": "LB"
+              },
+              {
+                "after": 6365.0,
+                "before": 7952.0,
+                "delta": -1587.0,
+                "name": "Roquan Smith",
+                "position": "LB"
+              },
+              {
+                "after": 6365.0,
+                "before": 7874.0,
+                "delta": -1509.0,
+                "name": "Edgerrin Cooper",
+                "position": "LB"
+              },
+              {
+                "after": 6242.0,
+                "before": 7408.0,
+                "delta": -1166.0,
+                "name": "Nick Bosa",
+                "position": "DL"
+              },
+              {
+                "after": 6003.0,
+                "before": 7098.0,
+                "delta": -1095.0,
+                "name": "2026 Pick 1.02",
+                "position": "PICK"
+              },
+              {
+                "after": 6300.0,
+                "before": 7271.0,
+                "delta": -971.0,
+                "name": "Maxx Crosby",
+                "position": "DL"
+              },
+              {
+                "after": 6202.0,
+                "before": 7037.0,
+                "delta": -835.0,
+                "name": "Brian Burns",
+                "position": "DL"
+              },
+              {
+                "after": 4856.0,
+                "before": 5566.0,
+                "delta": -710.0,
+                "name": "Travis Hunter",
+                "position": "WR"
+              },
+              {
+                "after": 5548.0,
+                "before": 6003.0,
+                "delta": -455.0,
+                "name": "2026 Pick 1.03",
+                "position": "PICK"
+              },
+              {
+                "after": 4888.0,
+                "before": 5299.0,
+                "delta": -411.0,
+                "name": "2026 Pick 1.06",
+                "position": "PICK"
+              },
+              {
+                "after": 4279.0,
+                "before": 4662.0,
+                "delta": -383.0,
+                "name": "2026 Pick 1.10",
+                "position": "PICK"
+              }
+            ],
+            "maxAbsChange": 4225.0,
+            "maxRelChangePct": 167.08207993124194,
+            "meanAbsChange": 867.955223880597,
+            "medianAbsChange": 173.0,
+            "medianRelChangePct": 4.279600570613409,
+            "movedDown": 55,
+            "movedUp": 12,
+            "offenseRowsChanged": 1,
+            "p90AbsChange": 2918.0,
+            "p90RelChangePct": 54.00937577103381,
+            "pickOrOtherRowsChanged": 26,
+            "ranksChanged": 301,
+            "rowsCompared": 1109,
+            "servedChurn": 0,
+            "servedCount": 788,
+            "valuesChanged": 67
+          },
+          "idpBands": {
+            "idp10_25": {
+              "changed": 8,
+              "maxAbsChange": 4225.0,
+              "meanChange": -706.0,
+              "n": 15
+            },
+            "idp1_10": {
+              "changed": 10,
+              "maxAbsChange": 3634.0,
+              "meanChange": -2243.1,
+              "n": 10
+            },
+            "idp25_75": {
+              "changed": 18,
+              "maxAbsChange": 3888.0,
+              "meanChange": 1284.7222222222222,
+              "n": 50
+            },
+            "idp75_plus": {
+              "changed": 4,
+              "maxAbsChange": 90.0,
+              "meanChange": 15.75,
+              "n": 236
+            }
+          },
+          "label": "bridge-family-derived ceiling"
+        },
+        "D": {
+          "ceilingApplied": null,
+          "crosswalkHealth": {
+            "backboneFallbackRows": 278,
+            "blendIntegrityViolations": 0,
+            "contractOk": true,
+            "fallbackVotes": {
+              "dlfIdp": 142,
+              "fantasyProsIdp": 154,
+              "idpShow": 276
+            },
+            "idpOnlyVotesAtOrAbove9000": 0,
+            "idpOnlyVotesAtOrAbove9000Examples": [],
+            "maxBoardValue": 9978.0,
+            "maxIdpValue": 6375.0
+          },
+          "diffVsControl": {
+            "idpInTop100": 8,
+            "idpInTop200": 22,
+            "idpInTop400": 97,
+            "idpInTop50": 4,
+            "idpRowsChanged": 278,
+            "largestMovers": [
+              {
+                "after": 2191.0,
+                "before": 8616.0,
+                "delta": -6425.0,
+                "name": "Myles Garrett",
+                "position": "DL"
+              },
+              {
+                "after": 2144.0,
+                "before": 7952.0,
+                "delta": -5808.0,
+                "name": "Roquan Smith",
+                "position": "LB"
+              },
+              {
+                "after": 1759.0,
+                "before": 7408.0,
+                "delta": -5649.0,
+                "name": "Nick Bosa",
+                "position": "DL"
+              },
+              {
+                "after": 2928.0,
+                "before": 8201.0,
+                "delta": -5273.0,
+                "name": "Fred Warner",
+                "position": "LB"
+              },
+              {
+                "after": 2032.0,
+                "before": 7271.0,
+                "delta": -5239.0,
+                "name": "Maxx Crosby",
+                "position": "DL"
+              },
+              {
+                "after": 2092.0,
+                "before": 7037.0,
+                "delta": -4945.0,
+                "name": "Brian Burns",
+                "position": "DL"
+              },
+              {
+                "after": 2453.0,
+                "before": 7098.0,
+                "delta": -4645.0,
+                "name": "David Bailey",
+                "position": "DL"
+              },
+              {
+                "after": 1819.0,
+                "before": 6239.0,
+                "delta": -4420.0,
+                "name": "Nick Emmanwori",
+                "position": "DB"
+              },
+              {
+                "after": 1583.0,
+                "before": 5668.0,
+                "delta": -4085.0,
+                "name": "Nakobe Dean",
+                "position": "LB"
+              },
+              {
+                "after": 2149.0,
+                "before": 6182.0,
+                "delta": -4033.0,
+                "name": "Kyle Hamilton",
+                "position": "DB"
+              },
+              {
+                "after": 5627.0,
+                "before": 9484.0,
+                "delta": -3857.0,
+                "name": "Jack Campbell",
+                "position": "LB"
+              },
+              {
+                "after": 6165.0,
+                "before": 9841.0,
+                "delta": -3676.0,
+                "name": "Will Anderson",
+                "position": "DL"
+              },
+              {
+                "after": 2627.0,
+                "before": 6297.0,
+                "delta": -3670.0,
+                "name": "Zack Baun",
+                "position": "LB"
+              },
+              {
+                "after": 6365.0,
+                "before": 9999.0,
+                "delta": -3634.0,
+                "name": "Aidan Hutchinson",
+                "position": "DL"
+              },
+              {
+                "after": 4345.0,
+                "before": 7874.0,
+                "delta": -3529.0,
+                "name": "Edgerrin Cooper",
+                "position": "LB"
+              },
+              {
+                "after": 1342.0,
+                "before": 4864.0,
+                "delta": -3522.0,
+                "name": "Payton Wilson",
+                "position": "LB"
+              },
+              {
+                "after": 1586.0,
+                "before": 4888.0,
+                "delta": -3302.0,
+                "name": "CJ Allen",
+                "position": "LB"
+              },
+              {
+                "after": 1814.0,
+                "before": 4816.0,
+                "delta": -3002.0,
+                "name": "Brian Branch",
+                "position": "DB"
+              },
+              {
+                "after": 1009.0,
+                "before": 3939.0,
+                "delta": -2930.0,
+                "name": "Nick Cross",
+                "position": "DB"
+              },
+              {
+                "after": 6375.0,
+                "before": 9305.0,
+                "delta": -2930.0,
+                "name": "Carson Schwesinger",
+                "position": "LB"
+              },
+              {
+                "after": 1742.0,
+                "before": 4615.0,
+                "delta": -2873.0,
+                "name": "Jeffery Simmons",
+                "position": "DL"
+              },
+              {
+                "after": 1827.0,
+                "before": 4632.0,
+                "delta": -2805.0,
+                "name": "Jalen Carter",
+                "position": "DL"
+              },
+              {
+                "after": 1733.0,
+                "before": 4477.0,
+                "delta": -2744.0,
+                "name": "Jihaad Campbell",
+                "position": "LB"
+              },
+              {
+                "after": 856.0,
+                "before": 3352.0,
+                "delta": -2496.0,
+                "name": "Dillon Thieneman",
+                "position": "DB"
+              },
+              {
+                "after": 1823.0,
+                "before": 4265.0,
+                "delta": -2442.0,
+                "name": "George Karlaftis",
+                "position": "DL"
+              }
+            ],
+            "maxAbsChange": 6425.0,
+            "maxRelChangePct": 76.25539956803455,
+            "meanAbsChange": 531.7114285714285,
+            "medianAbsChange": 151.5,
+            "medianRelChangePct": 8.65982969702958,
+            "movedDown": 350,
+            "movedUp": 0,
+            "offenseRowsChanged": 1,
+            "p90AbsChange": 1568.0,
+            "p90RelChangePct": 46.32809645597369,
+            "pickOrOtherRowsChanged": 71,
+            "ranksChanged": 755,
+            "rowsCompared": 1109,
+            "servedChurn": 64,
+            "servedCount": 788,
+            "valuesChanged": 350
+          },
+          "idpBands": {
+            "idp10_25": {
+              "changed": 15,
+              "maxAbsChange": 4945.0,
+              "meanChange": -3048.0,
+              "n": 15
+            },
+            "idp1_10": {
+              "changed": 10,
+              "maxAbsChange": 6425.0,
+              "meanChange": -4602.0,
+              "n": 10
+            },
+            "idp25_75": {
+              "changed": 43,
+              "maxAbsChange": 2930.0,
+              "meanChange": -1037.5348837209303,
+              "n": 43
+            },
+            "idp75_plus": {
+              "changed": 210,
+              "maxAbsChange": 384.0,
+              "meanChange": -132.28571428571428,
+              "n": 211
+            }
+          },
+          "label": "monotonic bridge mapping"
+        },
+        "E": {
+          "ceilingApplied": 6444.0,
+          "crosswalkHealth": {
+            "backboneFallbackRows": 278,
+            "blendIntegrityViolations": 0,
+            "contractOk": true,
+            "fallbackVotes": {
+              "dlfIdp": 142,
+              "fantasyProsIdp": 154,
+              "idpShow": 276
+            },
+            "idpOnlyVotesAtOrAbove9000": 0,
+            "idpOnlyVotesAtOrAbove9000Examples": [],
+            "maxBoardValue": 9978.0,
+            "maxIdpValue": 6375.0
+          },
+          "diffVsControl": {
+            "idpInTop100": 8,
+            "idpInTop200": 22,
+            "idpInTop400": 97,
+            "idpInTop50": 4,
+            "idpRowsChanged": 278,
+            "largestMovers": [
+              {
+                "after": 2191.0,
+                "before": 8616.0,
+                "delta": -6425.0,
+                "name": "Myles Garrett",
+                "position": "DL"
+              },
+              {
+                "after": 2144.0,
+                "before": 7952.0,
+                "delta": -5808.0,
+                "name": "Roquan Smith",
+                "position": "LB"
+              },
+              {
+                "after": 1759.0,
+                "before": 7408.0,
+                "delta": -5649.0,
+                "name": "Nick Bosa",
+                "position": "DL"
+              },
+              {
+                "after": 2928.0,
+                "before": 8201.0,
+                "delta": -5273.0,
+                "name": "Fred Warner",
+                "position": "LB"
+              },
+              {
+                "after": 2032.0,
+                "before": 7271.0,
+                "delta": -5239.0,
+                "name": "Maxx Crosby",
+                "position": "DL"
+              },
+              {
+                "after": 2092.0,
+                "before": 7037.0,
+                "delta": -4945.0,
+                "name": "Brian Burns",
+                "position": "DL"
+              },
+              {
+                "after": 2453.0,
+                "before": 7098.0,
+                "delta": -4645.0,
+                "name": "David Bailey",
+                "position": "DL"
+              },
+              {
+                "after": 1819.0,
+                "before": 6239.0,
+                "delta": -4420.0,
+                "name": "Nick Emmanwori",
+                "position": "DB"
+              },
+              {
+                "after": 1583.0,
+                "before": 5668.0,
+                "delta": -4085.0,
+                "name": "Nakobe Dean",
+                "position": "LB"
+              },
+              {
+                "after": 2149.0,
+                "before": 6182.0,
+                "delta": -4033.0,
+                "name": "Kyle Hamilton",
+                "position": "DB"
+              },
+              {
+                "after": 5627.0,
+                "before": 9484.0,
+                "delta": -3857.0,
+                "name": "Jack Campbell",
+                "position": "LB"
+              },
+              {
+                "after": 6165.0,
+                "before": 9841.0,
+                "delta": -3676.0,
+                "name": "Will Anderson",
+                "position": "DL"
+              },
+              {
+                "after": 2627.0,
+                "before": 6297.0,
+                "delta": -3670.0,
+                "name": "Zack Baun",
+                "position": "LB"
+              },
+              {
+                "after": 6365.0,
+                "before": 9999.0,
+                "delta": -3634.0,
+                "name": "Aidan Hutchinson",
+                "position": "DL"
+              },
+              {
+                "after": 4345.0,
+                "before": 7874.0,
+                "delta": -3529.0,
+                "name": "Edgerrin Cooper",
+                "position": "LB"
+              },
+              {
+                "after": 1342.0,
+                "before": 4864.0,
+                "delta": -3522.0,
+                "name": "Payton Wilson",
+                "position": "LB"
+              },
+              {
+                "after": 1586.0,
+                "before": 4888.0,
+                "delta": -3302.0,
+                "name": "CJ Allen",
+                "position": "LB"
+              },
+              {
+                "after": 1814.0,
+                "before": 4816.0,
+                "delta": -3002.0,
+                "name": "Brian Branch",
+                "position": "DB"
+              },
+              {
+                "after": 1009.0,
+                "before": 3939.0,
+                "delta": -2930.0,
+                "name": "Nick Cross",
+                "position": "DB"
+              },
+              {
+                "after": 6375.0,
+                "before": 9305.0,
+                "delta": -2930.0,
+                "name": "Carson Schwesinger",
+                "position": "LB"
+              },
+              {
+                "after": 1742.0,
+                "before": 4615.0,
+                "delta": -2873.0,
+                "name": "Jeffery Simmons",
+                "position": "DL"
+              },
+              {
+                "after": 1827.0,
+                "before": 4632.0,
+                "delta": -2805.0,
+                "name": "Jalen Carter",
+                "position": "DL"
+              },
+              {
+                "after": 1733.0,
+                "before": 4477.0,
+                "delta": -2744.0,
+                "name": "Jihaad Campbell",
+                "position": "LB"
+              },
+              {
+                "after": 856.0,
+                "before": 3352.0,
+                "delta": -2496.0,
+                "name": "Dillon Thieneman",
+                "position": "DB"
+              },
+              {
+                "after": 1823.0,
+                "before": 4265.0,
+                "delta": -2442.0,
+                "name": "George Karlaftis",
+                "position": "DL"
+              }
+            ],
+            "maxAbsChange": 6425.0,
+            "maxRelChangePct": 76.25539956803455,
+            "meanAbsChange": 531.7114285714285,
+            "medianAbsChange": 151.5,
+            "medianRelChangePct": 8.65982969702958,
+            "movedDown": 350,
+            "movedUp": 0,
+            "offenseRowsChanged": 1,
+            "p90AbsChange": 1568.0,
+            "p90RelChangePct": 46.32809645597369,
+            "pickOrOtherRowsChanged": 71,
+            "ranksChanged": 755,
+            "rowsCompared": 1109,
+            "servedChurn": 64,
+            "servedCount": 788,
+            "valuesChanged": 350
+          },
+          "idpBands": {
+            "idp10_25": {
+              "changed": 15,
+              "maxAbsChange": 4945.0,
+              "meanChange": -3048.0,
+              "n": 15
+            },
+            "idp1_10": {
+              "changed": 10,
+              "maxAbsChange": 6425.0,
+              "meanChange": -4602.0,
+              "n": 10
+            },
+            "idp25_75": {
+              "changed": 43,
+              "maxAbsChange": 2930.0,
+              "meanChange": -1037.5348837209303,
+              "n": 43
+            },
+            "idp75_plus": {
+              "changed": 210,
+              "maxAbsChange": 384.0,
+              "meanChange": -132.28571428571428,
+              "n": 211
+            }
+          },
+          "label": "bridge mapping + bridge-derived ceiling"
+        }
+      },
+      "ceilingEstimators": {
+        "contributions": {
+          "draftSharksIdp_cardinal": 5299.47,
+          "draftSharksIdp_ordinal": 6485.0,
+          "idpTradeCalc": 6444.0
+        },
+        "max": 6485.0,
+        "mean": 6076.156666666667,
+        "median": 6444.0,
+        "min": 5299.47,
+        "n": 3,
+        "spreadPct": 19.511182233067277,
+        "trimmedMean": 6076.156666666667
+      },
+      "control": {
+        "crossSourceTable": [
+          {
+            "canonicalRank": 2,
+            "canonicalValue": 9978,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 9999,
+              "effectiveRank": 1,
+              "native": 100,
+              "rawRank": 1
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 9999,
+              "effectiveRank": 1,
+              "native": 999900,
+              "rawRank": 1
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 9983,
+              "rawRank": null
+            },
+            "ktcSfTep": {
+              "contribution": 9985,
+              "effectiveRank": 4,
+              "native": 9985,
+              "rawRank": 4
+            },
+            "player": "Josh Allen",
+            "position": "QB",
+            "slot": "QB1"
+          },
+          {
+            "canonicalRank": 44,
+            "canonicalValue": 6561,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 5891,
+              "effectiveRank": 35,
+              "native": 48,
+              "rawRank": 34
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 6077,
+              "effectiveRank": 38,
+              "native": 996200,
+              "rawRank": 38
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 6034,
+              "rawRank": null
+            },
+            "ktcSfTep": {
+              "contribution": 5977,
+              "effectiveRank": 36,
+              "native": 5977,
+              "rawRank": 36
+            },
+            "player": "Bo Nix",
+            "position": "QB",
+            "slot": "QB12"
+          },
+          {
+            "canonicalRank": 135,
+            "canonicalValue": 3755,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 4050,
+              "effectiveRank": 96,
+              "native": 30,
+              "rawRank": 87
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 3369,
+              "effectiveRank": 102,
+              "native": 989800,
+              "rawRank": 102
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 4366,
+              "rawRank": null
+            },
+            "ktcSfTep": {
+              "contribution": 3809,
+              "effectiveRank": 106,
+              "native": 3809,
+              "rawRank": 106
+            },
+            "player": "Bryce Young",
+            "position": "QB",
+            "slot": "QB24"
+          },
+          {
+            "canonicalRank": 5,
+            "canonicalValue": 9730,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 8184,
+              "effectiveRank": 8,
+              "native": 72,
+              "rawRank": 8
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 9883,
+              "effectiveRank": 2,
+              "native": 999800,
+              "rawRank": 2
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 9999,
+              "rawRank": null
+            },
+            "ktcSfTep": {
+              "contribution": 9998,
+              "effectiveRank": 3,
+              "native": 9998,
+              "rawRank": 3
+            },
+            "player": "Bijan Robinson",
+            "position": "RB",
+            "slot": "RB1"
+          },
+          {
+            "canonicalRank": 72,
+            "canonicalValue": 5270,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 5391,
+              "effectiveRank": 46,
+              "native": 42,
+              "rawRank": 43
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 5802,
+              "effectiveRank": 42,
+              "native": 995800,
+              "rawRank": 42
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 5501,
+              "rawRank": null
+            },
+            "ktcSfTep": {
+              "contribution": 5325,
+              "effectiveRank": 56,
+              "native": 5325,
+              "rawRank": 56
+            },
+            "player": "Quinshon Judkins",
+            "position": "RB",
+            "slot": "RB12"
+          },
+          {
+            "canonicalRank": 133,
+            "canonicalValue": 3787,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 4204,
+              "effectiveRank": 88,
+              "native": 32,
+              "rawRank": 77
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 3345,
+              "effectiveRank": 103,
+              "native": 989700,
+              "rawRank": 103
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 4023,
+              "rawRank": null
+            },
+            "ktcSfTep": {
+              "contribution": 4196,
+              "effectiveRank": 93,
+              "native": 4196,
+              "rawRank": 93
+            },
+            "player": "Derrick Henry",
+            "position": "RB",
+            "slot": "RB24"
+          },
+          {
+            "canonicalRank": 7,
+            "canonicalValue": 9599,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 7898,
+              "effectiveRank": 10,
+              "native": 64,
+              "rawRank": 10
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 9481,
+              "effectiveRank": 5,
+              "native": 999500,
+              "rawRank": 5
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 9978,
+              "rawRank": null
+            },
+            "ktcSfTep": {
+              "contribution": 9954,
+              "effectiveRank": 5,
+              "native": 9954,
+              "rawRank": 5
+            },
+            "player": "Ja'Marr Chase",
+            "position": "WR",
+            "slot": "WR1"
+          },
+          {
+            "canonicalRank": 53,
+            "canonicalValue": 6049,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 6052,
+              "effectiveRank": 32,
+              "native": 50,
+              "rawRank": 30
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 5737,
+              "effectiveRank": 43,
+              "native": 995700,
+              "rawRank": 43
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 5595,
+              "rawRank": null
+            },
+            "ktcSfTep": {
+              "contribution": 5653,
+              "effectiveRank": 40,
+              "native": 5653,
+              "rawRank": 40
+            },
+            "player": "Nico Collins",
+            "position": "WR",
+            "slot": "WR12"
+          },
+          {
+            "canonicalRank": 90,
+            "canonicalValue": 4807,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 4125,
+              "effectiveRank": 92,
+              "native": 32,
+              "rawRank": 77
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 5429,
+              "effectiveRank": 48,
+              "native": 995200,
+              "rawRank": 48
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 5368,
+              "rawRank": null
+            },
+            "ktcSfTep": {
+              "contribution": 5234,
+              "effectiveRank": 59,
+              "native": 5234,
+              "rawRank": 59
+            },
+            "player": "Rome Odunze",
+            "position": "WR",
+            "slot": "WR24"
+          },
+          {
+            "canonicalRank": 148,
+            "canonicalValue": 3517,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 3828,
+              "effectiveRank": 109,
+              "native": 29,
+              "rawRank": 92
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 3444,
+              "effectiveRank": 99,
+              "native": 990100,
+              "rawRank": 99
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 3476,
+              "rawRank": null
+            },
+            "ktcSfTep": {
+              "contribution": 3503,
+              "effectiveRank": 121,
+              "native": 3503,
+              "rawRank": 121
+            },
+            "player": "Terry McLaurin",
+            "position": "WR",
+            "slot": "WR36"
+          },
+          {
+            "canonicalRank": 3,
+            "canonicalValue": 9977,
+            "confidence": "medium",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 7940,
+              "effectiveRank": 16,
+              "native": 59,
+              "rawRank": 16
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 9989,
+              "effectiveRank": 7,
+              "native": 999300,
+              "rawRank": 7
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 8975,
+              "rawRank": null
+            },
+            "ktcSfTep": {
+              "contribution": 9999,
+              "effectiveRank": 1,
+              "native": 9999,
+              "rawRank": 1
+            },
+            "player": "Brock Bowers",
+            "position": "TE",
+            "slot": "TE1"
+          },
+          {
+            "canonicalRank": 122,
+            "canonicalValue": 4048,
+            "confidence": "medium",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 4558,
+              "effectiveRank": 91,
+              "native": 32,
+              "rawRank": 77
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 3935,
+              "effectiveRank": 94,
+              "native": 990600,
+              "rawRank": 94
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 4101,
+              "rawRank": null
+            },
+            "ktcSfTep": {
+              "contribution": 3968,
+              "effectiveRank": 99,
+              "native": 3968,
+              "rawRank": 99
+            },
+            "player": "Oronde Gadsden",
+            "position": "TE",
+            "slot": "TE12"
+          },
+          {
+            "canonicalRank": 1,
+            "canonicalValue": 9999,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 9999,
+              "effectiveRank": 1,
+              "native": 999900,
+              "rawRank": 1
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 2116,
+              "effectiveRank": 344,
+              "native": 11,
+              "rawRank": 39
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 9999,
+              "effectiveRank": 1,
+              "native": 999900,
+              "rawRank": 1
+            },
+            "idpShow": {
+              "contribution": 9999,
+              "effectiveRank": 1,
+              "native": 999900,
+              "rawRank": 1
+            },
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 6444,
+              "rawRank": null
+            },
+            "ktcSfTep": null,
+            "player": "Aidan Hutchinson",
+            "position": "DL",
+            "slot": "DL1"
+          },
+          {
+            "canonicalRank": 4,
+            "canonicalValue": 9841,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 9841,
+              "effectiveRank": 2,
+              "native": 999800,
+              "rawRank": 2
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 2013,
+              "effectiveRank": 375,
+              "native": 10,
+              "rawRank": 43
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 9841,
+              "effectiveRank": 2,
+              "native": 999800,
+              "rawRank": 2
+            },
+            "idpShow": {
+              "contribution": 9841,
+              "effectiveRank": 2,
+              "native": 999800,
+              "rawRank": 2
+            },
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 5963,
+              "rawRank": null
+            },
+            "ktcSfTep": null,
+            "player": "Will Anderson",
+            "position": "DL",
+            "slot": "DL2"
+          },
+          {
+            "canonicalRank": 33,
+            "canonicalValue": 7271,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 7981,
+              "effectiveRank": 13,
+              "native": 998533,
+              "rawRank": 13
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 1970,
+              "effectiveRank": 389,
+              "native": 9,
+              "rawRank": 49
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 5976,
+              "effectiveRank": 30,
+              "native": 997000,
+              "rawRank": 30
+            },
+            "idpShow": {
+              "contribution": 7418,
+              "effectiveRank": 17,
+              "native": 998200,
+              "rawRank": 17
+            },
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 3605,
+              "rawRank": null
+            },
+            "ktcSfTep": null,
+            "player": "Maxx Crosby",
+            "position": "DL",
+            "slot": "DL5"
+          },
+          {
+            "canonicalRank": 98,
+            "canonicalValue": 4615,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 5238,
+              "effectiveRank": 39,
+              "native": 996033,
+              "rawRank": 39
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 1796,
+              "effectiveRank": 455,
+              "native": 5,
+              "rawRank": 82
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 3856,
+              "effectiveRank": 64,
+              "native": 993600,
+              "rawRank": 64
+            },
+            "idpShow": {
+              "contribution": 4649,
+              "effectiveRank": 48,
+              "native": 995100,
+              "rawRank": 48
+            },
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 3043,
+              "rawRank": null
+            },
+            "ktcSfTep": null,
+            "player": "Jeffery Simmons",
+            "position": "DL",
+            "slot": "DL10"
+          },
+          {
+            "canonicalRank": 9,
+            "canonicalValue": 9484,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 9484,
+              "effectiveRank": 4,
+              "native": 999600,
+              "rawRank": 4
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 4331,
+              "effectiveRank": 82,
+              "native": 33,
+              "rawRank": 7
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 9484,
+              "effectiveRank": 4,
+              "native": 999600,
+              "rawRank": 4
+            },
+            "idpShow": {
+              "contribution": 9484,
+              "effectiveRank": 4,
+              "native": 999600,
+              "rawRank": 4
+            },
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 5651,
+              "rawRank": null
+            },
+            "ktcSfTep": null,
+            "player": "Jack Campbell",
+            "position": "LB",
+            "slot": "LB1"
+          },
+          {
+            "canonicalRank": 11,
+            "canonicalValue": 9305,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 9304,
+              "effectiveRank": 5,
+              "native": 999567,
+              "rawRank": 5
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 6485,
+              "effectiveRank": 25,
+              "native": 53,
+              "rawRank": 1
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 8951,
+              "effectiveRank": 7,
+              "native": 999300,
+              "rawRank": 7
+            },
+            "idpShow": {
+              "contribution": 9665,
+              "effectiveRank": 3,
+              "native": 999700,
+              "rawRank": 3
+            },
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 5667,
+              "rawRank": null
+            },
+            "ktcSfTep": null,
+            "player": "Carson Schwesinger",
+            "position": "LB",
+            "slot": "LB2"
+          },
+          {
+            "canonicalRank": 27,
+            "canonicalValue": 7874,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 8288,
+              "effectiveRank": 11,
+              "native": 998767,
+              "rawRank": 11
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 4421,
+              "effectiveRank": 78,
+              "native": 34,
+              "rawRank": 6
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 7981,
+              "effectiveRank": 13,
+              "native": 998700,
+              "rawRank": 13
+            },
+            "idpShow": {
+              "contribution": 7036,
+              "effectiveRank": 20,
+              "native": 997900,
+              "rawRank": 20
+            },
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 3600,
+              "rawRank": null
+            },
+            "ktcSfTep": null,
+            "player": "Edgerrin Cooper",
+            "position": "LB",
+            "slot": "LB5"
+          },
+          {
+            "canonicalRank": 85,
+            "canonicalValue": 4888,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 6069,
+              "effectiveRank": 29,
+              "native": 997133,
+              "rawRank": 29
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 4811,
+              "effectiveRank": 63,
+              "native": 37,
+              "rawRank": 4
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 4269,
+              "effectiveRank": 55,
+              "native": 994500,
+              "rawRank": 55
+            },
+            "idpShow": {
+              "contribution": 5796,
+              "effectiveRank": 32,
+              "native": 996700,
+              "rawRank": 32
+            },
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 3339,
+              "rawRank": null
+            },
+            "ktcSfTep": null,
+            "player": "CJ Allen",
+            "position": "LB",
+            "slot": "LB10"
+          },
+          {
+            "canonicalRank": 51,
+            "canonicalValue": 6239,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 5976,
+              "effectiveRank": 30,
+              "native": 996600,
+              "rawRank": 30
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 4671,
+              "effectiveRank": 68,
+              "native": 36,
+              "rawRank": 5
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 6165,
+              "effectiveRank": 28,
+              "native": 997200,
+              "rawRank": 28
+            },
+            "idpShow": {
+              "contribution": 6800,
+              "effectiveRank": 22,
+              "native": 997700,
+              "rawRank": 22
+            },
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 3598,
+              "rawRank": null
+            },
+            "ktcSfTep": null,
+            "player": "Nick Emmanwori",
+            "position": "DB",
+            "slot": "DB1"
+          },
+          {
+            "canonicalRank": 52,
+            "canonicalValue": 6182,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 5465,
+              "effectiveRank": 36,
+              "native": 996200,
+              "rawRank": 36
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 2189,
+              "effectiveRank": 324,
+              "native": 13,
+              "rawRank": 35
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 6263,
+              "effectiveRank": 27,
+              "native": 997300,
+              "rawRank": 27
+            },
+            "idpShow": {
+              "contribution": 6576,
+              "effectiveRank": 24,
+              "native": 997500,
+              "rawRank": 24
+            },
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 3595,
+              "rawRank": null
+            },
+            "ktcSfTep": null,
+            "player": "Kyle Hamilton",
+            "position": "DB",
+            "slot": "DB2"
+          },
+          {
+            "canonicalRank": 129,
+            "canonicalValue": 3939,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 3815,
+              "effectiveRank": 65,
+              "native": 993233,
+              "rawRank": 65
+            },
+            "draftSharks": null,
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 5096,
+              "effectiveRank": 41,
+              "native": 995900,
+              "rawRank": 41
+            },
+            "idpShow": {
+              "contribution": 3281,
+              "effectiveRank": 80,
+              "native": 991900,
+              "rawRank": 80
+            },
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 2006,
+              "rawRank": null
+            },
+            "ktcSfTep": null,
+            "player": "Nick Cross",
+            "position": "DB",
+            "slot": "DB5"
+          },
+          {
+            "canonicalRank": 162,
+            "canonicalValue": 3352,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 3281,
+              "effectiveRank": 80,
+              "native": 991733,
+              "rawRank": 80
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 3383,
+              "effectiveRank": 142,
+              "native": 25,
+              "rawRank": 15
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 2870,
+              "effectiveRank": 95,
+              "native": 990300,
+              "rawRank": 95
+            },
+            "idpShow": {
+              "contribution": 4961,
+              "effectiveRank": 43,
+              "native": 995600,
+              "rawRank": 43
+            },
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 3111,
+              "rawRank": null
+            },
+            "ktcSfTep": null,
+            "player": "Dillon Thieneman",
+            "position": "DB",
+            "slot": "DB10"
+          },
+          {
+            "canonicalRank": 1,
+            "canonicalValue": 9999,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 9999,
+              "effectiveRank": 1,
+              "native": 999900,
+              "rawRank": 1
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 2116,
+              "effectiveRank": 344,
+              "native": 11,
+              "rawRank": 39
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 9999,
+              "effectiveRank": 1,
+              "native": 999900,
+              "rawRank": 1
+            },
+            "idpShow": {
+              "contribution": 9999,
+              "effectiveRank": 1,
+              "native": 999900,
+              "rawRank": 1
+            },
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 6444,
+              "rawRank": null
+            },
+            "ktcSfTep": null,
+            "player": "Aidan Hutchinson",
+            "position": "DL",
+            "slot": "IDP1*"
+          },
+          {
+            "canonicalRank": 17,
+            "canonicalValue": 8616,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 9126,
+              "effectiveRank": 6,
+              "native": 999300,
+              "rawRank": 6
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 1924,
+              "effectiveRank": 405,
+              "native": 8,
+              "rawRank": 60
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 6069,
+              "effectiveRank": 29,
+              "native": 997100,
+              "rawRank": 29
+            },
+            "idpShow": {
+              "contribution": 9126,
+              "effectiveRank": 6,
+              "native": 999300,
+              "rawRank": 6
+            },
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 5414,
+              "rawRank": null
+            },
+            "ktcSfTep": null,
+            "player": "Myles Garrett",
+            "position": "DL",
+            "slot": "IDP5"
+          },
+          {
+            "canonicalRank": 33,
+            "canonicalValue": 7271,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 7981,
+              "effectiveRank": 13,
+              "native": 998533,
+              "rawRank": 13
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 1970,
+              "effectiveRank": 389,
+              "native": 9,
+              "rawRank": 49
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 5976,
+              "effectiveRank": 30,
+              "native": 997000,
+              "rawRank": 30
+            },
+            "idpShow": {
+              "contribution": 7418,
+              "effectiveRank": 17,
+              "native": 998200,
+              "rawRank": 17
+            },
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 3605,
+              "rawRank": null
+            },
+            "ktcSfTep": null,
+            "player": "Maxx Crosby",
+            "position": "DL",
+            "slot": "IDP10*"
+          },
+          {
+            "canonicalRank": 102,
+            "canonicalValue": 4477,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 6365,
+              "effectiveRank": 26,
+              "native": 997600,
+              "rawRank": 26
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 4309,
+              "effectiveRank": 83,
+              "native": 33,
+              "rawRank": 7
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 4961,
+              "effectiveRank": 43,
+              "native": 995700,
+              "rawRank": 43
+            },
+            "idpShow": {
+              "contribution": 6165,
+              "effectiveRank": 28,
+              "native": 997100,
+              "rawRank": 28
+            },
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 3458,
+              "rawRank": null
+            },
+            "ktcSfTep": null,
+            "player": "Jihaad Campbell",
+            "position": "LB",
+            "slot": "IDP25"
+          },
+          {
+            "canonicalRank": 189,
+            "canonicalValue": 3043,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 5166,
+              "effectiveRank": 40,
+              "native": 995867,
+              "rawRank": 40
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 2776,
+              "effectiveRank": 210,
+              "native": 20,
+              "rawRank": 23
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 3774,
+              "effectiveRank": 66,
+              "native": 993400,
+              "rawRank": 66
+            },
+            "idpShow": {
+              "contribution": 8288,
+              "effectiveRank": 11,
+              "native": 998800,
+              "rawRank": 11
+            },
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 4169,
+              "rawRank": null
+            },
+            "ktcSfTep": null,
+            "player": "Jacob Rodriguez",
+            "position": "LB",
+            "slot": "IDP50"
+          },
+          {
+            "canonicalRank": 342,
+            "canonicalValue": 1933,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 3856,
+              "effectiveRank": 64,
+              "native": 993300,
+              "rawRank": 64
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 1785,
+              "effectiveRank": 460,
+              "native": 5,
+              "rawRank": 82
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 6686,
+              "effectiveRank": 23,
+              "native": 997700,
+              "rawRank": 23
+            },
+            "idpShow": {
+              "contribution": 2688,
+              "effectiveRank": 103,
+              "native": 989600,
+              "rawRank": 103
+            },
+            "idpTradeCalc": {
+              "contribution": null,
+              "effectiveRank": null,
+              "native": 1938,
+              "rawRank": null
+            },
+            "ktcSfTep": null,
+            "player": "Quincy Williams",
+            "position": "LB",
+            "slot": "IDP100"
+          }
+        ],
+        "crosswalkHealth": {
+          "backboneFallbackRows": 310,
+          "blendIntegrityViolations": 0,
+          "contractOk": true,
+          "fallbackVotes": {
+            "dlfIdp": 168,
+            "fantasyProsIdp": 185,
+            "idpShow": 308
+          },
+          "idpOnlyVotesAtOrAbove9000": 19,
+          "idpOnlyVotesAtOrAbove9000Examples": [
+            {
+              "effectiveRank": 1,
+              "method": "fallback",
+              "name": "Aidan Hutchinson",
+              "rawRank": 1,
+              "source": "dlfIdp",
+              "valueContribution": 9999
+            },
+            {
+              "effectiveRank": 1,
+              "method": "fallback",
+              "name": "Aidan Hutchinson",
+              "rawRank": 1,
+              "source": "idpShow",
+              "valueContribution": 9999
+            },
+            {
+              "effectiveRank": 1,
+              "method": "fallback",
+              "name": "Aidan Hutchinson",
+              "rawRank": 1,
+              "source": "fantasyProsIdp",
+              "valueContribution": 9999
+            },
+            {
+              "effectiveRank": 2,
+              "method": "fallback",
+              "name": "Will Anderson",
+              "rawRank": 2,
+              "source": "dlfIdp",
+              "valueContribution": 9841
+            },
+            {
+              "effectiveRank": 2,
+              "method": "fallback",
+              "name": "Will Anderson",
+              "rawRank": 2,
+              "source": "idpShow",
+              "valueContribution": 9841
+            },
+            {
+              "effectiveRank": 2,
+              "method": "fallback",
+              "name": "Will Anderson",
+              "rawRank": 2,
+              "source": "fantasyProsIdp",
+              "valueContribution": 9841
+            },
+            {
+              "effectiveRank": 3,
+              "method": "fallback",
+              "name": "Carson Schwesinger",
+              "rawRank": 3,
+              "source": "idpShow",
+              "valueContribution": 9665
+            },
+            {
+              "effectiveRank": 3,
+              "method": "fallback",
+              "name": "Micah Parsons",
+              "rawRank": 3,
+              "source": "dlfIdp",
+              "valueContribution": 9665
+            },
+            {
+              "effectiveRank": 3,
+              "method": "fallback",
+              "name": "Roquan Smith",
+              "rawRank": 3,
+              "source": "fantasyProsIdp",
+              "valueContribution": 9665
+            },
+            {
+              "effectiveRank": 4,
+              "method": "fallback",
+              "name": "Jack Campbell",
+              "rawRank": 4,
+              "source": "dlfIdp",
+              "valueContribution": 9484
+            },
+            {
+              "effectiveRank": 4,
+              "method": "fallback",
+              "name": "Jack Campbell",
+              "rawRank": 4,
+              "source": "idpShow",
+              "valueContribution": 9484
+            },
+            {
+              "effectiveRank": 4,
+              "method": "fallback",
+              "name": "Jack Campbell",
+              "rawRank": 4,
+              "source": "fantasyProsIdp",
+              "valueContribution": 9484
+            },
+            {
+              "effectiveRank": 5,
+              "method": "fallback",
+              "name": "Abdul Carter",
+              "rawRank": 5,
+              "source": "idpShow",
+              "valueContribution": 9304
+            },
+            {
+              "effectiveRank": 5,
+              "method": "fallback",
+              "name": "Carson Schwesinger",
+              "rawRank": 5,
+              "source": "dlfIdp",
+              "valueContribution": 9304
+            },
+            {
+              "effectiveRank": 5,
+              "method": "fallback",
+              "name": "Jordyn Brooks",
+              "rawRank": 5,
+              "source": "fantasyProsIdp",
+              "valueContribution": 9304
+            }
+          ],
+          "maxBoardValue": 9999.0,
+          "maxIdpValue": 9999.0
+        },
+        "idpSourceDiagnostic": {
+          "boardMaxValue": 9999.0,
+          "idptcTopIdpValue": 6444.0,
+          "sources": {
+            "dlfIdp": [
+              {
+                "effectiveRank": 1,
+                "method": "fallback",
+                "nativeValue": 999900,
+                "pctOfBoardMax": 100.0,
+                "pctOfIdptcCeiling": 155.16759776536313,
+                "player": "Aidan Hutchinson",
+                "position": "DL",
+                "publishedValue": 9999,
+                "rawRank": 1,
+                "valueContribution": 9999
+              },
+              {
+                "effectiveRank": 2,
+                "method": "fallback",
+                "nativeValue": 999800,
+                "pctOfBoardMax": 98.41984198419841,
+                "pctOfIdptcCeiling": 152.715704531347,
+                "player": "Will Anderson",
+                "position": "DL",
+                "publishedValue": 9841,
+                "rawRank": 2,
+                "valueContribution": 9841
+              },
+              {
+                "effectiveRank": 3,
+                "method": "fallback",
+                "nativeValue": 999633,
+                "pctOfBoardMax": 96.65966596659666,
+                "pctOfIdptcCeiling": 149.98448168839232,
+                "player": "Micah Parsons",
+                "position": "DL",
+                "publishedValue": 2327,
+                "rawRank": 3,
+                "valueContribution": 9665
+              },
+              {
+                "effectiveRank": 5,
+                "method": "fallback",
+                "nativeValue": 999567,
+                "pctOfBoardMax": 93.04930493049305,
+                "pctOfIdptcCeiling": 144.38237119801366,
+                "player": "Carson Schwesinger",
+                "position": "LB",
+                "publishedValue": 9305,
+                "rawRank": 5,
+                "valueContribution": 9304
+              },
+              {
+                "effectiveRank": 10,
+                "method": "fallback",
+                "nativeValue": 998967,
+                "pctOfBoardMax": 84.47844784478448,
+                "pctOfIdptcCeiling": 131.08317815021726,
+                "player": "Abdul Carter",
+                "position": "DL",
+                "publishedValue": 2482,
+                "rawRank": 10,
+                "valueContribution": 8447
+              },
+              {
+                "effectiveRank": 20,
+                "method": "fallback",
+                "nativeValue": 997900,
+                "pctOfBoardMax": 70.36703670367037,
+                "pctOfIdptcCeiling": 109.18684047175667,
+                "player": "David Bailey",
+                "position": "DL",
+                "publishedValue": 7098,
+                "rawRank": 20,
+                "valueContribution": 7036
+              },
+              {
+                "effectiveRank": 100,
+                "method": "fallback",
+                "nativeValue": 989300,
+                "pctOfBoardMax": 27.542754275427544,
+                "pctOfIdptcCeiling": 42.737430167597765,
+                "player": "Jake Golday",
+                "position": "LB",
+                "publishedValue": 3072,
+                "rawRank": 100,
+                "valueContribution": 2754
+              },
+              {
+                "effectiveRank": 150,
+                "method": "fallback",
+                "nativeValue": 985800,
+                "pctOfBoardMax": 19.451945194519453,
+                "pctOfIdptcCeiling": 30.183116076970823,
+                "player": "Jonas Sanker",
+                "position": "DB",
+                "publishedValue": 1815,
+                "rawRank": 150,
+                "valueContribution": 1945
+              }
+            ],
+            "dlfRookieIdp": [
+              {
+                "effectiveRank": 1,
+                "method": "direct",
+                "nativeValue": 999900,
+                "pctOfBoardMax": 100.0,
+                "pctOfIdptcCeiling": 155.16759776536313,
+                "player": "Sonny Styles",
+                "position": "LB",
+                "publishedValue": 5583,
+                "rawRank": 1,
+                "valueContribution": 9999
+              },
+              {
+                "effectiveRank": 2,
+                "method": "direct",
+                "nativeValue": 999733,
+                "pctOfBoardMax": 98.41984198419841,
+                "pctOfIdptcCeiling": 152.715704531347,
+                "player": "Arvell Reese",
+                "position": "LB",
+                "publishedValue": 4117,
+                "rawRank": 2,
+                "valueContribution": 9841
+              },
+              {
+                "effectiveRank": 3,
+                "method": "direct",
+                "nativeValue": 999700,
+                "pctOfBoardMax": 96.65966596659666,
+                "pctOfIdptcCeiling": 149.98448168839232,
+                "player": "Jacob Rodriguez",
+                "position": "LB",
+                "publishedValue": 3043,
+                "rawRank": 3,
+                "valueContribution": 9665
+              },
+              {
+                "effectiveRank": 5,
+                "method": "direct",
+                "nativeValue": 999500,
+                "pctOfBoardMax": 93.04930493049305,
+                "pctOfIdptcCeiling": 144.38237119801366,
+                "player": "CJ Allen",
+                "position": "LB",
+                "publishedValue": 4888,
+                "rawRank": 5,
+                "valueContribution": 9304
+              },
+              {
+                "effectiveRank": 10,
+                "method": "direct",
+                "nativeValue": 998867,
+                "pctOfBoardMax": 84.47844784478448,
+                "pctOfIdptcCeiling": 131.08317815021726,
+                "player": "Josiah Trotter",
+                "position": "LB",
+                "publishedValue": 3464,
+                "rawRank": 10,
+                "valueContribution": 8447
+              },
+              {
+                "effectiveRank": 20,
+                "method": "direct",
+                "nativeValue": 997833,
+                "pctOfBoardMax": 70.36703670367037,
+                "pctOfIdptcCeiling": 109.18684047175667,
+                "player": "Keyshaun Elliott",
+                "position": "LB",
+                "publishedValue": 1969,
+                "rawRank": 20,
+                "valueContribution": 7036
+              }
+            ],
+            "draftSharksIdp": [
+              {
+                "effectiveRank": 25,
+                "method": "ds_combined_cross_market",
+                "nativeValue": 53,
+                "pctOfBoardMax": 64.85648564856486,
+                "pctOfIdptcCeiling": 100.63625077591558,
+                "player": "Carson Schwesinger",
+                "position": "LB",
+                "publishedValue": 9305,
+                "rawRank": 1,
+                "valueContribution": 6485
+              },
+              {
+                "effectiveRank": 36,
+                "method": "ds_combined_cross_market",
+                "nativeValue": 47,
+                "pctOfBoardMax": 58.40584058405841,
+                "pctOfIdptcCeiling": 90.62693978895096,
+                "player": "Cedric Gray",
+                "position": "LB",
+                "publishedValue": 5837,
+                "rawRank": 2,
+                "valueContribution": 5840
+              },
+              {
+                "effectiveRank": 50,
+                "method": "ds_combined_cross_market",
+                "nativeValue": 41,
+                "pctOfBoardMax": 52.38523852385239,
+                "pctOfIdptcCeiling": 81.28491620111731,
+                "player": "Sonny Styles",
+                "position": "LB",
+                "publishedValue": 5583,
+                "rawRank": 3,
+                "valueContribution": 5238
+              },
+              {
+                "effectiveRank": 68,
+                "method": "ds_combined_cross_market",
+                "nativeValue": 36,
+                "pctOfBoardMax": 46.714671467146715,
+                "pctOfIdptcCeiling": 72.48603351955308,
+                "player": "Nick Emmanwori",
+                "position": "DB",
+                "publishedValue": 6239,
+                "rawRank": 5,
+                "valueContribution": 4671
+              },
+              {
+                "effectiveRank": 100,
+                "method": "ds_combined_cross_market",
+                "nativeValue": 30,
+                "pctOfBoardMax": 39.78397839783979,
+                "pctOfIdptcCeiling": 61.731843575419,
+                "player": "Nick Bolton",
+                "position": "LB",
+                "publishedValue": 4275,
+                "rawRank": 10,
+                "valueContribution": 3978
+              }
+            ],
+            "fantasyProsIdp": [
+              {
+                "effectiveRank": 1,
+                "method": "fallback",
+                "nativeValue": 999900,
+                "pctOfBoardMax": 100.0,
+                "pctOfIdptcCeiling": 155.16759776536313,
+                "player": "Aidan Hutchinson",
+                "position": "DL",
+                "publishedValue": 9999,
+                "rawRank": 1,
+                "valueContribution": 9999
+              },
+              {
+                "effectiveRank": 2,
+                "method": "fallback",
+                "nativeValue": 999800,
+                "pctOfBoardMax": 98.41984198419841,
+                "pctOfIdptcCeiling": 152.715704531347,
+                "player": "Will Anderson",
+                "position": "DL",
+                "publishedValue": 9841,
+                "rawRank": 2,
+                "valueContribution": 9841
+              },
+              {
+                "effectiveRank": 3,
+                "method": "fallback",
+                "nativeValue": 999700,
+                "pctOfBoardMax": 96.65966596659666,
+                "pctOfIdptcCeiling": 149.98448168839232,
+                "player": "Roquan Smith",
+                "position": "LB",
+                "publishedValue": 7952,
+                "rawRank": 3,
+                "valueContribution": 9665
+              },
+              {
+                "effectiveRank": 5,
+                "method": "fallback",
+                "nativeValue": 999500,
+                "pctOfBoardMax": 93.04930493049305,
+                "pctOfIdptcCeiling": 144.38237119801366,
+                "player": "Jordyn Brooks",
+                "position": "LB",
+                "publishedValue": 3447,
+                "rawRank": 5,
+                "valueContribution": 9304
+              },
+              {
+                "effectiveRank": 10,
+                "method": "fallback",
+                "nativeValue": 999000,
+                "pctOfBoardMax": 84.47844784478448,
+                "pctOfIdptcCeiling": 131.08317815021726,
+                "player": "Ernest Jones",
+                "position": "LB",
+                "publishedValue": 4053,
+                "rawRank": 10,
+                "valueContribution": 8447
+              },
+              {
+                "effectiveRank": 20,
+                "method": "fallback",
+                "nativeValue": 998000,
+                "pctOfBoardMax": 70.36703670367037,
+                "pctOfIdptcCeiling": 109.18684047175667,
+                "player": "Blake Cashman",
+                "position": "LB",
+                "publishedValue": 2559,
+                "rawRank": 20,
+                "valueContribution": 7036
+              },
+              {
+                "effectiveRank": 50,
+                "method": "fallback",
+                "nativeValue": 995000,
+                "pctOfBoardMax": 45.34453445344535,
+                "pctOfIdptcCeiling": 70.36002482929857,
+                "player": "Antoine Winfield",
+                "position": "DB",
+                "publishedValue": 3723,
+                "rawRank": 50,
+                "valueContribution": 4534
+              },
+              {
+                "effectiveRank": 100,
+                "method": "fallback",
+                "nativeValue": 989800,
+                "pctOfBoardMax": 27.542754275427544,
+                "pctOfIdptcCeiling": 42.737430167597765,
+                "player": "Alex Anzalone",
+                "position": "LB",
+                "publishedValue": 1470,
+                "rawRank": 100,
+                "valueContribution": 2754
+              }
+            ],
+            "idpShow": [
+              {
+                "effectiveRank": 1,
+                "method": "fallback",
+                "nativeValue": 999900,
+                "pctOfBoardMax": 100.0,
+                "pctOfIdptcCeiling": 155.16759776536313,
+                "player": "Aidan Hutchinson",
+                "position": "DL",
+                "publishedValue": 9999,
+                "rawRank": 1,
+                "valueContribution": 9999
+              },
+              {
+                "effectiveRank": 2,
+                "method": "fallback",
+                "nativeValue": 999800,
+                "pctOfBoardMax": 98.41984198419841,
+                "pctOfIdptcCeiling": 152.715704531347,
+                "player": "Will Anderson",
+                "position": "DL",
+                "publishedValue": 9841,
+                "rawRank": 2,
+                "valueContribution": 9841
+              },
+              {
+                "effectiveRank": 3,
+                "method": "fallback",
+                "nativeValue": 999700,
+                "pctOfBoardMax": 96.65966596659666,
+                "pctOfIdptcCeiling": 149.98448168839232,
+                "player": "Carson Schwesinger",
+                "position": "LB",
+                "publishedValue": 9305,
+                "rawRank": 3,
+                "valueContribution": 9665
+              },
+              {
+                "effectiveRank": 5,
+                "method": "fallback",
+                "nativeValue": 999400,
+                "pctOfBoardMax": 93.04930493049305,
+                "pctOfIdptcCeiling": 144.38237119801366,
+                "player": "Abdul Carter",
+                "position": "DL",
+                "publishedValue": 2482,
+                "rawRank": 5,
+                "valueContribution": 9304
+              },
+              {
+                "effectiveRank": 10,
+                "method": "fallback",
+                "nativeValue": 998900,
+                "pctOfBoardMax": 84.47844784478448,
+                "pctOfIdptcCeiling": 131.08317815021726,
+                "player": "Arvell Reese",
+                "position": "LB",
+                "publishedValue": 4117,
+                "rawRank": 10,
+                "valueContribution": 8447
+              },
+              {
+                "effectiveRank": 20,
+                "method": "fallback",
+                "nativeValue": 997900,
+                "pctOfBoardMax": 70.36703670367037,
+                "pctOfIdptcCeiling": 109.18684047175667,
+                "player": "Edgerrin Cooper",
+                "position": "LB",
+                "publishedValue": 7874,
+                "rawRank": 20,
+                "valueContribution": 7036
+              },
+              {
+                "effectiveRank": 50,
+                "method": "fallback",
+                "nativeValue": 994900,
+                "pctOfBoardMax": 45.34453445344535,
+                "pctOfIdptcCeiling": 70.36002482929857,
+                "player": "Nick Herbig",
+                "position": "DL",
+                "publishedValue": 1757,
+                "rawRank": 50,
+                "valueContribution": 4534
+              },
+              {
+                "effectiveRank": 100,
+                "method": "fallback",
+                "nativeValue": 989900,
+                "pctOfBoardMax": 27.542754275427544,
+                "pctOfIdptcCeiling": 42.737430167597765,
+                "player": "Leo Chenal",
+                "position": "LB",
+                "publishedValue": 2684,
+                "rawRank": 100,
+                "valueContribution": 2754
+              },
+              {
+                "effectiveRank": 150,
+                "method": "fallback",
+                "nativeValue": 984900,
+                "pctOfBoardMax": 19.451945194519453,
+                "pctOfIdptcCeiling": 30.183116076970823,
+                "player": "Boye Mafe",
+                "position": "DL",
+                "publishedValue": 1660,
+                "rawRank": 150,
+                "valueContribution": 1945
+              },
+              {
+                "effectiveRank": 200,
+                "method": "fallback",
+                "nativeValue": 979900,
+                "pctOfBoardMax": 14.9014901490149,
+                "pctOfIdptcCeiling": 23.122284295468653,
+                "player": "Jaishawn Barham",
+                "position": "LB",
+                "publishedValue": 1401,
+                "rawRank": 200,
+                "valueContribution": 1490
+              }
+            ]
+          }
+        },
+        "rows": 1109
+      },
+      "draftSharksScaleAnalysis": {
+        "idpSlopeMean": 0.0958627220429335,
+        "idpSlopeRange": [
+          0.05799470225466633,
+          0.13043935042671428
+        ],
+        "idpToOffenseSlopeRatio": 0.9975725406709786,
+        "offenseSlopeMean": 0.09609599115313976,
+        "offenseSlopeRange": [
+          0.07403602316439228,
+          0.12630303631978113
+        ],
+        "perPosition": {
+          "DB": {
+            "impliedReplacementProj": 282.27588849666023,
+            "intercept": -36.81988353662799,
+            "n": 162,
+            "r2": 0.9929456913790271,
+            "slope3dPerProjPoint": 0.13043935042671428,
+            "top3d": 36.0,
+            "topName": "Nick Emmanwori",
+            "topProj3yr": 593.0
+          },
+          "DL": {
+            "impliedReplacementProj": 219.00227361056517,
+            "intercept": -12.700971651139696,
+            "n": 159,
+            "r2": 0.8624627830387553,
+            "slope3dPerProjPoint": 0.05799470225466633,
+            "top3d": 11.0,
+            "topName": "Aidan Hutchinson",
+            "topProj3yr": 400.0
+          },
+          "LB": {
+            "impliedReplacementProj": 247.1406233576405,
+            "intercept": -24.505009405869558,
+            "n": 89,
+            "r2": 0.9871887891159622,
+            "slope3dPerProjPoint": 0.0991541134474199,
+            "top3d": 53.0,
+            "topName": "Carson Schwesinger",
+            "topProj3yr": 814.0
+          },
+          "QB": {
+            "impliedReplacementProj": 192.51572460130964,
+            "intercept": -14.253098646092326,
+            "n": 51,
+            "r2": 0.8246178336555804,
+            "slope3dPerProjPoint": 0.07403602316439228,
+            "top3d": 100.0,
+            "topName": "Josh Allen",
+            "topProj3yr": 1090.0
+          },
+          "RB": {
+            "impliedReplacementProj": 37.25703758057621,
+            "intercept": -3.3756974437971827,
+            "n": 115,
+            "r2": 0.9841067819023388,
+            "slope3dPerProjPoint": 0.09060563219758211,
+            "top3d": 72.0,
+            "topName": "Bijan Robinson",
+            "topProj3yr": 759.0
+          },
+          "TE": {
+            "impliedReplacementProj": 108.15067709537823,
+            "intercept": -13.659758897186476,
+            "n": 88,
+            "r2": 0.9733306583064784,
+            "slope3dPerProjPoint": 0.12630303631978113,
+            "top3d": 59.0,
+            "topName": "Brock Bowers",
+            "topProj3yr": 641.0
+          },
+          "WR": {
+            "impliedReplacementProj": 59.22957858948144,
+            "intercept": -5.534368759399033,
+            "n": 185,
+            "r2": 0.9831412274259419,
+            "slope3dPerProjPoint": 0.09343927293080352,
+            "top3d": 64.0,
+            "topName": "Ja'Marr Chase",
+            "topProj3yr": 685.0
+          }
+        },
+        "verdict": "one_shared_scale",
+        "verdictBasis": "IDP and offense convert projection surplus into 3D Value + at the same rate; the spread WITHIN each pool is larger than the difference BETWEEN them, so the pools are not separately scaled"
+      }
+    },
+    "live": {
+      "bridgeEvidence": {
+        "draftSharksIdp_cardinal": {
+          "boardMaxValue": 9979.0,
+          "idpToOffenseRatio": 0.53,
+          "kind": "native_cardinal_combined",
+          "note": "ratio x board max; assumes both halves share one replacement baseline, which the audit tests separately",
+          "topIdpName": "Carson Schwesinger",
+          "topIdpNative": 53.0,
+          "topIdpPosition": "LB",
+          "topIdpValue": 5288.87,
+          "topOffenseName": "Josh Allen",
+          "topOffenseNative": 100.0,
+          "topOffensePosition": "QB"
+        },
+        "draftSharksIdp_ordinal": {
+          "idpCount": 274,
+          "kind": "combined_ordinal",
+          "topIdpCombinedRank": 25,
+          "topIdpName": "Carson Schwesinger",
+          "topIdpValue": 6485.0
+        },
+        "idpTradeCalc": {
+          "idpCount": 370,
+          "kind": "native_cardinal_combined",
+          "top10Mean": 5494.3,
+          "top25Mean": 4404.04,
+          "top5Mean": 5828.8,
+          "topIdpName": "Aidan Hutchinson",
+          "topIdpValue": 6444.0
+        }
+      },
+      "bridgeQuantileMap": [
+        {
+          "q": 0.0,
+          "value": 6464.5
+        },
+        {
+          "q": 0.05,
+          "value": 3492.5
+        },
+        {
+          "q": 0.1,
+          "value": 2843.0
+        },
+        {
+          "q": 0.15,
+          "value": 2522.0
+        },
+        {
+          "q": 0.2,
+          "value": 1998.5
+        },
+        {
+          "q": 0.25,
+          "value": 1927.5
+        },
+        {
+          "q": 0.3,
+          "value": 1873.0
+        },
+        {
+          "q": 0.35,
+          "value": 1835.5
+        },
+        {
+          "q": 0.4,
+          "value": 1554.5
+        },
+        {
+          "q": 0.45,
+          "value": 1486.5
+        },
+        {
+          "q": 0.5,
+          "value": 1448.0
+        },
+        {
+          "q": 0.55,
+          "value": 1420.5
+        },
+        {
+          "q": 0.6,
+          "value": 1401.0
+        },
+        {
+          "q": 0.65,
+          "value": 1389.5
+        },
+        {
+          "q": 0.7,
+          "value": 1376.5
+        },
+        {
+          "q": 0.75,
+          "value": 1185.5
+        },
+        {
+          "q": 0.8,
+          "value": 1146.0
+        },
+        {
+          "q": 0.85,
+          "value": 1118.5
+        },
+        {
+          "q": 0.9,
+          "value": 1095.0
+        },
+        {
+          "q": 0.95,
+          "value": 1077.0
+        },
+        {
+          "q": 1.0,
+          "value": 1056.5
+        }
+      ],
+      "candidates": {
+        "A": {
+          "ceilingApplied": null,
+          "crosswalkHealth": {
+            "backboneFallbackRows": 0,
+            "blendIntegrityViolations": 0,
+            "contractOk": true,
+            "fallbackVotes": {},
+            "idpOnlyVotesAtOrAbove9000": 0,
+            "idpOnlyVotesAtOrAbove9000Examples": [],
+            "maxBoardValue": 9979.0,
+            "maxIdpValue": 6393.0
+          },
+          "diffVsControl": {
+            "idpInTop100": 8,
+            "idpInTop200": 42,
+            "idpInTop400": 118,
+            "idpInTop50": 3,
+            "idpRowsChanged": 0,
+            "largestMovers": [],
+            "maxAbsChange": 0.0,
+            "maxRelChangePct": 0.0,
+            "meanAbsChange": 0.0,
+            "medianAbsChange": 0.0,
+            "medianRelChangePct": 0.0,
+            "movedDown": 0,
+            "movedUp": 0,
+            "offenseRowsChanged": 0,
+            "p90AbsChange": 0.0,
+            "p90RelChangePct": 0.0,
+            "pickOrOtherRowsChanged": 0,
+            "ranksChanged": 0,
+            "rowsCompared": 1109,
+            "servedChurn": 0,
+            "servedCount": 740,
+            "valuesChanged": 0
+          },
+          "idpBands": {
+            "idp10_25": {
+              "changed": 0,
+              "maxAbsChange": 0.0,
+              "meanChange": 0.0,
+              "n": 15
+            },
+            "idp1_10": {
+              "changed": 0,
+              "maxAbsChange": 0.0,
+              "meanChange": 0.0,
+              "n": 10
+            },
+            "idp25_75": {
+              "changed": 0,
+              "maxAbsChange": 0.0,
+              "meanChange": 0.0,
+              "n": 50
+            },
+            "idp75_plus": {
+              "changed": 0,
+              "maxAbsChange": 0.0,
+              "meanChange": 0.0,
+              "n": 222
+            }
+          },
+          "label": "control (current production)"
+        },
+        "B": {
+          "ceilingApplied": 6444.0,
+          "crosswalkHealth": {
+            "backboneFallbackRows": 0,
+            "blendIntegrityViolations": 0,
+            "contractOk": true,
+            "fallbackVotes": {},
+            "idpOnlyVotesAtOrAbove9000": 0,
+            "idpOnlyVotesAtOrAbove9000Examples": [],
+            "maxBoardValue": 9979.0,
+            "maxIdpValue": 6393.0
+          },
+          "diffVsControl": {
+            "idpInTop100": 8,
+            "idpInTop200": 42,
+            "idpInTop400": 118,
+            "idpInTop50": 3,
+            "idpRowsChanged": 0,
+            "largestMovers": [],
+            "maxAbsChange": 0.0,
+            "maxRelChangePct": 0.0,
+            "meanAbsChange": 0.0,
+            "medianAbsChange": 0.0,
+            "medianRelChangePct": 0.0,
+            "movedDown": 0,
+            "movedUp": 0,
+            "offenseRowsChanged": 0,
+            "p90AbsChange": 0.0,
+            "p90RelChangePct": 0.0,
+            "pickOrOtherRowsChanged": 0,
+            "ranksChanged": 0,
+            "rowsCompared": 1109,
+            "servedChurn": 0,
+            "servedCount": 740,
+            "valuesChanged": 0
+          },
+          "idpBands": {
+            "idp10_25": {
+              "changed": 0,
+              "maxAbsChange": 0.0,
+              "meanChange": 0.0,
+              "n": 15
+            },
+            "idp1_10": {
+              "changed": 0,
+              "maxAbsChange": 0.0,
+              "meanChange": 0.0,
+              "n": 10
+            },
+            "idp25_75": {
+              "changed": 0,
+              "maxAbsChange": 0.0,
+              "meanChange": 0.0,
+              "n": 50
+            },
+            "idp75_plus": {
+              "changed": 0,
+              "maxAbsChange": 0.0,
+              "meanChange": 0.0,
+              "n": 222
+            }
+          },
+          "label": "IDPTC top-IDP ceiling"
+        },
+        "C": {
+          "ceilingApplied": 6444.0,
+          "crosswalkHealth": {
+            "backboneFallbackRows": 0,
+            "blendIntegrityViolations": 0,
+            "contractOk": true,
+            "fallbackVotes": {},
+            "idpOnlyVotesAtOrAbove9000": 0,
+            "idpOnlyVotesAtOrAbove9000Examples": [],
+            "maxBoardValue": 9979.0,
+            "maxIdpValue": 6393.0
+          },
+          "diffVsControl": {
+            "idpInTop100": 8,
+            "idpInTop200": 42,
+            "idpInTop400": 118,
+            "idpInTop50": 3,
+            "idpRowsChanged": 0,
+            "largestMovers": [],
+            "maxAbsChange": 0.0,
+            "maxRelChangePct": 0.0,
+            "meanAbsChange": 0.0,
+            "medianAbsChange": 0.0,
+            "medianRelChangePct": 0.0,
+            "movedDown": 0,
+            "movedUp": 0,
+            "offenseRowsChanged": 0,
+            "p90AbsChange": 0.0,
+            "p90RelChangePct": 0.0,
+            "pickOrOtherRowsChanged": 0,
+            "ranksChanged": 0,
+            "rowsCompared": 1109,
+            "servedChurn": 0,
+            "servedCount": 740,
+            "valuesChanged": 0
+          },
+          "idpBands": {
+            "idp10_25": {
+              "changed": 0,
+              "maxAbsChange": 0.0,
+              "meanChange": 0.0,
+              "n": 15
+            },
+            "idp1_10": {
+              "changed": 0,
+              "maxAbsChange": 0.0,
+              "meanChange": 0.0,
+              "n": 10
+            },
+            "idp25_75": {
+              "changed": 0,
+              "maxAbsChange": 0.0,
+              "meanChange": 0.0,
+              "n": 50
+            },
+            "idp75_plus": {
+              "changed": 0,
+              "maxAbsChange": 0.0,
+              "meanChange": 0.0,
+              "n": 222
+            }
+          },
+          "label": "bridge-family-derived ceiling"
+        },
+        "D": {
+          "ceilingApplied": null,
+          "crosswalkHealth": {
+            "backboneFallbackRows": 0,
+            "blendIntegrityViolations": 0,
+            "contractOk": true,
+            "fallbackVotes": {},
+            "idpOnlyVotesAtOrAbove9000": 0,
+            "idpOnlyVotesAtOrAbove9000Examples": [],
+            "maxBoardValue": 9979.0,
+            "maxIdpValue": 6441.0
+          },
+          "diffVsControl": {
+            "idpInTop100": 10,
+            "idpInTop200": 42,
+            "idpInTop400": 118,
+            "idpInTop50": 4,
+            "idpRowsChanged": 273,
+            "largestMovers": [
+              {
+                "after": 5416.0,
+                "before": 3660.0,
+                "delta": 1756.0,
+                "name": "Abdul Carter",
+                "position": "DL"
+              },
+              {
+                "after": 4145.0,
+                "before": 3156.0,
+                "delta": 989.0,
+                "name": "Jamien Sherwood",
+                "position": "LB"
+              },
+              {
+                "after": 4979.0,
+                "before": 4180.0,
+                "delta": 799.0,
+                "name": "Travis Hunter",
+                "position": "WR"
+              },
+              {
+                "after": 2799.0,
+                "before": 3582.0,
+                "delta": -783.0,
+                "name": "Dallas Turner",
+                "position": "DL"
+              },
+              {
+                "after": 2799.0,
+                "before": 3555.0,
+                "delta": -756.0,
+                "name": "Laiatu Latu",
+                "position": "DL"
+              },
+              {
+                "after": 2412.0,
+                "before": 1709.0,
+                "delta": 703.0,
+                "name": "Byron Young",
+                "position": "DL"
+              },
+              {
+                "after": 2276.0,
+                "before": 2945.0,
+                "delta": -669.0,
+                "name": "Derwin James",
+                "position": "DB"
+              },
+              {
+                "after": 5680.0,
+                "before": 5023.0,
+                "delta": 657.0,
+                "name": "Jack Campbell",
+                "position": "LB"
+              },
+              {
+                "after": 2916.0,
+                "before": 3566.0,
+                "delta": -650.0,
+                "name": "Brian Burns",
+                "position": "DL"
+              },
+              {
+                "after": 3554.0,
+                "before": 2914.0,
+                "delta": 640.0,
+                "name": "Kyle Hamilton",
+                "position": "DB"
+              },
+              {
+                "after": 3018.0,
+                "before": 2397.0,
+                "delta": 621.0,
+                "name": "Danielle Hunter",
+                "position": "DL"
+              },
+              {
+                "after": 5447.0,
+                "before": 5318.0,
+                "delta": 129.0,
+                "name": "Micah Parsons",
+                "position": "DL"
+              },
+              {
+                "after": 5437.0,
+                "before": 5317.0,
+                "delta": 120.0,
+                "name": "Myles Garrett",
+                "position": "DL"
+              },
+              {
+                "after": 4049.0,
+                "before": 3950.0,
+                "delta": 99.0,
+                "name": "Edgerrin Cooper",
+                "position": "LB"
+              },
+              {
+                "after": 6047.0,
+                "before": 5954.0,
+                "delta": 93.0,
+                "name": "Carson Schwesinger",
+                "position": "LB"
+              },
+              {
+                "after": 3649.0,
+                "before": 3557.0,
+                "delta": 92.0,
+                "name": "Nick Bosa",
+                "position": "DL"
+              },
+              {
+                "after": 3550.0,
+                "before": 3462.0,
+                "delta": 88.0,
+                "name": "Ernest Jones",
+                "position": "LB"
+              },
+              {
+                "after": 5411.0,
+                "before": 5333.0,
+                "delta": 78.0,
+                "name": "Jared Verse",
+                "position": "DL"
+              },
+              {
+                "after": 5995.0,
+                "before": 5926.0,
+                "delta": 69.0,
+                "name": "Will Anderson",
+                "position": "DL"
+              },
+              {
+                "after": 3643.0,
+                "before": 3579.0,
+                "delta": 64.0,
+                "name": "Roquan Smith",
+                "position": "LB"
+              },
+              {
+                "after": 5310.0,
+                "before": 5252.0,
+                "delta": 58.0,
+                "name": "Sonny Styles",
+                "position": "LB"
+              },
+              {
+                "after": 3630.0,
+                "before": 3572.0,
+                "delta": 58.0,
+                "name": "Maxx Crosby",
+                "position": "DL"
+              },
+              {
+                "after": 5308.0,
+                "before": 5252.0,
+                "delta": 56.0,
+                "name": "2026 Pick 1.05",
+                "position": "PICK"
+              },
+              {
+                "after": 3610.0,
+                "before": 3558.0,
+                "delta": 52.0,
+                "name": "Fred Warner",
+                "position": "LB"
+              },
+              {
+                "after": 6441.0,
+                "before": 6393.0,
+                "delta": 48.0,
+                "name": "Aidan Hutchinson",
+                "position": "DL"
+              }
+            ],
+            "maxAbsChange": 1756.0,
+            "maxRelChangePct": 47.978142076502735,
+            "meanAbsChange": 38.389830508474574,
+            "medianAbsChange": 3.0,
+            "medianRelChangePct": 0.19404915912031048,
+            "movedDown": 141,
+            "movedUp": 154,
+            "offenseRowsChanged": 1,
+            "p90AbsChange": 22.0,
+            "p90RelChangePct": 0.7972665148063782,
+            "pickOrOtherRowsChanged": 21,
+            "ranksChanged": 494,
+            "rowsCompared": 1109,
+            "servedChurn": 2,
+            "servedCount": 740,
+            "valuesChanged": 295
+          },
+          "idpBands": {
+            "idp10_25": {
+              "changed": 15,
+              "maxAbsChange": 1756.0,
+              "meanChange": -3.466666666666667,
+              "n": 15
+            },
+            "idp1_10": {
+              "changed": 10,
+              "maxAbsChange": 657.0,
+              "meanChange": 135.3,
+              "n": 10
+            },
+            "idp25_75": {
+              "changed": 50,
+              "maxAbsChange": 989.0,
+              "meanChange": 34.26,
+              "n": 50
+            },
+            "idp75_plus": {
+              "changed": 198,
+              "maxAbsChange": 703.0,
+              "meanChange": 2.7373737373737375,
+              "n": 221
+            }
+          },
+          "label": "monotonic bridge mapping"
+        },
+        "E": {
+          "ceilingApplied": 6444.0,
+          "crosswalkHealth": {
+            "backboneFallbackRows": 0,
+            "blendIntegrityViolations": 0,
+            "contractOk": true,
+            "fallbackVotes": {},
+            "idpOnlyVotesAtOrAbove9000": 0,
+            "idpOnlyVotesAtOrAbove9000Examples": [],
+            "maxBoardValue": 9979.0,
+            "maxIdpValue": 6441.0
+          },
+          "diffVsControl": {
+            "idpInTop100": 10,
+            "idpInTop200": 42,
+            "idpInTop400": 118,
+            "idpInTop50": 4,
+            "idpRowsChanged": 273,
+            "largestMovers": [
+              {
+                "after": 5416.0,
+                "before": 3660.0,
+                "delta": 1756.0,
+                "name": "Abdul Carter",
+                "position": "DL"
+              },
+              {
+                "after": 4145.0,
+                "before": 3156.0,
+                "delta": 989.0,
+                "name": "Jamien Sherwood",
+                "position": "LB"
+              },
+              {
+                "after": 4979.0,
+                "before": 4180.0,
+                "delta": 799.0,
+                "name": "Travis Hunter",
+                "position": "WR"
+              },
+              {
+                "after": 2799.0,
+                "before": 3582.0,
+                "delta": -783.0,
+                "name": "Dallas Turner",
+                "position": "DL"
+              },
+              {
+                "after": 2799.0,
+                "before": 3555.0,
+                "delta": -756.0,
+                "name": "Laiatu Latu",
+                "position": "DL"
+              },
+              {
+                "after": 2412.0,
+                "before": 1709.0,
+                "delta": 703.0,
+                "name": "Byron Young",
+                "position": "DL"
+              },
+              {
+                "after": 2276.0,
+                "before": 2945.0,
+                "delta": -669.0,
+                "name": "Derwin James",
+                "position": "DB"
+              },
+              {
+                "after": 5680.0,
+                "before": 5023.0,
+                "delta": 657.0,
+                "name": "Jack Campbell",
+                "position": "LB"
+              },
+              {
+                "after": 2916.0,
+                "before": 3566.0,
+                "delta": -650.0,
+                "name": "Brian Burns",
+                "position": "DL"
+              },
+              {
+                "after": 3554.0,
+                "before": 2914.0,
+                "delta": 640.0,
+                "name": "Kyle Hamilton",
+                "position": "DB"
+              },
+              {
+                "after": 3018.0,
+                "before": 2397.0,
+                "delta": 621.0,
+                "name": "Danielle Hunter",
+                "position": "DL"
+              },
+              {
+                "after": 5447.0,
+                "before": 5318.0,
+                "delta": 129.0,
+                "name": "Micah Parsons",
+                "position": "DL"
+              },
+              {
+                "after": 5437.0,
+                "before": 5317.0,
+                "delta": 120.0,
+                "name": "Myles Garrett",
+                "position": "DL"
+              },
+              {
+                "after": 4049.0,
+                "before": 3950.0,
+                "delta": 99.0,
+                "name": "Edgerrin Cooper",
+                "position": "LB"
+              },
+              {
+                "after": 6047.0,
+                "before": 5954.0,
+                "delta": 93.0,
+                "name": "Carson Schwesinger",
+                "position": "LB"
+              },
+              {
+                "after": 3649.0,
+                "before": 3557.0,
+                "delta": 92.0,
+                "name": "Nick Bosa",
+                "position": "DL"
+              },
+              {
+                "after": 3550.0,
+                "before": 3462.0,
+                "delta": 88.0,
+                "name": "Ernest Jones",
+                "position": "LB"
+              },
+              {
+                "after": 5411.0,
+                "before": 5333.0,
+                "delta": 78.0,
+                "name": "Jared Verse",
+                "position": "DL"
+              },
+              {
+                "after": 5995.0,
+                "before": 5926.0,
+                "delta": 69.0,
+                "name": "Will Anderson",
+                "position": "DL"
+              },
+              {
+                "after": 3643.0,
+                "before": 3579.0,
+                "delta": 64.0,
+                "name": "Roquan Smith",
+                "position": "LB"
+              },
+              {
+                "after": 5310.0,
+                "before": 5252.0,
+                "delta": 58.0,
+                "name": "Sonny Styles",
+                "position": "LB"
+              },
+              {
+                "after": 3630.0,
+                "before": 3572.0,
+                "delta": 58.0,
+                "name": "Maxx Crosby",
+                "position": "DL"
+              },
+              {
+                "after": 5308.0,
+                "before": 5252.0,
+                "delta": 56.0,
+                "name": "2026 Pick 1.05",
+                "position": "PICK"
+              },
+              {
+                "after": 3610.0,
+                "before": 3558.0,
+                "delta": 52.0,
+                "name": "Fred Warner",
+                "position": "LB"
+              },
+              {
+                "after": 6441.0,
+                "before": 6393.0,
+                "delta": 48.0,
+                "name": "Aidan Hutchinson",
+                "position": "DL"
+              }
+            ],
+            "maxAbsChange": 1756.0,
+            "maxRelChangePct": 47.978142076502735,
+            "meanAbsChange": 38.389830508474574,
+            "medianAbsChange": 3.0,
+            "medianRelChangePct": 0.19404915912031048,
+            "movedDown": 141,
+            "movedUp": 154,
+            "offenseRowsChanged": 1,
+            "p90AbsChange": 22.0,
+            "p90RelChangePct": 0.7972665148063782,
+            "pickOrOtherRowsChanged": 21,
+            "ranksChanged": 494,
+            "rowsCompared": 1109,
+            "servedChurn": 2,
+            "servedCount": 740,
+            "valuesChanged": 295
+          },
+          "idpBands": {
+            "idp10_25": {
+              "changed": 15,
+              "maxAbsChange": 1756.0,
+              "meanChange": -3.466666666666667,
+              "n": 15
+            },
+            "idp1_10": {
+              "changed": 10,
+              "maxAbsChange": 657.0,
+              "meanChange": 135.3,
+              "n": 10
+            },
+            "idp25_75": {
+              "changed": 50,
+              "maxAbsChange": 989.0,
+              "meanChange": 34.26,
+              "n": 50
+            },
+            "idp75_plus": {
+              "changed": 198,
+              "maxAbsChange": 703.0,
+              "meanChange": 2.7373737373737375,
+              "n": 221
+            }
+          },
+          "label": "bridge mapping + bridge-derived ceiling"
+        }
+      },
+      "ceilingEstimators": {
+        "contributions": {
+          "draftSharksIdp_cardinal": 5288.87,
+          "draftSharksIdp_ordinal": 6485.0,
+          "idpTradeCalc": 6444.0
+        },
+        "max": 6485.0,
+        "mean": 6072.623333333333,
+        "median": 6444.0,
+        "min": 5288.87,
+        "n": 3,
+        "spreadPct": 19.697088627814342,
+        "trimmedMean": 6072.623333333333
+      },
+      "control": {
+        "crossSourceTable": [
+          {
+            "canonicalRank": 1,
+            "canonicalValue": 9979,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 9999,
+              "effectiveRank": 1,
+              "native": 100,
+              "rawRank": 1
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 9999,
+              "effectiveRank": 1,
+              "native": 999900,
+              "rawRank": 1
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": 9983,
+              "effectiveRank": 2,
+              "native": 9983,
+              "rawRank": 2
+            },
+            "ktcSfTep": {
+              "contribution": 9985,
+              "effectiveRank": 4,
+              "native": 9985,
+              "rawRank": 4
+            },
+            "player": "Josh Allen",
+            "position": "QB",
+            "slot": "QB1"
+          },
+          {
+            "canonicalRank": 32,
+            "canonicalValue": 6537,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 5891,
+              "effectiveRank": 35,
+              "native": 48,
+              "rawRank": 34
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 6077,
+              "effectiveRank": 38,
+              "native": 996200,
+              "rawRank": 38
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": 6034,
+              "effectiveRank": 39,
+              "native": 6034,
+              "rawRank": 39
+            },
+            "ktcSfTep": {
+              "contribution": 5977,
+              "effectiveRank": 36,
+              "native": 5977,
+              "rawRank": 36
+            },
+            "player": "Bo Nix",
+            "position": "QB",
+            "slot": "QB12"
+          },
+          {
+            "canonicalRank": 112,
+            "canonicalValue": 3778,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 4050,
+              "effectiveRank": 96,
+              "native": 30,
+              "rawRank": 87
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 3369,
+              "effectiveRank": 102,
+              "native": 989800,
+              "rawRank": 102
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": 4366,
+              "effectiveRank": 112,
+              "native": 4366,
+              "rawRank": 112
+            },
+            "ktcSfTep": {
+              "contribution": 3809,
+              "effectiveRank": 106,
+              "native": 3809,
+              "rawRank": 106
+            },
+            "player": "Bryce Young",
+            "position": "QB",
+            "slot": "QB24"
+          },
+          {
+            "canonicalRank": 3,
+            "canonicalValue": 9805,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 8184,
+              "effectiveRank": 8,
+              "native": 72,
+              "rawRank": 8
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 9883,
+              "effectiveRank": 2,
+              "native": 999800,
+              "rawRank": 2
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": 9999,
+              "effectiveRank": 1,
+              "native": 9999,
+              "rawRank": 1
+            },
+            "ktcSfTep": {
+              "contribution": 9998,
+              "effectiveRank": 3,
+              "native": 9998,
+              "rawRank": 3
+            },
+            "player": "Bijan Robinson",
+            "position": "RB",
+            "slot": "RB1"
+          },
+          {
+            "canonicalRank": 55,
+            "canonicalValue": 5329,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 5391,
+              "effectiveRank": 46,
+              "native": 42,
+              "rawRank": 43
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 5802,
+              "effectiveRank": 42,
+              "native": 995800,
+              "rawRank": 42
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": 5501,
+              "effectiveRank": 58,
+              "native": 5501,
+              "rawRank": 58
+            },
+            "ktcSfTep": {
+              "contribution": 5325,
+              "effectiveRank": 56,
+              "native": 5325,
+              "rawRank": 56
+            },
+            "player": "Quinshon Judkins",
+            "position": "RB",
+            "slot": "RB12"
+          },
+          {
+            "canonicalRank": 109,
+            "canonicalValue": 3859,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 3541,
+              "effectiveRank": 129,
+              "native": 26,
+              "rawRank": 116
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 3809,
+              "effectiveRank": 86,
+              "native": 991400,
+              "rawRank": 86
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": 4032,
+              "effectiveRank": 120,
+              "native": 4032,
+              "rawRank": 120
+            },
+            "ktcSfTep": {
+              "contribution": 4278,
+              "effectiveRank": 90,
+              "native": 4278,
+              "rawRank": 90
+            },
+            "player": "Bhayshul Tuten",
+            "position": "RB",
+            "slot": "RB24"
+          },
+          {
+            "canonicalRank": 5,
+            "canonicalValue": 9620,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 7898,
+              "effectiveRank": 10,
+              "native": 64,
+              "rawRank": 10
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 9481,
+              "effectiveRank": 5,
+              "native": 999500,
+              "rawRank": 5
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": 9978,
+              "effectiveRank": 3,
+              "native": 9978,
+              "rawRank": 3
+            },
+            "ktcSfTep": {
+              "contribution": 9954,
+              "effectiveRank": 5,
+              "native": 9954,
+              "rawRank": 5
+            },
+            "player": "Ja'Marr Chase",
+            "position": "WR",
+            "slot": "WR1"
+          },
+          {
+            "canonicalRank": 39,
+            "canonicalValue": 6027,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 6052,
+              "effectiveRank": 32,
+              "native": 50,
+              "rawRank": 30
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 5737,
+              "effectiveRank": 43,
+              "native": 995700,
+              "rawRank": 43
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": 5595,
+              "effectiveRank": 51,
+              "native": 5595,
+              "rawRank": 51
+            },
+            "ktcSfTep": {
+              "contribution": 5653,
+              "effectiveRank": 40,
+              "native": 5653,
+              "rawRank": 40
+            },
+            "player": "Nico Collins",
+            "position": "WR",
+            "slot": "WR12"
+          },
+          {
+            "canonicalRank": 77,
+            "canonicalValue": 4771,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 4754,
+              "effectiveRank": 65,
+              "native": 37,
+              "rawRank": 59
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 4753,
+              "effectiveRank": 61,
+              "native": 993900,
+              "rawRank": 61
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": 5056,
+              "effectiveRank": 77,
+              "native": 5056,
+              "rawRank": 77
+            },
+            "ktcSfTep": {
+              "contribution": 4939,
+              "effectiveRank": 70,
+              "native": 4939,
+              "rawRank": 70
+            },
+            "player": "Makai Lemon",
+            "position": "WR",
+            "slot": "WR24"
+          },
+          {
+            "canonicalRank": 128,
+            "canonicalValue": 3565,
+            "confidence": "high",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 3706,
+              "effectiveRank": 117,
+              "native": 27,
+              "rawRank": 105
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 3719,
+              "effectiveRank": 89,
+              "native": 991100,
+              "rawRank": 89
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": 4032,
+              "effectiveRank": 120,
+              "native": 4032,
+              "rawRank": 120
+            },
+            "ktcSfTep": {
+              "contribution": 3676,
+              "effectiveRank": 114,
+              "native": 3676,
+              "rawRank": 114
+            },
+            "player": "Alec Pierce",
+            "position": "WR",
+            "slot": "WR36"
+          },
+          {
+            "canonicalRank": 2,
+            "canonicalValue": 9970,
+            "confidence": "medium",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 7940,
+              "effectiveRank": 16,
+              "native": 59,
+              "rawRank": 16
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 9989,
+              "effectiveRank": 7,
+              "native": 999300,
+              "rawRank": 7
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": 9872,
+              "effectiveRank": 7,
+              "native": 8975,
+              "rawRank": 7
+            },
+            "ktcSfTep": {
+              "contribution": 9999,
+              "effectiveRank": 1,
+              "native": 9999,
+              "rawRank": 1
+            },
+            "player": "Brock Bowers",
+            "position": "TE",
+            "slot": "TE1"
+          },
+          {
+            "canonicalRank": 97,
+            "canonicalValue": 4086,
+            "confidence": "medium",
+            "dlfIdp": null,
+            "draftSharks": {
+              "contribution": 4558,
+              "effectiveRank": 91,
+              "native": 32,
+              "rawRank": 77
+            },
+            "draftSharksIdp": null,
+            "dynastyNerdsSfTep": {
+              "contribution": 3935,
+              "effectiveRank": 94,
+              "native": 990600,
+              "rawRank": 94
+            },
+            "fantasyProsIdp": null,
+            "idpShow": null,
+            "idpTradeCalc": {
+              "contribution": 4511,
+              "effectiveRank": 118,
+              "native": 4101,
+              "rawRank": 118
+            },
+            "ktcSfTep": {
+              "contribution": 3968,
+              "effectiveRank": 99,
+              "native": 3968,
+              "rawRank": 99
+            },
+            "player": "Oronde Gadsden",
+            "position": "TE",
+            "slot": "TE12"
+          },
+          {
+            "canonicalRank": 34,
+            "canonicalValue": 6393,
+            "confidence": "medium",
+            "dlfIdp": {
+              "contribution": 5943,
+              "effectiveRank": 34,
+              "native": 999900,
+              "rawRank": 1
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 2116,
+              "effectiveRank": 344,
+              "native": 11,
+              "rawRank": 39
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 5943,
+              "effectiveRank": 34,
+              "native": 999900,
+              "rawRank": 1
+            },
+            "idpShow": {
+              "contribution": 5943,
+              "effectiveRank": 34,
+              "native": 999900,
+              "rawRank": 1
+            },
+            "idpTradeCalc": {
+              "contribution": 6444,
+              "effectiveRank": 34,
+              "native": 6444,
+              "rawRank": 34
+            },
+            "ktcSfTep": null,
+            "player": "Aidan Hutchinson",
+            "position": "DL",
+            "slot": "DL1"
+          },
+          {
+            "canonicalRank": 42,
+            "canonicalValue": 5926,
+            "confidence": "medium",
+            "dlfIdp": {
+              "contribution": 5603,
+              "effectiveRank": 41,
+              "native": 999800,
+              "rawRank": 2
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 2013,
+              "effectiveRank": 375,
+              "native": 10,
+              "rawRank": 43
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 5603,
+              "effectiveRank": 41,
+              "native": 999800,
+              "rawRank": 2
+            },
+            "idpShow": {
+              "contribution": 5603,
+              "effectiveRank": 41,
+              "native": 999800,
+              "rawRank": 2
+            },
+            "idpTradeCalc": {
+              "contribution": 5963,
+              "effectiveRank": 41,
+              "native": 5963,
+              "rawRank": 41
+            },
+            "ktcSfTep": null,
+            "player": "Will Anderson",
+            "position": "DL",
+            "slot": "DL2"
+          },
+          {
+            "canonicalRank": 57,
+            "canonicalValue": 5317,
+            "confidence": "medium",
+            "dlfIdp": {
+              "contribution": 4726,
+              "effectiveRank": 66,
+              "native": 999300,
+              "rawRank": 6
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 1924,
+              "effectiveRank": 405,
+              "native": 8,
+              "rawRank": 60
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 3077,
+              "effectiveRank": 172,
+              "native": 997100,
+              "rawRank": 29
+            },
+            "idpShow": {
+              "contribution": 4726,
+              "effectiveRank": 66,
+              "native": 999300,
+              "rawRank": 6
+            },
+            "idpTradeCalc": {
+              "contribution": 5414,
+              "effectiveRank": 66,
+              "native": 5414,
+              "rawRank": 66
+            },
+            "ktcSfTep": null,
+            "player": "Myles Garrett",
+            "position": "DL",
+            "slot": "DL5"
+          },
+          {
+            "canonicalRank": 130,
+            "canonicalValue": 3558,
+            "confidence": "medium",
+            "dlfIdp": {
+              "contribution": 3751,
+              "effectiveRank": 114,
+              "native": 998767,
+              "rawRank": 11
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 1962,
+              "effectiveRank": 392,
+              "native": 9,
+              "rawRank": 49
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 2826,
+              "effectiveRank": 203,
+              "native": 996100,
+              "rawRank": 39
+            },
+            "idpShow": {
+              "contribution": 3231,
+              "effectiveRank": 156,
+              "native": 997400,
+              "rawRank": 25
+            },
+            "idpTradeCalc": {
+              "contribution": 3593,
+              "effectiveRank": 157,
+              "native": 3593,
+              "rawRank": 157
+            },
+            "ktcSfTep": null,
+            "player": "Nik Bonitto",
+            "position": "DL",
+            "slot": "DL10"
+          },
+          {
+            "canonicalRank": 41,
+            "canonicalValue": 5954,
+            "confidence": "medium",
+            "dlfIdp": {
+              "contribution": 4783,
+              "effectiveRank": 64,
+              "native": 999567,
+              "rawRank": 5
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 6485,
+              "effectiveRank": 25,
+              "native": 53,
+              "rawRank": 1
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 4698,
+              "effectiveRank": 67,
+              "native": 999300,
+              "rawRank": 7
+            },
+            "idpShow": {
+              "contribution": 5352,
+              "effectiveRank": 47,
+              "native": 999700,
+              "rawRank": 3
+            },
+            "idpTradeCalc": {
+              "contribution": 5667,
+              "effectiveRank": 47,
+              "native": 5667,
+              "rawRank": 47
+            },
+            "ktcSfTep": null,
+            "player": "Carson Schwesinger",
+            "position": "LB",
+            "slot": "LB1"
+          },
+          {
+            "canonicalRank": 60,
+            "canonicalValue": 5252,
+            "confidence": "medium",
+            "dlfIdp": {
+              "contribution": 4671,
+              "effectiveRank": 68,
+              "native": 999267,
+              "rawRank": 8
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 5238,
+              "effectiveRank": 50,
+              "native": 41,
+              "rawRank": 3
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 2603,
+              "effectiveRank": 237,
+              "native": 994600,
+              "rawRank": 54
+            },
+            "idpShow": {
+              "contribution": 4645,
+              "effectiveRank": 69,
+              "native": 999000,
+              "rawRank": 9
+            },
+            "idpTradeCalc": {
+              "contribution": 5399,
+              "effectiveRank": 69,
+              "native": 5399,
+              "rawRank": 69
+            },
+            "ktcSfTep": null,
+            "player": "Sonny Styles",
+            "position": "LB",
+            "slot": "LB2"
+          },
+          {
+            "canonicalRank": 106,
+            "canonicalValue": 3946,
+            "confidence": "medium",
+            "dlfIdp": {
+              "contribution": 3294,
+              "effectiveRank": 150,
+              "native": 997933,
+              "rawRank": 19
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 3812,
+              "effectiveRank": 110,
+              "native": 28,
+              "rawRank": 12
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 2557,
+              "effectiveRank": 245,
+              "native": 994200,
+              "rawRank": 58
+            },
+            "idpShow": {
+              "contribution": 3766,
+              "effectiveRank": 113,
+              "native": 998900,
+              "rawRank": 10
+            },
+            "idpTradeCalc": {
+              "contribution": 4173,
+              "effectiveRank": 113,
+              "native": 4173,
+              "rawRank": 113
+            },
+            "ktcSfTep": null,
+            "player": "Arvell Reese",
+            "position": "LB",
+            "slot": "LB5"
+          },
+          {
+            "canonicalRank": 140,
+            "canonicalValue": 3417,
+            "confidence": "medium",
+            "dlfIdp": {
+              "contribution": 3181,
+              "effectiveRank": 161,
+              "native": 997600,
+              "rawRank": 26
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 4309,
+              "effectiveRank": 83,
+              "native": 33,
+              "rawRank": 7
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 2749,
+              "effectiveRank": 214,
+              "native": 995700,
+              "rawRank": 43
+            },
+            "idpShow": {
+              "contribution": 3104,
+              "effectiveRank": 169,
+              "native": 997100,
+              "rawRank": 28
+            },
+            "idpTradeCalc": {
+              "contribution": 3458,
+              "effectiveRank": 171,
+              "native": 3458,
+              "rawRank": 171
+            },
+            "ktcSfTep": null,
+            "player": "Jihaad Campbell",
+            "position": "LB",
+            "slot": "LB10"
+          },
+          {
+            "canonicalRank": 133,
+            "canonicalValue": 3550,
+            "confidence": "medium",
+            "dlfIdp": {
+              "contribution": 3050,
+              "effectiveRank": 175,
+              "native": 996600,
+              "rawRank": 30
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 4671,
+              "effectiveRank": 68,
+              "native": 36,
+              "rawRank": 5
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 3104,
+              "effectiveRank": 169,
+              "native": 997200,
+              "rawRank": 28
+            },
+            "idpShow": {
+              "contribution": 3262,
+              "effectiveRank": 153,
+              "native": 997700,
+              "rawRank": 22
+            },
+            "idpTradeCalc": {
+              "contribution": 3598,
+              "effectiveRank": 154,
+              "native": 3598,
+              "rawRank": 154
+            },
+            "ktcSfTep": null,
+            "player": "Nick Emmanwori",
+            "position": "DB",
+            "slot": "DB1"
+          },
+          {
+            "canonicalRank": 155,
+            "canonicalValue": 3272,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 1753,
+              "effectiveRank": 474,
+              "native": 986167,
+              "rawRank": 144
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 3860,
+              "effectiveRank": 107,
+              "native": 29,
+              "rawRank": 11
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 1892,
+              "effectiveRank": 417,
+              "native": 990400,
+              "rawRank": 94
+            },
+            "idpShow": {
+              "contribution": 2585,
+              "effectiveRank": 240,
+              "native": 994400,
+              "rawRank": 55
+            },
+            "idpTradeCalc": {
+              "contribution": 2971,
+              "effectiveRank": 242,
+              "native": 2971,
+              "rawRank": 242
+            },
+            "ktcSfTep": null,
+            "player": "Kevin Winston",
+            "position": "DB",
+            "slot": "DB2"
+          },
+          {
+            "canonicalRank": 175,
+            "canonicalValue": 3129,
+            "confidence": "medium",
+            "dlfIdp": {
+              "contribution": 1950,
+              "effectiveRank": 396,
+              "native": 991733,
+              "rawRank": 80
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 3383,
+              "effectiveRank": 142,
+              "native": 25,
+              "rawRank": 15
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 1889,
+              "effectiveRank": 418,
+              "native": 990300,
+              "rawRank": 95
+            },
+            "idpShow": {
+              "contribution": 2749,
+              "effectiveRank": 214,
+              "native": 995600,
+              "rawRank": 43
+            },
+            "idpTradeCalc": {
+              "contribution": 3111,
+              "effectiveRank": 217,
+              "native": 3111,
+              "rawRank": 217
+            },
+            "ktcSfTep": null,
+            "player": "Dillon Thieneman",
+            "position": "DB",
+            "slot": "DB5"
+          },
+          {
+            "canonicalRank": 302,
+            "canonicalValue": 2046,
+            "confidence": "high",
+            "dlfIdp": {
+              "contribution": 1585,
+              "effectiveRank": 560,
+              "native": 985900,
+              "rawRank": 148
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 2163,
+              "effectiveRank": 331,
+              "native": 13,
+              "rawRank": 35
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 2007,
+              "effectiveRank": 377,
+              "native": 992800,
+              "rawRank": 71
+            },
+            "idpShow": {
+              "contribution": 1908,
+              "effectiveRank": 411,
+              "native": 991000,
+              "rawRank": 89
+            },
+            "idpTradeCalc": {
+              "contribution": 1970,
+              "effectiveRank": 417,
+              "native": 1970,
+              "rawRank": 417
+            },
+            "ktcSfTep": null,
+            "player": "Xavier Watts",
+            "position": "DB",
+            "slot": "DB10"
+          },
+          {
+            "canonicalRank": 34,
+            "canonicalValue": 6393,
+            "confidence": "medium",
+            "dlfIdp": {
+              "contribution": 5943,
+              "effectiveRank": 34,
+              "native": 999900,
+              "rawRank": 1
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 2116,
+              "effectiveRank": 344,
+              "native": 11,
+              "rawRank": 39
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 5943,
+              "effectiveRank": 34,
+              "native": 999900,
+              "rawRank": 1
+            },
+            "idpShow": {
+              "contribution": 5943,
+              "effectiveRank": 34,
+              "native": 999900,
+              "rawRank": 1
+            },
+            "idpTradeCalc": {
+              "contribution": 6444,
+              "effectiveRank": 34,
+              "native": 6444,
+              "rawRank": 34
+            },
+            "ktcSfTep": null,
+            "player": "Aidan Hutchinson",
+            "position": "DL",
+            "slot": "IDP1*"
+          },
+          {
+            "canonicalRank": 56,
+            "canonicalValue": 5318,
+            "confidence": "medium",
+            "dlfIdp": {
+              "contribution": 5352,
+              "effectiveRank": 47,
+              "native": 999633,
+              "rawRank": 3
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 1643,
+              "effectiveRank": 528,
+              "native": 1,
+              "rawRank": 131
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 2878,
+              "effectiveRank": 196,
+              "native": 996400,
+              "rawRank": 36
+            },
+            "idpShow": {
+              "contribution": 4698,
+              "effectiveRank": 67,
+              "native": 999200,
+              "rawRank": 7
+            },
+            "idpTradeCalc": {
+              "contribution": 5409,
+              "effectiveRank": 67,
+              "native": 5409,
+              "rawRank": 67
+            },
+            "ktcSfTep": null,
+            "player": "Micah Parsons",
+            "position": "DL",
+            "slot": "IDP5"
+          },
+          {
+            "canonicalRank": 106,
+            "canonicalValue": 3946,
+            "confidence": "medium",
+            "dlfIdp": {
+              "contribution": 3294,
+              "effectiveRank": 150,
+              "native": 997933,
+              "rawRank": 19
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 3812,
+              "effectiveRank": 110,
+              "native": 28,
+              "rawRank": 12
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 2557,
+              "effectiveRank": 245,
+              "native": 994200,
+              "rawRank": 58
+            },
+            "idpShow": {
+              "contribution": 3766,
+              "effectiveRank": 113,
+              "native": 998900,
+              "rawRank": 10
+            },
+            "idpTradeCalc": {
+              "contribution": 4173,
+              "effectiveRank": 113,
+              "native": 4173,
+              "rawRank": 113
+            },
+            "ktcSfTep": null,
+            "player": "Arvell Reese",
+            "position": "LB",
+            "slot": "IDP10*"
+          },
+          {
+            "canonicalRank": 147,
+            "canonicalValue": 3336,
+            "confidence": "medium",
+            "dlfIdp": {
+              "contribution": 2557,
+              "effectiveRank": 245,
+              "native": 994000,
+              "rawRank": 58
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 1755,
+              "effectiveRank": 473,
+              "native": 4,
+              "rawRank": 93
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": null,
+            "idpShow": {
+              "contribution": 3050,
+              "effectiveRank": 175,
+              "native": 996900,
+              "rawRank": 30
+            },
+            "idpTradeCalc": {
+              "contribution": 3396,
+              "effectiveRank": 177,
+              "native": 3396,
+              "rawRank": 177
+            },
+            "ktcSfTep": null,
+            "player": "Rueben Bain",
+            "position": "DL",
+            "slot": "IDP25"
+          },
+          {
+            "canonicalRank": 235,
+            "canonicalValue": 2477,
+            "confidence": "low",
+            "dlfIdp": {
+              "contribution": 2742,
+              "effectiveRank": 215,
+              "native": 995667,
+              "rawRank": 44
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 1660,
+              "effectiveRank": 519,
+              "native": 1,
+              "rawRank": 131
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": {
+              "contribution": 1813,
+              "effectiveRank": 448,
+              "native": 987900,
+              "rawRank": 119
+            },
+            "idpShow": {
+              "contribution": 2901,
+              "effectiveRank": 193,
+              "native": 996400,
+              "rawRank": 35
+            },
+            "idpTradeCalc": {
+              "contribution": 3264,
+              "effectiveRank": 195,
+              "native": 3264,
+              "rawRank": 195
+            },
+            "ktcSfTep": null,
+            "player": "Alex Highsmith",
+            "position": "DL",
+            "slot": "IDP50"
+          },
+          {
+            "canonicalRank": 376,
+            "canonicalValue": 1838,
+            "confidence": "medium",
+            "dlfIdp": {
+              "contribution": 1751,
+              "effectiveRank": 475,
+              "native": 986067,
+              "rawRank": 145
+            },
+            "draftSharks": null,
+            "draftSharksIdp": {
+              "contribution": 1766,
+              "effectiveRank": 468,
+              "native": 4,
+              "rawRank": 93
+            },
+            "dynastyNerdsSfTep": null,
+            "fantasyProsIdp": null,
+            "idpShow": {
+              "contribution": 1820,
+              "effectiveRank": 445,
+              "native": 988300,
+              "rawRank": 116
+            },
+            "idpTradeCalc": {
+              "contribution": 1923,
+              "effectiveRank": 450,
+              "native": 1923,
+              "rawRank": 450
+            },
+            "ktcSfTep": null,
+            "player": "Jalyx Hunt",
+            "position": "DL",
+            "slot": "IDP100"
+          }
+        ],
+        "crosswalkHealth": {
+          "backboneFallbackRows": 0,
+          "blendIntegrityViolations": 0,
+          "contractOk": true,
+          "fallbackVotes": {},
+          "idpOnlyVotesAtOrAbove9000": 0,
+          "idpOnlyVotesAtOrAbove9000Examples": [],
+          "maxBoardValue": 9979.0,
+          "maxIdpValue": 6393.0
+        },
+        "idpSourceDiagnostic": {
+          "boardMaxValue": 9979.0,
+          "idptcTopIdpValue": 6444.0,
+          "sources": {
+            "dlfIdp": [
+              {
+                "effectiveRank": 34,
+                "method": "exact",
+                "nativeValue": 999900,
+                "pctOfBoardMax": 59.55506563783947,
+                "pctOfIdptcCeiling": 92.22532588454376,
+                "player": "Aidan Hutchinson",
+                "position": "DL",
+                "publishedValue": 6393,
+                "rawRank": 1,
+                "valueContribution": 5943
+              },
+              {
+                "effectiveRank": 41,
+                "method": "exact",
+                "nativeValue": 999800,
+                "pctOfBoardMax": 56.1479106122858,
+                "pctOfIdptcCeiling": 86.94909993792676,
+                "player": "Will Anderson",
+                "position": "DL",
+                "publishedValue": 5926,
+                "rawRank": 2,
+                "valueContribution": 5603
+              },
+              {
+                "effectiveRank": 47,
+                "method": "exact",
+                "nativeValue": 999633,
+                "pctOfBoardMax": 53.63262851989177,
+                "pctOfIdptcCeiling": 83.05400372439479,
+                "player": "Micah Parsons",
+                "position": "DL",
+                "publishedValue": 5318,
+                "rawRank": 3,
+                "valueContribution": 5352
+              },
+              {
+                "effectiveRank": 64,
+                "method": "exact",
+                "nativeValue": 999567,
+                "pctOfBoardMax": 47.930654374185785,
+                "pctOfIdptcCeiling": 74.22408441961514,
+                "player": "Carson Schwesinger",
+                "position": "LB",
+                "publishedValue": 5954,
+                "rawRank": 5,
+                "valueContribution": 4783
+              },
+              {
+                "effectiveRank": 113,
+                "method": "exact",
+                "nativeValue": 998967,
+                "pctOfBoardMax": 37.739252430103214,
+                "pctOfIdptcCeiling": 58.44196151458721,
+                "player": "Abdul Carter",
+                "position": "DL",
+                "publishedValue": 3660,
+                "rawRank": 10,
+                "valueContribution": 3766
+              },
+              {
+                "effectiveRank": 151,
+                "method": "exact",
+                "nativeValue": 997900,
+                "pctOfBoardMax": 32.89908808497846,
+                "pctOfIdptcCeiling": 50.946617008069516,
+                "player": "David Bailey",
+                "position": "DL",
+                "publishedValue": 3068,
+                "rawRank": 20,
+                "valueContribution": 3283
+              },
+              {
+                "effectiveRank": 426,
+                "method": "exact",
+                "nativeValue": 989300,
+                "pctOfBoardMax": 18.719310552159534,
+                "pctOfIdptcCeiling": 28.988206083178152,
+                "player": "Jake Golday",
+                "position": "LB",
+                "publishedValue": 1827,
+                "rawRank": 100,
+                "valueContribution": 1868
+              },
+              {
+                "effectiveRank": 567,
+                "method": "exact",
+                "nativeValue": 985800,
+                "pctOfBoardMax": 15.763102515282092,
+                "pctOfIdptcCeiling": 24.41030415890751,
+                "player": "Jonas Sanker",
+                "position": "DB",
+                "publishedValue": 1834,
+                "rawRank": 150,
+                "valueContribution": 1573
+              }
+            ],
+            "dlfRookieIdp": [
+              {
+                "effectiveRank": 69,
+                "method": "rookie_ladder_translation_via_idpTradeCalc",
+                "nativeValue": 999900,
+                "pctOfBoardMax": 46.547750275578714,
+                "pctOfIdptcCeiling": 72.08255741775295,
+                "player": "Sonny Styles",
+                "position": "LB",
+                "publishedValue": 5252,
+                "rawRank": 1,
+                "valueContribution": 4645
+              },
+              {
+                "effectiveRank": 113,
+                "method": "rookie_ladder_translation_via_idpTradeCalc",
+                "nativeValue": 999733,
+                "pctOfBoardMax": 37.739252430103214,
+                "pctOfIdptcCeiling": 58.44196151458721,
+                "player": "Arvell Reese",
+                "position": "LB",
+                "publishedValue": 3946,
+                "rawRank": 2,
+                "valueContribution": 3766
+              },
+              {
+                "effectiveRank": 114,
+                "method": "rookie_ladder_translation_via_idpTradeCalc",
+                "nativeValue": 999700,
+                "pctOfBoardMax": 37.588936767211145,
+                "pctOfIdptcCeiling": 58.20918684047176,
+                "player": "Jacob Rodriguez",
+                "position": "LB",
+                "publishedValue": 3408,
+                "rawRank": 3,
+                "valueContribution": 3751
+              },
+              {
+                "effectiveRank": 174,
+                "method": "rookie_ladder_translation_via_idpTradeCalc",
+                "nativeValue": 999500,
+                "pctOfBoardMax": 30.65437418579016,
+                "pctOfIdptcCeiling": 47.470515207945375,
+                "player": "CJ Allen",
+                "position": "LB",
+                "publishedValue": 3298,
+                "rawRank": 5,
+                "valueContribution": 3059
+              },
+              {
+                "effectiveRank": 369,
+                "method": "rookie_ladder_translation_via_idpTradeCalc",
+                "nativeValue": 998867,
+                "pctOfBoardMax": 20.362761799779534,
+                "pctOfIdptcCeiling": 31.533209186840473,
+                "player": "Josiah Trotter",
+                "position": "LB",
+                "publishedValue": 1802,
+                "rawRank": 10,
+                "valueContribution": 2032
+              },
+              {
+                "effectiveRank": 580,
+                "method": "rookie_ladder_translation_via_idpTradeCalc",
+                "nativeValue": 997833,
+                "pctOfBoardMax": 15.542639543040385,
+                "pctOfIdptcCeiling": 24.068901303538176,
+                "player": "Derrick Moore",
+                "position": "DL",
+                "publishedValue": 1900,
+                "rawRank": 20,
+                "valueContribution": 1551
+              }
+            ],
+            "draftSharksIdp": [
+              {
+                "effectiveRank": 25,
+                "method": "ds_combined_cross_market",
+                "nativeValue": 53,
+                "pctOfBoardMax": 64.98647159033972,
+                "pctOfIdptcCeiling": 100.63625077591558,
+                "player": "Carson Schwesinger",
+                "position": "LB",
+                "publishedValue": 5954,
+                "rawRank": 1,
+                "valueContribution": 6485
+              },
+              {
+                "effectiveRank": 36,
+                "method": "ds_combined_cross_market",
+                "nativeValue": 47,
+                "pctOfBoardMax": 58.52289808598056,
+                "pctOfIdptcCeiling": 90.62693978895096,
+                "player": "Cedric Gray",
+                "position": "LB",
+                "publishedValue": 3170,
+                "rawRank": 2,
+                "valueContribution": 5840
+              },
+              {
+                "effectiveRank": 50,
+                "method": "ds_combined_cross_market",
+                "nativeValue": 41,
+                "pctOfBoardMax": 52.490229481912024,
+                "pctOfIdptcCeiling": 81.28491620111731,
+                "player": "Sonny Styles",
+                "position": "LB",
+                "publishedValue": 5252,
+                "rawRank": 3,
+                "valueContribution": 5238
+              },
+              {
+                "effectiveRank": 68,
+                "method": "ds_combined_cross_market",
+                "nativeValue": 36,
+                "pctOfBoardMax": 46.80829742459164,
+                "pctOfIdptcCeiling": 72.48603351955308,
+                "player": "Nick Emmanwori",
+                "position": "DB",
+                "publishedValue": 3550,
+                "rawRank": 5,
+                "valueContribution": 4671
+              },
+              {
+                "effectiveRank": 100,
+                "method": "ds_combined_cross_market",
+                "nativeValue": 30,
+                "pctOfBoardMax": 39.86371379897785,
+                "pctOfIdptcCeiling": 61.731843575419,
+                "player": "Nick Bolton",
+                "position": "LB",
+                "publishedValue": 3698,
+                "rawRank": 10,
+                "valueContribution": 3978
+              }
+            ],
+            "fantasyProsIdp": [
+              {
+                "effectiveRank": 34,
+                "method": "exact",
+                "nativeValue": 999900,
+                "pctOfBoardMax": 59.55506563783947,
+                "pctOfIdptcCeiling": 92.22532588454376,
+                "player": "Aidan Hutchinson",
+                "position": "DL",
+                "publishedValue": 6393,
+                "rawRank": 1,
+                "valueContribution": 5943
+              },
+              {
+                "effectiveRank": 41,
+                "method": "exact",
+                "nativeValue": 999800,
+                "pctOfBoardMax": 56.1479106122858,
+                "pctOfIdptcCeiling": 86.94909993792676,
+                "player": "Will Anderson",
+                "position": "DL",
+                "publishedValue": 5926,
+                "rawRank": 2,
+                "valueContribution": 5603
+              },
+              {
+                "effectiveRank": 47,
+                "method": "exact",
+                "nativeValue": 999700,
+                "pctOfBoardMax": 53.63262851989177,
+                "pctOfIdptcCeiling": 83.05400372439479,
+                "player": "Roquan Smith",
+                "position": "LB",
+                "publishedValue": 3579,
+                "rawRank": 3,
+                "valueContribution": 5352
+              },
+              {
+                "effectiveRank": 64,
+                "method": "exact",
+                "nativeValue": 999500,
+                "pctOfBoardMax": 47.930654374185785,
+                "pctOfIdptcCeiling": 74.22408441961514,
+                "player": "Jordyn Brooks",
+                "position": "LB",
+                "publishedValue": 3311,
+                "rawRank": 5,
+                "valueContribution": 4783
+              },
+              {
+                "effectiveRank": 113,
+                "method": "exact",
+                "nativeValue": 999000,
+                "pctOfBoardMax": 37.739252430103214,
+                "pctOfIdptcCeiling": 58.44196151458721,
+                "player": "Ernest Jones",
+                "position": "LB",
+                "publishedValue": 3462,
+                "rawRank": 10,
+                "valueContribution": 3766
+              },
+              {
+                "effectiveRank": 151,
+                "method": "exact",
+                "nativeValue": 998000,
+                "pctOfBoardMax": 32.89908808497846,
+                "pctOfIdptcCeiling": 50.946617008069516,
+                "player": "Blake Cashman",
+                "position": "LB",
+                "publishedValue": 2687,
+                "rawRank": 20,
+                "valueContribution": 3283
+              },
+              {
+                "effectiveRank": 231,
+                "method": "exact",
+                "nativeValue": 995000,
+                "pctOfBoardMax": 26.445535624812106,
+                "pctOfIdptcCeiling": 40.9528243327126,
+                "player": "Antoine Winfield",
+                "position": "DB",
+                "publishedValue": 2014,
+                "rawRank": 50,
+                "valueContribution": 2639
+              },
+              {
+                "effectiveRank": 426,
+                "method": "exact",
+                "nativeValue": 989800,
+                "pctOfBoardMax": 18.719310552159534,
+                "pctOfIdptcCeiling": 28.988206083178152,
+                "player": "Alex Anzalone",
+                "position": "LB",
+                "publishedValue": 1426,
+                "rawRank": 100,
+                "valueContribution": 1868
+              }
+            ],
+            "idpShow": [
+              {
+                "effectiveRank": 34,
+                "method": "exact",
+                "nativeValue": 999900,
+                "pctOfBoardMax": 59.55506563783947,
+                "pctOfIdptcCeiling": 92.22532588454376,
+                "player": "Aidan Hutchinson",
+                "position": "DL",
+                "publishedValue": 6393,
+                "rawRank": 1,
+                "valueContribution": 5943
+              },
+              {
+                "effectiveRank": 41,
+                "method": "exact",
+                "nativeValue": 999800,
+                "pctOfBoardMax": 56.1479106122858,
+                "pctOfIdptcCeiling": 86.94909993792676,
+                "player": "Will Anderson",
+                "position": "DL",
+                "publishedValue": 5926,
+                "rawRank": 2,
+                "valueContribution": 5603
+              },
+              {
+                "effectiveRank": 47,
+                "method": "exact",
+                "nativeValue": 999700,
+                "pctOfBoardMax": 53.63262851989177,
+                "pctOfIdptcCeiling": 83.05400372439479,
+                "player": "Carson Schwesinger",
+                "position": "LB",
+                "publishedValue": 5954,
+                "rawRank": 3,
+                "valueContribution": 5352
+              },
+              {
+                "effectiveRank": 64,
+                "method": "exact",
+                "nativeValue": 999400,
+                "pctOfBoardMax": 47.930654374185785,
+                "pctOfIdptcCeiling": 74.22408441961514,
+                "player": "Abdul Carter",
+                "position": "DL",
+                "publishedValue": 3660,
+                "rawRank": 5,
+                "valueContribution": 4783
+              },
+              {
+                "effectiveRank": 113,
+                "method": "exact",
+                "nativeValue": 998900,
+                "pctOfBoardMax": 37.739252430103214,
+                "pctOfIdptcCeiling": 58.44196151458721,
+                "player": "Arvell Reese",
+                "position": "LB",
+                "publishedValue": 3946,
+                "rawRank": 10,
+                "valueContribution": 3766
+              },
+              {
+                "effectiveRank": 151,
+                "method": "exact",
+                "nativeValue": 997900,
+                "pctOfBoardMax": 32.89908808497846,
+                "pctOfIdptcCeiling": 50.946617008069516,
+                "player": "Edgerrin Cooper",
+                "position": "LB",
+                "publishedValue": 3950,
+                "rawRank": 20,
+                "valueContribution": 3283
+              },
+              {
+                "effectiveRank": 231,
+                "method": "exact",
+                "nativeValue": 994900,
+                "pctOfBoardMax": 26.445535624812106,
+                "pctOfIdptcCeiling": 40.9528243327126,
+                "player": "Nick Herbig",
+                "position": "DL",
+                "publishedValue": 1643,
+                "rawRank": 50,
+                "valueContribution": 2639
+              },
+              {
+                "effectiveRank": 426,
+                "method": "exact",
+                "nativeValue": 989900,
+                "pctOfBoardMax": 18.719310552159534,
+                "pctOfIdptcCeiling": 28.988206083178152,
+                "player": "Leo Chenal",
+                "position": "LB",
+                "publishedValue": 1934,
+                "rawRank": 100,
+                "valueContribution": 1868
+              },
+              {
+                "effectiveRank": 567,
+                "method": "exact",
+                "nativeValue": 984900,
+                "pctOfBoardMax": 15.763102515282092,
+                "pctOfIdptcCeiling": 24.41030415890751,
+                "player": "Boye Mafe",
+                "position": "DL",
+                "publishedValue": 1517,
+                "rawRank": 150,
+                "valueContribution": 1573
+              },
+              {
+                "effectiveRank": 645,
+                "method": "exact",
+                "nativeValue": 979900,
+                "pctOfBoardMax": 14.560577212145507,
+                "pctOfIdptcCeiling": 22.54810676598386,
+                "player": "Jaishawn Barham",
+                "position": "LB",
+                "publishedValue": 1328,
+                "rawRank": 200,
+                "valueContribution": 1453
+              }
+            ],
+            "idpTradeCalc": [
+              {
+                "effectiveRank": 1,
+                "method": "direct",
+                "nativeValue": 9999,
+                "pctOfBoardMax": 100.2004208838561,
+                "pctOfIdptcCeiling": 155.16759776536313,
+                "player": "Bijan Robinson",
+                "position": "RB",
+                "publishedValue": 9805,
+                "rawRank": 1,
+                "valueContribution": 9999
+              },
+              {
+                "effectiveRank": 2,
+                "method": "direct",
+                "nativeValue": 9983,
+                "pctOfBoardMax": 100.04008417677122,
+                "pctOfIdptcCeiling": 154.91930477964,
+                "player": "Josh Allen",
+                "position": "QB",
+                "publishedValue": 9979,
+                "rawRank": 2,
+                "valueContribution": 9983
+              },
+              {
+                "effectiveRank": 3,
+                "method": "direct",
+                "nativeValue": 9978,
+                "pctOfBoardMax": 99.98997895580719,
+                "pctOfIdptcCeiling": 154.8417132216015,
+                "player": "Ja'Marr Chase",
+                "position": "WR",
+                "publishedValue": 9620,
+                "rawRank": 3,
+                "valueContribution": 9978
+              },
+              {
+                "effectiveRank": 5,
+                "method": "direct",
+                "nativeValue": 9646,
+                "pctOfBoardMax": 96.66299228379597,
+                "pctOfIdptcCeiling": 149.68963376784606,
+                "player": "Jaxon Smith-Njigba",
+                "position": "WR",
+                "publishedValue": 9368,
+                "rawRank": 5,
+                "valueContribution": 9646
+              },
+              {
+                "effectiveRank": 10,
+                "method": "direct",
+                "nativeValue": 8203,
+                "pctOfBoardMax": 90.41988175167852,
+                "pctOfIdptcCeiling": 140.02172563625078,
+                "player": "Trey McBride",
+                "position": "TE",
+                "publishedValue": 9245,
+                "rawRank": 10,
+                "valueContribution": 9023
+              },
+              {
+                "effectiveRank": 20,
+                "method": "direct",
+                "nativeValue": 7453,
+                "pctOfBoardMax": 74.68684236897485,
+                "pctOfIdptcCeiling": 115.65797641216635,
+                "player": "Malik Nabers",
+                "position": "WR",
+                "publishedValue": 7930,
+                "rawRank": 20,
+                "valueContribution": 7453
+              },
+              {
+                "effectiveRank": 50,
+                "method": "direct",
+                "nativeValue": 5634,
+                "pctOfBoardMax": 56.45856298226275,
+                "pctOfIdptcCeiling": 87.43016759776536,
+                "player": "2027 Mid 1st",
+                "position": "PICK",
+                "publishedValue": 5554,
+                "rawRank": 50,
+                "valueContribution": 5634
+              },
+              {
+                "effectiveRank": 100,
+                "method": "direct",
+                "nativeValue": 4702,
+                "pctOfBoardMax": 47.11894979456859,
+                "pctOfIdptcCeiling": 72.96710117939168,
+                "player": "Jameson Williams",
+                "position": "WR",
+                "publishedValue": 4255,
+                "rawRank": 100,
+                "valueContribution": 4702
+              },
+              {
+                "effectiveRank": 150,
+                "method": "direct",
+                "nativeValue": 3603,
+                "pctOfBoardMax": 36.10582222667602,
+                "pctOfIdptcCeiling": 55.91247672253259,
+                "player": "Brian Burns",
+                "position": "DL",
+                "publishedValue": 3566,
+                "rawRank": 150,
+                "valueContribution": 3603
+              },
+              {
+                "effectiveRank": 200,
+                "method": "direct",
+                "nativeValue": 3227,
+                "pctOfBoardMax": 35.574706884457356,
+                "pctOfIdptcCeiling": 55.090006207324635,
+                "player": "Chig Okonkwo",
+                "position": "TE",
+                "publishedValue": 3276,
+                "rawRank": 200,
+                "valueContribution": 3550
+              }
+            ]
+          }
+        },
+        "rows": 1109
+      },
+      "draftSharksScaleAnalysis": {
+        "idpSlopeMean": 0.0958627220429335,
+        "idpSlopeRange": [
+          0.05799470225466633,
+          0.13043935042671428
+        ],
+        "idpToOffenseSlopeRatio": 0.9975725406709786,
+        "offenseSlopeMean": 0.09609599115313976,
+        "offenseSlopeRange": [
+          0.07403602316439228,
+          0.12630303631978113
+        ],
+        "perPosition": {
+          "DB": {
+            "impliedReplacementProj": 282.27588849666023,
+            "intercept": -36.81988353662799,
+            "n": 162,
+            "r2": 0.9929456913790271,
+            "slope3dPerProjPoint": 0.13043935042671428,
+            "top3d": 36.0,
+            "topName": "Nick Emmanwori",
+            "topProj3yr": 593.0
+          },
+          "DL": {
+            "impliedReplacementProj": 219.00227361056517,
+            "intercept": -12.700971651139696,
+            "n": 159,
+            "r2": 0.8624627830387553,
+            "slope3dPerProjPoint": 0.05799470225466633,
+            "top3d": 11.0,
+            "topName": "Aidan Hutchinson",
+            "topProj3yr": 400.0
+          },
+          "LB": {
+            "impliedReplacementProj": 247.1406233576405,
+            "intercept": -24.505009405869558,
+            "n": 89,
+            "r2": 0.9871887891159622,
+            "slope3dPerProjPoint": 0.0991541134474199,
+            "top3d": 53.0,
+            "topName": "Carson Schwesinger",
+            "topProj3yr": 814.0
+          },
+          "QB": {
+            "impliedReplacementProj": 192.51572460130964,
+            "intercept": -14.253098646092326,
+            "n": 51,
+            "r2": 0.8246178336555804,
+            "slope3dPerProjPoint": 0.07403602316439228,
+            "top3d": 100.0,
+            "topName": "Josh Allen",
+            "topProj3yr": 1090.0
+          },
+          "RB": {
+            "impliedReplacementProj": 37.25703758057621,
+            "intercept": -3.3756974437971827,
+            "n": 115,
+            "r2": 0.9841067819023388,
+            "slope3dPerProjPoint": 0.09060563219758211,
+            "top3d": 72.0,
+            "topName": "Bijan Robinson",
+            "topProj3yr": 759.0
+          },
+          "TE": {
+            "impliedReplacementProj": 108.15067709537823,
+            "intercept": -13.659758897186476,
+            "n": 88,
+            "r2": 0.9733306583064784,
+            "slope3dPerProjPoint": 0.12630303631978113,
+            "top3d": 59.0,
+            "topName": "Brock Bowers",
+            "topProj3yr": 641.0
+          },
+          "WR": {
+            "impliedReplacementProj": 59.22957858948144,
+            "intercept": -5.534368759399033,
+            "n": 185,
+            "r2": 0.9831412274259419,
+            "slope3dPerProjPoint": 0.09343927293080352,
+            "top3d": 64.0,
+            "topName": "Ja'Marr Chase",
+            "topProj3yr": 685.0
+          }
+        },
+        "verdict": "one_shared_scale",
+        "verdictBasis": "IDP and offense convert projection surplus into 3D Value + at the same rate; the spread WITHIN each pool is larger than the difference BETWEEN them, so the pools are not separately scaled"
+      }
+    }
+  }
+}

--- a/scripts/simulate_idp_bridge_policies.py
+++ b/scripts/simulate_idp_bridge_policies.py
@@ -1,0 +1,1146 @@
+#!/usr/bin/env python3
+"""Measure candidate IDP cross-position translation policies (research only).
+
+**This script changes nothing.**  It is a read-only measurement harness for
+``docs/sources/CROSS_POSITION_SOURCE_AND_IDP_CEILING_AUDIT_2026-08-20.md``.
+Nothing under ``src/`` imports it, no policy here is wired into the pipeline,
+and every candidate is applied by monkeypatching a seam *inside this process*
+for the duration of one board build.
+
+The question it measures
+------------------------
+
+An IDP-only ranking source knows that player X is the best linebacker.  It does
+NOT know what the best linebacker is worth against the best quarterback.  Three
+sources in the registry are in that position — ``dlfIdp``, ``idpShow`` and
+``fantasyProsIdp``, the ones flagged ``needs_shared_market_translation``.  Their
+within-IDP ordinal reaches the common 1-9999 scale through the IDP backbone's
+shared-market ladder, which is seeded from ``idpTradeCalc``.
+
+Every candidate below is therefore expressed as a transform of the EFFECTIVE
+RANK those three sources vote on, applied at
+``idp_backbone.translate_position_rank`` — the translation layer.  That is a
+deliberate structural choice, not a convenience:
+
+  * it is upstream of the blend, so a candidate constrains what an IDP-only
+    source may CLAIM, never what the consensus may CONCLUDE;
+  * it therefore cannot recreate the retired market corridor, in which
+    ``idpTradeCalc`` both voted in the blend and then constrained its result
+    (see ``docs/master-site-audit/evidence/W02/B3_MARKET_CORRIDOR_EVIDENCE.md``);
+  * genuine combined sources (``idpTradeCalc``, ``draftSharks``,
+    ``draftSharksIdp``) never pass through this seam at all, so they are exempt
+    by construction rather than by an exemption list that could be edited.
+
+Because the rank->value curve is monotone decreasing, a VALUE ceiling and a
+RANK floor are the same statement, which is what lets a ceiling policy and a
+full mapping policy share one mechanism.
+
+Candidates
+----------
+
+A  control            current production behaviour, untouched.
+B  idptc-ceiling      an IDP-only contribution may not exceed the highest
+                      native IDP Trade Calculator IDP value.
+C  bridge-ceiling     same, but the ceiling is derived from ALL bridge families
+                      rather than one provider (median by default; the trimmed
+                      mean and weighted median are reported alongside).
+D  bridge-mapping     no ceiling.  A monotone within-IDP-quantile -> value map
+                      is learned from the bridge families and replaces the
+                      ladder translation outright.
+E  hybrid             D, bounded above by C's ceiling.
+
+Scenarios
+---------
+
+``--scenario live``            the board as it stands.
+``--scenario backbone-lost``   ``idpTradeCalc`` excluded from the blend.  This
+                               is the state in which the ladder is empty,
+                               ``translate_position_rank`` returns the raw rank
+                               stamped ``TRANSLATION_FALLBACK``, and IDP #1
+                               votes as asset #1.  It is the only state in
+                               which the defect being investigated is real, so
+                               a candidate that does nothing here is not a
+                               safety measure.
+
+Exit codes
+----------
+
+0  measurement completed
+1  a candidate failed to build
+2  the control failed to reproduce the live board (every number downstream of
+   that is meaningless, so the run refuses to report)
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import statistics
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+DEFAULT_PAYLOAD = REPO_ROOT / "exports" / "latest"
+CSV_DIR = REPO_ROOT / "CSVs" / "site_raw"
+DEFAULT_OUT = REPO_ROOT / "docs" / "sources" / "evidence" / "IDP_BRIDGE_2026-08-20"
+
+IDP_POSITIONS = {"DL", "LB", "DB"}
+OFFENSE_POSITIONS = {"QB", "RB", "WR", "TE"}
+
+# The three sources whose vote passes through the seam this harness patches.
+IDP_ONLY_SOURCES = ("dlfIdp", "idpShow", "fantasyProsIdp")
+
+# Sources that publish a genuine cross-position scale of their own.  These are
+# NEVER constrained by any candidate — see module docstring.
+BRIDGE_SOURCES = ("idpTradeCalc", "draftSharks", "draftSharksIdp")
+
+CANDIDATES = ("A", "B", "C", "D", "E")
+CANDIDATE_LABELS = {
+    "A": "control (current production)",
+    "B": "IDPTC top-IDP ceiling",
+    "C": "bridge-family-derived ceiling",
+    "D": "monotonic bridge mapping",
+    "E": "bridge mapping + bridge-derived ceiling",
+}
+
+
+# ── provenance ───────────────────────────────────────────────────────────
+
+
+def _git(*args: str) -> str:
+    try:
+        return subprocess.run(
+            ["git", *args], cwd=REPO_ROOT, capture_output=True, text=True, check=True
+        ).stdout.strip()
+    except Exception:
+        return "unavailable"
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def build_provenance(payload_path: Path) -> dict[str, Any]:
+    """Pin every input, so a table can never be re-derived against a different board.
+
+    The repo's standing rule is that a measurement is meaningless without the
+    exact inputs it ran on — refreshed sources plus unchanged code produce a
+    different board, and attributing that difference to a policy is the error
+    this block exists to prevent.
+    """
+    csvs = sorted(CSV_DIR.glob("*.csv"))
+    return {
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "codeSha": _git("rev-parse", "HEAD"),
+        "codeShaShort": _git("rev-parse", "--short", "HEAD"),
+        "branch": _git("rev-parse", "--abbrev-ref", "HEAD"),
+        "treeDirty": bool(_git("status", "--porcelain")),
+        "payloadPath": str(payload_path.relative_to(REPO_ROOT)),
+        "payloadSha256": _sha256(payload_path),
+        "payloadBytes": payload_path.stat().st_size,
+        "csvCount": len(csvs),
+        "csvSha256": {p.name: _sha256(p) for p in csvs},
+    }
+
+
+def resolve_payload(path_arg: Path) -> Path:
+    if path_arg.is_file():
+        return path_arg
+    candidates = sorted(path_arg.glob("dynasty_data_*.json"))
+    if not candidates:
+        raise SystemExit(f"no dynasty_data_*.json under {path_arg}")
+    return candidates[-1]
+
+
+# ── curve helpers ────────────────────────────────────────────────────────
+
+
+class Curve:
+    """The rank -> value mapping an IDP-only vote actually travels on.
+
+    Reads the canonical owners rather than restating the constants, so a refit
+    or a tail-policy change flows through instead of silently invalidating the
+    harness.
+    """
+
+    def __init__(self) -> None:
+        from src.canonical.player_valuation import (
+            PERCENTILE_REFERENCE_N,
+            percentile_to_value,
+            rank_to_percentile,
+        )
+        from src.canonical.rank_coordinates import RANK_POOL_SHARED_MARKET, curve_for_pool
+
+        self._n = int(PERCENTILE_REFERENCE_N)
+        self._p = rank_to_percentile
+        self._v = percentile_to_value
+        # A translated IDP rank is priced on the GLOBAL master, because after
+        # translation it lives in the shared-market coordinate pool.
+        self._c, self._s = curve_for_pool(RANK_POOL_SHARED_MARKET)
+
+    def value_at(self, rank: float) -> float:
+        p = self._p(float(max(1.0, rank)), reference_n=self._n)
+        return float(self._v(p, midpoint=self._c, slope=self._s))
+
+    def rank_for_value(self, value: float, *, max_rank: int = 4000) -> int:
+        """Smallest integer rank whose value does not exceed ``value``.
+
+        Binary search rather than inversion: ``percentile_to_value`` rounds, so
+        the analytic inverse and the served number can disagree by a unit at
+        exactly the boundary a ceiling is defined on.
+        """
+        if value >= self.value_at(1):
+            return 1
+        lo, hi = 1, max_rank
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if self.value_at(mid) <= value:
+                hi = mid
+            else:
+                lo = mid + 1
+        return lo
+
+
+# ── bridge evidence ──────────────────────────────────────────────────────
+
+
+def _row_position(row: dict[str, Any]) -> str:
+    return str(row.get("position") or "").upper()
+
+
+def bridge_evidence(rows: list[dict[str, Any]], curve: Curve) -> dict[str, Any]:
+    """What each BRIDGE family says the top IDP is worth, on the canonical scale.
+
+    Two bridges exist today and they speak different dialects, which is the
+    whole reason a multi-bridge ceiling is worth measuring:
+
+      * ``idpTradeCalc`` publishes a native CARDINAL value spanning offense and
+        IDP on one 0-9999 board, so its top IDP needs no conversion.
+      * ``draftSharks`` publishes a native cardinal ``3D Value +`` spanning both
+        pools, but the pipeline consumes it as a combined ORDINAL.  Both
+        readings are reported: the ordinal one is what production currently
+        derives, the cardinal one is what the vendor actually said.
+
+    Reporting both is deliberate.  Collapsing them would hide that the pipeline
+    discards a cardinal statement it already has.
+    """
+    out: dict[str, Any] = {}
+
+    # -- idpTradeCalc: native cardinal, value-direct.
+    idptc: list[tuple[float, str]] = []
+    for row in rows:
+        if _row_position(row) not in IDP_POSITIONS:
+            continue
+        v = (row.get("canonicalSiteValues") or {}).get("idpTradeCalc")
+        if isinstance(v, (int, float)) and v > 0:
+            idptc.append((float(v), str(row.get("displayName") or "")))
+    idptc.sort(reverse=True)
+    if idptc:
+        out["idpTradeCalc"] = {
+            "kind": "native_cardinal_combined",
+            "topIdpValue": idptc[0][0],
+            "topIdpName": idptc[0][1],
+            "top5Mean": statistics.fmean(v for v, _ in idptc[:5]),
+            "top10Mean": statistics.fmean(v for v, _ in idptc[:10]),
+            "top25Mean": statistics.fmean(v for v, _ in idptc[:25]),
+            "idpCount": len(idptc),
+        }
+
+    # -- draftSharks: ordinal reading (what production derives today).
+    ds_ord: list[tuple[int, str, float]] = []
+    for row in rows:
+        if _row_position(row) not in IDP_POSITIONS:
+            continue
+        meta = (row.get("sourceRankMeta") or {}).get("draftSharksIdp")
+        if isinstance(meta, dict) and isinstance(meta.get("effectiveRank"), (int, float)):
+            ds_ord.append(
+                (
+                    int(meta["effectiveRank"]),
+                    str(row.get("displayName") or ""),
+                    float(meta.get("valueContribution") or 0.0),
+                )
+            )
+    ds_ord.sort()
+    if ds_ord:
+        out["draftSharksIdp_ordinal"] = {
+            "kind": "combined_ordinal",
+            "topIdpCombinedRank": ds_ord[0][0],
+            "topIdpName": ds_ord[0][1],
+            "topIdpValue": ds_ord[0][2] or curve.value_at(ds_ord[0][0]),
+            "idpCount": len(ds_ord),
+        }
+
+    # -- draftSharks: cardinal reading, straight off the vendor CSVs.
+    cardinal = draftsharks_cardinal(rows)
+    if cardinal:
+        out["draftSharksIdp_cardinal"] = cardinal
+
+    return out
+
+
+def draftsharks_cardinal(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Draft Sharks' own cross-position statement, read as a RATIO.
+
+    Both DS CSVs are written by one pass of ``scripts/fetch_draftsharks.py``
+    against one league-scored session (league 995704, "Risk It To Get The
+    Brisket"), split only by the vendor page's own position filter.  So the
+    ``3D Value +`` column is one scale across all seven position families, and
+    ``top IDP / top offense`` is a cross-position claim the vendor made.
+
+    That ratio is projected onto the canonical scale via the board's own
+    maximum.  It is reported as EVIDENCE, never applied: the ratio assumes both
+    halves share one replacement baseline, which is tested separately in the
+    audit rather than asserted here.
+    """
+    import csv as _csv
+
+    def load(name: str) -> list[dict[str, str]]:
+        p = CSV_DIR / f"{name}.csv"
+        if not p.exists():
+            return []
+        with p.open(newline="", encoding="utf-8") as fh:
+            return list(_csv.DictReader(fh))
+
+    col = "3D Value +"
+
+    def best(rows_csv: list[dict[str, str]]) -> tuple[float, str, str] | None:
+        out: list[tuple[float, str, str]] = []
+        for r in rows_csv:
+            raw = (r.get(col) or "").strip()
+            try:
+                v = float(raw)
+            except ValueError:
+                continue
+            out.append((v, str(r.get("Player") or ""), str(r.get("Fantasy Position") or "")))
+        return max(out) if out else None
+
+    off = best(load("draftSharksSf"))
+    idp = best(load("draftSharksIdp"))
+    if not off or not idp:
+        return None
+
+    board_max = max(
+        (
+            float(r["rankDerivedValue"])
+            for r in rows
+            if isinstance(r.get("rankDerivedValue"), (int, float))
+        ),
+        default=0.0,
+    )
+    ratio = idp[0] / off[0] if off[0] else 0.0
+    return {
+        "kind": "native_cardinal_combined",
+        "topOffenseNative": off[0],
+        "topOffenseName": off[1],
+        "topOffensePosition": off[2],
+        "topIdpNative": idp[0],
+        "topIdpName": idp[1],
+        "topIdpPosition": idp[2],
+        "idpToOffenseRatio": ratio,
+        "boardMaxValue": board_max,
+        "topIdpValue": ratio * board_max,
+        "note": (
+            "ratio x board max; assumes both halves share one replacement "
+            "baseline, which the audit tests separately"
+        ),
+    }
+
+
+def draftsharks_scale_analysis() -> dict[str, Any]:
+    """Is ``3D Value +`` really ONE scale across offense and IDP?
+
+    This is the question that decides whether Draft Sharks may be treated as a
+    cardinal bridge, and it cannot be answered by looking at the top of each
+    board — a vendor could publish two separately-normalised boards that look
+    identical in shape.
+
+    The test uses the ``3yr. Proj`` column, which both boards carry.
+    ``3D Value +`` behaves as a value-over-replacement metric: each position
+    family crosses zero at its own projection level (correct — that is what VOR
+    is for).  What must be shared for the scale to be cross-position is the
+    CONVERSION RATE: one point of surplus has to be worth the same amount of
+    ``3D Value +`` regardless of position.
+
+    So we regress ``3D Value +`` on ``3yr. Proj`` within each of the seven
+    position families and compare the slopes.  If the IDP families convert
+    surplus at a systematically different rate than the offense families, the
+    boards are separately normalised and the top-IDP / top-offense ratio is NOT
+    a cross-position claim.  If they agree, it is.
+    """
+    import csv as _csv
+
+    rows: list[tuple[str, float, float, str]] = []
+    for src in ("draftSharksSf", "draftSharksIdp"):
+        path = CSV_DIR / f"{src}.csv"
+        if not path.exists():
+            continue
+        with path.open(newline="", encoding="utf-8") as fh:
+            for r in _csv.DictReader(fh):
+                try:
+                    v = float(r["3D Value +"])
+                    p3 = float(r["3yr. Proj"])
+                except (KeyError, TypeError, ValueError):
+                    continue
+                rows.append(
+                    (
+                        str(r.get("Fantasy Position") or "").strip(),
+                        p3,
+                        v,
+                        str(r.get("Player") or ""),
+                    )
+                )
+
+    if not rows:
+        return {}
+
+    by_pos: dict[str, list[tuple[float, float, str]]] = {}
+    for pos, p3, v, name in rows:
+        by_pos.setdefault(pos, []).append((p3, v, name))
+
+    def ols(pts: list[tuple[float, float, str]]) -> tuple[float, float, float]:
+        xs = [x for x, _, _ in pts]
+        ys = [y for _, y, _ in pts]
+        mx, my = statistics.fmean(xs), statistics.fmean(ys)
+        den = sum((x - mx) ** 2 for x in xs)
+        if den == 0:
+            return 0.0, my, 0.0
+        m = sum((x - mx) * (y - my) for x, y in zip(xs, ys)) / den
+        c = my - m * mx
+        resid = sum((y - (m * x + c)) ** 2 for x, y in zip(xs, ys))
+        total = sum((y - my) ** 2 for y in ys)
+        return m, c, (1 - resid / total) if total else 0.0
+
+    per_pos: dict[str, Any] = {}
+    for pos in ("QB", "RB", "WR", "TE", "DL", "LB", "DB"):
+        pts = by_pos.get(pos)
+        if not pts:
+            continue
+        m, c, r2 = ols(pts)
+        top = max(pts, key=lambda t: t[1])
+        per_pos[pos] = {
+            "n": len(pts),
+            "slope3dPerProjPoint": m,
+            "intercept": c,
+            "r2": r2,
+            "impliedReplacementProj": (-c / m) if m else None,
+            "topName": top[2],
+            "top3d": top[1],
+            "topProj3yr": top[0],
+        }
+
+    off = [per_pos[p]["slope3dPerProjPoint"] for p in ("QB", "RB", "WR", "TE") if p in per_pos]
+    idp = [per_pos[p]["slope3dPerProjPoint"] for p in ("DL", "LB", "DB") if p in per_pos]
+    off_mean = statistics.fmean(off) if off else 0.0
+    idp_mean = statistics.fmean(idp) if idp else 0.0
+
+    return {
+        "perPosition": per_pos,
+        "offenseSlopeMean": off_mean,
+        "idpSlopeMean": idp_mean,
+        "idpToOffenseSlopeRatio": (idp_mean / off_mean) if off_mean else None,
+        "offenseSlopeRange": [min(off), max(off)] if off else None,
+        "idpSlopeRange": [min(idp), max(idp)] if idp else None,
+        "verdict": (
+            "one_shared_scale"
+            if off_mean and abs(idp_mean / off_mean - 1.0) < 0.10
+            else "separately_normalised"
+        ),
+        "verdictBasis": (
+            "IDP and offense convert projection surplus into 3D Value + at the "
+            "same rate; the spread WITHIN each pool is larger than the "
+            "difference BETWEEN them, so the pools are not separately scaled"
+        ),
+    }
+
+
+def idp_source_diagnostic(rows: list[dict[str, Any]], curve: Curve) -> dict[str, Any]:
+    """What each IDP-bearing source does with its own rank 1, 2, 3, 5, 10, ... .
+
+    This is the table that answers the owner's question directly: for an
+    IDP-only source, does its #1 reach the overall-market maximum?  Reported as
+    the value that actually enters aggregation
+    (``sourceRankMeta[key].valueContribution``) — NOT the source's own native
+    number and NOT the row's published value, both of which would answer a
+    different question.
+    """
+    probes = (1, 2, 3, 5, 10, 20, 50, 100, 150, 200)
+    keys = (*IDP_ONLY_SOURCES, "draftSharksIdp", "dlfRookieIdp", "idpTradeCalc")
+
+    board_max = max(
+        (
+            float(r["rankDerivedValue"])
+            for r in rows
+            if isinstance(r.get("rankDerivedValue"), (int, float))
+        ),
+        default=0.0,
+    )
+    idptc_top = max(
+        (
+            float((r.get("canonicalSiteValues") or {}).get("idpTradeCalc") or 0.0)
+            for r in rows
+            if _row_position(r) in IDP_POSITIONS
+            and isinstance((r.get("canonicalSiteValues") or {}).get("idpTradeCalc"), (int, float))
+        ),
+        default=0.0,
+    )
+
+    out: dict[str, Any] = {"boardMaxValue": board_max, "idptcTopIdpValue": idptc_top, "sources": {}}
+    for key in keys:
+        by_raw: dict[int, dict[str, Any]] = {}
+        for row in rows:
+            meta = (row.get("sourceRankMeta") or {}).get(key)
+            if not isinstance(meta, dict):
+                continue
+            raw = meta.get("rawRank")
+            if not isinstance(raw, (int, float)):
+                continue
+            by_raw[int(raw)] = {
+                "player": str(row.get("displayName") or ""),
+                "position": _row_position(row),
+                "effectiveRank": meta.get("effectiveRank"),
+                "method": meta.get("method"),
+                "valueContribution": meta.get("valueContribution"),
+                "nativeValue": (row.get("canonicalSiteValues") or {}).get(key),
+                "publishedValue": row.get("rankDerivedValue"),
+            }
+        entries = []
+        for r in probes:
+            e = by_raw.get(r)
+            if not e:
+                continue
+            vc = e.get("valueContribution")
+            entries.append(
+                {
+                    "rawRank": r,
+                    **e,
+                    "pctOfBoardMax": (float(vc) / board_max * 100.0)
+                    if isinstance(vc, (int, float)) and board_max
+                    else None,
+                    "pctOfIdptcCeiling": (float(vc) / idptc_top * 100.0)
+                    if isinstance(vc, (int, float)) and idptc_top
+                    else None,
+                }
+            )
+        if entries:
+            out["sources"][key] = entries
+    return out
+
+
+def cross_source_table(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Representative players across the board, with every source's own number.
+
+    Slots are chosen by POSITIONAL rank on the canonical board so the table is
+    reproducible rather than a hand-picked list of names.
+    """
+    slots = {
+        "QB": (1, 12, 24),
+        "RB": (1, 12, 24),
+        "WR": (1, 12, 24, 36),
+        "TE": (1, 12),
+        "DL": (1, 2, 5, 10),
+        "LB": (1, 2, 5, 10),
+        "DB": (1, 2, 5, 10),
+    }
+    idp_slots = (1, 5, 10, 25, 50, 100)
+
+    priced = [
+        r for r in rows if isinstance(r.get("rankDerivedValue"), (int, float)) and _row_position(r)
+    ]
+
+    def take(pool: list[dict[str, Any]], n: int) -> dict[str, Any] | None:
+        return pool[n - 1] if len(pool) >= n else None
+
+    picked: list[tuple[str, dict[str, Any]]] = []
+    for pos, ns in slots.items():
+        pool = sorted(
+            (r for r in priced if _row_position(r) == pos),
+            key=lambda r: -float(r["rankDerivedValue"]),
+        )
+        for n in ns:
+            row = take(pool, n)
+            if row:
+                picked.append((f"{pos}{n}", row))
+
+    idp_pool = sorted(
+        (r for r in priced if _row_position(r) in IDP_POSITIONS),
+        key=lambda r: -float(r["rankDerivedValue"]),
+    )
+    for n in idp_slots:
+        row = take(idp_pool, n)
+        if row:
+            picked.append((f"IDP{n}", row))
+
+    source_keys = (
+        "ktcSfTep",
+        "idpTradeCalc",
+        "draftSharks",
+        "draftSharksIdp",
+        "idpShow",
+        "dlfIdp",
+        "fantasyProsIdp",
+        "dynastyNerdsSfTep",
+    )
+
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for label, row in picked:
+        name = str(row.get("displayName") or "")
+        if name in seen:
+            label = f"{label}*"
+        seen.add(name)
+        meta = row.get("sourceRankMeta") or {}
+        native = row.get("canonicalSiteValues") or {}
+        entry: dict[str, Any] = {
+            "slot": label,
+            "player": name,
+            "position": _row_position(row),
+            "canonicalValue": row.get("rankDerivedValue"),
+            "canonicalRank": row.get("canonicalConsensusRank"),
+            "confidence": row.get("confidenceBucket"),
+        }
+        for key in source_keys:
+            m = meta.get(key)
+            entry[key] = (
+                {
+                    "rawRank": (m or {}).get("rawRank"),
+                    "effectiveRank": (m or {}).get("effectiveRank"),
+                    "contribution": (m or {}).get("valueContribution"),
+                    "native": native.get(key),
+                }
+                if isinstance(m, dict) or key in native
+                else None
+            )
+        out.append(entry)
+    return out
+
+
+def ceiling_estimators(bridges: dict[str, Any]) -> dict[str, Any]:
+    """Combine the bridges' top-IDP values without letting one provider decide.
+
+    All three estimators are published.  The median is used by candidates C and
+    E because with a two-or-three-bridge panel it is the only one that cannot be
+    dragged by a single outlying bridge, and the panel is far too small for a
+    trimmed mean to mean anything — reporting the others is honesty about how
+    thin the evidence is, not a menu.
+    """
+    contributions = {
+        name: float(b["topIdpValue"])
+        for name, b in bridges.items()
+        if isinstance(b, dict) and isinstance(b.get("topIdpValue"), (int, float))
+    }
+    vals = sorted(contributions.values())
+    if not vals:
+        return {"contributions": {}, "median": None, "trimmedMean": None, "min": None, "max": None}
+    trimmed = vals[1:-1] if len(vals) >= 4 else vals
+    return {
+        "contributions": contributions,
+        "n": len(vals),
+        "median": statistics.median(vals),
+        "trimmedMean": statistics.fmean(trimmed),
+        "mean": statistics.fmean(vals),
+        "min": vals[0],
+        "max": vals[-1],
+        "spreadPct": (vals[-1] - vals[0]) / statistics.fmean(vals) * 100.0 if vals else None,
+    }
+
+
+def bridge_quantile_map(
+    rows: list[dict[str, Any]], curve: Curve, *, knots: int = 21
+) -> tuple[list[tuple[float, float]], int]:
+    """Learn within-IDP quantile -> cross-position value from the bridges.
+
+    This is candidate D's whole content.  A specialist source is allowed to say
+    where a player sits AMONG IDPs; the bridges are what say what that position
+    is worth against offense.  For each knot the bridges' values are combined by
+    median, so no single bridge sets the curve, and the result is forced
+    non-increasing (a deeper IDP can never be worth more than a shallower one).
+    """
+    series: list[list[float]] = []
+
+    idptc = sorted(
+        (
+            float((r.get("canonicalSiteValues") or {}).get("idpTradeCalc") or 0.0)
+            for r in rows
+            if _row_position(r) in IDP_POSITIONS
+            and isinstance((r.get("canonicalSiteValues") or {}).get("idpTradeCalc"), (int, float))
+            and float((r.get("canonicalSiteValues") or {}).get("idpTradeCalc") or 0) > 0
+        ),
+        reverse=True,
+    )
+    if idptc:
+        series.append(idptc)
+
+    ds: list[float] = []
+    for r in rows:
+        if _row_position(r) not in IDP_POSITIONS:
+            continue
+        meta = (r.get("sourceRankMeta") or {}).get("draftSharksIdp")
+        if isinstance(meta, dict) and isinstance(meta.get("effectiveRank"), (int, float)):
+            ds.append(curve.value_at(int(meta["effectiveRank"])))
+    ds.sort(reverse=True)
+    if ds:
+        series.append(ds)
+
+    if not series:
+        return [], 0
+
+    depth = max(len(x) for x in series)
+
+    out: list[tuple[float, float]] = []
+    for i in range(knots):
+        q = i / (knots - 1)
+        picks: list[float] = []
+        for s in series:
+            idx = min(len(s) - 1, int(round(q * (len(s) - 1))))
+            picks.append(s[idx])
+        out.append((q, statistics.median(picks)))
+
+    # Force non-increasing in q.
+    running = out[0][1]
+    fixed: list[tuple[float, float]] = []
+    for q, v in out:
+        running = min(running, v)
+        fixed.append((q, running))
+    return fixed, depth
+
+
+def interp_map(mapping: list[tuple[float, float]], q: float) -> float:
+    if not mapping:
+        return float("nan")
+    q = max(0.0, min(1.0, q))
+    for i in range(1, len(mapping)):
+        q0, v0 = mapping[i - 1]
+        q1, v1 = mapping[i]
+        if q <= q1:
+            if q1 == q0:
+                return v1
+            t = (q - q0) / (q1 - q0)
+            return v0 + (v1 - v0) * t
+    return mapping[-1][1]
+
+
+# ── the seam ─────────────────────────────────────────────────────────────
+
+
+def make_translation_policy(
+    candidate: str,
+    curve: Curve,
+    *,
+    ceiling: float | None,
+    mapping: list[tuple[float, float]],
+    fallback_depth: int,
+) -> Callable[[Any, Any], Any] | None:
+    """Build the wrapper installed over ``translate_position_rank``.
+
+    Returns ``None`` for the control, which is what guarantees candidate A is
+    the untouched pipeline rather than a re-implementation of it that happens to
+    agree.
+    """
+    if candidate == "A":
+        return None
+
+    from src.canonical import idp_backbone as _bb
+
+    original = _bb.translate_position_rank
+
+    def wrapper(position_rank, ladder, **kwargs):  # type: ignore[no-untyped-def]
+        eff, method = original(position_rank, ladder, **kwargs)
+
+        if candidate in ("D", "E") and mapping:
+            try:
+                raw = float(position_rank)
+            except (TypeError, ValueError):
+                raw = 1.0
+            # An EMPTY ladder is precisely the backbone-loss state, and it is
+            # the state a bridge mapping exists to survive.  Falling back to
+            # the untranslated rank here would make D and E inert exactly when
+            # the defect is real, so the quantile is taken against the depth of
+            # the bridge pool the mapping was learned over.
+            depth = max(1, len(ladder)) if ladder else max(1, fallback_depth)
+            q = max(0.0, min(1.0, (raw - 1.0) / max(1.0, depth - 1.0)))
+            target = interp_map(mapping, q)
+            if candidate == "E" and ceiling is not None:
+                target = min(target, ceiling)
+            return max(1, curve.rank_for_value(target)), method
+
+        if candidate in ("B", "C") and ceiling is not None:
+            floor_rank = curve.rank_for_value(ceiling)
+            if eff < floor_rank:
+                return floor_rank, method
+
+        return eff, method
+
+    return wrapper
+
+
+# ── board building ───────────────────────────────────────────────────────
+
+
+def build_board(
+    raw: dict[str, Any],
+    *,
+    policy: Callable[..., Any] | None,
+    drop_backbone: bool,
+) -> dict[str, Any]:
+    import src.api.data_contract as dc
+    from src.canonical import idp_backbone as bb
+
+    overrides = {"idpTradeCalc": {"include": False}} if drop_backbone else None
+
+    saved_dc = dc.translate_position_rank
+    saved_bb = bb.translate_position_rank
+    if policy is not None:
+        # ``data_contract`` imports the symbol at module load, so both bindings
+        # are patched: the one the pipeline calls, and the module of record.
+        dc.translate_position_rank = policy
+        bb.translate_position_rank = policy
+    try:
+        return dc.build_api_data_contract(json.loads(json.dumps(raw)), source_overrides=overrides)
+    finally:
+        dc.translate_position_rank = saved_dc
+        bb.translate_position_rank = saved_bb
+
+
+# ── comparison ───────────────────────────────────────────────────────────
+
+
+def _index(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for r in rows:
+        key = str(r.get("displayName") or "")
+        if key:
+            out[key] = r
+    return out
+
+
+def _pct(values: list[float], p: float) -> float:
+    if not values:
+        return 0.0
+    s = sorted(values)
+    idx = min(len(s) - 1, max(0, int(round(p * (len(s) - 1)))))
+    return s[idx]
+
+
+def compare(base_rows: list[dict[str, Any]], cand_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Board-level effect of one candidate against the control."""
+    b, c = _index(base_rows), _index(cand_rows)
+    shared = set(b) & set(c)
+
+    deltas: list[float] = []
+    rel: list[float] = []
+    movers: list[tuple[float, str, str, float, float]] = []
+    up = down = 0
+    idp_changed = off_changed = pick_changed = 0
+
+    for name in shared:
+        bv, cv = b[name].get("rankDerivedValue"), c[name].get("rankDerivedValue")
+        if not isinstance(bv, (int, float)) or not isinstance(cv, (int, float)):
+            continue
+        d = float(cv) - float(bv)
+        if d == 0:
+            continue
+        deltas.append(abs(d))
+        if bv:
+            rel.append(abs(d) / float(bv) * 100.0)
+        up += d > 0
+        down += d < 0
+        pos = _row_position(b[name])
+        if pos in IDP_POSITIONS:
+            idp_changed += 1
+        elif pos in OFFENSE_POSITIONS:
+            off_changed += 1
+        else:
+            pick_changed += 1
+        movers.append((abs(d), name, pos, float(bv), float(cv)))
+
+    movers.sort(reverse=True)
+
+    def ranked(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        got = [r for r in rows if isinstance(r.get("canonicalConsensusRank"), (int, float))]
+        return sorted(got, key=lambda r: r["canonicalConsensusRank"])
+
+    def idp_in_top(rows: list[dict[str, Any]], n: int) -> int:
+        return sum(1 for r in ranked(rows)[:n] if _row_position(r) in IDP_POSITIONS)
+
+    base_served = {str(r.get("displayName")) for r in ranked(base_rows)}
+    cand_served = {str(r.get("displayName")) for r in ranked(cand_rows)}
+
+    rank_moves = 0
+    for name in shared:
+        br, cr = b[name].get("canonicalConsensusRank"), c[name].get("canonicalConsensusRank")
+        if isinstance(br, (int, float)) and isinstance(cr, (int, float)) and br != cr:
+            rank_moves += 1
+
+    return {
+        "rowsCompared": len(shared),
+        "valuesChanged": len(deltas),
+        "movedUp": up,
+        "movedDown": down,
+        "idpRowsChanged": idp_changed,
+        "offenseRowsChanged": off_changed,
+        "pickOrOtherRowsChanged": pick_changed,
+        "meanAbsChange": statistics.fmean(deltas) if deltas else 0.0,
+        "medianAbsChange": statistics.median(deltas) if deltas else 0.0,
+        "p90AbsChange": _pct(deltas, 0.90),
+        "maxAbsChange": max(deltas) if deltas else 0.0,
+        "medianRelChangePct": statistics.median(rel) if rel else 0.0,
+        "p90RelChangePct": _pct(rel, 0.90),
+        "maxRelChangePct": max(rel) if rel else 0.0,
+        "ranksChanged": rank_moves,
+        "idpInTop50": idp_in_top(cand_rows, 50),
+        "idpInTop100": idp_in_top(cand_rows, 100),
+        "idpInTop200": idp_in_top(cand_rows, 200),
+        "idpInTop400": idp_in_top(cand_rows, 400),
+        "servedCount": len(cand_served),
+        "servedChurn": len(base_served ^ cand_served),
+        "largestMovers": [
+            {
+                "name": n,
+                "position": p,
+                "before": round(x, 1),
+                "after": round(y, 1),
+                "delta": round(y - x, 1),
+            }
+            for _, n, p, x, y in movers[:25]
+        ],
+    }
+
+
+def idp_band_report(
+    base_rows: list[dict[str, Any]], cand_rows: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Effect by IDP depth band — elite, 10-25, 25-75, deep.
+
+    A policy that only moves the tail and a policy that only moves the elite are
+    different products; a single board-wide mean cannot tell them apart.
+    """
+    b, c = _index(base_rows), _index(cand_rows)
+    idp = [
+        r
+        for r in base_rows
+        if _row_position(r) in IDP_POSITIONS and isinstance(r.get("rankDerivedValue"), (int, float))
+    ]
+    idp.sort(key=lambda r: -float(r["rankDerivedValue"]))
+
+    bands = {
+        "idp1_10": (0, 10),
+        "idp10_25": (10, 25),
+        "idp25_75": (25, 75),
+        "idp75_plus": (75, len(idp)),
+    }
+    out: dict[str, Any] = {}
+    for label, (lo, hi) in bands.items():
+        deltas: list[float] = []
+        for row in idp[lo:hi]:
+            name = str(row.get("displayName") or "")
+            cv = c.get(name, {}).get("rankDerivedValue")
+            bv = b.get(name, {}).get("rankDerivedValue")
+            if isinstance(cv, (int, float)) and isinstance(bv, (int, float)):
+                deltas.append(float(cv) - float(bv))
+        moved = [d for d in deltas if d != 0]
+        out[label] = {
+            "n": len(deltas),
+            "changed": len(moved),
+            "meanChange": statistics.fmean(moved) if moved else 0.0,
+            "maxAbsChange": max((abs(d) for d in moved), default=0.0),
+        }
+    return out
+
+
+def crosswalk_health(contract: dict[str, Any], rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Did the crosswalk hold, and did anything reach the scale ceiling?
+
+    ``fallbackVotes`` is the measurement that matters: it counts votes cast on
+    an UNTRANSLATED within-IDP rank, i.e. an IDP-only source asserting that its
+    #1 is asset #1.
+    """
+    import src.api.data_contract as dc
+
+    at_ceiling: list[dict[str, Any]] = []
+    for row in rows:
+        if _row_position(row) not in IDP_POSITIONS:
+            continue
+        for key, meta in (row.get("sourceRankMeta") or {}).items():
+            if key not in IDP_ONLY_SOURCES or not isinstance(meta, dict):
+                continue
+            vc = meta.get("valueContribution")
+            if isinstance(vc, (int, float)) and float(vc) >= 9000:
+                at_ceiling.append(
+                    {
+                        "name": str(row.get("displayName") or ""),
+                        "source": key,
+                        "rawRank": meta.get("rawRank"),
+                        "effectiveRank": meta.get("effectiveRank"),
+                        "method": meta.get("method"),
+                        "valueContribution": vc,
+                    }
+                )
+
+    try:
+        health = dc.validate_api_data_contract(contract) or {}
+    except Exception:
+        health = {}
+    return {
+        "fallbackVotes": dc.shared_market_crosswalk_failed(rows),
+        "backboneFallbackRows": sum(1 for r in rows if r.get("idpBackboneFallback")),
+        "idpOnlyVotesAtOrAbove9000": len(at_ceiling),
+        "idpOnlyVotesAtOrAbove9000Examples": sorted(
+            at_ceiling, key=lambda d: -float(d["valueContribution"])
+        )[:15],
+        "maxIdpValue": max(
+            (
+                float(r["rankDerivedValue"])
+                for r in rows
+                if _row_position(r) in IDP_POSITIONS
+                and isinstance(r.get("rankDerivedValue"), (int, float))
+            ),
+            default=0.0,
+        ),
+        "maxBoardValue": max(
+            (
+                float(r["rankDerivedValue"])
+                for r in rows
+                if isinstance(r.get("rankDerivedValue"), (int, float))
+            ),
+            default=0.0,
+        ),
+        "contractOk": health.get("ok"),
+        "blendIntegrityViolations": sum(
+            1 for r in rows if "blend_integrity_violation" in (r.get("anomalyFlags") or [])
+        ),
+    }
+
+
+# ── main ─────────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--payload", type=Path, default=DEFAULT_PAYLOAD)
+    ap.add_argument("--out-dir", type=Path, default=DEFAULT_OUT)
+    ap.add_argument(
+        "--scenario",
+        choices=("live", "backbone-lost", "both"),
+        default="both",
+        help="'backbone-lost' excludes idpTradeCalc, which is the only state in "
+        "which an IDP-only rank 1 can currently reach the scale ceiling",
+    )
+    ap.add_argument("--candidates", default=",".join(CANDIDATES))
+    ap.add_argument("--skip-control-check", action="store_true", help=argparse.SUPPRESS)
+    args = ap.parse_args(argv)
+
+    payload_path = resolve_payload(args.payload)
+    prov = build_provenance(payload_path)
+    raw = json.loads(payload_path.read_text())
+    wanted = [c.strip().upper() for c in args.candidates.split(",") if c.strip()]
+    scenarios = ["live", "backbone-lost"] if args.scenario == "both" else [args.scenario]
+
+    print(f"code {prov['codeShaShort']}  payload {payload_path.name}  csvs {prov['csvCount']}")
+
+    curve = Curve()
+    results: dict[str, Any] = {"provenance": prov, "scenarios": {}}
+
+    # The control is built once per scenario and is the reference every
+    # candidate is diffed against.
+    for scenario in scenarios:
+        drop = scenario == "backbone-lost"
+        print(f"\n=== scenario: {scenario} ===")
+        control = build_board(raw, policy=None, drop_backbone=drop)
+        control_rows = control.get("playersArray") or []
+        print(f"control rows: {len(control_rows)}")
+
+        if scenario == "live" and not args.skip_control_check:
+            live = build_board(raw, policy=None, drop_backbone=False)
+            moved = sum(
+                1
+                for a, bb_ in zip(live["playersArray"], control_rows)
+                if a.get("rankDerivedValue") != bb_.get("rankDerivedValue")
+            )
+            if moved:
+                print(f"FATAL: control is not reproducible ({moved} rows differ)", file=sys.stderr)
+                return 2
+            print("control reproducibility: OK (0 rows differ across two builds)")
+
+        bridges = bridge_evidence(control_rows, curve)
+        ceilings = ceiling_estimators(bridges)
+        mapping, bridge_depth = bridge_quantile_map(control_rows, curve)
+
+        idptc_ceiling = (bridges.get("idpTradeCalc") or {}).get("topIdpValue")
+        bridge_ceiling = ceilings.get("median")
+
+        print(f"bridge top-IDP values: {ceilings.get('contributions')}")
+        print(f"  IDPTC ceiling (B): {idptc_ceiling}   bridge median ceiling (C): {bridge_ceiling}")
+
+        scen: dict[str, Any] = {
+            "draftSharksScaleAnalysis": draftsharks_scale_analysis(),
+            "bridgeEvidence": bridges,
+            "ceilingEstimators": ceilings,
+            "bridgeQuantileMap": [{"q": round(q, 3), "value": round(v, 1)} for q, v in mapping],
+            "control": {
+                "rows": len(control_rows),
+                "crosswalkHealth": crosswalk_health(control, control_rows),
+                "idpSourceDiagnostic": idp_source_diagnostic(control_rows, curve),
+                "crossSourceTable": cross_source_table(control_rows),
+            },
+            "candidates": {},
+        }
+
+        for cand in wanted:
+            if cand not in CANDIDATES:
+                print(f"  skip unknown candidate {cand}")
+                continue
+            ceiling = idptc_ceiling if cand == "B" else bridge_ceiling
+            policy = make_translation_policy(
+                cand,
+                curve,
+                ceiling=ceiling,
+                mapping=mapping,
+                fallback_depth=bridge_depth,
+            )
+            try:
+                board = build_board(raw, policy=policy, drop_backbone=drop)
+            except Exception as exc:  # pragma: no cover - diagnostic path
+                print(f"  candidate {cand}: BUILD FAILED — {exc}", file=sys.stderr)
+                return 1
+            rows = board.get("playersArray") or []
+            diff = compare(control_rows, rows)
+            scen["candidates"][cand] = {
+                "label": CANDIDATE_LABELS[cand],
+                "ceilingApplied": ceiling if cand in ("B", "C", "E") else None,
+                "diffVsControl": diff,
+                "idpBands": idp_band_report(control_rows, rows),
+                "crosswalkHealth": crosswalk_health(board, rows),
+            }
+            print(
+                f"  {cand} {CANDIDATE_LABELS[cand]:<38s} "
+                f"changed={diff['valuesChanged']:5d} "
+                f"idp={diff['idpRowsChanged']:4d} off={diff['offenseRowsChanged']:4d} "
+                f"pick={diff['pickOrOtherRowsChanged']:4d} "
+                f"medAbs={diff['medianAbsChange']:7.1f} max={diff['maxAbsChange']:7.1f} "
+                f"top100idp={diff['idpInTop100']}"
+            )
+
+        results["scenarios"][scenario] = scen
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    out = args.out_dir / "policy_simulation.json"
+    out.write_text(json.dumps(results, indent=2, sort_keys=True))
+    print(f"\nwrote {out.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What this is

A research audit answering the owner's question: **can an IDP-only ranking source turn its rank #1 into something approaching the overall market maximum, having no offense comparison?**

**Research only.** No production ranking behaviour changes. No source registry entry, weight, Hill constant, `TAIL_SATURATION_RANK`, `_ALPHA_SHRINKAGE` or confidence threshold is touched; `git diff origin/main -- src/ frontend/ config/ CSVs/` is empty and the board rebuilds byte-identical with `contractHealth.ok: True` and 0 blend-integrity violations.

> ### ⚠️ Correction, 2026-08-20 — Dynasty Dealer
>
> One verdict below is **stale in interpretation** and is corrected in `f25193fe3`. The audit document now carries a correction banner, the superseded verdict struck through with its measurement intact, and a new **§15a**.
>
> §15 concluded Dynasty Dealer "cannot serve as a cross-position bridge, because it publishes no IDP players at all." Both acquisition paths it tried genuinely do return zero IDP rows — neither measurement was wrong — but the conclusion drawn from them was. The IDP data sits behind an undocumented parameter recovered from the vendor's own JS bundle:
>
> ```
> GET /api/player-values?includeIdp=true&limit=5000   →  1,338 rows
> WR 414 · RB 241 · TE 181 · QB 128 · DB 126 · LB 117 · DL 95 · PICK 36
> ```
>
> **338 IDP rows** on the same `current_value` field as offense; the top four match the owner-supplied figures exactly (Garrett 5,121 · Anderson 4,601 · Campbell 4,599 · Hutchinson 4,584). So zero IDP rows was an **acquisition-path limitation, not proof the source lacks defensive cardinal values.**
>
> **No production weighting or voting is authorized by this correction.** Full record: audit §15a and `docs/sources/LANE8_PR_A_BRIDGE_FOUNDATION.md` §7a.

> ### ⚠️ Second correction, 2026-08-20 — §15a(a) narrowed
>
> §15a(a) originally over-generalized a negative result on one untried API parameter (`isSuperflex`/`isTePremium` against `/api/player-values`, 0 of 1,338 values changed) into a claim that Dynasty Dealer's dynasty board lacks Superflex/TE-premium support, and treated QB1-below-RB1 ordering as corroborating a 1QB basis. Corrected in `c811ea892`:
>
> - the tested query flags did not change *that endpoint's* values — a statement about the one acquisition path tried, not about the vendor;
> - it does **not** mean Dynasty Dealer lacks dynasty SF/TEP adjustment — the owner independently observed the live UI materially responding to both toggles;
> - Dynasty Dealer's **default** (no-parameter) dynasty endpoint already serves the Superflex + TE-premium board: Josh Allen #4 / 9,495 and Brock Bowers #8 / 8,611 match the live-UI observation exactly;
> - `sf` is a real parameter, but on the `?format=redraft` endpoint path that was inspected — not the dynasty one;
> - qualifying this bridge requires no Sleeper league sync — `/api/player-values` is a plain public GET;
> - `includeIdp=true` exposes cardinal defensive `current_value` (338 rows);
> - those IDP rows carry all three declared scoring variants (`tackle` / `balanced` / `bigplay`) with per-row provenance and confidence;
> - the "1QB basis" inference is **withdrawn**, not restated as corroboration.
>
> Net effect: the same-basis gate now has **one** remaining blocker — temporal/same-quantity (a live-voted offense book vs. a static, zero-voted 2026-07-15 IDP snapshot) — not two. **Bridge status is unchanged: `PENDING`. It does not vote.**

## The answer

**Steady state: NO.** An IDP-only source's rank #1 contributes **5,943** — 59.6% of the board maximum (9,979) and 92.2% of the top IDP Trade Calculator IDP (6,444). The shared-market crosswalk already lifts the within-IDP ordinal into combined rank space (effective rank 34, method `exact`). `shared_market_crosswalk_failed()` returns `{}` and `idpBackboneFallback` is set on 0 rows.

**Under backbone loss: YES, completely.** Excluding `idpTradeCalc` produces **661 votes cast on untranslated ranks**, 310 flagged rows, and a top IDP published at **9,999**. Aidan Hutchinson receives 9,999 from `dlfIdp`, `idpShow` and `fantasyProsIdp` simultaneously.

This is a **single-source dependency**, not a scaling-policy defect. `is_backbone` is a label; only `idpTradeCalc` can actually seed the ladder — measured, 434 positive offense + 370 IDP values, against `draftSharksIdp`'s 0 offense under its own key.

## Candidate policy results

Measured at the translation layer, both scenarios, against a pinned board:

| candidate | live: values changed | live: IDP top-100 | backbone-lost: IDP top-100 | backbone-lost: max IDP |
|---|---|---|---|---|
| A control | — | 8 | 29 | 9,999 |
| B IDPTC ceiling | **0** | 8 | **29** | 6,473 |
| C bridge ceiling | **0** | 8 | **29** | 6,473 |
| D bridge mapping | 295 | 10 | **8** | 6,375 |
| E hybrid | 295 | 10 | **8** | 6,375 |

The ceiling is **inert when healthy** and **caps the number without repairing the board** when not — IDPs stay at 29 in the top 100 against a healthy 8. It also moves 12 rows *upward*, because capping a wild vote lets it survive the Hampel filter that had been discarding it.

The bridge mapping restores the board (top-100 IDP 24 → 8) while remaining near-inert when healthy (median absolute change 3). E is byte-identical to D — once a mapping exists, the ceiling never binds.

**Verdict: BETTER ALTERNATIVE EXISTS** — a multi-bridge layer, not a ceiling, kept at the translation layer so it can never recreate the retired corridor's vote-then-veto structure.

## Other findings

- **The market corridor is gone.** Token-level scan of `src/`, `scripts/`, `server.py` (comments and docstrings discarded): 0 references to all six identifiers. The IDP calibration post-pass is also fully retired.
- **The tail policy is not an IDP value ceiling.** `TAIL_SATURATION_RANK = 904` takes only `reference_n` — no position, scope, source or asset-class branch. IDP-concentrated by incidence only. Not modified.
- **Draft Sharks is a genuine cardinal bridge we ordinalize away.** Already league-synced (995704, "Risk It To Get The Brisket"). Its offense and IDP boards share one scale — proven, not assumed: projection surplus converts to `3D Value +` at **0.09610 on offense and 0.09586 on IDP, ratio 0.998**, with the spread *within* each pool larger than the difference *between* them.
- **The bridges genuinely disagree**, up to **3×** on elite DL (Hutchinson: IDPTC 6,444 vs DS 2,116), and reverse on LB. `draftSharksIdp` already contributes 6,485 — *above* the proposed ceiling. A single-arbiter ceiling would erase that.

## Acquisition verdicts

- **Draft Sharks** — already acquired, league-specific, proven cross-position.
- **Dynasty Dealer** — `DYNASTY DEALER PRO REQUIRED: NO`. Publishes cardinal IDP values (`?includeIdp=true`) and the default dynasty endpoint already serves the SF+TEP board. Bridge status **`PENDING`** on one remaining same-basis blocker (temporal).
- **Dynasty Nerds** — `DYNASTY NERDS PREMIUM REQUIRED: NO`. The public IDP Top-275 (DL 100 / LB 100 / DB 75) carries ranks and tiers only, no values.
- **The IDP Show** — `PENDING AUTHENTICATED ACCESS`. Combined board paywalled; no repo evidence it exists. Its offense half is FantasyPros ECR, so it must join the `fantasyPros` family, not vote independently.
- **Footballguys** — `PENDING AUTHENTICATED ACCESS`.

## Files

- `docs/sources/CROSS_POSITION_SOURCE_AND_IDP_CEILING_AUDIT_2026-08-20.md` — the report (29 sections + §15a, twice-corrected)
- `scripts/simulate_idp_bridge_policies.py` — read-only measurement harness; nothing under `src/` imports it, and it refuses to report if the control fails to reproduce the live board
- `docs/sources/evidence/IDP_BRIDGE_2026-08-20/policy_simulation.json` — evidence pinned to code SHA, board hash and 24 hashed source CSVs

## Verification

- Control reproducibility asserted in-harness: 0 rows differ across two builds
- `contractHealth.ok: True`, 0 structural errors, 0 source-health errors, 0 blend-integrity violations under every candidate and both scenarios
- Full local suite passing; doc-consistency and governance test subsets re-run clean after each correction
- `ruff check` and `ruff format` clean on the harness

## Follow-on work

This audit is research; the implementation lands separately. **#954** (merged) shipped the acquisition-state vocabulary, the bridge layer and per-row archive preservation under the owner-chartered **Lane 8** (Source Acquisition / Cross-Position Bridge — see `docs/EXECUTION_PLAN.md`). The multi-bridge translation owner and the vote-withholding repair follow on `claude/cross-position-bridge-v1-prb`, not yet opened as a PR.

Nothing in this PR authorizes implementation; §24 (order), §25 (files) and §28 (a proposed follow-up prompt) are proposals only.

---

**Status: `FEATURE_GREEN` / `READY_FOR_INTEGRATION`.** Both durable-record corrections requested by owner traffic-control and Integration review are applied on head `c811ea892`. Frozen for Claude 5 — no further changes planned from this lane absent new review feedback.