### PR TITLE
V1-63: publish per-player manager concentration on Sharp Roster Percentage (W15-F009)

### DIFF
--- a/frontend/__tests__/sharp-roster-percentage-lib.test.js
+++ b/frontend/__tests__/sharp-roster-percentage-lib.test.js
@@ -6,6 +6,7 @@ import {
   buildTransparencyTiles,
   classifyEmptyState,
   describeBuySell,
+  describeManagerConcentration,
   describeTrend,
   formatCount,
   formatDelta,
@@ -40,6 +41,62 @@ describe("formatting", () => {
     expect(formatCount(null)).toBe("—");
     expect(formatTimestamp(null)).toBe("—");
     expect(formatTimestamp(0)).toBe("—");
+  });
+});
+
+// W15-F009 (inv 4.6): a per-player manager count so "N sharp rosters" does
+// not read as N independent opinions when they belong to fewer managers.
+describe("manager concentration", () => {
+  it("adds the manager count only when it differs from the roster count", () => {
+    expect(
+      formatSample({ sharpRosters: 5, eligibleRosters: 12, distinctManagers: 1 }),
+    ).toBe("5 of 12 (1 manager)");
+    expect(
+      formatSample({ sharpRosters: 4, eligibleRosters: 12, distinctManagers: 3 }),
+    ).toBe("4 of 12 (3 managers)");
+  });
+
+  it("omits the manager count when every roster belongs to a different manager", () => {
+    expect(
+      formatSample({ sharpRosters: 4, eligibleRosters: 12, distinctManagers: 4 }),
+    ).toBe("4 of 12");
+  });
+
+  it("does not touch the base sample when the backend published nothing", () => {
+    expect(formatSample({ sharpRosters: 3, eligibleRosters: 12 })).toBe("3 of 12");
+  });
+
+  it("describes concentration only when a manager holds more than one counted roster", () => {
+    expect(
+      describeManagerConcentration({
+        sharpRosters: 5,
+        distinctManagers: 1,
+        managerConcentration: 1,
+      }),
+    ).toBe(
+      "1 distinct manager behind these 5 rosters — one manager accounts for 100%.",
+    );
+    expect(
+      describeManagerConcentration({
+        sharpRosters: 4,
+        distinctManagers: 3,
+        managerConcentration: 0.5,
+      }),
+    ).toBe(
+      "3 distinct managers behind these 4 rosters — one manager accounts for 50%.",
+    );
+  });
+
+  it("returns undefined rather than a redundant note for the even case", () => {
+    expect(
+      describeManagerConcentration({
+        sharpRosters: 4,
+        distinctManagers: 4,
+        managerConcentration: 0.25,
+      }),
+    ).toBeUndefined();
+    expect(describeManagerConcentration(null)).toBeUndefined();
+    expect(describeManagerConcentration({})).toBeUndefined();
   });
 });
 

