### PR TITLE
V1-35: close the model/UI evidence gap the audit doc still claimed open

### DIFF
--- a/docs/roster-intelligence/V1_35_METRIC_SEPARATION_AUDIT.md
+++ b/docs/roster-intelligence/V1_35_METRIC_SEPARATION_AUDIT.md
@@ -3,6 +3,18 @@
 **Row:** `V1-35` · **Lane:** L1 Roster Intelligence · **Required evidence
 level:** EVIDENCE-L1 · **Status entering this audit:** `NOT STARTED`
 
+**Re-verified 2026-08-22, current `main` `faafefb71`.** Both live
+violations this audit originally found (F-1, F-3) are now retired in
+production — `frontend/lib/league-analysis.js`'s `scoreTeamTiers` is
+deleted (see `docs/rosters/ROSTERS_TEAM_STRENGTH_MIGRATION.md`) and
+`frontend/lib/team-phase.js` reads canonical `strengthTotal` /
+`valueWeightedCoreAge`. Confirmed by reading the actual files, not by
+trusting this document — see §0 and §5's updates, and the new §7. This
+re-verification landed in a session where an earlier PR carrying the
+same H-1/H-2 changes (#1002) was independently closed without merging;
+the fix reached `main` some other way, so it was checked against the
+code rather than assumed from that PR's history.
+
 **Binding source** — `docs/OWNER_REQUESTED_TODO.md` decision 69, verbatim:
 
 > **Total Asset Value, Meaningful Roster Strength, Exact Starting Lineup,
@@ -20,40 +32,41 @@ are recorded as such precisely so nobody "fixes" them.
 
 ---
 
-## 0. The headline finding
+## 0. The headline finding — SUPERSEDED, see §7
 
 > **Six live production answers to "how good is this team" exist on six
 > different units — and the module documented as "THE canonical Team
 > Strength owner" is the one nobody renders.**
 
-`src/roster_intel/strength.py` opens with "the canonical Team Strength
-owner". `grep -rn "roster/intelligence" frontend/` returns **zero
-hits**: no page, hook or bridge route fetches it. Meanwhile
-`frontend/lib/nav-model.js:147` labels **`/rosters`** as "Team Strength",
-and `/rosters` renders a client-side composite with no server
-equivalent.
+This was true when first measured: `grep -rn "roster/intelligence"
+frontend/` returned zero hits, and `/rosters` rendered a client-side
+composite with no server equivalent. **It is no longer true.**
+Re-measured 2026-08-22: `grep -rn "roster/intelligence" frontend/ |
+grep -v __tests__` returns 12 hits including
+`components/TeamStrengthCard.jsx` ("Renders `GET
+/api/roster/intelligence`. It computes nothing…") and
+`app/rosters/page.jsx`. §7 has the current census row.
 
-This is the V1 contract's own false-green test failing —
-*"is the intended production consumer actually using the canonical
-implementation, with truthful data semantics?"* — and it is why V1-31
-cannot claim EVIDENCE-L4 no matter how correct the owner is.
-
-**The repair is a frontend change on `/rosters`, which is Claude 6's
-lane.** It is handed over in §3, not made here.
+This finding motivated §3's H-1 handoff, which Claude 6 has since
+closed — see `docs/rosters/ROSTERS_TEAM_STRENGTH_MIGRATION.md`. Kept
+here, struck rather than deleted, so a reader mid-investigation does not
+rediscover a defect that is already fixed.
 
 ---
 
 ## 1. Census
 
-Verified file-by-file at `fd70515`. "Rendered?" means a frontend
-fetch/render path exists, not merely that the route responds.
+Verified file-by-file at `fd70515`; rows 3-4's "rendered?" column
+re-verified 2026-08-22 against current `main` (see §7). "Rendered?"
+means a frontend fetch/render path exists, not merely that the route
+responds.
 
 | # | concept | canonical owner | quantity · unit | production path | rendered? | classification |
 |---|---|---|---|---|---|---|
 | 1 | Canonical asset value | `src/api/data_contract.py::_compute_unified_rankings` → `rankDerivedValue` | dynasty market value · **1–9999** | `/api/data` and every engine | yes | **canonical** |
 | 2 | Exact starting lineup | `src/ros/lineup.py::solve_optimal_assignment` | assignment + score · **unit-agnostic** (score is in whatever unit the pool carries) | contract stamp `sleeper.teams[].optimalLineup` | yes, via `starter-slots.js::fillLineup` | **canonical** |
-| 3 | Meaningful Roster Strength | `src/roster_intel/strength.py::build_team_strength` | Σ `rankDerivedValue` over the meaningful core · **1–9999 scale, uncapped in aggregate** | `src/api/roster_intelligence.py:259` → `GET /api/roster/intelligence` | **NO — zero frontend fetchers** | **canonical, UNCONSUMED** |
-| 4 | Team Weakness / need priority | `src/roster_intel/weakness.py::build_team_weakness` | rung status vs `k × teamCount` · **ordinal, not a score** | same endpoint, `:261` | **NO** | **canonical, UNCONSUMED** |
+| 3 | Meaningful Roster Strength | `src/roster_intel/strength.py::build_team_strength` | Σ `rankDerivedValue` over the meaningful core · **1–9999 scale, uncapped in aggregate** | `src/api/roster_intelligence.py:259` → `GET /api/roster/intelligence` | **YES (was NO)** — `components/TeamStrengthCard.jsx` on `/rosters`, `lib/team-phase.js` on `/phases` | **canonical, consumed** |
+| 4 | Team Weakness / need priority | `src/roster_intel/weakness.py::build_team_weakness` | rung status vs `k × teamCount` · **ordinal, not a score** | same endpoint, `:261` | **NO** — still no frontend fetcher for the `weakness` block specifically (V1-32's own row, not this one) | **canonical, UNCONSUMED** |
 | 5 | ROS team strength | `src/ros/team_strength.py::compute_team_strength` | `teamRosStrength` · **0–100 log-rank production index** | `data/ros/team_strength/<key>.json` → `/api/public/league/rosTeamStrength` | yes — "ROS Strength" tab | **legitimate different quantity** |
 | 6 | Power ranking | v2 `src/ros/power_v2.py` (live) · v1 `src/public_league/power.py` | v2 `power_score` **0–1 weighted percentile** · v1 `power` **0–100** | `public_contract.py` → one Power tab, switched by `useRosPowerRankings` | v2 yes, v1 dormant | **duplicate — cross-lane (V1-52)** |
 | 7 | Playoff probability | `src/ros/playoff_sim.py::simulate_playoff_odds` · `src/public_league/playoff_odds.py::compute_playoff_odds` | probability **0–1** | both registered in `public_contract.py` | yes | **duplicate — cross-lane (V1-51)** |
@@ -238,7 +251,7 @@ As H-3, for V1-51.
 ## 5. What this closes, and what it does not
 
 **Closed at EVIDENCE-L1** by `tests/roster_intel/test_metric_separation.py`
-(10 tests, all mutation-proven — see §6):
+(17 tests, all mutation-proven — see §6):
 
 * no collapsed generic team score anywhere in the canonical roster payload;
 * Meaningful Roster Strength and Total Asset Value separately named, with
@@ -250,13 +263,30 @@ As H-3, for V1-51.
   from roster value;
 * the dynasty-value lane structurally cannot import the ROS-production
   modules (`team_strength`, `aggregate`, `power_v2`, `playoff_sim`,
-  `championship`, `direction`).
+  `championship`, `direction`);
+* **as of §7's re-verification**, `/rosters` (`frontend/lib/league-analysis.js`,
+  `app/rosters/page.jsx`) and `/phases` (`frontend/lib/team-phase.js`,
+  `components/TeamPhasePanel.jsx`) carry no weighted-composite team
+  score, no client-side contender/rebuilder tier cut, and no raw-row
+  value/age derivation — read DIRECTLY from those files by this lane's
+  own suite, not inferred from `no-frontend-team-strength-methodology.test.js`
+  (a JS file this lane does not own, though it independently agrees —
+  confirmed by mutating both files at once and watching both suites
+  fail on the identical line);
+* at least two of decision 69's quantities (Team Strength rank, Young
+  Core Index rank) are shown to GENUINELY DIVERGE on the newest real
+  archived board, not merely asserted distinct on a toy fixture.
 
-**Not closed.** V1-35 says "in the model **and the UI**". This audit
-closes the model half inside this lane and hands the UI half to Claude 6
-as H-1/H-2. The row should read `IN PROGRESS` with the model half
-evidenced, not `VERIFIED` — a green suite here is necessary and not
-sufficient.
+**Previously reported "not closed."** This section used to say V1-35's
+UI half was handed to Claude 6 and unclosed, and that the row should
+read `IN PROGRESS` rather than `VERIFIED`. **That is stale** — Claude 6
+closed H-1/H-2 in the interim (see §0, §7), and this lane's own suite
+now independently confirms it rather than trusting the earlier claim.
+The model-and-UI split this section drew is gone: **both halves now
+have production evidence inside this repository's hard test gate.**
+Whether that clears V1-35's full bar (its own row still names "in the
+model and the UI") is Claude 5's call, per the standing rule that this
+lane does not edit `VERSION_1_COMPLETION_CONTRACT.md`.
 
 ---
 
@@ -273,5 +303,49 @@ sufficient.
 | the payload walk is not vacuous | asserted > 500 keys traversed on a real rebuilt contract | passes |
 | two playoff engines exist | read both signatures | `playoff_seeds: int = 6` vs `playoff_spots: int \| None` |
 
-Suite: `python -m pytest tests/roster_intel/test_metric_separation.py -q` →
-**10 passed**, hard gate (`-m "not livedata"`), no network.
+Suite (at this audit's original writing): `python -m pytest
+tests/roster_intel/test_metric_separation.py -q` → 10 passed, hard gate
+(`-m "not livedata"`), no network. **See §7 for the current count and
+the re-verification evidence.**
+
+---
+
+## 7. Re-verification and UI-half closure, 2026-08-22
+
+Performed on `main` `faafefb71`, independently of this document's own
+prior claims — every row below was checked against the live file or a
+live run, not copied forward.
+
+| claim | how it was checked | result |
+|---|---|---|
+| `/rosters` fetches `GET /api/roster/intelligence` | `grep -rn "roster/intelligence" frontend/ \| grep -v __tests__` | 12 hits incl. `components/TeamStrengthCard.jsx`, `app/rosters/page.jsx` — §0's "zero hits" is stale |
+| `scoreTeamTiers` deleted | `grep -n "scoreTeamTiers\|starterValue.*0.7" frontend/lib/league-analysis.js` | 0 executable hits; only the retirement comment and its own name |
+| `team-phase.js` reads canonical inputs | read `frontend/lib/team-phase.js:1-30` | `strengthTotal` / `valueWeightedCoreAge`, sourced from `teamStrengthLadder` |
+| this lane's suite reaches the two frontend files directly (not via the doc's word) | new tests §5, `tests/roster_intel/test_metric_separation.py::test_rosters_surface_has_no_weighted_composite_team_score` / `test_rosters_surface_has_no_tier_classification` / `test_phases_surface_reads_canonical_strength_not_raw_rows` | read `frontend/lib/league-analysis.js`, `app/rosters/page.jsx`, `frontend/lib/team-phase.js`, `components/TeamPhasePanel.jsx` from disk; pass |
+| the UI scan is not decoration (F-1 half) | reintroduced the exact retired `scoreTeamTiers` line into `frontend/lib/league-analysis.js` (a real, tracked production file), re-ran the suite | `test_rosters_surface_has_no_weighted_composite_team_score` and `test_rosters_surface_has_no_tier_classification` both RED, naming the exact file:line; reverted (`git checkout --`), suite green again |
+| the UI scan is not decoration (F-3 half) | reintroduced the retired `rawData?.sleeper?.teams` raw-row read into `frontend/lib/team-phase.js` | `test_phases_surface_reads_canonical_strength_not_raw_rows` RED, naming the file:line; reverted, suite green |
+| the two independent guards (this lane's Python scan, Claude 6's JS scan) agree | ran `npx vitest run __tests__/no-frontend-team-strength-methodology.test.js` against the SAME `league-analysis.js` mutation | both guards failed on the same reintroduced line, independently |
+| two of decision 69's quantities genuinely diverge, not just assert `!=` on a toy fixture | `test_metrics_genuinely_diverge_on_a_representative_real_board`, real 12-team archived board | Team Strength rank 1 (Brent) has Young Core Index rank 11 on the same board; 11 of 12 teams' ranks differ across the two axes |
+| V1-36 (Claude 2, shared package generator) does not touch any file this unit edits | `git diff $(git merge-base origin/claude/v1-36-shared-package-generator origin/main) origin/claude/v1-36-shared-package-generator --stat` | empty — that branch has no commits past its shared base yet; no overlap to report |
+
+Suite now: `python -m pytest tests/roster_intel/test_metric_separation.py -q`
+→ **17 passed** (10 original + 7 new), hard gate, no network.
+
+**What this closes.** Both F-1 and F-3 — the only two live decision-69
+violations this audit ever found — are confirmed retired in production,
+by this lane's own direct evidence rather than by trusting another
+lane's file or an earlier version of this document. Combined with §1-4's
+pre-existing model-half coverage, EVIDENCE-L1 for V1-35 ("in the model
+and the UI") now has a single hard-gated Python suite proving both
+halves from inside this lane, plus an independently-agreeing JS suite
+Claude 6 maintains.
+
+**What this does not do.** It does not promote the row —
+`docs/VERSION_1_COMPLETION_CONTRACT.md` is Claude 5's file. It does not
+touch F-4/F-5 (the V1-51/V1-52 power/playoff-odds duplicate engines),
+which remain a different lane's rows; a quick re-check found the F-5
+file paths (`LeagueClient.jsx`, `useSettings.js`) no longer contain the
+`useRosPowerRankings` string this audit originally cited, which may mean
+that stale comment was separately fixed or the setting was renamed —
+worth a fresh look by whoever owns V1-51/V1-52, not re-investigated here
+since it is outside V1-35's own scope either way.

--- a/tests/roster_intel/test_metric_separation.py
+++ b/tests/roster_intel/test_metric_separation.py
@@ -14,16 +14,21 @@ records the census and the cross-lane findings; this file pins the half
 that lives inside the Roster lane and can be enforced in CI.
 
 **Scope, stated so a green run is not over-read.**  This suite proves
-separation *where this lane owns the code*.  It cannot prove it on
-`/rosters`, `/phases` or the `src/ros/` and `src/public_league/`
-surfaces — those are other lanes' files, and the audit hands their
-findings to integration rather than editing them.  A green result here
-is necessary for V1-35 and not sufficient for it.
+separation *where this lane owns the code* (sections 1-4), plus a direct
+read of the two frontend files the audit's F-1/F-3 findings named
+(section 5) — not because this lane owns those files, but because a
+census claim that another lane's file stays retired is worth this
+lane's OWN evidence rather than a trusted document, per the repo's
+"do not assume features work" rule.  It still cannot prove separation on
+`src/ros/` and `src/public_league/` — those are a different lane's
+production code and a different V1 row (V1-51/V1-52); the audit records
+that boundary rather than crossing it.
 """
 
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
 from typing import Any, Iterator, Mapping
 
@@ -332,3 +337,194 @@ def test_the_collapsed_score_detector_would_catch_one():
         f"{path}.{key}" for path, key, _ in _walk(payload) if key in COLLAPSED_SCORE_FIELDS
     ]
     assert offenders == [".teams.o1.strength.teamScore"]
+
+
+# ---------------------------------------------------------------------------
+# 5. The UI half, read directly — not trusted from a document.
+#
+# The audit (``V1_35_METRIC_SEPARATION_AUDIT.md`` F-1/F-3, handoffs H-1/
+# H-2) found two live decision-69 violations on `/rosters` and `/phases`
+# and records both as retired by a later, Claude-6-owned change:
+# `scoreTeamTiers` (a weighted starterValue/depthValue/pickValue blend,
+# tercile-cut into contender/mid-tier/rebuilder) deleted from
+# `frontend/lib/league-analysis.js`, and `frontend/lib/team-phase.js`'s
+# raw top-25-`rankDerivedValue` + raw-age derivation redirected onto
+# `strengthTotal` / `valueWeightedCoreAge`.  Both are ALSO guarded by
+# `frontend/__tests__/no-frontend-team-strength-methodology.test.js`, a
+# JS/vitest file this lane does not own.
+#
+# Trusting that guard's existence from its docstring would be exactly
+# the failure mode CLAUDE.md's non-negotiable rules warn against ("do
+# not assume features work — trace the live execution path").  So this
+# lane's OWN suite reads the two real production files directly and
+# proves the same absence with its own regexes, mirrored from the JS
+# guard's patterns rather than re-derived, so a future edit to one guard
+# is a visible prompt to check the other rather than a silent drift.
+# ---------------------------------------------------------------------------
+
+#: Mirrors the JS guard's ``COMPOSITE``: a numeric coefficient applied to
+#: a *-Value/-Score term, the shape of the retired ``scoreTeamTiers``.
+_UI_COMPOSITE = re.compile(
+    r"\b0?\.\d+\s*\*\s*\w*(?:[Vv]alue|[Ss]core)\w*|\w*(?:[Vv]alue|[Ss]core)\w*\s*\*\s*0?\.\d+"
+)
+
+#: Mirrors the JS guard's ``TIER_CUT``: the contender/rebuilder tier cut.
+_UI_TIER_CUT = re.compile(r"""["'`](?:contender|rebuilder|mid-?tier)["'`]""", re.IGNORECASE)
+
+#: Mirrors the JS guard's ``RAW_ROW_DERIVATION``: the retired team-phase.js
+#: shape — a raw top-25 value sum plus a raw per-player age lookup.
+_UI_RAW_ROW_DERIVATION = re.compile(r"\brankDerivedValue\b|useDynastyData\s*\(|sleeper\??\.teams\b")
+
+#: `/rosters` — where the weighted-composite / tier-cut collapse lived.
+_UI_COMPOSITE_FILES = ("frontend/lib/league-analysis.js", "frontend/app/rosters/page.jsx")
+
+#: `/phases` — where the raw-row Team Strength duplicate lived.
+_UI_RAW_ROW_FILES = ("frontend/lib/team-phase.js", "frontend/components/TeamPhasePanel.jsx")
+
+
+def _strip_js_comments(src: str) -> str:
+    """Blank comments so prose ABOUT the retired shapes cannot trip the
+    scan — mirrors the JS guard's own ``stripComments``, including its
+    equal-length-blank approach so any future offender's line number is
+    still correct."""
+    src = re.sub(r"/\*.*?\*/", lambda m: re.sub(r"[^\n]", " ", m.group(0)), src, flags=re.S)
+    return re.sub(r"^\s*//.*$", "", src, flags=re.M)
+
+
+def _ui_offenders(rel_paths: tuple[str, ...], pattern: re.Pattern[str]) -> list[str]:
+    offenders = []
+    for rel in rel_paths:
+        text = (REPO / rel).read_text(encoding="utf-8")
+        clean = _strip_js_comments(text)
+        for i, line in enumerate(clean.splitlines(), start=1):
+            if pattern.search(line):
+                offenders.append(f"{rel}:{i}  {line.strip()}")
+    return offenders
+
+
+def test_the_ui_scan_reads_real_files_not_nothing():
+    """Non-vacuity: the scoped files exist and are non-empty, so an
+    absent-file typo cannot make every scan below pass by finding
+    nothing to search."""
+    for rel in _UI_COMPOSITE_FILES + _UI_RAW_ROW_FILES:
+        path = REPO / rel
+        assert path.is_file(), f"{rel} not found — the UI scope is stale"
+        assert path.stat().st_size > 0
+
+
+def test_rosters_surface_has_no_weighted_composite_team_score():
+    """`/rosters` — decision 69's F-1 violation (`scoreTeamTiers`) stays
+    retired, read directly from the real production file."""
+    offenders = _ui_offenders(_UI_COMPOSITE_FILES, _UI_COMPOSITE)
+    assert not offenders, (
+        "a weighted blend of value/score terms is a Team Strength "
+        "methodology living in the browser (decision 69, F-1). Read "
+        f"strength.total from GET /api/roster/intelligence instead:\n{offenders}"
+    )
+
+
+def test_rosters_surface_has_no_tier_classification():
+    """`/rosters` publishes no client-side contender/rebuilder cut — the
+    classification half of the same F-1 violation."""
+    offenders = _ui_offenders(_UI_COMPOSITE_FILES, _UI_TIER_CUT)
+    assert not offenders, (
+        "tiering teams client-side is a backend classification (decision 69, "
+        f"F-1). Use strength.leagueRank / leaguePercentile instead:\n{offenders}"
+    )
+
+
+def test_phases_surface_reads_canonical_strength_not_raw_rows():
+    """`/phases` — decision 69's F-3 violation (a raw top-25 value sum
+    plus a raw per-player age lookup) stays retired."""
+    offenders = _ui_offenders(_UI_RAW_ROW_FILES, _UI_RAW_ROW_DERIVATION)
+    assert not offenders, (
+        "a raw player-row value/age derivation is a second Team Strength "
+        "engine (decision 69, F-3). Read strengthTotal / valueWeightedCoreAge "
+        f"from GET /api/roster/intelligence instead:\n{offenders}"
+    )
+
+
+def test_the_ui_composite_scan_would_catch_the_retired_formula():
+    """Mutation proof: the exact retired `scoreTeamTiers` line, verbatim
+    from the audit, must trip the detector — a scan that cannot be made
+    to fail is decoration."""
+    line = (
+        "const score = starterValue * 0.7 + depthValue * 0.2 + "
+        "(pickValue > 0 ? -pickValue * 0.1 : 0);"
+    )
+    assert _UI_COMPOSITE.search(line), "the detector missed the exact retired formula shape"
+    assert _UI_TIER_CUT.search('tier: i < top ? "contender" : "rebuilder"')
+
+
+def test_the_ui_raw_row_scan_would_catch_the_retired_derivation():
+    """Mutation proof for the raw-row detector, against the exact retired
+    `team-phase.js` lines named in the audit (F-3)."""
+    assert _UI_RAW_ROW_DERIVATION.search("value: Number(r.rankDerivedValue || 0),")
+    assert _UI_RAW_ROW_DERIVATION.search("const { rows, rawData } = useDynastyData();")
+    assert _UI_RAW_ROW_DERIVATION.search("const teams = rawData?.sleeper?.teams || [];")
+    # Negative control: the canonical materializer's own field names,
+    # including a MEDIAN of ages, must not trip it.
+    assert not _UI_RAW_ROW_DERIVATION.search("totalValue: t.strengthTotal,")
+    assert not _UI_RAW_ROW_DERIVATION.search("medianAge: t.valueWeightedCoreAge,")
+
+
+# ---------------------------------------------------------------------------
+# 6. Positive control: on a representative real board, distinct metrics
+#    genuinely diverge — the separation is not vacuous because there was
+#    never anything to conflate.
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_genuinely_diverge_on_a_representative_real_board():
+    """decision 69 only matters if the seven quantities actually take
+    DIFFERENT values on a real team — if they always agreed, "do not
+    collapse them" would be a distinction without a difference.
+
+    Team Strength (`strength.leagueRank`, value on the meaningful core)
+    and the Young Core Index (`agePortfolio.leagueRank`, a value-weighted
+    youth percentile — not one of decision 69's seven, but the axis
+    `V1-33`'s own validation proved genuinely separate from Strength on
+    this same board) are the two fields this endpoint actually populates
+    for every team, so this is a real measurement rather than a fixture
+    contrived to differ.  Measured on the newest complete archived
+    board: a team can be the single STRONGEST roster in the league by
+    value while ranking near the BOTTOM on youth (or the reverse) —
+    exactly the divergence decision 69 exists to keep visible rather
+    than average into one number.
+    """
+    from tests.archive_fixtures import newest_complete_raw_payload
+
+    raw, _archive = newest_complete_raw_payload()
+    if raw is None:
+        import pytest
+
+        pytest.skip("no complete archived payload available in this environment")
+
+    from src.api.data_contract import build_api_data_contract
+    from src.api.roster_intelligence import build_league_roster_intelligence
+
+    payload = build_league_roster_intelligence(build_api_data_contract(raw), team_count=12)
+    teams = payload.get("teams") or {}
+    assert len(teams) >= 8, "too few teams to call this representative"
+
+    pairs = []
+    for team in teams.values():
+        strength_rank = (team.get("strength") or {}).get("leagueRank")
+        yci_rank = (team.get("agePortfolio") or {}).get("leagueRank")
+        if strength_rank is not None and yci_rank is not None:
+            pairs.append((strength_rank, yci_rank))
+
+    assert len(pairs) >= len(teams) - 1, "too many teams missing a rank to measure divergence"
+
+    inversions = sum(1 for s, y in pairs if s != y)
+    assert inversions >= len(pairs) // 2, (
+        "Team Strength rank and Young Core Index rank should diverge for "
+        f"most teams; only {inversions} of {len(pairs)} differed at all — "
+        "either the board is unrepresentative or the two axes have collapsed"
+    )
+
+    strongest = min(pairs, key=lambda p: p[0])
+    assert strongest[0] != strongest[1], (
+        "the single strongest-by-value team should not also rank identically "
+        f"on youth by coincidence: {strongest}"
+    )


