### PR TITLE
feat: turn arbitrage into a true public-market inefficiency finder

### DIFF
--- a/frontend/__tests__/market-arbitrage.test.js
+++ b/frontend/__tests__/market-arbitrage.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  arbitrageDescriptor,
+  buildArbitrageRows,
+  publicMarketFor,
+  publicMarketValueOf,
+} from "@/lib/market-arbitrage";
+
+function row(overrides = {}) {
+  return {
+    name: "Test Player",
+    pos: "WR",
+    assetClass: "offense",
+    rank: 25,
+    values: { full: 6300 },
+    rankDerivedValue: 6300,
+    canonicalSites: { ktcSfTep: 5000, idpTradeCalc: 5200 },
+    confidenceBucket: "high",
+    quarantined: false,
+    ...overrides,
+  };
+}
+
+describe("market arbitrage", () => {
+  it("routes offense to KTC and IDP to IDP Trade Calculator", () => {
+    expect(publicMarketFor(row())).toEqual({ key: "ktcSfTep", label: "KTC" });
+    expect(
+      publicMarketFor(row({ assetClass: "idp", pos: "LB" })),
+    ).toEqual({ key: "idpTradeCalc", label: "IDP Trade Calculator" });
+  });
+
+  it("measures our canonical value directly against the public transaction anchor", () => {
+    const edge = arbitrageDescriptor(row());
+    expect(edge.action).toBe("strong_buy");
+    expect(edge.ourValue).toBe(6300);
+    expect(edge.marketValue).toBe(5000);
+    expect(edge.edgePoints).toBe(1300);
+    expect(edge.edgeRatio).toBeCloseTo(0.26);
+  });
+
+  it("does not require broad source disagreement to surface a buy", () => {
+    const opportunities = buildArbitrageRows([
+      row({ sourceRankSpread: 0, hasSourceDisagreement: false }),
+    ], { action: "buy" });
+    expect(opportunities).toHaveLength(1);
+    expect(opportunities[0].edge.action).toBe("strong_buy");
+  });
+
+  it("keeps missing public prices missing instead of coercing them to zero", () => {
+    const missing = row({ canonicalSites: {} });
+    expect(publicMarketValueOf(missing)).toBeNull();
+    expect(arbitrageDescriptor(missing)).toBeNull();
+    expect(buildArbitrageRows([missing], { action: "buy" })).toEqual([]);
+  });
+
+  it("uses IDP Trade Calculator rather than KTC for an IDP buy", () => {
+    const idp = row({
+      assetClass: "idp",
+      pos: "LB",
+      values: { full: 6000 },
+      canonicalSites: { ktcSfTep: 1000, idpTradeCalc: 5000 },
+    });
+    const edge = arbitrageDescriptor(idp);
+    expect(edge.marketLabel).toBe("IDP Trade Calculator");
+    expect(edge.marketValue).toBe(5000);
+    expect(edge.edgeRatio).toBeCloseTo(0.20);
+    expect(edge.action).toBe("strong_buy");
+  });
+
+  it("surfaces public-friendly win-win offers only when both sides clear their margins", () => {
+    const edge = arbitrageDescriptor(row());
+    expect(edge.winWin).toBe(true);
+    expect(edge.publicFriendlyOfferCeiling).toBe(5250);
+    expect(edge.publicWinRatio).toBeCloseTo(0.05);
+    expect(edge.internalWinRatio).toBeCloseTo(0.20);
+  });
+
+  it("sorts by actionable percentage edge, not sourceRankSpread", () => {
+    const opportunities = buildArbitrageRows([
+      row({ name: "Huge disagreement small edge", values: { full: 5400 }, sourceRankSpread: 400 }),
+      row({ name: "Tight consensus big edge", values: { full: 6500 }, sourceRankSpread: 0 }),
+    ], { action: "buy" });
+    expect(opportunities.map((x) => x.row.name)).toEqual([
+      "Tight consensus big edge",
+      "Huge disagreement small edge",
+    ]);
+  });
+});

--- a/frontend/app/arbitrage/page.jsx
+++ b/frontend/app/arbitrage/page.jsx
@@ -18,30 +18,25 @@ import {
 } from "@/components/ds";
 import { withValuationMode } from "@/lib/valuation-mode";
 import { buildShareUrl } from "@/lib/trade-share";
+import { buildArbitrageRows } from "@/lib/market-arbitrage";
 import styles from "./arbitrage.module.css";
 
-// ── /arbitrage — the board-vs-market arbitrage finder ─────────────────
+// ── /arbitrage — board-vs-public-market arbitrage finder ─────────────
 //
-// This is the UI caller for src/trade/finder.py, which had none. The
-// engine was built, audited (per-market top-150 gating, marketCoverage,
-// assetsUnpricedByBoard, valueSource stamping), exposed at
-// POST /api/trade/finder — and never invoked by anything. Backlog #6.
+// Two layers intentionally live together here:
+//   1. Player-level market inefficiencies — canonical board versus the public
+//      transaction market a trade partner is likely to check (KTC for offense,
+//      IDP Trade Calculator for IDP).
+//   2. Package-level trade finder — src/trade/finder.py, which searches actual
+//      roster-to-roster constructions through POST /api/trade/finder.
 //
