### PR TITLE
V1-88: non-vacuous flag-to-route reachability guard (F-26)

### DIFF
--- a/src/api/flag_reachability.py
+++ b/src/api/flag_reachability.py
@@ -1,0 +1,231 @@
+"""Structural reachability: which route a feature flag's gate actually reaches.
+
+Audit **F-26** found a feature-flag comment naming the wrong endpoint
+(``/api/gameplan`` instead of the route the gate genuinely reaches,
+``/api/valuation/league-adjusted``).  The repair was correct, but nothing
+in the test suite could have caught the *original* defect: the existing
+guards compare a docstring's ON/OFF claim against ``_DEFAULTS``
+(:mod:`tests.league_intel.test_flag_docs_match_reality`) or check that a
+named route is registered somewhere in the app
+(:func:`scripts.verify_lane4_production._registered_routes_static`).
+Neither links the flag to a SPECIFIC route through the code that actually
+reads it.  Reintroducing F-26's exact defect — renaming the endpoint back
+to ``/api/gameplan`` in the comment — leaves every existing guard green.
+
+This module closes that gap by tracing, structurally, in one direction:
+
+    flag name
+      -> every ``is_enabled("<flag>")`` call site (the gate)
+      -> that call's enclosing function
+      -> every function that calls it, transitively, up to a bounded depth
+      -> any FastAPI route handler reached along the way, and its path(s)
+
+and, independently, extracting what the flag's own comment block in
+``_DEFAULTS`` claims via any ``/api/...`` token — so the test that uses
+both can assert the claim is actually reachable rather than merely
+present somewhere in the source tree.
+
+Name-based, not import-resolved.  Two functions sharing a bare name would
+over-approximate reachability (a caller of "the wrong" same-named
+function looks like a caller of the right one) but never under-approximate
+it, so a real reachable route is never missed — the failure mode this
+guard exists to catch is a route named that is NOT reachable, and
+over-approximation cannot hide that.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+_HTTP_VERBS = {"GET", "POST", "PUT", "DELETE", "PATCH"}
+
+_ENDPOINT_TOKEN = re.compile(r"/api/[A-Za-z0-9/_-]+")
+# The convention this file already uses for "this is the answer, not
+# just a mention": ``**`/api/...`**``. A comment explaining a past
+# defect (F-26's own block does exactly this) legitimately mentions the
+# WRONG endpoint in plain prose while stating the real one in bold --
+# so when any bold-marked mention exists, it is authoritative and
+# unmarked mentions are historical color, not a second claim.
+_BOLD_ENDPOINT_TOKEN = re.compile(r"\*\*`(/api/[A-Za-z0-9/_-]+)`\*\*")
+
+# Bounded so a runaway or accidental cycle in the name-based caller graph
+# cannot hang the test; every real chain in this codebase (gate ->
+# private resolver -> module-level assembler -> route handler) is 2-3
+# hops deep.
+_MAX_HOPS = 6
+
+
+def _iter_source_files() -> list[Path]:
+    return [REPO_ROOT / "server.py", *sorted((REPO_ROOT / "src").rglob("*.py"))]
+
+
+def _parse(path: Path) -> ast.Module | None:
+    try:
+        return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return None
+
+
+def _called_names(node: ast.AST) -> set[str]:
+    """Every function-shaped name this subtree touches -- called OR referenced.
+
+    Deliberately broader than "names directly invoked as ``Call.func``":
+    this codebase routes several sync functions to a thread pool with
+    ``await run_in_threadpool(_gameplan.get_league_adjusted_values, ...)``,
+    where the target is passed as a plain argument, never itself the
+    ``func`` of a ``Call`` node. Restricting this to call sites produced a
+    real false negative -- the route handler that reaches
+    ``get_league_adjusted_values`` this way was invisible to the BFS.
+    Capturing every ``Name``/``Attribute`` load is a safe over-approximation
+    for reachability (see the module docstring): it can only ADD edges,
+    never hide the one this guard exists to find.
+    """
+    names: set[str] = set()
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Name):
+            names.add(sub.id)
+        elif isinstance(sub, ast.Attribute):
+            names.add(sub.attr)
+    return names
+
+
+def _route_paths(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    paths: set[str] = set()
+    for dec in node.decorator_list:
+        if not isinstance(dec, ast.Call) or not isinstance(dec.func, ast.Attribute):
+            continue
+        if dec.func.attr.upper() not in _HTTP_VERBS:
+            continue
+        if (
+            dec.args
+            and isinstance(dec.args[0], ast.Constant)
+            and isinstance(dec.args[0].value, str)
+        ):
+            paths.add(dec.args[0].value)
+    return paths
+
+
+class _FunctionIndex:
+    """Every top-level-reachable function/method in the tree, with its calls and route paths."""
+
+    def __init__(self) -> None:
+        # (module_path, qualname) -> set of names it calls
+        self.calls: dict[tuple[str, str], set[str]] = {}
+        # name -> set of (module_path, qualname) defining a function with that name
+        self.by_name: dict[str, set[tuple[str, str]]] = {}
+        # (module_path, qualname) -> set of route paths, if it's a route handler
+        self.routes: dict[tuple[str, str], set[str]] = {}
+        # (module_path, qualname) -> True if a gate for some flag lives directly in its body
+        self.gate_flags: dict[tuple[str, str], set[str]] = {}
+
+    def index(self, path: Path, tree: ast.Module) -> None:
+        module = str(path.relative_to(REPO_ROOT))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            key = (module, node.name)
+            self.calls.setdefault(key, set()).update(_called_names(node))
+            self.by_name.setdefault(node.name, set()).add(key)
+            route_paths = _route_paths(node)
+            if route_paths:
+                self.routes.setdefault(key, set()).update(route_paths)
+            for gate_node in ast.walk(node):
+                if not isinstance(gate_node, ast.Call):
+                    continue
+                func = gate_node.func
+                func_name = (
+                    func.id
+                    if isinstance(func, ast.Name)
+                    else (func.attr if isinstance(func, ast.Attribute) else None)
+                )
+                if func_name != "is_enabled":
+                    continue
+                if (
+                    gate_node.args
+                    and isinstance(gate_node.args[0], ast.Constant)
+                    and isinstance(gate_node.args[0].value, str)
+                ):
+                    self.gate_flags.setdefault(key, set()).add(gate_node.args[0].value)
+
+
+def _build_index() -> _FunctionIndex:
+    index = _FunctionIndex()
+    for path in _iter_source_files():
+        tree = _parse(path)
+        if tree is not None:
+            index.index(path, tree)
+    return index
+
+
+def reachable_routes_for_flag(flag: str, index: _FunctionIndex | None = None) -> set[str]:
+    """Every route path reachable from ``is_enabled(flag)`` via the caller graph.
+
+    BFS over "who calls this function name", starting at every function
+    whose body contains the gate for ``flag`` directly, up to
+    :data:`_MAX_HOPS`. Any visited function that is a registered route
+    handler contributes its path(s) to the result.
+    """
+    idx = index or _build_index()
+
+    start_nodes = {key for key, flags in idx.gate_flags.items() if flag in flags}
+    visited: set[tuple[str, str]] = set()
+    frontier: set[tuple[str, str]] = set(start_nodes)
+    found_routes: set[str] = set()
+
+    for _ in range(_MAX_HOPS):
+        if not frontier:
+            break
+        next_frontier: set[tuple[str, str]] = set()
+        for node_key in frontier:
+            if node_key in visited:
+                continue
+            visited.add(node_key)
+            found_routes.update(idx.routes.get(node_key, set()))
+            _module, funcname = node_key
+            # Who calls a function named `funcname`? Name-based, so this
+            # over-approximates rather than under-approximates -- see the
+            # module docstring for why that direction is safe here.
+            for caller_key, called_names in idx.calls.items():
+                if caller_key in visited:
+                    continue
+                if funcname in called_names:
+                    next_frontier.add(caller_key)
+        frontier = next_frontier
+
+    return found_routes
+
+
+def documented_endpoints(flag: str, feature_flags_source: str | None = None) -> set[str]:
+    """``/api/...`` tokens in the comment block immediately above ``"<flag>":`` in ``_DEFAULTS``.
+
+    Walks upward from the flag's dict-entry line collecting contiguous
+    ``#``-comment lines (this codebase writes long prose blocks directly
+    above each entry, with no blank-line separator from the previous
+    entry), stopping at the first non-comment line -- the previous flag's
+    entry, or the dict's opening line for the first flag.
+    """
+    if feature_flags_source is None:
+        feature_flags_source = (REPO_ROOT / "src" / "api" / "feature_flags.py").read_text(
+            encoding="utf-8"
+        )
+    lines = feature_flags_source.splitlines()
+    entry_pattern = re.compile(r'^\s*"' + re.escape(flag) + r'"\s*:')
+    entry_idx = next((i for i, line in enumerate(lines) if entry_pattern.match(line)), None)
+    if entry_idx is None:
+        return set()
+
+    block: list[str] = []
+    i = entry_idx - 1
+    while i >= 0 and lines[i].strip().startswith("#"):
+        block.append(lines[i])
+        i -= 1
+    block.reverse()
+    text = "\n".join(block)
+    bold = set(_BOLD_ENDPOINT_TOKEN.findall(text))
+    if bold:
+        return bold
+    return set(_ENDPOINT_TOKEN.findall(text))

--- a/tests/api/test_feature_flag_endpoint_reachability.py
+++ b/tests/api/test_feature_flag_endpoint_reachability.py
@@ -1,0 +1,152 @@
+"""A flag's documented ROUTE must be the one its gate actually reaches.
+
+Audit **F-26**: a comment in ``_DEFAULTS`` named ``/api/gameplan`` as the
+endpoint ``reception_scoring_fit`` gates. Measured, that was wrong — the
+gate reaches only ``/api/valuation/league-adjusted``. The repair (naming
+the right endpoint) is correct and already shipped. What was missing is
+a test that could have caught the ORIGINAL defect, and Integration
+proved by mutation that none of the existing guards do:
+
+* ``tests/api/test_feature_flag_docs_match_registry.py`` /
+  ``tests/league_intel/test_flag_docs_match_reality.py`` compare a
+  docstring's ON/OFF claim against ``_DEFAULTS`` — never a route name.
+* ``tests/api/test_feature_flag_reachability.py`` measures whether a
+  flag's gate is reachable from ``server.py`` AT ALL (LIVE / UNREACHABLE
+  / SCRIPT_ONLY / NO_GATE) — module-level, not route-specific. A flag
+  correctly measured LIVE tells you nothing about which of the app's
+  ~100 routes it actually affects.
+* A route-existence check (``scripts/verify_lane4_production.py``'s
+  ``_registered_routes_static``) would also pass vacuously here:
+  ``/api/gameplan`` IS a registered route. The defect was reachability
+  FROM THIS FLAG, not existence of the named route anywhere in the app.
+
+This file closes that gap using ``src.api.flag_reachability``, which
+resolves flag -> gate call site -> enclosing function -> every function
+that calls it, transitively -> any route handler reached along the way.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.api import flag_reachability as fr
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FEATURE_FLAGS_PATH = REPO_ROOT / "src" / "api" / "feature_flags.py"
+
+#: Flags whose ``_DEFAULTS`` comment makes a bold-marked ``/api/...``
+#: claim today. Reused across the positive and mutation tests below so
+#: there is exactly one place naming "the relevant flag".
+_DOCUMENTED_FLAG = "reception_scoring_fit"
+_DOCUMENTED_ROUTE = "/api/valuation/league-adjusted"
+_F26_WRONG_ROUTE = "/api/gameplan"
+
+
+def test_the_documented_endpoint_is_actually_reachable():
+    """The positive case: today's comment names a route the gate reaches.
+
+    This is the assertion the original F-26 defect would have failed:
+    with the comment naming ``/api/gameplan``, the documented set would
+    not be a subset of what the gate structurally reaches, because
+    ``/api/gameplan``'s handler (``get_gameplan``) never calls the
+    reception-fit resolver at all.
+    """
+    documented = fr.documented_endpoints(_DOCUMENTED_FLAG)
+    assert documented, (
+        f"{_DOCUMENTED_FLAG}'s _DEFAULTS comment makes no bold-marked /api/... "
+        "claim -- update _DOCUMENTED_FLAG or the comment"
+    )
+    reachable = fr.reachable_routes_for_flag(_DOCUMENTED_FLAG)
+    assert reachable, (
+        f"no route is structurally reachable from is_enabled({_DOCUMENTED_FLAG!r}) at all "
+        "-- the BFS or the gate scan is broken, not just this flag"
+    )
+    assert documented.issubset(reachable), (
+        f"{_DOCUMENTED_FLAG} documents {sorted(documented)} but the gate only "
+        f"structurally reaches {sorted(reachable)}"
+    )
+    assert _DOCUMENTED_ROUTE in reachable
+
+
+def test_the_f26_wrong_route_is_not_reachable_from_this_flag():
+    """Negative control.
+
+    Proves the guard can actually say NO: if ``reachable_routes_for_flag``
+    returned "every route in the app" regardless of the flag, this would
+    fail. It doesn't -- ``/api/gameplan``'s handler (``get_gameplan``)
+    never touches ``_resolve_reception_fit`` or anything that calls it.
+    """
+    reachable = fr.reachable_routes_for_flag(_DOCUMENTED_FLAG)
+    assert _F26_WRONG_ROUTE not in reachable
+
+
+def test_reintroducing_the_exact_f26_defect_fails_the_guard():
+    """Mutation proof, against the REAL file's actual current text.
+
+    Takes ``src/api/feature_flags.py`` as it exists on disk right now,
+    performs the exact edit F-26 reverted (rename the bold-marked
+    endpoint claim from ``/api/valuation/league-adjusted`` back to
+    ``/api/gameplan``), and re-runs the same extraction against the
+    mutated text. The claim must fail the reachability check -- if it
+    doesn't, this guard is exactly as vacuous as the ones Integration
+    already refuted.
+    """
+    real_source = FEATURE_FLAGS_PATH.read_text(encoding="utf-8")
+    marker = f"**`{_DOCUMENTED_ROUTE}`**"
+    assert marker in real_source, (
+        "the bold-marked claim this test mutates is no longer present verbatim "
+        "in feature_flags.py -- the comment changed shape, update this test"
+    )
+
+    mutated_source = real_source.replace(marker, f"**`{_F26_WRONG_ROUTE}`**", 1)
+    assert mutated_source != real_source
+
+    documented_after_mutation = fr.documented_endpoints(
+        _DOCUMENTED_FLAG, feature_flags_source=mutated_source
+    )
+    assert documented_after_mutation == {_F26_WRONG_ROUTE}, (
+        "the mutation did not change what documented_endpoints() extracts -- "
+        f"got {documented_after_mutation}, extraction logic drifted from the marker"
+    )
+
+    reachable = fr.reachable_routes_for_flag(_DOCUMENTED_FLAG)  # unaffected by the text mutation
+    assert not documented_after_mutation.issubset(reachable), (
+        "REGRESSION: reintroducing the exact F-26 defect (claiming "
+        f"{_F26_WRONG_ROUTE!r} for {_DOCUMENTED_FLAG!r}) did not fail this guard"
+    )
+
+
+def test_documented_endpoints_prefers_the_bold_marked_claim_over_history():
+    """Non-vacuity for the extraction itself.
+
+    The real comment legitimately mentions BOTH endpoints in prose --
+    ``/api/gameplan`` as "this line used to name", ``/api/valuation/
+    league-adjusted`` as the bold-marked current answer. A naive
+    "every /api/... token in the block" extraction would make the
+    positive test above fail permanently (the retired route is always
+    mentioned), which would make a real operator either delete the
+    historical note or ignore a red test. Bold-marking is what lets the
+    comment keep its own history AND stay machine-checkable.
+    """
+    real_source = FEATURE_FLAGS_PATH.read_text(encoding="utf-8")
+    assert _F26_WRONG_ROUTE in real_source  # the historical mention is still there
+    documented = fr.documented_endpoints(_DOCUMENTED_FLAG, feature_flags_source=real_source)
+    assert documented == {_DOCUMENTED_ROUTE}
+    assert _F26_WRONG_ROUTE not in documented
+
+
+def test_reachable_routes_sees_the_run_in_threadpool_indirection():
+    """Non-vacuity for the caller graph's over-approximation.
+
+    ``server.py``'s route handler reaches the module-level assembler via
+    ``await run_in_threadpool(_gameplan.get_league_adjusted_values, ...)``
+    -- the target is a plain argument, never itself a ``Call.func``. A
+    caller graph built only from direct call sites would miss this hop
+    entirely and report zero reachable routes for a flag that
+    demonstrably affects a real endpoint.
+    """
+    reachable = fr.reachable_routes_for_flag(_DOCUMENTED_FLAG)
+    assert reachable, (
+        "reachable_routes_for_flag found nothing -- the run_in_threadpool "
+        "indirection is invisible again, the exact false negative this guards"
+    )


