### PR TITLE
V1-89: make DraftSharks content-age observable and prove ROS auth

### DIFF
--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -61,6 +61,9 @@ from src.utils.name_clean import is_first_name_variant  # noqa: E402
 from src.utils.name_clean import resolve_idp_position as _resolve_idp_position  # noqa: E402
 from src.utils.age import age_from_birthdate as _age_from_birthdate  # noqa: E402
 from src.utils.owner_names import owner_label as _owner_label  # noqa: E402
+from src.sources.site_raw_mirror import (  # noqa: E402
+    mirror_site_raw_csvs as _mirror_site_raw_csvs,
+)
 
 # ── C1-ID-01: the name-matching primitives this file defined are now
 # owned by the canonical identity package and imported back, so this
@@ -663,6 +666,7 @@ _KTC_SITE_RAW_FLOOR: int = 400
 #: the display-only one is what created the gap.
 _KTC_TEP_SITE_RAW_FLOOR: int = 400
 _IDPTC_SITE_RAW_FLOOR: int = 700
+
 DLF_IMPORT_DEBUG = {}
 
 # KTC blocker diagnosis — set by scrape_ktc on failure for source reporting
@@ -6734,6 +6738,28 @@ async def run(progress_callback=None):
                 except Exception:
                     pass
 
+        # Mirror raw vendor CSVs that a standalone fetcher owns into the
+        # bundle, so the archive — and with it the existing content-age
+        # detector in ``scripts/check_source_health`` — can observe them
+        # at all.  Policy, the file list and the absent-is-absent rule
+        # all live in ``src/sources/site_raw_mirror``; this is the one
+        # call site.
+        try:
+            _mirror_outcomes = _mirror_site_raw_csvs(
+                repo_root=SCRIPT_DIR,
+                site_raw_dir=site_raw_dir,
+                produced_this_run=_fresh_site_raw,
+            )
+        except Exception as _mirror_exc:
+            print(f"  [site_raw] mirror pass failed: {_mirror_exc}", flush=True)
+            _mirror_outcomes = {}
+        _mirrored_site_raw = {
+            name for name, outcome in _mirror_outcomes.items() if outcome == "mirrored"
+        }
+        for _name, _outcome in sorted(_mirror_outcomes.items()):
+            if _outcome != "mirrored":
+                print(f"  [site_raw] mirror {_name}: {_outcome}", flush=True)
+
         # Write manifest with per-source freshness metadata.
         manifest = {
             "generatedAt": datetime.datetime.now().isoformat(),
@@ -6742,6 +6768,7 @@ async def run(progress_callback=None):
             "siteRawCount": len(os.listdir(site_raw_dir)) if os.path.exists(site_raw_dir) else 0,
             "siteRawFresh": sorted(_fresh_site_raw),
             "siteRawPreserved": sorted(_preserved_site_raw),
+            "siteRawMirrored": sorted(_mirrored_site_raw),
         }
         with open(os.path.join(latest_dir, "manifest.json"), "w", encoding="utf-8") as f:
             json.dump(manifest, f, indent=2, ensure_ascii=False)

