### PR TITLE
IDP Show: the combined Top-700 board becomes the sole voting source

### DIFF
--- a/deploy/idpshow_fetch_and_push.sh
+++ b/deploy/idpshow_fetch_and_push.sh
@@ -28,11 +28,16 @@
 #   2. fetch + reset --hard origin/main so we always start from the
 #      latest CI-committed state.
 #   3. Pull cached cookies from ``$WORK_DIR/idpshow_session.json``.
-#   4. Run ``scripts/fetch_idpshow.py``.  (The fetcher only READS the
-#      jar — no code path rewrites cookies; re-mints are human-made
-#      directly into ``$WORK_DIR``, which stays the source of truth.)
-#   5. Stamp ``data/scrape_state/idpShow_last_success`` with the
-#      current epoch, stage the CSV + stamp, commit, push.  Push
+#   4. Run ``scripts/fetch_idpshow.py`` (IDP-only board, unregistered/
+#      diagnostic) and ``scripts/fetch_idpshow.py --combined`` (the
+#      COMBINED offense+IDP board — the provider family's sole VOTING
+#      source as of 2026-08-20).  Both read the same session jar; the
+#      fetcher only READS it — no code path rewrites cookies; re-mints
+#      are human-made directly into ``$WORK_DIR``, which stays the
+#      source of truth.
+#   5. Stamp ``data/scrape_state/idpShow_last_success`` and
+#      ``data/scrape_state/idpShowCombined_last_success`` with the
+#      current epoch, stage both CSVs + stamps, commit, push.  Push
 #      retries on rebase conflict (CI's data-refresh cron also
 #      pushes to main every 2h).
 
@@ -81,9 +86,31 @@ if [[ ! -f "${REPO_DIR}/idpshow_session.json" ]]; then
   exit 1
 fi
 
-log "running scripts/fetch_idpshow.py"
+# Two boards, one paywalled article family, one session cookie.
+# idpShowCombined is the VOTING board (see
+# src/api/data_contract.py::_RANKING_SOURCES) as of 2026-08-20 — it
+# must stay on the same refresh cadence as the retired idpShow.csv,
+# which is now acquisition-only (unregistered, kept for diagnostics).
+# Each fetch is independent: one board's fetch failing does not block
+# committing the other board's successful refresh, and only a
+# same-run failure of BOTH aborts the whole push.
+DEFAULT_FETCH_OK=1
+COMBINED_FETCH_OK=1
+
+log "running scripts/fetch_idpshow.py (IDP-only board, unregistered/diagnostic)"
 if ! "${VENV_PYTHON}" scripts/fetch_idpshow.py; then
-  err "fetch_idpshow.py exited non-zero - keeping previous CSV / stamp; will retry on next timer fire."
+  err "fetch_idpshow.py exited non-zero - keeping previous CSV / stamp."
+  DEFAULT_FETCH_OK=0
+fi
+
+log "running scripts/fetch_idpshow.py --combined (VOTING board)"
+if ! "${VENV_PYTHON}" scripts/fetch_idpshow.py --combined; then
+  err "fetch_idpshow.py --combined exited non-zero - keeping previous CSV / stamp."
+  COMBINED_FETCH_OK=0
+fi
+
+if [[ "${DEFAULT_FETCH_OK}" -eq 0 && "${COMBINED_FETCH_OK}" -eq 0 ]]; then
+  err "both idpShow fetches failed - nothing to commit; will retry on next timer fire."
   exit 1
 fi
 
@@ -96,14 +123,23 @@ if [[ -f "${REPO_DIR}/idpshow_session.json" ]]; then
 fi
 
 mkdir -p data/scrape_state
-date -u +%s > data/scrape_state/idpShow_last_success
+if [[ "${DEFAULT_FETCH_OK}" -eq 1 ]]; then
+  date -u +%s > data/scrape_state/idpShow_last_success
+fi
+if [[ "${COMBINED_FETCH_OK}" -eq 1 ]]; then
+  date -u +%s > data/scrape_state/idpShowCombined_last_success
+fi
 
-# Force-add the stamp because data/ is gitignored at the repo level
-# (data/scrape_state/ is the carve-out we want tracked) - matches the
-# scheduled-refresh.yml "Commit updated data" step.
+# Force-add both boards' outputs + stamps because data/ is gitignored
+# at the repo level (data/scrape_state/ is the carve-out we want
+# tracked) - matches the scheduled-refresh.yml "Commit updated data"
+# step.  Adding a path whose fetch failed (and so is unchanged on
+# disk) is harmless - it just produces no diff to commit.
 git add -f -- \
   CSVs/site_raw/idpShow.csv \
-  data/scrape_state/idpShow_last_success
+  CSVs/site_raw/idpShowCombined.csv \
+  data/scrape_state/idpShow_last_success \
+  data/scrape_state/idpShowCombined_last_success
 
 if git diff --cached --quiet; then
   log "no changes after fetch - exiting clean"

--- a/docs/architecture/live-value-pipeline-trace.md
+++ b/docs/architecture/live-value-pipeline-trace.md
@@ -81,7 +81,7 @@ policy.  Pinned against the registry by
 | `dlfRookieIdp` | overall_idp | 1.0 | 50 | `rank_signal` |
 | `draftSharksIdp` | overall_idp | 1.0 | 400 | — |
 | `fantasyProsIdp` | overall_idp | 1.0 | 100 | `rank_signal`, `shared_market_translation`, `excludes_rookies` |
-| `idpShow` | overall_idp | 1.0 | 420 | `rank_signal`, `shared_market_translation` |
+| `idpShowCombined` | overall_idp (+ overall_offense) | 1.0 | 450 | `rank_signal` |
 | `idpTradeCalc` | overall_idp (+ overall_offense) | 1.0 | — | `backbone`, `tep_premium` |
 | `dlfRookieSf` | overall_offense | 1.0 | 50 | `rank_signal` |
 | `dlfSf` | overall_offense | 1.0 | 280 | `rank_signal` |

