### PR TITLE
/waivers: the FAAB recommendation survives the phone, and an absent bid says why

### DIFF
--- a/frontend/__tests__/components/waivers-mobile-faab.test.jsx
+++ b/frontend/__tests__/components/waivers-mobile-faab.test.jsx
@@ -1,0 +1,141 @@
+/**
+ * `WaiverBidFigure` — the ONE renderer for a backend-stamped FAAB bid
+ * on /waivers, used by both the desktop column and the phone's inline
+ * chip.
+ *
+ * RED-FIRST, against `2bb62b996`. The component does not exist there;
+ * the board's bid lived only in a `hideBelow: "md"` column, so a phone
+ * got no bid at all.
+ *
+ * One renderer, deliberately: two copies of "how do we print a bid"
+ * is how the desktop and mobile boards would come to disagree about a
+ * dollar figure — the same class of defect as the compact-view parity
+ * break (`F-13`), where mobile and desktop rendered different numbers
+ * for the same player.
+ *
+ * It renders. It does not compute. Every figure here arrives from
+ * `src/trade/faab_engine.py` via `/api/waiver/suggestions`.
+ */
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import WaiverBidFigure from "@/components/waivers/WaiverBidFigure";
+import { waiverBidStateForRow, buildWaiverBidIndex } from "@/lib/waiver-faab";
+
+const PRICED = {
+  state: "priced",
+  bid: { reasonable: 15, aggressive: 22, lowball: 8 },
+  label: "$15",
+  reason: "",
+};
+
+describe("WaiverBidFigure — priced", () => {
+  it("headlines the backend's reasonable figure verbatim", () => {
+    render(<WaiverBidFigure entry={PRICED} />);
+    expect(screen.getByTestId("waiver-bid-figure")).toHaveTextContent("$15");
+  });
+
+  it("does not round, scale or otherwise move the number", () => {
+    render(
+      <WaiverBidFigure
+        entry={{ ...PRICED, bid: { reasonable: 37, aggressive: 53, lowball: 19 } }}
+      />,
+    );
+    expect(screen.getByTestId("waiver-bid-figure")).toHaveTextContent("$37");
+  });
+
+  it("renders a real zero as $0, not as an absence", () => {
+    // Roughly half this league's real adds cost exactly $0 — see the
+    // `bid_range` docstring in src/trade/waiver.py on why the $1 floor
+    // was deliberately not carried over. $0 is an answer.
+    render(
+      <WaiverBidFigure
+        entry={{ ...PRICED, bid: { reasonable: 0, aggressive: 0, lowball: 0 } }}
+      />,
+    );
+    const el = screen.getByTestId("waiver-bid-figure");
+    expect(el).toHaveTextContent("$0");
+    expect(el.textContent).not.toContain("—");
+  });
+
+  it("carries the lowball and aggressive ends as supporting detail", () => {
+    render(<WaiverBidFigure entry={PRICED} />);
+    const detail = screen.getByTestId("waiver-bid-detail").textContent;
+    expect(detail).toContain("8");
+    expect(detail).toContain("22");
+  });
+});
+
+describe("WaiverBidFigure — absent, with a reason", () => {
+  // Entries come from the REAL resolver, not from strings invented
+  // here. A fixture that makes up its own copy agrees with the test
+  // and with nothing else — which is how a frontend defect on this
+  // repo's last lane survived a green suite.
+  const index = buildWaiverBidIndex({
+    by_position: {
+      WR: [
+        {
+          name: "Unpriced Guy",
+          position: "WR",
+          consensusValue: 400,
+          bid: null,
+        },
+        { name: "Priced Guy", position: "WR", consensusValue: 3000, bid: { aggressive: 9, reasonable: 6, lowball: 3 } },
+      ],
+      DL: [{ name: "Two Ways", position: "DE", consensusValue: 900, bid: { aggressive: 4, reasonable: 3, lowball: 1 } }],
+      TE: [{ name: "Two Ways", position: "TE", consensusValue: 800, bid: { aggressive: 3, reasonable: 2, lowball: 1 } }],
+    },
+  });
+
+  const cases = [
+    ["unavailable", waiverBidStateForRow(null, { name: "Priced Guy", pos: "WR" })],
+    ["unpriced", waiverBidStateForRow(index, { name: "Unpriced Guy", pos: "WR" })],
+    ["ambiguous", waiverBidStateForRow(index, { name: "Two Ways", pos: null })],
+  ];
+
+  for (const [state, entry] of cases) {
+    it(`"${state}" states its reason instead of a bare dash`, () => {
+      expect(entry.state, "resolver did not produce the state under test").toBe(state);
+      render(<WaiverBidFigure entry={entry} />);
+      const el = screen.getByTestId("waiver-bid-figure");
+      expect(el.textContent.trim()).not.toBe("—");
+      expect(el.textContent.trim().length).toBeGreaterThan(1);
+      expect(el.dataset.state).toBe(state);
+      // The explanation is reachable, not merely implied by a glyph,
+      // and it is the resolver's own words.
+      expect(el.getAttribute("title")).toBe(entry.reason);
+      expect(el.getAttribute("title").length).toBeGreaterThan(20);
+    });
+  }
+
+  it("never prints a dollar sign when there is no bid", () => {
+    render(
+      <WaiverBidFigure
+        entry={waiverBidStateForRow(buildWaiverBidIndex({
+          by_position: { WR: [{ name: "Priced Guy", position: "WR", bid: { aggressive: 9, reasonable: 6, lowball: 3 } }] },
+        }), { name: "Nobody", pos: "RB" })}
+      />,
+    );
+    expect(screen.getByTestId("waiver-bid-figure").textContent).not.toContain("$");
+    expect(screen.queryByTestId("waiver-bid-detail")).toBeNull();
+  });
+});
+
+describe("the phone surface sits beside the recommendation", () => {
+  it("the inline variant is labelled so it reads as a bid, not a value", () => {
+    // Three quantities live on this page and must stay distinct
+    // (`docs/faab-model.md`): what the player is WORTH (the board's
+    // Value column / objective ceiling), what you should BID, and the
+    // posture that shapes the bid desk's recommendation. A naked "$15"
+    // beside a player's name would read as the first.
+    render(<WaiverBidFigure entry={PRICED} inline />);
+    const el = screen.getByTestId("waiver-bid-figure");
+    expect(el.textContent).toMatch(/FAAB|bid/i);
+    expect(el.className).toMatch(/faabInline/);
+  });
+
+  it("the desktop variant carries no inline class", () => {
+    render(<WaiverBidFigure entry={PRICED} />);
+    expect(screen.getByTestId("waiver-bid-figure").className).not.toMatch(/faabInline/);
+  });
+});