### PR DESCRIPTION
## Summary

V1-35 (metric separation, decision 69: asset value / roster strength / lineup / depth / power / playoff / championship stay distinct, "in the model and the UI"). Target level **L1**.

Re-verified against current `main` rather than trusting the audit doc (`docs/roster-intelligence/V1_35_METRIC_SEPARATION_AUDIT.md`), per the task's own instruction to read the current row and do a fresh census before editing.

**Finding:** both live violations the audit originally found are already retired in production —
- **F-1**: `/rosters`' `scoreTeamTiers` weighted composite (`starterValue×0.7 + depthValue×0.2 − pickValue×0.1`, tercile-cut into contender/mid-tier/rebuilder) — deleted, replaced by `TeamStrengthCard.jsx` reading `GET /api/roster/intelligence`.
- **F-3**: `/phases`' raw top-25-`rankDerivedValue` + raw-age derivation — redirected onto canonical `strengthTotal` / `valueWeightedCoreAge`.

Both fixes landed on `main` through some path other than PR #1002 (which carried the same change and was independently closed without merging earlier in this session's history) — confirmed by reading the actual current files, not by trusting the doc or the PR's fate.

**Classification: D** — behavior already correct, but the evidence for it was incomplete/stale:
- This lane's own `tests/roster_intel/test_metric_separation.py` explicitly disclaimed "cannot prove separation on `/rosters`, `/phases` — other lanes' files."
- The audit doc's own §5 still said "not closed... hands the UI half to Claude 6."
- Both statements were true when written and are now stale.

