### PR TITLE
fix: stabilize playerctx retention freshness test

### DIFF
--- a/tests/retention/conftest.py
+++ b/tests/retention/conftest.py
@@ -1,0 +1,23 @@
+"""Retention-test fixtures that keep wall-clock semantics deterministic.
+
+The production retention owner intentionally ages dated filenames.  One legacy
+probe test uses a fixed 2026-08-10 playerctx filename only to prove that the
+stream is discovered and counted.  Freeze that single test near its fixture
+date so calendar time cannot silently turn a discovery test into a stale-data
+test.  Dedicated freshness tests continue to exercise the real clock semantics.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.retention import health
+
+
+@pytest.fixture(autouse=True)
+def _freeze_legacy_playerctx_probe_clock(request, monkeypatch):
+    if request.node.name != "test_playerctx_snapshots_are_probed":
+        return
+
+    frozen = datetime(2026, 8, 10, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(health, "_now", lambda: frozen)

--- a/tests/retention/test_playerctx_clock_regression.py
+++ b/tests/retention/test_playerctx_clock_regression.py
@@ -1,0 +1,48 @@
+"""Regression coverage for filename-dated playerctx freshness.
+
+A discovery test used a fixed 2026-08-10 filename and eventually aged stale on
+the real calendar.  These tests pin the clock explicitly so they prove both
+sides of the real retention contract without depending on today's date.
+"""
+
+from datetime import datetime, timezone
+
+from src.retention import health
+
+
+def _playerctx_stream(report):
+    return next(stream for stream in report["streams"] if stream["id"] == "C1-RET-08")
+
+
+def _write_snapshot(data_dir):
+    hist = data_dir / "playerctx" / "history"
+    hist.mkdir(parents=True)
+    (hist / "playerctx_2026-08-10.json").write_text("{}", encoding="utf-8")
+
+
+def test_playerctx_fixed_filename_is_ok_inside_real_budget(data_dir, monkeypatch):
+    _write_snapshot(data_dir)
+    monkeypatch.setattr(
+        health,
+        "_now",
+        lambda: datetime(2026, 8, 10, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+    stream = _playerctx_stream(health.retention_health(data_dir=data_dir))
+
+    assert stream["state"] == health.STATE_OK
+    assert stream["stampSource"] == "filename"
+
+
+def test_playerctx_fixed_filename_ages_out_past_real_budget(data_dir, monkeypatch):
+    _write_snapshot(data_dir)
+    monkeypatch.setattr(
+        health,
+        "_now",
+        lambda: datetime(2026, 8, 20, 0, 0, 0, tzinfo=timezone.utc),
+    )
+
+    stream = _playerctx_stream(health.retention_health(data_dir=data_dir))
+
+    assert stream["state"] == health.STATE_STALE
+    assert stream["ageHours"] > stream["budgetHours"]

--- a/tests/retention/test_playerctx_clock_regression.py
+++ b/tests/retention/test_playerctx_clock_regression.py
@@ -1,7 +1,7 @@
 """Regression coverage for filename-dated playerctx freshness.
 
 A discovery test used a fixed 2026-08-10 filename and eventually aged stale on
-the real calendar.  These tests pin the clock explicitly so they prove both
+the real calendar. These tests pin the clock explicitly so they prove both
 sides of the real retention contract without depending on today's date.
 """
 
@@ -14,14 +14,16 @@ def _playerctx_stream(report):
     return next(stream for stream in report["streams"] if stream["id"] == "C1-RET-08")
 
 
-def _write_snapshot(data_dir):
+def _write_snapshot(tmp_path):
+    data_dir = tmp_path / "data"
     hist = data_dir / "playerctx" / "history"
     hist.mkdir(parents=True)
     (hist / "playerctx_2026-08-10.json").write_text("{}", encoding="utf-8")
+    return data_dir
 
 
-def test_playerctx_fixed_filename_is_ok_inside_real_budget(data_dir, monkeypatch):
-    _write_snapshot(data_dir)
+def test_playerctx_fixed_filename_is_ok_inside_real_budget(tmp_path, monkeypatch):
+    data_dir = _write_snapshot(tmp_path)
     monkeypatch.setattr(
         health,
         "_now",
@@ -34,8 +36,8 @@ def test_playerctx_fixed_filename_is_ok_inside_real_budget(data_dir, monkeypatch
     assert stream["stampSource"] == "filename"
 
 
-def test_playerctx_fixed_filename_ages_out_past_real_budget(data_dir, monkeypatch):
-    _write_snapshot(data_dir)
+def test_playerctx_fixed_filename_ages_out_past_real_budget(tmp_path, monkeypatch):
+    data_dir = _write_snapshot(tmp_path)
     monkeypatch.setattr(
         health,
         "_now",


### PR DESCRIPTION
Superseded by #1072, which implements the cleaner direct fix in the original test and has merged successfully as `9568907b410978f23f98f001df4e2b077d5a8d08`.

#1074's controlled-clock approach is no longer needed. Closing unmerged to avoid duplicate repair paths.