### PR TITLE
V1-94: teamAssignment availability contract, proven through the real pipeline

### DIFF
--- a/tests/public_league/test_public_contract.py
+++ b/tests/public_league/test_public_contract.py
@@ -95,6 +95,38 @@ class PublicContractSafetyTests(unittest.TestCase):
             payload = build_section_payload(self.snapshot, key)
             assert_public_payload_safe(payload)
 
+    def test_team_assignment_healthy_snapshot_reports_available(self) -> None:
+        """V1-94 / #815, healthy half, through the REAL assembly pipeline
+        (not a hand-built ``PublicLeagueSnapshot`` — this one comes from
+        ``build_public_snapshot`` over stubbed Sleeper responses, same as
+        every other section this class checks)."""
+        payload = build_section_payload(self.snapshot, "teamAssignment")
+        data = payload["data"]
+        self.assertTrue(data["available"])
+        self.assertIsNone(data["unavailableReason"])
+        self.assertGreater(len(data["assignments"]), 0)
+
+    def test_team_assignment_degraded_snapshot_reports_unavailable_not_empty(
+        self,
+    ) -> None:
+        """V1-94 / #815, degraded half, through the SAME real pipeline.
+
+        An unknown league id makes ``fetch_league`` return ``None``, which
+        ``build_public_snapshot`` turns into zero seasons — a real
+        degraded-fetch shape, not a hand-constructed one. Before #815 this
+        rendered as a bare ``assignments: []`` indistinguishable from a
+        healthy empty league; it must now say why, and the safety walk
+        must still accept the shape.
+        """
+        degraded_snapshot = build_public_snapshot("L_UNKNOWN_LEAGUE_ID", max_seasons=2)
+        self.assertIsNone(degraded_snapshot.current_season)
+        payload = build_section_payload(degraded_snapshot, "teamAssignment")
+        assert_public_payload_safe(payload)
+        data = payload["data"]
+        self.assertFalse(data["available"])
+        self.assertEqual(data["unavailableReason"], "no_current_season")
+        self.assertEqual(data["assignments"], [])
+
     def test_private_field_guard_rejects_leaks(self) -> None:
         # Direct invariant test — if someone adds a private field to
         # the header, the guard MUST trip.


### PR DESCRIPTION
## Summary

Deep audit of V1-94 (`teamAssignment` degraded/missing must not be served as `assignments: []`, #815) per the V1 70% sprint's "convert cheapest legitimate rows" mandate. **Determined current-main truth directly, not the old #914 description.**

**The repair genuinely exists and is correct.** `src/api/team_assignment.py` already models three distinct failure states (`no_current_season`, `no_rosters`, `player_directory_unavailable` as a partial-degradation flag, not a total one). `frontend/app/league/sections/team-assignment.jsx` already branches on `available`/`unavailableReason`, including an honest third state (`available === undefined`) for an old payload from a pre-repair server — never silently rendering nothing or fabricating a diagnosis. No path in the aggregate assembly (`build_public_contract`/`build_section_payload`) or the HTTP route (`server.py::get_public_league`) converts a degraded snapshot into a fabricated 200 — the assembly loop has no swallowing `try/except` before the safety assert, and a genuine exception becomes a 503, never a silent empty success.

Re-ran the row's own decisive mutation (reintroduce `return {"assignments": []}` on a missing snapshot) against the existing unit suite (`tests/api/test_team_assignment_availability.py`): confirmed **RED** (2 failures naming the exact defect), restored **GREEN** (37/37). The #815 regression test still catches the defect it was written for.

`tests/e2e/specs/public-league.spec.js:577` (`prod-e2e-smoke.yml`, not the PR gate) is genuinely non-vacuous — read in full: it asserts strict properties on both branches (`available:false` → reason must be one of two named constants, empty assignments, `rosterScoringAvailable: false`; `available:true` → exact ownerId-set match against the league header, favorite-first ordering, non-favorite scores must clear the threshold). Not a smoke test that can pass trivially.

## What was actually missing

Every existing unit test constructs its `PublicLeagueSnapshot` **by hand**. Nothing exercised the degraded path through the **real** assembly pipeline (`build_public_snapshot` → `build_section_payload` → `assert_public_payload_safe`) the way `test_every_section_is_safe_on_its_own` already does for the healthy path — that test iterates every section including `teamAssignment`, but only against the one healthy stub fixture.

Added two tests to `tests/public_league/test_public_contract.py`:
- `test_team_assignment_healthy_snapshot_reports_available` — confirms the existing healthy-path evidence explicitly (`available: True`, 4 real assignments from the stub fixture).
- `test_team_assignment_degraded_snapshot_reports_unavailable_not_empty` — an **unknown league id** makes `sleeper_client.fetch_league` return `None`, which `build_public_snapshot` itself turns into zero seasons: a real degraded-fetch shape produced by the real code, not a hand-constructed dataclass. Confirms `available: False`, `unavailableReason: "no_current_season"`, `assignments: []`, and that the shape survives `assert_public_payload_safe`.

Re-ran the same mutation against this file: confirmed **RED** at the integration level too (`KeyError: 'available'`), restored **GREEN**.

**No implementation change.** This closes a verification gap (no test exercised the degraded path end-to-end through real code), not a defect — the defect was already fixed.

## Test plan

- [x] `pytest tests/public_league/ -q -m "not livedata"` — 415 passed, 50 subtests
- [x] `pytest tests/api/test_team_assignment_availability.py tests/api/test_team_assignment.py` — 37/37 (re-confirmed unchanged)
- [x] Mutation re-proof at both the unit level and this PR's new integration level: RED confirmed naming the exact defect, GREEN restored, `git diff` empty on `src/api/team_assignment.py` afterward
- [x] `ruff format --check` / `ruff check` — clean
- [x] `scripts/check_decision_coercions.py` — clean, no new coercions

## Handoff

**FEATURE_GREEN / READY_FOR_INTEGRATION.** Recommend this row can move to `VERIFIED` at **L2** — L1 (mutation-tested, both unit and integration level) plus a measured statement of the contract's exact behavior in both branches, through the real pipeline. Full V1 70% sprint findings (V1-32, PR #1002 conflict map, this row, and the easy-win census) are being reported together to Claude 5 in this session; this PR is one committed slice of that report, self-contained and independently mergeable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyqbZejxh7ytbfijL5pmdE)_