### PR TITLE
V1-29: close the discovery gap in the replacement-level single-owner guard

### DIFF
--- a/scripts/replacement_census.py
+++ b/scripts/replacement_census.py
@@ -324,6 +324,67 @@ def retired_reachable(extra: Path | None = None) -> dict[str, list[str]]:
     return call_sites(set(RETIRED_SYMBOLS), extra=extra)
 
 
+def _owner_symbol_paths() -> dict[str, str]:
+    """Every OWNER row's call names, mapped to the ONE path each may live at."""
+    out: dict[str, str] = {}
+    for impl in CENSUS:
+        if impl.disposition != OWNER:
+            continue
+        for name in impl.call_names:
+            out[name] = impl.path
+    return out
+
+
+def definition_sites(names: set[str], extra: Path | None = None) -> dict[str, list[str]]:
+    """Every function/method/class DEFINITION named one of ``names``.
+
+    This is the check ``call_sites`` structurally cannot make. A call-site
+    scan tracks only the bare name in CALL position — it has no notion of
+    which DEFINITION that name resolves to, because it never imports or
+    binds anything, it just walks an AST. So a second module that defines
+    its own ``replacement_per_game`` produces a call site the census
+    happily counts as evidence the declared OWNER is consumed (MR1), and
+    adding a call to that duplicate doesn't change the verdict either
+    (MR2) — the census was verifying "is this NAME called somewhere",
+    which a same-named duplicate satisfies for free. Verifying "is this
+    NAME DEFINED anywhere but its declared home" catches both, independent
+    of whether anything calls the duplicate at all.
+    """
+    hits: dict[str, list[str]] = {}
+    for path in _python_files(extra):
+        rel = str(path.relative_to(REPO)) if REPO in path.parents else str(path)
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                continue
+            if node.name in names:
+                hits.setdefault(node.name, []).append(rel)
+    return hits
+
+
+def undeclared_owner_definitions(extra: Path | None = None) -> dict[str, list[str]]:
+    """OWNER symbol names DEFINED somewhere other than their declared path.
+
+    This is the single-owner discovery guard V1-29 was missing: it does
+    not care whether the duplicate is registered in CENSUS, whether it is
+    ever called, or whether it was introduced before or after this scan
+    runs. Any second definition of an OWNER's own symbol name is, by
+    construction, an undeclared second owner for that (unit, population).
+    """
+    owner_paths = _owner_symbol_paths()
+    sites = definition_sites(set(owner_paths), extra=extra)
+    violations: dict[str, list[str]] = {}
+    for name, paths in sites.items():
+        declared_path = owner_paths[name]
+        stray = sorted(p for p in set(paths) if p != declared_path)
+        if stray:
+            violations[name] = stray
+    return violations
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
@@ -359,6 +420,13 @@ def main(argv: list[str] | None = None) -> int:
     if reachable:
         failures.append(f"retired symbols are reachable again: {reachable}")
 
+    stray_definitions = undeclared_owner_definitions()
+    if stray_definitions:
+        failures.append(
+            "an OWNER symbol name is DEFINED outside its declared path — an "
+            f"undeclared second owner: {stray_definitions}"
+        )
+
     for r in rows:
         if r.disposition in (DEAD, RETIRED) and (r.callers or r.intra):
             failures.append(
@@ -387,9 +455,11 @@ def main(argv: list[str] | None = None) -> int:
             f"{', '.join(unconsumed)}"
         )
     dead = [r.key for r in rows if r.disposition == DEAD]
+    owner_names = sorted(_owner_symbol_paths())
     print(
         f"{TAG} clean: {len(RETIRED_SYMBOLS)} retired symbol(s) deleted and unreachable; "
-        f"{len(dead)} DEAD row(s); every OWNER consumed; every OWNER unit distinct."
+        f"{len(dead)} DEAD row(s); every OWNER consumed; every OWNER unit distinct; "
+        f"no undeclared definition of {len(owner_names)} OWNER symbol(s) elsewhere."
     )
 
     if args.json_out:
