### PR TITLE
Lane 4: add the on-box verification workflow CI was always able to run

### DIFF
--- a/.github/workflows/lane4-onbox-verification.yml
+++ b/.github/workflows/lane4-onbox-verification.yml
@@ -1,0 +1,142 @@
+name: Lane 4 On-Box Verification (read-only)
+
+# Lane 4 V1 production evidence, run FROM THE BOX.
+#
+# WHY THIS EXISTS
+# ---------------
+# `scripts/verify_lane4_production.py --mode onbox` is the owner of Lane 4's
+# per-row production checks, and its inputs are all prod-only and gitignored:
+# `data/intel/ledger.sqlite3`, `data/faab/crowd_history_<leagueKey>.json`,
+# the league scoring cards, the installed systemd units.  A repository cannot
+# prove any of them, and a sandbox that reads its own empty copies proves
+# something worse than nothing — it proves a false negative.
+#
+# The 2026-08-25 Lane 4 batch recorded every one of V1-57/58/59/60/61/65/129
+# as BLOCKED-EXTERNAL for want of on-box access.  That was true of the
+# *session*, and it was the wrong conclusion about the *repository*: CI has
+# held working SSH to production all along (`DEPLOY_*` secrets, strict
+# host-key verification), and what was missing was a workflow that runs this
+# particular script.  Eleven SSH workflows exist; each takes narrow typed
+# inputs and none references it.  This is that workflow, and nothing more.
+#
+# READ-ONLY, and enforced by shape rather than by promise:
+#   * `--out` is deliberately NOT passed, so the script writes nothing to
+#     production disk.  Its stdout is captured on the RUNNER and uploaded
+#     as an artifact.
+#   * every check the script performs is a GET, a file read, or a
+#     `systemctl` query (see its module docstring, rule 3).
+#
+# WHAT IT CANNOT DO
+# -----------------
+# `--mode remote`, and on-box checks C8/C9, read `server.py`'s assembled
+# `/api/waiver/faab-recommend` response.  Those are session-gated by
+# `_private_api_gate` with no localhost exemption and no bearer path, so they
+# need `--origin` + `--add-player` + a real session.  They stay blocked until
+# a `PROD_VERIFY_GUEST_PASS` environment secret exists.  This workflow does
+# not attempt them, does not enable `E2E_TEST_MODE`, and does not widen the
+# public allowlist — the gate refusing us is the gate working.
+#
+# EXIT CODES (from the script, passed through unchanged):
+#   0  applicable checks ran and passed
+#   1  error
+#   2  a check FAILED
+#   3  proved nothing — NOT green.  A 401 is UNVERIFIABLE_UNAUTHENTICATED,
+#      never a pass and never a failure.
+#
+# Same SSH mechanism, permissions and concurrency posture as
+# temporal-ledger-diagnostics.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      league:
+        description: League key to verify against (registry key, never a raw Sleeper id)
+        required: false
+        default: "dynasty_main"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+jobs:
+  lane4-onbox:
+    name: Lane 4 on-box verification
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: production
+    steps:
+      - name: Configure production SSH
+        env:
+          DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          install -d -m 700 "$HOME/.ssh"
+          printf '%s\n' "$DEPLOY_SSH_PRIVATE_KEY" | sed 's/\r$//' > "$HOME/.ssh/id_ed25519"
+          printf '%s\n' "$DEPLOY_KNOWN_HOSTS" | sed 's/\r$//' > "$HOME/.ssh/known_hosts"
+          chmod 600 "$HOME/.ssh/id_ed25519"
+          chmod 644 "$HOME/.ssh/known_hosts"
+          ssh-keygen -y -f "$HOME/.ssh/id_ed25519" >/dev/null
+          echo "PORT=${DEPLOY_PORT:-22}" >> "$GITHUB_ENV"
+
+      - name: Run Lane 4 on-box verification
+        id: verify
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          APP_DIR: ${{ vars.PROD_APP_DIR || '/home/dynasty/trade-calculator' }}
+          LEAGUE_KEY: ${{ inputs.league }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          # `tee` must not mask the remote exit status, and the remote
+          # status is the whole point: 3 means "proved nothing", which
+          # reads identically to success in a log nobody scrolls.
+          set -o pipefail
+          rc=0
+          ssh -i "$HOME/.ssh/id_ed25519" \
+            -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+            -o ConnectTimeout=15 -o ServerAliveInterval=15 \
+            -p "$PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "APP_DIR=$(printf %q "$APP_DIR") LEAGUE_KEY=$(printf %q "$LEAGUE_KEY") bash -s" <<'REMOTE' 2>&1 | tee lane4-onbox.txt || rc=$?
+          set -Eeuo pipefail
+          cd "$APP_DIR"
+          # The deployed SHA is part of the evidence: a Lane 4 verdict is
+          # only attributable to a tree if the tree is recorded with it.
+          echo "### deployed_sha: $(git rev-parse HEAD)"
+          echo "### app_dir: $APP_DIR"
+          echo "### league: $LEAGUE_KEY"
+          echo "### utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "###"
+          PY="$APP_DIR/.venv/bin/python"
+          [ -x "$PY" ] || PY="$APP_DIR/venv/bin/python"
+          [ -x "$PY" ] || PY=python3
+          # No --out: nothing is written to production disk.
+          exec "$PY" scripts/verify_lane4_production.py \
+            --mode onbox --league "$LEAGUE_KEY"
+          REMOTE
+          echo "verifier_exit=$rc" >> "$GITHUB_OUTPUT"
+          echo "Lane 4 verifier exit code: $rc"
+          case "$rc" in
+            0) echo "::notice title=Lane 4::applicable checks ran and PASSED" ;;
+            2) echo "::error title=Lane 4::a check FAILED (exit 2)" ;;
+            3) echo "::error title=Lane 4::proved nothing (exit 3) — NOT green" ;;
+            *) echo "::error title=Lane 4::verifier errored (exit $rc)" ;;
+          esac
+          exit "$rc"
+
+      - name: Upload the report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: lane4-onbox-report
+          path: lane4-onbox.txt
+          if-no-files-found: warn
+          retention-days: 30

