### PR TITLE
fix: clear 2027 Late 1st blend-integrity deploy blocker

### DIFF
--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 
 import argparse
 import importlib
+import json
 import sys
+from pathlib import Path
 from typing import Iterable
 
 
@@ -73,6 +75,65 @@ def _check(modules: Iterable[str], label: str) -> list[str]:
     return failures
 
 
+def _diagnose_live_pick_blend() -> bool:
+    """Temporary PR-only diagnostic for the active production blocker."""
+    from src.api.data_contract import build_api_data_contract
+
+    candidates = sorted(Path("exports/latest").glob("dynasty_data_*.json"))
+    if not candidates:
+        print("[blend-debug] no tracked payload", file=sys.stderr)
+        return False
+    with candidates[-1].open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    contract = build_api_data_contract(
+        payload,
+        data_source={"type": "test_file", "path": "exports/latest"},
+    )
+    row = next(
+        (
+            candidate
+            for candidate in contract.get("playersArray") or []
+            if candidate.get("canonicalName") == "2027 Late 1st"
+        ),
+        None,
+    )
+    if row is None:
+        print("[blend-debug] target row missing", file=sys.stderr)
+        return False
+    source_meta = {}
+    for key, value in (row.get("sourceRankMeta") or {}).items():
+        if isinstance(value, dict):
+            source_meta[key] = {
+                "valueContribution": value.get("valueContribution"),
+                "contributedToBlend": value.get("contributedToBlend"),
+                "isAnchor": value.get("isAnchor"),
+                "hampelDropped": value.get("hampelDropped"),
+                "supersededBy": value.get("supersededBy"),
+                "valueContributionPath": value.get("valueContributionPath"),
+                "rawRank": value.get("rawRank"),
+                "effectiveRank": value.get("effectiveRank"),
+                "rankCoordinatePool": value.get("rankCoordinatePool"),
+                "method": value.get("method"),
+                "appliedWeight": value.get("appliedWeight"),
+            }
+    diagnostic = {
+        "rankDerivedValue": row.get("rankDerivedValue"),
+        "canonicalConsensusRank": row.get("canonicalConsensusRank"),
+        "anchorValue": row.get("anchorValue"),
+        "subgroupBlendValue": row.get("subgroupBlendValue"),
+        "subgroupDelta": row.get("subgroupDelta"),
+        "alphaShrinkage": row.get("alphaShrinkage"),
+        "pickYearDiscount": row.get("pickYearDiscount"),
+        "pickValueProvenance": row.get("pickValueProvenance"),
+        "canonicalSiteValues": row.get("canonicalSiteValues"),
+        "sourceRanks": row.get("sourceRanks"),
+        "sourceRankMeta": source_meta,
+        "violation": row.get("blendIntegrityViolation"),
+    }
+    print("[blend-debug] " + json.dumps(diagnostic, sort_keys=True, default=str))
+    return row.get("blendIntegrityViolation") is not None
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -96,6 +157,10 @@ def main() -> int:
             " every declared dep, then re-run this check.",
             file=sys.stderr,
         )
+        return 1
+
+    if not args.runtime and _diagnose_live_pick_blend():
+        print("[blend-debug] reproduced production blocker", file=sys.stderr)
         return 1
 
     print("[check_env] All required modules importable.")

