### PR TITLE
V1-108: transitive import-graph guard for the no-player-data routes

### DIFF
--- a/frontend/__tests__/route-gate-no-player-data-transitive.test.js
+++ b/frontend/__tests__/route-gate-no-player-data-transitive.test.js
@@ -1,0 +1,108 @@
+/**
+ * V1-108 committed regression evidence: the six NO_PLAYER_DATA routes
+ * (frontend/components/AppShell.jsx) must not be able to reacquire the
+ * player pipeline (useDynastyData / useApp) through ANY chain of
+ * production imports, not just their own page.jsx source.
+ *
+ * V1-108 was previously refused for exactly the gap this file closes:
+ * the route-gating logic (isNoPlayerDataRoute) was measured working in
+ * the browser, but nothing durable proved the SIX ROUTES' actual import
+ * graphs stay clear of the two hooks as the codebase changes around
+ * them. `app-shell-route-gates.test.js` pins the STRING-MATCHING gate
+ * (does "/admin/x" match the "/admin" prefix?) — a real, separate
+ * concern, but it says nothing about what admin/page.jsx's own imports
+ * actually pull in.
+ *
+ * This test walks the REAL transitive import graph from each route's
+ * own page module (frontend/scripts/route-import-graph.mjs) — no
+ * hand-maintained "these are the files this route touches" list.
+ */
+import { describe, expect, it } from "vitest";
+import path from "node:path";
+import url from "node:url";
+import {
+  findTransitivePlayerDataConsumers,
+  findPageModulesUnder,
+} from "../scripts/route-import-graph.mjs";
+import { __routeGates } from "@/components/AppShell";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const FRONTEND_ROOT = path.resolve(__dirname, "..");
+
+function describeConsumers(consumers) {
+  return consumers
+    .map((c) => `${c.hook}() reachable via ${path.relative(FRONTEND_ROOT, c.file)}`)
+    .join("\n  ");
+}
+
+// Route prefix -> app directory. Mirrors how Next.js itself maps a
+// route prefix to a directory; not duplicated route-by-route logic.
+function appDirForPrefix(prefix) {
+  return path.join(FRONTEND_ROOT, "app", prefix.replace(/^\//, ""));
+}
+
+describe("no-player-data routes cannot transitively reacquire useDynastyData/useApp", () => {
+  const prefixes = __routeGates.NO_PLAYER_DATA_ROUTE_PREFIXES;
+
+  it("the gate list itself is non-empty (a vacuous list would pass every assertion below)", () => {
+    expect(prefixes.length).toBeGreaterThan(0);
+  });
+
+  for (const prefix of prefixes) {
+    describe(prefix, () => {
+      const dir = appDirForPrefix(prefix);
+      const pageFiles = findPageModulesUnder(dir);
+
+      it("has at least one real page.jsx under it (a route with none would pass vacuously)", () => {
+        expect(pageFiles.length, `no page.jsx found under ${dir}`).toBeGreaterThan(0);
+      });
+
+      it.each(pageFiles.length ? pageFiles : ["<none found>"])(
+        "%s reaches no useDynastyData()/useApp() call in its transitive import graph",
+        (pageFile) => {
+          if (pageFile === "<none found>") return; // covered by the assertion above
+          const { visitedFiles, consumers } = findTransitivePlayerDataConsumers(pageFile);
+          // A graph of 1 (just the entry file, nothing resolved) means the
+          // walker never actually traversed anything real — that would be
+          // this test lying about coverage, not a clean route.
+          expect(
+            visitedFiles.size,
+            `${path.relative(FRONTEND_ROOT, pageFile)}: import graph walk only reached ` +
+              `${visitedFiles.size} file(s) — the walker is not resolving this route's imports`,
+          ).toBeGreaterThan(1);
+          expect(
+            consumers,
+            `${path.relative(FRONTEND_ROOT, pageFile)} transitively reaches a player-data ` +
+              `consumer it must not have:\n  ${describeConsumers(consumers)}`,
+          ).toEqual([]);
+        },
+      );
+    });
+  }
+});
+
+// Positive control (requirement: the scanner must demonstrably detect a
+// REAL transitive consumer, not just report "clean" because it never
+// looks at anything). These two routes are the deliberate exclusions —
+// audited and pinned in app-shell-route-gates.test.js as staying ON the
+// player pipeline because they really consume it. If the scanner ever
+// stopped detecting them, every "no consumers found" result above would
+// be meaningless.
+describe("positive control — the scanner detects real consumers on the two deliberate exclusions", () => {
+  it("/settings calls useDynastyData() directly", () => {
+    const file = path.join(FRONTEND_ROOT, "app", "settings", "page.jsx");
+    const { consumers } = findTransitivePlayerDataConsumers(file);
+    expect(consumers.some((c) => c.hook === "useDynastyData")).toBe(true);
+  });
+
+  it("/tools/trade-coverage reaches useApp() — directly, and transitively via useTeam()", () => {
+    const file = path.join(FRONTEND_ROOT, "app", "tools", "trade-coverage", "page.jsx");
+    const { consumers } = findTransitivePlayerDataConsumers(file);
+    const appConsumers = consumers.filter((c) => c.hook === "useApp");
+    expect(appConsumers.length).toBeGreaterThan(0);
+    // At least one hit must come from a file OTHER than the route's own
+    // page.jsx — proving this is genuinely a TRANSITIVE-graph detection,
+    // not just "does the entry file itself mention the hook".
+    expect(appConsumers.some((c) => c.file !== file)).toBe(true);
+  });
+});

--- a/frontend/scripts/route-import-graph.mjs
+++ b/frontend/scripts/route-import-graph.mjs
@@ -1,0 +1,337 @@
+// Static transitive-import-graph walker for one specific question:
+// "does this route module's production import graph reach a real call
+// to useDynastyData() or useApp()?"
+//
+// V1-108 (docs/VERSION_1_COMPLETION_CONTRACT.md) requires committed
+// regression evidence that the six NO_PLAYER_DATA_ROUTE_PREFIXES routes
+// (frontend/components/AppShell.jsx) cannot reacquire the player
+// pipeline. A hand-maintained list of "files these routes import" would
+// itself be the kind of shallow evidence the target was refused for —
+// this walks the REAL import graph starting from the route's own page
+// module, following every local import/re-export it resolves.
+//
+// This is intentionally NOT a full JS/TS parser (this repo has none —
+// see the a11y and CSS-contract tests for the same regex-based
+// convention). Three things make a regex approach trustworthy enough
+// for this specific question, each earned by measurement against the
+// real tree during development (not asserted a priori):
+//
+//   1. Comments are stripped first (string/template-aware), so a prose
+//      comment mentioning "useApp()" cannot be mistaken for a call —
+//      this codebase's own comments are dense enough that this is not
+//      hypothetical (AppShell.jsx's own doc comments name both hooks).
+//   2. A hook CALL (`useApp(`) is distinguished from the hook's own
+//      DECLARATION (`function useApp(`) via a negative lookbehind, so
+//      walking into the hook's defining file does not self-flag.
+//   3. Imports are resolved per NAMED BINDING, not whole-file: when a
+//      route imports one named export from a multi-export file, only
+//      that export's own top-level declaration (plus the file's module
+//      header) is scanned and only ITS OWN referenced imports are
+//      followed — otherwise an unrelated sibling export in the same
+//      file (e.g. AppShellWrapper.jsx's unrelated search-bridge
+//      component, which does call useApp()) would falsely implicate
+//      every importer of any OTHER export from that file.
+//
+// Where a binding cannot be precisely narrowed (barrel re-export chains
+// deeper than 6 hops, an unrecognized export shape), this walker fails
+// SAFE by scanning/following the whole file rather than skipping it —
+// under-approximating a security/perf guard is the wrong direction to
+// be wrong in.
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
+
+const FRONTEND_ROOT = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), "..");
+const EXTENSIONS = [".js", ".jsx", ".ts", ".tsx"];
+const HOOK_NAMES = ["useDynastyData", "useApp"];
+
+function stripComments(src) {
+  let out = "";
+  let i = 0;
+  const n = src.length;
+  while (i < n) {
+    const c = src[i];
+    const c2 = src[i + 1];
+    if (c === "/" && c2 === "/") {
+      while (i < n && src[i] !== "\n") i++;
+      continue;
+    }
+    if (c === "/" && c2 === "*") {
+      i += 2;
+      while (i < n && !(src[i] === "*" && src[i + 1] === "/")) i++;
+      i += 2;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      const quote = c;
+      out += c;
+      i++;
+      while (i < n && src[i] !== quote) {
+        if (src[i] === "\\") {
+          out += src[i] + (src[i + 1] ?? "");
+          i += 2;
+          continue;
+        }
+        out += src[i];
+        i++;
+      }
+      out += src[i] ?? "";
+      i++;
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
+function resolveModule(spec, fromFile) {
+  let base;
+  if (spec.startsWith(".")) {
+    base = path.resolve(path.dirname(fromFile), spec);
+  } else if (spec.startsWith("@/")) {
+    base = path.resolve(FRONTEND_ROOT, spec.slice(2));
+  } else {
+    return null; // external package (react, next/*, ...) — not traversed
+  }
+  if (fs.existsSync(base) && fs.statSync(base).isFile()) return base;
+  for (const ext of EXTENSIONS) if (fs.existsSync(base + ext)) return base + ext;
+  for (const ext of EXTENSIONS) {
+    const idx = path.join(base, "index" + ext);
+    if (fs.existsSync(idx)) return idx;
+  }
+  return null;
+}
+
+// "*" (namespace/dynamic/require — need whole module) or an array of
+// { local, imported } bindings.
+function parseBindings(clauseText) {
+  clauseText = clauseText.trim();
+  if (clauseText.startsWith("*")) return "*";
+  const bindings = [];
+  const rest = clauseText;
+  const braceStart = rest.indexOf("{");
+  if (braceStart > 0) {
+    const defaultPart = rest.slice(0, braceStart).replace(/,\s*$/, "").trim();
+    if (defaultPart) bindings.push({ local: defaultPart, imported: "default" });
+  } else if (braceStart === -1 && rest) {
+    bindings.push({ local: rest, imported: "default" });
+    return bindings;
+  }
+  const braceEnd = rest.lastIndexOf("}");
+  if (braceStart !== -1 && braceEnd !== -1) {
+    const inner = rest.slice(braceStart + 1, braceEnd);
+    for (const part of inner.split(",")) {
+      const p = part.trim();
+      if (!p) continue;
+      const asMatch = p.split(/\s+as\s+/);
+      bindings.push({ local: (asMatch[1] || asMatch[0]).trim(), imported: asMatch[0].trim() });
+    }
+  }
+  return bindings;
+}
+
+function extractClauses(src) {
+  const out = [];
+  const importRe = /(?:^|\n)\s*import\s+([^'";]*?)\s+from\s+["']([^"']+)["']/g;
+  const exportFromRe = /(?:^|\n)\s*export\s+([^'";]*?)\s+from\s+["']([^"']+)["']/g;
+  const dynImportRe = /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g;
+  const requireRe = /\brequire\(\s*["']([^"']+)["']\s*\)/g;
+  let m;
+  while ((m = importRe.exec(src))) out.push({ spec: m[2], bindings: parseBindings(m[1]) });
+  while ((m = exportFromRe.exec(src))) out.push({ spec: m[2], bindings: parseBindings(m[1]) });
+  while ((m = dynImportRe.exec(src))) out.push({ spec: m[1], bindings: "*" });
+  while ((m = requireRe.exec(src))) out.push({ spec: m[1], bindings: "*" });
+  return out;
+}
+
+const DECL_RE =
+  /^(?:export\s+)?(?:default\s+)?(?:async\s+)?function\s+(\w+)|^(?:export\s+)?const\s+(\w+)\s*=|^(?:export\s+)?class\s+(\w+)/gm;
+
+function sliceDeclarations(src) {
+  const bounds = [];
+  let m;
+  while ((m = DECL_RE.exec(src))) bounds.push({ name: m[1] || m[2] || m[3], start: m.index });
+  const slices = new Map();
+  for (let i = 0; i < bounds.length; i++) {
+    const start = bounds[i].start;
+    const end = i + 1 < bounds.length ? bounds[i + 1].start : src.length;
+    slices.set(bounds[i].name, (slices.get(bounds[i].name) || "") + src.slice(start, end));
+  }
+  const header = src.slice(0, bounds.length ? bounds[0].start : src.length);
+  return { header, slices };
+}
+
+function defaultExportLocalName(src) {
+  const m1 = src.match(/^export\s+default\s+(?:async\s+)?function\s+(\w+)/m);
+  if (m1) return m1[1];
+  const m2 = src.match(/^export\s+default\s+(\w+)\s*;?\s*$/m);
+  if (m2) return m2[1];
+  return null;
+}
+
+function findConsumerCalls(text, extraLocalNames = []) {
+  const found = [];
+  for (const hook of HOOK_NAMES) {
+    if (new RegExp(`(?<!function\\s)\\b${hook}\\s*\\(`).test(text)) found.push(hook);
+  }
+  for (const { local, hook } of extraLocalNames) {
+    if (local === hook) continue;
+    if (new RegExp(`(?<!function\\s)\\b${local}\\s*\\(`).test(text)) found.push(hook);
+  }
+  return found;
+}
+
+// Local alias names bound to useApp/useDynastyData via THIS file's own
+// imports, e.g. `import { useApp as useShell } from "..."` — rare (no
+// current file does this), but a rename should not defeat the guard.
+function hookAliasesInFile(rec) {
+  const aliases = [];
+  for (const clause of rec.clauses) {
+    if (clause.bindings === "*") continue;
+    for (const b of clause.bindings) {
+      if (b.imported === "useApp" || b.imported === "useDynastyData") {
+        aliases.push({ local: b.local, hook: b.imported });
+      }
+    }
+  }
+  return aliases;
+}
+
+const fileCache = new Map();
+function loadFile(file) {
+  if (fileCache.has(file)) return fileCache.get(file);
+  let raw;
+  try {
+    raw = fs.readFileSync(file, "utf-8");
+  } catch {
+    const empty = { stripped: "", header: "", slices: new Map(), clauses: [] };
+    fileCache.set(file, empty);
+    return empty;
+  }
+  const stripped = stripComments(raw);
+  const { header, slices } = sliceDeclarations(stripped);
+  const clauses = extractClauses(header); // imports always live in the header
+  const rec = { stripped, header, slices, clauses };
+  fileCache.set(file, rec);
+  return rec;
+}
+
+function resolveExportToSliceOrFile(file, importedName, depth = 0) {
+  if (depth > 6) return { kind: "whole", file };
+  const rec = loadFile(file);
+  if (importedName === "default") {
+    const local = defaultExportLocalName(rec.stripped);
+    if (local && rec.slices.has(local)) return { kind: "slice", file, body: rec.slices.get(local) };
+  } else if (rec.slices.has(importedName)) {
+    return { kind: "slice", file, body: rec.slices.get(importedName) };
+  }
+  for (const clause of rec.clauses) {
+    if (clause.bindings === "*") continue;
+    for (const b of clause.bindings) {
+      if (b.imported === importedName) {
+        const resolved = resolveModule(clause.spec, file);
+        if (resolved) return resolveExportToSliceOrFile(resolved, importedName, depth + 1);
+      }
+    }
+  }
+  return null; // could not narrow — caller falls back to whole-file
+}
+
+/**
+ * Walk the transitive production import graph from `entryFile` and
+ * report every reached call site of useDynastyData()/useApp().
+ *
+ * @param {string} entryFile absolute path to a route module (page.jsx)
+ * @returns {{ visitedFiles: Set<string>, consumers: Array<{file: string, hook: string}> }}
+ */
+export function findTransitivePlayerDataConsumers(entryFile) {
+  const visitedFiles = new Set();
+  const visitedWhole = new Set();
+  const visitedSliceKeys = new Set();
+  const consumers = [];
+  const queue = [{ file: entryFile, bindings: "*" }];
+
+  while (queue.length) {
+    const { file, bindings } = queue.pop();
+    const rec = loadFile(file);
+    if (!rec.stripped) continue;
+    visitedFiles.add(file);
+
+    const textsToScan = [];
+    const followClauses = [];
+
+    if (bindings === "*") {
+      if (visitedWhole.has(file)) continue;
+      visitedWhole.add(file);
+      textsToScan.push(rec.stripped);
+      followClauses.push(...rec.clauses);
+    } else {
+      for (const b of bindings) {
+        const key = `${file}::${b.imported}`;
+        if (visitedSliceKeys.has(key)) continue;
+        visitedSliceKeys.add(key);
+        const resolved = resolveExportToSliceOrFile(file, b.imported);
+        if (resolved && resolved.kind === "slice") {
+          textsToScan.push(resolved.body);
+          // Only follow an import the slice's OWN body actually uses —
+          // otherwise an unrelated sibling export's dependencies leak in.
+          for (const clause of rec.clauses) {
+            if (clause.bindings === "*") {
+              followClauses.push(clause);
+              continue;
+            }
+            const used = clause.bindings.some((cb) => new RegExp(`\\b${cb.local}\\b`).test(resolved.body));
+            if (used) followClauses.push(clause);
+          }
+        } else if (resolved && resolved.kind === "whole") {
+          if (!visitedWhole.has(resolved.file)) {
+            visitedWhole.add(resolved.file);
+            const rec2 = loadFile(resolved.file);
+            textsToScan.push(rec2.stripped);
+            followClauses.push(...rec2.clauses);
+          }
+        } else if (!visitedWhole.has(file)) {
+          visitedWhole.add(file);
+          textsToScan.push(rec.stripped);
+          followClauses.push(...rec.clauses);
+        }
+      }
+    }
+
+    const aliases = hookAliasesInFile(rec);
+    for (const text of textsToScan) {
+      for (const hook of findConsumerCalls(text, aliases)) consumers.push({ file, hook });
+    }
+    for (const clause of followClauses) {
+      const resolved = resolveModule(clause.spec, file);
+      if (resolved) queue.push({ file: resolved, bindings: clause.bindings });
+    }
+  }
+  return { visitedFiles, consumers };
+}
+
+// Recursively find every `page.jsx`/`page.js` under `dir` — the actual
+// route modules, not a hand-maintained list, so a new sub-page under a
+// gated prefix is covered automatically.
+export function findPageModulesUnder(dir) {
+  const found = [];
+  function walkDir(d) {
+    let entries;
+    try {
+      entries = fs.readdirSync(d, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(d, entry.name);
+      if (entry.isDirectory()) {
+        walkDir(full);
+      } else if (/^page\.(jsx?|tsx?)$/.test(entry.name)) {
+        found.push(full);
+      }
+    }
+  }
+  walkDir(dir);
+  return found;
+}


### PR DESCRIPTION
## Target

`V1-108` (`docs/VERSION_1_COMPLETION_CONTRACT.md`, `C8-PERF-02`) — "Non-data routes stop fetching the contract." Previously refused: the route-gating implementation (`AppShell.jsx`'s `NO_PLAYER_DATA_ROUTE_PREFIXES` / `isNoPlayerDataRoute`) exists and was browser-measured, but no durable test proved the six gated routes' **actual production import graphs** stay clear of `useDynastyData()`/`useApp()` — only the string-matching gate logic itself was pinned (`app-shell-route-gates.test.js`), which says nothing about what e.g. `admin/page.jsx`'s own imports pull in.

## What this adds

**`frontend/scripts/route-import-graph.mjs`** — a static walker that starts from a route's own `page.jsx` and follows its real production imports (relative + `@/`-aliased), resolved **per named binding** through re-export barrels — so importing one export from a multi-export file (e.g. `AppShellWrapper.jsx`'s `useAuthContext`) doesn't falsely implicate that file's unrelated sibling exports (its own `AppShellSearchBridge`, which does call `useApp()`). Comments are stripped first (string/template-aware) — this codebase's own doc comments literally contain the strings `useApp()` / `useDynastyData()` in prose (`AppShell.jsx`'s own docstring), which a naive scan would self-trigger on. Hook *declarations* are excluded from *call* detection via lookbehind, and local aliasing of either hook name is tracked so a rename can't quietly defeat the guard.

**`frontend/__tests__/route-gate-no-player-data-transitive.test.js`**:
- Discovers route modules by walking the filesystem under each of `AppShell.jsx`'s own `NO_PLAYER_DATA_ROUTE_PREFIXES` (read from `__routeGates`, not re-typed) — requirements #1/#2.
- Asserts each one's transitive graph reaches neither hook — requirement #3.
- Preserves `/settings` and `/tools/trade-coverage` unguarded — requirement #4 (untouched; this PR adds no gating changes).
- **Positive control** (requirement #5): asserts the scanner *does* detect a real transitive consumer on those same two deliberately-excluded routes — `/settings` calls `useDynastyData()` directly; `/tools/trade-coverage` reaches `useApp()` both directly and transitively through `components/useTeam.js`. Proves the "no consumers found" results on the six gated routes aren't vacuous.
- Two more anti-vacuity guards: each gated prefix must have ≥1 real `page.jsx`, and the walker must have visited more than just the entry file.

## Mutation proof (requirement #6)

Not committed as a fixture — a manual proof against the real tree, reverted after:

1. Added `app/admin/sharp-identities/_mutationProbe.js` (`import { useApp } from "@/components/AppShell"`, calls it) and imported it from that route's `page.jsx`.
2. Re-ran the new test → **RED**, with `useApp() reachable via app/admin/sharp-identities/_mutationProbe.js` named explicitly in the failure message.
3. Reverted both files → **GREEN** again.

No product code was touched to make this pass or fail — the test and the walker are the only new files in this PR.

## Validation

- `npx vitest run --project logic`: **85 files, 1722 tests passed** (was 1706; +16 new)
- `npx vitest run __tests__/app-shell-route-gates.test.js`: **18/18** (existing gate-composition test, untouched, unaffected)
- `npm run build:nocheck`: production build succeeds; all six gated routes still emit static (`○`)

## L2 evidence

No runtime/gating code changed in this PR, so the browser-measured behavior from PR #759 is unchanged — this closes the *missing regression-prevention evidence* gap specifically, not a behavior change. The new test itself is a fresh, automated, current-tree verification that the import graph is clean today; a live network re-capture wasn't necessary since nothing observable changed.

## Boundaries respected

- No auth/privacy boundary changed (requirement #7).
- No player-contract or canonical frontend value logic touched (requirement #8) — both new files are dev tooling + a test.
- `#965` PSI remains untouched and out of scope here — still POST-V1, still needs real browser visual verification before Integration, not waived by this PR.

---

`FEATURE_GREEN` / `READY_FOR_INTEGRATION`. Head: `1d62b8682`. Freezing this branch — will only resume on a branch-caused CI failure, substantive review feedback, or an explicit Integration request.

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3RzLM83tcVjrziFjZmyUn)_