### PR DESCRIPTION
**READY FOR INTEGRATION — Claude 5 promotes/merges. I do not.** Off current `main` at `7901b4733` (includes #977).

## What this closes

Integration's V1-88 note: the F-26 repair itself is correct — `src/api/feature_flags.py:228-237` now names `/api/valuation/league-adjusted` instead of the wrong `/api/gameplan` — but no test could have caught the *original* defect. Quoted from the ledger: *"reintroducing F-26's exact defect ... leaves `tests/league_intel/test_flag_docs_match_reality.py` + `tests/api/test_feature_flags.py` + `tests/league_intel/test_reception_fit.py` at 35 passed, 0 failed."* Those guards compare a docstring's ON/OFF claim against `_DEFAULTS` — never a route name. A route-existence check is also vacuous here: `/api/gameplan` **is** a registered route; the defect was reachability *from this flag*, not existence anywhere in the app. `tests/api/test_feature_flag_reachability.py` (pre-existing, untouched) answers a related but coarser question — is the gate reachable from `server.py` at all (LIVE/UNREACHABLE/SCRIPT_ONLY/NO_GATE) — not which specific route.

**What Integration asked for, quoted:** *"a guard that resolves flag → gate call site → enclosing function → route handler."*

## What this adds (2 new files, +383/-0)

**`src/api/flag_reachability.py`** — resolves the chain structurally:

```
flag name
  -> every is_enabled("<flag>") call site (the gate)
  -> that call's enclosing function
  -> every function that calls it, transitively (bounded BFS, name-based caller graph)
  -> any FastAPI route handler reached along the way, and its path(s)
```

Independently extracts what the flag's `_DEFAULTS` comment *claims*, via a bold-marked `` **`/api/...`** `` token — the convention this codebase already uses for "the current answer" vs. plain-backtick historical mentions. (The real F-26 comment narrates its own history — it mentions `/api/gameplan` in plain prose as "this line used to name" *and* the real route in bold. A naive "every token" extraction would permanently fail against the comment's own explanation of the bug it fixed.)