@@ -399,6 +469,7 @@ def main(argv: list[str] | None = None) -> int:
                 {
                     "implementations": [r.to_dict() for r in rows],
                     "retiredSymbols": list(RETIRED_SYMBOLS),
+                    "ownerSymbolsGuarded": owner_names,
                 },
                 indent=2,
                 sort_keys=True,

--- a/tests/roster_intel/test_replacement_owner.py
+++ b/tests/roster_intel/test_replacement_owner.py
@@ -134,11 +134,13 @@ def test_the_guard_catches_a_same_named_duplicate_nobody_calls():
     )
     try:
         dups = undeclared_owner_definitions()
-        assert "replacement_per_game" in dups, (
-            "the guard did NOT detect an undeclared duplicate definition (MR1)"
-        )
+        assert (
+            "replacement_per_game" in dups
+        ), "the guard did NOT detect an undeclared duplicate definition (MR1)"
         assert "src/league_intel/_v129_dup_probe.py" in dups["replacement_per_game"]
-        assert main([]) == EXIT_VIOLATION, "the census exited clean with an undeclared owner present"
+        assert (
+            main([]) == EXIT_VIOLATION
+        ), "the census exited clean with an undeclared owner present"
     finally:
         probe.unlink(missing_ok=True)
 
@@ -165,9 +167,9 @@ def test_the_guard_catches_a_same_named_duplicate_with_a_call_site():
     )
     try:
         dups = undeclared_owner_definitions()
-        assert "replacement_per_game" in dups, (
-            "the guard did NOT detect an undeclared duplicate definition with a call site (MR2)"
-        )
+        assert (
+            "replacement_per_game" in dups
+        ), "the guard did NOT detect an undeclared duplicate definition with a call site (MR2)"
         assert main([]) == EXIT_VIOLATION, "the census exited clean with a called, undeclared owner"
     finally:
         probe.unlink(missing_ok=True)

--- a/tests/roster_intel/test_replacement_owner.py
+++ b/tests/roster_intel/test_replacement_owner.py
@@ -34,6 +34,7 @@ from scripts.replacement_census import (
     build_census,
     main,
     retired_reachable,
+    undeclared_owner_definitions,
 )
 
 REPO = pathlib.Path(__file__).resolve().parents[2]
@@ -100,6 +101,74 @@ def test_the_census_detects_a_reintroduced_duplicate(tmp_path):
     try:
         assert retired_reachable(), "the census did NOT detect a reintroduced retired symbol"
         assert main([]) == EXIT_VIOLATION, "the census exited clean with a duplicate present"