--- a/frontend/app/market/sharp-roster-percentage/page.jsx
+++ b/frontend/app/market/sharp-roster-percentage/page.jsx
@@ -26,6 +26,7 @@ import {
   buildTransparencyTiles,
   classifyEmptyState,
   describeBuySell,
+  describeManagerConcentration,
   describeTrend,
   formatCount,
   formatDelta,
@@ -246,8 +247,14 @@ export default function SharpRosterPercentagePage() {
       {
         key: "sample",
         header: "Sample",
-        headerInfo: "Rosters holding the player / eligible rosters in his calculation.",
-        render: (row) => <span className="muted">{formatSample(row)}</span>,
+        headerInfo:
+          "Rosters holding the player / eligible rosters in his calculation. " +
+          "A manager count in parens means those rosters are not all independent opinions.",
+        render: (row) => (
+          <span className="muted" title={describeManagerConcentration(row)}>
+            {formatSample(row)}
+          </span>
+        ),
         sortAccessor: (row) => row.eligibleRosters,
       },
       {

--- a/frontend/lib/sharp-roster-percentage.js
+++ b/frontend/lib/sharp-roster-percentage.js
@@ -43,12 +43,52 @@ export function formatTimestamp(ms) {
   }
 }
 
-/** `3 of 12 rosters` — the sample behind one cell, always shown. */
+/**
+ * `3 of 12 rosters` — the sample behind one cell, always shown.
+ *
+ * When the holding rosters concentrate on fewer managers than rosters
+ * (W15-F009 / inv 4.6 — one manager's several teams reading as several
+ * independent opinions), the manager count is appended so the row says
+ * so where the percentage is read, not only in the pool-wide transparency
+ * strip. Equal counts (the common case: one roster per manager) add
+ * nothing, since "N of M (N managers)" would be a redundant restatement.
+ */
 export function formatSample(row) {
   if (!row) return "—";
   const held = formatCount(row.sharpRosters);
   const total = formatCount(row.eligibleRosters);
-  return `${held} of ${total}`;
+  const base = `${held} of ${total}`;
+  if (
+    typeof row.distinctManagers === "number" &&
+    typeof row.sharpRosters === "number" &&
+    row.distinctManagers < row.sharpRosters
+  ) {
+    return `${base} (${row.distinctManagers} manager${row.distinctManagers === 1 ? "" : "s"})`;
+  }
+  return base;
+}
+
+/**
+ * Tooltip note when the rosters behind a player concentrate on one
+ * manager, else `undefined`. Backend-computed (`managerConcentration`);
+ * this only formats it.
+ */
+export function describeManagerConcentration(row) {
+  if (!row) return undefined;
+  const { distinctManagers, sharpRosters, managerConcentration } = row;
+  if (
+    typeof distinctManagers !== "number" ||
+    typeof sharpRosters !== "number" ||
+    typeof managerConcentration !== "number" ||
+    distinctManagers >= sharpRosters
+  ) {
+    return undefined;
+  }
+  const pct = Math.round(managerConcentration * 100);
+  return (
+    `${distinctManagers} distinct manager${distinctManagers === 1 ? "" : "s"} behind these ` +
+    `${sharpRosters} rosters — one manager accounts for ${pct}%.`
+  );
 }
 
 const BUY_SELL_LABELS = {

--- a/src/sharp/roster_percentage.py
+++ b/src/sharp/roster_percentage.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import logging
 import time
+from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Iterable, Sequence
@@ -592,6 +593,11 @@ def build_board(
     roster_keys = {str(r["rosterKey"]) for r in filtered}
     holders, slot_counts = _tally(filtered)
     denominators, unknown_format = _denominators(filtered)
+    # W15-F009 (inv 4.6): every ``filtered`` roster already passed the
+    # cohort-membership gate in ``eligible_rosters``, so its ``managerKey``
+    # is guaranteed present — this map is total over ``roster_keys``, not
+    # a best-effort join, and needs no "unknown manager" fallback bucket.
+    roster_manager = {str(r["rosterKey"]): str(r["managerKey"]) for r in filtered}
 
     player_index = build_player_index(contract)
     asset_catalog = _catalog_metadata(ledger_path)
@@ -652,6 +658,15 @@ def build_board(
         if meta.get("value") is None:
             unpriced += 1
 
+        # W15-F009 (inv 4.6): a player rostered by five teams belonging to
+        # one manager is not five independent opinions. ``counted`` is
+        # never empty here (every asset_id in ``holders`` has at least one
+        # holding roster), so this is always a real measurement, never an
+        # undefined ratio standing in for a missing one.
+        manager_counts = Counter(roster_manager[rk] for rk in counted)
+        distinct_managers = len(manager_counts)
+        manager_concentration = max(manager_counts.values()) / len(counted)
+
         market = market_pct.get(asset_id)
         row = {
             "assetId": asset_id,
@@ -663,6 +678,8 @@ def build_board(
             "sharpRosters": len(counted),
             "eligibleRosters": len(applicable),
             "sharpRosterPct": round(pct, 6),
+            "distinctManagers": distinct_managers,
+            "managerConcentration": round(manager_concentration, 6),
             "marketRosterPct": market,
             "sharpRosterAdvantage": (round(pct - market, 6) if market is not None else None),
             "value": meta.get("value"),

--- a/tests/sharp/test_roster_percentage.py
+++ b/tests/sharp/test_roster_percentage.py
@@ -169,6 +169,59 @@ def test_one_manager_many_leagues_contributes_one_roster_each(ledger, cohort_of)
     assert row_for(payload, "Star Receiver")["sharpRosters"] == 5
     assert payload["transparency"]["uniqueSharpManagers"] == 1
     assert payload["transparency"]["rostersPerManager"] == 5.0
+    # W15-F009 (inv 4.6): the pool-level stat above already proves this is
+    # one person, but nothing on the PER-PLAYER row said so until this
+    # field existed — an 83%-style number could read as five independent
+    # opinions with no local signal otherwise.
+    row = row_for(payload, "Star Receiver")
+    assert row["distinctManagers"] == 1
+    assert row["managerConcentration"] == 1.0
+
+
+def test_manager_concentration_reflects_independent_holders_not_just_roster_count(
+    ledger, cohort_of
+):
+    """Four managers, four rosters, one each: concentration is low, not undefined."""
+    cohort_of([f"sleeper:u{i}" for i in range(1, 5)])
+    rs.record_rosters(
+        [
+            roster("sleeper:u1", "sleeper:L1", assets=["wr1", "rb1"]),
+            roster("sleeper:u2", "sleeper:L2", assets=["wr1", "rb1"]),
+            roster("sleeper:u3", "sleeper:L3", assets=["wr1"]),
+            roster("sleeper:u4", "sleeper:L4", assets=["wr1"]),
+        ],
+        path=ledger,
+    )
+    payload = board(ledger)
+    wr = row_for(payload, "Star Receiver")
+    rb = row_for(payload, "Good Back")
+    # wr1: 4 holding rosters, 4 distinct managers, nobody dominates.
+    assert wr["distinctManagers"] == 4
+    assert wr["managerConcentration"] == 0.25
+    # rb1: 2 holding rosters (u1, u2), 2 distinct managers, still even.
+    assert rb["distinctManagers"] == 2
+    assert rb["managerConcentration"] == 0.5
+
+
+def test_manager_concentration_flags_one_person_behind_several_rosters(ledger, cohort_of):
+    """One manager's two leagues plus two independent managers: NOT three opinions."""
+    cohort_of(["sleeper:u1", "sleeper:u2", "sleeper:u3"])
+    rs.record_rosters(
+        [
+            roster("sleeper:u1", "sleeper:L1", assets=["wr1"]),
+            roster("sleeper:u1", "sleeper:L2", assets=["wr1"]),
+            roster("sleeper:u2", "sleeper:L3", assets=["wr1"]),
+            roster("sleeper:u3", "sleeper:L4", assets=["wr1"]),
+        ],
+        path=ledger,
+    )
+    payload = board(ledger)
+    wr = row_for(payload, "Star Receiver")
+    assert wr["sharpRosters"] == 4
+    assert wr["distinctManagers"] == 3
+    # u1 holds 2 of the 4 counted rosters -> the single-manager ceiling is 0.5,
+    # not 0.25 (1/4), which is what a roster-only count would imply.
+    assert wr["managerConcentration"] == 0.5
 
 
 def test_a_player_counts_once_per_roster_even_across_slots(ledger, cohort_of):


### PR DESCRIPTION
**READY FOR INTEGRATION — Claude 5 promotes/merges. I do not.** Off current `main` at `59c4ec907`.

## What this closes

`docs/OWNER_FEATURE_INVENTORY.md:132`, inv 4.6 / `W15-F009` (P1): *"No per-player manager concentration published"* — the last named blocker on **V1-63**, per Integration's own note in `docs/VERSION_1_COMPLETION_CONTRACT.md` after #927 merged. #927 fixed `personManagerQuality`'s zero-voter defect (a different row/surface); Integration correctly held V1-63 because that repair lives in `src/sharp/market.py` (the Buy/Sell Tracker), while inv 4.6 names `src/sharp/roster_percentage.py:582-625` — the **Sharp Roster Percentage** board, where one manager's five teams could render as an 83% sharp roster percentage with nothing on the row saying it's one human.

Measured before this PR, on merged `main`: `grep -i 'concentration\|distinctManager\|uniqueHuman\|managersBehind\|perPerson\|humanCount' src/sharp/roster_percentage.py` → **none**.

## What changed (5 files, +178/-4)

**`src/sharp/roster_percentage.py`** — every roster reaching this computation already passed the cohort-membership gate in `eligible_rosters()` (`roster.get("managerKey") not in cohort_manager_keys` excludes it otherwise), so the `roster_key -> manager_key` map built from `filtered` is **total**, not a best-effort join — no "unknown manager" fallback state is needed. Per player row, `Counter` over the `counted` holding rosters' manager keys yields two new fields:

- `distinctManagers` — how many separate managers hold this player
- `managerConcentration` — the single most-represented manager's share of the counted rosters

`counted` is structurally never empty for a row that exists (every `asset_id` in `holders` has ≥1 holding roster), so this is always a real measurement, never an undefined ratio standing in for a missing one.

**`frontend/lib/sharp-roster-percentage.js`** — `formatSample` appends the manager count only when it differs from the roster count (`"5 of 12 (1 manager)"`), so the common one-roster-per-manager case shows nothing redundant. New `describeManagerConcentration` supplies a tooltip. Both stay pure formatters — no division, no re-derivation (the file's own guard test scans for that).

**`frontend/app/market/sharp-roster-percentage/page.jsx`** — the Sample column gets the concentration tooltip.

## Verification

- **RED before the fix**: stashed the production change, ran the 3 new/extended tests — `KeyError: 'distinctManagers'` on all three.
- **GREEN after**: `tests/sharp/test_roster_percentage.py` 45/45.
- **Mutation-proven**: temporarily changed `manager_concentration = max(manager_counts.values()) / len(counted)` to a roster-count-only `1 / len(counted)` — `test_manager_concentration_flags_one_person_behind_several_rosters` went red (`0.25 != 0.5`, the exact "roster count alone would understate concentration" failure mode). Restored, green again.
- **Frontend**: both roster-percentage test files 33/33; full `vitest run` 2063/2063.
- `tests/sharp` + `tests/trade` on this branch: **987 passed**.
- `ruff check` / `format --check`: clean.
- `scripts/check_decision_coercions.py`: clean, no new debt (664 baseline unchanged).
- **No canonical-value surface touched** — `roster_percentage.py` sits entirely outside `_compute_unified_rankings`, so no board-influence check applies; this is Sharp-only.

## Standing prohibitions honored

Does not touch cohort qualification, scoring, or weighting; does not change any FAAB/Sharp methodology; does not weaken `/api/sharp/*` auth; does not add a second concentration mechanism (`market.py`'s `_CONCENTRATION_CAPS` — a vote-weight cap — is untouched and unrelated to this per-row transparency field). I am not marking V1-63 (or any row) VERIFIED myself — that determination, and any ledger edit, is Claude 5's.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqEBEngbUtzXsbHRYrPLkF)_