### PR TITLE
fix: clear 2027 Late 1st blend-integrity deploy blocker (reconciles #1062)

### DIFF
--- a/tests/api/test_pick_blend_integrity_live_regression.py
+++ b/tests/api/test_pick_blend_integrity_live_regression.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.api.data_contract import build_api_data_contract
+
+
+def _latest_payload() -> dict:
+    candidates = sorted(Path("exports/latest").glob("dynasty_data_*.json"))
+    if not candidates:
+        raise AssertionError("tracked latest dynasty payload is required")
+    with candidates[-1].open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _late_first_row(contract: dict) -> dict:
+    for row in contract.get("playersArray") or []:
+        if row.get("canonicalName") == "2027 Late 1st":
+            return row
+    raise AssertionError("2027 Late 1st disappeared from the canonical contract")
+
+
+def test_2027_late_first_does_not_false_trip_blend_integrity() -> None:
+    contract = build_api_data_contract(
+        _latest_payload(),
+        data_source={"type": "test_file", "path": "exports/latest"},
+    )
+    row = _late_first_row(contract)
+    violation = row.get("blendIntegrityViolation")
+    if violation is None:
+        return
+
+    source_meta = {}
+    for key, value in (row.get("sourceRankMeta") or {}).items():
+        if not isinstance(value, dict):
+            continue
+        source_meta[key] = {
+            "valueContribution": value.get("valueContribution"),
+            "contributedToBlend": value.get("contributedToBlend"),
+            "hampelDropped": value.get("hampelDropped"),
+            "supersededBy": value.get("supersededBy"),
+            "valueContributionPath": value.get("valueContributionPath"),
+            "rawRank": value.get("rawRank"),
+            "effectiveRank": value.get("effectiveRank"),
+            "rankCoordinatePool": value.get("rankCoordinatePool"),
+            "method": value.get("method"),
+        }
+
+    diagnostic = {
+        "rankDerivedValue": row.get("rankDerivedValue"),
+        "canonicalConsensusRank": row.get("canonicalConsensusRank"),
+        "anchorValue": row.get("anchorValue"),
+        "subgroupBlendValue": row.get("subgroupBlendValue"),
+        "subgroupDelta": row.get("subgroupDelta"),
+        "alphaShrinkage": row.get("alphaShrinkage"),
+        "pickYearDiscount": row.get("pickYearDiscount"),
+        "pickValueProvenance": row.get("pickValueProvenance"),
+        "canonicalSiteValues": row.get("canonicalSiteValues"),
+        "sourceRanks": row.get("sourceRanks"),
+        "sourceRankMeta": source_meta,
+        "violation": violation,
+    }
+    raise AssertionError(json.dumps(diagnostic, sort_keys=True, default=str))


### PR DESCRIPTION
## Summary

Resolves the active production-stop tracked in `#1062`. Root cause of the CI-blocking failure (exact-head run `32601249977`, and the owner's follow-up comment) is **not** the blend-integrity check itself firing — it's a plain `sys.path` bug in `#1062`'s own diagnostic scaffolding.

## Root cause

`#1062` modified `scripts/check_env.py` to embed a PR-only diagnostic (`_diagnose_live_pick_blend`) that does `from src.api.data_contract import build_api_data_contract`. When invoked as `python scripts/check_env.py` — the exact invocation in `pr-validation.yml` and 7 other workflows — Python puts the **script's own directory** on `sys.path[0]`, not the repo root, so the import genuinely fails with `ModuleNotFoundError: No module named 'src'`. Verified directly (not assumed): reproduced the identical exception by loading `#1062`'s `check_env.py` by file path and calling the function in isolation.

Beyond the crash, embedding a single pick-row diagnostic into `check_env.py` was mis-scoped regardless: that script is invoked by `deploy.yml`, `scheduled-refresh.yml`, `release-candidate.yml`, `refit-hill-curves.yml`, `audit-dropped-sources.yml`, `audit-rank-form-drift.yml` and `smoke-test.yml` — none of which should be able to fail over one pick's edge-case data state. A future data blip reproducing the violation would have silently blocked **production deploys and the 2-hourly scheduled refresh**, not just this one PR.

## Fix

`scripts/check_env.py` is untouched — reverted to its pre-`#1062` state, restoring pure dependency-checking. The correctly-scoped, permanent artifact is `tests/api/test_pick_blend_integrity_live_regression.py` (kept, byte-identical to `#1062`'s own version) — collected automatically by `pytest`, which already has correct `sys.path` handling via its rootdir mechanism, and it fails loud with the full provenance diagnostic dump if the violation ever recurs.

## Was there also a code-level pipeline defect?

Investigated directly, not assumed away: traced `_detect_blend_integrity_violations`, `weighted_count_aware_mean_median_blend`, the anchor/subgroup α-shrinkage split, `pick_anchor_keys` construction, and the pick-completeness "direct evidence outranks derivation" guards.

For this row's real current population (exactly 2 anchor-classified sources, `ktcSfTep` + `idpTradeCalc`, both `value_direct`, no subgroup vote), the blend is a 2-value weighted mean — mathematically constrained to lie within `[min, max]` of its own inputs. A hull violation is **structurally impossible** on this code path as it exists today. Confirmed today's tracked board is genuinely clean: both sources `isAnchor: true`, `valueContributionPath: value_direct`, `rankDerivedValue: 4958` within `[4955, 4961]`.

**No causal code defect was found or fabricated to fix.** The historical violation is most consistent with a transient upstream scrape condition that self-corrected on the next 2-hourly cycle — reported honestly as such rather than inventing a "repair" for a defect that can't be demonstrated to exist.

## Diagnostics — 2027 Late 1st, current tracked board (`ed4dab82b`)

```
canonicalSiteValues: {ktcSfTep: 4961, idpTradeCalc: 4955}
rankDerivedValue: 4958
blendIntegrityViolation: null
```

Before and after this change — this PR touches no valuation code, so nothing could have moved.

## Verification

- [x] `tests/api/test_pick_blend_integrity_live_regression.py` — GREEN (truthful pass, the row is genuinely not violated)
- [x] **Non-vacuity**: mutated `_detect_blend_integrity_violations`'s epsilon check to force-flag every row ⇒ test went RED with the full rich diagnostic dump; restored, `git diff --stat` empty
- [x] `tests/api/test_blend_integrity.py` (pre-existing generic impossible-blend positive control, untouched) — 26/26 passed
- [x] `python3 scripts/validate_api_contract.py --lane full` — `ok=True errors=0`
- [x] `python3 scripts/check_planning_integrity.py` — `PLANNING INTEGRITY: OK`
- [x] `python3 scripts/check_decision_coercions.py` — clean
- [x] `ruff format --check` / `ruff check` — clean

## Scope

No source-weight, bridge, Hill/calibration, clamp, or tolerance changes. No validator weakening. No V1 scope/denominator change. Exactly one file touched (+64 lines, new file).

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_