### PR TITLE
V1-32: confirm frontend consumer not required; commit reproducible L2 evidence

### DIFF
--- a/docs/roster-intelligence/V1_ROSTER_EVIDENCE_MATRIX.md
+++ b/docs/roster-intelligence/V1_ROSTER_EVIDENCE_MATRIX.md
@@ -78,3 +78,33 @@ It is deliberately **not** the Team Strength consumer gap. That gap is
 real and is the V1-35 audit's headline, but its repair is a frontend
 change on `/rosters` — Claude 6's lane. Naming it as this lane's next
 unit would be claiming another lane's files.
+
+---
+
+## Addendum, 2026-08-20 (superseding rows V1-29, V1-31, V1-32 above)
+
+This table's body is from an earlier point in the same lane's work and is
+now stale on three rows; rather than rewrite history, this addendum
+records what changed and where the current record lives.
+
+- **V1-29** is now `VERIFIED` at L2 (#987, merge `faa50ba9a`; L1 half
+  confirmed by mutation at Integration — see
+  `docs/VERSION_1_COMPLETION_CONTRACT.md`). The "Next Roster-only unit"
+  section above is resolved and no longer describes outstanding work.
+- **V1-31**: `/phases`' independent top-25-value × raw-age classifier
+  (audit finding F-3 / handoff H-2) is retired and redirected onto this
+  lane's own `teamStrengthLadder()` materializer (PR #1002). `/rosters`'
+  `scoreTeamTiers` composite (F-1 / H-1) remains open and is still
+  Claude 6's file.
+- **V1-32**: a backend AST single-owner discovery guard for
+  `TeamStrength` / `TeamWeakness` now exists
+  (`tests/roster_intel/test_strength_weakness_single_owner.py`, PR
+  #1004), and a census at the current tree confirms no live frontend
+  Weakness duplicate exists to retire.
+- **Whether V1-32 needs a frontend consumer to close was investigated
+  and answered NO** — it is an **L4** question, V1-32's target is
+  **L2**, and L2 is independently re-confirmed today (`V1_ROSTER_
+  VERIFICATION_PACK.md` §3.1/§6, via the newly-committed
+  `--offline` reproduction command). No frontend code was added for
+  either row in this pass; building one would exceed both rows' actual
+  acceptance bar and duplicate handoff H-1, already assigned to Claude 6.

--- a/docs/roster-intelligence/V1_ROSTER_VERIFICATION_PACK.md
+++ b/docs/roster-intelligence/V1_ROSTER_VERIFICATION_PACK.md
@@ -87,7 +87,7 @@ refusing an anonymous caller, and retrying it is guaranteed to fail
 identically. `verify-sharp-production.yml` spent 40 minutes per run
 learning that.
 
-### Offline (EVIDENCE-L1 / L2) — runs in CI already
+### Offline, check-correctness only (EVIDENCE-L1) — runs in CI already
 
 ```bash
 python -m pytest tests/roster_intel/test_verification_pack.py \
@@ -99,6 +99,43 @@ Both files are pure-logic and stay in the **hard gate**
 touches the network —
 `tests/infra/test_unit_suite_does_not_probe_production.py` forbids it,
 which is why the pack is built as `fetch → payload → pure check`.
+
+**This proves the checks are live** (each can PASS and can be made to
+FAIL — see the file's own docstring) **against a hand-built synthetic
+fixture.** It does NOT reproduce §3's real-board numbers ("216 rungs",
+"215 rung credits", …) — those were originally produced by hand against
+`newest_complete_raw_payload()`, with no committed command to regenerate
+them. That gap is what `--offline` below closes.
+
+### Offline, real board (EVIDENCE-L2) — `--offline`
+
+```bash
+python scripts/verify_roster_intelligence.py --offline \
+    --json-out data/ops/roster-intelligence-verification-offline.json
+```
+
+No server, no auth, no network — `build_bundle_offline()` rebuilds the
+contract from the newest **COMPLETE** archived scrape via
+`build_api_data_contract` → `build_league_roster_intelligence`, the same
+two functions the doc's original hand-run used. Ceiling **EVIDENCE-L2**:
+a locally rebuilt contract is real, but it is not a deployed response.
+Defaults `--league-key` to `dynasty_main`, the one league this repo's
+archive fixture covers (`newest_complete_raw_payload()` — see §4 item 01
+for the second league).
+
+Two checks are **structurally** UNMEASURABLE offline, and that is
+correct rather than a gap to close here: check 12 needs the deployed
+public-league `teamAssignment` section this archive does not carry, and
+check 13 needs a timed HTTP round-trip — `build_bundle_offline` leaves
+`bundle.latency_ms` empty on purpose rather than timing local
+contract-rebuild CPU work and reporting it as "endpoint latency", which
+would be a fabricated pass on a quantity the run never measured. Pinned
+by `tests/roster_intel/test_verify_offline.py`.
+
+Marked `livedata` (`tests/roster_intel/test_verify_offline.py`) — it
+reads a real archived scrape, same convention as `test_real_rosters.py`
+— so it runs outside the blocking hard gate, same as the pack's own
+`--base-url` HTTP path always has.
 
 ---
 
@@ -136,6 +173,47 @@ slots; 83 unpriced is 12.6% of 660 rostered, the same figure
 `src/api/roster_intelligence.py`'s module docstring records. Had the
 join silently failed, these would read 0 and the harness would have
 downgraded every PASS.
+
+### 3.1 Re-run at a later head, via the now-committed `--offline` command
+
+Re-measured **2026-08-20** at `8be59e267`, on merged `main` (post
+#914/#922/#933/#929, i.e. after V1-27/28/29/30/33/34/130 all reached
+`VERIFIED`), via `python scripts/verify_roster_intelligence.py --offline`
+— the first time this table was produced by a **committed, re-runnable
+command** rather than by hand. Source:
+`dynasty_export_20260820_210638.zip`, a fresher board than the original
+run's, two days later.
+
+| # | check | result | level | denominator | vs 2026-08-19 |
+|---|---|---|---|---|---|
+| 01 | every active configured league answers | **PASS** | EVIDENCE-L2 | 1 | unchanged |
+| 02 | weakness thresholds scale with `teamCount` | **PASS** | EVIDENCE-L1 | **216 rungs** | unchanged |
+| 03 | flex slots from actual league configuration | **PASS** | EVIDENCE-L2 | **36 flex slots** | unchanged |
+| 04 | every player appears at most once per core | **PASS** | EVIDENCE-L2 | **374 members** | unchanged |
+| 05 | starters removed before the reserve solve | **PASS** | EVIDENCE-L2 | **240 starters** | unchanged |
+| 06 | core size respects starters + reserve demand | **PASS** | EVIDENCE-L2 | **12 teams** | unchanged |
+| 07 | unpriced players reported, not coerced | **PASS** | EVIDENCE-L2 | **660 rostered** | unchanged |
+| 08 | unpriced excluded from every value aggregate | **PASS** | EVIDENCE-L2 | **86 unpriced** | 83 → 86 (board drift, not a defect — see below) |
+| 09 | Team Strength groups re-sum to total | **PASS** | EVIDENCE-L2 | **12 teams** | unchanged |
+| 10 | weakness credits no player to two rungs | **PASS** | EVIDENCE-L2 | **215 rung credits** | unchanged |
+| 11 | Young Core uses core-only value, discloses PRIOR | **PASS** | EVIDENCE-L2 | **12 portfolios** | unchanged |
+| 12 | teamAssignment degrades honestly | **UNMEASURABLE** | — | 0 | unchanged (still needs a deploy) |
+| 13 | endpoint latency within budget | **UNMEASURABLE** | — | 0 | unchanged (still needs a live HTTP request — see §2's note on why `build_bundle_offline` refuses to fake this one) |
+
+Exit code **2**, same shape as the original run: 11 PASS, 2
+UNMEASURABLE, 0 FAIL. **The 216-rung / 215-credit figures for V1-32 are
+identical two days and one merged 12-item train apart** — the strongest
+form of "consolidation is behaviorally inert" available short of a
+before/after diff on the exact same board, because #914/#922/#933/#929
+touched replacement level, the lineup solver and the untouchable-control
+lane, none of which this row's threshold/credit math reads. Check 08's
+denominator moving 83→86 is the live board's own unpriced-rostered-player
+count drifting with scrape health (per `src/api/roster_intelligence.py`'s
+own docstring) — a change in the INPUT, not in V1-31/V1-32's code, and
+exactly the kind of honest movement `unpricedIds` exists to surface
+rather than hide.
+
+Reproduce: `python scripts/verify_roster_intelligence.py --offline`.
 
 ---
 
@@ -210,3 +288,54 @@ really is a duplicate. The test therefore asserts "the intended check is
 among the red ones" with a bounded allowance, not "exactly one is red".
 Claiming the stricter property would mean weakening a check to buy a
 tidier table.
+
+---
+
+## 6. V1-32: does closing it need a frontend consumer? (2026-08-20)
+
+Investigated because a later dispatch, reading the F-2 finding and
+PR #1004's own "no live Team Weakness duplicate to retire" report,
+proposed the missing frontend consumer as V1-32's actual remaining gap.
+It is not, and this is why, re-derived from primary sources rather than
+re-trusted from the earlier summary:
+
+1. `docs/VERSION_1_COMPLETION_CONTRACT.md` §2 defines the level ladder:
+   **L2** = "L1 plus a measured statement of the effect on the live board
+   or contract"; **L4** = "L3 plus proof the intended user-facing surface
+   consumes the canonical implementation with truthful semantics". A
+   frontend consumer is an **L4** requirement, not an L2 one.
+2. §3.2's own row states V1-32's **target level is L2**, not L4.
+3. `V1_35_METRIC_SEPARATION_AUDIT.md` F-2 (written earlier in this same
+   lane, before this task) already reached this conclusion: *"V1-31 and
+   V1-32 require EVIDENCE-L2 ... so the missing consumer does not block
+   their required level. It blocks any future L4 claim."*
+4. `C2_CANONICAL_ROSTER_CHAIN.md` §7, this lane's own build record for
+   the owner, is explicit: *"UI — none from this lane. Claude 6 owns the
+   frontend."*
+5. Re-checked against the current tree rather than assumed stale:
+   `grep -rn "weakness" frontend/` (case-insensitive) returns **zero
+   hits** — no frontend code reads `TeamWeakness` output today, including
+   after this session's own V1-31 work wired `strength`/ladder data
+   through `TeamStrengthCard.jsx` and `TeamPhasePanel.jsx`. The audit's
+   finding is current, not stale.
+6. §3.1 above supplies the L2 evidence itself: checks 02 and 10, PASS at
+   EVIDENCE-L2/L1, reproduced today at a different head against a
+   different board than the original 2026-08-19 run, with the same
+   passing counts (216 rungs, 215 credits, 0 violations).
+
+**Conclusion: V1-32's own acceptance bar does not require a frontend
+consumer, and none was built here.** A future **L4** claim for V1-31 or
+V1-32 does need one — handoff **H-1** in `V1_35_METRIC_SEPARATION_AUDIT.md`
+already names it (`/rosters`, folding `scoreTeamTiers` onto
+`strength.total` / `strength.starterValue` / `strength.reserveValue` and
+rendering `weakness.needs` beside it) and already assigns it to Claude 6.
+Building that frontend surface from this lane would be inventing scope
+this row does not require and duplicating an assignment that already
+exists elsewhere — the opposite of the single-owner discipline V1-31/32
+exist to enforce.
+
+What genuinely *was* missing and is fixed here instead: V1-32's L2
+evidence existed only as a hand-run result with no committed reproduction
+command (§2/§3.1's `--offline` addition), and that command was not
+verified to still hold on the current merged tree until this task ran it.
+Both are now true and both are in-lane, non-frontend work.

--- a/scripts/verify_roster_intelligence.py
+++ b/scripts/verify_roster_intelligence.py
@@ -48,6 +48,9 @@ Usage:
     python scripts/verify_roster_intelligence.py --base-url http://127.0.0.1:8000
     python scripts/verify_roster_intelligence.py --base-url "$PROD_PUBLIC_URL" \
         --league-key dynasty_main --league-key dynasty_new --json-out evidence.json
+    python scripts/verify_roster_intelligence.py --offline --json-out evidence.json
+        # rebuilds from the newest COMPLETE archived scrape — no server,
+        # no auth, no network. Ceiling EVIDENCE-L2, never L3/L4.
 
 Exit codes (the repo convention — ``scripts/backtest_perfect_draft.py``):
     0  every check was MEASURED and PASSED
@@ -1241,6 +1244,51 @@ def build_bundle_http(base_url: str, league_key: str, registry: Mapping[str, Any
     return bundle
 
 
+def build_bundle_offline(
+    league_key: str, registry: Mapping[str, Any] | None
+) -> tuple[Bundle, str | None]:
+    """Rebuild one league's payload from the newest COMPLETE archived scrape.
+
+    EVIDENCE-L2, never higher: this reads a locally rebuilt contract, not
+    a deployed response.  It exists because the pack's own documented
+    offline command — ``pytest tests/roster_intel/test_verification_pack.py``
+    — drives every check from a hand-built synthetic fixture and proves
+    the checks are LIVE (RED on a violated payload), not that they hold
+    on a real board.  ``V1_ROSTER_VERIFICATION_PACK.md`` §3's "216
+    rungs" / "215 rung credits" table was produced against
+    ``newest_complete_raw_payload()`` by hand, with no committed command
+    to reproduce it.  This is that command, mirroring ``build_bundle_http``
+    exactly except for where the payload comes from.
+
+    ``team_assignment`` is left unset: the public teamAssignment section
+    is a deploy-time overlay this archive does not carry, so check 12
+    correctly reports UNMEASURABLE rather than a fabricated pass.
+
+    ``bundle.latency_ms`` is likewise left EMPTY, deliberately: check 13
+    polices HTTP endpoint latency against a p95 budget, and timing this
+    function's local dict/CPU work would let it silently report a
+    fabricated "PASS" for a quantity — a network round-trip — that was
+    never measured. Local build time is not the evidence this check
+    claims to carry.
+    """
+    from src.api.data_contract import build_api_data_contract
+    from src.api.roster_intelligence import build_league_roster_intelligence
+    from tests.archive_fixtures import newest_complete_raw_payload
+
+    bundle = Bundle(league_key=league_key, registry=registry)
+    raw, source_path = newest_complete_raw_payload()
+    if raw is None:
+        bundle.errors["intelligence"] = "no complete archived scrape available"
+        return bundle, None
+
+    contract = build_api_data_contract(raw)
+    team_count = (registry or {}).get("teamCount")
+    bundle.intelligence = build_league_roster_intelligence(
+        contract, team_count=team_count if isinstance(team_count, int) else None
+    )
+    return bundle, source_path
+
+
 def _registry_entries(keys: Sequence[str] | None) -> list[tuple[str, dict[str, Any]]]:
     """Active leagues from the local registry, or exactly the keys asked for."""
     from src.api.league_registry import (
@@ -1354,7 +1402,59 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         help="Write the machine-readable evidence artifact here.",
     )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Rebuild from the newest COMPLETE archived scrape instead of "
+        "probing a server. No --base-url, no auth, no network. Ceiling "
+        "EVIDENCE-L2 — a locally rebuilt contract, never a deployed "
+        "response. Defaults --league-key to dynasty_main, the one this "
+        "repo's archive fixture covers; pass --league-key to override.",
+    )
     args = parser.parse_args(argv)
+
+    if args.offline:
+        keys = args.league_keys or ["dynasty_main"]
+        try:
+            entries = _registry_entries(keys)
+        except Exception as exc:  # noqa: BLE001
+            print(f"{TAG} ::error title=Registry unreadable::{exc}")
+            return EXIT_UNMEASURED
+        bundles, source_paths = [], []
+        for key, reg in entries:
+            bundle, source_path = build_bundle_offline(key, reg)
+            bundles.append(bundle)
+            if source_path:
+                source_paths.append(source_path)
+        results = run_checks(bundles, source_level=L2)
+        source_desc = ", ".join(sorted(set(source_paths))) or "(no archive found)"
+        render(
+            results,
+            base_url="",
+            source=f"offline_archive:{source_desc}",
+            source_level=L2,
+            expect_sha=args.expect_sha,
+        )
+        code = exit_code_for(results)
+        if args.json_out:
+            artifact = {
+                "checkedAt": datetime.now(timezone.utc).isoformat(),
+                "baseUrl": "",
+                "archiveSource": source_paths,
+                "operatorAssertedSha": args.expect_sha,
+                "shaPublishedByApi": None,
+                "sourceLevel": L2,
+                "exitCode": code,
+                "leagues": [b.league_key for b in bundles],
+                "fetchErrors": {b.league_key: b.errors for b in bundles if b.errors},
+                "checks": [r.to_dict() for r in results],
+            }
+            args.json_out.parent.mkdir(parents=True, exist_ok=True)
+            args.json_out.write_text(
+                json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+            print(f"{TAG} evidence written to {args.json_out}")
+        return code
 
     if not args.base_url:
         print(f"{TAG} ::error title=No base URL::Pass --base-url or set ROSTER_VERIFY_BASE_URL.")

--- a/tests/roster_intel/test_verify_offline.py
+++ b/tests/roster_intel/test_verify_offline.py
@@ -1,0 +1,110 @@
+"""Pin the ``--offline`` mode of ``scripts/verify_roster_intelligence.py``.
+
+``V1_ROSTER_VERIFICATION_PACK.md`` §3's real-board results table ("216
+rungs", "215 rung credits", ...) was produced by hand against
+``newest_complete_raw_payload()``, and the doc's own documented offline
+reproduction command — ``pytest tests/roster_intel/test_verification_pack.py``
+— only drives the checks from a synthetic fixture, so it proves the
+checks are LIVE, never that they hold on a real board. ``--offline``
+closes that gap: a committed, re-runnable command that rebuilds a real
+contract from the newest COMPLETE archive and reports EVIDENCE-L2, the
+same evidence class the hand-run produced.
+
+Marked ``livedata`` — like ``test_real_rosters.py`` — because it reads a
+real archived scrape and is excluded from the blocking hard gate
+(``-m "not livedata"``); the check LOGIC itself stays pinned by the
+synthetic-fixture suite in ``test_verification_pack.py``, which does run
+in the hard gate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.verify_roster_intelligence import (
+    L1,
+    L2,
+    PASS,
+    UNMEASURABLE,
+    build_bundle_offline,
+    run_checks,
+)
+from tests.archive_fixtures import newest_complete_raw_payload
+
+pytestmark = pytest.mark.livedata
+
+
+def _skip_if_no_archive():
+    raw, _ = newest_complete_raw_payload()
+    if raw is None:
+        pytest.skip("no complete archived scrape available in this environment")
+
+
+def test_offline_bundle_rebuilds_a_real_board_not_a_synthetic_one():
+    _skip_if_no_archive()
+    bundle, source = build_bundle_offline("dynasty_main", {"teamCount": 12, "known": True})
+    assert source is not None
+    assert bundle.intelligence is not None
+    assert len(bundle.teams) > 0
+    # A synthetic pack fixture in test_verification_pack.py has exactly
+    # 12 teams and a handful of members; a real board has hundreds.
+    total_members = sum(len((t.get("core") or {}).get("members") or []) for t in bundle.teams)
+    assert total_members > 100, "this looks like a synthetic fixture, not a real board"
+
+
+def test_offline_run_measures_v1_31_and_v1_32_at_evidence_l2():
+    _skip_if_no_archive()
+    bundle, _ = build_bundle_offline("dynasty_main", {"teamCount": 12, "known": True})
+    results = {r.id: r for r in run_checks([bundle], source_level=L2)}
+
+    strength = results["09/dynasty_main"]
+    assert strength.result == PASS
+    assert strength.level == L2
+    assert strength.denominator == 12, "one row per team — Team Strength re-sum (V1-31)"
+
+    weakness_scaling = results["02/dynasty_main"]
+    assert weakness_scaling.result == PASS
+    # This check's own ceiling is EVIDENCE-L1 (a config-scaling fact) —
+    # it does not rise to L2 merely because the run's SOURCE did.
+    assert weakness_scaling.level == L1
+    assert weakness_scaling.denominator > 0, "must examine real rungs, not 0-of-0"
+
+    weakness_credit = results["10/dynasty_main"]
+    assert weakness_credit.result == PASS
+    assert weakness_credit.level == L2
+    assert weakness_credit.denominator > 0, "must examine real rung credits, not 0-of-0"
+
+
+def test_offline_run_never_fabricates_team_assignment():
+    """check 12 needs the deployed public-league section this archive does
+    not carry — it must report UNMEASURABLE, never a fabricated PASS."""
+    _skip_if_no_archive()
+    bundle, _ = build_bundle_offline("dynasty_main", {"teamCount": 12, "known": True})
+    results = {r.id: r for r in run_checks([bundle], source_level=L2)}
+    assert results["12/dynasty_main"].result == UNMEASURABLE
+
+
+def test_offline_run_never_fabricates_endpoint_latency():
+    """check 13 polices HTTP round-trip latency against a p95 budget. The
+    offline path never makes an HTTP request, so ``bundle.latency_ms``
+    must stay empty and this must report UNMEASURABLE — not a fabricated
+    PASS built from local contract-rebuild CPU time, which is a
+    different quantity than the one this check claims to measure."""
+    _skip_if_no_archive()
+    bundle, _ = build_bundle_offline("dynasty_main", {"teamCount": 12, "known": True})
+    assert bundle.latency_ms == {}, "offline mode must not time local work as endpoint latency"
+    results = {r.id: r for r in run_checks([bundle], source_level=L2)}
+    assert results["13/dynasty_main"].result == UNMEASURABLE
+
+
+def test_offline_run_touches_no_network():
+    """The offline path must not import the HTTP fetch layer's transport
+    call. ``build_bundle_offline`` reaches archive fixtures + the
+    contract builder only — never ``fetch_json``."""
+    import inspect
+
+    import scripts.verify_roster_intelligence as mod
+
+    src = inspect.getsource(mod.build_bundle_offline)
+    assert "fetch_json" not in src
+    assert "urllib" not in src


### PR DESCRIPTION
## Summary

The dispatch for this slice flagged "canonical Team Weakness has no truthful intended frontend consumer" as V1-32's actual remaining gap, per PR #1004's own report and the earlier V1-35 audit. Investigated per the task's own instruction to prove that before changing code — and found it does not hold, from primary sources:

- `docs/VERSION_1_COMPLETION_CONTRACT.md` §2 defines the level ladder: **L2** = board/contract measured; **L4** = L3 + proof the intended *frontend* surface consumes it with truthful semantics. A frontend consumer is an L4 requirement.
- V1-32's declared target level (§3.2) is **L2**, not L4.
- This lane's own `V1_35_METRIC_SEPARATION_AUDIT.md` (finding F-2, written before this task) already says exactly this: *"the missing consumer does not block their required level. It blocks any future L4 claim."*
- `C2_CANONICAL_ROSTER_CHAIN.md` §7 (this lane's own build record) already assigns any frontend work to Claude 6: *"UI — none from this lane."*
- Re-grepped the current tree rather than trusting the earlier summary: `frontend/` has zero mentions of `weakness` today, confirming the audit is still current — including after this session's own V1-31 slice (PR #1002) wired Strength/ladder data through the frontend.

**No frontend code was built.** Per the task's own fallback ("If no intended V1 frontend surface can be established from the canonical contract, STOP and report that rather than inventing one"), building one here would exceed V1-32's actual acceptance bar and duplicate handoff **H-1**, already named in the audit and assigned to Claude 6.

## What was actually missing (and is fixed here)

V1-32's L2 evidence (verification pack checks 02/10 — weakness threshold scaling, no double-credited rung) existed only as a **hand-run result** with no committed command to reproduce it. Added:

- `scripts/verify_roster_intelligence.py --offline`: rebuilds a real contract from the newest complete archived scrape (no server, no auth, no network) and runs the pack against it at EVIDENCE-L2.
- Re-ran it at the current merged head (`8be59e267`): **216 rungs / 215 rung credits, 0 violations** — identical to the original 2026-08-19 hand-run, two days and one merged 12-item train (#914/#922/#933/#929) later. That stability is itself evidence none of that train touched V1-32's threshold/credit math.
- Caught and fixed a truthfulness bug while building this: the offline path must not time local contract-rebuild CPU work and report it as HTTP endpoint latency for check 13 — that would be a fabricated PASS on a quantity (a network round-trip) the run never measured. Fixed before being counted; pinned by test.

## Test plan

- [x] `pytest tests/roster_intel/ -q -m "not livedata"` — 611 passed
- [x] `pytest tests/roster_intel/ -q -m "livedata"` — new `test_verify_offline.py` (5 tests) passes; includes an explicit assertion that offline mode never fabricates endpoint-latency evidence
- [x] `pytest tests/infra/test_unit_suite_does_not_probe_production.py` — 6 passed (confirms the new offline path stays network-free)
- [x] `ruff format --check` / `ruff check` — clean
- [x] `scripts/check_decision_coercions.py` — clean, no new coercions
- [x] `python scripts/verify_roster_intelligence.py --offline` run end-to-end, output captured in the docs update (§3.1 of `V1_ROSTER_VERIFICATION_PACK.md`)

## Handoff

**FEATURE_GREEN / READY_FOR_INTEGRATION.** No production code paths changed — this is evidence/tooling only (a new offline verification mode + a docs-only clarification). V1-31 (PR #1002) and V1-32 backend guard (PR #1004) remain frozen and untouched by this branch, which is based independently off `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyqbZejxh7ytbfijL5pmdE)_