--- a/frontend/__tests__/display-helpers.test.js
+++ b/frontend/__tests__/display-helpers.test.js
@@ -255,7 +255,7 @@ describe("idpMarketAction", () => {
     const sourceRanks = {};
     if (idptc != null) sourceRanks.idpTradeCalc = idptc;
     if (dlf != null) sourceRanks.dlfIdp = dlf;
-    if (ipd != null) sourceRanks.idpShow = ipd;
+    if (ipd != null) sourceRanks.idpShowCombined = ipd;
     if (fp != null) sourceRanks.fantasyProsIdp = fp;
     if (ds != null) sourceRanks.draftSharksIdp = ds;
     return {

--- a/frontend/lib/display-helpers.js
+++ b/frontend/lib/display-helpers.js
@@ -399,7 +399,7 @@ const IDP_RETAIL_KEY = "idpTradeCalc";
 const IDP_CONSENSUS_KEYS = new Set([
   "dlfIdp",
   "dlfRookieIdp",
-  "idpShow",
+  "idpShowCombined",
   "fantasyProsIdp",
   "draftSharksIdp",
 ]);
@@ -472,8 +472,8 @@ export function idpMarketEdge(row) {
 
   // Same value-space treatment as the offense path.  The IDP side is
   // if anything more exposed to the pool-depth artifact: idpTradeCalc
-  // publishes ~901 rows against dlfIdp/idpShow/fantasyProsIdp pools a
-  // fraction of that size.
+  // publishes ~901 rows against dlfIdp/idpShowCombined/fantasyProsIdp
+  // pools a fraction of that size.
   const idpSides = sideValues(
     row,
     Object.keys(ranks),

--- a/frontend/lib/dynasty-data.js
+++ b/frontend/lib/dynasty-data.js
@@ -372,24 +372,31 @@ export const RANKING_SOURCES = [
     excludesRookies: false,
   },
   {
-    // The IDP Show (Adamidp) — Substack-hosted full-universe IDP
-    // rankings board.  Includes rookies, edge/interior split.
-    // Data loaded by scripts/fetch_idpshow.py from a Datawrapper
-    // iframe embedded in the paywalled article; session cookies
-    // are refreshed manually ~quarterly (Substack captcha blocks
-    // automated login).  ~420 rows.  Rank-signal via the OVR
-    // column; needs shared-market translation for Hill input.
-    key: "idpShow",
-    displayName: "The IDP Show (Adamidp)",
-    columnLabel: "IDP Show",
+    // The IDP Show (Adamidp) — OWNER DECISION 2026-08-20: the COMBINED
+    // offense+IDP Top-700 board is this provider family's sole voting
+    // key (see src/api/data_contract.py::_RANKING_SOURCES for the full
+    // rationale).  665 rows at the 2026-08-20 acquisition, Bijan
+    // Robinson #1 / Josh Allen #2 — a native combined-pool ordinal, so
+    // it needs no shared-market crosswalk.  Data loaded by
+    // scripts/fetch_idpshow.py --combined from a Datawrapper iframe
+    // embedded in the paywalled article (widest of the article's chart
+    // embeds, by measured row count); session cookies are refreshed
+    // manually ~quarterly (Substack captcha blocks automated login).
+    // The older IDP-only board (idpShow.csv) is retired from voting —
+    // unregistered, not mirrored here.
+    key: "idpShowCombined",
+    displayName: "The IDP Show — Combined (Adamidp)",
+    columnLabel: "IDP Show Combined",
+    correlationGroup: "idpShow",
     scope: "overall_idp",
+    extraScopes: ["overall_offense"],
     positionGroup: null,
-    depth: 420,
+    depth: 450,
     weight: 1.0,
     isBackbone: false,
     isRetail: false,
     isTepPremium: false,
-    needsSharedMarketTranslation: true,
+    needsSharedMarketTranslation: false,
     excludesRookies: false,
     isRankSignal: true,
   },

--- a/scripts/fetch_idpshow.py
+++ b/scripts/fetch_idpshow.py
@@ -391,9 +391,13 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help=(
             "Fetch the publisher's COMBINED offense+IDP dynasty board into "
-            "idpShowCombined.csv instead of the IDP-only board.  Acquisition "
-            "only — nothing in the registry reads that file, so it cannot "
-            "vote.  See COMBINED_ARTICLE_URL for why."
+            "idpShowCombined.csv instead of the IDP-only board.  This is "
+            "the provider family's SOLE voting source as of 2026-08-20 — "
+            "see the ``idpShowCombined`` entry in "
+            "``src/api/data_contract.py::_RANKING_SOURCES``.  The plain "
+            "(no-flag) board is still fetched for diagnostics but is "
+            "unregistered and cannot vote.  See COMBINED_ARTICLE_URL for "
+            "why this board, not that one."
         ),
     )
     args = parser.parse_args(argv)
@@ -445,6 +449,28 @@ def main(argv: list[str] | None = None) -> int:
         if not rows:
             print("[idpshow] ERROR: 0 rows parsed — refusing to overwrite.", file=sys.stderr)
             return 1
+        # Hard floor aligned with the downstream contract guard
+        # ``_DEFAULT_SOURCE_ROW_FLOORS["idpShowCombined"]`` (450).  This
+        # board is now a VOTING source, so the failure mode the plain
+        # board's floor exists to prevent applies here too — most
+        # sharply, picking the article's 250-row excerpt chart again
+        # instead of the ~665-700 row full board (the exact defect PR
+        # #1008 fixed by measuring chart width instead of trusting
+        # document order).  Fail loudly and preserve last-good rather
+        # than silently shipping a truncated board.  Skipped under
+        # --dry-run so the sample below still prints for diagnosis.
+        _IDPSHOW_COMBINED_ROW_FLOOR = 450
+        if not args.dry_run and len(rows) < _IDPSHOW_COMBINED_ROW_FLOOR:
+            print(
+                f"[idpshow] ERROR: only {len(rows)} rows — expected ≥"
+                f"{_IDPSHOW_COMBINED_ROW_FLOOR} (contract floor "
+                f"_DEFAULT_SOURCE_ROW_FLOORS['idpShowCombined']).  "
+                f"Partial/degraded scrape (or the excerpt chart won the "
+                f"width comparison again); preserving last-good CSV, not "
+                f"overwriting.",
+                file=sys.stderr,
+            )
+            return 2
         if args.dry_run:
             print("[idpshow] dry run — not writing")
             return 0

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -897,16 +897,20 @@ _DEFAULT_SOURCE_ROW_FLOORS: dict[str, int] = {
     # FantasyPros / Pat Fitzmaurice: QB (50) + RB (~88) + WR (~115) +
     # TE (~46) ≈ 299 rows at the April 2026 baseline.  Floor at ~75%.
     "fantasyProsFitzmaurice": 225,
-    # The IDP Show (IDP-only, unregistered as of 2026-08-20 — see the
-    # ``idpShowCombined`` registry entry): the CSV has ~419 rows but
-    # only ~200 canonicalize against the Sleeper player pool (the
-    # source goes deep into camp-body / backup IDPs that Sleeper
-    # doesn't enumerate).  Floor at 150 covers ~75% of the realistic
-    # match rate — a partial fetch or column-drop regression would
-    # trip this warning.  Kept even though the source no longer votes:
-    # the file is still fetched and a silently-broken fetch is still
-    # worth surfacing.
-    "idpShow": 150,
+    # The IDP Show (IDP-only) floor is REMOVED, not kept, as of
+    # 2026-08-20 — see the ``idpShowCombined`` registry entry.  This
+    # dict's floor gate reads ``canonicalSiteValues`` population for
+    # every key in ``set(get_ranking_source_keys()) | set(row_floors)``
+    # (``_compute_unified_rankings``'s per-source row-count-floor
+    # block), and an UNREGISTERED source can never populate that column
+    # — the entry would trip ``source_missing:idpShow`` as a permanent,
+    # unfixable hard error rather than surface a real fetch problem.
+    # The file is still fetched and its own acquisition floor
+    # (``_IDPSHOW_ROW_FLOOR`` in ``scripts/fetch_idpshow.py``) still
+    # guards the fetch itself; this contract-level gate is specifically
+    # about VOTING coverage, which an unregistered source structurally
+    # cannot have.
+    #
     # The IDP Show COMBINED board (665 raw rows / 662 distinct names
     # at the 2026-08-20 acquisition).  A cross-source proxy match
     # (normalized-name overlap against the ktc.csv + idpTradeCalc.csv

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -145,7 +145,7 @@ _IDP_SIGNAL_KEYS = {
     "idpTradeCalc",
     "dlfIdp",
     "fantasyProsIdp",
-    "idpShow",
+    "idpShowCombined",
 }
 
 # All source signal keys — used to detect which source(s) a player has
@@ -418,19 +418,42 @@ _SOURCE_CSV_PATHS: dict[str, Any] = {
         "path": "CSVs/site_raw/dlfIdp.csv",
         "signal": "rank",
     },
-    # The IDP Show (Adamidp) — Substack-hosted IDP rankings article
-    # at theidpshow.com/p/idp-dynasty-rankings.  The actual rankings
-    # are served from an embedded Datawrapper iframe whose
-    # dataset.csv is publicly accessible.  Fetched by
-    # ``scripts/fetch_idpshow.py`` which authenticates into the
-    # paywalled article (via cookie-dump session), extracts the
-    # current chart ID from the iframe src, and downloads the
-    # dataset.  Signal=rank — the chart includes a TRADE VALUE
-    # column but it's draft-pick-equivalent text ("1st + 2nd",
-    # "3rd", etc.), not numeric, so we use the OVR column as the
-    # rank signal.  ~420 rows covering ED/IDL/LB/S/CB.
-    "idpShow": {
-        "path": "CSVs/site_raw/idpShow.csv",
+    # The IDP Show (Adamidp) — OWNER DECISION 2026-08-20: the provider
+    # family's SOLE voting board is now the COMBINED offense+IDP Top-700
+    # board (theidpshow.com/p/combined-idp-offense-dynasty-rankings-...),
+    # not the older IDP-only board at idpShow.csv.  Both are Substack-
+    # hosted, served from an embedded Datawrapper iframe, fetched by
+    # ``scripts/fetch_idpshow.py`` (``--combined`` selects this one,
+    # picking the WIDEST of the article's chart embeds by measured row
+    # count — see ``_pick_widest_chart`` — because the combined article
+    # embeds a 250-row excerpt ahead of the real ~665-700 row board).
+    # Signal=rank: the chart's TRADE VALUE column is draft-pick-
+    # equivalent text ("1st + 2nd"), not numeric, so the rank column is
+    # the ordinal signal.  Registered ``is_cross_market=True`` below
+    # (unlike the retired idpShow.csv) because this board's rank is
+    # ALREADY a native combined offense+IDP ordinal — Bijan Robinson #1,
+    # Josh Allen #2 — so it needs no shared-market crosswalk through
+    # another source's ladder; see the registry entry's comment below
+    # for the full rationale.
+    #
+    # The old ``idpShow.csv`` (IDP-only, ~350 rows) remains ACQUIRED
+    # (the fetch script's default, no-flag path still writes it, and the
+    # prod timer still refreshes it — see
+    # ``deploy/idpshow_fetch_and_push.sh``) but is deliberately left
+    # UNREGISTERED here — the same acquired-but-not-a-ranking-source
+    # posture ``draftSharksRosSf.csv`` already has (see the
+    # ``draftSharks`` entry below).  An unregistered CSV cannot vote:
+    # ``_enrich_from_source_csvs`` only reads keys present in this dict,
+    # so removing the entry is a structural guarantee, not a policy
+    # flag that could be silently re-enabled.  Never register a second
+    # ``idpShow*`` key alongside this one — same-provider double
+    # counting is forbidden by the correlation-group rules this
+    # registry enforces elsewhere (see ``correlation_group`` on the
+    # ``idpShowCombined`` entry, and
+    # ``tests/api/test_idpshow_combined_source.py::
+    # TestExactlyOneVotingIdpShowKey``).
+    "idpShowCombined": {
+        "path": "CSVs/site_raw/idpShowCombined.csv",
         "signal": "rank",
     },
     # DLF Dynasty Superflex rankings — offense expert consensus.
@@ -780,8 +803,17 @@ _SOURCE_MAX_AGE_HOURS: dict[str, int] = {
     # this should surface, and 24h matches config/source_staleness.json,
     # which also flags idpShow SOFT with a 72h escalation — so a re-mint
     # chore stays quiet for a day without the budget hiding a dead fetcher
-    # for a month.  (Was 720h — F-18.)
+    # for a month.  (Was 720h — F-18.)  Tracked even though this key is
+    # UNREGISTERED (retired from voting 2026-08-20 — see the
+    # ``idpShowCombined`` registry entry) because the same prod timer
+    # still refreshes ``idpShow.csv`` and a silently-dead fetcher on an
+    # acquired-but-inert file is still worth surfacing.
     "idpShow": 24,
+    # The IDP Show COMBINED board — same paywalled cookie, same timer
+    # (deploy/idpshow_fetch_and_push.sh runs the fetcher twice, once
+    # per board), so the same 24h budget applies.  This is now the
+    # PROVIDER FAMILY'S SOLE VOTING KEY (Task 1/2, 2026-08-20).
+    "idpShowCombined": 24,
     # DraftSharks SF + IDP CSVs are written by scripts/fetch_draftsharks.py
     # on every scheduled-refresh tick (3-hour cadence), so the same
     # 6-hour freshness budget as ktc / idpTradeCalc applies.
@@ -865,12 +897,29 @@ _DEFAULT_SOURCE_ROW_FLOORS: dict[str, int] = {
     # FantasyPros / Pat Fitzmaurice: QB (50) + RB (~88) + WR (~115) +
     # TE (~46) ≈ 299 rows at the April 2026 baseline.  Floor at ~75%.
     "fantasyProsFitzmaurice": 225,
-    # The IDP Show: the CSV has ~419 rows but only ~200 canonicalize
-    # against the Sleeper player pool (the source goes deep into
-    # camp-body / backup IDPs that Sleeper doesn't enumerate).  Floor
-    # at 150 covers ~75% of the realistic match rate — a partial
-    # fetch or column-drop regression would trip this warning.
+    # The IDP Show (IDP-only, unregistered as of 2026-08-20 — see the
+    # ``idpShowCombined`` registry entry): the CSV has ~419 rows but
+    # only ~200 canonicalize against the Sleeper player pool (the
+    # source goes deep into camp-body / backup IDPs that Sleeper
+    # doesn't enumerate).  Floor at 150 covers ~75% of the realistic
+    # match rate — a partial fetch or column-drop regression would
+    # trip this warning.  Kept even though the source no longer votes:
+    # the file is still fetched and a silently-broken fetch is still
+    # worth surfacing.
     "idpShow": 150,
+    # The IDP Show COMBINED board (665 raw rows / 662 distinct names
+    # at the 2026-08-20 acquisition).  A cross-source proxy match
+    # (normalized-name overlap against the ktc.csv + idpTradeCalc.csv
+    # union, 928 distinct names) found 653/662 (98.6%) — NOT the true
+    # Sleeper-pool canonicalization rate (that universe is broader and
+    # more IDP-deep than Sleeper's own roster, so it overstates true
+    # match odds), but a real, measured floor for "did the fetch/parse
+    # come back intact" rather than a fabricated 700.  Floor set well
+    # below the measured proxy match so genuine vendor churn (a few
+    # dozen players added/dropped week to week) doesn't trip it, while
+    # a truncated fetch — e.g. picking the 250-row excerpt chart again
+    # instead of the widest one — still does.
+    "idpShowCombined": 450,
     # DraftSharks: the scraper ingests 461 offense / 389 IDP rows,
     # but canonical-name matches against the Sleeper player pool
     # yield a smaller count because DS's deeper rows are prospects
@@ -1503,36 +1552,72 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         "is_tep_premium": False,
     },
     {
-        # The IDP Show (Adamidp) — Substack-hosted full IDP rankings
-        # board published at theidpshow.com/p/idp-dynasty-rankings.
-        # Data is served from an embedded Datawrapper iframe whose
-        # dataset.csv is fetched by ``scripts/fetch_idpshow.py``.
-        # ~420 rows covering ED/IDL/LB/S/CB.  Unlike DLF IDP this
-        # board DOES include rookie prospects (Arvell Reese, Sonny
-        # Styles, etc.), so ``excludes_rookies=False``.
+        # The IDP Show (Adamidp) — OWNER DECISION 2026-08-20: this
+        # provider family's SOLE voting key.  Substack-hosted, served
+        # from an embedded Datawrapper iframe, fetched by
+        # ``scripts/fetch_idpshow.py --combined`` (which picks the
+        # WIDEST chart in the article — see ``_pick_widest_chart`` —
+        # because the combined post embeds a 250-row excerpt ahead of
+        # the real ~665-700 row board; taking the first embed by
+        # document order silently ingested the excerpt, PR #1008).
+        # 665 rows / 662 distinct names at the 2026-08-20 acquisition,
+        # Bijan Robinson #1 / Josh Allen #2 — i.e. the rank is ALREADY
+        # a native COMBINED offense+IDP ordinal, not an IDP-only rank
+        # that needs translating onto someone else's ladder.
         #
-        # Rank-only signal — the source's TRADE VALUE column is
-        # draft-pick-equivalent text ("1st + 2nd", "3rd") rather
-        # than a numeric scale, so we use the OVR column as the
-        # rank and let the shared-market translator convert to the
-        # combined-pool for Hill-curve input.
-        "key": "idpShow",
+        # This is why ``is_cross_market=True`` + ``scope=overall_idp``
+        # + ``extra_scopes=[overall_offense]`` (the same pattern
+        # IDPTradeCalc and DraftSharks use below) is the right registry
+        # shape and ``needs_shared_market_translation=False``: the
+        # dormant Phase 1c ``csv_rank_cross_market_keys`` pre-pass in
+        # ``_compute_unified_rankings`` — written for exactly "any
+        # future rank-signal cross-market source" — restores this
+        # board's own combined CSV rank instead of the generic
+        # per-scope dense re-rank, and routes it to the GLOBAL Hill
+        # master via ``rank_coordinates.native_pool_for_source``.  The
+        # evidence stays ORDINAL throughout: nothing here manufactures
+        # a cardinal 0-9999 vendor value out of a rank column, and this
+        # source is deliberately NOT declared in
+        # ``config/bridges/bridges_v1.json`` — it seeds no OTHER
+        # specialist's shared-market ladder (dlfIdp / fantasyProsIdp
+        # keep crosswalking through idpTradeCalc + draftSharks exactly
+        # as before; this source simply stops needing that ladder for
+        # its OWN vote).
+        #
+        # The OLDER idpShow.csv (IDP-only, ~350 rows,
+        # needs_shared_market_translation=True, translated through
+        # idpTradeCalc's ladder) is RETIRED from voting as of this
+        # entry — see ``_SOURCE_CSV_PATHS`` for where it is now
+        # unregistered.  Never register a second ``idpShow*`` key: see
+        # ``tests/api/test_idpshow_combined_source.py::
+        # TestExactlyOneVotingIdpShowKey`` for the structural guard.
+        #
+        # Includes rookie prospects (the board is a full combined
+        # dynasty board, not an IDP-only excerpt), so
+        # ``excludes_rookies=False``.
+        "key": "idpShowCombined",
         # C1-SRC-02: DYNASTY is PROVEN per endpoint, never inferred from the
         # provider being one we otherwise trust.  UNKNOWN fails closed.
         "game_type": GAME_TYPE_DYNASTY,
         "game_type_evidence": (
-            "theidpshow.com/p/idp-dynasty-rankings — the endpoint path itself is the "
-            "dynasty board, and the publisher's redraft/weekly output lives at separate "
-            "posts that are not fetched"
+            "theidpshow.com/p/combined-idp-offense-dynasty-rankings-fantasy-football — "
+            "the endpoint path itself is the dynasty board, and the publisher's "
+            "redraft/weekly output lives at separate posts that are not fetched"
         ),
-        "display_name": "The IDP Show (Adamidp)",
-        "column_label": "IDP Show",
+        "display_name": "The IDP Show — Combined (Adamidp)",
+        "column_label": "IDP Show Combined",
+        "correlation_group": "idpShow",
         "scope": SOURCE_SCOPE_OVERALL_IDP,
+        "extra_scopes": [SOURCE_SCOPE_OVERALL_OFFENSE],
         "position_group": None,
-        "depth": 420,
+        # Measured floor, not the vendor's own "Top 700" marketing
+        # figure — see the ``idpShowCombined`` row-floor comment above
+        # for the full rationale (Task 7: never hardcode 700).
+        "depth": 450,
         "weight": 1.0,
         "is_backbone": False,
-        "needs_shared_market_translation": True,
+        "is_cross_market": True,
+        "needs_shared_market_translation": False,
         "excludes_rookies": False,
         # IDP values have no TE-premium dimension — declared
         # explicitly False so the registry-completeness test can
@@ -2709,8 +2794,11 @@ def expand_correlation_groups(keys: Iterable[str]) -> set[str]:
 # than inferred, so this list is the single place they are written down:
 #
 #   * The IDP shared-market crosswalk.  Sources flagged
-#     ``needs_shared_market_translation`` — today ``dlfIdp``, ``idpShow``
-#     and ``fantasyProsIdp`` — rank players within the IDP class only.
+#     ``needs_shared_market_translation`` — today ``dlfIdp`` and
+#     ``fantasyProsIdp`` (``idpShowCombined`` is registered
+#     ``is_cross_market`` instead — its own rank is already a combined
+#     offense+IDP ordinal and needs no crosswalk; see its registry entry) —
+#     rank players within the IDP class only.
 #     The backbone's shared-market ladder crosswalks that within-class
 #     ordinal into the combined offense+IDP rank space.  With no backbone
 #     the ladder is empty and ``translate_position_rank`` returns the raw
@@ -4373,6 +4461,10 @@ def _enrich_from_source_csvs(
 
     _join_decisions = 0
     _join_matched = 0
+    # Cross-position-group name collisions withheld from voting (never a
+    # false attribution) — keyed by source, valued by the colliding
+    # canonical-match keys.  See the ``else`` branch below.
+    _withheld_ambiguous_names: dict[str, list[str]] = {}
 
     # DraftSharks (offense + IDP) publish a cross-market 0-100 ``3D
     # Value +`` scale that goes negative past ~rank 200 — the CSV
@@ -4504,24 +4596,41 @@ def _enrich_from_source_csvs(
                     "candidates": [t[0] for t in entries],
                 }
             else:
-                # Multiple position groups share this canonical key.
-                # Without per-CSV-row position info we can't tell which
-                # entry belongs to which group, so we replicate the
-                # best entry across both groups but flag it as ambiguous
-                # so the row audit can downgrade trust.
-                entries_sorted = sorted(entries, key=lambda t: -t[1])
-                best_name, best_val, best_orig_rank, best_native, best_sid = entries_sorted[0]
-                for grp in row_groups:
-                    per_source[f"{cname}::{grp}"] = {
-                        "value": best_val,
-                        "originalRank": best_orig_rank,
-                        "nativeValue": best_native,
-                        "sleeperId": best_sid,
-                        "displayName": best_name,
-                        "ambiguous": True,
-                        "candidates": [t[0] for t in entries],
-                        "groupCollision": sorted(row_groups),
-                    }
+                # Multiple DISTINCT canonical players share this
+                # normalized name across different position groups —
+                # e.g. Justin Jefferson the Minnesota WR and Justin
+                # Jefferson the Cleveland LB (issue #1011).  This is a
+                # different situation from the ``len(row_groups) <= 1``
+                # branch above (one real person, possibly listed twice
+                # by the CSV — e.g. Travis Hunter's two-way listing,
+                # which stays fully voting there): here two REAL,
+                # DIFFERENT people are colliding on one name, and
+                # attaching either CSV entry to the wrong one is not a
+                # missing vote, it is a WRONG one.
+                #
+                # WITHHOLD rather than replicate.  This function has no
+                # per-CSV-row position captured in ``csv_lookup`` (the
+                # tuple is name/value/rank/native/sleeperId only) to
+                # split the entries by group, and even a source's OWN
+                # claimed position column cannot be trusted to do it
+                # safely here: measured 2026-08-20, the IDP Show
+                # combined board itself mislabels the Minnesota WR's
+                # row "LB" (its true position), which is exactly the
+                # signal a position-based split would have to trust.
+                # Vendor TEAM — the other candidate disambiguator — is
+                # not published by this CSV at all.
+                #
+                # So: no ``per_source`` entry is written for any of the
+                # colliding groups.  ``match_row_to_source_entry`` then
+                # finds no ``{cname}::{grp}`` key for ANY of the
+                # colliding canonical rows and returns no match — the
+                # source contributes NOTHING for this name (not a zero;
+                # the row's ``canonicalSiteValues`` simply carries no
+                # key for this source, the same "missing" state a row
+                # this source never covered would have).  Only the
+                # colliding names are affected; every other row from
+                # this CSV still joins and votes normally.
+                _withheld_ambiguous_names.setdefault(source_key, []).append(cname)
         csv_index[source_key] = per_source
 
         # Sleeper-ID join index (sources whose CSV carries a
@@ -4689,6 +4798,18 @@ def _enrich_from_source_csvs(
         "legacyCascadeRetired": True,
         "decisions": _join_decisions,
         "matched": _join_matched,
+        # Names withheld because they collide across DIFFERENT canonical
+        # players' position groups (issue #1011) — never attached to the
+        # wrong person, never a false zero.  Per-source so a golden-board
+        # diff can name exactly which players a source's vote is missing
+        # for and why.
+        "withheldForCrossGroupNameCollision": {
+            source_key: sorted(set(names))
+            for source_key, names in _withheld_ambiguous_names.items()
+        },
+        "withheldForCrossGroupNameCollisionCount": sum(
+            len(set(names)) for names in _withheld_ambiguous_names.values()
+        ),
     }
 
     return csv_index
@@ -8234,9 +8355,12 @@ def _compute_unified_rankings(
     # synthetic overall rank, with a caution flag on the per-source meta.
     #
     # WHICH sources that actually affects, measured rather than assumed:
-    # the ``needs_shared_market_translation`` ones — today ``dlfIdp``,
-    # ``idpShow`` and ``fantasyProsIdp``, which flip method ``exact`` →
-    # ``fallback`` on 159 / 235 / 177 rows of the live board.  The
+    # the ``needs_shared_market_translation`` ones — today ``dlfIdp`` and
+    # ``fantasyProsIdp`` (``idpShowCombined`` no longer crosswalks through
+    # this backbone as of 2026-08-20 — it is registered ``is_cross_market``
+    # and reads its own native combined rank instead; the 235-row figure in
+    # the dated table below predates that change and describes the retired
+    # ``idpShow`` key).  The
     # ``position_idp`` branch below is ALSO backbone-dependent and is
     # currently dead: no registered source carries that scope, and a
     # census of every ``sourceRankMeta`` stamp across the 973-row live

--- a/tests/api/test_idpshow_combined_source.py
+++ b/tests/api/test_idpshow_combined_source.py
@@ -1,0 +1,273 @@
+"""IDP Show provider family: the combined Top-700 board is the sole vote.
+
+Owner decision (2026-08-20): ``CSVs/site_raw/idpShowCombined.csv`` (the
+COMBINED offense+IDP board) is the only ranking source The IDP Show may
+contribute.  The older IDP-only board, ``CSVs/site_raw/idpShow.csv``, is
+retired from voting — it remains acquired (see ``scripts/fetch_idpshow.py``
+and ``deploy/idpshow_fetch_and_push.sh``) but unregistered, the same
+acquired-but-inert posture ``draftSharksRosSf.csv`` already has.
+
+This module pins four things:
+
+1. Exactly one ``idpShow*`` key is ever registered as a voting source
+   (never both boards at once — same-provider double counting).
+2. The registered shape routes the combined board's native combined-pool
+   rank through the GLOBAL Hill master via the ``is_cross_market`` /
+   ``csv_rank_cross_market_keys`` path, not a shared-market crosswalk
+   through another source's ladder.
+3. A name that collides across two DIFFERENT canonical players in
+   different position groups (issue #1011 — the Minnesota WR Justin
+   Jefferson vs the Cleveland LB Justin Jefferson) is WITHHELD from
+   voting for both, never attached to the wrong one and never a false
+   zero.
+4. A name that appears twice for the SAME canonical player (Travis
+   Hunter's legitimate two-way listing) is unaffected by (3) — the
+   source still votes, using its best entry.
+"""
+
+from __future__ import annotations
+
+import csv
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from src.api import data_contract as dc
+from src.api.data_contract import (
+    _RANKING_SOURCES,
+    _SOURCE_CSV_PATHS,
+    _compute_unified_rankings,
+    _enrich_from_source_csvs,
+)
+from src.canonical.rank_coordinates import RANK_POOL_SHARED_MARKET
+
+
+def _row(name: str, pos: str, *, idp=None, ktc=None) -> dict:
+    sites: dict = {}
+    if idp is not None:
+        sites["idpTradeCalc"] = idp
+    if ktc is not None:
+        sites["ktc"] = ktc
+    return {
+        "canonicalName": name,
+        "displayName": name,
+        "legacyRef": name,
+        "position": pos,
+        "assetClass": "offense" if pos in {"QB", "RB", "WR", "TE"} else "idp",
+        "values": {"overall": 0, "rawComposite": 0, "finalAdjusted": 0, "displayValue": None},
+        "canonicalSiteValues": sites,
+        "sourceCount": 1,
+    }
+
+
+def _run_with_idpshow_combined_csv(players: list[dict], rows: list[tuple[str, str, int]]) -> None:
+    """Enrich ``players`` from a synthetic idpShowCombined.csv.
+
+    ``rows`` is a list of (name, position, rank) tuples matching the
+    real vendor CSV shape (``name,position,rank``).
+    """
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "idpShowCombined.csv"
+        with p.open("w", encoding="utf-8", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(("name", "position", "rank"))
+            for name, pos, rank in rows:
+                w.writerow([name, pos, rank])
+        patched = dict(_SOURCE_CSV_PATHS)
+        patched["idpShowCombined"] = {"path": str(p), "signal": "rank"}
+        with mock.patch.object(dc, "_SOURCE_CSV_PATHS", patched):
+            _enrich_from_source_csvs(players)
+
+
+class TestExactlyOneVotingIdpShowKey(unittest.TestCase):
+    """Structural guard: never register both IDP Show boards at once.
+
+    This is the guard Task 2/4 of the owner decision asks for — it reads
+    the actual production registry objects, not a hand-maintained mirror,
+    so a future PR that re-adds ``idpShow`` (or any other ``idpShow*``
+    key) alongside ``idpShowCombined`` fails this test immediately.
+    """
+
+    def test_ranking_sources_has_exactly_one_idpshow_key(self) -> None:
+        matches = [
+            str(s.get("key") or "")
+            for s in _RANKING_SOURCES
+            if str(s.get("key") or "").lower().startswith("idpshow")
+        ]
+        self.assertEqual(
+            matches,
+            ["idpShowCombined"],
+            "exactly one idpShow* key may vote — found: " f"{matches!r}",
+        )
+
+    def test_source_csv_paths_has_exactly_one_idpshow_voting_key(self) -> None:
+        matches = [k for k in _SOURCE_CSV_PATHS if k.lower().startswith("idpshow")]
+        self.assertEqual(
+            matches,
+            ["idpShowCombined"],
+            "exactly one idpShow* key may be a registered (voting) CSV source — "
+            f"found: {matches!r}",
+        )
+
+    def test_old_idp_only_board_is_not_a_registered_source(self) -> None:
+        self.assertNotIn("idpShow", _SOURCE_CSV_PATHS)
+        keys = {str(s.get("key") or "") for s in _RANKING_SOURCES}
+        self.assertNotIn("idpShow", keys)
+
+
+class TestIdpShowCombinedRegistryShape(unittest.TestCase):
+    def _entry(self) -> dict:
+        return next(s for s in _RANKING_SOURCES if s.get("key") == "idpShowCombined")
+
+    def test_is_cross_market_not_shared_market_translated(self) -> None:
+        entry = self._entry()
+        self.assertTrue(entry.get("is_cross_market"))
+        self.assertFalse(entry.get("needs_shared_market_translation"))
+
+    def test_scope_spans_both_pools(self) -> None:
+        entry = self._entry()
+        self.assertEqual(entry.get("scope"), dc.SOURCE_SCOPE_OVERALL_IDP)
+        self.assertIn(dc.SOURCE_SCOPE_OVERALL_OFFENSE, entry.get("extra_scopes") or [])
+
+    def test_declares_provider_family_for_the_dedup_guard(self) -> None:
+        self.assertEqual(self._entry().get("correlation_group"), "idpShow")
+
+    def test_is_not_declared_a_shared_market_bridge(self) -> None:
+        # Task 6: this source's own vote is cross-market, but it must not
+        # become a declared bridge that seeds OTHER specialists' ladders —
+        # that is a different, CARDINAL-shaped commitment this evidence
+        # (ordinal) does not support.
+        from src.bridges.registry import load_bridge_descriptors
+
+        families = {d.family for d in load_bridge_descriptors()}
+        self.assertNotIn("idpShow", families)
+        self.assertNotIn("idpShowCombined", families)
+
+
+class TestIdpShowCombinedEndToEnd(unittest.TestCase):
+    """Exercises the real ``_compute_unified_rankings`` pipeline."""
+
+    def _anchor_offense_and_idp(self) -> list[dict]:
+        # A small combined offense+IDP anchor population so the blend
+        # has something to compute percentiles against.
+        return [
+            _row("Offense One", "WR", idp=9900, ktc=9900),
+            _row("Offense Two", "RB", idp=9500, ktc=9500),
+            _row("Myles Garrett", "DL", idp=9000, ktc=None),
+        ]
+
+    def test_combined_rank_routes_through_global_cross_market_pool(self) -> None:
+        players = self._anchor_offense_and_idp()
+        players.append(_row("Aidan Hutchinson", "DL"))
+        _run_with_idpshow_combined_csv(
+            players,
+            [
+                ("Bijan Robinson", "RB", 1),
+                ("Josh Allen", "QB", 2),
+                ("Aidan Hutchinson", "DL", 3),
+            ],
+        )
+        _compute_unified_rankings(players, {})
+        hutch = next(r for r in players if r["canonicalName"] == "Aidan Hutchinson")
+        self.assertIn("idpShowCombined", hutch.get("canonicalSiteValues", {}))
+        meta = (hutch.get("sourceRankMeta") or {}).get("idpShowCombined") or {}
+        self.assertEqual(meta.get("rankCoordinatePool"), RANK_POOL_SHARED_MARKET)
+        self.assertEqual(meta.get("method"), "csv_combined_cross_market")
+
+    def test_does_not_need_a_shared_market_ladder_to_vote(self) -> None:
+        # No idpTradeCalc / draftSharks backbone at all — an
+        # idpShowCombined-only IDP row must still vote, because its own
+        # rank is already a combined-pool ordinal.
+        players = [
+            _row("Offense One", "WR", ktc=9900),
+            _row("Offense Two", "RB", ktc=9500),
+            _row("Aidan Hutchinson", "DL"),
+        ]
+        _run_with_idpshow_combined_csv(
+            players,
+            [
+                ("Bijan Robinson", "RB", 1),
+                ("Josh Allen", "QB", 2),
+                ("Aidan Hutchinson", "DL", 3),
+            ],
+        )
+        _compute_unified_rankings(players, {})
+        hutch = next(r for r in players if r["canonicalName"] == "Aidan Hutchinson")
+        self.assertIn("idpShowCombined", hutch.get("sourceRanks", {}))
+
+
+class TestCrossPositionNameCollisionWithheld(unittest.TestCase):
+    """Issue #1011: two real, different people sharing a name."""
+
+    def test_offense_and_idp_namesakes_are_both_withheld(self) -> None:
+        players = [
+            _row("Justin Jefferson", "WR"),  # the real Minnesota WR
+            _row("Justin Jefferson", "LB"),  # the real Cleveland LB
+        ]
+        _run_with_idpshow_combined_csv(
+            players,
+            [
+                # The vendor's own position label is untrustworthy here —
+                # both rows say "LB" even though rank 13 is really the WR
+                # (measured 2026-08-20) — so position-based disambiguation
+                # is not attempted; both entries are withheld.
+                ("Justin Jefferson", "LB", 13),
+                ("Justin Jefferson", "LB", 622),
+            ],
+        )
+        wr_row = players[0]
+        lb_row = players[1]
+        self.assertNotIn("idpShowCombined", wr_row.get("canonicalSiteValues", {}))
+        self.assertNotIn("idpShowCombined", lb_row.get("canonicalSiteValues", {}))
+        summary = dc._LAST_CONTRACT_JOIN_SUMMARY or {}
+        withheld = summary.get("withheldForCrossGroupNameCollision") or {}
+        self.assertIn("justin jefferson", withheld.get("idpShowCombined", []))
+
+    def test_same_name_different_team_offense_idp_collision(self) -> None:
+        # Byron Murphy: a DL (Seattle) and a CB (Minnesota) — two real
+        # people, both IDP-adjacent-but-different groups is not this
+        # shape, so use the DL/WR shape which is the one the join logic
+        # actually distinguishes on (position GROUP, not full position).
+        players = [
+            _row("Byron Murphy", "DL"),
+            _row("Byron Murphy", "WR"),
+        ]
+        _run_with_idpshow_combined_csv(
+            players,
+            [
+                ("Byron Murphy", "DL", 237),
+                ("Byron Murphy", "DL", 588),
+            ],
+        )
+        for row in players:
+            self.assertNotIn("idpShowCombined", row.get("canonicalSiteValues", {}))
+
+
+class TestSingleCanonicalPlayerDuplicateStillVotes(unittest.TestCase):
+    """Travis Hunter: one real person, listed twice by the vendor.
+
+    Must NOT be destroyed by the cross-group withholding above — there
+    is only one canonical position group here, so this never enters the
+    ambiguous-groups branch.
+    """
+
+    def test_two_way_player_still_gets_a_vote(self) -> None:
+        players = [_row("Travis Hunter", "DB")]
+        _run_with_idpshow_combined_csv(
+            players,
+            [
+                ("Travis Hunter", "DB", 109),
+                ("Travis Hunter", "DB", 214),
+            ],
+        )
+        sites = players[0]["canonicalSiteValues"]
+        self.assertIn("idpShowCombined", sites)
+        self.assertGreater(sites["idpShowCombined"], 0)
+        summary = dc._LAST_CONTRACT_JOIN_SUMMARY or {}
+        withheld = summary.get("withheldForCrossGroupNameCollision") or {}
+        self.assertNotIn("travis hunter", withheld.get("idpShowCombined", []))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/api/test_source_floor_invariant.py
+++ b/tests/api/test_source_floor_invariant.py
@@ -114,6 +114,7 @@ _SCRAPER_FLOOR_RESOLVERS = {
     "dynastyDaddySf": lambda: _module_int_const("fetch_dynasty_daddy.py", "_DD_ROW_COUNT_FLOOR"),
     "flockFantasySf": lambda: _module_int_const("fetch_flock_fantasy.py", "_FF_ROW_COUNT_FLOOR"),
     "idpShow": lambda: _module_int_const("fetch_idpshow.py", "_IDPSHOW_ROW_FLOOR"),
+    "idpShowCombined": lambda: _module_int_const("fetch_idpshow.py", "_IDPSHOW_COMBINED_ROW_FLOOR"),
     "dlfSf": lambda: _dlf_board_min_rows("dlfSf"),
     "dlfIdp": lambda: _dlf_board_min_rows("dlfIdp"),
     # No aligned internal floor today (legacy Dynasty Scraper.py

--- a/tests/api/test_source_overrides.py
+++ b/tests/api/test_source_overrides.py
@@ -683,7 +683,17 @@ class TestBuildRankingsDeltaPayload(unittest.TestCase):
         # (+6.3%), which is what the user pays.  ``confidenceMetrics``
         # was deliberately left OFF the payload to hold it there; the
         # reasons already carry its numbers in readable form.
-        self.assertLess(delta_bytes, 60_000)
+        #
+        # Bumped 60KB → 65KB 2026-08-20: The IDP Show's combined board
+        # replaced the retired IDP-only board as the provider family's
+        # sole voting source (docs: idpShowCombined registry entry).
+        # Registered ``is_cross_market``, it legitimately votes on this
+        # fixture's OFFENSE rows too — something the retired IDP-only
+        # ``idpShow`` never did — so more rows carry its
+        # sourceRanks/sourceRankMeta/confidence stamps than before.
+        # Measured 60,717 bytes on this fixture; the ratio assertion
+        # below is unaffected (0.355, well under 0.60).
+        self.assertLess(delta_bytes, 65_000)
         self.assertLess(delta_bytes / full_bytes, 0.60)
 
     def test_delta_carries_all_override_sensitive_fields(self) -> None:

--- a/tests/api/test_trust_confidence.py
+++ b/tests/api/test_trust_confidence.py
@@ -538,7 +538,7 @@ class TestPayloadLevelBlocks(unittest.TestCase):
                 "ktcSfTep",
                 "idpTradeCalc",
                 "dlfIdp",
-                "idpShow",
+                "idpShowCombined",
                 "dlfSf",
                 "dynastyNerdsSfTep",
                 "fantasyCalc",

--- a/tests/api/test_two_way_player_boost.py
+++ b/tests/api/test_two_way_player_boost.py
@@ -105,7 +105,7 @@ def _build_board() -> list[dict[str, Any]]:
                 f"Defender {i:02d}",
                 "LB",
                 idpTradeCalc=6400 - i * 150,
-                idpShow=_synthetic_rank(i),
+                idpShowCombined=_synthetic_rank(i),
             )
         )
     # Offense carries the top of the board — including the top
@@ -125,7 +125,7 @@ def _build_board() -> list[dict[str, Any]]:
             "Two Way Player",
             "WR",
             ktcSfTep=3000,
-            idpShow=_synthetic_rank(5),
+            idpShowCombined=_synthetic_rank(5),
             idpTradeCalc=5200,
         )
     )


### PR DESCRIPTION
Closes the open methodology question from the #1008 follow-up thread and issue #1011.
Owner decision, verbatim: **`CSVs/site_raw/idpShowCombined.csv` (the combined offense+IDP
board) is the provider family's SOLE voting source. The IDP-only board (`idpShow.csv`) is
retired from voting — never both at once.**

## What changed

1. **Registry** (`src/api/data_contract.py`): `idpShowCombined` replaces `idpShow` in
   `_SOURCE_CSV_PATHS` and `_RANKING_SOURCES`. Registered `is_cross_market=True`,
   `scope=overall_idp` + `extra_scopes=[overall_offense]`, `needs_shared_market_translation=False`
   — the same pattern IDPTradeCalc/DraftSharks use for a source whose own rank already spans
   both pools. This routes through the *existing, dormant* Phase 1c `csv_rank_cross_market_keys`
   pre-pass (its own comment says "any future rank-signal cross-market source") instead of a new
   translation mechanism. `correlation_group="idpShow"` keeps the two boards one provider
   family.
2. **Old board retired, not deleted.** `idpShow.csv` is unregistered — the same
   acquired-but-inert posture `draftSharksRosSf.csv` already has. `_enrich_from_source_csvs`
   only reads registered keys, so this is structural, not a policy flag.
3. **Structural guard** (`tests/api/test_idpshow_combined_source.py::TestExactlyOneVotingIdpShowKey`):
   scans `_RANKING_SOURCES`/`_SOURCE_CSV_PATHS` directly for `idpShow*` keys. Exactly one,
   always.
4. **Identity fix (issue #1011).** `_enrich_from_source_csvs` had a real, pre-existing chimera:
   when a CSV name collides with TWO DIFFERENT canonical players in different position groups
   (Minnesota's WR Justin Jefferson vs. Cleveland's LB Justin Jefferson), it replicated the
   single best-valued CSV entry across BOTH canonical rows — misattributing one real person's
   evidence to a different real person. Fixed: on a cross-group collision, WITHHOLD the vote
   from all colliding rows (no entry, not a zero) rather than guess. Verified NOT to destroy
   Travis Hunter's legitimate two-way listing (single canonical group, unaffected branch).
   Withheld names are now stamped on `identityJoin.withheldForCrossGroupNameCollision` for
   auditability.
5. **Bridge posture unchanged.** `idpShowCombined` is NOT declared in
   `config/bridges/bridges_v1.json` — it seeds no other specialist's ladder. `dlfIdp` /
   `fantasyProsIdp` keep crosswalking through idpTradeCalc + draftSharks exactly as before.
   Evidence stays ORDINAL throughout (no fabricated 0-9999 vendor value).
6. **Acquisition kept fresh.** `deploy/idpshow_fetch_and_push.sh` now runs
   `fetch_idpshow.py` (plain) AND `fetch_idpshow.py --combined`, staging both CSVs + stamps.
   Previously only the (now-retired) plain board was refreshed on prod — the voting board
   would have gone stale forever. Added `_IDPSHOW_COMBINED_ROW_FLOOR` (450) guarding the
   `--combined` fetch the same way the plain fetch is guarded, closing the gap that let
   #1008's 250-row-excerpt defect happen a second time undetected.
7. **Row floor, not "700".** Contract floor 450 is a measured, conservative bound (665 raw
   rows / 662 distinct names; 653/662 = 98.6% match against a ktc.csv ∪ idpTradeCalc.csv
   proxy universe — explicitly NOT the true Sleeper canonicalization rate, which this proxy
   overstates). No literal "700" anywhere in the guard.

## Proof: exactly one vote, never zero for the retired board

Live mutation run against `_RANKING_SOURCES` (register a second `idpShow` key alongside
`idpShowCombined`):
```
FAIL: test_old_idp_only_board_is_not_a_registered_source
FAIL: test_ranking_sources_has_exactly_one_idpshow_key
```
Mutation A (both boards registered) is RED, confirmed live. Mutation C (idpShowCombined CSV
missing) confirmed: contributes nothing, no silent fallback to the retired board.

## Golden-board diff (truthful, not minimized — pinned CSV + code-only comparison)

Same committed pinned input (`tests/fixtures/golden/input_export.json.gz`), same on-disk
`CSVs/site_raw/*` (unchanged by this PR — `idpShowCombined.csv` was already on `main` via
#1008), code before vs. after this PR only.

```
rows: 1111 -> 1111   ranked: 740 -> 740   priced: 849 -> 849   picks: 162   idp: 398
VALUES: 715 moved, 19 newly priced, 19 newly unpriced
  |pct change|  p50=1.8%  p90=11.0%  max=29.0%
RANKS: 709 changed
SOURCE COVERAGE: 670 rows vote differently
idpShow (old) voted on 294/1111 rows (IDP only, by scope)
idpShowCombined (new) votes on 635/1111 rows (IDP AND offense, by scope)
```

Position-family value movement (mean / median / max|Δ|):
```
WR   n=154  +0.40% / +0.36% / -9.1%
PICK n=144  +0.71% /  0.00% / +8.2%
DL   n=115  +4.51% / +4.60% / -29.0%
RB   n=102  +1.14% / +1.11% / +5.7%
DB   n= 93  +7.92% / +8.40% / +24.9%
LB   n= 85  +7.13% / +7.04% / -27.7%
TE   n= 81  +1.07% / +0.91% / +4.6%
QB   n= 56  +0.76% / +0.74% / +4.1%
```

Top-of-board composition (nearly untouched — the change is concentrated deep in the IDP pool):
```
top-25:  0 in / 0 out
top-50:  1 in / 1 out;   IDP count 3 -> 2
top-100: 3 in / 3 out;   IDP count 9 -> 7
top-200: 4 in / 4 out;   IDP count 45 -> 47
```

Biggest risers (all IDP, ranks 280-680 — deeper board, more/better source coverage):
Christian Harris 620→479, Bobby Wagner 642→504, Keionte Scott 584→456, Jalon Walker
397→283, Ivan Pace 669→558.

Biggest fallers: Jamien Sherwood 131→232, Kool-Aid McKinstry 332→426, Jared Verse 55→113,
Cody Simon 280→337, Brock Wright 544→601.

**Why the direction makes sense.** The old `idpShow` vote only ever counted for IDP-scoped
rows (294 of 1111), and most of those rows fell back to a single real vote (idpTradeCalc)
after `idpShow`'s crosswalk-through-idpTradeCalc's-ladder frequently missed — meaning the
30% single-source haircut applied. `idpShowCombined` gives those same rows a REAL second
vote (no fallback needed — its own rank is native combined-pool), lifting them off the
haircut, and it also legitimately votes on offense rows for the first time (small, ~+0.4–1.1%
moves) since it's registered cross-market. IDP players move up on average; offense moves only
slightly.

**Identity-withheld rows on this run:** 0. This pinned fixture's canonical player population
does not happen to contain the specific Minnesota-WR / Cleveland-LB Justin Jefferson name
collision described in issue #1011 (it's an older/smaller snapshot than the live board). The
mechanism is verified directly: `TestCrossPositionNameCollisionWithheld` constructs that exact
collision and confirms neither canonical row receives a vote, and issue #1011's own quoted
excerpt from the LIVE production contract (`sleeperId=6794`, `_canonicalSiteValues.idpShow=967100`,
`sourceRanks.idpShow=None`) is the real-world defect this closes.

## Test status

- `tests/api/test_idpshow_combined_source.py` (new): 12/12 pass — registry shape, structural
  one-key guard, identity withholding (Jefferson/Murphy shape), Travis Hunter regression,
  end-to-end GLOBAL-pool routing.
- Updated for the new key: `test_two_way_player_boost.py` (fixture used the retired key;
  swapped to `idpShowCombined`, all 5 pass — confirmed this is a fixture update, not a pipeline
  defect: `sourcesConsidered` in the two-way boost was `['idpTradeCalc']` either way, and the
  fixture change restores realistic 2-source IDP coverage rather than the false single-source
  state the stale key produced), `test_trust_confidence.py`, `test_source_registry_parity.py`
  (frontend mirror), `test_source_floor_invariant.py` (new `--combined` floor resolver),
  `frontend/lib/display-helpers.js` + its two tests (`IDP_CONSENSUS_KEYS` mirror,
  registry-parity-tested).
- Targeted regression batch across every file touching this pipeline (freshness, blend
  integrity, confidence, source floors, two-way boost, curve routing, source health, registry
  parity, name-join hygiene, DraftSharks, identity validation, fair-value, tail policy, source
  correlation, fetcher argv contract, BDVM baseline/projections): 363/363 pass.
- Frontend: `npx vitest run` — 147 files / 2282 tests, all green.
- `ruff check .` / `ruff format --check` on every changed file: clean.
- `scripts/check_decision_coercions.py`: clean, no new coercions.
- Full `python -m pytest tests/ -q -m "not livedata"` (10,118 tests) was launched before this
  push; the targeted subset above already covers every module this change touches, and I'll
  report/fix anything the full run surfaces beyond that subset.

## Known, deliberately out of scope

- `scripts/simulate_idp_bridge_policies.py` (a standalone, untested audit script) still lists
  `idpShow` in its `IDP_ONLY_SOURCES` tuple. It has no test coverage and isn't part of the live
  pipeline; left untouched to keep this the smallest coherent PR.
- `config/bridges/bridges_v1.json` untouched — deliberate, see point 5 above.

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_