--- a/docs/lane4/V1_89_DRAFTSHARKS_DECISION_PACKET.md
+++ b/docs/lane4/V1_89_DRAFTSHARKS_DECISION_PACKET.md
@@ -1,0 +1,182 @@
+# V1-89 — DraftSharks acquisition: decision packet and repair record
+
+**Lane 4 (Market / FAAB / Sharp).  Owner decision OD-04: re-mint / accept /
+retire.  Measured 2026-08-25 against `main` `13456dd5`.**
+
+Claude 5 owns reconciliation, merge, deployment, L3 verification and ledger
+promotion.  Nothing here edits V1 status.
+
+---
+
+## 1. What the fetchers actually authenticate with
+
+Recorded because "credentials may be needed" is not an actionable statement
+and this question had been asked three times.
+
+| fetcher | mechanism |
+|---|---|
+| `scripts/fetch_draftsharks.py` (offense + IDP) | **username/password login that mints a session.**  Reads `DRAFTSHARKS_EMAIL` + `DRAFTSHARKS_PASSWORD` from the gitignored `.env`, drives headless Chromium through `/login`, requires an `_identity` cookie to be issued, and persists four auth cookies to `draftsharks_session.json` at mode 0600.  Cached cookies are tried first; a page returning without the league marker triggers an automatic re-mint. |
+| `scripts/fetch_draftsharks_ros.py` | **consumes that cookie jar only.**  No credentials, no login flow of its own. |
+
+Not a pre-minted cookie the operator pastes in, not an API token, not
+persisted browser state.  **No owner credential action is required, and none
+should be requested.**
+
+## 2. Measured state
+
+Feeds, at `origin/main` `13456dd5`:
+
+| feed | file | rows × cols | sha256[:16] | previous sha256[:16] | diff |
+|---|---|---|---|---|---|
+| `draftSharks` | `draftSharksSf.csv` | 441 × 13 | `cc4b31a8016b12ee` | `5cdbd0c763e4c70f` | 518 lines |
+| `draftSharksIdp` | `draftSharksIdp.csv` | 410 × 13 | `c45a01e7e51e3506` | `27647e9eef9a7336` | 382 lines |
+| `draftSharksRos` (SF) | `draftSharksRosSf.csv` | 250 × 7 | `7f38d30e295d314d` | `a18601030aca6428` | 368 lines |
+| `draftSharksRos` (IDP) | `draftSharksRosIdp.csv` | 425 × 7 | `e833b1e02fbea0be` | `0769d0a2239738b5` | 712 lines |
+
+Ages: fetch 2.7 h (stamps 23:05:49Z / 23:06:01Z), content last **changed**
+4.6 h, content **re-confirmed byte-identical against upstream** at the 2.7 h
+fetch.  All three pages expose an upstream publication marker —
+`<time datetime="2026-08-25T00:15:02Z">` — i.e. the vendor published 1.6 h
+ago, *after* our last fetch.  That is ordinary 2-hourly cadence lag, not
+staleness.
+
+Differences are substantive rather than cosmetic: rank reorderings (Jayden
+Daniels ↔ Lamar Jackson at 6/7) and projection movement (Drake Maye 1-year
+449 → 447).
+
+Consumption is real: in the built contract `draftSharks` carries **412**
+players and `draftSharksIdp` **245**, against declared floors of 190 / 85.
+
+## 3. OD-04 — **A. HEALTHY_CURRENT**
+
+Authenticated access works and content is demonstrably current.  **Accept.**
+Do not re-mint.  Do not retire.
+
+## 4. Why L3 was still blocked, and what this PR repairs
+
+Two gaps, both engineering, neither an owner action.
+
+### 4a. DraftSharks content-age was structurally unobservable
+
+`scripts/check_source_health.measure_content_staleness` reads exactly one
+evidence lane — the tracked `exports/archive/*.zip` bundles — and those
+bundles are assembled from `Dynasty Scraper.py`'s own `FULL_DATA` maps.  Any
+source acquired by a standalone fetcher writes straight into `CSVs/site_raw/`
+and therefore **never entered an archive at all**.  The archive carried three
+`site_raw` members: `ktc`, `ktcSfTep`, `idpTradeCalc`.
+
+Control run before the repair: 8-day-stale DraftSharks CSVs substituted into
+the tree with fetch stamps left current produced a health verdict
+**byte-identical** to the healthy run (`22 fresh / content-stale: 1
+(idpTradeCalc)`).  A synthetic-archive control confirmed the detector's logic
+*does* discriminate (frozen 5 d vs moving 0 d) when it is given the bytes.
+The detector was never wrong; it was never given the bytes.
+
+**Repair.**  `src/sources/site_raw_mirror.py` owns the list of raw vendor CSVs
+that must reach the bundle and copies them verbatim into
+`exports/latest/site_raw/` during the existing export pass.  No second
+detector, no new health vocabulary, no second archive writer.  The manifest
+gains `siteRawMirrored`.
+
+Two properties recorded rather than hidden:
+
+* **Absent is absent.**  A missing source file is skipped, never written as an
+  empty placeholder — a placeholder would make a never-acquired source read as
+  perfectly byte-stable, which is the exact failure being removed.
+* **One-run lag.**  `scheduled-refresh.yml` runs the scraper *before* the
+  DraftSharks fetchers, so the bundle written by run N carries the CSVs
+  acquired by run N-1.  A constant offset does not distort a "how long has this
+  been byte-identical" measurement, and closing it would require a second
+  archive writer.
+
+### 4b. ROS could not prove it was looking at the league's board
+
+`fetch_draftsharks.py` proves each pass is league-scored by showing the
+WebAssembly worker rewrote values away from the static
+`data-scoring-value-*` public defaults, and fails closed otherwise.
+`fetch_draftsharks_ros.py` had no equivalent: it checked that a cookie *file*
+existed and published whatever came back.  An expired jar still renders a
+public board and still exits 0.
+
+**That proof cannot be copied mechanically.**  Measured 2026-08-25, the ROS
+pages carry **zero** `data-scoring-value` attributes, so there is no public
+default to diverge from; a look-alike predicate would be true of every page,
+authenticated or not.
+
+**Repair.**  `prove_ros_page_is_league_scoped` asserts the two strongest things
+the ROS pages actually expose, and requires **both**:
+
+1. the authenticated **league marker** is present in the rendered shell —
+   measured 0 occurrences on all three pages unauthenticated;
+2. the rendered **row count** meets a per-URL floor.
+
+Either alone is bypassable: a cached shell can carry the marker with no board
+behind it, and a full public board can carry no marker at all.  Failure raises
+`RosAuthError`, which aborts **before any CSV is written**, so both last-good
+files survive and `run_fetcher` leaves the freshness stamp where it was.
+
+Floors are `120` (SF) and `200` (IDP) — bracketed by measurement, not pinned to
+a snapshot: an unauthenticated fetch renders **25** rows, the authenticated
+boards carried **250** and **425**.  They must not be tightened toward today's
+counts; the vendor reshaped both boards between 2026-07-30 and 2026-08-25.
+
+A pre-existing silent-degradation bug was fixed alongside it, because the new
+gate would otherwise make it reachable: a failed SF fetch overwrote last-good
+with a header-only file, while the IDP branch already guarded against exactly
+that.
+
+## 5. Documentation corrections
+
+Both the ROS fetcher and the ROS adapter asserted that `/ros-rankings/idp` is a
+978-row 1QB mirror over a universe identical to the SF board, and that the
+name-first union therefore "contributes zero".  **Re-measured 2026-08-25 that
+is false in every part**: SF 250 rows, IDP 425 rows genuinely restricted to
+DB/DL/LB, 66 names in common, and the union contributes **358** players.
+
+The claim has now been wrong twice in opposite directions, so both docstrings
+were rewritten as rules that do not depend on a count: the two pages are
+separate acquisitions whose populations may differ at any time, each carries
+its own `total_ranked` so the scales union safely, and the size of the
+contribution is measured when it matters and never assumed.  The adapter's
+stale "PR 1 proxy / PR 2 swap" header was replaced with what the module does
+today.
+
+No weight, bridge, dedup, Hill, valuation, rank or IDP-translation change.
+
+## 6. L3 re-execution recipe for Claude 5
+
+Local repair is FEATURE_GREEN.  L3 needs the deployed box:
+
+1. deploy the exact merged SHA;
+2. confirm the production DraftSharks fetch succeeds (`run_fetcher` stamps
+   `draftSharks` / `draftSharksIdp` / `draftSharksRos` — stamps advance only on
+   exit 0);
+3. confirm the authenticated dynasty/IDP proof succeeded — the run passed
+   `_prove_pass_is_league_scored`, so a non-zero exit is the only alternative;
+4. confirm the independent ROS proof succeeded — a public or truncated board
+   now exits 2 with `auth_required:` / `implausible_population:` on stderr and
+   writes nothing;
+5. confirm all four DraftSharks files appear under `site_raw/` in the newest
+   `exports/archive/*.zip`, and in `manifest.json` under `siteRawMirrored`;
+6. confirm `measure_content_staleness()` now returns keys `draftSharksSf`,
+   `draftSharksIdp`, `draftSharksRosSf`, `draftSharksRosIdp`;
+7. confirm a currently-publishing DraftSharks does **not** false-alert
+   (`daysSinceChange` 0-1 while the vendor is live);
+8. confirm the stale-content control **does** alert — freeze the mirrored
+   bytes across archives beyond `contentStaleness.defaultDays` and require a
+   `Content unchanged` warning naming DraftSharks;
+9. confirm `idpTradeCalc`'s existing content-age reading is unchanged.
+
+Steps 5-6 are the ones that were structurally impossible before this PR.
+
+## 7. Known limits, stated
+
+* The mirror covers the four DraftSharks files only.  **19 other sources
+  acquired by standalone fetchers remain outside the content-age lane** — the
+  same class of blindness, out of scope here, and worth its own unit.
+* Whole-file content age masks a frozen sub-section: `idpTradeCalc.csv` reads
+  hours old whole-file while its pick rows have been frozen for 40 days.  The
+  detector already measures pick rows separately; nothing equivalent exists for
+  other sub-populations.
+* The ROS row floors are a plausibility gate, not a correctness proof.  A
+  vendor serving a full-size but wrong board would pass them.

--- a/scripts/fetch_draftsharks_ros.py
+++ b/scripts/fetch_draftsharks_ros.py
@@ -12,7 +12,9 @@ ROS proxy), this hits the actual ROS-specific pages:
 
 These pages render ~25 rows server-side and lazy-load the rest via
 JS scroll, so we need a real browser to capture the full ranked
-universe (~990 players on the SF page in late April 2026).
+universe (the SF page's size is vendor-controlled and has ranged from
+several hundred to ~1000 rows across 2026; see ``_ROS_ROW_FLOORS`` for
+why the floors are set well below whatever it currently is).
 
 Reuses the same ``draftsharks_session.json`` cookie store + login
 flow that ``fetch_draftsharks.py`` already established — no new
@@ -26,24 +28,39 @@ where the adapter ``src/ros/sources/draftsharks_ros.py`` reads them:
   * ``CSVs/site_raw/draftSharksRosIdp.csv`` (the ``/ros-rankings/idp``
                                              page verbatim)
 