--- a/frontend/__tests__/waivers-mobile-faab-state.test.js
+++ b/frontend/__tests__/waivers-mobile-faab-state.test.js
@@ -1,0 +1,201 @@
+/**
+ * The FAAB recommendation must survive the mobile breakpoint, and an
+ * absent bid must say WHY.
+ *
+ * RED-FIRST. Written against `2bb62b996` (current main). Two defects
+ * are pinned here, both visible on the deployed waiver page:
+ *
+ *  1. The "Best add/drop moves" board configures its FAAB column with
+ *     `hideBelow: "md"`, which is `display: none` below 768px
+ *     (`app/ds.css` — `.ds-col-hide-md`). The board therefore shows
+ *     # / Add / Drop / Net gain / Tier on a phone and no bid at all,
+ *     while the page still offers a FAAB bid-posture control. There is
+ *     no other mobile surface for the number.
+ *
+ *  2. When no bid resolves, the cell renders a bare `—`. That single
+ *     glyph currently stands for four genuinely different facts:
+ *     bids were never fetched (no team picked, or the endpoint failed),
+ *     the backend declined to price this player, the name was
+ *     ambiguous, or the row simply is not on the backend's board.
+ *     "MISSING IS NEVER ZERO" has a sibling — missing is never
+ *     *unexplained* on a decision surface.
+ *
+ * Nothing here computes a bid. `lib/waiver-faab.js` indexes and looks
+ * up backend-stamped figures and this adds only a REASON alongside the
+ * same lookup — see that module's header for why a locally derived
+ * dollar figure is forbidden on this page.
+ */
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
+import { buildWaiverBidIndex, waiverBidStateForRow } from "@/lib/waiver-faab";
+
+const ROOT = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), "..");
+
+/** A `/api/waiver/suggestions` payload shaped like `WaiverCandidate.to_dict`
+ *  (`src/trade/waiver.py:79`): the bid triplet, or `bid: null` when the
+ *  engine priced nothing. */
+const PAYLOAD = {
+  by_position: {
+    WR: [
+      {
+        name: "Emeka Egbuka",
+        position: "WR",
+        consensusValue: 3100,
+        rank: 61,
+        isRookie: true,
+        bid: { aggressive: 22, reasonable: 15, lowball: 8 },
+      },
+      {
+        name: "Unpriced Guy",
+        position: "WR",
+        consensusValue: 400,
+        rank: null,
+        isRookie: false,
+        bid: null,
+      },
+    ],
+    // Same display name, two positions — the index suppresses the
+    // name-only fallback rather than guessing which one you meant.
+    DL: [
+      {
+        name: "Two Ways",
+        position: "DE",
+        consensusValue: 900,
+        rank: 500,
+        isRookie: false,
+        bid: { aggressive: 4, reasonable: 3, lowball: 1 },
+      },
+    ],
+    TE: [
+      {
+        name: "Two Ways",
+        position: "TE",
+        consensusValue: 800,
+        rank: 520,
+        isRookie: false,
+        bid: { aggressive: 3, reasonable: 2, lowball: 1 },
+      },
+    ],
+  },
+};
+
+describe("waiverBidStateForRow — an absent bid names its reason", () => {
+  const index = buildWaiverBidIndex(PAYLOAD);
+
+  it("reports a priced bid verbatim", () => {
+    const out = waiverBidStateForRow(index, { name: "Emeka Egbuka", pos: "WR" });
+    expect(out.state).toBe("priced");
+    expect(out.bid.reasonable).toBe(15);
+    expect(out.bid.aggressive).toBe(22);
+    expect(out.bid.lowball).toBe(8);
+  });
+
+  it("distinguishes 'bids were never fetched' from 'this player has none'", () => {
+    // No index at all: no team selected, wrong league, or the endpoint
+    // did not answer. The board is fine; the bid layer is absent.
+    expect(waiverBidStateForRow(null, { name: "Emeka Egbuka", pos: "WR" }).state).toBe(
+      "unavailable",
+    );
+    // Index present, player on it, backend declined to price him.
+    expect(waiverBidStateForRow(index, { name: "Unpriced Guy", pos: "WR" }).state).toBe(
+      "unpriced",
+    );
+    // Index present, player simply not on the backend's board.
+    expect(waiverBidStateForRow(index, { name: "Nobody At All", pos: "RB" }).state).toBe(
+      "unpriced",
+    );
+  });
+
+  it("reports an ambiguous name as ambiguous, never as a guessed bid", () => {
+    // Two different players share this display name. A row that cannot
+    // say which one it means gets a reason, not somebody else's dollars.
+    const out = waiverBidStateForRow(index, { name: "Two Ways", pos: null });
+    expect(out.state).toBe("ambiguous");
+    expect(out.bid).toBeNull();
+  });
+
+  it("never invents a figure for any non-priced state", () => {
+    for (const args of [
+      [null, { name: "Emeka Egbuka", pos: "WR" }],
+      [index, { name: "Unpriced Guy", pos: "WR" }],
+      [index, { name: "Two Ways", pos: null }],
+      [index, null],
+    ]) {
+      const out = waiverBidStateForRow(...args);
+      expect(out.state).not.toBe("priced");
+      expect(out.bid).toBeNull();
+    }
+  });
+
+  it("every state carries human-readable copy — no bare dash", () => {
+    for (const s of ["unavailable", "unpriced", "ambiguous"]) {
+      const out =
+        s === "unavailable"
+          ? waiverBidStateForRow(null, { name: "x", pos: "WR" })
+          : s === "unpriced"
+            ? waiverBidStateForRow(index, { name: "Unpriced Guy", pos: "WR" })
+            : waiverBidStateForRow(index, { name: "Two Ways", pos: null });
+      expect(out.label, `${s} needs a short label`).toBeTruthy();
+      expect(out.label).not.toBe("—");
+      expect(out.reason, `${s} needs an explanation`).toBeTruthy();
+      expect(out.reason.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe("the mobile breakpoint actually reveals the bid", () => {
+  const css = fs.readFileSync(
+    path.join(ROOT, "app/waivers/waivers.module.css"),
+    "utf8",
+  );
+
+  it("a mobile-only bid surface exists in the stylesheet", () => {
+    expect(
+      /\.faabInline\b/.test(css),
+      "no `.faabInline` rule — the phone has no surface for the bid",
+    ).toBe(true);
+  });
+
+  it("it is HIDDEN at desktop width and SHOWN below the md breakpoint", () => {
+    // Desktop keeps the dedicated sortable column; the inline chip is
+    // the phone's copy of the same number and must not double up.
+    const base = css.match(/\.faabInline\s*\{[^}]*\}/)?.[0] || "";
+    expect(base, ".faabInline has no base rule").toBeTruthy();
+    expect(/display:\s*none/.test(base), ".faabInline must be hidden by default").toBe(
+      true,
+    );
+
+    // 768px is the canonical --breakpoint-md that `hideBelow: "md"`
+    // uses in app/ds.css. Any other number here and the chip and the
+    // column would either overlap or leave a gap with no bid at all.
+    //
+    // The stylesheet holds SEVERAL `width < 768px` blocks, so scan all
+    // of them: matching only the first one tests whichever block
+    // happens to be highest in the file, which is a property of
+    // authoring order rather than of the breakpoint.
+    const blocks = [
+      ...css.matchAll(/@media\s*\(width\s*<\s*768px\s*\)\s*\{([\s\S]*?)\n\}/g),
+    ].map((m) => m[1]);
+    expect(blocks.length, "no `@media (width < 768px)` block").toBeGreaterThan(0);
+
+    // READ the declared value; do not merely assert "not none" with a
+    // lookahead. `display:\s*(?!none)` looks right and is vacuous:
+    // `\s*` backtracks to zero width, so the lookahead lands on the
+    // SPACE before `none` and trivially succeeds. Verified by mutation
+    // — flipping this very rule to `display: none` left that version
+    // of the test green, which is the defect it exists to catch.
+    const declared = blocks
+      .map((b) => b.match(/\.faabInline\s*\{[^}]*?display:[ \t]*([a-z-]+)/)?.[1])
+      .filter(Boolean);
+    expect(
+      declared.length,
+      "no `.faabInline` display declaration inside a `width < 768px` block",
+    ).toBeGreaterThan(0);
+    expect(
+      declared.some((v) => v !== "none"),
+      `below 768px \`.faabInline\` must become visible — declared: ${declared.join(", ")}`,
+    ).toBe(true);
+  });
+});

--- a/frontend/app/waivers/page.jsx
+++ b/frontend/app/waivers/page.jsx
@@ -28,7 +28,8 @@ import { useLeague } from "@/components/useLeague";
 import { useTeam } from "@/components/useTeam";
 import { useSettings } from "@/components/useSettings";
 import { useWaiverAnalysis } from "@/components/useWaiverAnalysis";
-import { waiverBidForRow } from "@/lib/waiver-faab";
+import { waiverBidStateForRow } from "@/lib/waiver-faab";
+import WaiverBidFigure from "@/components/waivers/WaiverBidFigure";
 import styles from "./waivers.module.css";
 
 // ── /waivers — the claim desk ─────────────────────────────────────────
@@ -166,14 +167,18 @@ function SummaryTiles({ summary, includeRookies }) {
 }
 
 /**
- * The backend-stamped FAAB bid for a move's add side, or null.
+ * The backend-stamped FAAB bid for a move's add side, as a STATE.
+ *
+ * Returns ``{state, bid, label, reason}`` — never a bare null, because
+ * "no bid" had four distinct causes and the board used to render all
+ * of them as one ``—``.  See ``waiverBidStateForRow``.
  *
  * Bids are produced by ``src/trade/faab_engine.py`` and reach the
  * client on ``/api/waiver/suggestions`` candidate rows as
  * ``bid: {aggressive, reasonable, lowball}`` (see
  * ``WaiverCandidate.to_dict``).  There is deliberately NO fallback
- * computation: this page renders what the backend stamped or renders
- * nothing, per the no-client-side-valuation rule.
+ * computation: this page renders what the backend stamped or says it
+ * has none, per the no-client-side-valuation rule.
  *
  * Two sources, in order:
  *   1. a bid already carried on the move/row — kept because it costs
@@ -185,30 +190,10 @@ function SummaryTiles({ summary, includeRookies }) {
  */
 function backendBid(move, faabIndex) {
   const stamped = move?.bid || move?.add?.bid || move?.add?.raw?.bid;
-  if (stamped && typeof stamped === "object") return stamped;
-  return waiverBidForRow(faabIndex, move?.add);
-}
-
-function fmtBackendBid(dollars) {
-  const n = Number(dollars);
-  return Number.isFinite(n) ? `$${Math.round(n).toLocaleString()}` : "—";
-}
-
-/**
- * Headline the reasonable bid; hold the aggressive/lowball ends in the
- * cell tooltip.  Same density trick the /rankings Fund-gap column
- * uses — a compact numeric column stays one number wide, and the
- * supporting figures are a hover away.
- */
-function FaabBidCell({ bid }) {
-  if (!bid || !Number.isFinite(Number(bid.reasonable))) {
-    return <span className="muted">—</span>;
+  if (stamped && typeof stamped === "object" && Number.isFinite(Number(stamped.reasonable))) {
+    return { state: "priced", bid: stamped, label: "", reason: "" };
   }
-  const title =
-    `Reasonable ${fmtBackendBid(bid.reasonable)} · ` +
-    `aggressive ${fmtBackendBid(bid.aggressive)} · ` +
-    `lowball ${fmtBackendBid(bid.lowball)}`;
-  return <span title={title}>{fmtBackendBid(bid.reasonable)}</span>;
+  return waiverBidStateForRow(faabIndex, move?.add);
 }
 
 function BestMovesPanel({ moves, faabIndex }) {
@@ -225,7 +210,18 @@ function BestMovesPanel({ moves, faabIndex }) {
         key: "add",
         header: "Add",
         accessor: (m) => m.add?.name,
-        render: (m) => <PlayerCell row={m.add} isRookie={m.isRookie} />,
+        // The FAAB column below carries `hideBelow: "md"`, so on a
+        // phone it is `display: none` and the board showed no bid at
+        // all — beside a page that still offers a bid-posture control.
+        // This chip is that breakpoint's surface for the SAME number,
+        // rendered by the same component, and is itself hidden at >= md
+        // so desktop is unchanged and the figure never doubles up.
+        render: (m) => (
+          <>
+            <PlayerCell row={m.add} isRookie={m.isRookie} />
+            <WaiverBidFigure entry={backendBid(m, faabIndex)} inline />
+          </>
+        ),
       },
       {
         key: "drop",
@@ -247,12 +243,12 @@ function BestMovesPanel({ moves, faabIndex }) {
         numeric: true,
         hideBelow: "md",
         accessor: (m) => {
-          const v = Number(backendBid(m, faabIndex)?.reasonable);
+          const v = Number(backendBid(m, faabIndex)?.bid?.reasonable);
           return Number.isFinite(v) ? v : null;
         },
-        render: (m) => <FaabBidCell bid={backendBid(m, faabIndex)} />,
+        render: (m) => <WaiverBidFigure entry={backendBid(m, faabIndex)} />,
         headerInfo:
-          "The recommender's reasonable bid, stamped by the backend FAAB engine — hover a figure for the aggressive and lowball ends. Blank when the backend priced no bid for that player (its board is capped per position); pick the pair in the bid desk above for a full recommendation.",
+          "The FAAB engine's bid ladder for this player, stamped by the backend: the headline is the reasonable rung, with the lowball and aggressive ends alongside. It is derived from the player's objective ceiling — what he is WORTH as a share of the league's original budget — and is not team-specific. For a recommendation that accounts for your balance, your drop side and your bid posture, use the bid desk above; posture shapes that answer, not this ladder. A row with no figure says why instead of going blank.",
       },
       {
         key: "tier",

--- a/frontend/app/waivers/waivers.module.css
+++ b/frontend/app/waivers/waivers.module.css
@@ -441,3 +441,65 @@
   font-family: var(--font-data);
   font-variant-numeric: tabular-nums;
 }
+
+/* ── FAAB bid figure (Best add/drop moves) ──────────────────────────
+   One renderer, two surfaces: the desktop column cell and the phone's
+   inline chip.  The column carries `hideBelow: "md"` — below 768px it
+   is `display: none` (app/ds.css `.ds-col-hide-md`), which is what put
+   a FAAB-posture control on a page whose board showed no bid at all on
+   a phone.  `.faabInline` is that breakpoint's replacement surface and
+   uses the SAME 768px boundary, so the two hand over exactly and never
+   overlap or leave a gap. */
+.faabFigure {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.faabAmount {
+  font-family: var(--mono);
+  font-weight: 600;
+}
+
+/* Supporting ends of the ladder.  Hidden in the dense desktop column
+   (they live in the cell's `title` there); shown inline on the phone,
+   where there is no hover to reveal them. */
+.faabDetail {
+  display: none;
+  font-size: 0.58rem;
+  color: var(--subtext);
+}
+
+/* An absence that names itself.  Quiet, but not a bare dash. */
+.faabAbsent {
+  font-size: 0.62rem;
+  color: var(--subtext);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.faabInlineLabel {
+  font-size: 0.55rem;
+  color: var(--subtext);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Desktop keeps the dedicated sortable column; the inline chip must
+   not double the number up there. */
+.faabInline {
+  display: none;
+}
+
+@media (width < 768px) {
+  .faabInline {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 4px 6px;
+    margin-top: 2px;
+  }
+  .faabInline .faabDetail {
+    display: inline;
+  }
+}

--- a/frontend/components/waivers/WaiverBidFigure.jsx
+++ b/frontend/components/waivers/WaiverBidFigure.jsx
@@ -1,0 +1,94 @@
+"use client";
+
+/**
+ * WaiverBidFigure — the ONE renderer for a backend-stamped FAAB bid on
+ * /waivers.
+ *
+ * Used twice by the "Best add/drop moves" board: once as the desktop
+ * column cell, once as the inline chip the phone gets beside each add.
+ * One component rather than two, because two printers for one dollar
+ * figure is exactly how the compact-view parity break (`F-13`) let
+ * mobile and desktop render different numbers for the same player.
+ *
+ * ── It renders; it does not compute ───────────────────────────────
+ * Every figure arrives from `src/trade/faab_engine.py` through
+ * `/api/waiver/suggestions` and is resolved by
+ * `lib/waiver-faab.js::waiverBidStateForRow`. There is no fallback
+ * arithmetic here — no scale, no cap, no floor. The deleted
+ * `computeFaabHint` (see the closing note in `lib/waiver-logic.js`) is
+ * precisely what this must never become.
+ *
+ * ── Three quantities, kept apart ──────────────────────────────────
+ * `docs/faab-model.md` separates what a player is WORTH (the objective
+ * ceiling, a share of the league's ORIGINAL budget) from what THIS
+ * team should BID, and the bid desk's posture shapes only the latter.
+ * The triplet this component prints is the engine's bid ladder off the
+ * objective ceiling (`src/trade/waiver.py::bid_range`: aggressive =
+ * ceiling × budget, reasonable = 0.70 of it, lowball = 0.35). It is
+ * NOT the posture-parameterised recommendation — that comes from
+ * `/api/waiver/faab-recommend` in the bid desk, and the suggestions
+ * endpoint neither accepts nor applies `riskPosture`. So the copy here
+ * says "FAAB bid" and points at the desk; it must not be relabelled as
+ * "your recommended bid" without the backend actually computing one
+ * per row.
+ *
+ * ── An absence states its reason ──────────────────────────────────
+ * A bare `—` stood for four different facts. `entry.state` names which
+ * one, and the label is rendered instead of the glyph.
+ */
+
+import styles from "@/app/waivers/waivers.module.css";
+
+/** Whole dollars. Unit formatting, not math — the engine already
+ *  rounded (`_round_half_up`), and rounding twice would move a
+ *  published number. */
+function fmtDollars(n) {
+  return `$${Number(n).toLocaleString()}`;
+}
+
+export default function WaiverBidFigure({ entry, inline = false }) {
+  const state = entry?.state || "unavailable";
+  const priced = state === "priced" && Number.isFinite(Number(entry?.bid?.reasonable));
+
+  const className = [
+    styles.faabFigure,
+    inline ? styles.faabInline : "",
+    priced ? "" : styles.faabAbsent,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  if (!priced) {
+    return (
+      <span
+        className={className}
+        data-testid="waiver-bid-figure"
+        data-state={state}
+        title={entry?.reason || ""}
+      >
+        {entry?.label || "Not priced"}
+      </span>
+    );
+  }
+
+  const { reasonable, aggressive, lowball } = entry.bid;
+  // The ladder ends ride along as a `title` on desktop and as visible
+  // small print inline, so a phone user is not asked to hover.
+  const detail =
+    `lowball ${fmtDollars(lowball)} · aggressive ${fmtDollars(aggressive)}`;
+
+  return (
+    <span
+      className={className}
+      data-testid="waiver-bid-figure"
+      data-state="priced"
+      title={`Reasonable ${fmtDollars(reasonable)} · ${detail}`}
+    >
+      {inline ? <span className={styles.faabInlineLabel}>FAAB bid</span> : null}
+      <span className={styles.faabAmount}>{fmtDollars(reasonable)}</span>
+      <span className={styles.faabDetail} data-testid="waiver-bid-detail">
+        {detail}
+      </span>
+    </span>
+  );
+}

--- a/frontend/lib/waiver-faab.js
+++ b/frontend/lib/waiver-faab.js
@@ -150,3 +150,68 @@ export function waiverBidForRow(index, row) {
   if (index.ambiguous.has(name)) return null;
   return index.byName.get(name) || null;
 }
+
+/**
+ * Why a row has no bid. Reported, never inferred by the caller from a
+ * null — the four situations below are genuinely different and the
+ * board used to render all of them as one `—`.
+ *
+ *   `unavailable`  no index at all: no team picked, a league mismatch,
+ *                  or the suggestions endpoint did not answer. Nothing
+ *                  is wrong with the player.
+ *   `unpriced`     the index exists and this player is not priced in
+ *                  it — either the engine declined him (`bid: null`)
+ *                  or he is off the backend's per-position board.
+ *   `ambiguous`    two candidates share this display name at different
+ *                  positions, so no bid can be attributed to this row.
+ *   `priced`       the backend stamped a figure.
+ *
+ * `unpriced` deliberately covers both "priced nothing" and "not on the
+ * board": from the reader's seat they are the same fact — the backend
+ * has no bid for this player — and splitting them would put a
+ * distinction on screen that the payload cannot actually support (an
+ * absent candidate and a `bid: null` candidate are indistinguishable
+ * once `_entryFor` has dropped both).
+ */
+const BID_STATE_COPY = {
+  unavailable: {
+    label: "No bids",
+    reason:
+      "FAAB bids have not loaded for this board. Pick your team above — bids are " +
+      "scaled to a specific manager's budget, so there is nothing to show until one " +
+      "is selected.",
+  },
+  unpriced: {
+    label: "Not priced",
+    reason:
+      "The backend FAAB engine published no bid for this player. Its board is capped " +
+      "per position, so players outside the cap are unpriced rather than worth zero.",
+  },
+  ambiguous: {
+    label: "Ambiguous",
+    reason:
+      "Two different players share this name at different positions, so no bid can be " +
+      "attributed to this row without guessing which one you mean.",
+  },
+};
+
+/**
+ * Like :func:`waiverBidForRow`, but says WHY when there is no bid.
+ *
+ * Returns ``{state, bid, label, reason}``. Computes nothing: the bid
+ * object is the backend's, and every other field is a fixed string
+ * chosen by ``state``.
+ */
+export function waiverBidStateForRow(index, row) {
+  const withCopy = (state) => ({ state, bid: null, ...BID_STATE_COPY[state] });
+  if (!index) return withCopy("unavailable");
+  if (!row) return withCopy("unpriced");
+  const name = normalizeName(row?.name || row?.displayName);
+  if (!name) return withCopy("unpriced");
+  const hit = index.byNamePos.get(`${name}|${familyOf(row?.pos || row?.position)}`);
+  if (hit) return { state: "priced", bid: hit, label: "", reason: "" };
+  if (index.ambiguous.has(name)) return withCopy("ambiguous");
+  const byName = index.byName.get(name);
+  if (byName) return { state: "priced", bid: byName, label: "", reason: "" };
+  return withCopy("unpriced");
+}


### PR DESCRIPTION
The "Best add/drop moves" board configured its FAAB column with `hideBelow: "md"` — `display: none` below 768px (`app/ds.css` → `.ds-col-hide-md`). A phone therefore got **# / Add / Drop / Net gain / Tier and no bid at all**, on a page that still offers a FAAB bid-posture control, with no other mobile surface for the number. That matches the deployed evidence exactly.

## The fix

An inline chip beside each add, below md only — **not** a sixth column pushed into a table that already scrolls horizontally at 390px, which would have made the figure technically present and practically unreachable.

`components/waivers/WaiverBidFigure.jsx` is the **one renderer** for both surfaces. Two printers for one dollar figure is how the compact-view parity break (`F-13`) let mobile and desktop show different numbers for the same player. The chip is `display: none` at ≥ md and the column keeps `hideBelow: "md"`, so the two hand over at the *same* 768px boundary — no overlap, no gap where neither shows, and **desktop is unchanged**.

**No bid math moved to the client.** Every figure still comes from `src/trade/faab_engine.py` via `/api/waiver/suggestions`. This adds a *reason* alongside the same lookup and nothing else; the deleted `computeFaabHint` stays deleted.

## An absence now states its cause

A bare `—` stood for four different facts. `waiverBidStateForRow` names which one:

| state | meaning |
|---|---|
| `unavailable` | no index — no team picked, wrong league, or the endpoint did not answer. Nothing is wrong with the player. |
| `unpriced` | the engine published no bid for him (its board is capped per position). |
| `ambiguous` | two players share the display name at different positions, so no bid can be attributed without guessing. |
| `priced` | the backend stamped a figure. |

`waiverBidForRow` is untouched for its existing callers.

## Three quantities kept apart

The column header called this *"the recommender's reasonable bid"*. That overstates it, and the corrected copy says so. The triplet is the engine's bid **ladder** off the player's objective ceiling (`src/trade/waiver.py::bid_range` — aggressive = ceiling × budget, reasonable = 0.70 of it, lowball = 0.35), i.e. what the player is **worth** as a share of the league's original budget.

It is **not** the posture-parameterised recommendation: `riskPosture` reaches `/api/waiver/faab-recommend` in the bid desk, and the suggestions endpoint neither accepts nor applies it (verified in `server.py` and `faab_engine.py`). So the copy now points at the desk for a team-specific answer rather than implying the ladder already is one. Mapping posture onto a ladder rung would have invented a semantic the backend never published.

## Proof

**RED-first at `2bb62b996`:** 7 of 7 state/CSS assertions fail, and the component file fails to resolve at all.

| mutation | guard that turns red |
|---|---|
| chip hidden at all widths (**the reported defect**) | 1 |
| chip breakpoint moved off 768px | 1 |
| absences collapsed back to a bare dash | 3 |
| ambiguous name given a guessed bid | 4 |
| a real `$0` bid treated as an absence | 1 |
| **control** | **17 pass** |

**The first mutation initially did not fail, and the guard was fixed rather than the mutation discarded.** `display:\s*(?!none)` looks correct and is vacuous: `\s*` backtracks to zero width, so the lookahead lands on the *space* before `none` and trivially succeeds. It now reads the declared value and reports it in the failure message.

## Real-browser verification (production build, both viewports)

| viewport | result |
|---|---|
| **390 px** | **32 inline chips visible** — `FAAB BID $0 / lowball $0 · aggressive $0` beside each add; both `priced` and `unpriced` states render; **0 page errors**, **0 horizontal overflow** |
| **1366 px** | 20 column figures, **0 inline chips** — desktop unchanged; unpriced rows read `NOT PRICED` where they read `—` before |

That pass earned its keep: it caught a **`faabIndex is not defined` crash that 2,235 unit tests did not** — the chip had also been inserted into `UniqueUpgradePanel`, which has no `faabIndex` in scope. Reverted there; that panel is not this unit's board.

Also confirmed the responsive rule survives the production build: Next lowers `(width < 768px)` to `(max-width:767px)`, and the hashed `.faabInline` rule is present in the emitted CSS. (`$0` figures are real — the model deliberately has no `$1` floor, and roughly half this league's real adds cost exactly nothing.)

## Gates

| gate | result |
|---|---|
| frontend suite | **142 files, 2,235 passed** |
| `next build` | clean |
| `check:bundles` | `/waivers` 37.8 / 42 KB — under budget, **no bump** |
| decision-path coercion gate | clean |

## Not claimed

No Playwright spec was added. In CI the E2E session selects no team, so `bidsEnabled` is false, no bids are fetched and no chip renders — an assertion there would be vacuous rather than protective. Making it real needs a seeded team in the E2E fixture; the browser evidence above was produced against a locally served production build with a team selected. Flagging that rather than shipping a test that cannot fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3RzLM83tcVjrziFjZmyUn

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3RzLM83tcVjrziFjZmyUn)_