### PR TITLE
V1-52: isolate the canonical power engine, thread the results-only lens through HTTP

### DIFF
--- a/config/coercion_baseline.json
+++ b/config/coercion_baseline.json
@@ -1,6 +1,6 @@
 {
  "note": "Known missing-data coercions on decision paths, recorded so the gate can block NEW ones while the remediation batches burn these down. Each batch deletes its findings' entries. Do not add to this file to make a build pass.",
- "count": 664,
+ "count": 663,
  "violations": [
   "frontend/lib/auction-power.js::const raw = names.map((n) => Number(totalsObj[n]) || 0);",
   "frontend/lib/bdvm.js::assetCount: _num(r?.assetCount) ?? 0,",

--- a/config/coercion_baseline.json
+++ b/config/coercion_baseline.json
@@ -483,7 +483,6 @@
   "src/ros/playoff_sim.py::str(r.get(\"ownerId\") or \"\"): float(r.get(\"teamRosStrength\") or 0.0)",
   "src/ros/power_v2.py::games = s[\"games\"] or 1",
   "src/ros/power_v2.py::score = float(r.get(\"teamRosStrength\") or 0.0)",
-  "src/ros/power_v2.py::weight_total = sum(active_weights.values()) or 1.0",
   "src/ros/scrape.py::base_weight=float(src_meta.get(\"base_weight\") or 0.0),",
   "src/ros/scrape.py::confidence=float(row.get(\"confidence\") or 1.0),",
   "src/ros/scrape.py::existing = float(row.get(\"confidence\") or 1.0)",

--- a/docs/power/V1_52_CANONICAL_POWER_ENGINE.md
+++ b/docs/power/V1_52_CANONICAL_POWER_ENGINE.md
@@ -1,0 +1,214 @@
+# V1-52 — one canonical weekly power-rankings engine
+
+Status: **IN PROGRESS.** Steps 1-4 landed; the retirement itself (step 5)
+is scoped and measured below but **not done**, and the reason is a real
+constraint rather than remaining effort.
+
+Companion to `docs/playoffs/V1_51_CANONICAL_PLAYOFF_BRACKET.md`, which
+established the precondition this unit builds on.
+
+## What was actually wrong
+
+Two engines answer "how strong is this team this week", and the site
+publishes both. The audit capture
+`docs/master-site-audit/evidence/W30/power-two-engines.json` records
+them on the same week:
+
+| engine | n | Jason |
+|---|---|---|
+| `public_league/power.py` | 10 | rank **10 of 10**, score 0.00 |
+| `ros/power_v2.py` | 12 | rank **3 of 12**, score 80.69 |
+
+mean \|rank shift\| 2.8, max 7.
+
+That capture is usually quoted for the rank shift. Reading its
+`effectiveWeights` is more damning, and it is what this unit turned on:
+
+```json
+"v2": { "preseason": true,
+        "effectiveWeights": {"team_ros_strength": 0.38, "roster_health": 0.03} }
+```
+
+So the comparison is **one week of last season's scoring percentiles**
+against **pure roster strength**. The two engines were not disagreeing
+about the answer — they were answering different questions, and nothing
+on either surface said so.
+
+Note also `n`: **10 against 12**. `power.py`'s `currentRanking` is the
+last *single week*'s ranking, so any owner who did not play that week is
+absent from the published power ranking entirely.
+
+## What the toggle actually did
+
+`settings.useRosPowerRankings` decides which engine renders the Power
+tab, and it **defaults to `true`** — so the public `/league` Power tab
+already shows `power_v2`. A comment in `LeagueClient.jsx` claimed the
+opposite ("false until validated per-user") until 2026-08-19; that
+mattered, because anyone reasoning about which ranking the site shows
+got the answer backwards.
+
+A toggle that picks an *implementation* is a champion/challenger switch
+left permanently in the UI. The destination is a toggle that picks a
+**lens** — a legitimate question about what to measure.
+
+## Steps landed
+
+### 1-2 — two lenses, and one trend
+
+`LENS_FORWARD_LOOKING` / `LENS_RESULTS_ONLY`. They are **not two
+formulas**: results-only is the same `WEIGHTS` vector with
+`team_ros_strength` declared missing and renormalised by the machinery
+that already handles an absent team-strength file, so every
+retrospective component keeps its weight *relative to the others*.
+
+The per-week trend moved into the canonical engine and runs through the
+same `_score_state` as the headline. A second scoring implementation for
+the series is how a chart ends up being a different quantity from the
+number printed beside it.
+
+The trend is **results-only at every point, including the last**.
+`team_ros_strength` is a single current snapshot with no per-week
+history, so back-filling it is the as-of defect and splicing it into
+only the final point is worse — the line would jump at the end for a
+reason unrelated to how the team played, and no reader could tell that
+from a real move.
+
+### 3 — refuse to rank when no component survives
+
+Renormalisation has a floor nobody had put in. When *every* component is
+dropped, `active_weights` is empty, `weight_total` fell back to `1.0`
+against an empty numerator, every owner scored exactly `0.0`, and the
+sort — stable over equal keys — handed out ranks `1..N` in `owner_ids`
+order. **An identifier ordering, published as a power ranking.**
+
+Reachable structurally, not rarely: results-only drops
+`team_ros_strength` by definition and preseason dropped all seven
+historical components, so the state was guaranteed for the whole
+offseason.
+
+On the committed dev snapshot it was visible and self-contradicting:
+five owners, every score `0.0`, and the published order **disagreed with
+the components printed beside it** — `owner-B` led `owner-A` on five of
+seven components and was ranked below it.
+
+Same family as the playoff-odds defect fixed in V1-51, where a
+placeholder made every matchup a tie and the third tiebreak (the
+`ownerId` string) became the answer. The coercion baseline had already
+registered the mechanism as debt — `weight_total = sum(...) or 1.0` —
+so this was a recorded hazard coming true, and the gate reports that
+entry retired.
+
+Now: no surviving component, no ranking. `powerScore` and `rank` are
+`None` — never `0.0`, which is a score a team can earn, and never
+`1..N`. An `unrankable` block names the reason and the missing inputs;
+the owners and their raw components are still listed. Same posture
+`playoff_structure` takes for an unknown bracket. The UI renders it as a
+named state rather than the "not ready, the next scrape will populate
+this" copy, which would promise numbers that are not coming.
+
+### 4 — the preseason suppression belongs to one lens
+
+`_is_preseason` dropped all seven historical-results components, and its
+docstring gave the reason: they "describe a finished year and don't
+project the upcoming one ... so the score reflects only forward-looking
+inputs". Correct for the **forward-looking** lens. Exactly backwards for
+the retrospective one, whose entire subject matter *is* the finished
+year.
+
+Step 1 added the results-only lens and it inherited a suppression
+written for the other one. The consequence was total: results-only
+already drops `team_ros_strength`, so preseason left it with nothing —
+the every-component-missing state above — while the completed seasons it
+is made of sat in the accumulators untouched.
+
+Repaired, and visible in one row on the dev snapshot: `owner-B`, ranked
+2nd on an all-zero score under the defect, is now 1st at 86.61.
+Forward-looking still refuses there, correctly — preseason with no
+team-strength file has genuinely nothing to look forward to.
+
+Mutation-checked in both directions: applying the suppression to both
+lenses again, and removing it entirely, each turn tests RED. The second
+is what stops the repair being "delete the rule".
+
+## Do the two engines agree? Measured
+
+With the lens working correctly, `power.py` versus the canonical engine
+under results-only:
+
+| fixture | mean \|rank shift\| | max | note |
+|---|---|---|---|
+| committed dev snapshot (real) | **0.00** | 0 | identical order on the 4 common owners; v2 also covers a 5th that v1 drops |
+| 12 owners, 6 weeks, monotone strength ladder | 0.33 | 1 | weak evidence by construction — a ladder makes most formulas agree |
+| adversarial: great scores, 0-6 record (schedule luck) | 0.67 | 1 | v1 has **no** W/L or streak component; v2 weights them 0.10 + 0.05 |
+
+So the retrospective quantities substantially agree, and the large
+real-world divergence in the W30 capture is the **forward-looking
+input** — which is exactly what the lens distinction names. That is the
+evidence that these are one engine's two lenses rather than two engines.
+
+**Limitation, stated rather than glossed:** two of those three fixtures
+are synthetic, and the one real artifact is a small dev snapshot. A
+comparison on the production league needs its snapshot plus the ROS
+team-strength file, neither of which exists in this environment
+(`data/` is gitignored). That measurement belongs with the retirement.
+
+## Step 5 — the retirement, and why it is not a shim
+
+`power.py` must stop being an engine. The obvious minimal move — make
+`build_section` an adapter that delegates to the canonical engine and
+renames fields — **does not work**, and it is worth recording why so it
+is not attempted again:
+
+`power.jsx` renders `components.pointsPerGame`, `components.recentAvg`
+and `components.allPlayWinPctThisWeek` as **raw values**. The canonical
+engine publishes `components.ppg` and `components.recent` as
+**percentiles**. An adapter cannot recover a raw PPG from a percentile,
+so it would have to compute one — which is a second owner again, one
+layer down, which is the defect this unit exists to remove.
+
+Shape differences, for the record:
+
+| | `power.py` | `power_v2.py` |
+|---|---|---|
+| series location | `weeks`, `seriesByOwner` (top level) | `trend.weeks`, `trend.seriesByOwner` |
+| `seriesByOwner` | list of `{ownerId, displayName, points[]}` | dict keyed by ownerId |
+| score field | `power` | `powerScore` |
+| per-row extras | `teamName`, `record`, `games`, `weekRankDelta` | `rosStrengthPercentile`, `weightsApplied` |
+
+So the retirement is **one renderer, one engine, the toggle selecting a
+lens**: `ros-power.jsx` absorbs the trend chart, `power.jsx` and
+`power.py` retire together. That changes what the Power tab *displays*
+for users on the v1 path — percentile component bars instead of raw
+PPG columns — which is a deliberate, user-visible change and needs the
+production measurement above alongside it.
+
+## Prerequisites fixed along the way
+
+* **Playoff odds published alphabetical order as certainty** — a flat
+  `[100.0]` placeholder made every matchup a tie, so the `ownerId`
+  string tiebreak decided the standings. The seven `1.0`s on the
+  committed production artifact are exactly the lexically-first seven
+  Sleeper user ids. (Shipped with V1-51, #919.)
+* **Roster health was double-counted** — once as its own 0.03 weight and
+  again inside `team_ros_strength`. Folded in (0.38 → 0.41).
+
+## A note on fixtures
+
+`_make_snapshot` never populated `roster_to_owner`, which
+`luck._season_weekly_scores` needs to attribute a matchup row to an
+owner — it **skips** rows it cannot resolve, so zero weeks scored, every
+component fell back to its neutral default, and every owner scored an
+identical `33.64` across three weeks of deliberately different points.
+
+Two of this unit's own lens tests were asserting shape while measuring
+nothing. Repaired at the shared helper, with the reason recorded there,
+because this trap cost three separate measurements in this lane before
+it was named.
+
+## Not claimed
+
+Nothing here is deployed. The refusal and the lens repair both change
+live public `/league` output the moment they ship — the refusal replaces
+a fabricated order with an honest empty state, and the lens repair gives
+the retrospective view real numbers all offseason where it previously
+had none. Both should be observed in production rather than assumed.

--- a/frontend/__tests__/components/RosPowerLensAndTrend.test.jsx
+++ b/frontend/__tests__/components/RosPowerLensAndTrend.test.jsx
@@ -1,0 +1,165 @@
+/**
+ * V1-52 — the canonical engine's results-only lens and per-week trend
+ * were shipped in the backend (power_v2.build_section) but nothing on
+ * the client ever asked for them: no lens toggle existed, and the
+ * `trend` field the engine already computes was never read. This
+ * closed two of the four named Step-5 prerequisites.
+ *
+ * The trend is RESULTS-ONLY at every point (see power_v2.py's own
+ * comment on why forward-looking has no per-week history to trend),
+ * so the delta indicator must never be described as agreeing with a
+ * forward-looking headline score — it is a distinct, always-retrospective
+ * quantity, named as such in the UI.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+
+vi.mock("@/components/ui", () => ({
+  LoadingState: ({ message }) => <div>{message}</div>,
+  EmptyState: ({ title, message }) => (
+    <div>
+      <h3>{title}</h3>
+      <p>{message}</p>
+    </div>
+  ),
+}));
+
+vi.mock("../../app/league/shared-server.jsx", () => ({
+  Card: ({ title, children }) => (
+    <section>
+      {title ? <h2>{title}</h2> : null}
+      {children}
+    </section>
+  ),
+}));
+
+function rankedPayload({ lens, ownerRank, priorRank }) {
+  return {
+    currentRanking: [
+      {
+        ownerId: "o1",
+        displayName: "Alice",
+        powerScore: 88.5,
+        rank: ownerRank,
+        components: { ppg: 0.9 },
+        rosStrengthPercentile: 0.7,
+        weightsApplied: { ppg: 0.18 },
+      },
+    ],
+    unrankable: null,
+    lens,
+    weights: { ppg: 0.18 },
+    effectiveWeights: { ppg: 0.18 },
+    missingInputs: [],
+    preseason: false,
+    trend: {
+      lens: "results_only",
+      weeks: [
+        { season: "2025", week: 1, rankings: [] },
+        { season: "2025", week: 2, rankings: [] },
+      ],
+      seriesByOwner: {
+        o1: [
+          { season: "2025", week: 1, powerScore: 70, rank: priorRank },
+          { season: "2025", week: 2, powerScore: 80, rank: ownerRank },
+        ],
+      },
+    },
+  };
+}
+
+async function renderFresh() {
+  vi.resetModules();
+  const mod = await import("../../app/league/sections/ros-power.jsx");
+  return mod.default;
+}
+
+describe("RosPowerSection — lens toggle and trend", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("fetches the default forward-looking lens with no query param", async () => {
+    const calls = [];
+    global.fetch = vi.fn((url) => {
+      calls.push(String(url));
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(rankedPayload({ lens: "forward_looking", ownerRank: 1, priorRank: 2 })),
+      });
+    });
+    const RosPowerSection = await renderFresh();
+    render(<RosPowerSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeTruthy());
+    expect(calls[0]).toBe("/api/public/league/rosPower");
+  });
+
+  it("switching to results-only re-fetches with the lens query param", async () => {
+    const calls = [];
+    global.fetch = vi.fn((url) => {
+      calls.push(String(url));
+      const lens = String(url).includes("lens=results_only") ? "results_only" : "forward_looking";
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(rankedPayload({ lens, ownerRank: 1, priorRank: 2 })),
+      });
+    });
+    const RosPowerSection = await renderFresh();
+    render(<RosPowerSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("button", { name: /results only/i }));
+
+    await waitFor(() =>
+      expect(calls.some((u) => u.includes("lens=results_only"))).toBe(true),
+    );
+  });
+
+  it("renders an up arrow when the trend series shows an improving rank", async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        // prior week rank 5, current week rank 1 -> moved up 4 spots
+        json: () => Promise.resolve(rankedPayload({ lens: "forward_looking", ownerRank: 1, priorRank: 5 })),
+      }),
+    );
+    const RosPowerSection = await renderFresh();
+    const { container } = render(<RosPowerSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeTruthy());
+    expect(container.textContent).toContain("▲");
+    expect(container.textContent).toContain("4");
+  });
+
+  it("renders a dash, not a fabricated zero, when trend history is too short", async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            currentRanking: [
+              {
+                ownerId: "o1",
+                displayName: "Alice",
+                powerScore: 88.5,
+                rank: 1,
+                components: {},
+                weightsApplied: {},
+              },
+            ],
+            unrankable: null,
+            lens: "forward_looking",
+            weights: {},
+            effectiveWeights: {},
+            missingInputs: [],
+            preseason: false,
+            trend: { lens: "results_only", weeks: [], seriesByOwner: {} },
+          }),
+      }),
+    );
+    const RosPowerSection = await renderFresh();
+    const { container } = render(<RosPowerSection />);
+    await waitFor(() => expect(screen.getByText("Alice")).toBeTruthy());
+    expect(container.textContent).not.toContain("▲");
+    expect(container.textContent).not.toContain("▼");
+  });
+});

--- a/frontend/__tests__/components/RosPowerUnrankable.test.jsx
+++ b/frontend/__tests__/components/RosPowerUnrankable.test.jsx
@@ -1,0 +1,112 @@
+/**
+ * V1-52 — "nothing to rank on" must not render as "not ready yet".
+ *
+ * The backend refuses to publish a ranking when every weighted component
+ * is unavailable, because the alternative is what it used to do: score
+ * every owner 0.0 and hand out ranks 1..N in owner-id order, an
+ * identifier ordering presented as a power ranking.
+ *
+ * On the client the two states look identical if nothing distinguishes
+ * them — both are "no numbers" — but they mean opposite things. "Not
+ * ready" promises the numbers arrive on their own; the refusal does not,
+ * and for the results-only lens in the offseason it persists until the
+ * season starts. Same argument as the unknown-playoff-bracket state.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("@/components/ui", () => ({
+  LoadingState: ({ message }) => <div>{message}</div>,
+  EmptyState: ({ title, message }) => (
+    <div>
+      <h3>{title}</h3>
+      <p>{message}</p>
+    </div>
+  ),
+}));
+
+vi.mock("../../app/league/shared-server.jsx", () => ({
+  Card: ({ title, children }) => (
+    <section>
+      {title ? <h2>{title}</h2> : null}
+      {children}
+    </section>
+  ),
+}));
+
+const UNRANKABLE = {
+  currentRanking: [
+    { ownerId: "o1", displayName: "Alice", powerScore: null, rank: null, components: {} },
+    { ownerId: "o2", displayName: "Bob", powerScore: null, rank: null, components: {} },
+  ],
+  unrankable: {
+    reason: "preseason_and_no_forward_looking_input",
+    missingInputs: ["ppg", "recent", "team_ros_strength (lens: results_only)"],
+    explanation:
+      "Every weighted component is unavailable, so there is no quantity to rank on.",
+  },
+  weights: {},
+  effectiveWeights: {},
+  missingInputs: [],
+  preseason: true,
+};
+
+async function renderWith(payload) {
+  vi.resetModules();
+  global.fetch = vi.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve(payload) }),
+  );
+  const mod = await import("../../app/league/sections/ros-power.jsx");
+  const RosPowerSection = mod.default;
+  return render(<RosPowerSection />);
+}
+
+describe("RosPowerSection — the refusal", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("names the state instead of promising the numbers are coming", async () => {
+    await renderWith(UNRANKABLE);
+    await waitFor(() => expect(screen.getByText(/Not enough to rank on/i)).toBeTruthy());
+    // The "not ready" copy promises a future scrape will populate it.
+    expect(screen.queryByText(/next scheduled scrape/i)).toBeNull();
+    expect(screen.queryByText(/ROS Power not ready/i)).toBeNull();
+  });
+
+  it("shows the reason the backend gave", async () => {
+    await renderWith(UNRANKABLE);
+    await waitFor(() => expect(screen.getByText(/no quantity to rank on/i)).toBeTruthy());
+    expect(screen.getByText(/team_ros_strength/)).toBeTruthy();
+  });
+
+  it("does not print a rank or a score for anyone", async () => {
+    const { container } = await renderWith(UNRANKABLE);
+    await waitFor(() => expect(screen.getByText(/Not enough to rank on/i)).toBeTruthy());
+    // No ranking table at all — not a table of dashes, which reads as
+    // "loading" to anyone scanning the page.
+    expect(container.querySelector("table")).toBeNull();
+  });
+
+  it("still ranks when a component survives (non-vacuity)", async () => {
+    await renderWith({
+      currentRanking: [
+        {
+          ownerId: "o1",
+          displayName: "Alice",
+          powerScore: 88.5,
+          rank: 1,
+          components: { ppg: 0.9 },
+          weightsApplied: { ppg: 0.18 },
+        },
+      ],
+      unrankable: null,
+      weights: { ppg: 0.18 },
+      effectiveWeights: { ppg: 0.18 },
+      missingInputs: [],
+      preseason: false,
+    });
+    await waitFor(() => expect(screen.getByText("Alice")).toBeTruthy());
+    expect(screen.queryByText(/Not enough to rank on/i)).toBeNull();
+  });
+});

--- a/frontend/app/league/LeagueClient.jsx
+++ b/frontend/app/league/LeagueClient.jsx
@@ -118,10 +118,13 @@ function LeaguePage({ initialContract = null, initialTab = DEFAULT_TAB }) {
   const urlTab = normalizeTabKey(searchParams.get("tab"));
   const urlOwner = searchParams.get("owner") || "";
   const urlWeek = searchParams.get("week") || "";
-  // Read the ROS feature flags so the Power tab can swap to v2 when
-  // the user opts in.  Defaults match the registry in
-  // ``components/useSettings.js`` (rosEnabled true,
-  // useRosPowerRankings false until validated per-user).
+  // Read the ROS feature flags so the Power tab can swap between the
+  // canonical engine's two lenses.  The registry in
+  // ``components/useSettings.js`` defaults ``useRosPowerRankings`` to
+  // TRUE — this comment said "false until validated per-user" until
+  // 2026-08-19, which was backwards and mattered: it meant anyone
+  // reasoning about which ranking the public /league Power tab shows
+  // got the answer wrong. It shows the forward-looking one.
   const { settings } = useSettings();
   const useRosPower = !!settings?.useRosPowerRankings;
 

--- a/frontend/app/league/sections/ros-power.jsx
+++ b/frontend/app/league/sections/ros-power.jsx
@@ -127,6 +127,42 @@ export default function RosPowerSection() {
     );
   }
   const rankings = data?.currentRanking || [];
+
+  // The engine refused to rank, and that is a DIFFERENT state from
+  // "not ready yet".  Every weighted component was unavailable, so
+  // there is no quantity to rank on — the backend withholds the score
+  // and the rank rather than publishing zeros in owner-id order.
+  //
+  // Rendering that as an empty table, or as a column of "—", would let
+  // the reader assume the data is still loading and will arrive. It is
+  // not loading: for the results-only lens in the offseason this state
+  // is structural and persists until the season starts. Say which one
+  // it is, and show the reason the backend gave.
+  const unrankable = data?.unrankable;
+  if (unrankable) {
+    return (
+      <Card title="ROS Power Rankings">
+        <EmptyState
+          title="Not enough to rank on"
+          message={
+            unrankable.explanation ||
+            "Every weighted component is unavailable, so no ranking is published."
+          }
+        />
+        {(unrankable.missingInputs || []).length > 0 && (
+          <div style={{ fontSize: "0.7rem", color: "var(--subtext)", marginTop: 8 }}>
+            Missing: {unrankable.missingInputs.join(", ")}
+          </div>
+        )}
+        {rankings.length > 0 && (
+          <div style={{ fontSize: "0.7rem", color: "var(--subtext)", marginTop: 8 }}>
+            {rankings.length} managers listed without a score.
+          </div>
+        )}
+      </Card>
+    );
+  }
+
   if (!rankings.length) {
     return (
       <Card>

--- a/frontend/app/league/sections/ros-power.jsx
+++ b/frontend/app/league/sections/ros-power.jsx
@@ -14,33 +14,60 @@ import { Card } from "../shared-server.jsx";
 
 // Module-level cache so tab-switching doesn't re-fetch on every mount.
 // Same pattern + 30-min TTL that power.jsx uses for playoff odds.
+//
+// V1-52: the canonical engine answers two lenses (forward-looking,
+// results-only) and they are genuinely different quantities, not a
+// re-sort of the same numbers — so each lens is cached and fetched
+// independently rather than sharing one slot.
 const CACHE_TTL_MS = 30 * 60 * 1000;
-const _cache = { data: null, error: null, inflight: null, fetchedAt: 0 };
+export const LENS_FORWARD_LOOKING = "forward_looking";
+export const LENS_RESULTS_ONLY = "results_only";
+const _caches = {
+  [LENS_FORWARD_LOOKING]: { data: null, error: null, inflight: null, fetchedAt: 0 },
+  [LENS_RESULTS_ONLY]: { data: null, error: null, inflight: null, fetchedAt: 0 },
+};
 
-async function _fetchRosPower() {
-  const fresh = _cache.data && Date.now() - _cache.fetchedAt < CACHE_TTL_MS;
-  if (fresh) return { data: _cache.data, error: null };
-  if (_cache.inflight) return _cache.inflight;
+async function _fetchRosPower(lens) {
+  const cache = _caches[lens] || _caches[LENS_FORWARD_LOOKING];
+  const fresh = cache.data && Date.now() - cache.fetchedAt < CACHE_TTL_MS;
+  if (fresh) return { data: cache.data, error: null };
+  if (cache.inflight) return cache.inflight;
 
-  const promise = fetch("/api/public/league/rosPower")
+  const qs = lens && lens !== LENS_FORWARD_LOOKING ? `?lens=${encodeURIComponent(lens)}` : "";
+  const promise = fetch(`/api/public/league/rosPower${qs}`)
     .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`${r.status}`))))
     .then((payload) => {
       const body = payload?.data || payload?.section || payload;
-      _cache.data = body;
-      _cache.error = null;
-      _cache.fetchedAt = Date.now();
-      _cache.inflight = null;
+      cache.data = body;
+      cache.error = null;
+      cache.fetchedAt = Date.now();
+      cache.inflight = null;
       return { data: body, error: null };
     })
     .catch((err) => {
-      _cache.inflight = null;
+      cache.inflight = null;
       const message = String(err?.message || err);
-      _cache.error = message;
-      return { data: _cache.data, error: message };
+      cache.error = message;
+      return { data: cache.data, error: message };
     });
 
-  _cache.inflight = promise;
+  cache.inflight = promise;
   return promise;
+}
+
+// Rank delta over the last two weeks of the RESULTS-ONLY trend series —
+// never mixed with the currently-selected headline lens. The trend is
+// results-only at every point by construction (see the backend's own
+// comment on why forward-looking has no per-week history to trend), so
+// diffing it against a forward-looking headline would silently compare
+// two different quantities, exactly the bug this unit exists to remove.
+function trendDelta(trend, ownerId) {
+  const series = trend?.seriesByOwner?.[ownerId];
+  if (!Array.isArray(series) || series.length < 2) return null;
+  const last = series[series.length - 1];
+  const prev = series[series.length - 2];
+  if (last?.rank == null || prev?.rank == null) return null;
+  return prev.rank - last.rank; // positive = moved up (lower rank number)
 }
 
 function fmtScore(v) {
@@ -98,14 +125,16 @@ const COMPONENT_LABELS = {
 };
 
 export default function RosPowerSection() {
-  const [data, setData] = useState(() => _cache.data);
-  const [error, setError] = useState(_cache.error);
-  const [loading, setLoading] = useState(!_cache.data);
+  const [lens, setLens] = useState(LENS_FORWARD_LOOKING);
+  const [data, setData] = useState(() => _caches[LENS_FORWARD_LOOKING].data);
+  const [error, setError] = useState(_caches[LENS_FORWARD_LOOKING].error);
+  const [loading, setLoading] = useState(!_caches[LENS_FORWARD_LOOKING].data);
   const [expanded, setExpanded] = useState(null);
 
   useEffect(() => {
     let active = true;
-    _fetchRosPower().then(({ data: d, error: e }) => {
+    setLoading(!_caches[lens]?.data);
+    _fetchRosPower(lens).then(({ data: d, error: e }) => {
       if (!active) return;
       setData(d);
       setError(e);
@@ -114,7 +143,33 @@ export default function RosPowerSection() {
     return () => {
       active = false;
     };
-  }, []);
+  }, [lens]);
+
+  const lensToggle = (
+    <div style={{ display: "flex", gap: 4, marginBottom: 8, fontSize: "0.72rem" }}>
+      {[
+        { key: LENS_FORWARD_LOOKING, label: "Forward-looking" },
+        { key: LENS_RESULTS_ONLY, label: "Results only" },
+      ].map((opt) => (
+        <button
+          key={opt.key}
+          type="button"
+          onClick={() => setLens(opt.key)}
+          aria-pressed={lens === opt.key}
+          style={{
+            padding: "3px 10px",
+            borderRadius: 4,
+            border: "1px solid var(--subtext)",
+            background: lens === opt.key ? "var(--cyan)" : "transparent",
+            color: lens === opt.key ? "#000" : "var(--subtext)",
+            cursor: "pointer",
+          }}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
 
   if (loading && !data) {
     return <LoadingState message="Loading ROS power rankings..." />;
@@ -142,6 +197,7 @@ export default function RosPowerSection() {
   if (unrankable) {
     return (
       <Card title="ROS Power Rankings">
+        {lensToggle}
         <EmptyState
           title="Not enough to rank on"
           message={
@@ -166,6 +222,7 @@ export default function RosPowerSection() {
   if (!rankings.length) {
     return (
       <Card>
+        {lensToggle}
         <EmptyState
           title="ROS Power not ready"
           message="The league snapshot or ROS roster-strength data is missing. Once the next scheduled scrape lands, this view will populate."
@@ -193,8 +250,11 @@ export default function RosPowerSection() {
         `${COMPONENT_LABELS[key] || key} (${Math.round(Number(w) * 100)}%)`,
     );
 
+  const trend = data.trend || null;
+
   return (
     <Card title="ROS Power Rankings">
+      {lensToggle}
       <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginBottom: 10 }}>
         {preseason && (
           <span style={{ color: "var(--cyan)" }}>
@@ -229,6 +289,9 @@ export default function RosPowerSection() {
             <th style={{ textAlign: "left", padding: "4px 0" }}>Owner</th>
             <th style={{ textAlign: "right", padding: "4px 8px" }}>Power</th>
             <th style={{ textAlign: "right", padding: "4px 8px" }}>ROS Pct</th>
+            <th style={{ textAlign: "right", padding: "4px 8px" }} title="Results-only rank change, last 2 weeks">
+              Trend
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -239,6 +302,7 @@ export default function RosPowerSection() {
               weights={row.weightsApplied || effectiveWeights}
               expanded={expanded === i}
               onToggle={() => setExpanded(expanded === i ? null : i)}
+              trendDeltaValue={trendDelta(trend, row.ownerId)}
             />
           ))}
         </tbody>
@@ -247,7 +311,40 @@ export default function RosPowerSection() {
   );
 }
 
-function RankingRow({ row, weights, expanded, onToggle }) {
+function TrendCell({ deltaValue }) {
+  // ``null`` covers two distinct cases the reader must not conflate: no
+  // trend history yet (< 2 weeks played) and a week where the owner was
+  // unrankable (results-only lens with nothing to score on). Neither is
+  // "flat" (delta 0), so neither renders an arrow.
+  if (deltaValue == null) {
+    return (
+      <td style={{ textAlign: "right", fontFamily: "var(--mono)", color: "var(--subtext)" }}>
+        —
+      </td>
+    );
+  }
+  if (deltaValue === 0) {
+    return (
+      <td style={{ textAlign: "right", fontFamily: "var(--mono)", color: "var(--subtext)" }}>
+        •
+      </td>
+    );
+  }
+  const up = deltaValue > 0;
+  return (
+    <td
+      style={{
+        textAlign: "right",
+        fontFamily: "var(--mono)",
+        color: up ? "var(--cyan)" : "var(--amber)",
+      }}
+    >
+      {up ? "▲" : "▼"} {Math.abs(deltaValue)}
+    </td>
+  );
+}
+
+function RankingRow({ row, weights, expanded, onToggle, trendDeltaValue }) {
   return (
     <>
       <tr style={{ cursor: "pointer" }} onClick={onToggle} title="Click for component breakdown">
@@ -268,10 +365,11 @@ function RankingRow({ row, weights, expanded, onToggle }) {
         <td style={{ textAlign: "right", fontFamily: "var(--mono)", color: "var(--subtext)" }}>
           {fmtPct(row.rosStrengthPercentile)}
         </td>
+        <TrendCell deltaValue={trendDeltaValue} />
       </tr>
       {expanded && (
         <tr>
-          <td colSpan={4} style={{ background: "rgba(255,255,255,0.02)", padding: "8px 12px" }}>
+          <td colSpan={5} style={{ background: "rgba(255,255,255,0.02)", padding: "8px 12px" }}>
             <div style={{ fontSize: "0.72rem" }}>
               {Object.entries(COMPONENT_LABELS).map(([key, label]) => (
                 <ComponentBar

--- a/server.py
+++ b/server.py
@@ -11263,6 +11263,7 @@ async def get_public_league_section(
     owner: str = "",
     refresh: str = "",
     leagueKey: str = "",
+    lens: str = "",
 ):
     """Single public-league section JSON payload.
 
@@ -11271,6 +11272,14 @@ async def get_public_league_section(
     also include a narrowed ``franchiseDetail`` block so the frontend
     can render a single franchise page without downloading every
     franchise's detail dict.
+
+    ``lens`` (V1-52) selects which of the canonical power engine's two
+    lenses the ``rosPower`` section answers with —
+    ``power_v2.LENS_FORWARD_LOOKING`` (default, matches the
+    aggregate-contract behavior) or ``power_v2.LENS_RESULTS_ONLY``.
+    Ignored for every other section.  Rejected outright rather than
+    silently falling back to the default: a typo'd lens value silently
+    answering the wrong question is worse than a 400.
 
     NOTE: the ``.csv`` variant above MUST remain registered before this
     route — FastAPI otherwise matches ``/{section}`` against
@@ -11284,6 +11293,18 @@ async def get_public_league_section(
                 "availableSections": list(PUBLIC_SECTION_KEYS),
             },
         )
+    if lens and section == "rosPower":
+        from src.ros import power_v2  # noqa: PLC0415
+
+        _valid_lenses = (power_v2.LENS_FORWARD_LOOKING, power_v2.LENS_RESULTS_ONLY)
+        if lens not in _valid_lenses:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "error": f"Unknown power lens: {lens!r}",
+                    "availableLenses": list(_valid_lenses),
+                },
+            )
     _league_err = _public_section_league_error(section, leagueKey)
     if _league_err is not None:
         return _league_err
@@ -11318,6 +11339,15 @@ async def get_public_league_section(
                 if section == "franchise" and owner:
                     detail_map = payload.get("data", {}).get("detail") or {}
                     payload["franchiseDetail"] = detail_map.get(str(owner).strip())
+                if section == "rosPower" and lens:
+                    # ``build_section_payload`` above already ran the
+                    # default (forward-looking) lens; only recompute when
+                    # a non-default lens was explicitly requested, so the
+                    # common case pays no extra cost.
+                    from src.ros import power_v2  # noqa: PLC0415
+
+                    if lens != power_v2.LENS_FORWARD_LOOKING:
+                        payload["data"] = power_v2.build_section(snapshot, lens=lens)
                 assert_public_payload_safe(payload)
                 return payload
 

--- a/src/league_intel/sim.py
+++ b/src/league_intel/sim.py
@@ -83,6 +83,8 @@ import statistics
 from dataclasses import dataclass, field
 from typing import Any, Iterable, Mapping, Sequence
 
+from src.league_intel import sim_calibration as _sim_calibration
+
 __all__ = [
     "SIM_MODEL_VERSION",
     "DEFAULT_SIM_WEEKS",
@@ -178,31 +180,35 @@ class _LegacyPointsModel:
     interface ``sim_calibration.PointsModel`` exposes.
 
     This exists so the draw model is a SEAM rather than a hardcoded
-    formula.  ``claude/league-intel-sim`` derives the real thing —
-    ``ros_value_per_point`` and the per-position CV table — from actual
-    stat lines scored under this league's own settings, replacing two
-    magic constants (a ``/2.7`` divisor tuned by eye and a CV table
-    citing a dataset named nowhere in the repo).  Its ``PointsModel``
-    already exposes ``draw(ros_value, position, rng)``; matching that
-    signature here means its calibrated model drops in as a parameter
-    with no edit to this module and no second copy of the arithmetic.
+    formula: a calibrated ``PointsModel`` drops in as the ``points_model``
+    parameter with no edit to this module.
 
-    That branch owns the schema.  This is the consumer.
+    It no longer restates the arithmetic. It used to hardcode the ``2.7``
+    divisor and import the per-position CV table from
+    ``ros/playoff_sim``, which itself held a byte-identical copy of
+    ``sim_calibration.FALLBACK_CV_BY_POSITION`` — three copies of three
+    numbers, and two implementations of one Gaussian draw. It now
+    delegates to a ``PointsModel`` built from the owner's own fallback
+    constants, which is an exact behavioural identity (pinned by
+    ``tests/league_intel/test_points_model_single_owner.py``).
+
+    What it keeps is its own ``source`` stamp. Parity of NUMBERS is not
+    parity of PROVENANCE: a run on this path must still report
+    ``legacy-constants`` rather than borrow the owner's
+    ``fallback-constants`` label, so ``pointsModelSource`` cannot claim a
+    provenance the run did not have.
     """
 
     source = "legacy-constants"
 
-    def draw(self, ros_value: float, position: str, rng: Any) -> float:
-        from src.ros.playoff_sim import (  # noqa: PLC0415
-            _DEFAULT_PLAYER_CV,
-            _PLAYER_CV_BY_POSITION,
-        )
+    def __init__(self) -> None:
+        # The owner's documented fallback — NOT a calibrated artifact.
+        # ``PointsModel()`` with no arguments is exactly the constants
+        # this class used to inline.
+        self._model = _sim_calibration.PointsModel()
 
-        mean = max(0.0, float(ros_value) / 2.7)
-        if mean <= 0.0:
-            return 0.0
-        cv = _PLAYER_CV_BY_POSITION.get((position or "").upper(), _DEFAULT_PLAYER_CV)
-        return max(0.0, rng.gauss(mean, max(0.5, mean * cv)))
+    def draw(self, ros_value: float, position: str, rng: Any) -> float:
+        return self._model.draw(ros_value, position, rng)
 
 
 _LEGACY_POINTS_MODEL = _LegacyPointsModel()

--- a/src/ros/playoff_sim.py
+++ b/src/ros/playoff_sim.py
@@ -105,27 +105,22 @@ PRESIM_CHECK_EVERY = 40
 # 1% of itself.
 PRESIM_MEAN_TOLERANCE = 0.01
 
-# Coefficient of variation per position for per-player weekly scores.
-# Calibrated from public weekly-scoring datasets — high-variance
-# positions (RB workload swings, WR target volatility) get larger
-# CVs, while QBs are tighter week-to-week.  These coefficients
-# combine with each player's rosValue to produce a per-player
-# Gaussian (mean = rosValue/17 × game-mean scale, sd = mean × cv).
-_PLAYER_CV_BY_POSITION: dict[str, float] = {
-    "QB": 0.32,
-    "RB": 0.55,
-    "WR": 0.60,
-    "TE": 0.65,
-    "DL": 0.55,
-    "DE": 0.55,
-    "DT": 0.55,
-    "EDGE": 0.55,
-    "LB": 0.45,
-    "DB": 0.50,
-    "S": 0.50,
-    "CB": 0.55,
-}
-_DEFAULT_PLAYER_CV = 0.55
+# The rosValue -> weekly-points conversion and its per-position CV table
+# belong to ``src/league_intel/sim_calibration.py``, which owns the
+# ``PointsModel`` this module already draws through
+# (``model.draw(ros, pos, rng)``).  This module used to restate that
+# table verbatim — byte-identical to
+# ``sim_calibration.FALLBACK_CV_BY_POSITION`` — and read it nowhere; its
+# only consumer was a second ``draw()`` implementation in the dormant
+# ``league_intel/sim.py``.  Three copies of three numbers.
+#
+# The comment that stood here also described arithmetic this module has
+# not performed for some time: "mean = rosValue/17 x game-mean scale".
+# The model divides by ``ros_value_per_point`` (2.7 as the documented
+# fallback, or whatever a calibrated ``sim_points_model.json`` supplies)
+# — a points-per-rosValue-unit conversion, not a season total spread
+# over 17 games.  A stale formula in a comment is worse than none: it is
+# the number a reader will quote.
 
 
 def _mean_is_converged(samples: list[float], rel_tolerance: float) -> bool:

--- a/src/ros/power_v2.py
+++ b/src/ros/power_v2.py
@@ -310,122 +310,29 @@ def _streak_score_from_outcomes(outcomes: list[float]) -> float:
     return 0.5  # tie or mixed
 
 
-#: The two lenses this engine publishes, and what separates them.
-#:
-#: They are NOT two formulas.  ``results_only`` is the same weight vector
-#: with ``team_ros_strength`` declared missing, renormalised by the
-#: machinery that already handles an absent team-strength file — so the
-#: relative weighting of every retrospective component is identical in
-#: both, and the only difference is whether the forward-looking input is
-#: in the mix.  That is what makes them lenses rather than engines.
-LENS_FORWARD_LOOKING = "forward_looking"
-LENS_RESULTS_ONLY = "results_only"
-
-#: Why a lens dropped ROS, distinguished from "the file was missing".
-#: A reader must be able to tell a deliberate retrospective view from an
-#: engine that wanted forward-looking strength and could not get it.
-_LENS_DROPPED_ROS = "team_ros_strength (lens: results_only)"
-
-
-def build_section(
-    snapshot: PublicLeagueSnapshot,
+def _score_state(
+    owner_ids: list[str],
+    state: dict[str, Any],
     *,
-    lens: str = LENS_FORWARD_LOOKING,
-) -> dict[str, Any]:
-    """Build the ROS power section for the public contract.
+    snapshot: PublicLeagueSnapshot,
+    ros_pct: dict[str, float],
+    schedule_by_owner: dict[str, float],
+    preseason: bool,
+    results_only: bool,
+) -> tuple[list[dict[str, Any]], list[str], dict[str, float]]:
+    """Score one league state into a ranking.
 
-    Output mirrors the existing ``power.py::build_section`` shape so
-    the frontend can render it side-by-side with no schema fork:
+    Extracted so the current ranking and every week of the trend series
+    run through ONE code path.  A second scoring implementation for the
+    trend is how a "series" ends up being a different quantity from the
+    number it is plotted beside — which is the whole defect V1-52 exists
+    to close, reproduced one layer down.
 
-        {
-            "currentRanking": [...],
-            "weights": { ... },
-            "missingInputs": [...]
-        }
-
-    The historical week-by-week series is intentionally NOT computed
-    here in PR2 — the v1 power section already exposes that, and the
-    ROS-team-strength input only has a single "now" snapshot.  PR3
-    adds historical playoff-odds; the chart on the new tab will hook
-    into that data instead.
+    ``state`` is ``{career, recent, allplay, expected, outcomes}`` as of
+    some point in the season.  Returns ``(rankings, missing_inputs,
+    active_weights)``.
     """
-    registry = snapshot.managers
-    seasons_sorted = sorted(snapshot.seasons, key=lambda s: luck._season_sort_key(s.season))
-    team_strength_rows = _load_team_strength_rows()
-    preseason = _is_preseason(snapshot)
-    if (
-        not seasons_sorted
-        and not team_strength_rows
-        and (snapshot.current_season is None or not (snapshot.current_season.rosters or []))
-    ):
-        return {
-            "currentRanking": [],
-            "lens": lens,
-            "weights": dict(WEIGHTS),
-            "missingInputs": ["snapshot empty"],
-            "rosTeamStrengthAvailable": False,
-        }
-
-    # Career totals across all seasons (matches power.py's accumulator
-    # semantics).  Recent buffer is per-season; the "recent form"
-    # metric is the trailing 3-game average within the current season.
-    career_state: dict[str, dict[str, float | int]] = defaultdict(
-        lambda: {"points": 0.0, "games": 0, "wins": 0.0, "losses": 0.0}
-    )
-    season_outcomes: dict[str, list[float]] = defaultdict(list)
-    last_season_recent: dict[str, list[float]] = defaultdict(list)
-    last_season_allplay_share: dict[str, float] = {}
-
-    for season in seasons_sorted:
-        week_scores = luck._season_weekly_scores(season, registry)
-        if not week_scores:
-            continue
-        if season is seasons_sorted[-1]:
-            recent_buffer: dict[str, list[float]] = defaultdict(list)
-        for wk in sorted(week_scores.keys()):
-            scores = week_scores[wk]
-            actuals, _ = luck._actual_week_results(season, wk, registry)
-            all_play = luck._all_play_week(scores)
-            for oid, pts in scores:
-                s = career_state[oid]
-                s["points"] += pts
-                s["games"] += 1
-                actual_share = actuals.get(oid, 0.0)
-                s["wins"] += actual_share
-                s["losses"] += 1.0 - actual_share
-                season_outcomes[oid].append(actual_share)
-                if season is seasons_sorted[-1]:
-                    rb = recent_buffer[oid]
-                    rb.append(pts)
-                    if len(rb) > _RECENT_WINDOW:
-                        rb.pop(0)
-                    last_season_recent[oid] = list(rb)
-                # Capture the last week's all-play expected share so
-                # the all-play-record percentile reflects current
-                # standings rather than a season-wide average that
-                # would lag mid-season trades.
-                ap = all_play.get(oid) or {}
-                last_season_allplay_share[oid] = float(ap.get("expectedShare", 0.0))
-
-    owner_ids = _enumerate_owner_ids(snapshot, team_strength_rows, sorted(career_state.keys()))
-    if not owner_ids:
-        return {
-            "currentRanking": [],
-            "lens": lens,
-            "weights": dict(WEIGHTS),
-            "missingInputs": ["no owners found"],
-            "rosTeamStrengthAvailable": False,
-        }
-
-    # The results-only lens does not consult team strength at all, rather
-    # than loading it and discarding it — so a reader cannot mistake the
-    # lens for a league whose team-strength file is missing, and so the
-    # schedule-adjusted component (which is derived FROM team strength)
-    # drops with it automatically rather than by a second rule.
-    results_only = lens == LENS_RESULTS_ONLY
-    ros_pct = {} if results_only else _load_team_strength_percentiles()
     ros_available = bool(ros_pct)
-    schedule_by_owner = _schedule_adjusted_scores(snapshot, ros_pct)
     schedule_available = bool(schedule_by_owner)
 
     # Compute per-owner inputs.  ``career_state`` is a defaultdict but
@@ -435,15 +342,15 @@ def build_section(
     # in preseason mode those weights are renormalised away anyway.
     inputs: dict[str, dict[str, float]] = {}
     for oid in owner_ids:
-        s = career_state.get(oid, _EMPTY_CAREER)
+        s = state["career"].get(oid, _EMPTY_CAREER)
         ppg = s["points"] / s["games"] if s["games"] else 0.0
-        rb = last_season_recent.get(oid, [])
+        rb = state["recent"].get(oid, [])
         recent = sum(rb) / len(rb) if rb else 0.0
         wins = s["wins"]
         games = s["games"] or 1
         wl = wins / games  # already in [0, 1]
-        all_play = last_season_allplay_share.get(oid, 0.0)
-        streak = _streak_score_from_outcomes(season_outcomes.get(oid, []))
+        all_play = state["allplay"].get(oid, 0.0)
+        streak = _streak_score_from_outcomes(state["outcomes"].get(oid, []))
         # Luck regression: a team whose actualWins lag expectedWins
         # gets a small boost (regression toward expected).  Clamp to
         # [-0.5, 0.5] then map to [0, 1].
@@ -451,15 +358,7 @@ def build_section(
         # this via build_section but at PR-2 budget we'd rather not
         # invoke the whole section).  Re-use the same all_play share
         # iteration (cheap; same data already in scope).
-        expected_share_running = 0.0
-        for season in seasons_sorted:
-            week_scores = luck._season_weekly_scores(season, registry)
-            for wk in sorted(week_scores.keys()):
-                scores = week_scores[wk]
-                ap_week = luck._all_play_week(scores)
-                if oid in {o for o, _ in scores}:
-                    ap = ap_week.get(oid) or {}
-                    expected_share_running += float(ap.get("expectedShare", 0.0))
+        expected_share_running = state["expected"].get(oid, 0.0)
         luck_delta = (wins - expected_share_running) / games if games else 0.0
         luck_score = max(
             0.0, min(1.0, 0.5 - luck_delta)
@@ -550,9 +449,223 @@ def build_section(
     for rank, row in enumerate(rankings, start=1):
         row["rank"] = rank
 
+    return rankings, missing_inputs, active_weights
+
+
+#: The two lenses this engine publishes, and what separates them.
+#:
+#: They are NOT two formulas.  ``results_only`` is the same weight vector
+#: with ``team_ros_strength`` declared missing, renormalised by the
+#: machinery that already handles an absent team-strength file — so the
+#: relative weighting of every retrospective component is identical in
+#: both, and the only difference is whether the forward-looking input is
+#: in the mix.  That is what makes them lenses rather than engines.
+LENS_FORWARD_LOOKING = "forward_looking"
+LENS_RESULTS_ONLY = "results_only"
+
+#: Why a lens dropped ROS, distinguished from "the file was missing".
+#: A reader must be able to tell a deliberate retrospective view from an
+#: engine that wanted forward-looking strength and could not get it.
+_LENS_DROPPED_ROS = "team_ros_strength (lens: results_only)"
+
+
+def build_section(
+    snapshot: PublicLeagueSnapshot,
+    *,
+    lens: str = LENS_FORWARD_LOOKING,
+) -> dict[str, Any]:
+    """Build the ROS power section for the public contract.
+
+    Output mirrors the existing ``power.py::build_section`` shape so
+    the frontend can render it side-by-side with no schema fork:
+
+        {
+            "currentRanking": [...],
+            "weights": { ... },
+            "missingInputs": [...]
+        }
+
+    The historical week-by-week series is intentionally NOT computed
+    here in PR2 — the v1 power section already exposes that, and the
+    ROS-team-strength input only has a single "now" snapshot.  PR3
+    adds historical playoff-odds; the chart on the new tab will hook
+    into that data instead.
+    """
+    registry = snapshot.managers
+    seasons_sorted = sorted(snapshot.seasons, key=lambda s: luck._season_sort_key(s.season))
+    team_strength_rows = _load_team_strength_rows()
+    preseason = _is_preseason(snapshot)
+    if (
+        not seasons_sorted
+        and not team_strength_rows
+        and (snapshot.current_season is None or not (snapshot.current_season.rosters or []))
+    ):
+        return {
+            "currentRanking": [],
+            "lens": lens,
+            "weights": dict(WEIGHTS),
+            "missingInputs": ["snapshot empty"],
+            "rosTeamStrengthAvailable": False,
+        }
+
+    # Career totals across all seasons (matches power.py's accumulator
+    # semantics).  Recent buffer is per-season; the "recent form"
+    # metric is the trailing 3-game average within the current season.
+    career_state: dict[str, dict[str, float | int]] = defaultdict(
+        lambda: {"points": 0.0, "games": 0, "wins": 0.0, "losses": 0.0}
+    )
+    season_outcomes: dict[str, list[float]] = defaultdict(list)
+    last_season_recent: dict[str, list[float]] = defaultdict(list)
+    last_season_allplay_share: dict[str, float] = {}
+    expected_share_total: dict[str, float] = defaultdict(float)
+    #: ``(season, week, state-as-of-that-week)`` for the trend series.
+    week_states: list[tuple[str, int, dict[str, Any]]] = []
+
+    for season in seasons_sorted:
+        week_scores = luck._season_weekly_scores(season, registry)
+        if not week_scores:
+            continue
+        if season is seasons_sorted[-1]:
+            recent_buffer: dict[str, list[float]] = defaultdict(list)
+        for wk in sorted(week_scores.keys()):
+            scores = week_scores[wk]
+            actuals, _ = luck._actual_week_results(season, wk, registry)
+            all_play = luck._all_play_week(scores)
+            for oid, pts in scores:
+                s = career_state[oid]
+                s["points"] += pts
+                s["games"] += 1
+                actual_share = actuals.get(oid, 0.0)
+                s["wins"] += actual_share
+                s["losses"] += 1.0 - actual_share
+                season_outcomes[oid].append(actual_share)
+                if season is seasons_sorted[-1]:
+                    rb = recent_buffer[oid]
+                    rb.append(pts)
+                    if len(rb) > _RECENT_WINDOW:
+                        rb.pop(0)
+                    last_season_recent[oid] = list(rb)
+                # Capture the last week's all-play expected share so
+                # the all-play-record percentile reflects current
+                # standings rather than a season-wide average that
+                # would lag mid-season trades.
+                ap = all_play.get(oid) or {}
+                last_season_allplay_share[oid] = float(ap.get("expectedShare", 0.0))
+                # Running sum, accumulated HERE rather than re-walked per
+                # owner below.  The re-walk was O(owners x weeks) inside an
+                # owner loop, and the per-week trend would have made it
+                # O(weeks x owners x weeks) for a quantity that is a running
+                # total by construction.
+                expected_share_total[oid] += float(ap.get("expectedShare", 0.0))
+
+            # Snapshot the state AS OF this week, for the trend series.
+            # A copy, because the accumulators keep mutating: a reference
+            # here would make every week's entry show the final standings,
+            # which is a trend line that cannot go down.
+            week_states.append(
+                (
+                    season.season,
+                    wk,
+                    {
+                        "career": {o: dict(v) for o, v in career_state.items()},
+                        "recent": {o: list(v) for o, v in last_season_recent.items()},
+                        "allplay": dict(last_season_allplay_share),
+                        "expected": dict(expected_share_total),
+                        "outcomes": {o: list(v) for o, v in season_outcomes.items()},
+                    },
+                )
+            )
+
+    owner_ids = _enumerate_owner_ids(snapshot, team_strength_rows, sorted(career_state.keys()))
+    if not owner_ids:
+        return {
+            "currentRanking": [],
+            "lens": lens,
+            "weights": dict(WEIGHTS),
+            "missingInputs": ["no owners found"],
+            "rosTeamStrengthAvailable": False,
+        }
+
+    # The results-only lens does not consult team strength at all, rather
+    # than loading it and discarding it — so a reader cannot mistake the
+    # lens for a league whose team-strength file is missing, and so the
+    # schedule-adjusted component (which is derived FROM team strength)
+    # drops with it automatically rather than by a second rule.
+    results_only = lens == LENS_RESULTS_ONLY
+    ros_pct = {} if results_only else _load_team_strength_percentiles()
+    ros_available = bool(ros_pct)
+    schedule_by_owner = _schedule_adjusted_scores(snapshot, ros_pct)
+
+    final_state = {
+        "career": career_state,
+        "recent": last_season_recent,
+        "allplay": last_season_allplay_share,
+        "expected": expected_share_total,
+        "outcomes": season_outcomes,
+    }
+    rankings, missing_inputs, active_weights = _score_state(
+        owner_ids,
+        final_state,
+        snapshot=snapshot,
+        ros_pct=ros_pct,
+        schedule_by_owner=schedule_by_owner,
+        preseason=preseason,
+        results_only=results_only,
+    )
+
+    # ── The trend series ────────────────────────────────────────────
+    #
+    # RESULTS-ONLY at every week, INCLUDING the current one, and that is
+    # deliberate.  ``team_ros_strength`` is a single current snapshot —
+    # ``data/ros/team_strength/latest.json`` — never a per-week history,
+    # so there is no observation of it for any past week.  Back-filling
+    # today's value would be the as-of defect: a number that was not
+    # known then, presented as if it had been.
+    #
+    # Splicing it into only the LAST point would be worse than either
+    # extreme: the line would jump at the final week for a reason that
+    # has nothing to do with how the team played, and no reader could
+    # tell that from a real move.  So the trend is one internally
+    # consistent quantity, and it is NAMED as a different one from the
+    # headline ranking rather than left to be discovered.
+    trend_weeks: list[dict[str, Any]] = []
+    series_by_owner: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for season_label, wk, wk_state in week_states:
+        wk_rankings, _wk_missing, _wk_weights = _score_state(
+            owner_ids,
+            wk_state,
+            snapshot=snapshot,
+            ros_pct={},
+            schedule_by_owner={},
+            preseason=False,
+            results_only=True,
+        )
+        trend_weeks.append({"season": season_label, "week": wk, "rankings": wk_rankings})
+        for row in wk_rankings:
+            series_by_owner[row["ownerId"]].append(
+                {
+                    "season": season_label,
+                    "week": wk,
+                    "powerScore": row["powerScore"],
+                    "rank": row["rank"],
+                }
+            )
+
     return {
         "currentRanking": rankings,
         "lens": lens,
+        "trend": {
+            "lens": LENS_RESULTS_ONLY,
+            "weeks": trend_weeks,
+            "seriesByOwner": {k: v for k, v in series_by_owner.items()},
+            "note": (
+                "Results only. Forward-looking roster strength is a current "
+                "snapshot with no per-week history, so it is excluded from "
+                "every point rather than back-filled into past weeks or "
+                "spliced into the last one. The headline ranking includes it "
+                "and will differ."
+            ),
+        },
         "weights": dict(WEIGHTS),
         "effectiveWeights": dict(active_weights),
         "missingInputs": sorted(missing_inputs),

--- a/src/ros/power_v2.py
+++ b/src/ros/power_v2.py
@@ -310,7 +310,28 @@ def _streak_score_from_outcomes(outcomes: list[float]) -> float:
     return 0.5  # tie or mixed
 
 
-def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
+#: The two lenses this engine publishes, and what separates them.
+#:
+#: They are NOT two formulas.  ``results_only`` is the same weight vector
+#: with ``team_ros_strength`` declared missing, renormalised by the
+#: machinery that already handles an absent team-strength file — so the
+#: relative weighting of every retrospective component is identical in
+#: both, and the only difference is whether the forward-looking input is
+#: in the mix.  That is what makes them lenses rather than engines.
+LENS_FORWARD_LOOKING = "forward_looking"
+LENS_RESULTS_ONLY = "results_only"
+
+#: Why a lens dropped ROS, distinguished from "the file was missing".
+#: A reader must be able to tell a deliberate retrospective view from an
+#: engine that wanted forward-looking strength and could not get it.
+_LENS_DROPPED_ROS = "team_ros_strength (lens: results_only)"
+
+
+def build_section(
+    snapshot: PublicLeagueSnapshot,
+    *,
+    lens: str = LENS_FORWARD_LOOKING,
+) -> dict[str, Any]:
     """Build the ROS power section for the public contract.
 
     Output mirrors the existing ``power.py::build_section`` shape so
@@ -339,6 +360,7 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     ):
         return {
             "currentRanking": [],
+            "lens": lens,
             "weights": dict(WEIGHTS),
             "missingInputs": ["snapshot empty"],
             "rosTeamStrengthAvailable": False,
@@ -389,12 +411,19 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     if not owner_ids:
         return {
             "currentRanking": [],
+            "lens": lens,
             "weights": dict(WEIGHTS),
             "missingInputs": ["no owners found"],
             "rosTeamStrengthAvailable": False,
         }
 
-    ros_pct = _load_team_strength_percentiles()
+    # The results-only lens does not consult team strength at all, rather
+    # than loading it and discarding it — so a reader cannot mistake the
+    # lens for a league whose team-strength file is missing, and so the
+    # schedule-adjusted component (which is derived FROM team strength)
+    # drops with it automatically rather than by a second rule.
+    results_only = lens == LENS_RESULTS_ONLY
+    ros_pct = {} if results_only else _load_team_strength_percentiles()
     ros_available = bool(ros_pct)
     schedule_by_owner = _schedule_adjusted_scores(snapshot, ros_pct)
     schedule_available = bool(schedule_by_owner)
@@ -458,14 +487,20 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     # project the upcoming one (see ``_is_preseason``).
     missing_inputs: list[str] = []
     if not ros_available:
-        missing_inputs.append("team_ros_strength")
+        missing_inputs.append(_LENS_DROPPED_ROS if results_only else "team_ros_strength")
     if not schedule_available:
         missing_inputs.append("schedule_adjusted")
     if preseason:
         for component in _HISTORICAL_RESULTS_COMPONENTS:
             if component not in missing_inputs:
                 missing_inputs.append(component)
-    active_weights = {k: v for k, v in WEIGHTS.items() if k not in missing_inputs}
+    # ``missing_inputs`` is a human-readable list; the weight lookup keys
+    # on component NAMES, so the lens marker is normalised back before it
+    # is used to drop a weight.  Without this the lens would leave
+    # ``team_ros_strength`` weighted at 0.41 against a component of 0.0 —
+    # a silent 41% deflation of every score rather than a renormalisation.
+    dropped_components = {m.split(" (")[0] for m in missing_inputs}
+    active_weights = {k: v for k, v in WEIGHTS.items() if k not in dropped_components}
     weight_total = sum(active_weights.values()) or 1.0
 
     rankings: list[dict[str, Any]] = []
@@ -517,6 +552,7 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
 
     return {
         "currentRanking": rankings,
+        "lens": lens,
         "weights": dict(WEIGHTS),
         "effectiveWeights": dict(active_weights),
         "missingInputs": sorted(missing_inputs),

--- a/src/ros/power_v2.py
+++ b/src/ros/power_v2.py
@@ -209,10 +209,21 @@ def _is_preseason(snapshot: PublicLeagueSnapshot) -> bool:
         games have been played yet" and "the prior year is complete
         and we're between seasons".
 
-    In this state the historical-results components describe a finished
-    season and don't project the upcoming year.  The build pipeline
-    drops them via ``missing_inputs`` so the score reflects only
-    forward-looking inputs (ROS strength, roster health, SOS).
+    This predicate answers only "is there an in-progress regular
+    season".  What that IMPLIES depends on the lens, and conflating the
+    two is what made this function's old docstring wrong:
+
+    * FORWARD-LOOKING — the historical-results components describe a
+      finished year and don't project the upcoming one, so the build
+      drops them via ``missing_inputs`` and the score reflects only
+      forward-looking inputs (ROS strength, SOS).
+    * RESULTS-ONLY — the finished year IS the answer.  Nothing is
+      dropped, or the lens would have nothing to say for the whole
+      offseason.
+
+    ``roster_health`` is not in that forward-looking list any more: it
+    was double-counted against ``team_ros_strength`` and was folded into
+    it (0.38 -> 0.41) earlier in V1-52.
     """
     current = snapshot.current_season
     if current is None:
@@ -381,15 +392,35 @@ def _score_state(
 
     # Renormalise weights when missing inputs are present so the score
     # stays in [0, 100] instead of being deflated by the unfilled
-    # weight budget.  Preseason / between-seasons drops the historical
-    # results components — they describe a finished year and don't
-    # project the upcoming one (see ``_is_preseason``).
+    # weight budget.
     missing_inputs: list[str] = []
     if not ros_available:
         missing_inputs.append(_LENS_DROPPED_ROS if results_only else "team_ros_strength")
     if not schedule_available:
         missing_inputs.append("schedule_adjusted")
-    if preseason:
+
+    # THE PRESEASON SUPPRESSION BELONGS TO ONE LENS, NOT BOTH.
+    #
+    # ``_is_preseason``'s own reason for dropping the historical-results
+    # components is that they "describe a finished year and don't project
+    # the upcoming one ... so the score reflects only forward-looking
+    # inputs".  That argument is correct — for the FORWARD-LOOKING lens.
+    # It is exactly backwards for the retrospective one, whose entire
+    # subject matter IS the finished year.
+    #
+    # The results-only lens was added in V1-52 and inherited this rule
+    # unexamined.  The consequence was not subtle: results-only already
+    # drops ``team_ros_strength`` by definition, so preseason left it
+    # with NOTHING — the every-component-missing state the refusal below
+    # exists for — while the completed seasons it is made of sat in the
+    # accumulators untouched, for every day of the offseason.
+    #
+    # Measured on ``evidence/W30/power-two-engines.json``:
+    # ``preseason: true``, ``effectiveWeights`` just
+    # ``{team_ros_strength: 0.38, roster_health: 0.03}``.  After the
+    # roster-health de-double-count, forward-looking preseason carries
+    # ONE component and results-only carries none.
+    if preseason and not results_only:
         for component in _HISTORICAL_RESULTS_COMPONENTS:
             if component not in missing_inputs:
                 missing_inputs.append(component)
@@ -523,20 +554,33 @@ def build_section(
 ) -> dict[str, Any]:
     """Build the ROS power section for the public contract.
 
-    Output mirrors the existing ``power.py::build_section`` shape so
-    the frontend can render it side-by-side with no schema fork:
-
         {
-            "currentRanking": [...],
-            "weights": { ... },
-            "missingInputs": [...]
+            "currentRanking": [...],   # rank/powerScore None when unrankable
+            "lens": "...",
+            "unrankable": {...} | None,
+            "trend": {"weeks": [...], "seriesByOwner": {...}},
+            "weights": {...},          # the spec vector
+            "effectiveWeights": {...}, # what actually applied, renormalised
+            "missingInputs": [...],
+            "preseason": bool,
         }
 
-    The historical week-by-week series is intentionally NOT computed
-    here in PR2 — the v1 power section already exposes that, and the
-    ROS-team-strength input only has a single "now" snapshot.  PR3
-    adds historical playoff-odds; the chart on the new tab will hook
-    into that data instead.
+    Two fields carry the honesty of the thing and are easy to drop:
+
+    * ``effectiveWeights`` is what the score was ACTUALLY computed from.
+      It differs from ``weights`` whenever an input is unavailable, and
+      a surface that renders the spec vector instead will describe a
+      formula the number did not come from.
+    * ``unrankable`` is non-None when NO component survived.  Then
+      ``powerScore`` and ``rank`` are ``None`` — never ``0.0``, never
+      ``1..N`` — because ranking on identically-zero scores publishes
+      the ``owner_ids`` order as if it were a result.
+
+    This docstring used to say the week-by-week series was "intentionally
+    NOT computed here in PR2" and that the v1 power section exposes it
+    instead.  Both halves are now false: ``trend`` is computed here (so
+    the table and the chart beside it are one quantity rather than two
+    formulas), and V1-52 is retiring the v1 section as an engine.
     """
     registry = snapshot.managers
     seasons_sorted = sorted(snapshot.seasons, key=lambda s: luck._season_sort_key(s.season))

--- a/src/ros/power_v2.py
+++ b/src/ros/power_v2.py
@@ -400,7 +400,54 @@ def _score_state(
     # a silent 41% deflation of every score rather than a renormalisation.
     dropped_components = {m.split(" (")[0] for m in missing_inputs}
     active_weights = {k: v for k, v in WEIGHTS.items() if k not in dropped_components}
-    weight_total = sum(active_weights.values()) or 1.0
+
+    # NOTHING SURVIVED -> NOTHING TO RANK ON.
+    #
+    # The renormalisation above is what makes the two lenses one engine,
+    # but it has a floor: when EVERY component is dropped there is no
+    # weighted score left to compute.  The old fallback made
+    # ``weight_total`` 1.0 against an empty numerator, so every owner
+    # scored exactly 0.0 — and the sort below, being stable over equal
+    # keys, then handed out ranks 1..N in ``owner_ids`` order.  An
+    # identifier ordering, published as a power ranking, contradicting
+    # the components printed beside it.
+    #
+    # This is reachable structurally rather than rarely: the
+    # results-only lens drops ``team_ros_strength`` BY DEFINITION and
+    # ``preseason`` drops all seven historical-results components, so
+    # the state is guaranteed for the whole offseason.
+    #
+    # Same failure family as the playoff-odds defect fixed in V1-51 — a
+    # placeholder made every entry tie and the tiebreak leaked an id
+    # ordering into a user-facing ranking.  Refuse instead: the owners
+    # are still listed and their components still published, but the
+    # score and the rank are ``None``.  ``None`` and not ``0.0``,
+    # because 0.0 is a real score a team can earn.
+    unrankable: list[dict[str, Any]] = []
+    if not active_weights:
+        for oid in owner_ids:
+            i = inputs[oid]
+            unrankable.append(
+                {
+                    "ownerId": oid,
+                    "displayName": _metrics.display_name_for(snapshot, oid),
+                    "powerScore": None,
+                    "rank": None,
+                    "components": {
+                        "ppg": round(_percentile(ppg_values, i["ppg"]), 4),
+                        "recent": round(_percentile(recent_values, i["recent"]), 4),
+                        "wl_record": round(i["wl_record"], 4),
+                        "all_play": round(i["all_play"], 4),
+                        "streak": round(i["streak"], 4),
+                        "luck_regression": round(i["luck_regression"], 4),
+                    },
+                    "rosStrengthPercentile": None,
+                    "weightsApplied": {},
+                }
+            )
+        return unrankable, missing_inputs, active_weights
+
+    weight_total = sum(active_weights.values())
 
     rankings: list[dict[str, Any]] = []
     for oid in owner_ids:
@@ -651,9 +698,31 @@ def build_section(
                 }
             )
 
+    # The refusal, surfaced. ``_score_state`` returns rows whose score and
+    # rank are None when no component survived; the section must SAY so
+    # rather than leave a consumer to infer it from null fields, which is
+    # how a refusal gets rendered as an empty table or a zero.
+    unrankable: dict[str, Any] | None = None
+    if not active_weights:
+        unrankable = {
+            "reason": (
+                "no_scoring_component_available"
+                if not preseason
+                else "preseason_and_no_forward_looking_input"
+            ),
+            "missingInputs": sorted(missing_inputs),
+            "explanation": (
+                "Every weighted component is unavailable, so there is no "
+                "quantity to rank on. The owners and their raw component "
+                "values are listed; the score and the rank are withheld "
+                "rather than published as zeros in identifier order."
+            ),
+        }
+
     return {
         "currentRanking": rankings,
         "lens": lens,
+        "unrankable": unrankable,
         "trend": {
             "lens": LENS_RESULTS_ONLY,
             "weeks": trend_weeks,

--- a/tests/league_intel/test_points_model_single_owner.py
+++ b/tests/league_intel/test_points_model_single_owner.py
@@ -1,0 +1,112 @@
+"""The rosValue -> weekly-points conversion has ONE owner.
+
+WHAT WAS DUPLICATED
+-------------------
+``src/league_intel/sim_calibration.py`` owns the conversion: a
+``PointsModel`` with ``ros_value_per_point``, a per-position CV table and
+a ``source`` stamp, loadable from a calibrated artifact and degrading to
+documented fallback constants.
+
+Two copies of its numbers had grown beside it:
+
+* ``ros/playoff_sim._PLAYER_CV_BY_POSITION`` / ``_DEFAULT_PLAYER_CV`` —
+  byte-identical to ``sim_calibration.FALLBACK_CV_BY_POSITION`` /
+  ``FALLBACK_DEFAULT_CV``, and read by nothing in that module;
+* ``league_intel/sim._LegacyPointsModel`` — a second implementation of
+  ``draw()`` with ``2.7`` hardcoded, importing the CV table from
+  ``playoff_sim`` rather than from the owner.
+
+So the same three numbers existed in three places and the same Gaussian
+draw in two.
+
+NOT A LIVE DEFECT, AND SAYING SO MATTERS
+----------------------------------------
+``league_intel/sim.py`` and ``league_intel/twin.py`` are reachable only
+from tests — no production caller — so the hardcoded ``2.7`` was never
+serving a user, and the live path (``playoff_sim`` -> ``PointsModel``)
+reads the owner correctly. This is dormant duplication being removed
+before it diverges, not a repair of something that was wrong on the
+site. Recording that distinction rather than claiming a bigger fix.
+
+The value of removing it is specific: a calibrated
+``sim_points_model.json`` changes the live path and would leave the
+dormant copy silently on the fallback constants, at which point two
+answers to "how many points is this rosValue" exist and only one of them
+tracks the calibration.
+"""
+
+from __future__ import annotations
+
+import random
+
+from src.league_intel import sim as _sim
+from src.league_intel import sim_calibration as _sc
+
+
+def test_the_cv_table_has_one_definition():
+    """``playoff_sim`` must not keep its own copy of the owner's table."""
+    from src.ros import playoff_sim
+
+    assert not hasattr(playoff_sim, "_PLAYER_CV_BY_POSITION"), (
+        "playoff_sim re-declares the owner's CV table; a second copy of "
+        "constants is a second owner waiting to diverge"
+    )
+    assert not hasattr(playoff_sim, "_DEFAULT_PLAYER_CV")
+
+
+def test_the_legacy_model_draws_identically_to_the_owner():
+    """Behavioural parity, not a reading of the two implementations.
+
+    Same seed, same inputs, same draws — which is what makes replacing
+    one with the other an exact identity rather than a judgement call.
+    """
+    owner = _sc.PointsModel()
+    legacy = _sim._LEGACY_POINTS_MODEL
+
+    for position in ("QB", "RB", "WR", "TE", "LB", "DB", "K", ""):
+        for ros in (0.0, 0.4, 5.0, 9.15, 25.0, 59.41, 100.0):
+            a = owner.draw(ros, position, random.Random(4242))
+            b = legacy.draw(ros, position, random.Random(4242))
+            assert a == b, f"diverged at position={position!r} rosValue={ros}: {a} vs {b}"
+
+
+def test_the_legacy_model_still_declares_its_own_source():
+    """Parity of NUMBERS is not parity of PROVENANCE. The dormant path
+    must keep saying it is on legacy constants, so a sim run reporting
+    ``pointsModelSource`` cannot claim calibration it did not get."""
+    assert _sim._LEGACY_POINTS_MODEL.source == "legacy-constants"
+    assert _sc.PointsModel().source == "fallback-constants"
+
+
+def test_the_conversion_constant_is_not_restated_in_code():
+    """``2.7`` must not appear as a divisor in the consumer's CODE.
+
+    Asserted over the AST rather than the source text, because the first
+    version of this test matched the module's own DOCSTRING describing
+    the constant — prose about a defect is not the defect. Same trap the
+    V1-51 structural guard hit, and the same fix.
+    """
+    import ast
+    import inspect
+
+    tree = ast.parse(inspect.getsource(_sim))
+    divisors = [
+        node.right.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.BinOp)
+        and isinstance(node.op, ast.Div)
+        and isinstance(node.right, ast.Constant)
+        and isinstance(node.right.value, (int, float))
+    ]
+    assert 2.7 not in divisors, (
+        "the rosValue->points divisor is restated as a literal in "
+        "league_intel.sim; it belongs to "
+        "sim_calibration.FALLBACK_ROS_VALUE_PER_POINT"
+    )
+
+
+def test_the_owner_still_holds_the_constant():
+    """NON-VACUITY: the test above passes trivially if the constant
+    stopped existing anywhere. It has an owner, and this names it."""
+    assert _sc.FALLBACK_ROS_VALUE_PER_POINT == 2.7
+    assert _sc.PointsModel().ros_value_per_point == 2.7

--- a/tests/public_league/test_server_routes.py
+++ b/tests/public_league/test_server_routes.py
@@ -81,6 +81,42 @@ class PublicLeagueRouteTests(unittest.TestCase):
         r = self.client.get("/api/public/league/nope")
         self.assertEqual(r.status_code, 404)
 
+    def test_ros_power_default_lens_is_forward_looking(self) -> None:
+        from src.ros import power_v2
+
+        r = self.client.get("/api/public/league/rosPower")
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertEqual(body["data"]["lens"], power_v2.LENS_FORWARD_LOOKING)
+
+    def test_ros_power_results_only_lens_is_reachable_over_http(self) -> None:
+        """V1-52 step 1 shipped the results-only lens inside power_v2, but
+        nothing threaded it through the HTTP route — the query param did
+        not exist. This is the plumbing that closes that gap."""
+        from src.ros import power_v2
+
+        r = self.client.get("/api/public/league/rosPower?lens=results_only")
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertEqual(body["data"]["lens"], power_v2.LENS_RESULTS_ONLY)
+        # A real ranking, not a passthrough of the default payload — the
+        # fixture has real weekly matchups so results-only components
+        # (wl_record, ppg, all_play, streak) survive without a team
+        # strength file.
+        self.assertTrue(body["data"]["currentRanking"])
+
+    def test_ros_power_unknown_lens_rejected(self) -> None:
+        r = self.client.get("/api/public/league/rosPower?lens=bogus")
+        self.assertEqual(r.status_code, 400)
+        self.assertIn("availableLenses", r.json())
+
+    def test_lens_param_is_a_noop_outside_ros_power(self) -> None:
+        # The lens only means something for rosPower; every other section
+        # must ignore it silently rather than erroring on an unrecognized
+        # query param that happens to be present.
+        r = self.client.get("/api/public/league/overview?lens=results_only")
+        self.assertEqual(r.status_code, 200)
+
     def test_full_contract_never_leaks_private_field_names(self) -> None:
         r = self.client.get("/api/public/league")
         self.assertEqual(r.status_code, 200)

--- a/tests/ros/test_power_lenses.py
+++ b/tests/ros/test_power_lenses.py
@@ -159,3 +159,156 @@ def test_every_payload_stamps_which_lens_produced_it(lens):
 
     out = power_v2.build_section(_empty_snapshot(), lens=lens)
     assert out["lens"] == lens
+
+
+# ── The trend series ─────────────────────────────────────────────────
+
+
+def _asymmetric_snapshot(through_week: int | None = None):
+    """A league whose weeks actually differ, so a trend can move.
+
+    ``through_week`` truncates the season, so a test can ask what the
+    engine would have said at that point in time."""
+    from src.public_league.identity import Manager, ManagerRegistry
+    from src.public_league.snapshot import PublicLeagueSnapshot, SeasonSnapshot
+
+    rosters = [{"roster_id": i, "owner_id": f"o{i}"} for i in (1, 2, 3, 4)]
+    matchups = {
+        1: [
+            {"roster_id": 1, "matchup_id": 1, "points": 90.0},
+            {"roster_id": 2, "matchup_id": 1, "points": 88.0},
+            {"roster_id": 3, "matchup_id": 2, "points": 140.0},
+            {"roster_id": 4, "matchup_id": 2, "points": 150.0},
+        ],
+        2: [
+            {"roster_id": 1, "matchup_id": 1, "points": 85.0},
+            {"roster_id": 3, "matchup_id": 1, "points": 130.0},
+            {"roster_id": 2, "matchup_id": 2, "points": 70.0},
+            {"roster_id": 4, "matchup_id": 2, "points": 60.0},
+        ],
+        3: [
+            {"roster_id": 1, "matchup_id": 1, "points": 100.0},
+            {"roster_id": 4, "matchup_id": 1, "points": 95.0},
+            {"roster_id": 2, "matchup_id": 2, "points": 115.0},
+            {"roster_id": 3, "matchup_id": 2, "points": 112.0},
+        ],
+    }
+    if through_week is not None:
+        matchups = {w: v for w, v in matchups.items() if w <= through_week}
+    registry = ManagerRegistry()
+    for r in rosters:
+        oid = str(r["owner_id"])
+        registry.by_owner_id[oid] = Manager(owner_id=oid, display_name=oid)
+        registry.roster_to_owner[("L2026", int(r["roster_id"]))] = oid
+    season = SeasonSnapshot(
+        season="2026",
+        league_id="L2026",
+        league={
+            "league_id": "L2026",
+            "season": "2026",
+            "season_type": "regular",
+            "settings": {"playoff_week_start": 15},
+            "total_rosters": 4,
+        },
+        users=[],
+        rosters=rosters,
+        matchups_by_week=matchups,
+        transactions_by_week={},
+        drafts=[],
+        draft_picks_by_draft={},
+        traded_picks=[],
+        winners_bracket=[],
+        losers_bracket=[],
+    )
+    return PublicLeagueSnapshot(
+        root_league_id="L2026",
+        generated_at="2026-04-30T00:00:00Z",
+        seasons=[season],
+        managers=registry,
+    )
+
+
+def test_each_trend_week_reflects_the_state_AS_OF_that_week(monkeypatch):
+    """THE BUG THIS AVOIDS, and it would have been invisible.
+
+    The accumulators keep mutating as the walk proceeds, so storing a
+    REFERENCE per week rather than a copy makes every week's entry show
+    the final standings — a trend line that is flat by construction and
+    cannot go down. Here week 1 and week 3 must differ, and at least one
+    manager's rank must change across the series.
+    """
+    monkeypatch.setattr(power_v2, "_load_team_strength_percentiles", lambda: {})
+    out = power_v2.build_section(_asymmetric_snapshot())
+    weeks = out["trend"]["weeks"]
+
+    assert [w["week"] for w in weeks] == [1, 2, 3]
+
+    # THE property, stated exactly: the trend's week-N point is what the
+    # engine would have said if the season had ended at week N. A weaker
+    # "the weeks differ from each other" check passes even when SOME of
+    # the five accumulators are shared by reference, because the others
+    # still vary — measured, and it is why this is written this way.
+    for n in (1, 2, 3):
+        as_of = power_v2.build_section(_asymmetric_snapshot(through_week=n))
+        expected = {r["ownerId"]: r["powerScore"] for r in as_of["currentRanking"]}
+        got = {r["ownerId"]: r["powerScore"] for r in weeks[n - 1]["rankings"]}
+        assert got == expected, f"week {n} of the trend is not the week-{n} state"
+
+    first = {r["ownerId"]: r["rank"] for r in weeks[0]["rankings"]}
+    last = {r["ownerId"]: r["rank"] for r in weeks[-1]["rankings"]}
+    assert any(first[o] != last[o] for o in first), "no rank moved — the trend is not a trend"
+
+
+def test_the_trend_is_results_only_at_every_point_including_the_last(monkeypatch):
+    """Forward-looking strength is a CURRENT snapshot with no per-week
+    history, so no past week has an observation of it. Back-filling
+    today's value is the as-of defect; splicing it into only the final
+    point is worse, because the line would jump for a reason unrelated to
+    play and no reader could tell that from a real move."""
+    monkeypatch.setattr(power_v2, "_load_team_strength_percentiles", lambda: {"o1": 0.99})
+    out = power_v2.build_section(_asymmetric_snapshot())
+
+    assert out["lens"] == power_v2.LENS_FORWARD_LOOKING
+    assert out["trend"]["lens"] == power_v2.LENS_RESULTS_ONLY
+    for week in out["trend"]["weeks"]:
+        for row in week["rankings"]:
+            assert "team_ros_strength" not in row["weightsApplied"]
+            assert row["rosStrengthPercentile"] is None
+
+
+def test_the_trend_says_it_differs_from_the_headline(monkeypatch):
+    """Named, not left to be discovered. With forward-looking strength
+    available the headline and the final trend point are different
+    quantities, and a reader comparing them needs to be told."""
+    monkeypatch.setattr(
+        power_v2,
+        "_load_team_strength_percentiles",
+        lambda: {"o1": 0.99, "o2": 0.5, "o3": 0.1, "o4": 0.2},
+    )
+    out = power_v2.build_section(_asymmetric_snapshot())
+
+    headline = {r["ownerId"]: r["powerScore"] for r in out["currentRanking"]}
+    final_point = {r["ownerId"]: r["powerScore"] for r in out["trend"]["weeks"][-1]["rankings"]}
+    assert headline != final_point, "fixture failed to make the lenses differ"
+    assert "Results only" in out["trend"]["note"]
+    assert "will differ" in out["trend"]["note"]
+
+
+def test_the_series_and_the_weeks_are_the_same_numbers(monkeypatch):
+    """``seriesByOwner`` is a re-shape for charting, not a second
+    computation — the defect this whole unit exists to close, one layer
+    down."""
+    monkeypatch.setattr(power_v2, "_load_team_strength_percentiles", lambda: {})
+    out = power_v2.build_section(_asymmetric_snapshot())
+
+    from_weeks = {
+        (w["week"], r["ownerId"]): r["powerScore"]
+        for w in out["trend"]["weeks"]
+        for r in w["rankings"]
+    }
+    from_series = {
+        (p["week"], oid): p["powerScore"]
+        for oid, points in out["trend"]["seriesByOwner"].items()
+        for p in points
+    }
+    assert from_weeks == from_series

--- a/tests/ros/test_power_lenses.py
+++ b/tests/ros/test_power_lenses.py
@@ -1,0 +1,161 @@
+"""V1-52 — two lenses, one engine.
+
+Two power rankings of this league are published today. Measured in the
+audit capture ``docs/master-site-audit/evidence/W30/power-two-engines.json``,
+on the same week:
+
+    public_league/power.py   Jason ranked 10 of 10   (0.00)
+    ros/power_v2.py          Jason ranked  3 of 12   (80.69)
+
+mean |rank shift| 2.8, max 7. Same manager, same week, two answers, and
+nothing on either surface says they are different quantities.
+
+The owner direction for V1-52 is one canonical power-ranking engine with
+explicitly defined public and private outputs/lenses, and specifically:
+
+> The public ranking should be the best legitimate power ranking we can
+> produce, including appropriate forward-looking roster strength — not
+> deliberately weaker standings-only math.
+
+This file pins the precondition for that: the retrospective view is the
+SAME engine with the forward-looking input declared missing, not a
+second formula. The renormalisation is the machinery that already
+handles an absent team-strength file, so every retrospective component
+keeps its weight RELATIVE to the others across both lenses.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from types import SimpleNamespace
+
+from src.ros import power_v2
+
+
+def _empty_snapshot():
+    """A snapshot with no seasons — enough to reach the lens decision."""
+    return SimpleNamespace(seasons=[], current_season=None, managers=None)
+
+
+def _scored_snapshot():
+    """A league with real scored weeks, so the engine produces real
+    scores rather than short-circuiting on a degenerate fixture."""
+    from tests.ros.test_power_v2 import _make_snapshot
+
+    rosters = [{"roster_id": i, "owner_id": f"o{i}"} for i in (1, 2, 3, 4)]
+    matchups = {
+        wk: [
+            {"roster_id": 1, "matchup_id": 1, "points": 120.0 + wk},
+            {"roster_id": 2, "matchup_id": 1, "points": 100.0 + wk},
+            {"roster_id": 3, "matchup_id": 2, "points": 95.0 + wk},
+            {"roster_id": 4, "matchup_id": 2, "points": 80.0 + wk},
+        ]
+        for wk in (1, 2, 3)
+    }
+    return _make_snapshot(rosters, matchups)
+
+
+def test_the_two_lenses_share_one_weight_vector():
+    """Not two formulas. ``WEIGHTS`` is the only weighting either lens
+    has, so a change to one is a change to both — which is what stops
+    them drifting into two engines again."""
+    assert set(power_v2.WEIGHTS) == {
+        "team_ros_strength",
+        "ppg",
+        "recent",
+        "wl_record",
+        "all_play",
+        "streak",
+        "schedule_adjusted",
+        "luck_regression",
+    }
+    assert sum(power_v2.WEIGHTS.values()) == pytest.approx(1.0)
+
+
+def test_dropping_ros_renormalises_rather_than_deflating(monkeypatch):
+    """THE BUG THIS AVOIDS, observed on the ENGINE rather than re-derived.
+
+    ``missing_inputs`` is a human-readable list and the weight lookup
+    keys on component NAMES. Marking the lens as
+    ``"team_ros_strength (lens: results_only)"`` without normalising it
+    back leaves the 0.41 weight active against a component of 0.0 — a
+    silent 41% deflation of every score, which reads as "every team got
+    worse" rather than "a different question was asked".
+
+    A first version of this test asserted the arithmetic on ``WEIGHTS``
+    directly and stayed GREEN when the engine's normalisation was
+    reverted. It was testing its own re-derivation. This one runs the
+    engine and checks the weights it actually applied.
+    """
+    monkeypatch.setattr(power_v2, "_load_team_strength_percentiles", lambda: {})
+    out = power_v2.build_section(_scored_snapshot(), lens=power_v2.LENS_RESULTS_ONLY)
+
+    applied = out["effectiveWeights"]
+    assert "team_ros_strength" not in applied, (
+        "the lens marker was not normalised back to a component name, so the "
+        "ROS weight stayed active against a zero component"
+    )
+    # ``schedule_adjusted`` is DERIVED from team strength, so it drops with
+    # it — one rule, not two. That is the reason the lens does not load
+    # team strength at all rather than loading and discarding it.
+    assert "schedule_adjusted" not in applied
+    assert sum(applied.values()) == pytest.approx(
+        1.0 - power_v2.WEIGHTS["team_ros_strength"] - power_v2.WEIGHTS["schedule_adjusted"]
+    )
+    # And the scores are renormalised, not scaled down by the dropped budget.
+    assert out["currentRanking"], "fixture produced no ranking"
+    assert max(r["powerScore"] for r in out["currentRanking"]) > 0.0
+
+
+def test_the_retrospective_components_keep_their_relative_weighting():
+    """What makes them lenses rather than engines: the results-only view
+    is the forward-looking one with a term removed and the rest scaled,
+    so no retrospective component is re-weighted against another."""
+    full = power_v2.WEIGHTS
+    active = {k: v for k, v in full.items() if k != "team_ros_strength"}
+    total = sum(active.values())
+    for a in active:
+        for b in active:
+            if a == b:
+                continue
+            assert (full[a] / full[b]) == pytest.approx((active[a] / total) / (active[b] / total))
+
+
+def test_the_lens_marker_says_it_was_a_CHOICE_not_a_missing_file():
+    """A reader must be able to tell a deliberate retrospective view from
+    an engine that wanted forward-looking strength and could not get it.
+    Both drop the same weight; only one of them is a defect."""
+    assert power_v2._LENS_DROPPED_ROS != "team_ros_strength"
+    assert power_v2._LENS_DROPPED_ROS.startswith("team_ros_strength")
+    assert "results_only" in power_v2._LENS_DROPPED_ROS
+
+
+def test_the_results_only_lens_never_reads_team_strength(monkeypatch):
+    """Not loaded-and-discarded. Loading it would make the lens
+    indistinguishable from a league whose file is present, and would
+    leave ``schedule_adjusted`` — which is DERIVED from team strength —
+    alive under a lens that is supposed to be results-only."""
+    calls = []
+    monkeypatch.setattr(
+        power_v2,
+        "_load_team_strength_percentiles",
+        lambda: calls.append(1) or {"o1": 0.9},
+    )
+
+    power_v2.build_section(_empty_snapshot(), lens=power_v2.LENS_RESULTS_ONLY)
+    assert calls == [], "the results-only lens consulted team strength"
+
+    power_v2.build_section(_empty_snapshot(), lens=power_v2.LENS_FORWARD_LOOKING)
+    # The forward-looking lens may short-circuit on an empty snapshot
+    # before loading; what matters is that the lens above did not.
+
+
+@pytest.mark.parametrize("lens", [power_v2.LENS_FORWARD_LOOKING, power_v2.LENS_RESULTS_ONLY])
+def test_every_payload_stamps_which_lens_produced_it(lens):
+    """Including the refusals. "This is the forward-looking ranking" and
+    "this field predates the lens" must not read the same — the rule
+    CLAUDE.md states for ``valuationMode``."""
+
+    out = power_v2.build_section(_empty_snapshot(), lens=lens)
+    assert out["lens"] == lens

--- a/tests/ros/test_power_unrankable.py
+++ b/tests/ros/test_power_unrankable.py
@@ -67,10 +67,12 @@ def _preseason_snapshot():
     return _make_snapshot(rosters, {})
 
 
-def test_results_only_in_preseason_refuses_rather_than_ordering_by_id():
-    """The structural case: this lens ALWAYS loses every component here."""
+def test_forward_looking_with_nothing_to_look_forward_to_refuses():
+    """The reachable case: preseason drops every historical component
+    from THIS lens by design, and a deploy without a team-strength file
+    drops the only forward-looking one. Nothing is left."""
     snapshot = _preseason_snapshot()
-    section = power_v2.build_section(snapshot, lens=power_v2.LENS_RESULTS_ONLY)
+    section = power_v2.build_section(snapshot, lens=power_v2.LENS_FORWARD_LOOKING)
 
     assert section["preseason"] is True
     assert section["effectiveWeights"] == {}, (
@@ -100,7 +102,7 @@ def test_the_owners_are_still_listed_when_it_refuses():
     """Withhold the certainty, not the league. A blank tab is a worse
     answer than an honest one, and the same posture playoff_structure
     already takes for an unknown bracket."""
-    section = power_v2.build_section(_preseason_snapshot(), lens=power_v2.LENS_RESULTS_ONLY)
+    section = power_v2.build_section(_preseason_snapshot(), lens=power_v2.LENS_FORWARD_LOOKING)
     owners = {r["ownerId"] for r in section["currentRanking"]}
     assert owners == {"o1", "o2", "o3", "o4"}
 
@@ -158,9 +160,14 @@ def test_the_trend_is_unaffected_because_it_is_never_preseason():
             assert row["rank"] is not None
 
 
-def test_the_committed_dev_snapshot_reproduces_the_defect_shape():
+def test_the_committed_dev_snapshot_shows_both_halves():
     """The measurement quoted in this module's docstring, pinned so the
-    claim cannot quietly stop being true."""
+    claim cannot quietly stop being true — and its repaired twin.
+
+    ``owner-B`` is the whole argument in one row. Under the defect it
+    scored 0.0 and was handed rank 2 while leading ``owner-A`` on five
+    of seven components. Under the results-only lens it is now first.
+    """
     path = REPO / "data" / "public_league" / "snapshot.json"
     if not path.exists():  # pragma: no cover - data/ is gitignored
         import pytest
@@ -170,8 +177,122 @@ def test_the_committed_dev_snapshot_reproduces_the_defect_shape():
     from src.public_league.snapshot_store import snapshot_from_dict
 
     snapshot = snapshot_from_dict(json.loads(path.read_text()))
+
+    # Forward-looking: preseason, and no team-strength file in this
+    # environment, so there is genuinely nothing to say. It refuses.
+    fwd = power_v2.build_section(snapshot, lens=power_v2.LENS_FORWARD_LOOKING)
+    assert fwd["preseason"] is True
+    assert fwd["effectiveWeights"] == {}
+    assert fwd.get("unrankable")
+    assert all(r["rank"] is None for r in fwd["currentRanking"])
+
+    # Results-only: the completed seasons are exactly its subject, so it
+    # ranks — and it puts the component leader on top.
+    res = power_v2.build_section(snapshot, lens=power_v2.LENS_RESULTS_ONLY)
+    assert not res.get("unrankable")
+    top = res["currentRanking"][0]
+    assert top["ownerId"] == "owner-B", (
+        "the row that exposed the defect must now rank first; it led "
+        "owner-A on five of seven components while ranked below it"
+    )
+    assert top["rank"] == 1 and top["powerScore"] > 0
+
+
+# ── The suppression rule belongs to ONE lens ─────────────────────────
+#
+# ``_is_preseason`` drops all seven ``_HISTORICAL_RESULTS_COMPONENTS``,
+# and its own docstring gives the reason: *"the historical-results
+# components describe a finished season and don't project the upcoming
+# year ... so the score reflects only forward-looking inputs"*.
+#
+# That is an argument about the FORWARD-LOOKING lens, and it is correct
+# there. It is exactly backwards for the retrospective one, whose entire
+# content IS the finished season. The results-only lens was added in
+# V1-52 step 1 and silently inherited a suppression written for the
+# other lens — my own defect, one step earlier.
+#
+# Measured consequence on the committed audit capture
+# ``docs/master-site-audit/evidence/W30/power-two-engines.json``:
+# ``preseason: true`` with ``effectiveWeights`` of just
+# ``{team_ros_strength: 0.38, roster_health: 0.03}``. After the
+# roster-health de-double-count in this same branch, forward-looking
+# preseason carries ONE component; results-only carries NONE, which is
+# the all-zero state the refusal above catches. So for the whole
+# offseason the retrospective lens had nothing to say, while the data it
+# is made of was sitting in the accumulators the entire time.
+
+
+def _completed_season_snapshot():
+    """A finished season and no current-season games — the live state of
+    every league between February and September."""
+    from tests.ros.test_power_v2 import _make_snapshot
+
+    rosters = [{"roster_id": i, "owner_id": f"o{i}"} for i in (1, 2, 3, 4)]
+    matchups = {
+        wk: [
+            {"roster_id": 1, "matchup_id": 1, "points": 130.0 + wk},
+            {"roster_id": 2, "matchup_id": 1, "points": 110.0 + wk},
+            {"roster_id": 3, "matchup_id": 2, "points": 95.0 - wk},
+            {"roster_id": 4, "matchup_id": 2, "points": 80.0 - wk},
+        ]
+        for wk in (1, 2, 3, 4)
+    }
+    return _make_snapshot(rosters, matchups, is_complete=True)
+
+
+def test_results_only_keeps_the_finished_season_it_is_made_of():
+    """The retrospective lens must not suppress the results."""
+    snapshot = _completed_season_snapshot()
     section = power_v2.build_section(snapshot, lens=power_v2.LENS_RESULTS_ONLY)
+
+    assert section["preseason"] is True, "fixture must reach the preseason branch"
+    assert not section.get("unrankable"), (
+        "a completed season is exactly what a results-only ranking is for; "
+        "refusing here means the lens has nothing to say all offseason"
+    )
+    kept = set(section["effectiveWeights"])
+    assert {
+        "ppg",
+        "recent",
+        "wl_record",
+        "all_play",
+    } <= kept, f"results-only dropped its own subject matter: kept {sorted(kept)}"
+    scores = [r["powerScore"] for r in section["currentRanking"]]
+    assert all(s is not None for s in scores)
+    assert len(set(scores)) > 1, "the finished season discriminates; the lens must too"
+
+
+def test_forward_looking_still_suppresses_them():
+    """NON-VACUITY, and the half that must NOT change. Last season's
+    results do not project the upcoming year, so the forward-looking
+    lens keeps dropping them — that rule was right for its own lens."""
+    section = power_v2.build_section(
+        _completed_season_snapshot(), lens=power_v2.LENS_FORWARD_LOOKING
+    )
     assert section["preseason"] is True
-    assert section["effectiveWeights"] == {}
-    assert section.get("unrankable")
-    assert all(r["rank"] is None for r in section["currentRanking"])
+    kept = set(section["effectiveWeights"])
+    assert not (
+        {"ppg", "recent", "wl_record", "all_play"} & kept
+    ), f"forward-looking must not price a finished season: kept {sorted(kept)}"
+
+
+def test_an_in_progress_season_is_unchanged_for_both_lenses():
+    """The suppression only ever applied in preseason; nothing about a
+    live season moves."""
+    from tests.ros.test_power_v2 import _make_snapshot
+
+    rosters = [{"roster_id": i, "owner_id": f"o{i}"} for i in (1, 2, 3, 4)]
+    matchups = {
+        wk: [
+            {"roster_id": 1, "matchup_id": 1, "points": 130.0 + wk},
+            {"roster_id": 2, "matchup_id": 1, "points": 110.0 + wk},
+            {"roster_id": 3, "matchup_id": 2, "points": 95.0 - wk},
+            {"roster_id": 4, "matchup_id": 2, "points": 80.0 - wk},
+        ]
+        for wk in (1, 2, 3)
+    }
+    snapshot = _make_snapshot(rosters, matchups)
+    for lens in (power_v2.LENS_RESULTS_ONLY, power_v2.LENS_FORWARD_LOOKING):
+        section = power_v2.build_section(snapshot, lens=lens)
+        assert section["preseason"] is False, lens
+        assert {"ppg", "recent"} <= set(section["effectiveWeights"]), lens

--- a/tests/ros/test_power_unrankable.py
+++ b/tests/ros/test_power_unrankable.py
@@ -1,0 +1,177 @@
+"""V1-52 — a power ranking with no surviving component must REFUSE.
+
+THE DEFECT, AND WHY IT IS NOT A CORNER CASE
+-------------------------------------------
+``build_section`` drops a component into ``missing_inputs`` when its
+input is unavailable, then renormalises the remaining weights.  That is
+right, and it is what makes the two lenses one engine rather than two
+formulas.
+
+But nothing stopped it dropping *all* of them.  When every component is
+missing, ``active_weights`` is empty, ``weight_total`` falls back to
+``1.0``, and every owner scores exactly ``0.0`` — at which point the
+sort is a stable sort over equal keys, so the published ``rank`` is
+whatever order ``_enumerate_owner_ids`` produced.  An identifier
+ordering, presented as a power ranking.
+
+**This is reachable, structurally, for the whole offseason.**  It does
+not depend on any data file:
+
+* ``preseason`` drops all seven ``_HISTORICAL_RESULTS_COMPONENTS``;
+* the results-only lens drops ``team_ros_strength`` *by definition*;
+* ``schedule_adjusted`` needs a schedule.
+
+So results-only + preseason is **always** every-component-missing —
+every day between the last game of one season and the first of the
+next.  The forward-looking lens reaches the same state whenever the
+team-strength file has not landed yet, which is exactly a fresh deploy.
+
+Measured on the committed dev snapshot, results-only lens: five owners,
+every ``powerScore`` 0.0, ranks 1-5 handed out in owner-id order — and
+the order **contradicts the components published beside it**, since
+``owner-B`` leads ``owner-A`` on five of seven components and ranks
+below it.
+
+Same defect family as the playoff-odds one fixed in V1-51 (a placeholder
+made every matchup a tie, so the third tiebreak — the ownerId string —
+became the answer, and the published order was the lexically-first
+seven Sleeper ids).  A ranking nobody can justify is worse than no
+ranking, because the reader cannot tell the difference.
+
+THE RULE
+--------
+No surviving component → no ranking.  ``powerScore`` and ``rank`` are
+``None`` (never 0.0, never 1..N), and an ``unrankable`` block names the
+reason.  The owners are still listed; only the certainty is withheld —
+the same posture ``playoff_structure`` takes for an unknown bracket and
+``RealizedPoints.unscored`` takes for a rule it cannot score.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.ros import power_v2
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _preseason_snapshot():
+    """Real seasons with real scores, but the CURRENT season unplayed —
+    which is the live state of every league right now."""
+    from tests.ros.test_power_v2 import _make_snapshot
+
+    rosters = [{"roster_id": i, "owner_id": f"o{i}"} for i in (1, 2, 3, 4)]
+    # No matchups at all in the current season → _is_preseason is True.
+    return _make_snapshot(rosters, {})
+
+
+def test_results_only_in_preseason_refuses_rather_than_ordering_by_id():
+    """The structural case: this lens ALWAYS loses every component here."""
+    snapshot = _preseason_snapshot()
+    section = power_v2.build_section(snapshot, lens=power_v2.LENS_RESULTS_ONLY)
+
+    assert section["preseason"] is True
+    assert section["effectiveWeights"] == {}, (
+        "fixture no longer reaches the every-component-missing state; "
+        "the test below would pass vacuously"
+    )
+
+    assert section.get("unrankable"), (
+        "every component is missing, so there is nothing to rank on — "
+        "the section must say so instead of publishing an order"
+    )
+    assert section["unrankable"].get("reason")
+    assert section["unrankable"].get("missingInputs")
+
+    for row in section["currentRanking"]:
+        assert row["powerScore"] is None, (
+            f"{row['ownerId']} scored {row['powerScore']!r} with no surviving "
+            f"component — 0.0 is a real score and this is not one"
+        )
+        assert row["rank"] is None, (
+            f"{row['ownerId']} was ranked {row['rank']!r} on identically-zero "
+            f"scores, so the rank is the owner-id order"
+        )
+
+
+def test_the_owners_are_still_listed_when_it_refuses():
+    """Withhold the certainty, not the league. A blank tab is a worse
+    answer than an honest one, and the same posture playoff_structure
+    already takes for an unknown bracket."""
+    section = power_v2.build_section(_preseason_snapshot(), lens=power_v2.LENS_RESULTS_ONLY)
+    owners = {r["ownerId"] for r in section["currentRanking"]}
+    assert owners == {"o1", "o2", "o3", "o4"}
+
+
+def test_a_lens_that_keeps_one_component_still_ranks():
+    """NON-VACUITY. A repair that refused whenever anything was missing
+    would satisfy every assertion above and destroy the renormalisation
+    that makes the two lenses one engine."""
+    from tests.ros.test_power_v2 import _make_snapshot
+
+    rosters = [{"roster_id": i, "owner_id": f"o{i}"} for i in (1, 2, 3, 4)]
+    matchups = {
+        wk: [
+            {"roster_id": 1, "matchup_id": 1, "points": 120.0 + wk},
+            {"roster_id": 2, "matchup_id": 1, "points": 100.0 + wk},
+            {"roster_id": 3, "matchup_id": 2, "points": 95.0 + wk},
+            {"roster_id": 4, "matchup_id": 2, "points": 80.0 + wk},
+        ]
+        for wk in (1, 2, 3)
+    }
+    section = power_v2.build_section(
+        _make_snapshot(rosters, matchups), lens=power_v2.LENS_RESULTS_ONLY
+    )
+
+    assert not section.get("unrankable")
+    assert section["effectiveWeights"], "components survived; this must rank"
+    scores = [r["powerScore"] for r in section["currentRanking"]]
+    assert all(s is not None for s in scores)
+    assert len(set(scores)) > 1, "real data must not produce one flat score"
+    assert [r["rank"] for r in section["currentRanking"]] == [1, 2, 3, 4]
+
+
+def test_the_trend_is_unaffected_because_it_is_never_preseason():
+    """The trend scores each week AS OF that week with preseason=False,
+    so its components survive. Pinned because the refusal must not
+    silently blank the series it is not about."""
+    from tests.ros.test_power_v2 import _make_snapshot
+
+    rosters = [{"roster_id": i, "owner_id": f"o{i}"} for i in (1, 2)]
+    matchups = {
+        wk: [
+            {"roster_id": 1, "matchup_id": 1, "points": 120.0 + wk},
+            {"roster_id": 2, "matchup_id": 1, "points": 100.0 - wk},
+        ]
+        for wk in (1, 2, 3)
+    }
+    section = power_v2.build_section(
+        _make_snapshot(rosters, matchups), lens=power_v2.LENS_RESULTS_ONLY
+    )
+    weeks = (section.get("trend") or {}).get("weeks") or []
+    assert len(weeks) == 3
+    for wk in weeks:
+        for row in wk["rankings"]:
+            assert row["powerScore"] is not None
+            assert row["rank"] is not None
+
+
+def test_the_committed_dev_snapshot_reproduces_the_defect_shape():
+    """The measurement quoted in this module's docstring, pinned so the
+    claim cannot quietly stop being true."""
+    path = REPO / "data" / "public_league" / "snapshot.json"
+    if not path.exists():  # pragma: no cover - data/ is gitignored
+        import pytest
+
+        pytest.skip("data/public_league/snapshot.json not present")
+
+    from src.public_league.snapshot_store import snapshot_from_dict
+
+    snapshot = snapshot_from_dict(json.loads(path.read_text()))
+    section = power_v2.build_section(snapshot, lens=power_v2.LENS_RESULTS_ONLY)
+    assert section["preseason"] is True
+    assert section["effectiveWeights"] == {}
+    assert section.get("unrankable")
+    assert all(r["rank"] is None for r in section["currentRanking"])

--- a/tests/ros/test_power_v2.py
+++ b/tests/ros/test_power_v2.py
@@ -224,21 +224,36 @@ def _make_snapshot(
     the supplied rosters.  Each roster's owner_id is registered as an
     active manager so ``_enumerate_owner_ids`` includes them.
     """
+    league_id = f"L{season_year}"
     registry = ManagerRegistry()
     for r in rosters:
         oid = str(r.get("owner_id") or "")
         if not oid:
             continue
         registry.by_owner_id[oid] = Manager(owner_id=oid, display_name=oid)
+        # ``roster_to_owner`` is LOAD-BEARING, not bookkeeping.
+        # ``luck._season_weekly_scores`` attributes a matchup row to an
+        # owner through it and SKIPS any row it cannot resolve, so a
+        # registry without it yields zero scored weeks — every component
+        # falls back to its neutral default and every owner scores the
+        # SAME number however different the fixture's points are.
+        # Fixtures built that way assert shape while measuring nothing
+        # about the data: measured 2026-08-19, every owner in
+        # ``test_power_lenses._scored_snapshot`` scored an identical
+        # 33.64 across three weeks of deliberately different points.
+        try:
+            registry.roster_to_owner[(league_id, int(r.get("roster_id")))] = oid
+        except (TypeError, ValueError):
+            continue
     season = _make_season(
         season_year,
-        f"L{season_year}",
+        league_id,
         rosters,
         matchups_by_week,
         is_complete=is_complete,
     )
     return PublicLeagueSnapshot(
-        root_league_id=f"L{season_year}",
+        root_league_id=league_id,
         generated_at="2026-04-30T00:00:00Z",
         seasons=[season],
         managers=registry,


### PR DESCRIPTION
## PROBLEM

V1-52 ("one weekly power-rankings engine") is `NOT STARTED` in
`docs/VERSION_1_COMPLETION_CONTRACT.md`, but substantial real work already
existed on `claude/v1-52-power-lenses` (PR #923) — 6 genuine V1-52 commits
implementing two lenses of one canonical engine (`src/ros/power_v2.py`), a
refuse-to-rank fix, and a preseason-suppression repair, all with their own
mutation-tested correctness proofs. That branch never merged: it went
`mergeable_state: dirty` on a one-line generated
`config/coercion_baseline.json` conflict, and — separately — 7 unrelated
V1-53/`C5-ROS-01` and "V1 projections" commits were pushed on top of it by a
different session after the PR was opened, mixing three lanes' history in
one branch.

Two engines still coexist on `main` for "how strong is this team": the
legacy `src/public_league/power.py` (eager `_SECTION_BUILDERS["power"]`,
single-week `currentRanking`, drops any owner absent that week) and the
canonical `src/ros/power_v2.py` (lazy `_LAZY_SECTION_BUILDERS["rosPower"]`,
ROS-driven weighted composite). `overview.py`'s landing-page
`currentPowerLeader` card is wired to the legacy engine unconditionally —
not behind the `useRosPowerRankings` settings flag that otherwise selects
the engine on the Power tab.

## ROOT CAUSE

1. The consolidation work existed but was stranded on a polluted,
   conflicted branch nobody could safely merge or build on.
2. Even the parts of the canonical engine that *were* implemented
   (`build_section(snapshot, lens=...)`, the per-week `trend` series) were
   never wired through the HTTP layer or the frontend — `_ros_power_section`
   called `build_section(snapshot)` with no way to request the
   `results_only` lens, and `ros-power.jsx` never read `trend` at all.

## CANONICAL CONTRACT

`V1-52 REQUIRES`:

- **A. One engine, two named lenses** (forward-looking / results-only), not
  two competing formulas answering the same question differently. —
  `SHIPPING_AND_PROVEN` (steps 1-4, mutation-tested in
  `tests/ros/test_power_lenses.py`, `tests/ros/test_power_unrankable.py`).
- **B. Refuse to rank rather than fabricate an identifier ordering** when no
  scoring component survives. — `SHIPPING_AND_PROVEN`.
- **C. Both lenses reachable end-to-end** (HTTP + UI), not just inside the
  Python module. — was `SHIPPING_BUT_UNPROVEN` before this PR;
  **`SHIPPING_AND_PROVEN` after** (this PR's slice).
- **D. One canonical engine consumed everywhere** — the legacy
  `power.py`/`power.jsx` retired, `overview.currentPowerLeader` redirected.
  — `PARTIAL`, see REMAINING WORK below; **not attempted here** because the
  obvious redirect is not safe (see IMPLEMENTATION).

## IMPLEMENTATION

**Branch isolation (no code change, provenance repair):** cherry-picked the
6 genuine V1-52 commits (`262befbbf`, `79efa8499`, `5d9c873c0`, `597378fb9`,
`ea9081e05`, `0341502b3`) from `claude/v1-52-power-lenses` onto a fresh
branch off current `main`, leaving the unrelated V1-53/projections commits
behind. Resolved the one merge conflict — the generated
`config/coercion_baseline.json` `count` field — by regenerating it via
`scripts/check_decision_coercions.py --write-baseline` against the merged
tree (664 → 663), never by picking either side's stale number.

**New work in this PR:**

- `server.py::get_public_league_section` gains a `lens` query param.
  Applies only to `section == "rosPower"`; every other section ignores it.
  Rejected (400) rather than silently defaulted when unrecognized. The
  default request pays no extra cost — `build_section_payload` already ran
  the forward-looking default; `results_only` triggers exactly one
  additional `power_v2.build_section` call, on demand.
- `frontend/app/league/sections/ros-power.jsx`: a two-button lens toggle,
  cached independently per lens (they are different quantities, not a
  re-sort of one board), and a new "Trend" column rendering the last-two-week
  rank delta from `data.trend.seriesByOwner`. The trend is results-only at
  every point by construction (no per-week ROS-strength history exists), so
  the delta is computed only within the trend series — never diffed against
  the currently-selected headline lens.

## PRODUCTION PATH

`GET /api/public/league/rosPower[?lens=results_only]` →
`server.py::get_public_league_section` → (unchanged default)
`build_section_payload` → `_LAZY_SECTION_BUILDERS["rosPower"]` →
`power_v2.build_section(snapshot)`; when `lens=results_only` is explicitly
requested, `power_v2.build_section(snapshot, lens="results_only")` replaces
`payload["data"]` before the response is returned. Frontend:
`ros-power.jsx` fetches this endpoint (module-level cache, one slot per
lens) and renders `currentRanking` + `trend`.

Not touched: `overview.py` (`currentPowerLeader` still legacy `power.py`),
`public_league/power.py`, `power.jsx`, `LeagueClient.jsx`'s
`useRosPowerRankings` toggle (Power tab default is unchanged).

## TESTS

- `tests/public_league/test_server_routes.py` — 4 new: default lens is
  forward-looking; `?lens=results_only` is reachable over HTTP and produces
  a real ranking from the fixture's real weekly matchup data; an unknown
  lens value 400s; `lens` is a no-op on non-`rosPower` sections.
- `frontend/__tests__/components/RosPowerLensAndTrend.test.jsx` — 4 new:
  default fetch has no query param; clicking the toggle refetches with
  `?lens=results_only`; an improving trend renders an up arrow with the
  correct magnitude; a trend series shorter than 2 points renders a dash,
  never a fabricated zero delta.
- Inherited from the cherry-picked commits: 24 tests in
  `tests/ros/test_power_lenses.py`, `tests/ros/test_power_unrankable.py`,
  `tests/league_intel/test_points_model_single_owner.py`.
- Full `tests/ros/` + `tests/public_league/`: 624 passed, 1 skipped.
  Full frontend suite: 537 passed.
- `scripts/check_decision_coercions.py`: clean, no new coercions.

## MUTATION PROOF

| mutation | expected failure | observed failure | restored |
|---|---|---|---|
| Delete the `lens` override branch in `get_public_league_section` | results-only-lens test fails | `AssertionError: 'forward_looking' != 'results_only'` | ✅ green |
| Delete the lens-validation branch | invalid-lens test fails | `AssertionError: 200 != 400` | ✅ green |
| Reverse `trendDelta`'s sign in `ros-power.jsx` | up-arrow test fails | rendered `"▼ 4"` instead of `"▲ 4"` | ✅ green |

(Steps 1-4's own mutation proofs — lens renormalization, refuse-to-rank,
preseason-suppression-per-lens — are recorded in
`docs/power/V1_52_CANONICAL_POWER_ENGINE.md`, inherited unchanged by this
PR.)

## BEHAVIOR BEFORE

- `power_v2`'s results-only lens and per-week trend existed in Python but
  were unreachable from any HTTP request or any rendered UI.
- Two power engines on `main`, `power.py` (legacy) still eager and still
  driving the landing-page power-leader card.

## BEHAVIOR AFTER

- `GET /api/public/league/rosPower?lens=results_only` returns a real,
  independently-cached, mutation-tested-lens ranking.
- The Power tab (`ros-power.jsx`) has a lens toggle and shows a results-only
  rank-trend indicator per owner.
- `power.py`/`overview.py` are byte-unchanged — zero risk to the landing
  page or the Power-tab default.

## V1-52 IMPACT

Converts contract item **C** (both lenses reachable end-to-end) from
`SHIPPING_BUT_UNPROVEN` to `SHIPPING_AND_PROVEN`. Items **A** and **B**
were already proven by the inherited commits; this PR is what makes them
*observable* rather than only unit-tested. Item **D** (one canonical
engine, no duplicate truth) remains open — see below.

## REMAINING V1-52 WORK

1. **Retire `power.py`/`power.jsx`.** Not a shim: `power.jsx` renders raw
   values (`pointsPerGame`, `recentAvg`, `allPlayWinPctThisWeek`) that
   `power_v2` only publishes as percentiles — an adapter would have to
   recompute raw values, i.e. become a second owner one layer down. Needs a
   deliberate frontend redesign of the Power tab's non-toggled path.
2. **Redirect `overview.currentPowerLeader` from `power.py` to
   `power_v2`.** Investigated in this PR and deliberately NOT attempted:
   `rosPower` is excluded from the eager overview walk today specifically
   because its trend computation is O(all seasons × all weeks) — wiring it
   into every public-contract request would be a real page-load regression
   (CLAUDE.md Performance Rules). It also needs a `weekRankDelta` for the
   headline lens, which is not computable from data that exists today
   (`team_ros_strength` has no per-week history) — under MISSING IS NEVER
   ZERO that field must stay `None`, not default to 0. Fixing this properly
   needs either a per-lens-headline cache design or an explicit decision on
   what the landing card shows when that field is genuinely unknown.
3. **Production-scale (12-owner) measurement of v1-vs-results-only rank
   agreement.** Only measured against a small dev fixture and synthetic
   rosters so far (see `docs/power/V1_52_CANONICAL_POWER_ENGINE.md`); needs
   the real league's `data/ros/team_strength/latest.json` snapshot, which
   is gitignored and unavailable in this environment.

## OWNER DECISIONS: NO new one introduced by this PR

The `overview.currentPowerLeader` item above may eventually need one (does
the landing card drop `weekRankDelta`, or is a new per-lens caching design
worth building for a display field), but that call belongs with whoever
picks up item 2 above, once the caching design tradeoffs are on the table —
raising it now would be inventing a decision before the engineering
alternatives are actually scoped.

---

`FEATURE_GREEN`
`READY_FOR_INTEGRATION`

Not stating V1-52 VERIFIED — that determination belongs to Integration.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PyqbZejxh7ytbfijL5pmdE)_