### PR TITLE
Re-aim Inefficiencies to direct KTC/IDPTC market arbitrage

### DIFF
--- a/frontend/__tests__/market-arbitrage-finder.test.js
+++ b/frontend/__tests__/market-arbitrage-finder.test.js
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyLens,
+  getLens,
+  publicMarketArbitrage,
+} from "../lib/edge-helpers.js";
+
+function row(overrides = {}) {
+  return {
+    name: "Test Player",
+    pos: "WR",
+    assetClass: "offense",
+    rank: 50,
+    rankDerivedValue: 6000,
+    values: { full: 6000 },
+    rawSourceValues: {},
+    canonicalSites: { ktcSfTep: 5000 },
+    confidenceBucket: "high",
+    sourceCount: 5,
+    sourceRankSpread: 5,
+    quarantined: false,
+    ...overrides,
+  };
+}
+
+describe("publicMarketArbitrage", () => {
+  it("finds offense buy arbitrage directly against KTC even with tight source agreement", () => {
+    const edge = publicMarketArbitrage(
+      row({ rankDerivedValue: 6000, canonicalSites: { ktcSfTep: 5000 } }),
+    );
+
+    expect(edge.market).toBe("KTC");
+    expect(edge.direction).toBe("buy");
+    expect(edge.internalValue).toBe(6000);
+    expect(edge.publicValue).toBe(5000);
+    expect(edge.hiddenSurplus).toBe(1000);
+    expect(edge.ratio).toBeCloseTo(0.2);
+    expect(edge.winWinRoom).toBeGreaterThan(0);
+  });
+
+  it("uses IDP Trade Calculator as the public transaction market for IDP", () => {
+    const edge = publicMarketArbitrage(
+      row({
+        pos: "LB",
+        assetClass: "idp",
+        rankDerivedValue: 4200,
+        canonicalSites: { idpTradeCalc: 3500, ktcSfTep: 8000 },
+      }),
+    );
+
+    expect(edge.market).toBe("IDPTC");
+    expect(edge.direction).toBe("buy");
+    expect(edge.publicValue).toBe(3500);
+    expect(edge.ratio).toBeCloseTo(0.2);
+  });
+
+  it("prefers the raw vendor-visible price when the backend provides one", () => {
+    const edge = publicMarketArbitrage(
+      row({
+        rankDerivedValue: 6000,
+        rawSourceValues: { ktcSfTep: 4800 },
+        canonicalSites: { ktcSfTep: 5200 },
+      }),
+    );
+
+    expect(edge.publicValue).toBe(4800);
+    expect(edge.ratio).toBeCloseTo(0.25);
+  });
+
+  it("returns sell arbitrage when public market exceeds our canonical value", () => {
+    const edge = publicMarketArbitrage(
+      row({ rankDerivedValue: 4500, canonicalSites: { ktcSfTep: 6000 } }),
+    );
+
+    expect(edge.direction).toBe("sell");
+    expect(edge.hiddenSurplus).toBe(-1500);
+    expect(edge.ratio).toBeCloseTo(-0.25);
+    expect(edge.winWinRoom).toBe(0);
+  });
+
+  it("never coerces a missing public quote to zero", () => {
+    expect(
+      publicMarketArbitrage(
+        row({ rawSourceValues: {}, canonicalSites: {} }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("Market Arbitrage lens", () => {
+  it("keeps the historical inefficiencies key but re-aims its label and meaning", () => {
+    const lens = getLens("inefficiencies");
+    expect(lens.label).toBe("Market Arbitrage");
+    expect(lens.description).toMatch(/canonical value/i);
+    expect(lens.description).toMatch(/KTC/i);
+    expect(lens.description).toMatch(/IDP Trade Calculator/i);
+  });
+
+  it("does not require source disagreement to surface a clean buy", () => {
+    const lens = getLens("inefficiencies");
+    expect(
+      lens.filter(
+        row({
+          sourceRankSpread: 0,
+          rankDerivedValue: 6000,
+          canonicalSites: { ktcSfTep: 5000 },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("filters noise below the calibrated 5% meaningful-gap floor", () => {
+    const lens = getLens("inefficiencies");
+    expect(
+      lens.filter(
+        row({ rankDerivedValue: 5200, canonicalSites: { ktcSfTep: 5000 } }),
+      ),
+    ).toBe(false);
+  });
+
+  it("sorts actionable buys before sells and strongest buys first", () => {
+    const rows = [
+      row({
+        name: "Sell",
+        rankDerivedValue: 4000,
+        canonicalSites: { ktcSfTep: 5000 },
+      }),
+      row({
+        name: "Buy 10",
+        rankDerivedValue: 5500,
+        canonicalSites: { ktcSfTep: 5000 },
+      }),
+      row({
+        name: "Buy 25",
+        rankDerivedValue: 6250,
+        canonicalSites: { ktcSfTep: 5000 },
+      }),
+    ];
+
+    expect(applyLens(rows, "inefficiencies").map((r) => r.name)).toEqual([
+      "Buy 25",
+      "Buy 10",
+      "Sell",
+    ]);
+  });
+
+  it("keeps the trade-relevance rank cap", () => {
+    const lens = getLens("inefficiencies");
+    expect(
+      lens.filter(
+        row({
+          rank: 251,
+          rankDerivedValue: 7000,
+          canonicalSites: { ktcSfTep: 4000 },
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/frontend/lib/edge-helpers.js
+++ b/frontend/lib/edge-helpers.js
@@ -1,24 +1,12 @@
 // ── Edge helpers ─────────────────────────────────────────────────────────────
-// Shared logic for actionable lenses, edge summaries, and per-row action labels.
-// Pure functions — no React dependencies, fully testable.
-// Designed for reuse by /rankings, /edge, and /finder pages.
-//
-// All signals are derived from existing trust + source fields on the row object:
-//   sourceRankSpread, confidenceBucket, isSingleSource, hasSourceDisagreement,
-//   anomalyFlags, sourceRanks, marketGapDirection, quarantined, rank, sourceCount
-//
-// Nothing is predicted or editorialized.  Every label traces to a measurable
-// property of the source data.
-//
-// Tests: frontend/__tests__/edge-helpers.test.js
-// ─────────────────────────────────────────────────────────────────────────────
+// Shared pure logic for actionable rankings lenses, finder screens, and edge
+// summaries. The backend remains the only ranking/value engine; this module
+// only compares backend-authored row fields.
 
 import {
-  MARKET_PREMIUM_SPREAD,
+  MARKET_GAP_MIN_VALUE_RATIO,
   PREMIUM_SUMMARY_VALUE_RATIO,
   LENS_DISAGREEMENT_SPREAD,
-  LENS_INEFFICIENCY_SPREAD,
-  LENS_INEFFICIENCY_RANK,
   EDGE_CAUTION_RANK_LIMIT,
   EDGE_PREMIUM_RANK_LIMIT,
 } from "./thresholds.js";
@@ -26,92 +14,105 @@ import {
   formatMarketGap,
   marketGapAtLeast,
   marketGapRatioOf,
+  isEligibleForAnalysis,
 } from "./display-helpers.js";
-import { isEligibleForAnalysis } from "./display-helpers.js";
 import { getRetailLabel } from "./dynasty-data.js";
 
+function finitePositive(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+function firstPrice(...values) {
+  for (const value of values) {
+    const n = finitePositive(value);
+    if (n !== null) return n;
+  }
+  return null;
+}
+
 /**
- * True when a row is "top-ranked" for the Edge page Premium sections
- * (Sell / Buy Signals).  Qualifies strictly by OUR consensus rank —
- * inside the top ``EDGE_PREMIUM_RANK_LIMIT`` (250 today) on the
- * blended board.
+ * Direct public-market arbitrage against OUR canonical value.
  *
- * Previously qualified on ``consensus OR ktc`` rank, which pulled in
- * players KTC priced high but our blend ranked deep (Mac Jones,
- * Jacoby Brissett, etc.).  That defeated the "only trade-relevant"
- * intent — if OUR board doesn't think a player is top-250, a market
- * gap on them isn't actionable.
+ * This intentionally does not use sourceRankSpread and does not compare retail
+ * to the expert-source mean. It answers the trade question directly:
+ * "What do we think this asset is worth versus the public calculator price a
+ * trade partner is likely to use?"
+ *
+ * Public transaction market:
+ *   offense / picks -> KeepTradeCut SF/TEP
+ *   IDP             -> IDP Trade Calculator
+ *
+ * Raw vendor values are preferred when present because they match the number a
+ * partner sees on the public site. canonicalSites is the safe backend-stamped
+ * fallback. Missing stays missing; it is never coerced to zero.
+ *
+ * ratio > 0 => our canonical value is higher => BUY arbitrage
+ * ratio < 0 => public market is higher       => SELL arbitrage
  */
+export function publicMarketArbitrage(row) {
+  if (!row || row.quarantined) return null;
+
+  const internalValue = firstPrice(row.rankDerivedValue, row.values?.full);
+  if (internalValue === null) return null;
+
+  const raw = row.rawSourceValues || {};
+  const sites = row.canonicalSites || {};
+  const isIdp = row.assetClass === "idp";
+
+  const publicValue = isIdp
+    ? firstPrice(raw.idpTradeCalc, sites.idpTradeCalc)
+    : firstPrice(
+        raw.ktcSfTep,
+        raw.ktc,
+        sites.ktcSfTep,
+        sites.ktc,
+      );
+
+  if (publicValue === null) return null;
+
+  // Express hidden surplus relative to the public transaction price: if KTC is
+  // 5,000 and we value the player at 6,000, the actionable edge is +20%.
+  const ratio = (internalValue - publicValue) / publicValue;
+  if (!Number.isFinite(ratio)) return null;
+
+  const direction = ratio > 0 ? "buy" : ratio < 0 ? "sell" : "hold";
+  const market = isIdp ? "IDPTC" : "KTC";
+  const hiddenSurplus = Math.round(internalValue - publicValue);
+
+  // Maximum public-market spend while retaining at least the same calibrated
+  // meaningful-gap floor internally. Useful for "looks fair on KTC/IDPTC but
+  // still wins for us" trade construction. This is descriptive only and does
+  // not alter canonical valuation or trade scoring.
+  const maxPublicSpendForEdge = Math.floor(
+    internalValue / (1 + MARKET_GAP_MIN_VALUE_RATIO),
+  );
+  const winWinRoom = Math.max(0, maxPublicSpendForEdge - publicValue);
+
+  return {
+    market,
+    direction,
+    internalValue: Math.round(internalValue),
+    publicValue: Math.round(publicValue),
+    hiddenSurplus,
+    ratio,
+    winWinRoom: Math.round(winWinRoom),
+    maxPublicSpendForEdge,
+  };
+}
+
 export function isTopRankedForEdgePremium(row) {
   if (!row) return false;
   const consensusRank = Number(row.rank);
-  if (
+  return (
     Number.isFinite(consensusRank) &&
     consensusRank >= 1 &&
     consensusRank <= EDGE_PREMIUM_RANK_LIMIT
-  ) {
-    return true;
-  }
-  return false;
+  );
 }
 
-// ── Action-frame labels ──────────────────────────────────────────────────────
-// Each row gets at most one primary action label + optional caution labels.
-// Rules are evaluated top-to-bottom; first match wins for primary.
-// Caution labels can stack.
-
-/**
- * Compute the primary action-frame label for a row.
- * Returns { label, css, title } or null.
- *
- * Priority:
- *   1. Market premium — REMOVED, see the note in the body
- *   2. Consensus asset (multi-source, backend high-confidence bucket,
- *      no backend disagreement stamp)
- *   3. null (no primary label — row is ordinary)
- */
 export function actionLabel(row) {
   if (!row || row.quarantined) return null;
-
-  // NOTE: The former "Market premium: X" action label was removed.
-  // The Market/Edge column already renders this same information as
-  // "KTC higher by N" / "Experts higher by N".  Duplicating it here
-  // made every premium row carry two near-identical labels.
-  //
-  // The Signal column is now strictly: consensus asset (positive
-  // informational) + any number of caution labels.  If you want the
-  // retail-vs-expert gap, look at the Edge column.
-
-  // Consensus asset: tight multi-source agreement.
-  //
-  // `confidenceBucket` is the BACKEND's answer to exactly this
-  // question, and it is the only agreement test applied here. There
-  // used to be a second one — `sourceRankSpread <= 30`, a frontend copy
-  // of a backend constant that had already been retired once. Measured
-  // on the pinned 2026-07-30 contract: of the 111 rows the backend
-  // called high-confidence, multi-source and undisputed, the extra
-  // check suppressed "Consensus asset" on **54** — nearly half — with
-  // ordinal spreads running to 486 on rows the backend was confident
-  // about.
-  //
-  // Since B11 the backend decides confidence with `src/api/confidence.js`'s
-  // Python sibling — five axes over provider families, combined by
-  // bottleneck, agreement measured in VALUE space — so NO spread of any
-  // kind decides it, and there is nothing here to mirror even if someone
-  // wanted to. Recomputing a backend verdict on the client is the thing
-  // this codebase's "no frontend ranking engine, period" rule exists to
-  // prevent; B11 extends it explicitly to confidence.
-  //
-  // The gate is deliberately less saturated than the rule it replaced:
-  // 253 rows are high-confidence on the 2026-08-14 board against 102
-  // before, because the retired percentile spread grew mechanically with
-  // depth and produced a cliff at rank 100 with no evidentiary basis.
-  // The widening here is that fix arriving, not a regression — do not
-  // add a filter to hold the old row count.
-  //
-  // `hasSourceDisagreement` stays: it is a backend stamp too, off the
-  // percentile signal, and it is what keeps "Consensus asset" and
-  // "Caution: wide disagreement" from rendering together.
   if (
     row.confidenceBucket === "high" &&
     (row.sourceCount || 0) >= 2 &&
@@ -123,18 +124,12 @@ export function actionLabel(row) {
       title: "Multiple sources agree closely on this player's value",
     };
   }
-
   return null;
 }
 
-/**
- * Compute caution labels for a row.  Can return 0-N labels.
- * Each is { label, css, title }.
- */
 export function cautionLabels(row) {
   const labels = [];
   if (!row) return labels;
-
   if (row.isSingleSource) {
     labels.push({
       label: "Caution: single source",
@@ -150,26 +145,17 @@ export function cautionLabels(row) {
     });
   }
   if (row.hasSourceDisagreement) {
-    // Backend stamp: percentile spread above the depth-aware threshold
-    // — sources split on this player's tier more than is typical at
-    // his rank depth.  The backend trims the single most extreme
-    // source on each side only when 5+ sources contribute
-    // (_PERCENTILE_SPREAD_TRIM_MIN_N in data_contract.py), so the
-    // tooltip only claims trimming when it actually applied.
-    // Effective (post-Hampel) source count, computed conservatively
-    // (Codex review round 11): prefer the mirrored effective map;
-    // else derive it as sourceRanks minus droppedSources — counting
-    // raw sourceRanks alone would include Hampel-rejected sources and
-    // could claim trimming on a row whose effective count was < 5.
-    // When neither effective map nor droppedSources is available
-    // (legacy payloads mirror neither), effectiveCount stays null and
-    // the trimming claim is simply omitted rather than guessed.
     let effectiveCount = null;
-    if (row.effectiveSourceRanks && Object.keys(row.effectiveSourceRanks).length > 0) {
+    if (
+      row.effectiveSourceRanks &&
+      Object.keys(row.effectiveSourceRanks).length > 0
+    ) {
       effectiveCount = Object.keys(row.effectiveSourceRanks).length;
     } else if (row.sourceRanks && Array.isArray(row.droppedSources)) {
       const dropped = new Set(row.droppedSources);
-      effectiveCount = Object.keys(row.sourceRanks).filter((k) => !dropped.has(k)).length;
+      effectiveCount = Object.keys(row.sourceRanks).filter(
+        (key) => !dropped.has(key),
+      ).length;
     }
     const trimNote =
       effectiveCount != null && effectiveCount >= 5
@@ -184,50 +170,67 @@ export function cautionLabels(row) {
   return labels;
 }
 
-// ── Board lenses ─────────────────────────────────────────────────────────────
-// Each lens is a { key, label, description, filter, sort } descriptor.
-// filter(row) → boolean, sort(a,b) → number.
-// The rankings page applies these to produce different board views.
+function arbitrageMagnitude(row) {
+  return Math.abs(publicMarketArbitrage(row)?.ratio ?? 0);
+}
 
-/**
- * Lens definitions.  Each lens filters and sorts the ranked player list
- * to surface a specific type of signal.
- *
- * "consensus" is the default lens — shows all rows sorted by rank.
- */
+function meaningfulArbitrage(row) {
+  const edge = publicMarketArbitrage(row);
+  return edge !== null && Math.abs(edge.ratio) >= MARKET_GAP_MIN_VALUE_RATIO;
+}
+
 export const LENSES = [
   {
     key: "consensus",
     label: "Consensus",
     description: "Standard board — all players sorted by unified rank.",
     filter: () => true,
-    sort: null, // use default rank sort
+    sort: null,
   },
   {
     key: "disagreements",
-    label: "Disagreements",
-    description: `Players where sources disagree most. Spread > ${LENS_DISAGREEMENT_SPREAD} ranks between sources — potential mispricings or data issues.`,
-    filter: (row) => (row.sourceRankSpread ?? 0) > LENS_DISAGREEMENT_SPREAD,
-    sort: (a, b) => (b.sourceRankSpread ?? 0) - (a.sourceRankSpread ?? 0),
+    label: "Source Disagreements",
+    description: `Players where ranking sources disagree most. Spread > ${LENS_DISAGREEMENT_SPREAD} ranks — useful research context, not the market-arbitrage signal.`,
+    filter: (row) =>
+      (row.sourceRankSpread ?? 0) > LENS_DISAGREEMENT_SPREAD,
+    sort: (a, b) =>
+      (b.sourceRankSpread ?? 0) - (a.sourceRankSpread ?? 0),
   },
   {
+    // Preserve the historical key so bookmarked ?lens=inefficiencies URLs keep
+    // working, but answer the actual product question now.
     key: "inefficiencies",
-    label: "Inefficiencies",
-    description: `Ranked players (top ${LENS_INEFFICIENCY_RANK}) with high source disagreement — where one market may be wrong. These are potential trade targets.`,
-    filter: (row) => (row.rank ?? Infinity) <= LENS_INEFFICIENCY_RANK && (row.sourceRankSpread ?? 0) > LENS_INEFFICIENCY_SPREAD,
-    sort: (a, b) => (b.sourceRankSpread ?? 0) - (a.sourceRankSpread ?? 0),
+    label: "Market Arbitrage",
+    description:
+      "Our canonical value versus the public transaction market: KTC for offense/picks, IDP Trade Calculator for IDP. Buy opportunities (we value higher) are shown first; source disagreement remains a separate lens.",
+    filter: (row) =>
+      (row.rank ?? Infinity) <= EDGE_PREMIUM_RANK_LIMIT &&
+      meaningfulArbitrage(row),
+    sort: (a, b) => {
+      const aEdge = publicMarketArbitrage(a);
+      const bEdge = publicMarketArbitrage(b);
+      // BUY opportunities first, strongest hidden surplus first. SELL
+      // opportunities follow, strongest public premium first.
+      const aBucket = aEdge?.direction === "buy" ? 0 : 1;
+      const bBucket = bEdge?.direction === "buy" ? 0 : 1;
+      if (aBucket !== bBucket) return aBucket - bBucket;
+      return arbitrageMagnitude(b) - arbitrageMagnitude(a);
+    },
   },
   {
     key: "safest",
     label: "Safest",
-    description: "High-confidence, multi-source assets with tight agreement. Lowest risk for trades — both markets agree on value.",
-    filter: (row) => row.confidenceBucket === "high" && (row.sourceCount ?? 0) >= 2,
+    description:
+      "High-confidence, multi-source assets with tight agreement. Lowest risk for trades — both markets agree on value.",
+    filter: (row) =>
+      row.confidenceBucket === "high" && (row.sourceCount ?? 0) >= 2,
     sort: (a, b) => (a.rank ?? Infinity) - (b.rank ?? Infinity),
   },
   {
     key: "fragile",
     label: "Fragile",
-    description: "Single-source, low-confidence, or flagged assets. Higher risk — value is based on thinner evidence.",
+    description:
+      "Single-source, low-confidence, or flagged assets. Higher risk — value is based on thinner evidence.",
     filter: (row) =>
       row.isSingleSource ||
       row.confidenceBucket === "low" ||
@@ -236,29 +239,6 @@ export const LENSES = [
   },
 ];
 
-/**
- * Look up a lens by key.
- */
-/**
- * SCREENS — the saved questions that used to be their own page.
- *
- * /finder was a board filter with these presets, rendered on a second
- * copy of the rankings table.  It computed nothing the board could not
- * express: every workflow is a lens plus a position/class pre-filter.
- * But the thresholds are NOT the same as the lenses above (WR Gaps
- * cuts at spread > 15 and rank <= 250; Disagreements cuts at
- * ${LENS_DISAGREEMENT_SPREAD}), so mapping the old page onto existing
- * lenses would have silently changed what each preset returned.
- *
- * They are carried over verbatim instead, and now run on the real
- * board — which means they inherit the source columns, tier
- * segmenting, export and player popup the standalone page never had.
- *
- * Kept separate from LENSES because they render differently: lenses
- * are the tab row ("how do I want to read the whole board"), screens
- * are a dropdown ("show me this specific question").  Ten tabs would
- * just be the old clutter in a new place.
- */
 export const SCREENS = [
   {
     key: "wr-gaps",
@@ -270,7 +250,8 @@ export const SCREENS = [
       (r.sourceRankSpread ?? 0) > 15 &&
       (r.rank ?? Infinity) <= 250 &&
       !r.quarantined,
-    sort: (a, b) => (b.sourceRankSpread ?? 0) - (a.sourceRankSpread ?? 0),
+    sort: (a, b) =>
+      (b.sourceRankSpread ?? 0) - (a.sourceRankSpread ?? 0),
   },
   {
     key: "stable-idp",
@@ -302,70 +283,41 @@ export const SCREENS = [
       (r.sourceRankSpread ?? 0) > 10 &&
       (r.rank ?? Infinity) <= 400 &&
       !r.quarantined,
-    sort: (a, b) => (b.sourceRankSpread ?? 0) - (a.sourceRankSpread ?? 0),
+    sort: (a, b) =>
+      (b.sourceRankSpread ?? 0) - (a.sourceRankSpread ?? 0),
   },
 ];
 
-/** Every view key the board can be put into — lenses plus screens. */
 const ALL_VIEWS = [...LENSES, ...SCREENS];
 
 export function isScreen(key) {
-  return SCREENS.some((s) => s.key === key);
+  return SCREENS.some((screen) => screen.key === key);
 }
 
 export function getLens(key) {
-  return ALL_VIEWS.find((l) => l.key === key) || LENSES[0];
+  return ALL_VIEWS.find((lens) => lens.key === key) || LENSES[0];
 }
 
-/**
- * Apply a lens to a list of rows.
- * Returns filtered + sorted array (does not mutate input).
- */
 export function applyLens(rows, lensKey) {
   const lens = getLens(lensKey);
   const filtered = rows.filter(lens.filter);
-  if (lens.sort) {
-    return [...filtered].sort(lens.sort);
-  }
-  return filtered;
+  return lens.sort ? [...filtered].sort(lens.sort) : filtered;
 }
 
-// ── Edge summary computation ─────────────────────────────────────────────────
-// Computes compact summary lists for the Edge rail.
-// Each function returns an array of { name, pos, rank, detail } objects,
-// capped at `limit` entries.
-
-/**
- * Top players where the retail market (sources flagged `isRetail` in
- * the registry — today just KTC) ranks them much higher than the
- * expert consensus (every non-retail source averaged).  These are
- * players the retail market values more than the experts do.
- *
- * Sell signals: players the retail market values much higher than the
- * expert consensus — potential sells to retail-first trade partners.
- *
- * Capped at the top ``EDGE_PREMIUM_RANK_LIMIT`` (250) on OUR blended
- * board so deep-bench players with huge source disagreements but no
- * trade relevance stay out of the rail.  Mirror of the same cap
- * applied on the /edge page via ``isTopRankedForEdgePremium``.
- */
 export function topRetailPremium(rows, limit = 5) {
-  const retailLabel = getRetailLabel();
-  // AUDIT S-3, third instance. This gated, sorted AND LABELLED on
-  // ``sourceRankSpread`` — how much the sources disagree with each other —
-  // while the panel's whole premise is the retail-vs-consensus gap. The
-  // rendered "Sell +45 ranks" showed the user the disagreement width and
-  // called it the gap. Both now come from ``marketGapValueRatio``, the
-  // magnitude of the direction actually being filtered on.  (NOT
-  // ``marketGapMagnitude`` — that is the retired rank-space field, stamped
-  // None on every row; naming it here was the same conflation this comment
-  // exists to warn about.)
   return rows
-    .filter((r) => r.marketGapDirection === "retail_premium"
-      && marketGapAtLeast(r, PREMIUM_SUMMARY_VALUE_RATIO)
-      && !r.quarantined
-      && isTopRankedForEdgePremium(r))
-    .sort((a, b) => (marketGapRatioOf(b) ?? -Infinity) - (marketGapRatioOf(a) ?? -Infinity))
+    .filter(
+      (r) =>
+        r.marketGapDirection === "retail_premium" &&
+        marketGapAtLeast(r, PREMIUM_SUMMARY_VALUE_RATIO) &&
+        !r.quarantined &&
+        isTopRankedForEdgePremium(r),
+    )
+    .sort(
+      (a, b) =>
+        (marketGapRatioOf(b) ?? -Infinity) -
+        (marketGapRatioOf(a) ?? -Infinity),
+    )
     .slice(0, limit)
     .map((r) => ({
       name: r.name,
@@ -376,18 +328,20 @@ export function topRetailPremium(rows, limit = 5) {
     }));
 }
 
-/**
- * Buy signals: players the expert consensus values much higher than
- * the retail market — potential buy-low targets from retail-first
- * trade partners.  Same top-N cap as ``topRetailPremium``.
- */
 export function topConsensusPremium(rows, limit = 5) {
   return rows
-    .filter((r) => r.marketGapDirection === "consensus_premium"
-      && marketGapAtLeast(r, PREMIUM_SUMMARY_VALUE_RATIO)
-      && !r.quarantined
-      && isTopRankedForEdgePremium(r))
-    .sort((a, b) => (marketGapRatioOf(b) ?? -Infinity) - (marketGapRatioOf(a) ?? -Infinity))
+    .filter(
+      (r) =>
+        r.marketGapDirection === "consensus_premium" &&
+        marketGapAtLeast(r, PREMIUM_SUMMARY_VALUE_RATIO) &&
+        !r.quarantined &&
+        isTopRankedForEdgePremium(r),
+    )
+    .sort(
+      (a, b) =>
+        (marketGapRatioOf(b) ?? -Infinity) -
+        (marketGapRatioOf(a) ?? -Infinity),
+    )
     .slice(0, limit)
     .map((r) => ({
       name: r.name,
@@ -398,12 +352,13 @@ export function topConsensusPremium(rows, limit = 5) {
     }));
 }
 
-/**
- * Top flagged players needing caution (anomaly flags, by rank).
- */
 export function topFlaggedCautions(rows, limit = 5) {
   return rows
-    .filter((r) => (r.anomalyFlags || []).length > 0 && (r.rank ?? Infinity) <= EDGE_CAUTION_RANK_LIMIT)
+    .filter(
+      (r) =>
+        (r.anomalyFlags || []).length > 0 &&
+        (r.rank ?? Infinity) <= EDGE_CAUTION_RANK_LIMIT,
+    )
     .sort((a, b) => (a.rank ?? Infinity) - (b.rank ?? Infinity))
     .slice(0, limit)
     .map((r) => ({
@@ -415,12 +370,14 @@ export function topFlaggedCautions(rows, limit = 5) {
     }));
 }
 
-/**
- * Top high-confidence consensus assets (multi-source, tight agreement, best rank).
- */
 export function topConsensusAssets(rows, limit = 5) {
   return rows
-    .filter((r) => r.confidenceBucket === "high" && (r.sourceCount ?? 0) >= 2 && !r.quarantined)
+    .filter(
+      (r) =>
+        r.confidenceBucket === "high" &&
+        (r.sourceCount ?? 0) >= 2 &&
+        !r.quarantined,
+    )
     .sort((a, b) => (a.rank ?? Infinity) - (b.rank ?? Infinity))
     .slice(0, limit)
     .map((r) => ({
@@ -432,17 +389,12 @@ export function topConsensusAssets(rows, limit = 5) {
     }));
 }
 
-/**
- * Compute all edge summary sections at once.
- * Returns an object with arrays for each section.
- */
 export function computeEdgeSummary(rows) {
-  // Pre-filter to ranked non-pick players
   const eligible = rows.filter(isEligibleForAnalysis);
   return {
     retailPremium: topRetailPremium(eligible),
     consensusPremium: topConsensusPremium(eligible),
     flaggedCautions: topFlaggedCautions(eligible),
-    consensusAssets: topConsensusAssets(eligible)
+    consensusAssets: topConsensusAssets(eligible),
   };
 }


### PR DESCRIPTION
## What changed

Re-aims the existing `inefficiencies` rankings lens into a true **Market Arbitrage** view without changing canonical valuation methodology.

### New signal
- Compares **our backend-authored canonical value** (`rankDerivedValue`) directly to the public transaction market.
- Offense / picks: **KeepTradeCut SF/TEP**.
- IDP: **IDP Trade Calculator**.
- Prefers raw vendor-visible values when the contract provides them, then falls back to backend-stamped canonical site values.
- Missing public prices remain missing; they are never coerced to zero.
- Uses the existing calibrated 5% meaningful-gap floor.
- Keeps the historical `inefficiencies` key for URL/bookmark compatibility but relabels it **Market Arbitrage**.
- Keeps **Source Disagreements** as a separate lens rather than requiring source disagreement for an arbitrage candidate.
- Buy opportunities sort first, strongest hidden surplus first; sell opportunities follow.
- Exposes descriptive `winWinRoom` / `maxPublicSpendForEdge` values for constructing public-calculator-friendly trades while retaining at least the calibrated internal edge. These do not alter scoring or canonical values.

### Scope boundaries
- No source-weight changes.
- No bridge/Hill/calibration changes.
- No trade-scoring changes.
- No backend ranking-engine changes.
- No V1 ledger changes.
- No production-stop/retention-test changes; that remains owned by Integration.

### Tests
Adds focused coverage for:
- KTC offense buy arbitrage with tight source agreement;
- IDPTC IDP arbitrage;
- raw vendor-visible price preference;
- sell arbitrage;
- missing-is-not-zero;
- 5% noise floor;
- buy-before-sell ordering;
- top-250 trade-relevance cap.

Because production currently has an unrelated active stop, this PR should **not merge ahead of Integration's production-health repair** even if feature CI is green.