-WHAT THE IDP FILE ACTUALLY IS (measured 2026-07-30, corrected here —
-this docstring previously claimed it was "IDP-only … filtered to IDP
-positions", which it has never been).  Both files carry 978 rows over
-the *identical* 978 players — zero names unique to either side — and
-the SF board already contains all 424 IDP-family rows by itself.  What
-differs is the FORMAT: 974 of 978 players sit at a different rank, and
-the deltas are positional (RB −171, QB +104, WR +109), i.e. the idp
-page is a 1QB board.  ``jahmyr gibbs`` is 1 there against ``josh
-allen``'s 17; on the SF board those are 2 and 1.
+WHAT THE IDP FILE ACTUALLY IS.  **The two pages are distinct boards
+with independent populations, and no code may assume otherwise.**
 
-It is therefore kept as forward-compat / pagination overflow, NOT as a
-second opinion.  The adapter unions it name-first behind the SF board
-so it contributes only players the SF page did not list (today: zero).
-Do not restore the ``_IDP_FAMILIES`` filter to the success branch to
-"make the file match its name": ``_write_csv`` renumbers ``rank`` 1..N
-and stamps ``total_ranked = N``, so a filtered file would arrive on a
-424-player scale for players already carried at 978, and every one of
-them would still be excluded by the union — a file nothing reads.
+This paragraph has now been wrong twice in opposite directions, which is
+the reason it is written as a rule rather than as a census.  It first
+claimed the file was "IDP-only … filtered to IDP positions"; a
+2026-07-30 audit replaced that with the opposite — two full boards over
+an *identical* 978-player universe, zero names unique to either side, so
+"the union contributes zero".  A 2026-08-25 re-measurement (V1-89)
+falsified that in turn: the vendor had reshaped both pages, the SF board
+was a few hundred rows rather than ~1000, the idp page was genuinely
+restricted to IDP families, and the union contributed several hundred
+players rather than none.
+
+So the durable statements, none of which depend on a count:
+
+* the SF page and the idp page are **separate acquisitions** whose
+  populations, position mixes and ranking formats may differ at any
+  time, and have differed in both directions;
+* ``_write_csv`` renumbers ``rank`` 1..N per file and stamps
+  ``total_ranked = N``, so each board carries its OWN scale.  That is
+  what makes unioning them safe without renormalising anything;
+* the adapter unions them name-first behind the SF board, so the idp
+  page contributes exactly the players the SF page did not list.  That
+  contribution may be zero, may be most of the file, and **must not be
+  assumed** either way;
+* nothing here may be re-derived from a remembered row count.  If a
+  decision needs the populations, measure them at the time.
+
+Do not restore an ``_IDP_FAMILIES`` filter to the success branch to
+"make the file match its name".  The file is what the vendor publishes
+at that URL; filtering it would renumber a subset onto a new scale and
+change what the union means.
 
 The CSV schema matches the ROS orchestrator's existing format
 (``canonicalName,sourceName,position,team,rank,total_ranked,projection``).
@@ -60,7 +77,18 @@ import os
 import sys
 from pathlib import Path
 
-from playwright.async_api import Page, async_playwright
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from playwright.async_api import Page
+
+# Playwright is imported INSIDE ``main_async`` rather than here, matching
+# ``scripts/fetch_draftsharks.py``.  A module-level import makes the file
+# unimportable wherever the browser stack is absent — which is the whole
+# blocking test tier — and the auth proof below is precisely the part
+# that must be exercised deterministically, without a browser or a
+# credentialed session.  ``Page`` is annotation-only and
+# ``from __future__ import annotations`` keeps those strings at runtime.
 
 
 REPO = Path(__file__).resolve().parents[1]
@@ -77,6 +105,93 @@ ROS_RAW_DIR = REPO / "CSVs" / "site_raw"
 
 ROS_SF_URL = "https://www.draftsharks.com/ros-rankings/superflex"
 ROS_IDP_URL = "https://www.draftsharks.com/ros-rankings/idp"
+
+#: The operator's DraftSharks league.  Its name is rendered into the
+#: rankings shell ONLY for an authenticated session with that league
+#: selected — measured 2026-08-25 against the live public pages: 0
+#: occurrences unauthenticated on ``/ros-rankings/superflex``,
+#: ``/ros-rankings/idp`` and the dynasty board.  Kept in step with
+#: ``scripts/fetch_draftsharks.LEAGUE_NAME`` by
+#: ``tests/scripts/test_draftsharks_ros_auth_proof.py``.
+LEAGUE_NAME = "Risk It To Get The Brisket"
+
+#: Minimum rendered rows per ROS page below which the acquisition is
+#: structurally implausible and the run fails closed.
+#:
+#: These are FLOORS, not expectations, and deliberately not today's
+#: counts.  Two measurements bracket them (2026-08-25): an
+#: unauthenticated fetch of either page renders **25** rows in the shell
+#: before lazy-load, while the authenticated boards carried **250** (SF)
+#: and **425** (IDP).  A floor has to sit far above the public shell and
+#: far below the live board so ordinary vendor churn never trips it —
+#: these sit ~5x above the public shell and roughly half of the observed
+#: board.
+#:
+#: Do NOT tighten these toward the live counts.  The vendor reshaped
+#: both boards between 2026-07-30 and 2026-08-25 (the SF page was 978
+#: rows then, 250 now), and a floor pinned to a snapshot converts an
+#: ordinary vendor change into a manufactured outage.
+_ROS_ROW_FLOORS: dict[str, int] = {
+    ROS_SF_URL: 120,
+    ROS_IDP_URL: 200,
+}
+
+
+class RosAuthError(RuntimeError):
+    """The ROS page could not be proven to be the authenticated league view.
+
+    Raised rather than returned so it cannot be mistaken for a per-page
+    soft failure: an unproven session is a whole-run condition, and the
+    caller must exit before any CSV is written so last-good is preserved.
+    """
+
+
+def prove_ros_page_is_league_scoped(
+    *,
+    url: str,
+    html: str,
+    rows: list[dict],
+    floor: int | None = None,
+) -> None:
+    """Fail closed unless this page is demonstrably the league's own view.
+
+    ``fetch_draftsharks.py`` proves its passes by showing that the
+    WebAssembly worker rewrote values away from the static
+    ``data-scoring-value-*`` public defaults.  That proof cannot be
+    copied here: the ROS pages carry **zero** ``data-scoring-value``
+    attributes (measured 2026-08-25), so there is no public default to
+    diverge from.  Inventing a look-alike would be a proof of nothing.
+
+    What IS available, and is used instead:
+
+    1. **the authenticated league marker** — the league's name appears in
+       the rendered shell only for a session with it selected.  Absent
+       marker is ``AUTH_REQUIRED``, never "the page was quiet";
+    2. **a row floor** — a public/expired session still renders a short
+       default board, so a plausible-looking page with an implausible
+       population is rejected too.
+
+    Both are required.  Either alone is bypassable: a cached shell can
+    carry the marker with no board behind it, and a full public board can
+    carry no marker at all.
+
+    Raises :class:`RosAuthError`; returns ``None`` on success.
+    """
+    if LEAGUE_NAME.casefold() not in (html or "").casefold():
+        raise RosAuthError(
+            f"auth_required: {url} rendered without the authenticated "
+            f"league marker — the session cookies are absent, expired, or "
+            f"scoped to no league.  Re-mint via scripts/fetch_draftsharks.py."
+        )
+    bar = _ROS_ROW_FLOORS.get(url, 0) if floor is None else floor
+    n = len(rows or [])
+    if n < bar:
+        raise RosAuthError(
+            f"implausible_population: {url} rendered {n} rows, below the "
+            f"floor of {bar}.  A truncated or default board must not be "
+            f"published as this league's rest-of-season view."
+        )
+
 
 _OFFENSE_FAMILIES: frozenset[str] = frozenset({"QB", "RB", "WR", "TE"})
 _IDP_FAMILIES: frozenset[str] = frozenset(
@@ -180,7 +295,12 @@ async def _fetch_page(page: Page, url: str) -> list[dict]:
     await page.goto(url, wait_until="networkidle", timeout=45000)
     await page.wait_for_timeout(2000)
     await _scroll_to_bottom(page)
-    return await _extract_rows(page)
+    rows = await _extract_rows(page)
+    # Proven AFTER the lazy-scroll settles: the row floor is a statement
+    # about the finished board, and asserting it mid-scroll would reject
+    # every healthy run.
+    prove_ros_page_is_league_scoped(url=url, html=await page.content(), rows=rows)
+    return rows
 
 
 def _classify_position(raw_pos: str) -> str:
@@ -223,17 +343,39 @@ async def main_async() -> int:
         )
         return 2
 
+    try:
+        from playwright.async_api import async_playwright
+    except ImportError:
+        print(
+            "[ds-ros] playwright not installed.  Run `pip install playwright "
+            "&& playwright install chromium`.",
+            file=sys.stderr,
+        )
+        return 2
+
     async with async_playwright() as pw:
         browser = await pw.chromium.launch(headless=True)
         ctx = await browser.new_context(user_agent=_USER_AGENT)
         await ctx.add_cookies(cookies)
         page = await ctx.new_page()
 
+        sf_rows: list[dict] = []
+        sf_page_failed = False
         try:
             sf_rows = await _fetch_page(page, ROS_SF_URL)
             print(f"[ds-ros] superflex page yielded {len(sf_rows)} unique rows")
+        except RosAuthError as exc:
+            # A session that cannot be proven is a whole-run condition,
+            # not a page hiccup: the IDP page is served by the same
+            # cookies and would fail the same way.  Abort BEFORE any
+            # write so both last-good CSVs survive, and exit non-zero so
+            # ``run_fetcher`` leaves the freshness stamp where it was.
+            await browser.close()
+            print(f"[ds-ros] ERROR: {exc}", file=sys.stderr)
+            return 2
         except Exception as exc:
             print(f"[ds-ros] superflex fetch failed: {exc}")
+            sf_page_failed = True
             sf_rows = []
 
         # The IDP-specific page mirrors SF for the IDP positions; we
@@ -245,6 +387,10 @@ async def main_async() -> int:
         try:
             idp_only_rows = await _fetch_page(page, ROS_IDP_URL)
             print(f"[ds-ros] idp page yielded {len(idp_only_rows)} unique rows")
+        except RosAuthError as exc:
+            await browser.close()
+            print(f"[ds-ros] ERROR: {exc}", file=sys.stderr)
+            return 2
         except Exception as exc:
             idp_page_failed = True
             print(f"[ds-ros] idp fetch failed: {exc}; preserving last-good if present")
@@ -258,9 +404,23 @@ async def main_async() -> int:
     sf_csv = ROS_RAW_DIR / "draftSharksRosSf.csv"
     idp_csv = ROS_RAW_DIR / "draftSharksRosIdp.csv"
 
-    # SF CSV gets every row from the SF page (offense + IDP combined,
-    # which is how DS publishes their ROS list).  Position is preserved.
-    n_sf = _write_csv(sf_csv, sf_rows)
+    # SF CSV gets every row from the SF page.  Same silent-degradation
+    # rule the IDP branch below already had, which this side lacked: a
+    # FAILED SF fetch must not overwrite last-good with a header-only
+    # file.  Reachable now that the auth proof can reject a page — and
+    # reachable before it, whenever the SF page failed while the IDP page
+    # succeeded.
+    sf_degraded = False
+    if sf_page_failed and sf_csv.exists():
+        print(
+            f"[ds-ros] ERROR: SF page fetch failed — preserving last-good "
+            f"{sf_csv.relative_to(REPO)} (NOT overwriting).",
+            file=sys.stderr,
+        )
+        sf_degraded = True
+        n_sf = -1
+    else:
+        n_sf = _write_csv(sf_csv, sf_rows)
 
     # IDP CSV — written verbatim from ``/ros-rankings/idp``, which is a
     # full 1QB board rather than an IDP subset (see the module
@@ -299,10 +459,11 @@ async def main_async() -> int:
             ]
         n_idp = _write_csv(idp_csv, idp_filtered)
 
