### PR TITLE
fix(ci): health-check.yml's gh issue calls fail with no git checkout

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -280,6 +280,18 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This job has no `actions/checkout` step (deliberately —
+          # it's a lightweight external HTTP ping), so `gh` cannot
+          # infer the repo from a `.git` directory the way the
+          # checked-out workflows do. Without this, every `gh issue`
+          # call below fails with "not a git repository" — silently
+          # turning both halves of F-21's own repair (file the alert,
+          # clear it later) into a false negative that reads as
+          # "checked and fine" instead of "did not run".  Measured:
+          # 9 consecutive scheduled runs failed on exactly this while
+          # production itself stayed healthy (2026-08-19 through
+          # 2026-08-21).
+          GH_REPO: ${{ github.repository }}
         run: |
           set -Eeuo pipefail
           RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
@@ -347,6 +359,9 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # See the matching comment on "Open or update the tracking
+          # issue on failure" — same missing-checkout cause.
+          GH_REPO: ${{ github.repository }}
         run: |
           set -Eeuo pipefail
           # Same identification as the alert step, and it must stay identical —

--- a/tests/deploy/test_production_checks_do_not_skip_green.py
+++ b/tests/deploy/test_production_checks_do_not_skip_green.py
@@ -121,3 +121,42 @@ def test_every_consumer_refuses_loudly_when_the_production_url_is_empty():
         "Running against an empty origin asserts nothing just as surely as skipping "
         "does; annotate with `::error` and `exit 1`:\n  " + "\n  ".join(missing)
     )
+
+
+def test_gh_issue_steps_declare_gh_repo():
+    """``health-check.yml`` has no ``actions/checkout``, so ``gh`` cannot infer
+    the repo from a ``.git`` directory the way the checked-out workflows do.
+
+    Measured 2026-08-21: every one of 9 consecutive scheduled runs
+    (2026-08-19 through 2026-08-21) failed with ``fatal: not a git
+    repository`` on the ``gh issue list`` calls in "Open or update the
+    tracking issue on failure" and "Close the tracking issue on a green
+    run" — silently turning both halves of F-21's own repair (file the
+    alert, clear it later) into a false negative, while production
+    itself stayed healthy throughout. The health/status/coverage/backup
+    assertions were never the problem; the issue-tracking plumbing was.
+
+    ``GH_REPO`` is the documented fix for exactly this shape (a ``gh``
+    call with no git checkout to infer from), and it covers every ``gh
+    issue`` subcommand in the step uniformly rather than needing a
+    ``--repo`` flag on each call.
+    """
+    path = WORKFLOWS / "health-check.yml"
+    document = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    offenders: list[str] = []
+    for job_name, job in (document.get("jobs") or {}).items():
+        if not isinstance(job, dict):
+            continue
+        for step in job.get("steps") or []:
+            if not isinstance(step, dict) or not isinstance(step.get("run"), str):
+                continue
+            if "gh issue" not in step["run"]:
+                continue
+            env = step.get("env") or {}
+            if "GH_REPO" not in env:
+                offenders.append(f"{job_name} :: {step.get('name', '<unnamed>')}")
+    assert not offenders, (
+        "a step calls `gh issue` with no `GH_REPO` set and no checkout to infer the "
+        "repo from -- every call will fail with 'not a git repository':\n  "
+        + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
## What
`.github/workflows/health-check.yml`'s issue-tracking steps ("Open or update the tracking issue on failure", "Close the tracking issue on a green run") call `gh issue list`/`create`/`comment`/`close` with no `actions/checkout` step in the job (deliberate — it's a lightweight external HTTP ping). Without a git checkout, `gh` cannot infer the target repo and every call fails with `fatal: not a git repository`.

## Measured impact
9 consecutive scheduled runs (2026-08-19 through 2026-08-21) failed on exactly this, while production itself stayed genuinely healthy the whole time (scrape success rate 1.0, 21/21 sources covered, backups fresh). This silently disabled both halves of F-21's own repair — filing an alert when production degrades, and clearing it later — the same "a check that cannot report the condition it exists for" class this repo's audit culture targets elsewhere, now living inside the repair itself.

## Fix
Added `GH_REPO: ${{ github.repository }}` to both steps' `env` blocks — the documented `gh` CLI mechanism for exactly this (no checkout to infer from), covering every `gh issue` subcommand in the step uniformly.

## Verification
New structural test `test_gh_issue_steps_declare_gh_repo` in `tests/deploy/test_production_checks_do_not_skip_green.py` (same file already carrying F-21's other CI-reliability guards). Mutation-proven: stripped both `GH_REPO` lines → RED, naming both offending steps; restored → GREEN. Full `tests/deploy/` suite: 372 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_