+    finally:
+        probe.unlink(missing_ok=True)
+
+
+def test_no_owner_symbol_is_defined_outside_its_declared_path():
+    """The discovery guard, checked clean at HEAD.
+
+    ``call_sites`` cannot tell an OWNER's real definition from a same-named
+    duplicate elsewhere — it only sees the bare name in CALL position. This
+    is the check that can: every OWNER symbol name must be DEFINED at
+    exactly the one path its CENSUS row declares.
+    """
+    assert undeclared_owner_definitions() == {}
+
+
+def test_the_guard_catches_a_same_named_duplicate_nobody_calls():
+    """MR1, reproduced as a positive control.
+
+    A new module defining its own ``replacement_per_game`` — the OWNER
+    symbol declared for ``src/scoring/replacement_level.py`` (row B) —
+    used to pass the census cleanly (exit 0, 18/18) because nothing calls
+    it, so ``retired_reachable``/``build_census`` never look at it. The
+    NEW guard must catch it anyway: an undeclared owner is a defect the
+    moment it is defined, whether or not it is ever invoked.
+    """
+    probe = REPO / "src" / "league_intel" / "_v129_dup_probe.py"
+    probe.write_text(
+        "def replacement_per_game(rows, position):\n"
+        "    return sum(r.get('points', 0.0) for r in rows) / max(len(rows), 1)\n",
+        encoding="utf-8",
+    )
+    try:
+        dups = undeclared_owner_definitions()
+        assert "replacement_per_game" in dups, (
+            "the guard did NOT detect an undeclared duplicate definition (MR1)"
+        )
+        assert "src/league_intel/_v129_dup_probe.py" in dups["replacement_per_game"]
+        assert main([]) == EXIT_VIOLATION, "the census exited clean with an undeclared owner present"
+    finally:
+        probe.unlink(missing_ok=True)
+
+
+def test_the_guard_catches_a_same_named_duplicate_with_a_call_site():
+    """MR2, reproduced as a positive control.
+
+    Same duplicate as MR1, but now it is live code with a real caller —
+    the exact shape that used to fool ``build_census`` into reporting the
+    real OWNER as consumed (the AST call scan matched the bare name
+    ``replacement_per_game`` and could not tell which definition answered
+    it). The guard must still fail: a second definition is the defect,
+    independent of whether it is called.
+    """
+    probe = REPO / "src" / "league_intel" / "_v129_dup_probe.py"
+    probe.write_text(
+        "def replacement_per_game(rows, position):\n"
+        "    return sum(r.get('points', 0.0) for r in rows) / max(len(rows), 1)\n"
+        "\n"
+        "\n"
+        "def call_it(rows):\n"
+        "    return replacement_per_game(rows, 'RB')\n",
+        encoding="utf-8",
+    )
+    try:
+        dups = undeclared_owner_definitions()
+        assert "replacement_per_game" in dups, (
+            "the guard did NOT detect an undeclared duplicate definition with a call site (MR2)"
+        )
+        assert main([]) == EXIT_VIOLATION, "the census exited clean with a called, undeclared owner"
     finally:
         probe.unlink(missing_ok=True)
 


### PR DESCRIPTION
## PROBLEM

`docs/VERSION_1_COMPLETION_CONTRACT.md` carries V1-29 ("One replacement
level / PAR owner") as `IN PROGRESS` at L2, with a precise, measured
residual: `scripts/replacement_census.py` is a **registry-consistency
check, not a single-owner check**. Its `call_sites()` scans for the bare
NAME of a declared symbol appearing in CALL position — it has no notion of
which DEFINITION that call resolves to.

Two mutations named in the contract defeat it, and I reproduced both
before making any change (both confirmed exit 0):

- **MR1** — a new, undeclared module defines its own `replacement_per_game`
  (the OWNER symbol for `src/scoring/replacement_level.py`, census row B).
  Nothing calls it → census stays clean, 18/18 pass.
- **MR2** — same duplicate, plus a real call site, so it is live code
  rather than dead → census **still** stays clean, 18/18 pass, exit 0.
  The call scan matches the bare name and happily counts it as evidence
  the real OWNER is consumed.

## ROOT CAUSE

Definition and consumption were never distinguished. A same-named
duplicate satisfies "is this name called somewhere" for free, which is
exactly what MR1/MR2 exploit — the census could tell you a name was
*used*, never whose *code* answered it.

## CANONICAL CONTRACT

No methodology change. The census's own declared rows (unit/population/
disposition for every replacement-level implementation in the tree) are
untouched — this PR closes the one named gap: *"a discovery rule that
fails when a replacement/PAR implementation appears outside the declared
owner set."*

## IMPLEMENTATION

`scripts/replacement_census.py` gains `undeclared_owner_definitions()` —
an AST scan (`FunctionDef` / `AsyncFunctionDef` / `ClassDef` nodes, not
text) over every declared OWNER symbol name, asserting each is DEFINED at
exactly the one path its CENSUS row declares. Any second definition is
flagged **regardless of whether it is ever called**, which is what closes
MR1 and MR2 with one mechanism instead of two. Wired into `main()`'s
failure list (`EXIT_VIOLATION`) and the JSON output
(`ownerSymbolsGuarded`).

No CENSUS row, disposition, unit, or population claim was touched — this
is a discovery-gap repair, not a re-audit.