-    print(f"[ds-ros] wrote {n_sf} rows → {sf_csv.relative_to(REPO)}")
+    if n_sf >= 0:
+        print(f"[ds-ros] wrote {n_sf} rows → {sf_csv.relative_to(REPO)}")
     if n_idp >= 0:
         print(f"[ds-ros] wrote {n_idp} rows → {idp_csv.relative_to(REPO)}")
-    return 1 if idp_degraded else 0
+    return 1 if (idp_degraded or sf_degraded) else 0
 
 
 def main() -> int:

--- a/src/ros/sources/draftsharks_ros.py
+++ b/src/ros/sources/draftsharks_ros.py
@@ -1,21 +1,22 @@
 """Draft Sharks ROS adapter.
 
-PR 1 strategy: read the existing dynasty Superflex + IDP CSVs that
-``scripts/fetch_draftsharks.py`` already maintains every 2h via the
-authenticated Playwright path.  Treat them as a ROS proxy with the
-spec-defined weight.  Zero new auth dependency, zero double-scraping.
+Reads the REAL rest-of-season boards that
+``scripts/fetch_draftsharks_ros.py`` acquires from
+``/ros-rankings/superflex`` and ``/ros-rankings/idp`` behind the
+authenticated Playwright session.  ``source_mode`` reports ``"ros"``
+when it served those.
 
-PR 2 swap: when DraftSharks' actual /rankings/rest-of-season page is
-verified accessible to our login, replace ``_load_existing_csvs`` with
-an actual scrape.  The adapter contract stays the same so the registry
-weight + aggregator behavior don't change.
+The dynasty Superflex + IDP CSVs remain a season-long PROXY fallback,
+used only when the real SF board is absent (fresh checkout, ROS page
+outage, an acquisition the fetcher refused).  ``source_mode`` reports
+``"dynasty_proxy"`` then, so "we served ROS" and "we served a
+stand-in" are distinguishable downstream rather than both reading as a
+DraftSharks ROS opinion.
 
-NOTE on weight: the spec calls Draft Sharks ROS the highest-confidence
-source (1.25).  Until PR 2's actual ROS scrape lands, the dynasty SF
-read is technically a season-long proxy — but DS's dynasty values
-already incorporate ROS context (their internal model blends them),
-so the 1.25 weight is still reasonable for PR 1.  Document the proxy
-status in run JSON so the source-health UI flags it.
+The staged "PR 1 proxy / PR 2 swap" plan this docstring used to
+describe is COMPLETE; the swap landed and ``_load_existing_csvs`` is
+gone.  Registry weight and aggregator behaviour are unchanged by that
+history and are not this module's business.
 """
 
 from __future__ import annotations
@@ -195,17 +196,33 @@ def scrape(src_meta: dict[str, Any]) -> ScrapeResult:
     proxy when the ROS fetcher hasn't run yet (fresh checkout, ROS
     page outage, etc.).
 