--- a/config/ci/release_gate_classification.json
+++ b/config/ci/release_gate_classification.json
@@ -356,6 +356,15 @@
     "intel-refresh.yml::refresh::Trigger intel refresh": {
       "category": "blocking"
     },
+    "lane4-onbox-verification.yml::lane4-onbox::Configure production SSH": {
+      "category": "blocking"
+    },
+    "lane4-onbox-verification.yml::lane4-onbox::Run Lane 4 on-box verification": {
+      "category": "blocking"
+    },
+    "lane4-onbox-verification.yml::lane4-onbox::Upload the report": {
+      "category": "blocking"
+    },
     "pr-validation.yml::validate::API data contract check (structural lane \u2014 blocking)": {
       "category": "blocking"
     },


### PR DESCRIPTION
## This corrects my own finding

The 2026-08-25 Lane 4 batch (`#1093`, §9b) recorded V1-57/58/59/60/61/65/129 as `BLOCKED-EXTERNAL` for want of on-box access.

**That was true of the *session* and it was the wrong conclusion about the *repository*.** CI has held working SSH to production the whole time — `DEPLOY_HOST` / `DEPLOY_USER` / `DEPLOY_PORT` / `DEPLOY_SSH_PRIVATE_KEY` / `DEPLOY_KNOWN_HOSTS`, strict host-key verification, proven by run `32812558147`'s own SSH preflight and its 4 m 28 s remote deploy. What was missing was **a workflow that runs this particular script**. Eleven SSH workflows exist; each takes narrow typed inputs and none references `scripts/verify_lane4_production.py`.

I tested my sandbox's access and reported that accurately. I did not test whether *CI* could reach the box, and that was the question worth asking.

## What this adds

Cloned from `temporal-ledger-diagnostics.yml` — same SSH mechanism, same `workflow_dispatch` + `environment: production`, same `permissions: contents: read`, same `production-deploy` concurrency group.

```
python scripts/verify_lane4_production.py --mode onbox --league dynasty_main
```

**Read-only by shape, not by promise:**

- **`--out` is deliberately not passed**, so the script writes nothing to production disk. Stdout is captured on the *runner* and uploaded as an artifact.
- Every check it performs is a GET, a file read, or a `systemctl` query — the script's own module docstring, rule 3.

The remote block prints the **deployed SHA**, app dir, league and UTC stamp before the run, because a Lane 4 verdict is only attributable to a tree if the tree is recorded with it.

## Exit codes are annotated, not swallowed

| code | meaning |
|---|---|
| 0 | applicable checks ran and **passed** |
| 1 | error |
| 2 | a check **FAILED** |
| 3 | **proved nothing — NOT green** |

`tee` runs under `set -o pipefail` with the status captured explicitly. Exit **3** is the one that matters most here and reads identically to success in a log nobody scrolls, so it gets its own `::error` annotation.

## What it deliberately does not do

`--mode remote`, and on-box checks **C8/C9**, read `server.py`'s assembled `/api/waiver/faab-recommend` response. Those are session-gated by `_private_api_gate` with **no localhost exemption and no bearer path** — `verify-sharp-production.yml` measured **80/80 401s over 79 runs**. They stay blocked until a `PROD_VERIFY_GUEST_PASS` environment secret exists.

No `E2E_TEST_MODE`. No public-allowlist widening. No new secret required to run what this adds. **The gate refusing us is the gate working**, and routing around it would destroy the property V1-103 depends on.

## Scope

One new workflow file. No source, test, config or ledger change. **Promotes no V1 row — tally stays 89 / 136.**

Once merged I can dispatch it and harvest the rows it makes measurable: sharp person-consensus from the real ledger, TEP card-derived checks, crowd-market population, IDP refusal, the FAAB history timer + artifact, the FFPC lane, single-cohort ownership, route existence, and the on-box `git rev-parse HEAD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_