--- a/tests/api/test_pick_blend_integrity_live_regression.py
+++ b/tests/api/test_pick_blend_integrity_live_regression.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.api.data_contract import build_api_data_contract
+
+
+def _latest_payload() -> dict:
+    candidates = sorted(Path("exports/latest").glob("dynasty_data_*.json"))
+    assert candidates, "tracked latest dynasty payload is required for the blend-integrity regression"
+    with candidates[-1].open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def test_2027_late_first_does_not_false_trip_blend_integrity() -> None:
+    """Reproduce the production deploy blocker with enough stage evidence to diagnose it."""
+    contract = build_api_data_contract(
+        _latest_payload(),
+        data_source={"type": "test_file", "path": "exports/latest"},
+    )
+    rows = list(contract.get("playersArray") or [])
+    row = next(
+        (
+            candidate
+            for candidate in rows
+            if candidate.get("canonicalName") == "2027 Late 1st"
+            or candidate.get("displayName") == "2027 Late 1st"
+        ),
+        None,
+    )
+    assert row is not None, "2027 Late 1st disappeared from the canonical contract"
+
+    violation = row.get("blendIntegrityViolation")
+    if violation:
+        meta = row.get("sourceRankMeta") or {}
+        diagnostic = {
+            "rankDerivedValue": row.get("rankDerivedValue"),
+            "canonicalConsensusRank": row.get("canonicalConsensusRank"),
+            "anchorValue": row.get("anchorValue"),
+            "subgroupBlendValue": row.get("subgroupBlendValue"),
+            "subgroupDelta": row.get("subgroupDelta"),
+            "alphaShrinkage": row.get("alphaShrinkage"),
+            "pickYearDiscount": row.get("pickYearDiscount"),
+            "pickValueProvenance": row.get("pickValueProvenance"),
+            "canonicalSiteValues": row.get("canonicalSiteValues"),
+            "sourceRanks": row.get("sourceRanks"),
+            "sourceRankMeta": {
+                key: {
+                    "valueContribution": value.get("valueContribution"),
+                    "contributedToBlend": value.get("contributedToBlend"),
+                    "hampelDropped": value.get("hampelDropped"),
+                    "supersededBy": value.get("supersededBy"),
+                    "valueContributionPath": value.get("valueContributionPath"),
+                    "rawRank": value.get("rawRank"),
+                    "effectiveRank": value.get("effectiveRank"),
+                    "rankCoordinatePool": value.get("rankCoordinatePool"),
+                    "method": value.get("method"),
+                }
+                for key, value in meta.items()
+                if isinstance(value, dict)
+            },
+            "violation": violation,
+        }
+        pytest.fail(json.dumps(diagnostic, sort_keys=True, default=str))

--- a/tests/api/test_pick_blend_integrity_live_regression.py
+++ b/tests/api/test_pick_blend_integrity_live_regression.py
@@ -3,67 +3,62 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from src.api.data_contract import build_api_data_contract
 
 
 def _latest_payload() -> dict:
     candidates = sorted(Path("exports/latest").glob("dynasty_data_*.json"))
-    assert candidates, (
-        "tracked latest dynasty payload is required for the blend-integrity regression"
-    )
-    with candidates[-1].open("r", encoding="utf-8") as handle:
+    if not candidates:
+        raise AssertionError("tracked latest dynasty payload is required")
+    with candidates[-1].open(r"r", encoding="utf-8") as handle:
         return json.load(handle)
 
 
+def _late_first_row(contract: dict) -> dict:
+    for row in contract.get("playersArray") or []:
+        if row.get("canonicalName") == "2027 Late 1st":
+            return row
+    raise AssertionError("2027 Late 1st disappeared from the canonical contract")
+
+
 def test_2027_late_first_does_not_false_trip_blend_integrity() -> None:
-    """Reproduce the production deploy blocker with enough stage evidence to diagnose it."""
     contract = build_api_data_contract(
         _latest_payload(),
         data_source={"type": "test_file", "path": "exports/latest"},
     )
-    rows = list(contract.get("playersArray") or [])
-    row = next(
-        (
-            candidate
-            for candidate in rows
-            if candidate.get("canonicalName") == "2027 Late 1st"
-            or candidate.get("displayName") == "2027 Late 1st"
-        ),
-        None,
-    )
-    assert row is not None, "2027 Late 1st disappeared from the canonical contract"
-
+    row = _late_first_row(contract)
     violation = row.get("blendIntegrityViolation")