-    The two files are UNIONED name-first, not concatenated (audit
-    2026-07-30).  ``/ros-rankings/idp`` is not an IDP-only mirror
-    despite its name: measured on the live files it is a second FULL
-    board over the identical 978-player universe (0 names unique to
-    either side) in a different format — a 1QB board, where
-    ``jahmyr gibbs`` is 1 and ``josh allen`` is 17 against the SF
-    board's 1 and 2.  Concatenating handed DraftSharks 67.4% of the
-    blend instead of 50.8%, inflated ``sourceCount``/``confidence`` on
-    939 of 1084 players, and systematically suppressed QB/LB in a
-    superflex IDP league.  Nothing is lost by collapsing: the SF board
-    already carries all 424 IDP-family rows itself.
+    The two files are UNIONED name-first, not concatenated.
+
+    WHY the union (audit 2026-07-30, still valid): concatenating the two
+    boards handed DraftSharks 67.4% of the blend instead of 50.8%,
+    inflated ``sourceCount`` / ``confidence`` on 939 of 1084 players, and
+    systematically suppressed QB/LB in a superflex IDP league.  Any
+    player listed on both pages must count once.
+
+    WHAT THE UNION CONTRIBUTES IS NOT FIXED, and this docstring used to
+    say it was.  The 2026-07-30 measurement found the two pages covering
+    an identical universe, so the union added nothing, and that
+    observation was written down as though it were a property.  It is
+    not: re-measured 2026-08-25 (V1-89) the vendor had reshaped both
+    pages — the idp page was genuinely IDP-restricted, the SF board was
+    a few hundred rows, and the union added several hundred IDP players
+    the SF page did not list.
+
+    The invariants that hold regardless:
+
+    * each file carries its OWN ``total_ranked``, and ``rank_to_score``
+      normalises against that per row.  Two boards of different sizes
+      therefore union safely with no renormalisation;
+    * the SF board is primary — it is the one this source key claims to
+      be (``is_superflex``) — and the idp page can only ADD names, never
+      displace an SF rank;
+    * the overlap between the pages, and hence the size of the
+      contribution, is measured when it matters and never assumed.
     """
     started = datetime.now(timezone.utc).isoformat()
     key = str(src_meta.get("key") or "draftSharksRosSf")

--- a/src/sources/site_raw_mirror.py
+++ b/src/sources/site_raw_mirror.py
@@ -1,0 +1,101 @@
+"""Raw vendor CSVs that must reach the export bundle to be observable.
+
+WHY THIS EXISTS (V1-89 / OD-04, measured 2026-08-25).
+
+``scripts/check_source_health.measure_content_staleness`` answers "how
+long has this source's raw CSV been byte-identical", and it reads
+exactly one evidence lane: the tracked ``exports/archive/*.zip``
+bundles.  Those bundles are assembled by ``Dynasty Scraper.py`` from its
+own ``FULL_DATA`` maps, so ``exports/latest/site_raw/`` carried the
+three sources the legacy scraper produces and nothing else.
+
+Every source acquired by a standalone fetcher writes straight into
+``CSVs/site_raw/`` and therefore never entered an archive — so the
+detector could not evaluate it, at all, ever.  Measured consequence for
+DraftSharks: substituting 8-day-old CSVs while leaving the fetch stamps
+current produced a health verdict byte-identical to the healthy run.
+The detector was not wrong; it was never given the bytes.
+
+WHAT THIS IS NOT.  Not a second staleness detector, not a new health
+vocabulary, not a new writer.  It copies files into the bundle the
+existing export path already builds, so the existing detector can see
+them and report them with the words it already uses.
+
+WHAT IT PRESERVES.  Files are copied VERBATIM — 13-column vendor rows
+for the dynasty boards, 7-column rows for the ROS boards, not the
+``name,value`` shape ``FULL_DATA`` emits.  The detector hashes bytes and
+asks only whether one acquisition is comparable with itself across
+archives, so the vendor's own schema is the right thing to preserve.
+
+ABSENT IS ABSENT.  A missing source file is skipped, never written as an
+empty placeholder: a placeholder would make a never-acquired source look
+perfectly byte-stable, which is the exact failure this module exists to
+remove.
+
+ONE-RUN LAG, stated rather than hidden.  ``scheduled-refresh.yml`` runs
+the scraper BEFORE the standalone fetchers, so the bundle written by run
+N carries the CSVs acquired by run N-1.  A constant offset does not
+distort a "how long has this been byte-identical" measurement — content
+changing every run still reads 0 days, content frozen for a month still
+reads a month — and closing it would mean a second archive writer.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+#: Raw vendor CSVs that vote through ``_RANKING_SOURCES`` in
+#: ``src/api/data_contract.py`` but are acquired by a standalone fetcher
+#: rather than by ``Dynasty Scraper.py``, so the export bundle never saw
+#: them.  Held in step with the registry by
+#: ``tests/sources/test_site_raw_mirror.py``, which fails if a name here
+#: stops being a registered source path.
+MIRRORED_SITE_RAW_CSVS: tuple[str, ...] = (
+    "draftSharksSf.csv",
+    "draftSharksIdp.csv",
+    "draftSharksRosSf.csv",
+    "draftSharksRosIdp.csv",
+)
+
+
+def mirror_site_raw_csvs(
+    *,
+    repo_root: Path,
+    site_raw_dir: Path,
+    produced_this_run: set[str] | frozenset[str] = frozenset(),
+    names: tuple[str, ...] = MIRRORED_SITE_RAW_CSVS,
+) -> dict[str, str]:
+    """Copy the named ``CSVs/site_raw`` files into the export bundle.
+
+    Returns ``{filename: outcome}`` where outcome is one of
+    ``"mirrored"``, ``"missing_source"`` (the fetcher has never produced
+    it, or produced nothing this cycle and no last-good exists) or
+    ``"skipped_scraper_owns"``.
+
+    ``produced_this_run`` is the set of filenames the scraper itself
+    wrote from ``FULL_DATA`` this run.  A name in that set is never
+    overwritten: ``FULL_DATA`` stays the owner of everything it emits,
+    and a future name collision has to be a visible skip rather than a
+    silent replacement.
+    """
+    source_dir = Path(repo_root) / "CSVs" / "site_raw"
+    dest_dir = Path(site_raw_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    outcomes: dict[str, str] = {}
+    for name in names:
+        if name in produced_this_run:
+            outcomes[name] = "skipped_scraper_owns"
+            continue
+        src = source_dir / name
+        if not src.is_file():
+            outcomes[name] = "missing_source"
+            continue
+        try:
+            shutil.copy2(src, dest_dir / name)
+        except OSError:
+            outcomes[name] = "missing_source"
+            continue
+        outcomes[name] = "mirrored"
+    return outcomes

--- a/tests/scripts/test_draftsharks_ros_auth_proof.py
+++ b/tests/scripts/test_draftsharks_ros_auth_proof.py
@@ -1,0 +1,190 @@
+"""V1-89: the ROS fetcher must PROVE it is looking at the league's board.
+
+THE GAP.  ``scripts/fetch_draftsharks.py`` proves each pass is
+league-scored by showing the WebAssembly worker rewrote values away from
+the static ``data-scoring-value-*`` public defaults, and it fails closed
+when it cannot.  ``scripts/fetch_draftsharks_ros.py`` had no equivalent:
+it checked that a cookie FILE existed and published whatever came back.
+An expired jar still renders a public board and still exits 0 — which
+would stamp a fresh success over public data.
+
+WHY THE PROOF IS DIFFERENT HERE, and this is the part worth not
+"fixing" later: the ROS pages carry **zero** ``data-scoring-value``
+attributes (measured 2026-08-25 against the live public pages), so there
+is no public default to diverge from.  Copying the dynasty proof would
+produce a predicate that is true of every page, authenticated or not —
+a proof of nothing.  The two assertions used instead are the strongest
+ones the pages actually expose, and BOTH are required because either
+alone is bypassable: a cached shell can carry the league marker with no
+board behind it, and a full public board can carry no marker at all.
+
+The fixtures are synthetic and deliberately minimal.  What is measured
+from the live site is recorded in ``_ROS_ROW_FLOORS``: an unauthenticated
+fetch renders 25 rows and 0 league markers; the authenticated boards
+carried 250 (SF) and 425 (IDP).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from scripts import fetch_draftsharks as ds_dynasty
+from scripts import fetch_draftsharks_ros as ros
+
+
+def _rows(n: int) -> list[dict]:
+    return [{"name": f"Player {i}", "pos": "WR"} for i in range(n)]
+
+
+def _authenticated_shell(extra: str = "") -> str:
+    return (
+        "<html><body><header><span class='league-name'>"
+        f"{ros.LEAGUE_NAME}</span></header>"
+        f"<table id='rankings'>{extra}</table></body></html>"
+    )
+
+
+def _public_shell() -> str:
+    """What an expired/absent session renders: a real-looking board with
+    a sign-in prompt and no league selected."""
+    return (
+        "<html><body><header><a href='/login'>Sign in</a>"
+        "<span class='league-name'>Select a league</span></header>"
+        "<table id='rankings'><tbody data-player-row></tbody></table>"
+        "</body></html>"
+    )
+
+
+class TestTheProofIsNotVacuous(unittest.TestCase):
+    def test_the_league_marker_is_absent_from_the_public_shell(self) -> None:
+        """Guard on the guard: if the fixture happened to contain the
+        marker, every assertion below would pass by checking nothing."""
+        self.assertNotIn(ros.LEAGUE_NAME.casefold(), _public_shell().casefold())
+
+    def test_the_floors_sit_above_a_public_board_and_below_a_live_one(self) -> None:
+        for url, floor in ros._ROS_ROW_FLOORS.items():
+            with self.subTest(url=url):
+                # An unauthenticated page rendered 25 rows.
+                self.assertGreater(floor, 25)
+                # ...and the live boards were 250 / 425, so a floor must
+                # leave real headroom rather than pin today's count.
+                self.assertLess(floor, 250)
+
+    def test_the_league_name_matches_the_minting_fetcher(self) -> None:
+        """Two spellings of the league would let one fetcher prove
+        something the other cannot."""
+        self.assertEqual(ros.LEAGUE_NAME, ds_dynasty.LEAGUE_NAME)
+
+
+class TestMutationA_Authenticated(unittest.TestCase):
+    def test_marker_plus_adequate_rows_passes(self) -> None:
+        for url, floor in ros._ROS_ROW_FLOORS.items():
+            with self.subTest(url=url):
+                ros.prove_ros_page_is_league_scoped(
+                    url=url,
+                    html=_authenticated_shell(),
+                    rows=_rows(floor + 5),
+                )
+
+    def test_exactly_at_the_floor_passes(self) -> None:
+        """The floor is a minimum, not a strict bound — an off-by-one
+        here would reject a healthy board on a quiet week."""
+        url = ros.ROS_SF_URL
+        ros.prove_ros_page_is_league_scoped(
+            url=url, html=_authenticated_shell(), rows=_rows(ros._ROS_ROW_FLOORS[url])
+        )
+
+
+class TestMutationB_MarkerRemoved(unittest.TestCase):
+    def test_same_rows_without_the_league_marker_fails_closed(self) -> None:
+        url = ros.ROS_SF_URL
+        with self.assertRaises(ros.RosAuthError) as ctx:
+            ros.prove_ros_page_is_league_scoped(
+                url=url,
+                html="<html><body><table id='rankings'></table></body></html>",
+                rows=_rows(500),
+            )
+        self.assertIn("auth_required", str(ctx.exception))
+
+    def test_an_empty_page_is_auth_required_not_merely_quiet(self) -> None:
+        with self.assertRaises(ros.RosAuthError):
+            ros.prove_ros_page_is_league_scoped(url=ros.ROS_SF_URL, html="", rows=_rows(500))
+
+
+class TestMutationC_PublicDefaultPage(unittest.TestCase):
+    def test_a_valid_looking_cookie_jar_serving_a_public_page_fails(self) -> None:
+        """The whole point: the jar existing proves nothing about what
+        came back."""
+        for url in (ros.ROS_SF_URL, ros.ROS_IDP_URL):
+            with self.subTest(url=url):
+                with self.assertRaises(ros.RosAuthError) as ctx:
+                    ros.prove_ros_page_is_league_scoped(
+                        url=url, html=_public_shell(), rows=_rows(25)
+                    )
+                self.assertIn("auth_required", str(ctx.exception))
+
+
+class TestMutationD_TruncatedBoard(unittest.TestCase):
+    def test_marker_present_but_implausible_population_fails(self) -> None:
+        for url, floor in ros._ROS_ROW_FLOORS.items():
+            with self.subTest(url=url):
+                with self.assertRaises(ros.RosAuthError) as ctx:
+                    ros.prove_ros_page_is_league_scoped(
+                        url=url, html=_authenticated_shell(), rows=_rows(floor - 1)
+                    )
+                self.assertIn("implausible_population", str(ctx.exception))
+
+    def test_zero_rows_behind_a_valid_marker_fails(self) -> None:
+        with self.assertRaises(ros.RosAuthError):
+            ros.prove_ros_page_is_league_scoped(
+                url=ros.ROS_SF_URL, html=_authenticated_shell(), rows=[]
+            )
+
+    def test_an_unknown_url_has_no_floor_and_leans_on_the_marker(self) -> None:
+        """Explicit, so it is a decision rather than an accident: a URL
+        with no configured floor is still gated by the marker."""
+        ros.prove_ros_page_is_league_scoped(
+            url="https://www.draftsharks.com/ros-rankings/other",
+            html=_authenticated_shell(),
+            rows=_rows(1),
+        )
+        with self.assertRaises(ros.RosAuthError):
+            ros.prove_ros_page_is_league_scoped(
+                url="https://www.draftsharks.com/ros-rankings/other",
+                html=_public_shell(),
+                rows=_rows(1),
+            )
+
+
+class TestTheProofIsWiredIn(unittest.TestCase):
+    """A correct predicate nothing calls proves nothing."""
+
+    def test_the_page_fetch_calls_the_proof(self) -> None:
+        import inspect
+
+        src = inspect.getsource(ros._fetch_page)
+        self.assertIn("prove_ros_page_is_league_scoped", src)
+
+    def test_an_auth_failure_aborts_before_any_csv_write(self) -> None:
+        """Fail-closed means last-good survives.  If the auth branch fell
+        through to the writers, a rejected page would truncate both CSVs
+        to a header — worse than the gap being closed."""
+        import inspect
+
+        src = inspect.getsource(ros.main_async)
+        self.assertIn("except RosAuthError", src)
+        write_at = src.index("_write_csv")
+        for handler in [m for m in src.split("except RosAuthError")[1:]]:
+            self.assertIn("return 2", handler[: handler.index("except Exception")])
+        self.assertLess(src.index("except RosAuthError"), write_at)
+
+    def test_a_failed_sf_fetch_preserves_last_good(self) -> None:
+        import inspect
+
+        src = inspect.getsource(ros.main_async)
+        self.assertIn("sf_page_failed", src)
+        self.assertIn("preserving last-good", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sources/test_site_raw_mirror.py
+++ b/tests/sources/test_site_raw_mirror.py
@@ -1,0 +1,254 @@
+"""V1-89: DraftSharks must be OBSERVABLE by the existing content-age scan.
+
+THE DEFECT.  ``scripts/check_source_health.measure_content_staleness``
+reads one evidence lane — the tracked ``exports/archive/*.zip`` bundles —
+and those bundles carried exactly three ``site_raw`` CSVs (``ktc``,
+``ktcSfTep``, ``idpTradeCalc``), because the export path is assembled
+from ``Dynasty Scraper.py``'s own ``FULL_DATA``.  Every source acquired
+by a standalone fetcher writes straight into ``CSVs/site_raw/`` and so
+never entered an archive at all.
+
+Measured 2026-08-25: substituting 8-day-old DraftSharks CSVs into the
+tree while leaving the fetch stamps current produced a health verdict
+byte-identical to the healthy run.  The detector was never wrong — it
+was never given the bytes.
+
+WHAT THESE TESTS PIN.  Not "a mirror function exists".  The property:
+frozen DraftSharks content with a fresh fetch timestamp must reach
+``content-stale`` through the EXISTING detector and the EXISTING
+vocabulary, and must return to current when the vendor publishes again —
+with ``idpTradeCalc``'s behaviour unchanged either way.
+"""
+
+from __future__ import annotations
+
+import unittest
+import zipfile
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from scripts.check_source_health import measure_content_staleness
+from src.sources.site_raw_mirror import MIRRORED_SITE_RAW_CSVS, mirror_site_raw_csvs
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_DRAFTSHARKS_FILES = (
+    "draftSharksSf.csv",
+    "draftSharksIdp.csv",
+    "draftSharksRosSf.csv",
+    "draftSharksRosIdp.csv",
+)
+
+# 12 archive stamps a day apart. Long enough to cross the 14-day default
+# budget when combined with a frozen payload, short enough to stay fast.
+_STAMPS = [f"202608{day:02d}_120000" for day in range(1, 25)]
+
+
+def _archive(root: Path, stamp: str, members: dict[str, bytes]) -> None:
+    out = root / "exports" / "archive"
+    out.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(out / f"dynasty_export_{stamp}.zip", "w") as zf:
+        for name, blob in members.items():
+            zf.writestr(f"site_raw/{name}", blob)
+
+
+def _board(marker: str) -> bytes:
+    return f"Rank,Team,Player\n1,,Player {marker}\n".encode()
+
+
+class TestTheMirrorListTracksRealConsumers(unittest.TestCase):
+    """A file may only be mirrored because live code reads it.
+
+    Without this the tuple degrades into a wishlist: a name could be
+    archived for months after its consumer was deleted, and the archive
+    would keep reporting a source nothing votes on.
+    """
+
+    def test_every_mirrored_name_is_read_by_live_code(self) -> None:
+        contract = (REPO_ROOT / "src" / "api" / "data_contract.py").read_text(encoding="utf-8")
+        ros_adapter = (REPO_ROOT / "src" / "ros" / "sources" / "draftsharks_ros.py").read_text(
+            encoding="utf-8"
+        )
+        haystack = contract + ros_adapter
+        for name in MIRRORED_SITE_RAW_CSVS:
+            with self.subTest(name=name):
+                self.assertIn(
+                    name,
+                    haystack,
+                    f"{name} is mirrored into the archive but no consumer reads it",
+                )
+
+    def test_the_four_draftsharks_files_are_covered(self) -> None:
+        for name in _DRAFTSHARKS_FILES:
+            self.assertIn(name, MIRRORED_SITE_RAW_CSVS)
+
+    def test_the_export_path_actually_calls_the_owner(self) -> None:
+        """A correct helper nothing invokes changes no archive."""
+        scraper = (REPO_ROOT / "Dynasty Scraper.py").read_text(encoding="utf-8")
+        self.assertIn("site_raw_mirror", scraper)
+        self.assertIn("_mirror_site_raw_csvs(", scraper)
+        self.assertIn("siteRawMirrored", scraper)
+
+
+class TestMirrorSemantics(unittest.TestCase):
+    def _tree(self, tmp: Path, files: dict[str, bytes]) -> Path:
+        src = tmp / "CSVs" / "site_raw"
+        src.mkdir(parents=True)
+        for name, blob in files.items():
+            (src / name).write_bytes(blob)
+        return tmp / "exports" / "latest" / "site_raw"
+
+    def test_files_are_copied_byte_for_byte(self) -> None:
+        with TemporaryDirectory() as td:
+            tmp = Path(td)
+            payload = "Rank,Team,Player,Fantasy Position\n1,,Só Meoné Jr.,QB\n".encode()
+            dest = self._tree(tmp, {"draftSharksSf.csv": payload})
+            outcomes = mirror_site_raw_csvs(repo_root=tmp, site_raw_dir=dest)
+            self.assertEqual(outcomes["draftSharksSf.csv"], "mirrored")
+            self.assertEqual((dest / "draftSharksSf.csv").read_bytes(), payload)
+
+    def test_a_missing_source_is_absent_not_an_empty_placeholder(self) -> None:
+        """An empty placeholder would make a never-acquired source read
+        as perfectly byte-stable — the exact failure being repaired."""
+        with TemporaryDirectory() as td:
+            tmp = Path(td)
+            dest = self._tree(tmp, {})
+            outcomes = mirror_site_raw_csvs(repo_root=tmp, site_raw_dir=dest)
+            self.assertEqual(set(outcomes.values()), {"missing_source"})
+            self.assertEqual(list(dest.glob("*.csv")), [])
+
+    def test_a_name_the_scraper_produced_is_never_overwritten(self) -> None:
+        with TemporaryDirectory() as td:
+            tmp = Path(td)
+            dest = self._tree(tmp, {"draftSharksSf.csv": b"vendor\n"})
+            dest.mkdir(parents=True, exist_ok=True)
+            (dest / "draftSharksSf.csv").write_bytes(b"scraper-owned\n")
+            outcomes = mirror_site_raw_csvs(
+                repo_root=tmp,
+                site_raw_dir=dest,
+                produced_this_run={"draftSharksSf.csv"},
+            )
+            self.assertEqual(outcomes["draftSharksSf.csv"], "skipped_scraper_owns")
+            self.assertEqual((dest / "draftSharksSf.csv").read_bytes(), b"scraper-owned\n")
+
+
+class TestFrozenContentReachesContentStale(unittest.TestCase):
+    """The headline control, and it is deliberately non-vacuous.
+
+    Every archive below is stamped later than the last, i.e. the fetch
+    kept succeeding throughout — which is the state that used to read as
+    healthy.  Only the BYTES decide.
+    """
+
+    def _lane(self, root: Path, *, freeze_draftsharks: bool) -> None:
+        """Build the archive lane THROUGH the real mirror, not around it.
+
+        Writing archive members directly would test the detector against
+        a hand-made bundle and leave the repair itself unexercised — the
+        DraftSharks rows would be there because the test put them there.
+        Here each run stages the vendor CSVs where a fetcher writes them
+        and lets ``mirror_site_raw_csvs`` decide what reaches the bundle,
+        so emptying the mirror list turns these tests RED.
+        """
+        for i, stamp in enumerate(_STAMPS):
+            run = root / "runs" / stamp
+            vendor = run / "CSVs" / "site_raw"
+            vendor.mkdir(parents=True)
+            for name in _DRAFTSHARKS_FILES:
+                (vendor / name).write_bytes(
+                    _board(f"{name}-frozen" if freeze_draftsharks else f"{name}-{i}")
+                )
+
+            bundle = run / "exports" / "latest" / "site_raw"
+            bundle.mkdir(parents=True)
+            # What Dynasty Scraper.py's own FULL_DATA pass writes.
+            (bundle / "idpTradeCalc.csv").write_bytes(_board("idptc-constant"))
+            (bundle / "ktc.csv").write_bytes(_board(f"ktc-{i}"))
+            mirror_site_raw_csvs(
+                repo_root=run,
+                site_raw_dir=bundle,
+                produced_this_run={"idpTradeCalc.csv", "ktc.csv"},
+            )
+
+            _archive(
+                root,
+                stamp,
+                {f.name: f.read_bytes() for f in sorted(bundle.glob("*.csv"))},
+            )
+
+    def test_frozen_draftsharks_becomes_content_stale(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            self._lane(root, freeze_draftsharks=True)
+            result = measure_content_staleness(root)
+            for name in _DRAFTSHARKS_FILES:
+                key = name[: -len(".csv")]
+                with self.subTest(source=key):
+                    self.assertIn(
+                        key,
+                        result,
+                        f"{key} is still invisible to the content-age scan",
+                    )
+                    days = result[key]["daysSinceChange"]
+                    self.assertIsNotNone(days, "unknown must not read as fresh")
+                    self.assertGreater(
+                        days,
+                        14,
+                        f"{key} frozen across the whole lane but reported {days}d",
+                    )
+
+    def test_a_publishing_vendor_does_not_false_alert(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            self._lane(root, freeze_draftsharks=False)
+            result = measure_content_staleness(root)
+            for name in _DRAFTSHARKS_FILES:
+                key = name[: -len(".csv")]
+                with self.subTest(source=key):
+                    self.assertEqual(result[key]["daysSinceChange"], 0)
+
+    def test_content_age_resets_when_the_vendor_publishes_again(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            self._lane(root, freeze_draftsharks=True)
+            stale = measure_content_staleness(root)["draftSharksSf"]["daysSinceChange"]
+            self.assertGreater(stale, 14)
+
+            run = root / "runs" / "20260826_120000"
+            vendor = run / "CSVs" / "site_raw"
+            vendor.mkdir(parents=True)
+            for name in _DRAFTSHARKS_FILES:
+                (vendor / name).write_bytes(_board(f"{name}-fresh"))
+            bundle = run / "exports" / "latest" / "site_raw"
+            bundle.mkdir(parents=True)
+            (bundle / "idpTradeCalc.csv").write_bytes(_board("idptc-constant"))
+            (bundle / "ktc.csv").write_bytes(_board("ktc-new"))
+            mirror_site_raw_csvs(
+                repo_root=run,
+                site_raw_dir=bundle,
+                produced_this_run={"idpTradeCalc.csv", "ktc.csv"},
+            )
+            _archive(
+                root,
+                "20260826_120000",
+                {f.name: f.read_bytes() for f in sorted(bundle.glob("*.csv"))},
+            )
+            after = measure_content_staleness(root)
+            self.assertEqual(after["draftSharksSf"]["daysSinceChange"], 0)
+
+    def test_idptradecalc_behaviour_is_unchanged_by_the_mirror(self) -> None:
+        """The repair must not perturb the source the lane already
+        watched: idpTradeCalc is frozen in both lanes and must report
+        frozen in both, with the same number."""
+        with TemporaryDirectory() as td_a, TemporaryDirectory() as td_b:
+            a, b = Path(td_a), Path(td_b)
+            self._lane(a, freeze_draftsharks=True)
+            self._lane(b, freeze_draftsharks=False)
+            days_a = measure_content_staleness(a)["idpTradeCalc"]["daysSinceChange"]
+            days_b = measure_content_staleness(b)["idpTradeCalc"]["daysSinceChange"]
+            self.assertEqual(days_a, days_b)
+            self.assertGreater(days_a, 14)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the two engineering gaps that kept **V1-89 BLOCKED at L3**. Verification/truthfulness only — no weight, bridge, family-dedup, Hill, valuation, rank, IDP-translation or cadence change.

**OD-04 is resolved as A / HEALTHY_CURRENT.** Production authentication works, vendor content is demonstrably current, and **no owner credential action is required** — nothing here asks anyone to log in, re-mint, or supply a secret. Full factual packet: `docs/lane4/V1_89_DRAFTSHARKS_DECISION_PACKET.md`.

> **Branch note for the integrator:** my designated lane branch `claude/market-faab-analyst-v1-bbieie` currently carries **open PR #921** (`#804` source-rank capture). Force-pushing V1-89 onto it would have destroyed that PR, so this went on a dedicated branch instead.

---

## A — DraftSharks was structurally unobservable to the content-age scan

`check_source_health.measure_content_staleness` reads exactly one evidence lane — the tracked `exports/archive/*.zip` bundles — and those are assembled from `Dynasty Scraper.py`'s own `FULL_DATA` maps. Every source a standalone fetcher acquires writes straight into `CSVs/site_raw/` and therefore **never entered an archive at all**. The bundles carried three `site_raw` members: `ktc`, `ktcSfTep`, `idpTradeCalc`.

Measured before the repair: substituting 8-day-old DraftSharks CSVs while leaving the fetch stamps current produced a health verdict **byte-identical** to the healthy run (`22 fresh / content-stale: 1 (idpTradeCalc)`). A synthetic-archive control confirmed the detector's logic *does* discriminate (frozen 5 d vs moving 0 d) once given the bytes. The detector was never wrong; it was never given the bytes.

`src/sources/site_raw_mirror.py` owns which raw vendor CSVs must reach the bundle and copies them verbatim during the **existing** export pass. No second detector, no new health vocabulary, no second archive writer. The manifest gains `siteRawMirrored`.

Two properties recorded rather than hidden:

- **Absent is absent.** A missing source file is skipped, never written as an empty placeholder — a placeholder would make a never-acquired source read as perfectly byte-stable, the exact failure being removed.
- **One-run lag.** `scheduled-refresh.yml` runs the scraper *before* the fetchers, so run N archives run N−1's CSVs. A constant offset cannot distort a "how long has this been byte-identical" measurement, and closing it would require a second archive writer.

## B — ROS could not prove it was looking at the league's board

`fetch_draftsharks.py` proves each pass is league-scored via divergence from the static `data-scoring-value-*` public defaults, and fails closed. `fetch_draftsharks_ros.py` checked that a cookie **file** existed and published whatever came back; an expired jar renders a public board and still exits 0.

**That proof cannot be copied.** The ROS pages carry **zero** `data-scoring-value` attributes (measured against the live pages), so there is no public default to diverge from — a look-alike predicate would be true of every page, authenticated or not.

`prove_ros_page_is_league_scoped` instead requires **both** of the strongest assertions the pages do expose:

1. the authenticated **league marker** — 0 occurrences unauthenticated on all three DraftSharks pages;
2. a per-URL **row floor**.

Either alone is bypassable: a cached shell can carry the marker with no board behind it, and a full public board can carry no marker at all. Failure raises `RosAuthError`, which aborts **before any CSV is written**, so last-good survives and `run_fetcher` leaves the freshness stamp where it was.

Floors are bracketed by measurement, not pinned to a snapshot — 25 rows unauthenticated, 250/425 authenticated, floors 120/200. The vendor reshaped both boards between 2026-07-30 and 2026-08-25, so a floor at today's count would manufacture an outage.

Fixed alongside, because the new gate makes it reachable: **a failed SF fetch overwrote last-good with a header-only file**, while the IDP branch already guarded exactly that. Playwright's import is deferred into `main_async` (matching the sibling fetcher) so the proof is exercisable in the blocking tier with no browser and no credentialed session.

## C — documentation corrected

Both the ROS fetcher and the ROS adapter asserted `/ros-rankings/idp` is a 978-row 1QB mirror over a universe identical to the SF board, and that the name-first union "contributes zero". Re-measured: **SF 250 rows, IDP 425 genuinely restricted to DB/DL/LB, 66 names in common, union contributes 358.** The claim has now been wrong twice in opposite directions, so both docstrings were rewritten as rules that do not depend on a count. The adapter's stale "PR 1 proxy / PR 2 swap" header was replaced with what the module does today.

---

## Mutation proof

| mutation | result |
|---|---|
| empty `MIRRORED_SITE_RAW_CSVS` (the pre-repair world) | **13 RED**, incl. `draftSharksSf is still invisible to the content-age scan` |
| restore | **GREEN** |
| neuter `prove_ros_page_is_league_scoped` | **8 RED** across marker-removed / public-default / truncated-board |
| restore | **GREEN** |

The staleness lane is built **through** the real mirror rather than around it — archive members are produced by `mirror_site_raw_csvs`, so the control cannot pass on hand-made bundles.

## Validation

`ruff check` clean · `ruff format --check` clean · planning integrity ✅ · decision coercions ✅ (no new) · work-claim collision ✅ (none) · new suites **24 passed, 20 subtests**.

**Full blocking suite (`-m "not livedata"`): 9989 passed, 53 skipped, 1 failed.** The one failure is **pre-existing and not mine** — `tests/roster_intel/test_metric_separation.py::test_metrics_genuinely_diverge_on_a_representative_real_board` asserts the strongest-by-value team is not *also* #1 by youth on the live board, and today's board happens to make that `(1, 1)`. Reproduced identically on pristine `origin/main` `13456dd5` in a clean worktree: `1 failed, 16 passed`. It is a live-board assertion in the hard gate, i.e. the class `docs/ops/STABILIZATION_2026-08-16.md` §3d describes; nothing in this PR touches roster-intel.

`idpTradeCalc`'s content-age behaviour is asserted unchanged by the repair, in both the frozen and publishing lanes.

## L3 re-execution

This is **FEATURE_GREEN local only** — L3 needs the deployed box. The nine-step recipe is in §6 of the decision packet; steps 5–6 (four DraftSharks files present in the archived `site_raw` snapshot, and the content-age scan actually returning keys for them) are the ones that were structurally impossible before this PR.

## Known limits, stated

- The mirror covers the four DraftSharks files. **19 other standalone-fetcher sources remain outside the content-age lane** — same class of blindness, out of scope here.
- Whole-file content age masks a frozen sub-section (`idpTradeCalc.csv` reads hours old while its pick rows are 40 days frozen; the detector already measures pick rows separately, nothing equivalent exists elsewhere).
- The ROS row floors are a plausibility gate, not a correctness proof: a vendor serving a full-size but wrong board would pass them.

Claude 5 owns reconciliation, merge, deployment, L3 verification and ledger promotion. No V1 status is edited here.