### PR TITLE
V1-106: regression-sensitive windowing evidence + current-tree FPS measurement (post-#984)

### DIFF
--- a/docs/master-site-audit/evidence/V1-106/capped.json
+++ b/docs/master-site-audit/evidence/V1-106/capped.json
@@ -1,0 +1,187 @@
+{
+  "fullCount": 200,
+  "mountedRows": 27,
+  "domNodes": 1206,
+  "hover": true,
+  "control": [
+    {
+      "rate": 1,
+      "frames": 231,
+      "elapsedMs": 3833.2,
+      "fps": 60.00208702911406,
+      "medianFrameMs": 16.699999999999818,
+      "p95FrameMs": 16.800000000000182,
+      "longFrames": 0,
+      "moved": 9000,
+      "maxScroll": 23700,
+      "thinSample": false
+    },
+    {
+      "rate": 4,
+      "frames": 231,
+      "elapsedMs": 3833.173999999999,
+      "fps": 60.00249401670784,
+      "medianFrameMs": 16.700000000000728,
+      "p95FrameMs": 16.700000000000728,
+      "longFrames": 0,
+      "moved": 9000,
+      "maxScroll": 23700,
+      "thinSample": false
+    },
+    {
+      "rate": 6,
+      "frames": 229,
+      "elapsedMs": 3799.7999999999993,
+      "fps": 60.00315806095058,
+      "medianFrameMs": 16.700000000000728,
+      "p95FrameMs": 16.700000000000728,
+      "longFrames": 0,
+      "moved": 9000,
+      "maxScroll": 23700,
+      "thinSample": false
+    }
+  ],
+  "results": [
+    {
+      "rate": 1,
+      "frames": 229,
+      "elapsedMs": 3816.3999999999996,
+      "fps": 59.742165391468404,
+      "medianFrameMs": 16.699999999999818,
+      "p95FrameMs": 16.700000000000728,
+      "longFrames": 1,
+      "moved": 8201,
+      "maxScroll": 8201,
+      "thinSample": false,
+      "samples": [
+        {
+          "frames": 221,
+          "elapsedMs": 3816.4999999999995,
+          "fps": 57.64443862177388,
+          "medianFrameMs": 16.699999999999818,
+          "p95FrameMs": 16.800000000000182,
+          "longFrames": 9,
+          "moved": 8201,
+          "maxScroll": 8201,
+          "thinSample": false
+        },
+        {
+          "frames": 229,
+          "elapsedMs": 3816.3999999999996,
+          "fps": 59.742165391468404,
+          "medianFrameMs": 16.699999999999818,
+          "p95FrameMs": 16.700000000000728,
+          "longFrames": 1,
+          "moved": 8201,
+          "maxScroll": 8201,
+          "thinSample": false
+        },
+        {
+          "frames": 229,
+          "elapsedMs": 3799.8999999999996,
+          "fps": 60.00157898892076,
+          "medianFrameMs": 16.69999999999891,
+          "p95FrameMs": 16.700000000000728,
+          "longFrames": 0,
+          "moved": 8201,
+          "maxScroll": 8201,
+          "thinSample": false
+        }
+      ]
+    },
+    {
+      "rate": 4,
+      "frames": 108,
+      "elapsedMs": 3816.434000000001,
+      "fps": 28.036643631201265,
+      "medianFrameMs": 33.29999999999927,
+      "p95FrameMs": 66.70000000000073,
+      "longFrames": 70,
+      "moved": 8201,
+      "maxScroll": 8201,
+      "thinSample": false,
+      "samples": [
+        {
+          "frames": 99,
+          "elapsedMs": 3799.899999999998,
+          "fps": 25.790152372430867,
+          "medianFrameMs": 33.400000000001455,
+          "p95FrameMs": 66.70000000000073,
+          "longFrames": 64,
+          "moved": 8201,
+          "maxScroll": 8201,
+          "thinSample": false
+        },
+        {
+          "frames": 108,
+          "elapsedMs": 3816.434000000001,
+          "fps": 28.036643631201265,
+          "medianFrameMs": 33.29999999999927,
+          "p95FrameMs": 66.70000000000073,
+          "longFrames": 70,
+          "moved": 8201,
+          "maxScroll": 8201,
+          "thinSample": false
+        },
+        {
+          "frames": 112,
+          "elapsedMs": 3799.7999999999993,
+          "fps": 29.212063792831206,
+          "medianFrameMs": 33.30000000000109,
+          "p95FrameMs": 66.59999999999854,
+          "longFrames": 71,
+          "moved": 8201,
+          "maxScroll": 8201,
+          "thinSample": false
+        }
+      ]
+    },
+    {
+      "rate": 6,
+      "frames": 62,
+      "elapsedMs": 3816.600000000002,
+      "fps": 15.982811926845875,
+      "medianFrameMs": 66.59999999999854,
+      "p95FrameMs": 116.70000000000073,
+      "longFrames": 49,
+      "moved": 8201,
+      "maxScroll": 8201,
+      "thinSample": false,
+      "samples": [
+        {
+          "frames": 61,
+          "elapsedMs": 3816.5999999999985,
+          "fps": 15.720798616569727,
+          "medianFrameMs": 66.60000000000218,
+          "p95FrameMs": 116.70000000000073,
+          "longFrames": 54,
+          "moved": 8201,
+          "maxScroll": 8201,
+          "thinSample": false
+        },
+        {
+          "frames": 62,
+          "elapsedMs": 3816.600000000002,
+          "fps": 15.982811926845875,
+          "medianFrameMs": 66.59999999999854,
+          "p95FrameMs": 116.70000000000073,
+          "longFrames": 49,
+          "moved": 8201,
+          "maxScroll": 8201,
+          "thinSample": false
+        },
+        {
+          "frames": 70,
+          "elapsedMs": 3833.133999999998,
+          "fps": 18.00093604867454,
+          "medianFrameMs": 66.5,
+          "p95FrameMs": 100,
+          "longFrames": 57,
+          "moved": 8201,
+          "maxScroll": 8201,
+          "thinSample": false
+        }
+      ]
+    }
+  ]
+}

--- a/docs/master-site-audit/evidence/V1-106/showall.json
+++ b/docs/master-site-audit/evidence/V1-106/showall.json
@@ -1,0 +1,187 @@
+{
+  "fullCount": 983,
+  "mountedRows": 37,
+  "domNodes": 1536,
+  "hover": true,
+  "control": [
+    {
+      "rate": 1,
+      "frames": 231,
+      "elapsedMs": 3833.0999999999995,
+      "fps": 60.00365239623282,
+      "medianFrameMs": 16.699999999999818,
+      "p95FrameMs": 16.799999999999272,
+      "longFrames": 0,
+      "moved": 9000,
+      "maxScroll": 23700,
+      "thinSample": false
+    },
+    {
+      "rate": 4,
+      "frames": 231,
+      "elapsedMs": 3833.199999999999,
+      "fps": 60.00208702911407,
+      "medianFrameMs": 16.700000000000728,
+      "p95FrameMs": 16.799999999999272,
+      "longFrames": 0,
+      "moved": 9000,
+      "maxScroll": 23700,
+      "thinSample": false
+    },
+    {
+      "rate": 6,
+      "frames": 229,
+      "elapsedMs": 3799.800000000003,
+      "fps": 60.00315806095053,
+      "medianFrameMs": 16.69999999999709,
+      "p95FrameMs": 16.700000000004366,
+      "longFrames": 0,
+      "moved": 9000,
+      "maxScroll": 23700,
+      "thinSample": false
+    }
+  ],
+  "results": [
+    {
+      "rate": 1,
+      "frames": 227,
+      "elapsedMs": 3783.1679999999997,
+      "fps": 59.738293409121674,
+      "medianFrameMs": 16.699999999999818,
+      "p95FrameMs": 16.800000000000182,
+      "longFrames": 1,
+      "moved": 9000,
+      "maxScroll": 40611,
+      "thinSample": false,
+      "samples": [
+        {
+          "frames": 226,
+          "elapsedMs": 3799.7999999999993,
+          "fps": 59.2136428233065,
+          "medianFrameMs": 16.69999999999891,
+          "p95FrameMs": 16.799999999999272,
+          "longFrames": 2,
+          "moved": 9000,
+          "maxScroll": 40611,
+          "thinSample": false
+        },
+        {
+          "frames": 227,
+          "elapsedMs": 3783.1679999999997,
+          "fps": 59.738293409121674,
+          "medianFrameMs": 16.699999999999818,
+          "p95FrameMs": 16.800000000000182,
+          "longFrames": 1,
+          "moved": 9000,
+          "maxScroll": 40611,
+          "thinSample": false
+        },
+        {
+          "frames": 230,
+          "elapsedMs": 3816.6000000000004,
+          "fps": 60.0010480532411,
+          "medianFrameMs": 16.69999999999891,
+          "p95FrameMs": 16.799999999999272,
+          "longFrames": 0,
+          "moved": 9000,
+          "maxScroll": 40611,
+          "thinSample": false
+        }
+      ]
+    },
+    {
+      "rate": 4,
+      "frames": 93,
+      "elapsedMs": 3833.2000000000007,
+      "fps": 24.000834811645618,
+      "medianFrameMs": 49.899999999999636,
+      "p95FrameMs": 66.70000000000073,
+      "longFrames": 72,
+      "moved": 9000,
+      "maxScroll": 40611,
+      "thinSample": false,
+      "samples": [
+        {
+          "frames": 89,
+          "elapsedMs": 3849.9000000000015,
+          "fps": 22.857736564586084,
+          "medianFrameMs": 50,
+          "p95FrameMs": 66.70000000000073,
+          "longFrames": 69,
+          "moved": 9000,
+          "maxScroll": 40611,
+          "thinSample": false
+        },
+        {
+          "frames": 93,
+          "elapsedMs": 3833.2000000000007,
+          "fps": 24.000834811645618,
+          "medianFrameMs": 49.899999999999636,
+          "p95FrameMs": 66.70000000000073,
+          "longFrames": 72,
+          "moved": 9000,
+          "maxScroll": 40611,
+          "thinSample": false
+        },
+        {
+          "frames": 98,
+          "elapsedMs": 3849.9000000000015,
+          "fps": 25.195459622327842,
+          "medianFrameMs": 33.400000000001455,
+          "p95FrameMs": 66.69999999999709,
+          "longFrames": 75,
+          "moved": 9000,
+          "maxScroll": 40611,
+          "thinSample": false
+        }
+      ]
+    },
+    {
+      "rate": 6,
+      "frames": 51,
+      "elapsedMs": 3966.4999999999964,
+      "fps": 12.605571662674915,
+      "medianFrameMs": 83.40000000000146,
+      "p95FrameMs": 133.40000000000146,
+      "longFrames": 46,
+      "moved": 9000,
+      "maxScroll": 40611,
+      "thinSample": false,
+      "samples": [
+        {
+          "frames": 47,
+          "elapsedMs": 4016.5,
+          "fps": 11.452757375824723,
+          "medianFrameMs": 100,
+          "p95FrameMs": 150,
+          "longFrames": 44,
+          "moved": 9000,
+          "maxScroll": 40611,
+          "thinSample": false
+        },
+        {
+          "frames": 51,
+          "elapsedMs": 3966.4999999999964,
+          "fps": 12.605571662674915,
+          "medianFrameMs": 83.40000000000146,
+          "p95FrameMs": 133.40000000000146,
+          "longFrames": 46,
+          "moved": 9000,
+          "maxScroll": 40611,
+          "thinSample": false
+        },
+        {
+          "frames": 51,
+          "elapsedMs": 3916.5,
+          "fps": 12.766500702157538,
+          "medianFrameMs": 83.40000000000146,
+          "p95FrameMs": 133.29999999999927,
+          "longFrames": 46,
+          "moved": 9000,
+          "maxScroll": 40611,
+          "thinSample": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/e2e/specs/rankings-windowing.spec.js
+++ b/tests/e2e/specs/rankings-windowing.spec.js
@@ -1,0 +1,151 @@
+/**
+ * V1-106 regression evidence: row windowing on the Rankings board stays
+ * ACTIVE as the board grows, on the current post-#984 (Premium Sports
+ * Intelligence) renderer.
+ *
+ * `journey-rankings.spec.js` and `mobile-smoke.spec.js` already assert
+ * `boardRowCount() >= 50` (the board's declared SIZE) and
+ * `rows.count() > 0` (something is mounted) — but neither discriminates
+ * between "windowed" and "every row mounted": both pass identically
+ * either way, because `boardRowCount()` reads `aria-rowcount` when
+ * present and falls back to the mounted `<tr>` count when it isn't, and
+ * a non-empty capped board already clears both bars without touching
+ * "Show all" at all. This file closes that gap: it proves the DOM stays
+ * BOUNDED once the board is uncapped to its full size, that scrolling
+ * moves the window rather than mounting everything, and that turning
+ * `virtualize` off makes it RED (verified manually during development —
+ * see the PR description for the mutation-proof transcript; not
+ * committed as a fixture, since flipping product behavior to fail a
+ * test on purpose is not itself something CI should carry).
+ *
+ * Renders through `components/ds/DataTable.jsx` (`virtualize` +
+ * `freezeColumnWidths`, wired in `app/rankings/page.jsx`) — no frontend
+ * canonical-value computation here or anywhere this file touches.
+ */
+const { test, expect } = require("../helpers/auth-fixture");
+const {
+  SEL,
+  desktopOnly,
+  mobileOnly,
+  gotoRankingsBoard,
+  boardRowCount,
+  attachConsoleGuards,
+} = require("../helpers/journey");
+
+// A capped board is a few hundred rows at most; the full board has run
+// ~900-1,100 in this repo's history (PR #760's evidence table). 500 is
+// comfortably below every observed full-board size and comfortably
+// above every observed capped size, so it discriminates "did Show all
+// actually grow the board" without hard-coding today's exact count.
+const FULL_BOARD_MIN_ROWS = 500;
+
+// However large the board gets, a windowed table only ever mounts a
+// viewport's worth of rows plus overscan — this repo's own harness
+// evidence (PR #760) measured ~40-60 mounted rows against a board of
+// 964-1,109. 200 is a generous multiple of that with headroom for a
+// taller viewport or a wider overscan, while still being an order of
+// magnitude below FULL_BOARD_MIN_ROWS — so it can only pass if the DOM
+// is meaningfully bounded, not merely "less than everything".
+const MAX_MOUNTED_ROWS = 200;
+
+async function showAllRows(page) {
+  const button = page.getByRole("button", { name: "Show all" });
+  await button.click();
+  await expect
+    .poll(() => boardRowCount(page), {
+      message: "board should grow to its full size after Show all",
+      timeout: 30_000,
+    })
+    .toBeGreaterThanOrEqual(FULL_BOARD_MIN_ROWS);
+}
+
+/** True total (via aria-rowcount) vs what's actually mounted. */
+async function boardShape(page) {
+  const total = await boardRowCount(page);
+  const mounted = await page.locator(SEL.boardRow).count();
+  const declaredRowcount = await page.evaluate(() => {
+    const table = document.querySelector(".ds-table-wrap table");
+    return table?.getAttribute("aria-rowcount") ?? null;
+  });
+  return { total, mounted, declaredRowcount };
+}
+
+test.describe("V1-106: rankings board windowing stays active at scale", () => {
+  test.describe("desktop", () => {
+    test.beforeEach(async ({}, testInfo) => desktopOnly(test, testInfo));
+
+    test("full board mounts a bounded DOM, not one row per player", async ({
+      authedPage: page,
+    }) => {
+      const guard = attachConsoleGuards(page);
+      await gotoRankingsBoard(page);
+      await showAllRows(page);
+
+      const { total, mounted, declaredRowcount } = await boardShape(page);
+
+      // Windowed, by the table's own account — this is what screen
+      // readers and this test both rely on instead of counting <tr>.
+      expect(declaredRowcount, "table should publish aria-rowcount when windowed").not.toBeNull();
+      expect(total).toBeGreaterThanOrEqual(FULL_BOARD_MIN_ROWS);
+      expect(
+        mounted,
+        `expected a bounded mount (<=${MAX_MOUNTED_ROWS}) against a ${total}-row board — ` +
+          `if this fires, either windowing is off or the window itself has grown unbounded`,
+      ).toBeLessThanOrEqual(MAX_MOUNTED_ROWS);
+
+      guard.assertClean();
+    });
+
+    test("scrolling moves the window instead of mounting the rest of the board", async ({
+      authedPage: page,
+    }) => {
+      await gotoRankingsBoard(page);
+      await showAllRows(page);
+
+      const before = await boardShape(page);
+      const firstNameBefore = await page.locator(SEL.playerName).first().innerText();
+
+      // Scroll the page well past the first window's worth of rows.
+      await page.evaluate(() => window.scrollBy(0, 6000));
+      await expect
+        .poll(async () => (await page.locator(SEL.playerName).first().innerText()) !== firstNameBefore, {
+          message: "top-of-window player should change after a large scroll",
+          timeout: 15_000,
+        })
+        .toBe(true);
+
+      const after = await boardShape(page);
+
+      // The window slid (different content on screen)...
+      const firstNameAfter = await page.locator(SEL.playerName).first().innerText();
+      expect(firstNameAfter).not.toBe(firstNameBefore);
+      // ...without the mount ballooning: the board's declared total is
+      // unchanged and the mounted count is still bounded.
+      expect(after.total).toBe(before.total);
+      expect(after.mounted).toBeLessThanOrEqual(MAX_MOUNTED_ROWS);
+    });
+  });
+
+  test.describe("mobile (390x844)", () => {
+    test.beforeEach(async ({}, testInfo) => mobileOnly(test, testInfo));
+
+    test("full board mounts a bounded DOM on a phone viewport too", async ({
+      authedPage: page,
+    }) => {
+      const guard = attachConsoleGuards(page);
+      await gotoRankingsBoard(page);
+      await showAllRows(page);
+
+      const { total, mounted, declaredRowcount } = await boardShape(page);
+
+      expect(declaredRowcount, "table should publish aria-rowcount when windowed").not.toBeNull();
+      expect(total).toBeGreaterThanOrEqual(FULL_BOARD_MIN_ROWS);
+      expect(
+        mounted,
+        `mobile mount should stay bounded (<=${MAX_MOUNTED_ROWS}) against a ${total}-row board`,
+      ).toBeLessThanOrEqual(MAX_MOUNTED_ROWS);
+
+      guard.assertClean();
+    });
+  });
+});

--- a/tests/e2e/stack-death-reporter.js
+++ b/tests/e2e/stack-death-reporter.js
@@ -164,12 +164,23 @@ function coverageBound(name, fallback) {
 // lose 39 of the suite's tests and still clear the floor — more than a
 // quarter of it — which is a lot of silence for a guard whose banner
 // says "this green is not trustworthy".  120 keeps 19 tests of headroom
-// for ordinary drift.  The skip ceiling stays at 60 against a measured
-// 49: project gating moves in steps of 2-4 whenever a describe block
-// gains desktopOnly/mobileOnly, and a bound that needs adjusting every
-// quarter stops being believed.
+// for ordinary drift.
+//
+// The skip ceiling is 70, raised from 60 (run 32415289607, job
+// 96574935284, head 357c9410e — passed=184, skipped=62). It had
+// already drifted from the 60-against-49 measurement this comment used
+// to cite: legitimate project-gating growth since then (more
+// desktopOnly/mobileOnly describes) had already spent nearly all of
+// that headroom before V1-106's rankings-windowing.spec.js added 3
+// more (1 mobileOnly + 2 desktopOnly, split across the desktop-1366 /
+// mobile-chromium projects) and tipped it over. 70 restores ~8 tests of
+// headroom above the new measured 62 — deliberately smaller than the
+// original 11, because a ceiling this close to a moving baseline is
+// exactly the "needs adjusting every quarter" trap the old comment
+// warned about; the fix for that is tracking real suite growth here
+// when it happens, not inflating the margin so nobody has to.
 const MIN_EXPECTED_PASSED = coverageBound("E2E_MIN_PASSED", 120);
-const MAX_EXPECTED_SKIPPED = coverageBound("E2E_MAX_SKIPPED", 60);
+const MAX_EXPECTED_SKIPPED = coverageBound("E2E_MAX_SKIPPED", 70);
 
 class StackDeathReporter {
   constructor() {


### PR DESCRIPTION
## Target

`V1-106` (`docs/VERSION_1_COMPLETION_CONTRACT.md`) — Rankings board windowing / virtualization, canonical id `C8-PERF-03` / inv 9.1, required level L2, current status `IN PROGRESS`. Re-evaluated against the **current post-#984** Rankings renderer per instruction — not the pre-PSI route.

## PHASE 1 — reconstructing the residual

1. **Virtualization is still active.** `app/rankings/page.jsx`'s `<DataTable>` call still passes both `virtualize` and `freezeColumnWidths` (`components/ds/DataTable.jsx`, backed by `components/ds/useRowWindow.js`). #984 restyled the page onto ds primitives; it did not touch this wiring.
2. **DOM population stays bounded as data grows.** Measured live on this head: "Show all" grows the board to 983 rows while only 37 `<tr>` mount (1,536 DOM nodes); the capped default is 200 rows / 27 mounted.
3. **#984 preserved `aria-rowcount`/`aria-rowindex`/virtual-row semantics.** `DataTable.jsx` is the same component instance before and after #984 — the migration changed the page around it, not the primitive. Confirmed live: `aria-rowcount` is present and non-null once windowed.
4. **The remaining gap is L2 evidence, not implementation.** The feature works and was already browser-measured (#760). What's missing is *committed, regression-sensitive* proof: the two existing specs touching the board (`journey-rankings.spec.js`, `mobile-smoke.spec.js`) assert `boardRowCount() >= 50` and `rows.count() > 0` — both pass identically whether or not virtualization is on, because `boardRowCount()` falls back to counting mounted rows when `aria-rowcount` is absent, and a non-empty **capped** board already clears both bars without ever touching "Show all". Neither discriminates windowed from every-row-mounted.
5. **What the owner's ruling actually requires.** `C_SERIES_SCOPE_MANIFEST.md`'s `C8-PERF-03` row sets required final state **"Windowed"** (structural) with evidence **"FPS harness"** (an artifact, not a number), under profile **P1** — and P1's own definition (§3, line 159) is entirely latency-based (warm ≤1s, cold ≤3s, p95 ≤2s, interaction <250ms, ack <100ms), with **no FPS quantity anywhere in it**. The only FPS numbers in this repo ("Phase-4 target was ≥30 FPS at 4× and ≥50 at 1×") live in `docs/performance-optimization.md`, a non-canonical L6 engineering ledger, stated as one conjunction rather than two independent thresholds. **No FPS threshold is owner-defined at the canonical tier, so none is invented here** — the L2 obligation is discharged with an honest measured statement, not a pass/fail against a manufactured number.

This is **not** an `OWNER_DECISION_REQUIRED` case: "Windowed" + "FPS harness ran and is reported" is what the manifest actually asks for, and both are true.

## PHASE 2 — closing the real gap (evidence only, no virtualization rewrite)

Added `tests/e2e/specs/rankings-windowing.spec.js`, run against the **current** post-#984 renderer:

- **Desktop:** "Show all" grows the board past 500 rows; asserts `aria-rowcount` is present, the board total is ≥500, and the **mounted** row count stays ≤200 — an order of magnitude below the board size, and well above this repo's own measured mount of ~40-60 rows, so it can only pass if the DOM is genuinely bounded.
- **Desktop:** scrolls 6000px past the first window; asserts the top-of-window player **name changes** (the window slid) while the board's declared total is unchanged and the mount stays bounded — proves windowing stays active **during** scrolling, not just at initial mount.
- **Mobile (390×844):** same bounded-mount assertion, for parity.

**Mutation-proven** (not committed as a fixture — flipping product behavior on purpose to fail a test doesn't belong in CI): temporarily changed `virtualize` → `virtualize={false}` in `app/rankings/page.jsx`, reran the three tests → **all three RED** (mounted count no longer bounded / no top-of-window change / `aria-rowcount` absent on mobile, each attributed correctly). Reverted → **all three GREEN** again. Zero net diff to `page.jsx`.

## L2 measurement

Exact head `357c9410e` (parent `36b7033f8`), measured with the harness already on this branch (CDP `Input.synthesizeScrollGesture` driver, no timer in the loop, control run first at every rate). Raw samples: `docs/master-site-audit/evidence/V1-106/{showall,capped}.json`.

| board | rows | mounted | DOM nodes | control 1×/4×/6× | board 1×/4×/6× |
|---|---|---|---|---|---|
| "Show all" | 983 | 37 | 1,536 | 60.0 / 60.0 / 60.0 | 59.7 / 24.0 / 12.6 |
| capped default | 200 | 27 | 1,206 | — | 59.7 / 28.0 / 16.0 |

Reported against three yardsticks, per prior V1-106 planning work:

1. **The non-canonical conjunction as stated** (≥50 at 1× AND ≥30 at 4×): 1× clears it (59.7); 4× does not (24.0 vs 30). Materially the same shape #760 measured (59.5 / 23.3) — **#984 did not regress the board**; this reproduces, not retracts, #760's finding.
2. **The binding P1 profile** (latency, not FPS): out of scope for this harness — V1-105 (route p95 baselines) is the correct instrument, and it's separately `NOT STARTED`.
3. **L2 — a measured statement of the effect on the live board**: this is that statement, on today's head, honestly reported both ways.

## Validation

- `npx vitest run --project logic` (frontend/): **86 files, 1,732 tests passed**
- `npx playwright test -g "V1-106" --project=desktop-1366 --project=mobile-chromium`: **3/3 passed** (RED under mutation, GREEN restored — see above)
- Production build succeeds (implicit via the E2E self-boot)

## Boundaries respected

- No virtualization rewrite — `useRowWindow.js`/`DataTable.jsx` untouched.
- No new PSI visual work.
- No frontend canonical-value computation anywhere this PR touches.

---

`FEATURE_GREEN` / `READY_FOR_INTEGRATION`. Head: `357c9410e`. Freezing this branch — will only resume on a branch-caused CI failure, substantive review feedback, or an explicit Integration request. `docs/performance-optimization.md`'s FPS-target framing and the `C_SERIES_SCOPE_MANIFEST.md` / `OWNER_FEATURE_INVENTORY.md` rows citing the retracted 59.5 self-measurement remain Claude 5's / Integration's to correct — not touched here, per the same division of labor as the earlier V1-106 planning pass.

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3RzLM83tcVjrziFjZmyUn)_