## What changed

**`tests/roster_intel/test_metric_separation.py`** — added 7 tests (10 → 17) that read the two real frontend files directly from disk (mirroring `no-frontend-team-strength-methodology.test.js`'s regex patterns rather than trusting that file's existence), so this lane's own hard-gated Python suite now proves the full "model and UI" claim without depending on another lane's separately-maintained JS file:
- 2 absence checks against the real production files (`/rosters`, `/phases`)
- 2 mutation-proof positive controls (synthetic strings matching the exact retired shapes)
- 1 positive-control divergence test: Team Strength rank vs Young Core Index rank genuinely diverge on the newest real archived board (11 of 12 teams differ) — the separation being asserted is not vacuous.

**`docs/roster-intelligence/V1_35_METRIC_SEPARATION_AUDIT.md`** — updated §0, §5, census rows 3-4, §6, and added §7 recording the re-verification evidence. No `VERSION_1_COMPLETION_CONTRACT.md` edit — that stays Claude 5's file, per the assignment.

## Required mutation — performed against real production owners, not fixtures

1. Reintroduced the exact retired `scoreTeamTiers` line into `frontend/lib/league-analysis.js` (a real, tracked production file).
2. Confirmed **both** the new Python tests AND the existing independent JS guard (`no-frontend-team-strength-methodology.test.js`) failed, naming the identical file:line.
3. Reverted (`git checkout --`), confirmed both suites green again.
4. Repeated for F-3's shape in `frontend/lib/team-phase.js` — same result.

Neither mutation is committed; the repo is clean of them (`git status --short` confirms).

## Overlap check with Claude 2's V1-36 branch

`git diff $(git merge-base origin/claude/v1-36-shared-package-generator origin/main) origin/claude/v1-36-shared-package-generator --stat` → empty. That branch has no commits past its shared base yet, so there was nothing to overlap with.

## Test plan

- [x] `pytest tests/roster_intel/ -q -m "not livedata"` — 628 passed
- [x] `pytest tests/roster_intel/test_metric_separation.py -q` — 17 passed
- [x] `npx vitest run __tests__/no-frontend-team-strength-methodology.test.js __tests__/team-phase.test.js __tests__/components/team-phase-panel.test.jsx` — 18 passed
- [x] `ruff format` / `ruff check` — clean
- [x] `scripts/check_decision_coercions.py` — clean, no new coercions
- [x] `scripts/check_planning_integrity.py` — OK, all 13 checks pass
- [x] Live mutation against real production files, confirmed RED on both independent guards, reverted

## Handoff

**FEATURE_GREEN / READY_FOR_INTEGRATION.** No ledger edit, no merge. FREEZE.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyqbZejxh7ytbfijL5pmdE)_