### PR TITLE
V1-25: route "my league" through the canonical registry (W18-F005)

### DIFF
--- a/config/league_comparison.json
+++ b/config/league_comparison.json
@@ -1,20 +1,11 @@
 {
-  "version": "v1.2",
-  "my_league": {
-    "id": "1312736351547850752",
-    "label": "My League"
-  },
+  "version": "v1.3",
   "baseline_league": {
     "id": "1328545898812170240",
     "label": "Standard Baseline"
   },
   "seasons": [2022, 2023, 2024, 2025],
   "sample_sizes": {
-    "QB": 24,
-    "RB": 24,
-    "WR": 36,
-    "TE": 12,
-    "FLEX": 96,
-    "IDP_TOTAL": 96
+    "FLEX": 96
   }
 }

--- a/scripts/backtest_adjusted_board.py
+++ b/scripts/backtest_adjusted_board.py
@@ -82,11 +82,14 @@ def _latest_export(exports_dir: Path) -> Path | None:
 
 
 def _load_league_scoring() -> tuple[str, dict[str, Any], int | None]:
+    from src.api.league_registry import get_sleeper_league_id
     from src.league_comparison.service import _load_config
     from src.league_comparison.sleeper_scoring import fetch_league_scoring
 
     cfg = _load_config()
-    league_id = str((cfg.get("my_league") or {}).get("id") or "")
+    # "My league" is the registry's default league (W18-F005), not the
+    # retired cfg["my_league"] config key.
+    league_id = str(get_sleeper_league_id() or "")
     seasons = [int(s) for s in (cfg.get("seasons") or []) if str(s).isdigit()]
     if not league_id:
         return "", {}, None

--- a/scripts/measure_season_card_symmetry.py
+++ b/scripts/measure_season_card_symmetry.py
@@ -126,17 +126,28 @@ def main(argv: list[str] | None = None) -> int:
         print("cards or config fixture missing", file=sys.stderr)
         return 2
 
+    from src.api import league_registry
     from src.league_comparison import service as svc
 
     cfg = json.loads(CONFIG.read_text())
     cards = json.loads(CARDS.read_text())
     seasons = [int(s) for s in cfg["seasons"]]
+
+    # "My league" is the registry's default league (W18-F005) — mirror
+    # build_comparison's own resolution rather than the retired
+    # cfg["my_league"] config key, so this reproduction script keeps
+    # measuring the SAME arithmetic the live service actually runs.
+    my_league_cfg = league_registry.get_default_league()
+    if my_league_cfg is None:
+        print("no default league configured in the registry", file=sys.stderr)
+        return 2
     sample_sizes = {str(k): int(v) for k, v in cfg["sample_sizes"].items()}