-    if violation:
-        meta = row.get("sourceRankMeta") or {}
-        diagnostic = {
-            "rankDerivedValue": row.get("rankDerivedValue"),
-            "canonicalConsensusRank": row.get("canonicalConsensusRank"),
-            "anchorValue": row.get("anchorValue"),
-            "subgroupBlendValue": row.get("subgroupBlendValue"),
-            "subgroupDelta": row.get("subgroupDelta"),
-            "alphaShrinkage": row.get("alphaShrinkage"),
-            "pickYearDiscount": row.get("pickYearDiscount"),
-            "pickValueProvenance": row.get("pickValueProvenance"),
-            "canonicalSiteValues": row.get("canonicalSiteValues"),
-            "sourceRanks": row.get("sourceRanks"),
-            "sourceRankMeta": {
-                key: {
-                    "valueContribution": value.get("valueContribution"),
-                    "contributedToBlend": value.get("contributedToBlend"),
-                    "hampelDropped": value.get("hampelDropped"),
-                    "supersededBy": value.get("supersededBy"),
-                    "valueContributionPath": value.get("valueContributionPath"),
-                    "rawRank": value.get("rawRank"),
-                    "effectiveRank": value.get("effectiveRank"),
-                    "rankCoordinatePool": value.get("rankCoordinatePool"),
-                    "method": value.get("method"),
-                }
-                for key, value in meta.items()
-                if isinstance(value, dict)
-            },
-            "violation": violation,
+    if violation is None:
+        return
+
+    source_meta = {}
+    for key, value in (row.get("sourceRankMeta") or {}).items():
+        if not isinstance(value, dict):
+            continue
+        source_meta[key] = {
+            "valueContribution": value.get("valueContribution"),
+            "contributedToBlend": value.get("contributedToBlend"),
+            "hampelDropped": value.get("hampelDropped"),
+            "supersededBy": value.get("supersededBy"),
+            "valueContributionPath": value.get("valueContributionPath"),
+            "rawRank": value.get("rawRank"),
+            "effectiveRank": value.get("effectiveRank"),
+            "rankCoordinatePool": value.get("rankCoordinatePool"),
+            "method": value.get("method"),
         }
-        pytest.fail(json.dumps(diagnostic, sort_keys=True, default=str))
+
+    diagnostic = {
+        "rankDerivedValue": row.get("rankDerivedValue"),
+        "canonicalConsensusRank": row.get("canonicalConsensusRank"),
+        "anchorValue": row.get("anchorValue"),
+        "subgroupBlendValue": row.get("subgroupBlendValue"),
+        "subgroupDelta": row.get("subgroupDelta"),
+        "alphaShrinkage": row.get("alphaShrinkage"),
+        "pickYearDiscount": row.get("pickYearDiscount"),
+        "pickValueProvenance": row.get("pickValueProvenance"),
+        "canonicalSiteValues": row.get("canonicalSiteValues"),
+        "sourceRanks": row.get("sourceRanks"),
+        "sourceRankMeta": source_meta,
+        "violation": violation,
+    }
+    raise AssertionError(json.dumps(diagnostic, sort_keys=True, default=str))

--- a/tests/api/test_pick_blend_integrity_live_regression.py
+++ b/tests/api/test_pick_blend_integrity_live_regression.py
@@ -10,7 +10,9 @@ from src.api.data_contract import build_api_data_contract
 
 def _latest_payload() -> dict:
     candidates = sorted(Path("exports/latest").glob("dynasty_data_*.json"))
-    assert candidates, "tracked latest dynasty payload is required for the blend-integrity regression"
+    assert candidates, (
+        "tracked latest dynasty payload is required for the blend-integrity regression"
+    )
     with candidates[-1].open("r", encoding="utf-8") as handle:
         return json.load(handle)
 

--- a/tests/api/test_pick_blend_integrity_live_regression.py
+++ b/tests/api/test_pick_blend_integrity_live_regression.py
@@ -10,7 +10,7 @@ def _latest_payload() -> dict:
     candidates = sorted(Path("exports/latest").glob("dynasty_data_*.json"))
     if not candidates:
         raise AssertionError("tracked latest dynasty payload is required")
-    with candidates[-1].open(r"r", encoding="utf-8") as handle:
+    with candidates[-1].open("r", encoding="utf-8") as handle:
         return json.load(handle)
 
 


### PR DESCRIPTION
Production-stop repair for the FULL API-contract failure on `2027 Late 1st`.

First commit intentionally adds a real-current-board regression reproducer. It fails with the row's stage/provenance diagnostics so the causal fix can be made against measured canonical pipeline state rather than by weakening the validator or guessing at pick methodology.

Guardrails: no source-weight changes, no bridge changes, no Hill changes, no clamp/tolerance widening, no V1 scope change. The PR will not be merged until the exact live regression is GREEN, the generic impossible-blend positive control remains RED-capable, FULL contract validation is GREEN, and exact-head CI is GREEN.