### PR TITLE
V1-31: retire /phases' duplicate Team Strength inputs (audit F-3/H-2)

### DIFF
--- a/config/coercion_baseline.json
+++ b/config/coercion_baseline.json
@@ -1,6 +1,6 @@
 {
  "note": "Known missing-data coercions on decision paths, recorded so the gate can block NEW ones while the remediation batches burn these down. Each batch deletes its findings' entries. Do not add to this file to make a build pass.",
- "count": 663,
+ "count": 661,
  "violations": [
   "frontend/lib/auction-power.js::const raw = names.map((n) => Number(totalsObj[n]) || 0);",
   "frontend/lib/bdvm.js::assetCount: _num(r?.assetCount) ?? 0,",
@@ -181,9 +181,7 @@
   "frontend/lib/signal-engine.js::c.volatility?.label === \"high\" && (c.trend7 ?? 0) <= -5,",
   "frontend/lib/signal-engine.js::return (b.context.value || 0) - (a.context.value || 0);",
   "frontend/lib/signal-engine.js::value: Number(row?.rankDerivedValue || row?.values?.full || 0),",
-  "frontend/lib/team-phase.js::const ageGap = (r.medianAge || 0) - (w.medianAge || 0);",
   "frontend/lib/team-phase.js::const score = Math.max(0, valueGap) * Math.max(0, ageGap || 1);",
-  "frontend/lib/team-phase.js::value: Number(r.rankDerivedValue || r.values?.full || 0),",
   "frontend/lib/trade-logic.js::.map((v) => Number(v) || 0)",
   "frontend/lib/trade-logic.js::const adjustment = adjustments[i] || 0;",
   "frontend/lib/trade-logic.js::const d = Number(mv.dollars) || 0;",

--- a/docs/roster-intelligence/V1_35_METRIC_SEPARATION_AUDIT.md
+++ b/docs/roster-intelligence/V1_35_METRIC_SEPARATION_AUDIT.md
@@ -62,7 +62,7 @@ fetch/render path exists, not merely that the route responds.
 | 10 | `/api/terminal` `totalValue` | `src/api/terminal.py::build_terminal_payload` | Σ `rankDerivedValue` over the **whole roster** · 1–9999 | `server.py:11944` → `useTerminal.js`, `PortfolioSummary.jsx` | yes | **legitimate different quantity** = decision 69's *Total Asset Value* |
 | A | `/rosters` value breakdown | `frontend/lib/league-analysis.js::buildAllTeamSummaries` | Σ 1–9999 by position group | `/rosters` | yes | **materializer — consumes the server's `optimalLineup`, computes no new concept** |
 | B | `/rosters` tier score | `frontend/lib/league-analysis.js:1224` | `starterValue×0.7 + depthValue×0.2 − pickValue×0.1` | `/rosters`, Contender/Mid-Tier/Rebuilder | yes | **STALE DUPLICATE — decision-69 violation** |
-| C | `/phases` classifier | `frontend/lib/team-phase.js` | top-25 value × median age → 4 labels | `/phases` | yes | **duplicate concept, client-only** |
+| C | `/phases` classifier | `frontend/lib/team-phase.js` | `strengthTotal` × `valueWeightedCoreAge` → 4 labels | `/phases` | yes | **RETIRED (H-2 closed) — was duplicate concept, client-only; inputs now canonical** |
 | D | BDVM roster | `src/bdvm/roster.py::analyze_rosters` | `starterFpg` · **projected fantasy points per game** | `/api/bdvm/roster`, flag `bdvm_engine` on | endpoint yes | **legitimate different quantity** |
 
 ---
@@ -109,19 +109,42 @@ is F-1's formula. Both facts belong in the row notes.
 
 * **Retirement path:** handoff **H-1** (same change closes both).
 
-### F-3 — `/phases` is a third client-side team classifier
+### F-3 — `/phases` is a third client-side team classifier — CLOSED (V1-31 discovery-guard PR)
 
-`frontend/lib/team-phase.js` classifies teams Win-now / Contender /
-Mixed / Rebuild from top-25 value × median age. `src/roster_intel/`
-already owns both inputs canonically — `age_portfolio.py` (value-weighted
-age, Young Core Index) and `window.py` (competitive state) — measured
-over the *meaningful core* rather than an arbitrary top-25.
+`frontend/lib/team-phase.js` classified teams Win-now / Contender /
+Mixed / Rebuild from a client-side top-25 `rankDerivedValue` sum × a raw
+per-player age lookup, scanning `rawData.sleeper.teams` directly (the
+duplicate value/age computation this finding names).
 
-Not the same defect as F-1: this one is a legitimate concept computed in
-the wrong place, rather than an invented composite. Lower priority, same
-owner.
+Not the same defect as F-1: this was a legitimate concept computed in
+the wrong place, rather than an invented composite, so the fix is
+narrower than H-1's — the classification RULE (value vs. league median,
+age vs. league median → 4 quadrants) and the trade-partner
+complementarity scoring are unchanged; only the two INPUT axes were
+redirected onto canonical sources already served league-wide by
+`GET /api/roster/intelligence` (`payload.leagueContext`, via
+`lib/roster-intelligence.js::teamStrengthLadder`):
 
-* **Retirement path:** handoff **H-2**.
+    value  <- strengthTotal          (src/roster_intel/strength.py, row 1.1)
+    age    <- valueWeightedCoreAge   (src/roster_intel/age_portfolio.py, row 1.6)
+
+`window.py`'s CompetitiveWindow was NOT used — it is not reachable
+league-wide today (only per-team, via the disconnected `/api/gameplan`),
+and redirecting the classification RULE itself onto it would need new
+backend surface plus a decision on how its contend/rebuild states map
+onto the 4-way Win-now/Contender/Mixed/Rebuild labels, which is a
+product question outside a duplicate-consolidation unit's scope, not a
+retirement this audit can close on its own.
+
+`TeamPhasePanel.jsx` now reads `useRosterIntelligence()` (same hook
+`/rosters`' `TeamStrengthCard.jsx` uses) instead of `useDynastyData()`.
+Discovery guard: `frontend/__tests__/no-frontend-team-strength-methodology.test.js`
+extended with a scan for `rankDerivedValue` / `useDynastyData(` /
+`sleeper.teams` in `lib/team-phase.js` + `components/TeamPhasePanel.jsx`,
+mutation-proven (a reintroduced raw-row read fails the guard; restored,
+green).
+
+* **Retirement path:** handoff **H-2** — closed.
 
 ### F-4 — two power engines and two playoff-odds engines
 
@@ -185,16 +208,16 @@ current quantity, desired owner and the test that would close it.
 | **test** | a frontend unit test asserting `/rosters` renders backend-stamped values and that `scoreTeamTiers` is gone; plus `tests/roster_intel/test_metric_separation.py::test_roster_intelligence_publishes_no_generic_team_score` extended to the rendered props |
 | **note** | this single change closes **F-1 and F-2 together** and is what would let V1-31 / V1-32 reach EVIDENCE-L4 |
 
-### H-2 — fold `/phases` onto the age-portfolio and window owners (**Claude 6**)
+### H-2 — fold `/phases` onto the age-portfolio and strength owners — CLOSED
 
 | field | value |
 |---|---|
 | **path** | `frontend/lib/team-phase.js`; `frontend/components/TeamPhasePanel.jsx` |
-| **consumer** | `frontend/app/phases/page.jsx:33` |
-| **current quantity** | top-25 `rankDerivedValue` total × median age → 4 labels, computed client-side |
-| **desired owner** | `agePortfolio.valueWeightedCoreAge` / `youngCoreIndex` (+ its `PRIOR` disclosure) and `src/roster_intel/window.py`'s competitive state, both over the **meaningful core** |
-| **test** | frontend test that the phase label comes from the payload; backend already covered |
-| **priority** | below H-1 — a right concept in the wrong place, not an invented one |
+| **consumer** | `frontend/app/phases/page.jsx` |
+| **quantity before** | top-25 `rankDerivedValue` total × median age → 4 labels, computed client-side from raw player rows |
+| **quantity after** | `strengthTotal` (`src/roster_intel/strength.py`) × `valueWeightedCoreAge` (`src/roster_intel/age_portfolio.py`), read from `GET /api/roster/intelligence`'s `leagueContext` via `teamStrengthLadder`; same classification rule, canonical inputs |
+| **not done** | folding the classification RULE itself onto `window.py`'s CompetitiveWindow — not reachable league-wide without new backend surface, and mapping its states onto 4 quadrant labels is a product decision outside this unit |
+| **test** | `frontend/__tests__/team-phase.test.js` (6, incl. an unmeasured-input case), `frontend/__tests__/components/team-phase-panel.test.jsx` (4), `no-frontend-team-strength-methodology.test.js`'s extended raw-row-derivation guard (mutation-proven) |
 
 ### H-3 — V1-52 power engines (**Claude 3 / public league**) — census only
 

--- a/frontend/__tests__/components/team-phase-panel.test.jsx
+++ b/frontend/__tests__/components/team-phase-panel.test.jsx
@@ -5,34 +5,36 @@
 // private contract on anything under the `/league` prefix
 // (PUBLIC_ONLY_ROUTE_PREFIXES in components/AppShell.jsx), so on this
 // route `useApp()` always yields `{loading: false, rows: [], rawData:
-// null}`.  `analyzeLeaguePhases(null, [])` returns zero teams, the
-// panel hit `if (!analysis.teams.length) return null`, and the page
-// rendered a title, a subtitle, and nothing else — forever, for
-// everyone.  Walked signed-in against a warm backend, every run:
+// null}`.  This pins that the panel does NOT read useApp() — it reads
+// the canonical `/api/roster/intelligence` endpoint via
+// useRosterIntelligence(), same as /rosters' TeamStrengthCard.
 //
-//   /league/phases  http=200 settled=3071ms len=282 rows=0
-//
-// (282 chars = global nav + heading + subtitle.)
-//
-// The sibling route /league/franchise/[owner] has the identical
-// problem and already solves it: RosterComparePanel calls
-// `useDynastyData()` directly instead of `useApp()`, and renders an
-// explicit message for every state rather than returning null.  This
-// pins that same contract for TeamPhasePanel.
+// V1-31 audit finding F-3: this panel used to derive its own "how good
+// is this team" number (a client-side top-25 rankDerivedValue sum plus
+// a raw age lookup) via useDynastyData() + lib/team-phase.js. That
+// duplicate is retired; this file now mocks useRosterIntelligence
+// instead of useDynastyData.
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 
-const mockUseDynastyData = vi.fn();
+const mockUseRosterIntelligence = vi.fn();
 const mockUseUserState = vi.fn();
 
-// AppShell's useApp is what the panel used to read.  Pin it to the
-// values AppShell really supplies under /league/* so a regression back
-// onto useApp() fails this suite instead of silently blanking the page.
+// AppShell's useApp is what the panel used to read (before it read
+// useDynastyData(), before it read useRosterIntelligence()). Pin it to
+// the values AppShell really supplies under /league/* so a regression
+// back onto useApp() fails this suite instead of silently blanking the
+// page.
 vi.mock("@/components/AppShell", () => ({
   useApp: () => ({ rows: [], rawData: null, loading: false, error: "" }),
 }));
 vi.mock("@/components/useDynastyData", () => ({
-  useDynastyData: () => mockUseDynastyData(),
+  useDynastyData: () => {
+    throw new Error("TeamPhasePanel must not read useDynastyData — see V1-31 audit F-3");
+  },
+}));
+vi.mock("@/components/useRosterIntelligence", () => ({
+  useRosterIntelligence: (...args) => mockUseRosterIntelligence(...args),
 }));
 vi.mock("@/components/useUserState", () => ({
   useUserState: () => mockUseUserState(),
@@ -40,45 +42,63 @@ vi.mock("@/components/useUserState", () => ({
 
 import TeamPhasePanel from "@/components/TeamPhasePanel";
 
-const ROWS = [
-  { name: "Young Star", rankDerivedValue: 9000, age: 23 },
-  { name: "Old Star", rankDerivedValue: 8500, age: 31 },
-  { name: "Young Depth", rankDerivedValue: 2000, age: 22 },
-  { name: "Old Depth", rankDerivedValue: 1500, age: 32 },
-];
-
-const RAW = {
-  sleeper: {
-    teams: [
-      { ownerId: "own-a", rosterId: 1, name: "Alpha", players: ["Young Star", "Young Depth"] },
-      { ownerId: "own-b", rosterId: 2, name: "Bravo", players: ["Old Star", "Old Depth"] },
-    ],
-  },
-};
+function payload(teams) {
+  return {
+    leagueContext: teams.map((t) => ({
+      ownerId: t.ownerId,
+      teamName: t.teamName,
+      strengthTotal: t.strengthTotal,
+      strengthRank: t.strengthRank ?? null,
+      youngCoreIndex: t.youngCoreIndex ?? null,
+      valueWeightedCoreAge: t.valueWeightedCoreAge,
+    })),
+  };
+}
 
 beforeEach(() => {
   mockUseUserState.mockReturnValue({ state: {} });
 });
 
-describe("TeamPhasePanel (the whole body of /league/phases)", () => {
-  it("renders league phases from the private contract, not from useApp", () => {
-    mockUseDynastyData.mockReturnValue({ rows: ROWS, rawData: RAW, loading: false });
+describe("TeamPhasePanel (the whole body of /phases)", () => {
+  it("renders league phases from GET /api/roster/intelligence, not from useApp or useDynastyData", () => {
+    mockUseRosterIntelligence.mockReturnValue({
+      loading: false,
+      failure: null,
+      data: payload([
+        { ownerId: "own-a", teamName: "Alpha", strengthTotal: 17500, valueWeightedCoreAge: 22.5 },
+        { ownerId: "own-b", teamName: "Bravo", strengthTotal: 4000, valueWeightedCoreAge: 30 },
+      ]),
+    });
     render(<TeamPhasePanel />);
-    // Both teams classified and listed.
     expect(screen.getByText("Alpha")).toBeInTheDocument();
     expect(screen.getByText("Bravo")).toBeInTheDocument();
     expect(document.querySelectorAll("tbody tr").length).toBe(2);
   });
 
   it("shows a loading state instead of rendering nothing", () => {
-    mockUseDynastyData.mockReturnValue({ rows: [], rawData: null, loading: true });
+    mockUseRosterIntelligence.mockReturnValue({ loading: true, failure: null, data: null });
     const { container } = render(<TeamPhasePanel />);
     expect(container.textContent.trim()).not.toBe("");
     expect(container.textContent).toMatch(/loading/i);
   });
 
-  it("explains itself instead of rendering nothing when there is no league data", () => {
-    mockUseDynastyData.mockReturnValue({ rows: [], rawData: null, loading: false });
+  it("explains itself instead of rendering nothing when there is no team selected", () => {
+    mockUseRosterIntelligence.mockReturnValue({
+      loading: false,
+      failure: { kind: "team_required", message: "" },
+      data: null,
+    });
+    const { container } = render(<TeamPhasePanel />);
+    expect(container.textContent.trim()).not.toBe("");
+    expect(container.textContent).toMatch(/choose a team/i);
+  });
+
+  it("explains itself instead of rendering nothing when the league has no data", () => {
+    mockUseRosterIntelligence.mockReturnValue({
+      loading: false,
+      failure: null,
+      data: payload([]),
+    });
     const { container } = render(<TeamPhasePanel />);
     expect(container.textContent.trim()).not.toBe("");
     expect(container.textContent).toMatch(/unavailable|sign in|no league/i);

--- a/frontend/__tests__/no-frontend-team-strength-methodology.test.js
+++ b/frontend/__tests__/no-frontend-team-strength-methodology.test.js
@@ -49,6 +49,29 @@ const SCOPE = [
 ];
 
 /**
+ * Files that must read the canonical value/age axes from
+ * `GET /api/roster/intelligence` rather than re-deriving them from raw
+ * player rows. This is `team-phase.js`'s retired shape (V1-31 audit
+ * finding F-3): not a weighted composite and not a tier-cut string —
+ * `/phases`'s "contender"/"rebuild" LABELS are legitimate product
+ * vocabulary for this page's own purpose, unlike `scoreTeamTiers`'
+ * retired tier cut, so this scope does NOT reuse SCOPE/COMPOSITE/
+ * TIER_CUT above. What was actually retired here is a client-side
+ * top-25 `rankDerivedValue` sum plus a raw per-player age lookup,
+ * scanning `rawData.sleeper.teams` directly.
+ */
+const NO_RAW_ROW_SCOPE = ["lib/team-phase.js", "components/TeamPhasePanel.jsx"];
+
+/** Reading a raw player row's value directly, or the raw contract/hook
+ *  that carries one, instead of the canonical `strengthTotal` /
+ *  `valueWeightedCoreAge` the backend already aggregated. Deliberately
+ *  NOT a bare `.age` check — `leagueMedians.age` is a legitimate median
+ *  of already-canonical ages, and a generic `.age` pattern would flag
+ *  it as if it were a raw player-row field access. */
+const RAW_ROW_DERIVATION =
+  /\brankDerivedValue\b|useDynastyData\s*\(|sleeper\?\.teams\b|sleeper\.teams\b/;
+
+/**
  * A weighted-composite scoring expression: a numeric coefficient applied
  * to a *-Value/-Score term and summed with another. This is the shape of
  * a team score, not of a unit conversion.
@@ -178,6 +201,35 @@ describe("no frontend Team Strength methodology", () => {
       offenders,
       "`scoreTeamTiers` is retired — /rosters consumes `strength` from " +
         "GET /api/roster/intelligence:\n" + offenders.join("\n"),
+    ).toEqual([]);
+  });
+
+  it("RAW_ROW_DERIVATION actually matches the retired shape", () => {
+    // Positive control: the exact lines team-phase.js used to carry.
+    expect(RAW_ROW_DERIVATION.test("value: Number(r.rankDerivedValue || 0),")).toBe(true);
+    expect(RAW_ROW_DERIVATION.test("const { rows, rawData } = useDynastyData();")).toBe(true);
+    expect(RAW_ROW_DERIVATION.test("const teams = rawData?.sleeper?.teams || [];")).toBe(true);
+    // Negative control: reading the canonical materializer's OWN output
+    // field names, including a MEDIAN OF ages, must not trip it.
+    expect(RAW_ROW_DERIVATION.test("totalValue: t.strengthTotal,")).toBe(false);
+    expect(RAW_ROW_DERIVATION.test("medianAge: t.valueWeightedCoreAge,")).toBe(false);
+    expect(RAW_ROW_DERIVATION.test("medianAge != null && leagueMedians.age != null")).toBe(false);
+  });
+
+  it("team-phase.js and TeamPhasePanel.jsx read canonical strength/age, not raw player rows", () => {
+    const offenders = [];
+    for (const rel of NO_RAW_ROW_SCOPE) {
+      const src = stripComments(read(rel) || "");
+      src.split("\n").forEach((line, i) => {
+        if (RAW_ROW_DERIVATION.test(line)) offenders.push(`${rel}:${i + 1}  ${line.trim()}`);
+      });
+    }
+    expect(
+      offenders,
+      "A raw player-row value/age derivation is a second Team Strength " +
+        "engine (V1-31 audit F-3). Read strengthTotal / valueWeightedCoreAge " +
+        "from lib/roster-intelligence.js::teamStrengthLadder instead:\n" +
+        offenders.join("\n"),
     ).toEqual([]);
   });
 });

--- a/frontend/__tests__/team-phase.test.js
+++ b/frontend/__tests__/team-phase.test.js
@@ -1,50 +1,33 @@
 import { describe, it, expect } from "vitest";
 import { analyzeLeaguePhases, PHASES } from "@/lib/team-phase";
 
-function row({ name, value = 5000, age = 26 }) {
-  return { name, rankDerivedValue: value, age };
-}
-
-function fakeLeague(teams) {
+function ladderRow(name, ownerId, { strengthTotal = 5000, valueWeightedCoreAge = 26 } = {}) {
   return {
-    sleeper: {
-      teams: teams.map((t, i) => ({
-        ownerId: `own${i}`,
-        rosterId: String(i + 1),
-        name: t.name,
-        players: t.players,
-      })),
-    },
+    ownerId,
+    teamName: name,
+    strengthTotal,
+    valueWeightedCoreAge,
+    isMe: false,
   };
 }
 
 describe("analyzeLeaguePhases", () => {
   it("classifies a young, valuable team as Win-now", () => {
-    const rows = [
-      row({ name: "young star A", value: 9000, age: 22 }),
-      row({ name: "young star B", value: 8500, age: 23 }),
-      row({ name: "veteran", value: 4000, age: 30 }),
+    const ladder = [
+      ladderRow("Young Squad", "o1", { strengthTotal: 17500, valueWeightedCoreAge: 22.5 }),
+      ladderRow("Old Squad", "o2", { strengthTotal: 4000, valueWeightedCoreAge: 30 }),
     ];
-    const teams = [
-      { name: "Young Squad", players: ["young star A", "young star B"] },
-      { name: "Old Squad", players: ["veteran"] },
-    ];
-    const result = analyzeLeaguePhases(fakeLeague(teams), rows);
+    const result = analyzeLeaguePhases(ladder);
     const young = result.teams.find((t) => t.name === "Young Squad");
     expect(young.phase.key).toBe(PHASES.WIN_NOW.key);
   });
 
   it("classifies a low-value young team as Rebuild", () => {
-    const rows = [
-      row({ name: "young rookie", value: 2000, age: 21 }),
-      row({ name: "veteran star A", value: 9000, age: 30 }),
-      row({ name: "veteran star B", value: 8500, age: 31 }),
+    const ladder = [
+      ladderRow("Rookies", "o1", { strengthTotal: 2000, valueWeightedCoreAge: 21 }),
+      ladderRow("Veterans", "o2", { strengthTotal: 17500, valueWeightedCoreAge: 30.5 }),
     ];
-    const teams = [
-      { name: "Rookies", players: ["young rookie"] },
-      { name: "Veterans", players: ["veteran star A", "veteran star B"] },
-    ];
-    const result = analyzeLeaguePhases(fakeLeague(teams), rows);
+    const result = analyzeLeaguePhases(ladder);
     const rebuilder = result.teams.find((t) => t.name === "Rookies");
     expect(rebuilder.phase.key).toBe(PHASES.REBUILD.key);
     const contender = result.teams.find((t) => t.name === "Veterans");
@@ -52,44 +35,43 @@ describe("analyzeLeaguePhases", () => {
   });
 
   it("returns trade partnerships pairing winners with rebuilders", () => {
-    const rows = [
-      row({ name: "young rookie", value: 2000, age: 21 }),
-      row({ name: "young star", value: 9000, age: 22 }),
-      row({ name: "young star B", value: 8800, age: 22 }),
-      row({ name: "vet", value: 8500, age: 30 }),
-      row({ name: "vet2", value: 8000, age: 31 }),
+    const ladder = [
+      ladderRow("Win-now", "o1", { strengthTotal: 17800, valueWeightedCoreAge: 22 }),
+      ladderRow("Contender", "o2", { strengthTotal: 16500, valueWeightedCoreAge: 30.5 }),
+      ladderRow("Rebuilder", "o3", { strengthTotal: 2000, valueWeightedCoreAge: 21 }),
     ];
-    const teams = [
-      { name: "Win-now", players: ["young star", "young star B"] },
-      { name: "Contender", players: ["vet", "vet2"] },
-      { name: "Rebuilder", players: ["young rookie"] },
-    ];
-    const result = analyzeLeaguePhases(fakeLeague(teams), rows);
+    const result = analyzeLeaguePhases(ladder);
     expect(result.partnerships.length).toBeGreaterThan(0);
-    // Winners → Rebuilders pairing.  Both Win-now and Contender pair
-    // with Rebuilder.
     const partnerNames = new Set(
       result.partnerships.map((p) => `${p.winnerName}→${p.rebuilderName}`),
     );
     expect(partnerNames.has("Win-now→Rebuilder")).toBe(true);
   });
 
-  it("returns empty when sleeper teams missing", () => {
-    expect(analyzeLeaguePhases({}, []).teams).toEqual([]);
-    expect(analyzeLeaguePhases({ sleeper: { teams: [] } }, []).teams).toEqual([]);
+  it("returns empty when the ladder is empty", () => {
+    expect(analyzeLeaguePhases([]).teams).toEqual([]);
+    expect(analyzeLeaguePhases(null).teams).toEqual([]);
   });
 
-  it("computes league medians from per-team snapshots", () => {
-    const rows = [
-      row({ name: "a", value: 1000, age: 25 }),
-      row({ name: "b", value: 2000, age: 27 }),
+  it("computes league medians from the ladder's own strengthTotal/valueWeightedCoreAge", () => {
+    const ladder = [
+      ladderRow("T1", "o1", { strengthTotal: 1000, valueWeightedCoreAge: 25 }),
+      ladderRow("T2", "o2", { strengthTotal: 2000, valueWeightedCoreAge: 27 }),
     ];
-    const teams = [
-      { name: "T1", players: ["a"] },
-      { name: "T2", players: ["b"] },
-    ];
-    const result = analyzeLeaguePhases(fakeLeague(teams), rows);
+    const result = analyzeLeaguePhases(ladder);
     expect(result.leagueMedians.value).toBe(1500);
     expect(result.leagueMedians.age).toBe(26);
+  });
+
+  it("treats an unmeasured strength/age as unmeasured, never a fabricated zero", () => {
+    const ladder = [
+      ladderRow("Unmeasured", "o1", { strengthTotal: null, valueWeightedCoreAge: null }),
+      ladderRow("Measured", "o2", { strengthTotal: 5000, valueWeightedCoreAge: 25 }),
+    ];
+    const result = analyzeLeaguePhases(ladder);
+    // A team with no measured strength/age defaults to Mixed (not
+    // high-value, not younger) rather than crashing or reading as 0.
+    const unmeasured = result.teams.find((t) => t.name === "Unmeasured");
+    expect(unmeasured.phase.key).toBe(PHASES.MIXED.key);
   });
 });

--- a/frontend/app/phases/page.jsx
+++ b/frontend/app/phases/page.jsx
@@ -10,10 +10,12 @@
  * public pipeline (src/public_league/) and AppShell deliberately
  * refuses to hydrate the private contract there.  But contention
  * classification IS private analysis: TeamPhasePanel calls
- * useDynastyData() directly — bypassing that refusal — to rank every
- * team by top-25 roster value.  A public-prefixed route that fetches
- * the private contract is a boundary violation waiting to become a
- * leak the first time the API allowlist is edited.
+ * useRosterIntelligence() directly — bypassing that refusal — to read
+ * GET /api/roster/intelligence (the canonical Team Strength +
+ * age-portfolio owners; see V1-35 audit finding F-3). A public-prefixed
+ * route that fetches private roster intelligence is a boundary
+ * violation waiting to become a leak the first time the API allowlist
+ * is edited.
  *
  * So the page moved to its own private route instead of being
  * special-cased.  /league/phases still resolves — see the redirect
@@ -28,7 +30,7 @@ export default function PhasesPage() {
     <section>
       <PageHeader
         title="Win-now vs Rebuild"
-        subtitle="Each team classified by top-25 roster value × median age, with natural trade-partner suggestions for your franchise."
+        subtitle="Each team classified by canonical Team Strength × value-weighted core age, with natural trade-partner suggestions for your franchise."
       />
       <TeamPhasePanel />
     </section>

--- a/frontend/components/TeamPhasePanel.jsx
+++ b/frontend/components/TeamPhasePanel.jsx
@@ -2,8 +2,11 @@
 
 import { useMemo } from "react";
 import Link from "next/link";
-import { useDynastyData } from "@/components/useDynastyData";
+import { FailureState } from "@/components/ds/FailureState";
+import { EmptyState, LoadingState } from "@/components/ui";
+import { useRosterIntelligence } from "@/components/useRosterIntelligence";
 import { useUserState } from "@/components/useUserState";
+import { teamStrengthLadder } from "@/lib/roster-intelligence";
 import { analyzeLeaguePhases } from "@/lib/team-phase";
 
 const TONE_COLOR = {
@@ -18,46 +21,93 @@ function fmtAge(a) {
 }
 
 function fmtValue(v) {
-  if (!Number.isFinite(v)) return "—";
+  if (v == null || !Number.isFinite(v)) return "—";
   return Math.round(v).toLocaleString();
 }
 
-export default function TeamPhasePanel() {
-  // This panel is the entire body of /phases.  It used to live at
-  // /league/phases and needed this hook specifically because AppShell
-  // refuses to hydrate the private contract under the ``/league``
-  // prefix (PUBLIC_ONLY_ROUTE_PREFIXES), making ``useApp()`` there
-  // permanently ``{rows: [], rawData: null}``.  That is exactly why
-  // the route moved: contention classification is private analysis and
-  // had no business on a public-prefixed URL.
-  //
-  // On /phases ``useApp()`` would now work too.  Keeping the direct
-  // hook costs nothing — the fetch layer dedups and ``buildRows`` is
-  // shared by contract identity through a WeakMap — and it keeps the
-  // panel host-agnostic, which is the same reason RosterComparePanel
-  // reads it directly on /league/franchise/[owner].  ``/api/data`` is
-  // auth-gated, so an anonymous visitor gets a 401 and the explicit
-  // message below rather than any leaked data.
-  const { rows, rawData, loading } = useDynastyData();
-  const { state: userState } = useUserState();
+/** Each refusal gets its own sentence — same posture as
+ *  TeamStrengthCard's StrengthFailure, since this panel reads the same
+ *  endpoint and can fail the same ways. */
+function PhaseFailure({ failure }) {
+  if (!failure) return null;
+  const { kind, message } = failure;
+  if (kind === "auth") {
+    return <EmptyState title="Sign in to see league phases" message={message} />;
+  }
+  if (kind === "team_required") {
+    return (
+      <EmptyState
+        title="Choose a team"
+        message={
+          message ||
+          "Pick your team above to see league phases and your natural trade partners."
+        }
+      />
+    );
+  }
+  if (kind === "team_not_found") {
+    return (
+      <EmptyState
+        title="That team is not in this league"
+        message={message || "Pick a different team above."}
+      />
+    );
+  }
+  if (kind === "not_ready") {
+    return (
+      <EmptyState
+        title="League phases are not ready yet"
+        message={
+          message ||
+          "The league's rosters have not been loaded on this server yet."
+        }
+      />
+    );
+  }
+  if (kind === "league" || kind === "unavailable") {
+    return (
+      <FailureState
+        failure={{ kind: "unavailable", message: message || "The roster intelligence service did not respond." }}
+        context="League phases"
+        variant="block"
+      />
+    );
+  }
+  return (
+    <EmptyState
+      title="League phases could not be measured"
+      message={message || "An unexpected error occurred."}
+    />
+  );
+}
 
+export default function TeamPhasePanel() {
+  const { state: userState } = useUserState();
   const myOwnerId = userState?.selectedTeam?.ownerId
     ? String(userState.selectedTeam.ownerId)
-    : null;
+    : "";
+
+  // Same canonical source `/rosters` uses (src/roster_intel/strength.py +
+  // age_portfolio.py via GET /api/roster/intelligence). Team-scoped by
+  // the endpoint's own contract (a team is needed to resolve "you are"),
+  // but `leagueContext` — every team's strengthTotal/valueWeightedCoreAge —
+  // is always included regardless of which team is asked.
+  const { loading, data, failure } = useRosterIntelligence({ ownerId: myOwnerId });
 
   const analysis = useMemo(
-    () => analyzeLeaguePhases(rawData, rows),
-    [rawData, rows],
+    () => analyzeLeaguePhases(teamStrengthLadder(data, { myOwnerId })),
+    [data, myOwnerId],
   );
 
-  // Never render nothing: this component owns a whole route, so a
-  // silent null is indistinguishable from a broken page.
   if (loading) {
     return (
       <p className="muted" style={{ fontSize: "0.72rem", margin: "8px 0" }}>
         Loading league rosters…
       </p>
     );
+  }
+  if (failure) {
+    return <PhaseFailure failure={failure} />;
   }
   if (!analysis.teams.length) {
     return (
@@ -82,8 +132,9 @@ export default function TeamPhasePanel() {
       <div>
         <h3 style={{ margin: 0, fontSize: "0.92rem" }}>Win-now vs Rebuild</h3>
         <p className="muted" style={{ fontSize: "0.7rem", margin: "4px 0 0" }}>
-          Each team classified by top-25 roster value × median age, against the league medians
-          ({fmtValue(analysis.leagueMedians.value)} value · {fmtAge(analysis.leagueMedians.age)} age).
+          Each team classified by Team Strength (meaningful core) × value-weighted core
+          age, against the league medians ({fmtValue(analysis.leagueMedians.value)} strength ·{" "}
+          {fmtAge(analysis.leagueMedians.age)} age).
         </p>
       </div>
 
@@ -95,7 +146,7 @@ export default function TeamPhasePanel() {
               {myRow.phase.label}
             </strong>
             <span className="muted" style={{ fontSize: "0.74rem" }}>
-              · top-25 value {fmtValue(myRow.totalValue)} · median age {fmtAge(myRow.medianAge)}
+              · strength {fmtValue(myRow.totalValue)} · core age {fmtAge(myRow.medianAge)}
             </span>
           </div>
         </div>
@@ -107,8 +158,8 @@ export default function TeamPhasePanel() {
             <tr>
               <th style={{ textAlign: "left" }}>Team</th>
               <th style={{ textAlign: "left" }}>Phase</th>
-              <th style={{ textAlign: "right" }}>Top-25 value</th>
-              <th style={{ textAlign: "right" }}>Median age</th>
+              <th style={{ textAlign: "right" }}>Team Strength</th>
+              <th style={{ textAlign: "right" }}>Core age</th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/lib/team-phase.js
+++ b/frontend/lib/team-phase.js
@@ -1,39 +1,41 @@
 /**
  * team-phase — classify each team in the league as
- * Win-now / Contender / Mixed / Rebuild based on roster age × value.
+ * Win-now / Contender / Mixed / Rebuild from the canonical Team
+ * Strength + age-value portfolio owners.
  *
- * Methodology
- * -----------
- * For every team in ``rawData.sleeper.teams``:
- *   1. Look up rankDerivedValue + age for each rostered player.
- *   2. Compute median age and total value (top-25 players, or all if
- *      shorter).
- *   3. Score along two dimensions:
- *        - value vs the league median (above / below)
- *        - age vs the league median (younger / older)
+ * V1-31 audit finding F-3 (`docs/roster-intelligence/V1_35_METRIC_SEPARATION_AUDIT.md`):
+ * this module used to derive its own "how good is this team" number —
+ * a client-side top-25 `rankDerivedValue` sum plus a raw per-player age
+ * lookup — independently of `src/roster_intel/strength.py` (feature
+ * inventory row 1.1, THE canonical Team Strength owner). Two production
+ * surfaces disagreeing about "how strong is this roster" is exactly the
+ * defect V1-31 exists to remove.
  *
- * Phase classification
- * --------------------
- *   high value × younger  →  Win-now    ("you're built to win now and later")
- *   high value × older    →  Contender  ("you're built to win now")
- *   low value × younger   →  Rebuild    ("you're young and still climbing")
- *   low value × older     →  Mixed      ("you should probably reset")
+ * Retired: the top-25 value sum and the raw age lookup. Kept: the
+ * classification RULE itself (value vs. league median, age vs. league
+ * median → 4 quadrants) and the trade-partner complementarity scoring —
+ * neither is a "position weight" or a "weakness threshold" the owner
+ * has decided; they are a generic bucketing of two axes that now come
+ * from canonical sources:
  *
- * Trade-partner suggestion: a Win-now/Contender team is a natural
- * buyer of older star talent from a Rebuild team.  We surface the
- * three most-complementary pairs in the UI.
+ *   value  <- strengthTotal          (src/roster_intel/strength.py, meaningful core)
+ *   age    <- valueWeightedCoreAge   (src/roster_intel/age_portfolio.py)
  *
- * No I/O — pure function from the live contract.
+ * Both are already served, league-wide, by `GET /api/roster/intelligence`
+ * (`payload.leagueContext`, reshaped by `lib/roster-intelligence.js::teamStrengthLadder`)
+ * — no second backend call and no new backend field.
+ *
+ * No I/O here — pure function over the ladder `useRosterIntelligence`
+ * already fetched.
  */
 
-const TOP_N_FOR_VALUE = 25;
-
-export const PHASES = Object.freeze({
+const PHASES = Object.freeze({
   WIN_NOW: { key: "win_now", label: "Win-now", tone: "up", order: 0 },
   CONTENDER: { key: "contender", label: "Contender", tone: "up", order: 1 },
   MIXED: { key: "mixed", label: "Mixed", tone: "warn", order: 2 },
   REBUILD: { key: "rebuild", label: "Rebuild", tone: "down", order: 3 },
 });
+export { PHASES };
 
 function median(values) {
   const arr = (values || [])
@@ -44,44 +46,12 @@ function median(values) {
   return arr.length % 2 ? arr[mid] : (arr[mid - 1] + arr[mid]) / 2;
 }
 
-function buildIndex(rows) {
-  const ix = new Map();
-  for (const r of rows || []) {
-    if (!r?.name) continue;
-    ix.set(String(r.name).toLowerCase(), {
-      value: Number(r.rankDerivedValue || r.values?.full || 0),
-      age: Number(r.age) || null,
-    });
-  }
-  return ix;
-}
-
-function teamSnapshot(team, valueIndex) {
-  const players = Array.isArray(team?.players) ? team.players : [];
-  const lookup = players
-    .map((n) => valueIndex.get(String(n).toLowerCase()))
-    .filter((p) => p && p.value > 0);
-  // Sort by value desc, take top N for the "starter-equivalent" total.
-  const top = [...lookup].sort((a, b) => b.value - a.value).slice(0, TOP_N_FOR_VALUE);
-  const totalValue = top.reduce((s, p) => s + p.value, 0);
-  const ages = top.map((p) => p.age).filter((a) => Number.isFinite(a));
-  return {
-    name: team?.name || "Team",
-    ownerId: String(team?.ownerId || ""),
-    rosterId: String(team?.rosterId || ""),
-    totalValue: Math.round(totalValue),
-    medianAge: median(ages),
-    rosterCount: players.length,
-    valuedCount: top.length,
-  };
-}
-
 function classifyPhase(snapshot, leagueMedians) {
   const { totalValue, medianAge } = snapshot;
-  const isHighValue = leagueMedians.value != null && totalValue > leagueMedians.value;
-  // ``younger`` is < median age (lower number = younger).  When
-  // medianAge is null (no age data), default to "older" so a team
-  // with missing data doesn't get pushed into the youth corner.
+  const isHighValue = leagueMedians.value != null && totalValue != null && totalValue > leagueMedians.value;
+  // ``younger`` is < the league's median age. When either side is
+  // unmeasured, default to "older" so a team with missing data doesn't
+  // get pushed into the youth corner.
   const isYounger =
     medianAge != null && leagueMedians.age != null && medianAge < leagueMedians.age;
 
@@ -91,27 +61,34 @@ function classifyPhase(snapshot, leagueMedians) {
   return PHASES.MIXED;
 }
 
-export function analyzeLeaguePhases(rawData, rows) {
-  const teams = rawData?.sleeper?.teams || [];
-  if (!Array.isArray(teams) || teams.length === 0) {
+/**
+ * @param {Array} ladder — `teamStrengthLadder(payload, {myOwnerId})` rows:
+ *   `{ownerId, teamName, strengthTotal, valueWeightedCoreAge, isMe, ...}`
+ */
+export function analyzeLeaguePhases(ladder) {
+  const rows = Array.isArray(ladder) ? ladder : [];
+  if (!rows.length) {
     return { teams: [], leagueMedians: { value: null, age: null }, partnerships: [] };
   }
-  const valueIndex = buildIndex(rows);
-  const snapshots = teams.map((t) => teamSnapshot(t, valueIndex));
+
+  const snapshots = rows.map((t) => ({
+    name: t.teamName || "Team",
+    ownerId: String(t.ownerId || ""),
+    isMe: Boolean(t.isMe),
+    totalValue: t.strengthTotal,
+    medianAge: t.valueWeightedCoreAge,
+  }));
 
   const leagueMedians = {
     value: median(snapshots.map((s) => s.totalValue)),
-    age: median(snapshots.map((s) => s.medianAge).filter((a) => a != null)),
+    age: median(snapshots.map((s) => s.medianAge)),
   };
 
-  const enriched = snapshots.map((s) => {
-    const phase = classifyPhase(s, leagueMedians);
-    return { ...s, phase };
-  });
+  const enriched = snapshots.map((s) => ({ ...s, phase: classifyPhase(s, leagueMedians) }));
 
   enriched.sort((a, b) => {
     if (a.phase.order !== b.phase.order) return a.phase.order - b.phase.order;
-    return b.totalValue - a.totalValue;
+    return (b.totalValue ?? -Infinity) - (a.totalValue ?? -Infinity);
   });
 
   const winners = enriched.filter((t) => t.phase.key === "win_now" || t.phase.key === "contender");
@@ -119,9 +96,12 @@ export function analyzeLeaguePhases(rawData, rows) {
   const partnerships = [];
   for (const w of winners) {
     for (const r of rebuilders) {
-      // Score by complementarity: bigger value gap × bigger age gap = better fit.
+      if (w.totalValue == null || r.totalValue == null) continue;
+      // Score by complementarity: bigger value gap x bigger age gap =
+      // better fit. Unchanged rule from the retired formula — only the
+      // two inputs it reads are now canonical.
       const valueGap = w.totalValue - r.totalValue;
-      const ageGap = (r.medianAge || 0) - (w.medianAge || 0);
+      const ageGap = (r.medianAge ?? w.medianAge ?? 0) - (w.medianAge ?? 0);
       const score = Math.max(0, valueGap) * Math.max(0, ageGap || 1);
       partnerships.push({
         winnerOwnerId: w.ownerId,

--- a/frontend/lib/team-phase.js
+++ b/frontend/lib/team-phase.js
@@ -96,12 +96,18 @@ export function analyzeLeaguePhases(ladder) {
   const partnerships = [];
   for (const w of winners) {
     for (const r of rebuilders) {
+      // An unmeasured value OR age must not silently become a real
+      // number in a complementarity SCORE that ranks recommendations —
+      // that is exactly the missing-is-never-zero violation the retired
+      // formula's own `|| 0` fallbacks used to commit. Skip the pairing
+      // rather than fabricate a gap.
       if (w.totalValue == null || r.totalValue == null) continue;
+      if (w.medianAge == null || r.medianAge == null) continue;
       // Score by complementarity: bigger value gap x bigger age gap =
       // better fit. Unchanged rule from the retired formula — only the
       // two inputs it reads are now canonical.
       const valueGap = w.totalValue - r.totalValue;
-      const ageGap = (r.medianAge ?? w.medianAge ?? 0) - (w.medianAge ?? 0);
+      const ageGap = r.medianAge - w.medianAge;
       const score = Math.max(0, valueGap) * Math.max(0, ageGap || 1);
       partnerships.push({
         winnerOwnerId: w.ownerId,


### PR DESCRIPTION
## PROBLEM

`docs/VERSION_1_COMPLETION_CONTRACT.md` carries V1-31 ("Canonical Team
Strength") `IN PROGRESS` at L2, with "4 competing notions to retire"
against `src/roster_intel/strength.py` (PR #914's owner — this
session's own prior work).
`docs/roster-intelligence/V1_35_METRIC_SEPARATION_AUDIT.md` (also this
session's own prior work) already measured the census and found exactly
**two** live frontend duplicates: **F-1** (`scoreTeamTiers` on
`/rosters`) and **F-3** (`/phases`' classifier).

F-1/H-1 was already closed: `scoreTeamTiers` is retired, guarded by
`no-frontend-team-strength-methodology.test.js`, and `/rosters` now
renders `TeamStrengthCard.jsx` off `GET /api/roster/intelligence`.

**F-3/H-2 was still open.** `frontend/lib/team-phase.js` computed its
own "how good is this team" number — a client-side top-25
`rankDerivedValue` sum plus a raw per-player age lookup, scanning
`rawData.sleeper.teams` directly — independently of the canonical
owner.

## ROOT CAUSE

The canonical Team Strength owner had a real frontend consumer for
**one** surface (`/rosters`) but not the other (`/phases`), so a second,
independent value+age computation kept running in production.

## CANONICAL CONTRACT

No methodology invented. The classification RULE in `team-phase.js`
(value vs. league median, age vs. league median → 4 quadrants:
Win-now/Contender/Mixed/Rebuild) and the trade-partner complementarity
scoring are **unchanged** — neither is a position weight, depth
multiplier or weakness threshold the owner has decided; they are a
generic bucketing of two axes. Only the axes' **sources** were
redirected onto canonical data already served, league-wide, by
`GET /api/roster/intelligence`'s `leagueContext`:

```
value <- strengthTotal          (src/roster_intel/strength.py, row 1.1)
age   <- valueWeightedCoreAge   (src/roster_intel/age_portfolio.py, row 1.6)
```

Zero backend changes needed: `leagueContext` already carried both
fields for every team (built inside `get_team_roster_intelligence`,
already consumed by `/rosters`' `TeamStrengthCard.jsx` via
`lib/roster-intelligence.js::teamStrengthLadder`). **This PR touches
zero `.py` files** — confirmed by `git diff --stat main -- '*.py'`
(empty).

**Not done, named rather than papered over:** folding the
classification RULE itself onto `src/roster_intel/window.py`'s
CompetitiveWindow (the audit's originally-hoped-for full redirect).
`window.py` is not reachable league-wide today — only per-team, via the
disconnected `/api/gameplan` — and mapping its contend/rebuild states
onto 4 quadrant labels is a product decision, not a duplicate to
retire. Doing that would need new backend surface **and** an owner call
on the label mapping, both outside a duplicate-consolidation unit's
scope.

## IMPLEMENTATION

- `frontend/lib/team-phase.js`: `analyzeLeaguePhases(ladder)` now takes
  `teamStrengthLadder()` rows instead of `(rawData, rows)`. Removed
  `buildIndex`/`teamSnapshot`'s raw player-row scanning entirely.
- `frontend/components/TeamPhasePanel.jsx`: reads
  `useRosterIntelligence()` (same hook `/rosters`' `TeamStrengthCard.jsx`
  uses) instead of `useDynastyData()`. Added `PhaseFailure` states
  mirroring `TeamStrengthCard`'s `StrengthFailure` (auth /
  team_required / team_not_found / not_ready / league / unavailable) —
  the endpoint's team-scoping requirement is a real, already-accepted
  tradeoff (same one `/rosters` already ships), not a new risk.
- `frontend/app/phases/page.jsx`: updated subtitle + a stale doc comment
  (was: *"TeamPhasePanel calls `useDynastyData()` ... to rank every team
  by top-25 roster value"*).

## DISCOVERY GUARD (step 8)

Extended `frontend/__tests__/no-frontend-team-strength-methodology.test.js`
with a new `NO_RAW_ROW_SCOPE` (`lib/team-phase.js`,
`components/TeamPhasePanel.jsx`) and `RAW_ROW_DERIVATION` pattern
(`rankDerivedValue` / `useDynastyData(` / `sleeper.teams`) — a
**different shape** from the existing `COMPOSITE`/`TIER_CUT` checks
(which police `scoreTeamTiers`' weighted-blend shape and would not have
caught `team-phase.js`'s raw-row-scan shape).

Deliberately did **not** add `team-phase.js` to the existing `SCOPE`
array: `TIER_CUT`'s `"contender"`/`"rebuild"` string match fired on
`/phases`' own legitimate product vocabulary (its whole job is
producing those labels) — confirmed by running the guard before
narrowing it; see MUTATION PROOF.

## TESTS

- `frontend/__tests__/team-phase.test.js` rewritten for the new
  ladder-based signature (6 tests, incl. an explicit unmeasured-input →
  Mixed case, never a fabricated zero).
- `frontend/__tests__/components/team-phase-panel.test.jsx` rewritten to
  mock `useRosterIntelligence` instead of `useDynastyData`, and now
  asserts `useDynastyData` throws if called (positive control that the
  old hook is genuinely gone, not just unused).
- Full frontend suite: **146 files / 2283 tests passed**, zero
  regressions.

## MUTATION PROOF

| step | action | result |
|---|---|---|
| False-positive check | Added `lib/team-phase.js` to `SCOPE` (reusing `COMPOSITE`/`TIER_CUT`/`PROSE_WEIGHTS`) | 2 false positives — `TIER_CUT` matched the literal string `"contender"` in `PHASES`' own label definitions and the winners/rebuilders filter. `/phases`' classification vocabulary is legitimate product labeling, not the retired `scoreTeamTiers` defect. Fixed with a separate, narrower `NO_RAW_ROW_SCOPE`/`RAW_ROW_DERIVATION` check |
| False-positive check | Early `RAW_ROW_DERIVATION` draft included a bare `\.age\b` clause | False positive on `leagueMedians.age` — a median of already-canonical ages, not a raw player-row field — inside my own new code. Fixed by dropping the `.age` clause; `rankDerivedValue`/`useDynastyData(`/`sleeper.teams` are specific and sufficient signals |
| Positive control | Injected a tracked function into `lib/team-phase.js` calling `useDynastyData()` and reading `rawData?.sleeper?.teams` | The new *"team-phase.js and TeamPhasePanel.jsx read canonical strength/age"* test failed, naming the exact injected line |
| Restored | — | 8/8 green in that file, 18/18 across the three touched test files |

## BEHAVIOR BEFORE

`/phases` classified every team from a client-computed top-25
`rankDerivedValue` sum and a raw per-player age lookup — independent
of, and periodically disagreeing with, the canonical `strength.total`
that `/rosters` already displayed for the same teams.

## BEHAVIOR AFTER

`/phases` classifies every team from the **exact same**
`strengthTotal` / `valueWeightedCoreAge` numbers `/rosters` shows. A
team's "how strong" number cannot read differently on the two pages
anymore. The team-scoping failure states (`team_required`, etc.) are
new and user-facing, but match `/rosters`' existing behavior for the
same endpoint — not a regression, a consistency fix.

## V1-31 IMPACT

Closes F-3/H-2, the second and last confirmed live duplicate the
audit's own census found (F-1/H-1 was already closed). Zero known live
duplicates remain for Team Strength. Discovery guard extended to cover
the newly-closed surface.

## L2 MEASUREMENT — board/team effect

Structural zero, proven by the diff itself — `git diff --stat main --
'*.py'` is empty. No canonical value, rank, lineup or Team Strength
computation changed; only a client consumer's data SOURCE changed, and
that source was already serving the exact same numbers to `/rosters`.
The classification LABELS a given team receives on `/phases` can change
(this is the intended repair — the old labels were computed from
different, non-canonical inputs), but that is a display consequence of
fixing the duplicate, not a board-value movement, and no automated
harness exists to capture "old vs new `/phases` labels" without a live
browser session — named as a gap rather than asserted away.

## REMAINING V1-31 WORK

None known for live duplicates. F-2's Strength half (no frontend
consumer) is closed (`TeamStrengthCard.jsx`). A backend Python
single-owner discovery guard (mirroring V1-29's
`undeclared_owner_definitions` AST scan) is a separate, smaller unit —
not included here to keep this PR reviewable; tracked as a follow-up
(V1-32's PR, or a subsequent slice).

## OWNER DECISIONS

None required to close F-3. One is named for future work: whether
`/phases`' classification RULE should eventually move onto
`window.py`'s CompetitiveWindow (requires new backend surface + a
label-mapping decision) — explicitly not decided here.

---

`FEATURE_GREEN`
`READY_FOR_INTEGRATION`

Head: `63285807`, off `main` `36b7033f8`. This PR closes V1-31's live
duplicate; V1-32 (Team Weakness) is a separable unit and will be a
separate PR per the assignment's own guidance.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PyqbZejxh7ytbfijL5pmdE)_