### PR TITLE
Derive the live-registry gate test's parametrization instead of hard-coding it

### DIFF
--- a/tests/model_registry/test_promote_scope_gate.py
+++ b/tests/model_registry/test_promote_scope_gate.py
@@ -132,22 +132,45 @@ class TestGateIsWired:
         assert round_tripped.scope_validation  # not {}
 
 
+def _live_registry() -> ModelRegistry:
+    return ModelRegistry.load("hill_scope_masters")
+
+
+def _standing_challengers() -> list[int]:
+    """Every challenger the live registry currently carries.
+
+    DERIVED, never hard-coded.  ``.github/workflows/refit-hill-curves.yml``
+    registers a new challenger every week, so a literal list is stale by
+    construction — and this was not hypothetical: the list shipped as
+    ``[3, 4, 5]`` and the very next refit added **v6**, which the test would
+    then have skipped in silence.  A coverage gap in a guard is worse than
+    no guard, because the guard still reports green.
+
+    ``rejected`` and ``retired`` versions are excluded on purpose: this
+    asserts what could still be promoted TODAY, and a rejected version is
+    already refused for a different reason.
+    """
+    return [v.version for v in _live_registry().versions if v.status == "challenger"]
+
+
 class TestAgainstTheLiveRegistry:
     """The gate's verdict on the real standing challengers.
 
-    Not a hypothetical: `hill_scope_masters` carries champion v2 and two
-    open challengers, and every one of them moves a routed scope that
-    nothing scored.  If this ever starts passing, either real per-scope
-    evidence arrived or the gate was weakened — both are things a reader
-    of this file should be forced to notice.
+    Not a hypothetical: `hill_scope_masters` carries champion v2 and open
+    challengers that each move a routed scope nothing scored.  If this ever
+    starts passing, either real per-scope evidence arrived or the gate was
+    weakened — both are things a reader of this file should be forced to
+    notice.
     """
 
-    def _live(self) -> ModelRegistry:
-        return ModelRegistry.load("hill_scope_masters")
+    def test_there_is_something_to_refuse(self):
+        """Positive control.  An empty challenger list would make the
+        parametrized test below vacuous — zero cases, still green."""
+        assert _standing_challengers(), "no standing challengers; the guard below proves nothing"
 
-    @pytest.mark.parametrize("version", [3, 4, 5])
+    @pytest.mark.parametrize("version", _standing_challengers())
     def test_every_standing_challenger_is_refused(self, version: int):
-        reg = self._live()
+        reg = _live_registry()
         assert reg.champion.version == 2, "test assumes v2 is champion"
         with pytest.raises(RegistryError, match="UNVALIDATED_NO_HOLDOUT"):
             reg.promote(version, reason="held-out criterion improved")


### PR DESCRIPTION
## The gap, found four hours after shipping it

`#1092` added `TestAgainstTheLiveRegistry::test_every_standing_challenger_is_refused`, parametrized on a literal `[3, 4, 5]`. The weekly refit (`refit-hill-curves.yml`) registers a **new challenger every week**, so that list is stale by construction — and it did not stay hypothetical for long. Commit `55de8a3c6` ("chore(calibration): record Hill refit challenger"), four hours after the merge, added **v6**. The test would have skipped it in silence while still reporting green.

A coverage gap in a guard is worse than no guard, because the guard keeps saying green.

## The fix

`_standing_challengers()` reads the live registry and returns every version whose status is `challenger`.

| | parametrization |
|---|---|
| before | hard-coded `[3, 4, 5]` |
| after | derived **`[4, 5, 6]`** |

It picks up the new challenger — and it also **drops v3**, which is `rejected`, not standing. The original list was wrong about that too: a rejected version is already refused for a different reason, so asserting on it proved nothing about what could be promoted today.

## The new failure mode, and its control

A derived list introduces a risk a literal one does not have: if the registry ever carries zero challengers, the parametrized test collapses to **zero cases and passes vacuously**. So `test_there_is_something_to_refuse` asserts the list is non-empty.

Mutation-proven rather than asserted — forcing `_standing_challengers()` to return `[]`:

```
1 failed, 7 passed, 1 skipped
FAILED ...::TestAgainstTheLiveRegistry::test_there_is_something_to_refuse
```

The parametrized test becomes `1 skipped` — silently green, exactly the failure being guarded. Only the control catches it. Restored: **11 passed**.

## First live exercise of the #1092 gate

Confirmed incidentally while investigating, and worth recording:

- the refit **did not self-promote** — `championVersion` is still **2**;
- **v6 is refused**: `GLOBAL=UNVALIDATED_NO_HOLDOUT, IDP=UNVALIDATED_NO_HOLDOUT`.

v6 moves `IDP_HILL_PERCENTILE_C` 0.083 → 0.038 and `HILL_GLOBAL_PERCENTILE_C` 0.112 → 0.080 — neither scored by the OFFENSE-only held-out criterion. Before `#1092` that promotion would have succeeded.

## Scope

**Test-only.** No production code, no registry file, no constant touched.

- `tests/model_registry/` — **168 passed**
- `ruff format --check` / `ruff check` — clean
- `check_planning_integrity.py` — OK, tally agrees with the row table
- `check_decision_coercions.py` — clean

No V1 row status changes; tally unchanged at **89 / 136**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_