### PR TITLE
Fix prod-e2e-smoke: cold per-section fetch (~14s) vs 15s needle-text timeout

### DIFF
--- a/frontend/__tests__/e2e-public-league-cold-section-timeout.test.js
+++ b/frontend/__tests__/e2e-public-league-cold-section-timeout.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
+
+// Regression guard for the prod-e2e-smoke.yml failure reproduced
+// 2026-08-20 (run 32351289881): tests/e2e/specs/public-league.spec.js's
+// visitLeague() waited only 15_000ms for a deep-linked tab's needle
+// text after "Loading section..." cleared, but that message is
+// next/dynamic's CODE-split loading state (LeagueClient.jsx's
+// `sectionLoading`), not the section's own DATA fetch. A cold
+// per-section Next Data Cache miss (revalidate: 60s, not proactively
+// warmed — only the aggregate /api/public/league is) makes
+// build_section_payload() a live request-time cost: GET
+// /api/public/league/awards measured 13.998s cold vs 2.6s warm against
+// production the same day, leaving almost no margin inside a 15s
+// budget. This test does not re-measure production; it pins the fixed
+// timeout so nobody quietly shrinks it back toward the value that was
+// proven to fail.
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const specPath = path.resolve(
+  __dirname,
+  "../../tests/e2e/specs/public-league.spec.js",
+);
+const src = fs.readFileSync(specPath, "utf-8");
+
+function extractVisitLeagueBody(source) {
+  const start = source.indexOf("async function visitLeague(");
+  expect(
+    start,
+    "visitLeague() must still exist in public-league.spec.js",
+  ).toBeGreaterThan(-1);
+  const end = source.indexOf("\ntest.describe(", start);
+  expect(
+    end,
+    "could not find the end of visitLeague() before test.describe(",
+  ).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe("public-league.spec.js visitLeague() cold-section timeout", () => {
+  it("waits at least 30s for the deep-linked tab's needle text, not the 15s that measured failing", () => {
+    const body = extractVisitLeagueBody(src);
+    const waitForTextBlock = body.slice(body.indexOf("if (waitForText)"));
+    const match = waitForTextBlock.match(/timeout:\s*(\d+)_?(\d*)/);
+    expect(
+      match,
+      "expected a `timeout: N` option on the waitForText waitForFunction call",
+    ).not.toBeNull();
+    const timeoutMs = Number(match[1] + (match[2] || ""));
+    expect(
+      timeoutMs,
+      "the waitForText timeout regressed toward the 15000ms budget measured " +
+        "failing against production (13.998s cold-section response) — see the " +
+        "comment above the waitForFunction call in visitLeague()",
+    ).toBeGreaterThanOrEqual(30_000);
+  });
+
+  it('still waits for "Loading section..." (the code-split loader) before the needle check', () => {
+    const body = extractVisitLeagueBody(src);
+    expect(body).toContain("Loading section...");
+    const loadingSectionIdx = body.indexOf("Loading section...");
+    const waitForTextIdx = body.indexOf("if (waitForText)");
+    expect(
+      loadingSectionIdx,
+      "the code-split loading wait must run before the needle-text wait",
+    ).toBeLessThan(waitForTextIdx);
+  });
+});

--- a/tests/e2e/specs/public-league.spec.js
+++ b/tests/e2e/specs/public-league.spec.js
@@ -106,10 +106,25 @@ async function visitLeague(
     );
   }
   if (waitForText) {
+    // Measured against production 2026-08-20: a cold Next Data Cache
+    // miss on a per-section endpoint (revalidate: 60s, not proactively
+    // warmed — only the aggregate /api/public/league is, by
+    // public-league-warmup.yml) makes build_section_payload() a live
+    // request-time cost. GET /api/public/league/awards took 13.998s on
+    // a cold hit vs 2.6s warm — right at the edge of the previous
+    // 15_000ms budget, and this step runs AFTER "Loading section..."
+    // has already cleared (that message is next/dynamic's CODE-split
+    // loading state, not the section's own DATA fetch — see
+    // LeagueClient.jsx's `sectionLoading`), so the data fetch is not
+    // covered by either of the waits above it. Reproduced: run
+    // 32351289881 timed out here on tab=awards and tab=franchise&owner=
+    // while every other assertion in the same run passed. 30s matches
+    // the sibling "Loading section..." budget a few lines up and clears
+    // the measured cold-path latency with headroom.
     await page.waitForFunction(
       (needle) => document.body.innerText.includes(needle),
       waitForText,
-      { timeout: 15_000 },
+      { timeout: 30_000 },
     );
   }
   return privateHits;