## PRODUCTION PATH

None. `scripts/replacement_census.py` has zero importers anywhere outside
its own test file (grepped repo-wide) and is not wired into any CI
workflow or server runtime. It is a standalone static-analysis tool run
manually / by an agent, same as before this PR.

## TESTS

3 new in `tests/roster_intel/test_replacement_owner.py`:
- guard is clean at `HEAD` (`undeclared_owner_definitions() == {}`)
- MR1 reproduced as a positive control (duplicate definition, no caller)
- MR2 reproduced as a positive control (duplicate definition + real caller)

All 21 tests (18 original + 3 new) pass.

## MUTATION PROOF

| step | action | result |
|---|---|---|
| Before the fix | Applied MR1 by hand against the unmodified census | exit 0 (defect reproduced) |
| Before the fix | Applied MR2 by hand against the unmodified census | exit 0 (defect reproduced) |
| After the fix, on the guard itself | Neutered `undeclared_owner_definitions()` (`definition_sites` forced to `{}`) | Both new positive-control tests failed: `"the guard did NOT detect an undeclared duplicate definition"` |
| Restored | — | 21/21 green |

## BEHAVIOR BEFORE

`scripts/replacement_census.py` exits clean (0) when an undeclared module
defines a same-named copy of an OWNER symbol, whether or not it is called.

## BEHAVIOR AFTER

Any such definition — called or not — fails the census with
`EXIT_VIOLATION` and names the symbol and the stray path(s).

## V1-29 IMPACT

Closes exactly the residual named in the completion contract. Does not
redesign census scope, does not touch any lineup/Team Strength/FLEX
methodology (this row shares no code path with V1-27/V1-28's
lineup-assignment owner), and does not re-classify any existing CENSUS row.

## L2 MEASUREMENT — board/roster quantity movement

Structural-only change, **proven rather than asserted**:

- `scripts/replacement_census.py` has zero importers outside its own test
  file and isn't wired into CI or the server runtime — it cannot move a
  published value by construction (confirmed by repo-wide grep, not
  assumed).
- Empirically: `tests/league_intel/test_replacement.py` +
  `tests/roster_intel/` + `tests/scoring/` (the actual production
  replacement/roster-intelligence consumers) — **682 passed before this
  change, 685 passed after** (exactly +3 — this PR's own new tests), zero
  change to any pre-existing test's outcome.
- `scripts/check_decision_coercions.py`: clean, no new coercions.
- Missing/unknown-vs-zero: N/A to this change — the guard's output is a
  presence/absence dict (violation or none), not a numeric quantity, so
  there is no missing-as-zero surface to protect.
- `git diff --stat main`: exactly 2 files touched
  (`scripts/replacement_census.py`, its test file) — no OWNER/ADAPTER/
  DISTINCT implementation file was touched.

## REMAINING V1-29 WORK

None known. This closes the specific, measured gap the contract names;
the census's broader scope (six replacement-level implementations across
distinct units/populations) is unchanged and was not re-audited here.

## OWNER DECISIONS

None. No new policy or methodology question was raised by this fix.

---

`FEATURE_GREEN`
`READY_FOR_INTEGRATION`

Head: `43d0ac8b2`, off `main` `892df5686`. Not stating V1-29 verified —
that determination belongs to Integration/Claude 5.

**Note on the task framing:** the assignment that produced this PR named
V1-29 as "one lineup optimizer / assignment engine," but the actual
contract row for V1-29 is "one replacement level / PAR owner"
(`C2-REPL-01`/`C2-U2`) — the specific defect text quoted in the
assignment (undeclared duplicate defeating single-owner protection,
contrast with V1-34/V1-130's guard) matches that row verbatim, and the
referenced precedent test
(`tests/trade/test_recommendation_constraints.py::test_there_is_exactly_one_constraint_owner`)
confirms it. This PR targets the real V1-29; lineup/slot assignment is a
separate row (V1-27) not touched here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PyqbZejxh7ytbfijL5pmdE)_