**`tests/api/test_feature_flag_endpoint_reachability.py`** (5 tests) — the guard itself, a negative control proving it can say NO, the doc-extraction non-vacuity test, an indirection non-vacuity test, and the mutation proof.

## Two real bugs found building this — both false negatives that would have shipped a silently-useless guard

1. **The caller graph only followed `Call.func` targets.** The real route handler reaches the gate via `await run_in_threadpool(_gameplan.get_league_adjusted_values, ...)` — the target is a plain positional *argument*, never itself a `Call.func`. The BFS found **zero** reachable routes until `_called_names` was broadened to capture every `Name`/`Attribute` reference, not just call sites.
2. **A naive "every `/api/...` token" extraction returns both endpoints** for `reception_scoring_fit`'s real comment (it legitimately mentions the retired route while explaining the fix). Fixed by preferring the bold-marked token.

## Verification

- **Structural sanity against the real repo**: gate found at `src/api/gameplan.py::_resolve_reception_fit`; reachable routes = `{"/api/valuation/league-adjusted"}`; documented claim is a subset; `/api/gameplan` confirmed **not** reachable (negative control).
- **Live on-disk mutation** — the exact F-26 defect, reproduced: replaced `` **`/api/valuation/league-adjusted`** `` with `` **`/api/gameplan`** `` directly in `src/api/feature_flags.py`. **RED**: 3 of 5 new tests failed, including the primary guard (`test_the_documented_endpoint_is_actually_reachable` — the claim was no longer a subset of the structurally-reachable set). Restored (`git diff` clean afterward); **GREEN**: 5/5 again.
- **Permanent in-repo mutation test** (`test_reintroducing_the_exact_f26_defect_fails_the_guard`) performs the same edit against an in-memory copy of the real file's current text on every run, so this stays enforced going forward rather than being a one-time manual check.
- `tests/api/test_feature_flag_endpoint_reachability.py` (new, 5) + `tests/api/test_feature_flag_reachability.py` (30, pre-existing, untouched) + `tests/api/test_feature_flag_docs_match_registry.py` + `tests/api/test_feature_flags.py` + `tests/league_intel/test_flag_docs_match_reality.py` + `tests/league_intel/test_reception_fit.py`: **88 passed**.
- `ruff check` / `format --check`: clean.
- `scripts/check_decision_coercions.py`: clean, no new debt (664 baseline unchanged).

## Standing prohibitions honored

No product methodology change, no feature-flag default change, no auth change. Test-and-tooling only — `src/api/flag_reachability.py` is read-only static analysis; it does not gate anything, change `is_enabled`'s behavior, or touch `_DEFAULTS`. I am not marking V1-88 VERIFIED myself — that determination is Claude 5's.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqEBEngbUtzXsbHRYrPLkF)_