### PR DESCRIPTION
## Defect

`prod-e2e-smoke.yml` ("Production E2E Smoke (public /league)") intermittently fails against real production, alternating pass/fail across many scheduled runs with no correlation to any commit — the signature of a timing budget sitting at the edge of real latency rather than a code regression.

**EXPECTED.** `tests/e2e/specs/public-league.spec.js`'s deep-link tests (`?tab=awards`, `?tab=franchise&owner=`) render their target text within `visitLeague()`'s 15s `waitForText` budget on every scheduled run.

**ACTUAL.** Run [32351289881](https://github.com/jasonleetucker-code/riskittogetthebrisket/actions/runs/32351289881) (2026-08-20 08:56 UTC, head `22e02cd3`) failed both of those tests with `TimeoutError: page.waitForFunction: Timeout 15000ms exceeded`, while the other 39 tests in the same run passed.

**REPRODUCTION.** Measured directly against production the same day:

| request | time |
|---|---|
| `GET /api/public/league` (aggregate, warmed every 20 min by `public-league-warmup.yml`) | 2.88s |
| `GET /api/public/league/overview` | 4.93s |
| `GET /api/public/league/awards` — **cold** | **13.998s** |
| `GET /api/public/league/awards` — repeat (warm) | 2.55–2.61s |

**ROOT CAUSE.** `/league?tab=X` fetches per-section data from `GET /api/public/league/<section>` (`frontend/app/league/page.jsx`), cached in Next's Data Cache with `revalidate: 60`. Only the *aggregate* `/api/public/league` endpoint is proactively warmed — `public-league-warmup.yml`'s own docstring explains this is deliberate (warming every section wasn't in scope of that change). On a cold per-section cache miss, the backend's `build_section_payload()` (`server.py::get_public_league_section`) is a live request-time cost.

`visitLeague()` already has a 30s wait for `"Loading section..."` to clear (added in a prior stabilization pass, run-142 fix), but that message is `next/dynamic`'s **code-split loading state** (`LeagueClient.jsx`'s `sectionLoading`) — it clears once the section's JS chunk loads, not once its data fetch resolves. The section's own data fetch happens after that, uncovered by either upstream wait, landing entirely inside the final 15s needle-text wait. A ~14s cold fetch leaves ~1s of margin there, which is why the failure is intermittent (cache warm → fast; cache cold → marginal/over).

## Fix

Widened the `waitForText` timeout in `visitLeague()` from 15s → 30s (`tests/e2e/specs/public-league.spec.js`), matching the sibling `"Loading section..."` budget a few lines above it, with ~2x headroom over the measured 14s worst case. No product code changed — this corrects a test assertion that assumed near-instant rendering once the loading indicator clears, an assumption the architecture (deliberate 60s per-section cache, no proactive per-section warmup) does not make.

## Regression test

`frontend/__tests__/e2e-public-league-cold-section-timeout.test.js` parses `visitLeague()` and pins the timeout at `>= 30_000`.

**Mutation-proven:** reverting the timeout to `15_000` fails the new test (`expected 15000 to be greater than or equal to 30000`); restoring `30_000` passes it again.

## Validation

- `npx vitest run --project logic` (frontend/): **85 files, 1708 tests passed**
- `node --check tests/e2e/specs/public-league.spec.js`: syntax OK
- Diff is scoped to the one test file + the one new regression test — no product code touched

## Scope discipline

One defect, one PR. While investigating this workflow I also found `retention-health.yml` has failed 9/9 runs since inception (`C1-RET-07`, identity-resolution-report collector halted since 2026-04-20). That is **not** included here: the producer script (`scripts/source_pull.py`) was deliberately deleted in `f8cb1009e` ("Retire the offline canonical pipeline"), the honest-labelling half of the acceptance bar is already done (`/api/scaffold/identity`'s `evidenceFreshness` stamp), and the remaining half — resume collection vs. formally retire the stream/scaffold endpoints — is a product/architecture decision, not a bounded causal repair. Flagging for the owner/Integration to decide rather than acting on it unilaterally.

---

`FEATURE_GREEN` / `READY_FOR_INTEGRATION`. Freezing this branch per the anti-thrashing policy — will only resume if a branch-caused failure, substantive review feedback, or an explicit Integration request comes back on it.

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3RzLM83tcVjrziFjZmyUn)_