-// WHY THIS IS NOT ON /finder, despite the name. /finder is a board
-// filter: five presets that sort the board on sourceRankSpread /
-// confidenceBucket / isSingleSource / rookie. It computes no
-// board-versus-market comparison at all. A stale header comment there
-// once called it "the arbitrage blotter", and that single word is what
-// made an earlier audit record a phantom second implementation
-// competing with this engine. Putting a real arbitrage view on that
-// route would recreate exactly that confusion.
-//
-// Everything below is rendered verbatim from the backend response. This
-// file computes no trade values, no deltas, and no scores — same rule as
-// buildRows. The one thing it derives is display formatting.
+// Source disagreement is deliberately NOT a qualification rule for layer 1.
+// "The sources disagree" and "our canonical value beats the public price" are
+// different questions. /rankings retains the disagreement research lens.
 
 function fmt(v) {
-  return Number(v || 0).toLocaleString();
+  if (v == null || !Number.isFinite(Number(v))) return "—";
+  return Number(v).toLocaleString();
 }
 
 function fmtSigned(v) {
@@ -49,9 +44,97 @@ function fmtSigned(v) {
   return `${n > 0 ? "+" : ""}${fmt(Math.round(n))}`;
 }
 
+function fmtPct(v) {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return "—";
+  return `${n > 0 ? "+" : ""}${Math.round(n * 100)}%`;
+}
+
+function edgeActionLabel(action) {
+  if (action === "strong_buy") return "STRONG BUY";
+  if (action === "buy") return "BUY";
+  if (action === "strong_sell") return "STRONG SELL";
+  if (action === "sell") return "SELL";
+  return "HOLD";
+}
+
 const MARKET_LABEL = { ktcSfTep: "KTC", ktc: "KTC", idpTradeCalc: "IDPTC" };
 
-function AssetList({ assets, tone }) {
+function PlayerEdgeTable({ opportunities }) {
+  if (!opportunities.length) {
+    return (
+      <EmptyState
+        title="No player-level edges at this threshold"
+        description="Missing public prices stay missing rather than becoming zero. Lower the threshold or switch asset class to inspect more of the board."
+      />
+    );
+  }
+
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 14 }}>
+        <thead>
+          <tr>
+            {[
+              "Player",
+              "Pos",
+              "Our rank",
+              "Our value",
+              "Public market",
+              "Public value",
+              "Hidden surplus",
+              "Edge",
+              "Signal",
+              "Confidence",
+              "Public-friendly offer",
+            ].map((label) => (
+              <th
+                key={label}
+                style={{ textAlign: "left", padding: "10px 9px", borderBottom: "1px solid var(--border, #333)", whiteSpace: "nowrap" }}
+              >
+                {label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {opportunities.map(({ row, edge }) => (
+            <tr key={row.playerId || `${row.name}-${row.pos}`}>
+              <td style={{ padding: "10px 9px", borderBottom: "1px solid var(--border, #292929)" }}>
+                <strong>{row.name}</strong>
+              </td>
+              <td style={{ padding: "10px 9px", borderBottom: "1px solid var(--border, #292929)" }}>{row.pos}</td>
+              <td style={{ padding: "10px 9px", borderBottom: "1px solid var(--border, #292929)" }}>{row.rank ?? "—"}</td>
+              <td style={{ padding: "10px 9px", borderBottom: "1px solid var(--border, #292929)" }}>{fmt(edge.ourValue)}</td>
+              <td style={{ padding: "10px 9px", borderBottom: "1px solid var(--border, #292929)" }}>{edge.marketLabel}</td>
+              <td style={{ padding: "10px 9px", borderBottom: "1px solid var(--border, #292929)" }}>{fmt(edge.marketValue)}</td>
+              <td style={{ padding: "10px 9px", borderBottom: "1px solid var(--border, #292929)" }}>{fmtSigned(edge.edgePoints)}</td>
+              <td style={{ padding: "10px 9px", borderBottom: "1px solid var(--border, #292929)" }}>{fmtPct(edge.edgeRatio)}</td>
+              <td style={{ padding: "10px 9px", borderBottom: "1px solid var(--border, #292929)" }}>
+                <Badge tone={edge.edgeRatio > 0 ? "positive" : "warning"}>{edgeActionLabel(edge.action)}</Badge>
+              </td>
+              <td style={{ padding: "10px 9px", borderBottom: "1px solid var(--border, #292929)" }}>{row.confidenceBucket || "unknown"}</td>
+              <td style={{ padding: "10px 9px", borderBottom: "1px solid var(--border, #292929)", minWidth: 190 }}>
+                {edge.winWin ? (
+                  <>
+                    <strong>{fmt(edge.publicFriendlyOfferCeiling)}</strong>
+                    <div style={{ opacity: 0.7, marginTop: 2 }}>
+                      public {fmtPct(edge.publicWinRatio)} · internal {fmtPct(edge.internalWinRatio)}
+                    </div>
+                  </>
+                ) : (
+                  "—"
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function AssetList({ assets }) {
   if (!assets?.length) return <span className={styles.muted}>—</span>;
   return (
     <ul className={styles.assetList}>
@@ -73,9 +156,6 @@ function TradeCard({ trade, myTeam, opponent }) {
   const boardDelta = Number(trade.boardDelta || 0);
   const ktcDelta = Number(trade.ktcDelta || 0);
 
-  // A found trade was a dead end: the engine surfaced it, and then you
-  // retyped both sides into the calculator by hand.  The share encoder
-  // already round-trips exactly this shape, so the hand-off is a link.
   const openInCalculator = useMemo(() => {
     const give = (trade.give || []).map((a) => a.name).filter(Boolean);
     const receive = (trade.receive || []).map((a) => a.name).filter(Boolean);
@@ -88,16 +168,11 @@ function TradeCard({ trade, myTeam, opponent }) {
         ],
       });
     } catch {
-      // A trade we cannot encode simply loses the shortcut; the card
-      // itself still renders.
       return null;
     }
   }, [trade, myTeam, opponent]);
 
   return (
-    // ``arbitrage-trade-card`` is a stable E2E hook alongside the
-    // CSS-module class, the same convention the news rows use — module
-    // class names are hashed at build time and cannot be selected on.
     <Panel className={`${styles.tradeCard} arbitrage-trade-card`}>
       <div className={styles.tradeHead}>
         <span className={styles.score}>
@@ -112,12 +187,6 @@ function TradeCard({ trade, myTeam, opponent }) {
             their market {fmtSigned(ktcDelta)}
           </span>
         </span>
-        {/* The backend stamps ``mixedMarket`` itself rather than making
-            the client infer it. A mixed delta adds two publishers'
-            numbers; they are directly comparable (median cross-board
-            ratio 1.000) but disagree +/-10% at p10-p90, so a delta
-            smaller than that is not distinguishable from the boards
-            simply disagreeing. Surfacing it is the point. */}
         {trade.mixedMarket ? (
           <Badge tone="warning">
             spans {(trade.marketsUsed || []).map((m) => MARKET_LABEL[m] || m).join(" + ")}
@@ -127,11 +196,11 @@ function TradeCard({ trade, myTeam, opponent }) {
       <div className={styles.tradeBody}>
         <div className={styles.side}>
           <h4 className={styles.sideLabel}>You give</h4>
-          <AssetList assets={trade.give} tone="give" />
+          <AssetList assets={trade.give} />
         </div>
         <div className={styles.side}>
           <h4 className={styles.sideLabel}>You get</h4>
-          <AssetList assets={trade.receive} tone="receive" />
+          <AssetList assets={trade.receive} />
         </div>
       </div>
       {openInCalculator ? (
@@ -146,7 +215,7 @@ function TradeCard({ trade, myTeam, opponent }) {
 }
 
 export default function ArbitragePage() {
-  const { loading: dataLoading, error: dataError, rawData } = useDynastyData();
+  const { loading: dataLoading, error: dataError, rawData, rows } = useDynastyData();
   const { selectedLeagueKey, selectedOwnerId } = useTeam();
 
   const teams = useMemo(() => {
@@ -165,8 +234,34 @@ export default function ArbitragePage() {
   const [result, setResult] = useState(null);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState("");
+  const [edgeAction, setEdgeAction] = useState("buy");
+  const [edgeClass, setEdgeClass] = useState("all");
+  const [edgeFloor, setEdgeFloor] = useState(0.05);
 
   const effectiveTeam = myTeam || defaultTeam;
+
+  const playerEdges = useMemo(
+    () =>
+      buildArbitrageRows(rows, {
+        action: edgeAction,
+        assetClass: edgeClass,
+        minEdge: edgeFloor,
+      }),
+    [rows, edgeAction, edgeClass, edgeFloor],
+  );
+
+  const buyCount = useMemo(
+    () => buildArbitrageRows(rows, { action: "buy", minEdge: edgeFloor }).length,
+    [rows, edgeFloor],
+  );
+  const sellCount = useMemo(
+    () => buildArbitrageRows(rows, { action: "sell", minEdge: edgeFloor }).length,
+    [rows, edgeFloor],
+  );
+  const winWinCount = useMemo(
+    () => buildArbitrageRows(rows, { action: "winwin", minEdge: edgeFloor }).length,
+    [rows, edgeFloor],
+  );
 
   async function run() {
     if (!effectiveTeam) return;
@@ -182,8 +277,6 @@ export default function ArbitragePage() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         cache: "no-store",
-        // Our side of the arbitrage follows the selected board; the
-        // market anchor it is measured against never does.
         body: JSON.stringify(withValuationMode(body)),
       });
       const data = await res.json().catch(() => ({}));
@@ -207,13 +300,56 @@ export default function ArbitragePage() {
     <div className={styles.page}>
       <PageHeader
         eyebrow="Trades"
-        title="Arbitrage"
-        description="Trades that gain on our blended board while still reading as fair on the market your counterparty checks."
+        title="Market Arbitrage Finder"
+        description="Find players our canonical board values above or below the public market, then turn those edges into trades that can still look fair to the counterparty."
       />
 
       {dataError ? <Banner tone="negative">{String(dataError)}</Banner> : null}
 
       <Panel>
+        <h3 style={{ marginTop: 0 }}>Player-level inefficiencies</h3>
+        <p className={styles.muted}>
+          Offense is compared directly with KTC. IDP is compared directly with IDP Trade Calculator. Source disagreement is not required; that remains a separate Rankings research lens.
+        </p>
+        <div className={styles.controls}>
+          <Field label="Signal">
+            <Select value={edgeAction} onChange={(e) => setEdgeAction(e.target.value)}>
+              <option value="buy">Buy arbitrage</option>
+              <option value="sell">Sell arbitrage</option>
+              <option value="winwin">Win-win on public market</option>
+              <option value="all">All edges</option>
+            </Select>
+          </Field>
+          <Field label="Player type">
+            <Select value={edgeClass} onChange={(e) => setEdgeClass(e.target.value)}>
+              <option value="all">All players</option>
+              <option value="offense">Offense — KTC</option>
+              <option value="idp">IDP — IDP Trade Calculator</option>
+            </Select>
+          </Field>
+          <Field label="Minimum edge">
+            <Select value={String(edgeFloor)} onChange={(e) => setEdgeFloor(Number(e.target.value))}>
+              <option value="0.05">5%+</option>
+              <option value="0.10">10%+</option>
+              <option value="0.15">15%+</option>
+              <option value="0.20">20%+</option>
+            </Select>
+          </Field>
+        </div>
+        <div className={styles.stats}>
+          <StatTile label="Buy edges" value={fmt(buyCount)} />
+          <StatTile label="Sell edges" value={fmt(sellCount)} />
+          <StatTile label="Win-win offers" value={fmt(winWinCount)} />
+          <StatTile label="Visible" value={fmt(playerEdges.length)} />
+        </div>
+        {dataLoading ? <SkeletonTable rows={5} /> : <PlayerEdgeTable opportunities={playerEdges} />}
+      </Panel>
+
+      <Panel>
+        <h3 style={{ marginTop: 0 }}>Turn the edge into a trade</h3>
+        <p className={styles.muted}>
+          This second layer scans actual rosters for packages that gain on our board while remaining plausible on the counterparty market.
+        </p>
         <div className={styles.controls}>
           <Field label="Your team">
             <Select
@@ -245,16 +381,13 @@ export default function ArbitragePage() {
             </Select>
           </Field>
           <Button onClick={run} disabled={running || dataLoading || !effectiveTeam}>
-            {running ? "Scanning…" : "Find arbitrage"}
+            {running ? "Scanning…" : "Find trade packages"}
           </Button>
         </div>
       </Panel>
 
       {error ? <Banner tone="negative">{error}</Banner> : null}
 
-      {/* Backend warnings are rendered verbatim. The engine emits a real
-          one when an IDP league has no priced IDP assets, which is the
-          regression that made this engine silently offense-only. */}
       {result?.warnings?.map((w, i) => (
         <Banner key={i} tone="warning">
           {w}
@@ -267,9 +400,6 @@ export default function ArbitragePage() {
           <StatTile label="Shown" value={fmt(meta.returned)} />
           <StatTile label="Asset pool" value={fmt(meta.assetPoolSize)} />
           <StatTile label="Market coverage" value={`${meta.marketCoveragePercent ?? 0}%`} />
-          {/* Assets the board declines to price leave the engine's
-              universe entirely. Surfaced because "not shown" and
-              "not priced" are different states — 202 on a real payload. */}
           <StatTile label="Unpriced by board" value={fmt(meta.assetsUnpricedByBoard)} />
           <StatTile label="Mixed-market" value={fmt(meta.mixedMarketTrades)} />
         </div>
@@ -286,7 +416,7 @@ export default function ArbitragePage() {
 
       {!running && result && !result.trades?.length ? (
         <EmptyState
-          title="No arbitrage found"
+          title="No package arbitrage found"
           description="Every candidate either lost value on our board or looked too lopsided on the counterparty's market to be plausible."
         />
       ) : null}
@@ -301,8 +431,8 @@ export default function ArbitragePage() {
 
       {!result && !running ? (
         <EmptyState
-          title="Pick a team and scan"
-          description="Choose your team and a counterparty above, then run the scan to surface trades the market prices differently than our board does."
+          title="Package scan ready"
+          description="The player-level opportunities above are live immediately. Choose your team and a counterparty to search actual trade constructions."
         />
       ) : null}
     </div>

--- a/frontend/app/arbitrage/page.jsx
+++ b/frontend/app/arbitrage/page.jsx
@@ -179,12 +179,18 @@ function TradeCard({ trade, myTeam, opponent }) {
           arbitrage {Number(trade.arbitrageScore || 0).toFixed(2)}
         </span>
         <span className={styles.deltas}>
-          <span className={boardDelta >= 0 ? styles.good : styles.bad}>our board {fmtSigned(boardDelta)}</span>
+          <span className={boardDelta >= 0 ? styles.good : styles.bad}>
+            our board {fmtSigned(boardDelta)}
+          </span>
           <span className={styles.sep}>/</span>
-          <span className={ktcDelta >= 0 ? styles.good : styles.bad}>their market {fmtSigned(ktcDelta)}</span>
+          <span className={ktcDelta >= 0 ? styles.good : styles.bad}>
+            their market {fmtSigned(ktcDelta)}
+          </span>
         </span>
         {trade.mixedMarket ? (
-          <Badge tone="warning">spans {(trade.marketsUsed || []).map((m) => MARKET_LABEL[m] || m).join(" + ")}</Badge>
+          <Badge tone="warning">
+            spans {(trade.marketsUsed || []).map((m) => MARKET_LABEL[m] || m).join(" + ")}
+          </Badge>
         ) : null}
       </div>
       <div className={styles.tradeBody}>
@@ -235,19 +241,37 @@ export default function ArbitragePage() {
   const effectiveTeam = myTeam || defaultTeam;
 
   const playerEdges = useMemo(
-    () => buildArbitrageRows(rows, { action: edgeAction, assetClass: edgeClass, minEdge: edgeFloor }),
+    () =>
+      buildArbitrageRows(rows, {
+        action: edgeAction,
+        assetClass: edgeClass,
+        minEdge: edgeFloor,
+      }),
     [rows, edgeAction, edgeClass, edgeFloor],
   );
-  const buyCount = useMemo(() => buildArbitrageRows(rows, { action: "buy", minEdge: edgeFloor }).length, [rows, edgeFloor]);
-  const sellCount = useMemo(() => buildArbitrageRows(rows, { action: "sell", minEdge: edgeFloor }).length, [rows, edgeFloor]);
-  const winWinCount = useMemo(() => buildArbitrageRows(rows, { action: "winwin", minEdge: edgeFloor }).length, [rows, edgeFloor]);
+
+  const buyCount = useMemo(
+    () => buildArbitrageRows(rows, { action: "buy", minEdge: edgeFloor }).length,
+    [rows, edgeFloor],
+  );
+  const sellCount = useMemo(
+    () => buildArbitrageRows(rows, { action: "sell", minEdge: edgeFloor }).length,
+    [rows, edgeFloor],
+  );
+  const winWinCount = useMemo(
+    () => buildArbitrageRows(rows, { action: "winwin", minEdge: edgeFloor }).length,
+    [rows, edgeFloor],
+  );
 
   async function run() {
     if (!effectiveTeam) return;
     setRunning(true);
     setError("");
     try {
-      const body = { myTeam: effectiveTeam, opponentTeams: opponent === "all" ? ["all"] : [opponent] };
+      const body = {
+        myTeam: effectiveTeam,
+        opponentTeams: opponent === "all" ? ["all"] : [opponent],
+      };
       if (selectedLeagueKey) body.leagueKey = selectedLeagueKey;
       const res = await fetch("/api/trade/finder", {
         method: "POST",
@@ -277,40 +301,139 @@ export default function ArbitragePage() {
       <PageHeader
         eyebrow="Trades"
         title="Arbitrage"
-        description="Market Arbitrage Finder — find players our canonical board values above or below the public market, then turn those edges into trades that can still look fair to the counterparty."
+        description="Find players our canonical board values above or below the public market, then turn those edges into trades that can still look fair to the counterparty."
       />
 
       {dataError ? <Banner tone="negative">{String(dataError)}</Banner> : null}
 
       <Panel>
         <h3 style={{ marginTop: 0 }}>Player-level inefficiencies</h3>
-        <p className={styles.muted}>Offense is compared directly with KTC. IDP is compared directly with IDP Trade Calculator. Source disagreement is not required; that remains a separate Rankings research lens.</p>
+        <p className={styles.muted}>
+          Offense is compared directly with KTC. IDP is compared directly with IDP Trade Calculator. Source disagreement is not required; that remains a separate Rankings research lens.
+        </p>
         <div className={styles.controls}>
-          <Field label="Signal"><Select value={edgeAction} onChange={(e) => setEdgeAction(e.target.value)}><option value="buy">Buy arbitrage</option><option value="sell">Sell arbitrage</option><option value="winwin">Win-win on public market</option><option value="all">All edges</option></Select></Field>
-          <Field label="Player type"><Select value={edgeClass} onChange={(e) => setEdgeClass(e.target.value)}><option value="all">All players</option><option value="offense">Offense — KTC</option><option value="idp">IDP — IDP Trade Calculator</option></Select></Field>
-          <Field label="Minimum edge"><Select value={String(edgeFloor)} onChange={(e) => setEdgeFloor(Number(e.target.value))}><option value="0.05">5%+</option><option value="0.10">10%+</option><option value="0.15">15%+</option><option value="0.20">20%+</option></Select></Field>
+          <Field label="Signal">
+            <Select value={edgeAction} onChange={(e) => setEdgeAction(e.target.value)}>
+              <option value="buy">Buy arbitrage</option>
+              <option value="sell">Sell arbitrage</option>
+              <option value="winwin">Win-win on public market</option>
+              <option value="all">All edges</option>
+            </Select>
+          </Field>
+          <Field label="Player type">
+            <Select value={edgeClass} onChange={(e) => setEdgeClass(e.target.value)}>
+              <option value="all">All players</option>
+              <option value="offense">Offense — KTC</option>
+              <option value="idp">IDP — IDP Trade Calculator</option>
+            </Select>
+          </Field>
+          <Field label="Minimum edge">
+            <Select value={String(edgeFloor)} onChange={(e) => setEdgeFloor(Number(e.target.value))}>
+              <option value="0.05">5%+</option>
+              <option value="0.10">10%+</option>
+              <option value="0.15">15%+</option>
+              <option value="0.20">20%+</option>
+            </Select>
+          </Field>
         </div>
-        <div className={styles.stats}><StatTile label="Buy edges" value={fmt(buyCount)} /><StatTile label="Sell edges" value={fmt(sellCount)} /><StatTile label="Win-win offers" value={fmt(winWinCount)} /><StatTile label="Visible" value={fmt(playerEdges.length)} /></div>
+        <div className={styles.stats}>
+          <StatTile label="Buy edges" value={fmt(buyCount)} />
+          <StatTile label="Sell edges" value={fmt(sellCount)} />
+          <StatTile label="Win-win offers" value={fmt(winWinCount)} />
+          <StatTile label="Visible" value={fmt(playerEdges.length)} />
+        </div>
         {dataLoading ? <SkeletonTable rows={5} /> : <PlayerEdgeTable opportunities={playerEdges} />}
       </Panel>
 
       <Panel>
         <h3 style={{ marginTop: 0 }}>Turn the edge into a trade</h3>
-        <p className={styles.muted}>This second layer scans actual rosters for packages that gain on our board while remaining plausible on the counterparty market.</p>
+        <p className={styles.muted}>
+          This second layer scans actual rosters for packages that gain on our board while remaining plausible on the counterparty market.
+        </p>
         <div className={styles.controls}>
-          <Field label="Your team"><Select value={effectiveTeam} onChange={(e) => setMyTeam(e.target.value)} disabled={dataLoading || !teams.length}>{teams.map((t) => <option key={t.name} value={t.name}>{t.name}</option>)}</Select></Field>
-          <Field label="Opponent"><Select value={opponent} onChange={(e) => setOpponent(e.target.value)} disabled={dataLoading || !teams.length}><option value="all">All teams</option>{teams.filter((t) => t.name !== effectiveTeam).map((t) => <option key={t.name} value={t.name}>{t.name}</option>)}</Select></Field>
-          <Button onClick={run} disabled={running || !effectiveTeam}>{running ? "Scanning…" : "Find trade packages"}</Button>
+          <Field label="Your team">
+            <Select
+              value={effectiveTeam}
+              onChange={(e) => setMyTeam(e.target.value)}
+              disabled={dataLoading || !teams.length}
+            >
+              {teams.map((t) => (
+                <option key={t.name} value={t.name}>
+                  {t.name}
+                </option>
+              ))}
+            </Select>
+          </Field>
+          <Field label="Opponent">
+            <Select
+              value={opponent}
+              onChange={(e) => setOpponent(e.target.value)}
+              disabled={dataLoading || !teams.length}
+            >
+              <option value="all">All teams</option>
+              {teams
+                .filter((t) => t.name !== effectiveTeam)
+                .map((t) => (
+                  <option key={t.name} value={t.name}>
+                    {t.name}
+                  </option>
+                ))}
+            </Select>
+          </Field>
+          <Button onClick={run} disabled={running || dataLoading || !effectiveTeam}>
+            {running ? "Scanning…" : "Find trade packages"}
+          </Button>
         </div>
       </Panel>
 
       {error ? <Banner tone="negative">{error}</Banner> : null}
-      {result ? (
-        <Panel>
-          <h3 style={{ marginTop: 0 }}>Roster-to-roster packages</h3>
-          {meta ? <p className={styles.muted}>Scanned {fmt(meta.candidatesScanned ?? meta.scanned)} candidates{meta.market ? ` · ${meta.market}` : ""}</p> : null}
-          {(result.trades || result.results || []).length ? (result.trades || result.results || []).map((trade, i) => <TradeCard key={trade.id || i} trade={trade} myTeam={effectiveTeam} opponent={opponent} />) : <EmptyState title="No package edge found" description="The player-level table may still show opportunities even when no current roster package clears the finder constraints." />}
-        </Panel>
+
+      {result?.warnings?.map((w, i) => (
+        <Banner key={i} tone="warning">
+          {w}
+        </Banner>
+      ))}
+
+      {meta ? (
+        <div className={styles.stats}>
+          <StatTile label="Qualified" value={fmt(meta.totalQualified)} />
+          <StatTile label="Shown" value={fmt(meta.returned)} />
+          <StatTile label="Asset pool" value={fmt(meta.assetPoolSize)} />
+          <StatTile label="Market coverage" value={`${meta.marketCoveragePercent ?? 0}%`} />
+          <StatTile label="Unpriced by board" value={fmt(meta.assetsUnpricedByBoard)} />
+          <StatTile label="Mixed-market" value={fmt(meta.mixedMarketTrades)} />
+        </div>
+      ) : null}
+
+      {meta?.valueSource && meta.valueSource !== "rankDerivedValue" ? (
+        <Banner tone="warning">
+          This run valued assets off <code>{meta.valueSource}</code>, not the board you see. Results
+          are not comparable to the rankings page.
+        </Banner>
+      ) : null}
+
+      {running ? <SkeletonTable rows={4} /> : null}
+
+      {!running && result && !result.trades?.length ? (
+        <EmptyState
+          title="No package arbitrage found"
+          description="Every candidate either lost value on our board or looked too lopsided on the counterparty's market to be plausible."
+        />
+      ) : null}
+
+      {!running && result?.trades?.length ? (
+        <div className={styles.trades}>
+          {result.trades.map((t, i) => (
+            <TradeCard key={i} trade={t} myTeam={effectiveTeam} opponent={opponent} />
+          ))}
+        </div>
+      ) : null}
+
+      {!result && !running ? (
+        <EmptyState
+          title="Package scan ready"
+          description="The player-level opportunities above are live immediately. Choose your team and a counterparty to search actual trade constructions."
+        />
       ) : null}
     </div>
   );

--- a/frontend/app/arbitrage/page.jsx
+++ b/frontend/app/arbitrage/page.jsx
@@ -179,18 +179,12 @@ function TradeCard({ trade, myTeam, opponent }) {
           arbitrage {Number(trade.arbitrageScore || 0).toFixed(2)}
         </span>
         <span className={styles.deltas}>
-          <span className={boardDelta >= 0 ? styles.good : styles.bad}>
-            our board {fmtSigned(boardDelta)}
-          </span>
+          <span className={boardDelta >= 0 ? styles.good : styles.bad}>our board {fmtSigned(boardDelta)}</span>
           <span className={styles.sep}>/</span>
-          <span className={ktcDelta >= 0 ? styles.good : styles.bad}>
-            their market {fmtSigned(ktcDelta)}
-          </span>
+          <span className={ktcDelta >= 0 ? styles.good : styles.bad}>their market {fmtSigned(ktcDelta)}</span>
         </span>
         {trade.mixedMarket ? (
-          <Badge tone="warning">
-            spans {(trade.marketsUsed || []).map((m) => MARKET_LABEL[m] || m).join(" + ")}
-          </Badge>
+          <Badge tone="warning">spans {(trade.marketsUsed || []).map((m) => MARKET_LABEL[m] || m).join(" + ")}</Badge>
         ) : null}
       </div>
       <div className={styles.tradeBody}>
@@ -241,37 +235,19 @@ export default function ArbitragePage() {
   const effectiveTeam = myTeam || defaultTeam;
 
   const playerEdges = useMemo(
-    () =>
-      buildArbitrageRows(rows, {
-        action: edgeAction,
-        assetClass: edgeClass,
-        minEdge: edgeFloor,
-      }),
+    () => buildArbitrageRows(rows, { action: edgeAction, assetClass: edgeClass, minEdge: edgeFloor }),
     [rows, edgeAction, edgeClass, edgeFloor],
   );
-
-  const buyCount = useMemo(
-    () => buildArbitrageRows(rows, { action: "buy", minEdge: edgeFloor }).length,
-    [rows, edgeFloor],
-  );
-  const sellCount = useMemo(
-    () => buildArbitrageRows(rows, { action: "sell", minEdge: edgeFloor }).length,
-    [rows, edgeFloor],
-  );
-  const winWinCount = useMemo(
-    () => buildArbitrageRows(rows, { action: "winwin", minEdge: edgeFloor }).length,
-    [rows, edgeFloor],
-  );
+  const buyCount = useMemo(() => buildArbitrageRows(rows, { action: "buy", minEdge: edgeFloor }).length, [rows, edgeFloor]);
+  const sellCount = useMemo(() => buildArbitrageRows(rows, { action: "sell", minEdge: edgeFloor }).length, [rows, edgeFloor]);
+  const winWinCount = useMemo(() => buildArbitrageRows(rows, { action: "winwin", minEdge: edgeFloor }).length, [rows, edgeFloor]);
 
   async function run() {
     if (!effectiveTeam) return;
     setRunning(true);
     setError("");
     try {
-      const body = {
-        myTeam: effectiveTeam,
-        opponentTeams: opponent === "all" ? ["all"] : [opponent],
-      };
+      const body = { myTeam: effectiveTeam, opponentTeams: opponent === "all" ? ["all"] : [opponent] };
       if (selectedLeagueKey) body.leagueKey = selectedLeagueKey;
       const res = await fetch("/api/trade/finder", {
         method: "POST",
@@ -300,140 +276,41 @@ export default function ArbitragePage() {
     <div className={styles.page}>
       <PageHeader
         eyebrow="Trades"
-        title="Market Arbitrage Finder"
-        description="Find players our canonical board values above or below the public market, then turn those edges into trades that can still look fair to the counterparty."
+        title="Arbitrage"
+        description="Market Arbitrage Finder — find players our canonical board values above or below the public market, then turn those edges into trades that can still look fair to the counterparty."
       />
 
       {dataError ? <Banner tone="negative">{String(dataError)}</Banner> : null}
 
       <Panel>
         <h3 style={{ marginTop: 0 }}>Player-level inefficiencies</h3>
-        <p className={styles.muted}>
-          Offense is compared directly with KTC. IDP is compared directly with IDP Trade Calculator. Source disagreement is not required; that remains a separate Rankings research lens.
-        </p>
+        <p className={styles.muted}>Offense is compared directly with KTC. IDP is compared directly with IDP Trade Calculator. Source disagreement is not required; that remains a separate Rankings research lens.</p>
         <div className={styles.controls}>
-          <Field label="Signal">
-            <Select value={edgeAction} onChange={(e) => setEdgeAction(e.target.value)}>
-              <option value="buy">Buy arbitrage</option>
-              <option value="sell">Sell arbitrage</option>
-              <option value="winwin">Win-win on public market</option>
-              <option value="all">All edges</option>
-            </Select>
-          </Field>
-          <Field label="Player type">
-            <Select value={edgeClass} onChange={(e) => setEdgeClass(e.target.value)}>
-              <option value="all">All players</option>
-              <option value="offense">Offense — KTC</option>
-              <option value="idp">IDP — IDP Trade Calculator</option>
-            </Select>
-          </Field>
-          <Field label="Minimum edge">
-            <Select value={String(edgeFloor)} onChange={(e) => setEdgeFloor(Number(e.target.value))}>
-              <option value="0.05">5%+</option>
-              <option value="0.10">10%+</option>
-              <option value="0.15">15%+</option>
-              <option value="0.20">20%+</option>
-            </Select>
-          </Field>
+          <Field label="Signal"><Select value={edgeAction} onChange={(e) => setEdgeAction(e.target.value)}><option value="buy">Buy arbitrage</option><option value="sell">Sell arbitrage</option><option value="winwin">Win-win on public market</option><option value="all">All edges</option></Select></Field>
+          <Field label="Player type"><Select value={edgeClass} onChange={(e) => setEdgeClass(e.target.value)}><option value="all">All players</option><option value="offense">Offense — KTC</option><option value="idp">IDP — IDP Trade Calculator</option></Select></Field>
+          <Field label="Minimum edge"><Select value={String(edgeFloor)} onChange={(e) => setEdgeFloor(Number(e.target.value))}><option value="0.05">5%+</option><option value="0.10">10%+</option><option value="0.15">15%+</option><option value="0.20">20%+</option></Select></Field>
         </div>
-        <div className={styles.stats}>
-          <StatTile label="Buy edges" value={fmt(buyCount)} />
-          <StatTile label="Sell edges" value={fmt(sellCount)} />
-          <StatTile label="Win-win offers" value={fmt(winWinCount)} />
-          <StatTile label="Visible" value={fmt(playerEdges.length)} />
-        </div>
+        <div className={styles.stats}><StatTile label="Buy edges" value={fmt(buyCount)} /><StatTile label="Sell edges" value={fmt(sellCount)} /><StatTile label="Win-win offers" value={fmt(winWinCount)} /><StatTile label="Visible" value={fmt(playerEdges.length)} /></div>
         {dataLoading ? <SkeletonTable rows={5} /> : <PlayerEdgeTable opportunities={playerEdges} />}
       </Panel>
 
       <Panel>
         <h3 style={{ marginTop: 0 }}>Turn the edge into a trade</h3>
-        <p className={styles.muted}>
-          This second layer scans actual rosters for packages that gain on our board while remaining plausible on the counterparty market.
-        </p>
+        <p className={styles.muted}>This second layer scans actual rosters for packages that gain on our board while remaining plausible on the counterparty market.</p>
         <div className={styles.controls}>
-          <Field label="Your team">
-            <Select
-              value={effectiveTeam}
-              onChange={(e) => setMyTeam(e.target.value)}
-              disabled={dataLoading || !teams.length}
-            >
-              {teams.map((t) => (
-                <option key={t.name} value={t.name}>
-                  {t.name}
-                </option>
-              ))}
-            </Select>
-          </Field>
-          <Field label="Opponent">
-            <Select
-              value={opponent}
-              onChange={(e) => setOpponent(e.target.value)}
-              disabled={dataLoading || !teams.length}
-            >
-              <option value="all">All teams</option>
-              {teams
-                .filter((t) => t.name !== effectiveTeam)
-                .map((t) => (
-                  <option key={t.name} value={t.name}>
-                    {t.name}
-                  </option>
-                ))}
-            </Select>
-          </Field>
-          <Button onClick={run} disabled={running || dataLoading || !effectiveTeam}>
-            {running ? "Scanning…" : "Find trade packages"}
-          </Button>
+          <Field label="Your team"><Select value={effectiveTeam} onChange={(e) => setMyTeam(e.target.value)} disabled={dataLoading || !teams.length}>{teams.map((t) => <option key={t.name} value={t.name}>{t.name}</option>)}</Select></Field>
+          <Field label="Opponent"><Select value={opponent} onChange={(e) => setOpponent(e.target.value)} disabled={dataLoading || !teams.length}><option value="all">All teams</option>{teams.filter((t) => t.name !== effectiveTeam).map((t) => <option key={t.name} value={t.name}>{t.name}</option>)}</Select></Field>
+          <Button onClick={run} disabled={running || !effectiveTeam}>{running ? "Scanning…" : "Find trade packages"}</Button>
         </div>
       </Panel>
 
       {error ? <Banner tone="negative">{error}</Banner> : null}
-
-      {result?.warnings?.map((w, i) => (
-        <Banner key={i} tone="warning">
-          {w}
-        </Banner>
-      ))}
-
-      {meta ? (
-        <div className={styles.stats}>
-          <StatTile label="Qualified" value={fmt(meta.totalQualified)} />
-          <StatTile label="Shown" value={fmt(meta.returned)} />
-          <StatTile label="Asset pool" value={fmt(meta.assetPoolSize)} />
-          <StatTile label="Market coverage" value={`${meta.marketCoveragePercent ?? 0}%`} />
-          <StatTile label="Unpriced by board" value={fmt(meta.assetsUnpricedByBoard)} />
-          <StatTile label="Mixed-market" value={fmt(meta.mixedMarketTrades)} />
-        </div>
-      ) : null}
-
-      {meta?.valueSource && meta.valueSource !== "rankDerivedValue" ? (
-        <Banner tone="warning">
-          This run valued assets off <code>{meta.valueSource}</code>, not the board you see. Results
-          are not comparable to the rankings page.
-        </Banner>
-      ) : null}
-
-      {running ? <SkeletonTable rows={4} /> : null}
-
-      {!running && result && !result.trades?.length ? (
-        <EmptyState
-          title="No package arbitrage found"
-          description="Every candidate either lost value on our board or looked too lopsided on the counterparty's market to be plausible."
-        />
-      ) : null}
-
-      {!running && result?.trades?.length ? (
-        <div className={styles.trades}>
-          {result.trades.map((t, i) => (
-            <TradeCard key={i} trade={t} myTeam={effectiveTeam} opponent={opponent} />
-          ))}
-        </div>
-      ) : null}
-
-      {!result && !running ? (
-        <EmptyState
-          title="Package scan ready"
-          description="The player-level opportunities above are live immediately. Choose your team and a counterparty to search actual trade constructions."
-        />
+      {result ? (
+        <Panel>
+          <h3 style={{ marginTop: 0 }}>Roster-to-roster packages</h3>
+          {meta ? <p className={styles.muted}>Scanned {fmt(meta.candidatesScanned ?? meta.scanned)} candidates{meta.market ? ` · ${meta.market}` : ""}</p> : null}
+          {(result.trades || result.results || []).length ? (result.trades || result.results || []).map((trade, i) => <TradeCard key={trade.id || i} trade={trade} myTeam={effectiveTeam} opponent={opponent} />) : <EmptyState title="No package edge found" description="The player-level table may still show opportunities even when no current roster package clears the finder constraints." />}
+        </Panel>
       ) : null}
     </div>
   );

--- a/frontend/lib/market-arbitrage.js
+++ b/frontend/lib/market-arbitrage.js
@@ -1,0 +1,120 @@
+// Canonical market-arbitrage helpers.
+//
+// This module answers a different question from source disagreement:
+// "How far is OUR canonical value from the public transaction market a trade
+// partner is likely to consult?"
+//
+// Offense -> KeepTradeCut SF/TEP (ktcSfTep)
+// IDP     -> IDP Trade Calculator (idpTradeCalc)
+//
+// No ranking or valuation math is recreated here. `ourValue` is read from the
+// backend-authored canonical board value already materialized on the row, and
+// public values are read from backend-authored canonicalSiteValues. Missing
+// public values remain missing; they are never coerced to zero.
+
+export const ARBITRAGE_MIN_EDGE = 0.05;
+export const ARBITRAGE_STRONG_EDGE = 0.15;
+export const ARBITRAGE_INTERNAL_MARGIN = 0.10;
+export const ARBITRAGE_PUBLIC_FRIENDLY_PREMIUM = 0.05;
+
+const PUBLIC_MARKETS = {
+  offense: { key: "ktcSfTep", label: "KTC" },
+  idp: { key: "idpTradeCalc", label: "IDP Trade Calculator" },
+};
+
+function finitePositive(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+export function publicMarketFor(row) {
+  return PUBLIC_MARKETS[row?.assetClass] || null;
+}
+
+export function canonicalValueOf(row) {
+  return finitePositive(row?.values?.full ?? row?.rankDerivedValue);
+}
+
+export function publicMarketValueOf(row) {
+  const market = publicMarketFor(row);
+  if (!market) return null;
+  const sites = row?.canonicalSites;
+  if (!sites || typeof sites !== "object") return null;
+  return finitePositive(sites[market.key]);
+}
+
+export function arbitrageDescriptor(row) {
+  if (!row || row.quarantined) return null;
+  const market = publicMarketFor(row);
+  if (!market) return null;
+
+  const ourValue = canonicalValueOf(row);
+  const marketValue = publicMarketValueOf(row);
+  if (ourValue === null || marketValue === null) return null;
+
+  const edgePoints = ourValue - marketValue;
+  const edgeRatio = edgePoints / marketValue;
+  const magnitude = Math.abs(edgeRatio);
+
+  let action = "hold";
+  if (edgeRatio >= ARBITRAGE_STRONG_EDGE) action = "strong_buy";
+  else if (edgeRatio >= ARBITRAGE_MIN_EDGE) action = "buy";
+  else if (edgeRatio <= -ARBITRAGE_STRONG_EDGE) action = "strong_sell";
+  else if (edgeRatio <= -ARBITRAGE_MIN_EDGE) action = "sell";
+
+  // A trade-partner-friendly budget: pay 5% above the public market while
+  // retaining at least a 10% internal edge.  If our edge is not wide enough to
+  // satisfy both conditions, this is null rather than pretending there is a
+  // win-win construction.
+  const publicFriendlyTarget = marketValue * (1 + ARBITRAGE_PUBLIC_FRIENDLY_PREMIUM);
+  const internalEdgeCeiling = ourValue / (1 + ARBITRAGE_INTERNAL_MARGIN);
+  const publicFriendlyOfferCeiling = Math.floor(
+    Math.min(publicFriendlyTarget, internalEdgeCeiling),
+  );
+  const publicWinRatio = publicFriendlyOfferCeiling / marketValue - 1;
+  const internalWinRatio = ourValue / publicFriendlyOfferCeiling - 1;
+  const winWin =
+    edgeRatio > 0 &&
+    publicWinRatio >= 0.03 &&
+    internalWinRatio >= ARBITRAGE_INTERNAL_MARGIN;
+
+  return {
+    action,
+    marketKey: market.key,
+    marketLabel: market.label,
+    ourValue,
+    marketValue,
+    edgePoints,
+    edgeRatio,
+    magnitude,
+    winWin,
+    publicFriendlyOfferCeiling: winWin ? publicFriendlyOfferCeiling : null,
+    publicWinRatio: winWin ? publicWinRatio : null,
+    internalWinRatio: winWin ? internalWinRatio : null,
+  };
+}
+
+export function buildArbitrageRows(rows, {
+  action = "all",
+  assetClass = "all",
+  minEdge = ARBITRAGE_MIN_EDGE,
+  search = "",
+} = {}) {
+  const needle = String(search || "").trim().toLowerCase();
+  return (rows || [])
+    .map((row) => ({ row, edge: arbitrageDescriptor(row) }))
+    .filter(({ row, edge }) => {
+      if (!edge) return false;
+      if (edge.magnitude < minEdge) return false;
+      if (assetClass !== "all" && row.assetClass !== assetClass) return false;
+      if (action === "buy" && !["buy", "strong_buy"].includes(edge.action)) return false;
+      if (action === "sell" && !["sell", "strong_sell"].includes(edge.action)) return false;
+      if (action === "winwin" && !edge.winWin) return false;
+      if (needle && !String(row.name || "").toLowerCase().includes(needle)) return false;
+      return true;
+    })
+    .sort((a, b) => {
+      if (b.edge.magnitude !== a.edge.magnitude) return b.edge.magnitude - a.edge.magnitude;
+      return (a.row.rank ?? Infinity) - (b.row.rank ?? Infinity);
+    });
+}


### PR DESCRIPTION
## What this changes

Adds the missing player-level market-arbitrage layer to the existing `/arbitrage` surface.

The old Rankings `Inefficiencies` lens is source-disagreement driven. That remains useful research, but it is not the user's trading question.

This PR adds a direct comparison of the canonical board against the public transaction anchor a trade partner is likely to check:

- offense -> KeepTradeCut SF/TEP (`ktcSfTep`)
- IDP -> IDP Trade Calculator (`idpTradeCalc`)

It then keeps the existing roster/package scan underneath, so the workflow becomes:

1. find individual BUY/SELL edges;
2. identify win-win public-market offer ceilings;
3. turn the edge into an actual roster-to-roster package.

## Truth / architecture boundaries

- Does **not** recompute player values.
- `ourValue` comes from backend-authored canonical board value.
- Public market values come from backend-authored `canonicalSiteValues`.
- Missing public prices remain missing and are excluded, never coerced to zero.
- Source disagreement is not required for arbitrage.
- No source weights, bridges, Hill calibration, clamps, or valuation methodology changed.
- No V1 ledger edit.

## Signals

- >= 5% canonical-over-public: BUY
- >= 15%: STRONG BUY
- <= -5%: SELL
- <= -15%: STRONG SELL
- Win-win offer: counterparty sees at least ~3% public-market overpay while our internal valuation still retains >=10% edge; target public premium is 5%.

## Tests

Adds focused tests for:

- offense routes to KTC;
- IDP routes to IDP Trade Calculator;
- canonical-vs-public edge calculation;
- source disagreement is *not* required;
- missing public price cannot become zero;
- IDP cannot accidentally route through KTC;
- win-win offer ceiling math;
- sorting by actionable percentage edge rather than source-rank spread.

## Integration traffic control

There is an active production stop unrelated to this PR (#1069 plus the deterministic playerctx retention-test deploy blocker). This PR should run exact-head CI but **must not merge ahead of production recovery**.