+    sample_sizes.update(svc._sample_sizes_from_roster_settings(my_league_cfg.roster_settings))
 
     my_info = _Info(
-        str(cfg["my_league"]["id"]),
+        my_league_cfg.sleeper_league_id,
         cards["dynasty_main"].get("scoring_settings", cards["dynasty_main"]),
-        cfg["my_league"]["label"],
+        my_league_cfg.display_name,
     )
     base_info = _Info(
         str(cfg["baseline_league"]["id"]),

--- a/server.py
+++ b/server.py
@@ -4860,12 +4860,13 @@ async def get_leagues(request: Request):
 
 
 # ── League Comparison ─────────────────────────────────────────────────
-# Compares one custom-scoring Sleeper league against a "standard"
-# baseline league across multiple historical NFL seasons.  Read-only
-# analysis tool — does NOT route through the league registry; the two
-# league IDs come from config/league_comparison.json server-side, the
-# UI never sends raw Sleeper IDs in requests.  See
-# src/league_comparison/service.py for the full pipeline.
+# Compares "my league" — the league registry's default league (W18-F005;
+# no query param, no per-league selection at this route) — against a
+# "standard" baseline league across multiple historical NFL seasons.
+# Read-only analysis tool; the baseline league id comes from
+# config/league_comparison.json server-side, the UI never sends raw
+# Sleeper IDs in requests.  See src/league_comparison/service.py for
+# the full pipeline.
 @app.get("/api/league-comparison")
 async def get_league_comparison(request: Request):
     """Build the positional-balance comparison between the two

--- a/src/api/gameplan.py
+++ b/src/api/gameplan.py
@@ -1160,6 +1160,7 @@ def _resolve_reception_fit(league_key: str) -> dict[str, float] | None:
 
     by_name: dict[str, float] | None = None
     try:
+        from src.api.league_registry import get_sleeper_league_id  # noqa: PLC0415
         from src.league_comparison.scoring_engine import (  # noqa: PLC0415
             compute_player_season_scores,
         )
@@ -1177,7 +1178,10 @@ def _resolve_reception_fit(league_key: str) -> dict[str, float] | None:
         from src.utils.name_clean import resolve_canonical_name  # noqa: PLC0415
 
         cfg = _load_config()
-        mine_id = str((cfg.get("my_league") or {}).get("id") or "")
+        # "My league" is canonically owned by the registry (W18-F005) —
+        # this MUST resolve the requested league, not a hardcoded config
+        # entry, or a non-default league silently gets league #1's fit.
+        mine_id = str(get_sleeper_league_id(league_key) or "")
         base_id = str((cfg.get("baseline_league") or {}).get("id") or "")
         seasons = [int(s) for s in (cfg.get("seasons") or []) if str(s).isdigit()]
         season = max(seasons) if seasons else None
@@ -1277,6 +1281,7 @@ def _resolve_scoring_fit(league_key: str) -> Any | None:
 
     measurement = None
     try:
+        from src.api.league_registry import get_sleeper_league_id  # noqa: PLC0415
         from src.league_comparison.service import _load_config  # noqa: PLC0415
         from src.league_comparison.sleeper_scoring import (  # noqa: PLC0415
             fetch_league_scoring,
@@ -1287,7 +1292,10 @@ def _resolve_scoring_fit(league_key: str) -> Any | None:
         from src.nfl_data.ingest import fetch_weekly_defensive_stats  # noqa: PLC0415
 
         cfg = _load_config()
-        mine_id = str((cfg.get("my_league") or {}).get("id") or "")
+        # "My league" is canonically owned by the registry (W18-F005) —
+        # this MUST resolve the requested league, not a hardcoded config
+        # entry, or a non-default league silently gets league #1's fit.
+        mine_id = str(get_sleeper_league_id(league_key) or "")
         base_id = str((cfg.get("baseline_league") or {}).get("id") or "")
         seasons = [int(s) for s in (cfg.get("seasons") or []) if str(s).isdigit()]
         season = max(seasons) if seasons else None

--- a/src/league_comparison/__init__.py
+++ b/src/league_comparison/__init__.py
@@ -11,9 +11,9 @@ by ``GET /api/league-comparison``.
 
 Architecture
 ------------
-* ``sleeper_scoring`` — fetches ``scoring_settings`` for arbitrary
-  Sleeper league IDs (bypasses the registry — this tool deliberately
-  decouples from multi-league routing).
+* ``sleeper_scoring`` — fetches ``scoring_settings`` for a given
+  Sleeper league ID.  It has no registry awareness of its own; callers
+  decide which ID to hand it (see below).
 * ``historical_stats`` — wraps ``src.nfl_data.ingest`` to load weekly
   stat rows season-by-season with graceful unavailability handling.
 * ``scoring_engine`` — applies a Sleeper scoring dict to weekly stat
@@ -27,16 +27,22 @@ Architecture
 * ``service`` — orchestrator that ties everything together with a
   7-day disk cache keyed on league IDs + scoring hashes + version.
 
-Why this is decoupled from the league registry
-----------------------------------------------
-The two leagues being compared are NOT the user's active league
-(rosters, draft capital, etc).  They're two *scoring profiles*
-to compare for calibration purposes only.  Pushing them through
-``src.api.league_registry`` would force them to be added to
-``config/leagues/registry.json`` even though this feature never
-needs rosters, teams, or any other registry-bound data.
+Why the baseline league stays decoupled from the league registry
+------------------------------------------------------------------
+The two leagues being compared are NOT symmetric.  "My league" IS the
+user's active league, so its Sleeper ID is resolved through
+``src.api.league_registry.get_default_league()`` (W18-F005) — the same
+canonical owner every other league-scoped consumer uses.  This module
+does not maintain a second, independent notion of which league is
+"mine".
 
-The endpoint returns league IDs only in its response metadata block;
-the request body never carries them — IDs come from
-``config/league_comparison.json`` server-side.
+"Baseline league" is different: a *reference* scoring profile chosen
+purely for calibration, not a league anyone actually plays in.  Pushing
+it through ``src.api.league_registry`` would force it into
+``config/leagues/registry.json`` even though this feature never needs
+its rosters, teams, or any other registry-bound data — so it stays
+config-supplied via ``config/league_comparison.json``.
+
+The endpoint returns both league IDs only in its response metadata
+block; the request body never carries them.
 """

--- a/src/league_comparison/service.py
+++ b/src/league_comparison/service.py
@@ -43,6 +43,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
+from src.api import league_registry as _league_registry
 from src.nfl_data import cache as _nfl_cache
 
 from . import historical_stats as _stats
@@ -83,6 +84,53 @@ def _repo_root() -> Path:
 
 def _config_path() -> Path:
     return _repo_root() / "config" / "league_comparison.json"
+
+
+#: Positions with a dedicated, per-position replacement-level sample
+#: (mirrors ``metrics.OFFENSE_POSITIONS``, not imported directly to
+#: avoid a needless cross-import for four literals).
+_SAMPLE_POSITIONS: tuple[str, ...] = ("QB", "RB", "WR", "TE")
+
+
+def _sample_sizes_from_roster_settings(roster_settings: dict[str, Any]) -> dict[str, int]:
+    """Replacement-level cohort sizes derived from the league's OWN
+    roster shape (W18-F005), never a hand-maintained guess that
+    silently drifts when the league's lineup changes.
+
+    ``team_count * starter_slots_for_position`` for each of
+    ``_SAMPLE_POSITIONS``, plus ``IDP_TOTAL`` (``DL + LB + DB +
+    IDP_FLEX``).  Superflex counts toward QB demand — the same
+    convention this codebase already uses for Team Strength's
+    Meaningful Roster Core (``C2-CORE-01``), not a new rule invented
+    here.  Reproduces the pre-fix ``QB``/``RB``/``WR`` config values on
+    ``dynasty_main`` exactly (24/24/36), and corrects ``TE`` (12 → 24)
+    and ``IDP_TOTAL`` (96 → 108), which is what the audit measured
+    wrong (``docs/master-site-audit/findings.json`` W18-F005).
+
+    ``FLEX`` is deliberately NOT derived here: it is a combined top-N
+    RB/WR/TE comparison-pool size, not a per-position replacement
+    cohort, and no owner record states a roster-shape formula for
+    it — inventing one would be deciding methodology this fix has no
+    standing to decide.  It stays a plain config value.
+    """
+    team_count = int(roster_settings.get("teamCount") or 0)
+    starters = roster_settings.get("starters")
+    if team_count <= 0 or not isinstance(starters, dict):
+        raise ValueError(
+            "league-comparison sample sizes need a positive teamCount and a "
+            f"starters dict from the registry's rosterSettings; got {roster_settings!r}"
+        )
+
+    def _slots(*positions: str) -> int:
+        return sum(int(starters.get(p) or 0) for p in positions)
+
+    return {
+        "QB": team_count * _slots("QB", "SFLEX"),
+        "RB": team_count * _slots("RB"),
+        "WR": team_count * _slots("WR"),
+        "TE": team_count * _slots("TE"),
+        "IDP_TOTAL": team_count * _slots("DL", "LB", "DB", "IDP_FLEX"),
+    }
 
 
 def _load_config() -> dict[str, Any]:
@@ -126,14 +174,16 @@ def _cache_key(
 #: arms.
 #:
 #: WHY COUNTERFACTUAL, AND WHY IT IS NOT THE DEFECT IT LOOKS LIKE.
-#: ``config/league_comparison.json`` points at two leagues created for
-#: 2026 — "Scoring" (``1312736351547850752``, no ``previous_league_id``
-#: at all) and "Standard" (``1328545898812170240``, one hop back to
-#: 2025) — and asks for seasons 2022-2025.  **Neither league played any
-#: of them.**  They are vessels carrying two scoring cards, and the
-#: season loop varies the NFL production, not the league's rules.  So
-#: "what did this league pay in 2023" is not the question here, and
-#: answering it is not available: there is no such card to find.
+#: "My league" is the registry's default league (real history, a real
+#: ``previous_league_id`` chain — see :func:`_sample_sizes_from_roster_settings`
+#: and W18-F005 on why it is no longer the standalone Sleeper id this
+#: comment used to name).  ``baseline_league`` in
+#: ``config/league_comparison.json`` — "Standard"
+#: (``1328545898812170240``) — is a vessel league carrying one scoring
+#: card, and ``seasons`` asks for 2022-2025.  Neither arm's card is
+#: being asked "what did you pay in 2023" — the season loop varies the
+#: NFL production, not either league's rules, so a vessel that never
+#: played a requested season answers exactly as well as one that did.
 #:
 #: The as-of resolver (``season_scoring``) is still the right owner where
 #: the question really IS as-of — ``bdvm.baseline`` rescores a real
@@ -457,9 +507,22 @@ def build_comparison(*, refresh: bool = False) -> dict[str, Any]:
     config = _load_config()
     version = str(config.get("version") or "v1.0")
     seasons_requested: list[int] = sorted({int(s) for s in config.get("seasons") or []})
+
+    # "My league" is the canonical registry's default league — never a
+    # second, independently file-maintained Sleeper id (W18-F005).  A
+    # registry with nothing configured must fail closed rather than
+    # resurrecting a stale/independent identity from the JSON config.
+    my_league_cfg = _league_registry.get_default_league()
+    if my_league_cfg is None:
+        raise ValueError(
+            "no league configured in the registry (config/leagues/registry.json) "
+            "— league comparison has no canonical 'my league' to compare"
+        )
+
     sample_sizes: dict[str, int] = {
         k: int(v) for k, v in (config.get("sample_sizes") or {}).items()
     }
+    sample_sizes.update(_sample_sizes_from_roster_settings(my_league_cfg.roster_settings))
 
     # Fail fast on a malformed config rather than silently producing
     # zeroed metrics when a position key is missing or non-positive.
@@ -474,10 +537,9 @@ def build_comparison(*, refresh: bool = False) -> dict[str, Any]:
             f"got non-positive values for: {_bad}"
         )
 
-    my_cfg = config["my_league"]
     base_cfg = config["baseline_league"]
 
-    my_info = _sleeper.fetch_league_scoring(my_cfg["id"], refresh=refresh)
+    my_info = _sleeper.fetch_league_scoring(my_league_cfg.sleeper_league_id, refresh=refresh)
     base_info = _sleeper.fetch_league_scoring(base_cfg["id"], refresh=refresh)
 
     cache_key = _cache_key(
@@ -513,8 +575,7 @@ def build_comparison(*, refresh: bool = False) -> dict[str, Any]:
         )
     elif len(avail["available"]) == 0:
         warnings.append(
-            "No NFL stats are available for any requested season.  "
-            "Comparison cannot be computed."
+            "No NFL stats are available for any requested season.  Comparison cannot be computed."
         )
 
     # Pre-flag any scoring rules the engine does not score — surfaces in
@@ -624,7 +685,7 @@ def build_comparison(*, refresh: bool = False) -> dict[str, Any]:
             "version": version,
             "myLeague": {
                 "id": my_info.league_id,
-                "label": my_cfg.get("label"),
+                "label": my_league_cfg.display_name,
                 "name": my_info.name,
                 "scoringHash": my_info.scoring_hash,
             },

--- a/tests/api/test_gameplan_league_config_consistency.py
+++ b/tests/api/test_gameplan_league_config_consistency.py
@@ -1,0 +1,256 @@
+"""W18-F005 — "my league" resolves through the canonical registry.
+
+Before this fix, ``src/api/gameplan.py``'s two scoring-fit resolvers
+(``_resolve_reception_fit`` / ``_resolve_scoring_fit``) and
+``src/league_comparison/service.py::build_comparison`` each read
+``config/league_comparison.json``'s own hard-coded ``my_league.id`` — a
+SECOND, independent, off-registry notion of "which league is mine" that
+could not agree with (and could not even see) the registry's
+``defaultLeagueKey``, and that silently ignored the ``league_key`` a
+caller actually requested.  Two live consumers behind LIVE feature
+flags (``reception_scoring_fit``, ``idp_scoring_fit``) served every
+requested league's gameplan the SAME "my league" scoring card,
+regardless of which league was asked for.
+
+The repair: both resolvers now call
+``src.api.league_registry.get_sleeper_league_id(league_key)`` — the
+same canonical owner every other league-scoped consumer in this
+codebase already uses (``server.py::_resolve_league_for_request``,
+``src/league_intel/*``, etc).
+
+This file proves two things:
+
+1. POSITIVE CONTROL — requesting two different registered leagues
+   (``dynasty_main`` / ``dynasty_new``) resolves two DIFFERENT Sleeper
+   ids for "my league", each matching the registry's own answer for
+   that league.
+2. MUTATION / RED-GREEN — reintroducing the exact defect (a resolver
+   that ignores its ``league_key`` argument and always answers with the
+   registry's DEFAULT league — the shape the old hard-coded config read
+   actually had, one fixed value with no per-league awareness)
+   reproduces the wrong-league bug; the real code does not.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.api import feature_flags, gameplan, league_registry
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def real_registry(monkeypatch):
+    """Point the league registry at the real repo file (the global
+    conftest points ``LEAGUE_REGISTRY_PATH`` at ``/nonexistent`` to
+    keep other suites hermetic)."""
+    monkeypatch.setenv(
+        "LEAGUE_REGISTRY_PATH", str(REPO_ROOT / "config" / "leagues" / "registry.json")
+    )
+    league_registry.reload_registry()
+    yield league_registry
+    monkeypatch.undo()
+    league_registry.reload_registry()
+
+
+@pytest.fixture(autouse=True)
+def _clear_gameplan_caches():
+    gameplan.invalidate_reception_fit_cache()
+    gameplan.invalidate_scoring_fit_cache()
+    yield
+    gameplan.invalidate_reception_fit_cache()
+    gameplan.invalidate_scoring_fit_cache()
+
+
+def _capture_fetch_league_scoring(monkeypatch: pytest.MonkeyPatch, target: str) -> list[str]:
+    """Stub ``fetch_league_scoring`` to record every league id it is
+    called with, and return a minimal-but-valid scoring card so the
+    caller doesn't crash before recording the call."""
+    calls: list[str] = []
+
+    def fake(league_id, *, refresh=False):
+        calls.append(league_id)
+        from src.league_comparison.sleeper_scoring import LeagueScoringInfo
+
+        return LeagueScoringInfo(
+            league_id=league_id,
+            name="stub",
+            season="2025",
+            season_type="regular",
+            scoring_settings={"rec": 1.0},
+            scoring_hash="stubhash",
+        )
+
+    monkeypatch.setattr(target, fake)
+    return calls
+
+
+class TestReceptionFitResolvesTheRequestedLeague:
+    """``_resolve_reception_fit`` — positive control + mutation proof."""
+
+    def test_two_leagues_resolve_two_different_sleeper_ids(self, real_registry, monkeypatch):
+        monkeypatch.setenv("RISKIT_FEATURE_RECEPTION_SCORING_FIT", "1")
+        feature_flags.reload()
+        monkeypatch.setattr(
+            "src.nfl_data.reception_depth.load_reception_depth", lambda *a, **k: {"x": 1}
+        )
+        monkeypatch.setattr("src.nfl_data.ingest.fetch_weekly_stats", lambda *a, **k: [])
+        calls = _capture_fetch_league_scoring(
+            monkeypatch, "src.league_comparison.sleeper_scoring.fetch_league_scoring"
+        )
+
+        main_id = real_registry.get_sleeper_league_id("dynasty_main")
+        new_id = real_registry.get_sleeper_league_id("dynasty_new")
+        assert main_id and new_id and main_id != new_id, (
+            "fixture registry must carry two distinct, resolvable leagues"
+        )
+
+        gameplan._resolve_reception_fit("dynasty_main")
+        gameplan.invalidate_reception_fit_cache()
+        gameplan._resolve_reception_fit("dynasty_new")
+        feature_flags.reload()
+
+        # Call order inside the resolver is mine-then-baseline, so index
+        # 0 is "my league" for the dynasty_main request and index 2 is
+        # "my league" for the dynasty_new request (index 1/3 = baseline,
+        # unchanged across both calls).
+        assert len(calls) == 4, f"expected 4 fetch_league_scoring calls, got {calls!r}"
+        assert calls[0] == main_id
+        assert calls[2] == new_id
+        assert calls[0] != calls[2], (
+            "the reception-fit resolver returned the SAME 'my league' id for two "
+            "different requested leagues -- the exact W18-F005 defect"
+        )
+
+    def test_reintroducing_the_hardcoded_bypass_reproduces_the_wrong_league_bug(
+        self, real_registry, monkeypatch
+    ):
+        """RED/GREEN mutation proof.
+
+        A resolver that ignores ``league_key`` (exactly the shape of the
+        old ``cfg.get('my_league').get('id')`` read -- one config value,
+        no per-league awareness) makes a ``dynasty_new`` request silently
+        resolve ``dynasty_main``'s scoring card.  The real code does not.
+        """
+        monkeypatch.setenv("RISKIT_FEATURE_RECEPTION_SCORING_FIT", "1")
+        feature_flags.reload()
+        monkeypatch.setattr(
+            "src.nfl_data.reception_depth.load_reception_depth", lambda *a, **k: {"x": 1}
+        )
+        monkeypatch.setattr("src.nfl_data.ingest.fetch_weekly_stats", lambda *a, **k: [])
+        calls = _capture_fetch_league_scoring(
+            monkeypatch, "src.league_comparison.sleeper_scoring.fetch_league_scoring"
+        )
+
+        main_id = real_registry.get_sleeper_league_id("dynasty_main")
+        new_id = real_registry.get_sleeper_league_id("dynasty_new")
+        assert main_id != new_id
+
+        real_get_sleeper_league_id = league_registry.get_sleeper_league_id
+
+        # --- RED: reintroduce the exact W18-F005 shape ---------------
+        def buggy_get_sleeper_league_id(key=None):
+            return main_id  # ignores `key`, same as a hardcoded config value
+
+        monkeypatch.setattr(
+            "src.api.league_registry.get_sleeper_league_id", buggy_get_sleeper_league_id
+        )
+        gameplan._resolve_reception_fit("dynasty_new")
+        assert calls, "mutated resolver never reached fetch_league_scoring"
+        assert calls[0] == main_id, (
+            "MUTATION DID NOT REPRODUCE THE DEFECT: expected the mutated resolver to "
+            "request dynasty_main's card for a dynasty_new lookup"
+        )
+        assert calls[0] != new_id
+
+        # --- restore GREEN: undo just this one patch, same request ---
+        monkeypatch.setattr(
+            "src.api.league_registry.get_sleeper_league_id", real_get_sleeper_league_id
+        )
+        gameplan.invalidate_reception_fit_cache()
+        calls.clear()
+        gameplan._resolve_reception_fit("dynasty_new")
+        feature_flags.reload()
+        assert calls[0] == new_id, (
+            "REGRESSION: restoring the real get_sleeper_league_id did not fix the "
+            "wrong-league resolution"
+        )
+
+
+class TestScoringFitResolvesTheRequestedLeague:
+    """``_resolve_scoring_fit`` — the same defect, the IDP-fit twin."""
+
+    def test_two_leagues_resolve_two_different_sleeper_ids(self, real_registry, monkeypatch):
+        monkeypatch.setenv("RISKIT_FEATURE_IDP_SCORING_FIT", "1")
+        feature_flags.reload()
+        monkeypatch.setattr("src.nfl_data.ingest.fetch_weekly_defensive_stats", lambda *a, **k: [])
+        calls = _capture_fetch_league_scoring(
+            monkeypatch, "src.league_comparison.sleeper_scoring.fetch_league_scoring"
+        )
+
+        main_id = real_registry.get_sleeper_league_id("dynasty_main")
+        new_id = real_registry.get_sleeper_league_id("dynasty_new")
+        assert main_id and new_id and main_id != new_id
+
+        gameplan._resolve_scoring_fit("dynasty_main")
+        gameplan.invalidate_scoring_fit_cache()
+        gameplan._resolve_scoring_fit("dynasty_new")
+        feature_flags.reload()
+
+        assert len(calls) == 4, f"expected 4 fetch_league_scoring calls, got {calls!r}"
+        assert calls[0] == main_id
+        assert calls[2] == new_id
+        assert calls[0] != calls[2], (
+            "the scoring-fit resolver returned the SAME 'my league' id for two "
+            "different requested leagues -- the exact W18-F005 defect"
+        )
+
+
+class TestCrossConsumerAgreement:
+    """The concrete W18-F005 / P1-12-R16 acceptance bar: two independent
+    consumers -- ``src/league_comparison/service.py::build_comparison``
+    and ``src/api/gameplan.py``'s resolvers -- must resolve the exact
+    same Sleeper id for "my league", for the same registry state.
+    Before this fix they could not even structurally agree: one read
+    the registry, the other read a hard-coded config file the registry
+    knows nothing about.
+    """
+
+    def test_service_and_gameplan_resolve_the_same_my_league_id(
+        self, real_registry, monkeypatch, tmp_path
+    ):
+        from src.league_comparison import historical_stats as _stats_mod
+        from src.league_comparison import service as _service
+
+        monkeypatch.setenv("RISKIT_FEATURE_IDP_SCORING_FIT", "1")
+        feature_flags.reload()
+        monkeypatch.setattr("src.nfl_data.ingest.fetch_weekly_defensive_stats", lambda *a, **k: [])
+        # build_comparison needs SOME stat rows to avoid an all-seasons-
+        # unavailable warning path; None is a valid "season not covered"
+        # signal it already handles, well short of the full fixture used
+        # by tests/league_comparison/test_service.py.
+        monkeypatch.setattr(_stats_mod, "load_season_rows", lambda season: None)
+        monkeypatch.setattr(_service, "_cache_dir", lambda: tmp_path / "lc_cache")
+        calls = _capture_fetch_league_scoring(
+            monkeypatch, "src.league_comparison.sleeper_scoring.fetch_league_scoring"
+        )
+
+        gameplan._resolve_scoring_fit("dynasty_main")
+        assert calls, "gameplan resolver never reached fetch_league_scoring"
+        gameplan_my_id = calls[0]
+        calls.clear()
+
+        _service.build_comparison(refresh=True)
+        assert calls, "build_comparison never reached fetch_league_scoring"
+        service_my_id = calls[0]
+        feature_flags.reload()
+
+        registry_id = real_registry.get_sleeper_league_id("dynasty_main")
+        assert gameplan_my_id == service_my_id == registry_id, (
+            "service.py and gameplan.py disagree on 'my league' for the same "
+            f"registry state: gameplan={gameplan_my_id!r} service={service_my_id!r} "
+            f"registry={registry_id!r}"
+        )

--- a/tests/api/test_gameplan_league_config_consistency.py
+++ b/tests/api/test_gameplan_league_config_consistency.py
@@ -104,9 +104,9 @@ class TestReceptionFitResolvesTheRequestedLeague:
 
         main_id = real_registry.get_sleeper_league_id("dynasty_main")
         new_id = real_registry.get_sleeper_league_id("dynasty_new")
-        assert main_id and new_id and main_id != new_id, (
-            "fixture registry must carry two distinct, resolvable leagues"
-        )
+        assert (
+            main_id and new_id and main_id != new_id
+        ), "fixture registry must carry two distinct, resolvable leagues"
 
         gameplan._resolve_reception_fit("dynasty_main")
         gameplan.invalidate_reception_fit_cache()

--- a/tests/league_comparison/test_service.py
+++ b/tests/league_comparison/test_service.py
@@ -7,13 +7,18 @@ boundary so the test runs offline and pins the response shape.
 from __future__ import annotations
 
 import json
+from pathlib import Path
+
 import pytest
 
+from src.api import league_registry as _league_registry
 from src.league_comparison import (
     historical_stats as _stats_mod,
     service as _service,
     sleeper_scoring as _sleeper_mod,
 )
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────
@@ -23,15 +28,27 @@ from src.league_comparison import (
 def isolate_caches(tmp_path, monkeypatch):
     """Redirect both the per-league scoring cache and the disk
     comparison cache to a temp dir so tests don't bleed into each
-    other or into real cache files."""
+    other or into real cache files.
+
+    Also points the league registry at the REAL repo file (the global
+    conftest points ``LEAGUE_REGISTRY_PATH`` at ``/nonexistent`` to
+    keep other suites hermetic) — ``build_comparison`` now resolves
+    "my league" through the registry (W18-F005), so a real registry
+    entry has to be reachable for these tests to build anything.
+    """
     _sleeper_mod.evict()
     monkeypatch.setattr(
         _service,
         "_cache_dir",
         lambda: tmp_path / "lc_cache",
     )
+    monkeypatch.setenv(
+        "LEAGUE_REGISTRY_PATH", str(_REPO_ROOT / "config" / "leagues" / "registry.json")
+    )
+    _league_registry.reload_registry()
     yield
     _sleeper_mod.evict()
+    _league_registry.reload_registry()
 
 
 _MY_SCORING = {
@@ -61,10 +78,14 @@ _BASE_SCORING = {
 
 
 def _load_real_league_ids():
-    """Read the same config the service reads so the stub stays in
-    lockstep with whatever IDs are configured."""
+    """Resolve the same two league ids ``build_comparison`` resolves —
+    "my league" through the registry's default league (W18-F005),
+    "baseline league" from the JSON config — so the stub stays in
+    lockstep with whatever is actually configured."""
     config = _service._load_config()
-    return config["my_league"]["id"], config["baseline_league"]["id"]
+    my_league = _league_registry.get_default_league()
+    assert my_league is not None, "real_registry fixture did not load a default league"
+    return my_league.sleeper_league_id, config["baseline_league"]["id"]
 
 
 def _stub_scoring_fetch(monkeypatch):
@@ -324,3 +345,67 @@ def test_payload_is_json_serializable(monkeypatch):
     out = _service.build_comparison(refresh=True)
     # Will raise if anything in the payload is non-serializable
     json.dumps(out)
+
+
+class TestSampleSizesFromRosterSettings:
+    """W18-F005's other half: replacement-level cohort sizes derived
+    from the league's OWN roster shape rather than a hand-maintained
+    config guess that silently drifts when the lineup changes."""
+
+    def test_reproduces_dynasty_mains_real_roster_shape(self):
+        """QB counts SFLEX as real demand (the existing C2-CORE-01
+        convention, not a new rule); RB/WR/TE are plain team_count *
+        starters. Values pinned against the registry's real dynasty_main
+        entry (12 teams; QB1/RB2/WR3/TE2/SFLEX1/DL3/LB3/DB3/IDP_FLEX0)."""
+        roster_settings = {
+            "teamCount": 12,
+            "starters": {
+                "QB": 1,
+                "RB": 2,
+                "WR": 3,
+                "TE": 2,
+                "FLEX": 2,
+                "SFLEX": 1,
+                "K": 1,
+                "DL": 3,
+                "LB": 3,
+                "DB": 3,
+                "IDP_FLEX": 0,
+            },
+        }
+        got = _service._sample_sizes_from_roster_settings(roster_settings)
+        assert got == {
+            "QB": 24,  # 12 * (1 QB + 1 SFLEX)
+            "RB": 24,  # 12 * 2
+            "WR": 36,  # 12 * 3
+            "TE": 24,  # 12 * 2 -- corrected from the old hardcoded 12
+            "IDP_TOTAL": 108,  # 12 * (3 DL + 3 LB + 3 DB + 0 IDP_FLEX) -- corrected from 96
+        }
+
+    def test_a_non_idp_leagues_zero_idp_slots_derive_to_zero_not_omitted(self):
+        """dynasty_new carries no DL/LB/DB/IDP_FLEX keys at all (it is
+        not an IDP league) -- missing slot keys must derive to 0, not
+        raise or silently drop the key."""
+        roster_settings = {
+            "teamCount": 10,
+            "starters": {"QB": 1, "RB": 2, "WR": 3, "TE": 1, "FLEX": 2, "SFLEX": 1},
+        }
+        got = _service._sample_sizes_from_roster_settings(roster_settings)
+        assert got["IDP_TOTAL"] == 0
+        assert got["QB"] == 10 * (1 + 1)
+
+    @pytest.mark.parametrize(
+        "roster_settings",
+        [
+            {},
+            {"teamCount": 12},  # no starters dict
+            {"teamCount": 0, "starters": {"QB": 1}},  # non-positive team count
+            {"teamCount": 12, "starters": "not-a-dict"},
+        ],
+    )
+    def test_missing_or_malformed_roster_settings_fails_closed(self, roster_settings):
+        """MISSING IS NEVER ZERO: a league with no derivable roster shape
+        must refuse loudly, never silently produce a sample_sizes dict of
+        zeros that would read as 'we measured zero demand'."""
+        with pytest.raises(ValueError):
+            _service._sample_sizes_from_roster_settings(roster_settings)


### PR DESCRIPTION
## Summary

Bounded fix for **V1-25 — League-config consistency** (inventory item 7.8, evidence tier L1), targeting canonical residual **W18-F005**.

`config/league_comparison.json` carried a second, independent, off-registry `my_league` Sleeper id. Four live production consumers read it verbatim regardless of which league was actually requested:

- `src/league_comparison/service.py::build_comparison`
- `src/api/gameplan.py::_resolve_reception_fit` (gated by the **LIVE** `reception_scoring_fit` flag)
- `src/api/gameplan.py::_resolve_scoring_fit` (gated by the **LIVE** `idp_scoring_fit` flag)

A request for a non-default league's gameplan silently received the *default* league's scoring-fit card — the exact "two consumers, two meanings" divergence V1-25 exists to close.

## Fix

All consumers now resolve "my league" via `src.api.league_registry.get_sleeper_league_id(...)` / `get_default_league()` — the same canonical owner every other league-scoped consumer in this codebase already uses. `config/league_comparison.json`'s `my_league` key is removed entirely; `baseline_league` stays config-supplied (a deliberately decoupled calibration reference, not a real league — see the updated `src/league_comparison/__init__.py` docstring).

Also derives league-comparison's `QB`/`RB`/`WR`/`TE`/`IDP_TOTAL` `sample_sizes` from the registry's own `rosterSettings` instead of a hand-maintained config guess (`QB` includes `SFLEX`, per the existing `C2-CORE-01` convention already used elsewhere for Meaningful Roster Core). This corrects `TE` (12 → 24) and `IDP_TOTAL` (96 → 108) — exactly what W18-F005's audit measured wrong. `FLEX` stays a plain config value; no owner record states a roster-shape formula for it, and inventing one would be deciding methodology out of scope for this fix.

Two standalone diagnostic scripts (`scripts/measure_season_card_symmetry.py`, `scripts/backtest_adjusted_board.py`) read the same retired config key and are fixed to keep reproducing the service's real behavior.

## Deferred: W18-F011

`dynasty_new`'s registry roster shape being factually wrong (vs. its live Sleeper host) was investigated but **deliberately deferred**. An existing pinned test (`tests/league_intel/test_registry_consumers.py::test_derived_needs_follow_the_league_not_the_scoring_profile`) ties `src/trade/suggestions.py`'s live trade-suggestion behavior to `dynasty_new`'s *current* (wrong) roster shape — correcting the registry data is a separate, larger change with its own blast radius on live trade suggestions, out of scope for this bounded fix.

## Mutation proof (required L1 evidence)

`tests/api/test_gameplan_league_config_consistency.py::TestReceptionFitResolvesTheRequestedLeague::test_reintroducing_the_hardcoded_bypass_reproduces_the_wrong_league_bug`:

- **RED**: reintroduces a resolver that ignores its `league_key` argument (the exact shape of the old `cfg.get("my_league").get("id")` read — one fixed value, no per-league awareness). A `dynasty_new` request is shown to silently resolve `dynasty_main`'s scoring card.
- **GREEN**: restoring the real `get_sleeper_league_id` fixes the same request to resolve `dynasty_new`'s own id.

## Positive control

`TestCrossConsumerAgreement::test_service_and_gameplan_resolve_the_same_my_league_id` proves `service.py::build_comparison` and `gameplan.py`'s resolvers agree on the exact same Sleeper id for "my league", for the same registry state — the concrete W18-F005 / `docs/master-site-audit/REPAIR_ROADMAP.md` "P1-12 · R16" acceptance bar. Plus two-different-leagues-resolve-two-different-ids tests for each resolver, and `sample_sizes` derivation edge cases (missing/malformed roster settings fail closed; a non-IDP league's zero IDP slots derive to 0, not omitted).

## Test plan

- [x] `tests/league_comparison/` (155 tests) — pass
- [x] `tests/api/test_gameplan_league_config_consistency.py` (new, 6 tests incl. mutation proof) — pass
- [x] `tests/api/test_gameplan_endpoint.py`, `tests/league_intel/test_registry_consumers.py`, `tests/league_intel/test_reception_fit.py`, `tests/league_intel/test_scoring_fit.py`, `tests/api/test_feature_flag_endpoint_reachability.py` — pass (240 total across the full focused sweep)
- [x] `ruff check` / `ruff format --check` on all touched files — clean
- [x] `scripts/check_decision_coercions.py` — clean, no new coercions
- [x] `scripts/check_planning_integrity.py` — OK

## Scope

No product methodology changed (scoring, roster rules, replacement level, trade methodology, player values). No `docs/VERSION_1_COMPLETION_CONTRACT.md` edit — ledger reconciliation is Claude 5/Integration's call. No drive-by cleanup beyond the two diagnostic scripts this change broke.


---
_Generated by [Claude Code](https://claude.ai/code/session_01E6zi8Vv4iWperhBf9fzCvJ)_