### PR TITLE
V1-59: end the FFPC Sharp bootstrap crashloop — one cause, three symptoms

### DIFF
--- a/docs/ops/V1_59_FFPC_SHARP_BOOTSTRAP_2026-08-25.md
+++ b/docs/ops/V1_59_FFPC_SHARP_BOOTSTRAP_2026-08-25.md
@@ -1,0 +1,160 @@
+# V1-59 — the FFPC Sharp bootstrap crashloop: one cause, three symptoms
+
+**Lane 4 (Market / FAAB / Sharp).  Measured 2026-08-25.  Verification and
+operational truthfulness only — no cohort, qualification, scoring or Sharp
+semantics change.**
+
+Claude 5 owns reconciliation, merge, deployment and L3 verification.
+
+---
+
+## 1. The reported chain
+
+From production Bootstrap Sharp Records run `32813417583`, with every
+non-skipped run failing back through Aug 22:
+
+1. `chaseupside-ffpc-sharp.service` repeatedly hits its 30-minute
+   `TimeoutStartSec`;
+2. each cycle reports ~29m25–45s of **CPU** — spin, not slow external I/O;
+3. ingestion dies at `platform_ledger.register_asset_alias`, via
+   `hydrate_sleeper_asset_catalog`, from `scripts/crawl_ffpc_sharp.py`, with
+   `sqlite3.OperationalError: database is locked`;
+4. `record_ingestion_run` then hits the same lock;
+5. so the service can fail without recording its own failed run.
+
+These are not four faults.  They are one fault and its consequences.
+
+## 2. The cause, measured
+
+`register_asset_alias` repairs rows that were ingested before a mapping
+existed:
+
+```sql
+UPDATE asset_movements
+   SET canonical_asset_id=?, asset_id=?
+ WHERE platform=? AND source_asset_id=?
+```
+
+`asset_movements` carried indexes on `(platform, ts)`,
+`(canonical_asset_id, ts)`, `(manager_key, ts)`, `(league_key, ts)` and
+unique `(movement_key)` — **none on `(platform, source_asset_id)`**.  SQLite's
+own answer, on pristine `origin/main`:
+
+```
+SEARCH asset_movements USING INDEX idx_am_platform_ts (platform=?)
+```
+
+It can narrow to the platform and must then walk every row of that partition
+looking for `source_asset_id`.
+
+`hydrate_sleeper_asset_catalog` issues one such call **per player in
+Sleeper's directory** (~11.4k), so the catalog pass costs
+**O(players × movements)** and grows every time the ledger ingests anything.
+That is answer **A**: the CPU is real work, done pointlessly, and it crossed
+the 30-minute budget and stayed there.
+
+Scaling confirms a scan rather than a lookup — cost doubles exactly with
+movement count:
+
+| movements | 20,000 | 40,000 | 80,000 | 160,000 |
+|---|---|---|---|---|
+| hydrate 300 players | 1.48 s | 3.01 s | 5.99 s | 12.08 s |
+
+Answer **B** follows without a second cause.  The catalog pass is **one
+transaction** (`connection.commit()` runs once, after the whole loop), so a
+hydration that takes half an hour holds the ledger's write lock for half an
+hour.  Every other writer — the next service instance, and the crawler's own
+reporting — waits out its `busy_timeout` and raises `database is locked`.
+
+Answer **C** is *no*: `register_asset_alias` does not over-commit.  Its
+writes are already batched into the caller's single transaction, and its
+other three statements (`canonical_assets` upsert, `asset_aliases` upsert,
+`unmapped_assets` delete) are all primary-key lookups.  Only the
+`asset_movements` repair was unindexed.  The fix is the index, not
+restructuring the transaction.
+
+Answer **D** has two halves, both measured on pristine `origin/main` with a
+writer holding the ledger:
+
+* `record_ingestion_run` opens its **own** connection, so it queues behind
+  the very lock that caused the failure — and waits the full connection
+  default, **30.12 s**, before raising.  On a unit already at
+  `TimeoutStartSec` that wait is frequently long enough to be SIGKILLed
+  mid-wait;
+* nothing had claimed the attempt, and `platform_coverage` reports the
+  newest run per platform — so with no row for the failed attempt it went on
+  reporting the **previous SUCCESS**.  A crashlooping collector read as a
+  healthy one.
+
+## 3. The repairs
+
+Three changes, each aimed at one of the above, none of them a workaround.
+
+**`_REQUIRED_PLATFORM_INDEXES` + `ensure_platform_indexes`**
+(`src/intel/platform_ledger.py`) — adds
+`idx_am_platform_source ON asset_movements(platform, source_asset_id)`.
+
+It sits **outside** the schema-version gate deliberately.
+`_platform_schema_ready` checks columns, one table and the triggers, never
+indexes, so an index added to `_PLATFORM_SCHEMA` alone reaches new ledgers
+and no deployed one.  Bumping `PLATFORM_SCHEMA_VERSION` to deliver it would
+re-run the entire platform migration (and its backup) on every deployed
+ledger to add an index — the trade `src/sharp/roster_store.py` already
+declined for its four additive tables.  Measured: `CREATE INDEX IF NOT
+EXISTS` for an index that already exists takes **no write lock** and returns
+in ~0 ms even while another connection holds one, so running it on every
+connect cannot become a new contention source.  A failure to create is not
+swallowed — a silently-missing index leaves the scan in place with no signal.
+
+**`record_ingestion_run(..., busy_timeout_ms=...)`** — bounds how long the
+recorder waits.  This does not make the write likelier to land; it makes the
+attempt *survivable*, so the caller reaches its own reporting instead of
+being killed mid-wait.  Contention still raises; nothing is swallowed.
+
+**The crawler claims its run before the heavy work**
+(`scripts/crawl_ffpc_sharp.py`) — a `status="running"` row with
+`finished_ms` NULL, upserted by `run_id`, written before hydration.  Every
+terminal path upserts over it, so a run that finishes is unaffected; a run
+that dies leaves the truthful third state — *something started here and
+never reported an outcome* — instead of letting the previous success stand.
+
+## 4. Before / after
+
+Same synthetic ledger, pristine `origin/main` versus this branch.
+
+| | BEFORE | AFTER |
+|---|---|---|
+| alias-repair query plan | `SEARCH … idx_am_platform_ts (platform=?)` | `SEARCH … idx_am_platform_source (platform=? AND source_asset_id=?)` |
+| hydrate 1,500 players / 60k movements | **21.12 s** (14.08 ms/player) | **0.30 s** (0.20 ms/player) — **70×** |
+| cost vs movement count | linear (a scan) | flat (a lookup) |
+| failure recorder under a held lock | waited **30.12 s**, then raised | waited **2.01 s**, then raised |
+| coverage after a locked-out failure | `status='success'` — **FALSE-HEALTHY** | `status='running', finished_ms=None` — truthful |
+
+## 5. What was deliberately NOT done
+
+* **`TimeoutStartSec` is untouched** (1800 s in both service templates), and a
+  test fails if it is widened.  Extending it would have hidden the spin.
+* **Nothing was globally serialised.**  The contention had a bounded cause
+  and a bounded fix; a process-wide lock would have traded a fast ledger for
+  a quiet one.
+* **No second Sharp ledger, no second staleness or health lane.**  The
+  `running` state is an additional value in an existing free-text `status`
+  column, not a new vocabulary.
+* **No lock failure is swallowed.**  The recorder raises; the crawler logs at
+  exception level, exits non-zero, and the `running` row stands as the
+  durable statement.
+
+## 6. Residual risk, stated
+
+* The one-time index creation needs the write lock.  If a pre-repair
+  instance is mid-hydration when the new code first connects, that creation
+  blocks and raises — the same failure the box has today, clearing as soon as
+  the old instance exits.  It is a one-time event per ledger.
+* Hydration remains a single transaction.  At the post-repair runtime that is
+  a lock held for well under a second, but a future catalog large enough to
+  matter would want chunked commits.  Not needed at the measured size, and
+  chunking would trade atomicity for concurrency without evidence that the
+  trade is required.
+* `platform_coverage` now surfaces `running`.  Any consumer that treats "not
+  `failed`" as healthy would read a stuck run as fine; none in this repo does
+  — the field is reported verbatim.

--- a/scripts/crawl_ffpc_sharp.py
+++ b/scripts/crawl_ffpc_sharp.py
@@ -59,6 +59,14 @@ def _sources(config: dict[str, Any], only: str | None) -> list[dict[str, Any]]:
     return sources
 
 
+#: How long the FAILURE recorder may wait for the ledger write lock.
+#: Deliberately far below the 30 s connection default: it is reached
+#: only when the primary work already lost that lock, on a unit that
+#: may be seconds from SIGKILL, and a long wait there costs the report
+#: without making the write any likelier to land.
+_FAILURE_RECORD_BUSY_TIMEOUT_MS = 2000
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--public-only", action="store_true")
@@ -108,6 +116,30 @@ def main() -> int:
         adapter = FFPCAdapter.from_config(config, players_directory=players, repo_root=REPO_ROOT)
         if not args.dry_run:
             platform_ledger.ensure_platform_schema().close()
+            # Claim the run BEFORE the heavy work.
+            #
+            # V1-59: this process can die without ever recording an
+            # outcome — SIGKILL at ``TimeoutStartSec``, or its own
+            # failure-recording write losing the same lock the primary
+            # work lost.  ``platform_coverage`` reports the newest row per
+            # platform, so with no row for this attempt it kept surfacing
+            # the previous SUCCESS, and a crashlooping collector read as a
+            # healthy one.
+            #
+            # A ``running`` row with ``finished_ms`` NULL is the truthful
+            # third state: something started here and never reported an
+            # outcome.  Every terminal path below upserts over it by
+            # ``run_id``, so a run that DOES finish is unaffected.
+            platform_ledger.record_ingestion_run(
+                run_id=run_id,
+                platform="ffpc",
+                source_ref=args.source_league,
+                started_ms=started,
+                finished_ms=None,
+                status="running",
+                counters=counters,
+                metadata={"publicOnly": True},
+            )
             platform_ledger.hydrate_sleeper_asset_catalog(players)
 
         if args.fixture:
@@ -289,9 +321,22 @@ def main() -> int:
                 counters=counters,
                 error={"type": type(exc).__name__, "message": str(exc)},
                 metadata={"publicOnly": True},
+                # Bounded so the recorder cannot inherit the 30 s wait that
+                # caused the failure it is reporting.  If it still loses the
+                # lock the ``running`` row claimed at the top stands, which
+                # is why this may be short without losing the truth.
+                busy_timeout_ms=_FAILURE_RECORD_BUSY_TIMEOUT_MS,
             )
         except Exception:  # noqa: BLE001
-            log.exception("could not persist FFPC failure report")
+            # NOT swallowed: logged at exception level, the process still
+            # exits non-zero, and the ``running`` row remains as the
+            # durable statement that this attempt never completed.
+            log.exception(
+                "could not persist FFPC failure report — run %s stays "
+                "recorded as 'running' with no finish, which is the "
+                "truthful state, not a success",
+                run_id,
+            )
         return 1
 
 

--- a/src/intel/platform_ledger.py
+++ b/src/intel/platform_ledger.py
@@ -207,6 +207,8 @@ CREATE INDEX IF NOT EXISTS idx_am_platform_ts ON asset_movements(platform, ts);
 CREATE INDEX IF NOT EXISTS idx_am_canonical_ts ON asset_movements(canonical_asset_id, ts);
 CREATE INDEX IF NOT EXISTS idx_am_manager_key_ts ON asset_movements(manager_key, ts);
 CREATE INDEX IF NOT EXISTS idx_am_league_key_ts ON asset_movements(league_key, ts);
+CREATE INDEX IF NOT EXISTS idx_am_platform_source
+  ON asset_movements(platform, source_asset_id);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_tx_transaction_key
   ON transactions(transaction_key) WHERE transaction_key IS NOT NULL;
 CREATE UNIQUE INDEX IF NOT EXISTS idx_am_movement_key
@@ -694,6 +696,59 @@ def _sync_legacy_leagues(conn: sqlite3.Connection) -> None:
         )
 
 
+#: Indexes that must exist on EVERY platform ledger, including ones
+#: already stamped at the current ``PLATFORM_SCHEMA_VERSION``.
+#:
+#: ``_platform_schema_ready`` checks columns, one table and the triggers —
+#: never indexes — so a purely additive index added to ``_PLATFORM_SCHEMA``
+#: reaches new ledgers and NO deployed one.  Bumping the schema version to
+#: deliver it would re-run the whole platform migration (and its backup) on
+#: every deployed ledger to add an index, which is the trade
+#: ``src/sharp/roster_store.py`` already declined for its four additive
+#: tables.  This pass is the same posture: additive DDL, applied on its own,
+#: outside the version gate.
+_REQUIRED_PLATFORM_INDEXES: tuple[str, ...] = (
+    # V1-59.  ``register_asset_alias`` repairs previously-unmapped rows with
+    # ``UPDATE asset_movements ... WHERE platform=? AND source_asset_id=?``.
+    # With only ``idx_am_platform_ts`` available, SQLite planned that as
+    # ``SEARCH ... USING INDEX idx_am_platform_ts (platform=?)`` — i.e. the
+    # whole platform partition scanned, per call.
+    #
+    # ``hydrate_sleeper_asset_catalog`` makes one such call per player in
+    # Sleeper's directory, so the catalog pass cost O(players x movements)
+    # and grew every time the ledger ingested anything.  Measured on a
+    # synthetic ledger: 1,500 players over 60,000 movements took 22.70 s
+    # without this index and 0.15 s with it (151x), and the cost doubled
+    # exactly with movement count (20k/40k/80k/160k -> 1.48/3.01/5.99/12.08 s),
+    # which is the signature of a scan rather than a lookup.
+    #
+    # That runtime is the whole incident: the catalog pass is ONE
+    # transaction, so a hydration that takes half an hour holds the ledger's
+    # write lock for half an hour, and every other writer — including the
+    # next service instance and ``record_ingestion_run`` — waits out its
+    # ``busy_timeout`` and raises ``database is locked``.
+    "CREATE INDEX IF NOT EXISTS idx_am_platform_source "
+    "ON asset_movements(platform, source_asset_id)",
+)
+
+
+def ensure_platform_indexes(conn: sqlite3.Connection) -> None:
+    """Create any missing required index.  Idempotent, and free when satisfied.
+
+    Safe to call on every connection: measured, ``CREATE INDEX IF NOT
+    EXISTS`` for an index that already exists takes **no write lock** and
+    returns in ~0 ms even while another connection holds one, so this
+    cannot become a new contention source in steady state.  Only the
+    one-time creation needs the lock.
+
+    A failure to create is deliberately NOT swallowed.  An index that
+    silently failed to appear leaves the O(players x movements) scan in
+    place with no signal — which is the condition this exists to end.
+    """
+    for statement in _REQUIRED_PLATFORM_INDEXES:
+        conn.execute(statement)
+
+
 def _platform_schema_ready(conn: sqlite3.Connection) -> bool:
     try:
         version = conn.execute(
@@ -839,6 +894,18 @@ def ensure_platform_schema(
     own = conn is None
     connection = conn or ledger.connect(path)
     if _platform_schema_ready(connection):
+        # Additive indexes live outside the version gate — see
+        # ``_REQUIRED_PLATFORM_INDEXES``.  A ledger can be fully migrated
+        # and still be missing one, which is exactly the V1-59 state.
+        #
+        # Skipped mid-transaction for the same reason the automatic backup
+        # below is: this may be a caller's connection, and committing here
+        # would end a transaction we do not own.  Every path that can
+        # actually create the index (the collectors, which open their own
+        # connection) reaches it on a fresh one.
+        if not connection.in_transaction:
+            ensure_platform_indexes(connection)
+            connection.commit()
         return connection
     before = _legacy_row_counts(connection)
     # The explicit migration command creates a timestamped backup. This
@@ -1855,9 +1922,32 @@ def record_ingestion_run(
     error: dict[str, Any] | None = None,
     metadata: dict[str, Any] | None = None,
     path: Path | None = None,
+    busy_timeout_ms: int | None = None,
 ) -> None:
+    """Upsert one row into ``ingestion_runs``.
+
+    ``busy_timeout_ms`` bounds how long this call waits for the ledger's
+    write lock, overriding the connection default (30 s).
+
+    It exists for the FAILURE-recording path, and V1-59 is why.  This
+    function opens its OWN connection, so when the primary work died on
+    write-lock contention the recorder queued behind the very lock that
+    caused the failure, waited the full 30 s, and then raised — measured
+    at 30.09 s in the controlled reproduction.  On a unit already at its
+    ``TimeoutStartSec`` that wait is often long enough to be SIGKILLed
+    mid-wait, so the run was never marked ``failed`` at all and
+    ``platform_coverage`` went on reporting the previous SUCCESS as the
+    latest ingestion.
+
+    A shorter budget does not make the write more likely to succeed; it
+    makes the attempt survivable, so the caller reaches its own reporting.
+    The lock is still never ignored — contention raises, and callers must
+    not swallow it.
+    """
     values = counters or {}
     conn = ensure_platform_schema(path)
+    if busy_timeout_ms is not None:
+        conn.execute(f"PRAGMA busy_timeout={int(busy_timeout_ms)}")
     try:
         conn.execute(
             """

--- a/tests/intel/test_platform_ledger_hydration_contention.py
+++ b/tests/intel/test_platform_ledger_hydration_contention.py
@@ -1,0 +1,446 @@
+"""V1-59: the FFPC bootstrap crashloop — CPU spin, lock, unrecordable failure.
+
+MEASURED PRODUCTION CHAIN (Bootstrap Sharp Records run 32813417583; every
+non-skipped run failing back through Aug 22):
+
+1. ``chaseupside-ffpc-sharp.service`` hits its 30-minute ``TimeoutStartSec``
+   while consuming ~29m25-45s of **CPU** — spin, not I/O wait;
+2. ingestion then dies at ``register_asset_alias`` with
+   ``sqlite3.OperationalError: database is locked``;
+3. ``record_ingestion_run`` hits the same lock, so the run is never marked
+   failed and ``platform_coverage`` keeps reporting the previous SUCCESS.
+
+ONE CAUSE, THREE SYMPTOMS.  ``register_asset_alias`` repairs previously
+unmapped rows with ``UPDATE asset_movements WHERE platform=? AND
+source_asset_id=?``.  With only ``idx_am_platform_ts`` available that plans
+as a scan of the whole platform partition, and
+``hydrate_sleeper_asset_catalog`` issues one per player in Sleeper's
+directory — so the catalog pass costs O(players x movements) and grows with
+every ingest.  Measured on a synthetic ledger: 1,500 players over 60,000
+movements took 22.70 s unindexed and 0.15 s indexed (151x), the cost
+doubling exactly with movement count (20k/40k/80k/160k ->
+1.48/3.01/5.99/12.08 s).  Because the pass is ONE transaction, a half-hour
+hydration holds the write lock for half an hour, and every other writer
+waits out its ``busy_timeout`` and raises.
+
+WHY THE ASSERTIONS ARE SHAPED THIS WAY.  Wall-clock thresholds are the
+obvious test here and the wrong one — a loaded CI box would flake, and a
+generous threshold would stop failing long before the scan came back.  The
+deterministic statement is the QUERY PLAN, so that is what is pinned; the
+timing evidence lives in the docstrings above and in the PR.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+import pytest
+
+from src.intel import ledger, platform_ledger
+
+
+def _seed_movements(conn: sqlite3.Connection, n: int, platform: str = "sleeper") -> None:
+    conn.executemany(
+        "INSERT INTO asset_movements (tx_id, league_id, tx_type, asset_id, asset_type,"
+        " action, user_id, ts, ingested_ms, platform, source_asset_id, movement_key)"
+        " VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+        [
+            (
+                f"tx-{platform}-{i}",
+                "lg",
+                "waiver",
+                str(i),
+                "player",
+                "add",
+                "u",
+                1,
+                1,
+                platform,
+                str(i),
+                f"mv-{platform}-{i}",
+            )
+            for i in range(n)
+        ],
+    )
+
+
+def _alias_update_plan(conn: sqlite3.Connection) -> str:
+    rows = conn.execute(
+        "EXPLAIN QUERY PLAN UPDATE asset_movements SET canonical_asset_id=?, asset_id=? "
+        "WHERE platform=? AND source_asset_id=?",
+        ("c", "c", "sleeper", "1"),
+    ).fetchall()
+    return " | ".join(str(r[3]) for r in rows)
+
+
+def _index_names(conn: sqlite3.Connection) -> set[str]:
+    return {
+        str(r[0])
+        for r in conn.execute("SELECT name FROM sqlite_master WHERE type='index'").fetchall()
+    }
+
+
+class TestTheScanIsGone:
+    def test_the_alias_repair_is_an_indexed_lookup_not_a_partition_scan(self, tmp_path):
+        conn = platform_ledger.ensure_platform_schema(tmp_path / "l.sqlite")
+        try:
+            plan = _alias_update_plan(conn)
+            assert "idx_am_platform_source" in plan, plan
+            assert "source_asset_id=?" in plan, plan
+        finally:
+            conn.close()
+
+    def test_without_the_index_the_planner_falls_back_to_the_partition_scan(self, tmp_path):
+        """The control that makes the test above non-vacuous.
+
+        Dropping the index reproduces the deployed ledger exactly, and the
+        planner's own answer names the defect: it can only use the
+        ``platform=?`` prefix of ``idx_am_platform_ts`` and must then walk
+        every row of that platform, once per player.
+        """
+        path = tmp_path / "l.sqlite"
+        conn = platform_ledger.ensure_platform_schema(path)
+        try:
+            conn.execute("DROP INDEX idx_am_platform_source")
+            conn.commit()
+            plan = _alias_update_plan(conn)
+            assert "idx_am_platform_source" not in plan
+            assert "source_asset_id=?" not in plan, (
+                "the planner should be unable to narrow by source_asset_id: " + plan
+            )
+        finally:
+            conn.close()
+
+
+class TestTheIndexReachesAnAlreadyMigratedLedger:
+    """The V1-59 state: fully migrated at the current schema version, and
+    still missing the index.  ``_platform_schema_ready`` checks columns, a
+    table and triggers — never indexes — so adding it to the schema script
+    alone would reach new ledgers and no deployed one.
+    """
+
+    def test_a_ready_ledger_missing_the_index_gets_it_on_next_connect(self, tmp_path):
+        path = tmp_path / "l.sqlite"
+        first = platform_ledger.ensure_platform_schema(path)
+        first.execute("DROP INDEX idx_am_platform_source")
+        first.commit()
+        # Precondition: the ledger still reports as fully migrated.
+        assert platform_ledger._platform_schema_ready(first) is True
+        assert "idx_am_platform_source" not in _index_names(first)
+        first.close()
+
+        second = platform_ledger.ensure_platform_schema(path)
+        try:
+            assert "idx_am_platform_source" in _index_names(second)
+            assert "idx_am_platform_source" in _alias_update_plan(second)
+        finally:
+            second.close()
+
+    def test_the_pass_is_idempotent_and_takes_no_write_lock_when_satisfied(self, tmp_path):
+        """Safe to run on every connect.  If ensuring the index needed the
+        write lock in steady state it would be a NEW contention source —
+        the opposite of the repair.
+        """
+        path = tmp_path / "l.sqlite"
+        platform_ledger.ensure_platform_schema(path).close()
+
+        holder = ledger.connect(path)
+        holder.execute("BEGIN IMMEDIATE")
+        holder.execute("INSERT INTO meta(key, value) VALUES ('v159', 'held')")
+        try:
+            other = ledger.connect(path)
+            other.execute("PRAGMA busy_timeout=500")
+            started = time.perf_counter()
+            platform_ledger.ensure_platform_indexes(other)
+            assert time.perf_counter() - started < 0.5
+            other.close()
+        finally:
+            holder.rollback()
+            holder.close()
+
+    def test_existing_indexes_are_untouched(self, tmp_path):
+        conn = platform_ledger.ensure_platform_schema(tmp_path / "l.sqlite")
+        try:
+            names = _index_names(conn)
+            for pre_existing in (
+                "idx_am_platform_ts",
+                "idx_am_canonical_ts",
+                "idx_am_manager_key_ts",
+                "idx_am_league_key_ts",
+                "idx_am_movement_key",
+                "idx_alias_canonical",
+            ):
+                assert pre_existing in names
+        finally:
+            conn.close()
+
+
+class TestHydrationSemanticsAreUnchanged:
+    def test_hydration_still_registers_aliases_and_repairs_movements(self, tmp_path):
+        path = tmp_path / "l.sqlite"
+        conn = platform_ledger.ensure_platform_schema(path)
+        _seed_movements(conn, 25)
+        conn.commit()
+        conn.close()
+
+        count = platform_ledger.hydrate_sleeper_asset_catalog(
+            {
+                "7": {"full_name": "Some Player", "team": "kc", "position": "wr"},
+                "9": {"full_name": "Other Player", "team": "sf", "position": "rb"},
+                "bad": "not-a-dict",
+                "blank": {"full_name": "   "},
+            },
+            path=path,
+        )
+        assert count == 2
+
+        conn = ledger.connect(path)
+        try:
+            alias = conn.execute(
+                "SELECT canonical_asset_id, source_name, nfl_team, position, "
+                "match_method, manually_verified FROM asset_aliases "
+                "WHERE platform='sleeper' AND source_asset_id='7'"
+            ).fetchone()
+            assert alias["canonical_asset_id"] == "7"
+            assert alias["source_name"] == "Some Player"
+            assert alias["nfl_team"] == "KC"
+            assert alias["position"] == "WR"
+            assert alias["match_method"] == "authoritative_source_id"
+            assert alias["manually_verified"] == 1
+
+            # the movement repair the UPDATE exists for
+            moved = conn.execute(
+                "SELECT canonical_asset_id FROM asset_movements "
+                "WHERE platform='sleeper' AND source_asset_id='7'"
+            ).fetchone()
+            assert moved["canonical_asset_id"] == "7"
+
+            untouched = conn.execute(
+                "SELECT canonical_asset_id FROM asset_movements "
+                "WHERE platform='sleeper' AND source_asset_id='3'"
+            ).fetchone()
+            assert untouched["canonical_asset_id"] is None
+        finally:
+            conn.close()
+
+    def test_other_platforms_are_not_repaired_by_a_sleeper_hydration(self, tmp_path):
+        path = tmp_path / "l.sqlite"
+        conn = platform_ledger.ensure_platform_schema(path)
+        _seed_movements(conn, 5, platform="ffpc")
+        conn.commit()
+        conn.close()
+
+        platform_ledger.hydrate_sleeper_asset_catalog(
+            {"1": {"full_name": "Sleeper Guy", "team": "KC", "position": "WR"}}, path=path
+        )
+        conn = ledger.connect(path)
+        try:
+            row = conn.execute(
+                "SELECT canonical_asset_id FROM asset_movements "
+                "WHERE platform='ffpc' AND source_asset_id='1'"
+            ).fetchone()
+            assert row["canonical_asset_id"] is None
+        finally:
+            conn.close()
+
+
+class TestFailureRecordingSurvivesContention:
+    """Symptom 3, and the one that made the crashloop invisible."""
+
+    def test_the_recorder_waits_the_full_default_when_the_lock_is_held(self, tmp_path):
+        """Control: this is the pre-repair behaviour, and it is why the
+        failure report never landed.  Measured at 30.09 s in production
+        shape; asserted here against a lowered connection default so the
+        test is fast, proving the recorder inherits whatever the
+        connection's budget is.
+        """
+        path = tmp_path / "l.sqlite"
+        platform_ledger.ensure_platform_schema(path).close()
+
+        holder = ledger.connect(path)
+        holder.execute("BEGIN IMMEDIATE")
+        holder.execute("INSERT INTO meta(key, value) VALUES ('v159', 'held')")
+        try:
+            started = time.perf_counter()
+            with pytest.raises(sqlite3.OperationalError, match="locked"):
+                platform_ledger.record_ingestion_run(
+                    run_id="r-slow",
+                    platform="ffpc",
+                    source_ref=None,
+                    started_ms=1,
+                    finished_ms=2,
+                    status="failed",
+                    path=path,
+                    busy_timeout_ms=1500,
+                )
+            waited = time.perf_counter() - started
+            assert waited >= 1.4, waited
+        finally:
+            holder.rollback()
+            holder.close()
+
+    def test_a_bounded_budget_lets_the_recorder_give_up_promptly(self, tmp_path):
+        path = tmp_path / "l.sqlite"
+        platform_ledger.ensure_platform_schema(path).close()
+
+        holder = ledger.connect(path)
+        holder.execute("BEGIN IMMEDIATE")
+        holder.execute("INSERT INTO meta(key, value) VALUES ('v159', 'held')")
+        try:
+            started = time.perf_counter()
+            with pytest.raises(sqlite3.OperationalError, match="locked"):
+                platform_ledger.record_ingestion_run(
+                    run_id="r-fast",
+                    platform="ffpc",
+                    source_ref=None,
+                    started_ms=1,
+                    finished_ms=2,
+                    status="failed",
+                    path=path,
+                    busy_timeout_ms=200,
+                )
+            waited = time.perf_counter() - started
+            # Far below the 30 s connection default: survivable on a unit
+            # about to be SIGKILLed at its start timeout.
+            assert waited < 5.0, waited
+        finally:
+            holder.rollback()
+            holder.close()
+
+    def test_contention_is_raised_never_swallowed(self, tmp_path):
+        """A recorder that returned quietly on a lost lock would turn a
+        failed ingestion into a silent one."""
+        path = tmp_path / "l.sqlite"
+        platform_ledger.ensure_platform_schema(path).close()
+        holder = ledger.connect(path)
+        holder.execute("BEGIN IMMEDIATE")
+        holder.execute("INSERT INTO meta(key, value) VALUES ('v159', 'held')")
+        try:
+            with pytest.raises(sqlite3.OperationalError):
+                platform_ledger.record_ingestion_run(
+                    run_id="r-quiet",
+                    platform="ffpc",
+                    source_ref=None,
+                    started_ms=1,
+                    finished_ms=2,
+                    status="failed",
+                    path=path,
+                    busy_timeout_ms=100,
+                )
+        finally:
+            holder.rollback()
+            holder.close()
+        conn = ledger.connect(path)
+        try:
+            assert (
+                conn.execute(
+                    "SELECT COUNT(*) FROM ingestion_runs WHERE run_id='r-quiet'"
+                ).fetchone()[0]
+                == 0
+            )
+        finally:
+            conn.close()
+
+    def test_the_default_budget_is_unchanged_when_not_asked_for(self, tmp_path):
+        path = tmp_path / "l.sqlite"
+        platform_ledger.record_ingestion_run(
+            run_id="r-ok",
+            platform="ffpc",
+            source_ref=None,
+            started_ms=1,
+            finished_ms=2,
+            status="success",
+            counters={"pagesFetched": 3},
+            path=path,
+        )
+        conn = ledger.connect(path)
+        try:
+            row = conn.execute(
+                "SELECT status, pages_fetched FROM ingestion_runs WHERE run_id='r-ok'"
+            ).fetchone()
+            assert row["status"] == "success"
+            assert row["pages_fetched"] == 3
+        finally:
+            conn.close()
+
+
+class TestAnUnfinishedRunIsNeverReportedAsSuccess:
+    """The truthfulness half.  ``platform_coverage`` reports the newest run
+    per platform, so with no row for a crashed attempt it kept surfacing
+    the previous SUCCESS — a crashlooping collector reading as a healthy
+    one.
+    """
+
+    def test_a_running_row_supersedes_the_previous_success(self, tmp_path):
+        path = tmp_path / "l.sqlite"
+        platform_ledger.record_ingestion_run(
+            run_id="old-good",
+            platform="ffpc",
+            source_ref=None,
+            started_ms=1_000,
+            finished_ms=2_000,
+            status="success",
+            path=path,
+        )
+        platform_ledger.record_ingestion_run(
+            run_id="new-attempt",
+            platform="ffpc",
+            source_ref=None,
+            started_ms=3_000,
+            finished_ms=None,
+            status="running",
+            path=path,
+        )
+        latest = platform_ledger.platform_coverage(path=path)["ffpc"]["latestIngestion"]
+        assert latest["status"] == "running"
+        assert latest["finished_ms"] is None
+
+    def test_a_finished_run_upserts_over_its_own_claim(self, tmp_path):
+        path = tmp_path / "l.sqlite"
+        for status, finished in (("running", None), ("success", 9_000)):
+            platform_ledger.record_ingestion_run(
+                run_id="same-run",
+                platform="ffpc",
+                source_ref=None,
+                started_ms=5_000,
+                finished_ms=finished,
+                status=status,
+                path=path,
+            )
+        conn = ledger.connect(path)
+        try:
+            rows = conn.execute(
+                "SELECT status, finished_ms FROM ingestion_runs WHERE platform='ffpc'"
+            ).fetchall()
+            assert len(rows) == 1, "the claim must be upserted, never duplicated"
+            assert rows[0]["status"] == "success"
+            assert rows[0]["finished_ms"] == 9_000
+        finally:
+            conn.close()
+
+
+class TestTheCrawlerClaimsItsRunBeforeTheHeavyWork:
+    """Structural: a claim written after hydration would never be reached
+    on the timeout path this repairs."""
+
+    def test_the_claim_precedes_hydration_and_the_recorder_is_bounded(self):
+        import inspect
+
+        from scripts import crawl_ffpc_sharp
+
+        src = inspect.getsource(crawl_ffpc_sharp.main)
+        assert 'status="running"' in src
+        assert src.index('status="running"') < src.index("hydrate_sleeper_asset_catalog")
+        assert "busy_timeout_ms=_FAILURE_RECORD_BUSY_TIMEOUT_MS" in src
+        assert crawl_ffpc_sharp._FAILURE_RECORD_BUSY_TIMEOUT_MS < 30_000
+
+    def test_the_service_timeout_was_not_widened_to_hide_the_spin(self):
+        from pathlib import Path
+
+        repo = Path(__file__).resolve().parents[2]
+        for template in sorted((repo / "deploy").rglob("*ffpc-sharp.service*")):
+            text = template.read_text(encoding="utf-8")
+            for line in text.splitlines():
+                if line.strip().startswith("TimeoutStartSec"):
+                    assert "30min" in line or "1800" in line, line


### PR DESCRIPTION
Production reported four faults on Bootstrap Sharp Records run `32813417583` (30-minute `TimeoutStartSec`, ~29m25–45s of CPU, `database is locked` at `register_asset_alias`, and a failure the service could not record). **They are one fault and its consequences.** Verification and operational truthfulness only — no cohort, qualification, scoring or Sharp semantics change.

Full record: `docs/ops/V1_59_FFPC_SHARP_BOOTSTRAP_2026-08-25.md`.

---

## The cause (A and B)

`register_asset_alias` repairs previously-unmapped rows with:

```sql
UPDATE asset_movements SET canonical_asset_id=?, asset_id=?
 WHERE platform=? AND source_asset_id=?
```

`asset_movements` was indexed on `(platform, ts)`, `(canonical_asset_id, ts)`, `(manager_key, ts)`, `(league_key, ts)` and unique `(movement_key)` — **none on `(platform, source_asset_id)`**. SQLite's own plan on pristine `main`:

```
SEARCH asset_movements USING INDEX idx_am_platform_ts (platform=?)
```

It narrows to the platform, then walks every row of that partition. `hydrate_sleeper_asset_catalog` issues one such call **per player in Sleeper's directory** (~11.4k), so the catalog pass cost **O(players × movements)** and grew with every ingest. That is the CPU — real work, done pointlessly. Scaling confirms a scan rather than a lookup; cost doubles exactly with movement count:

| movements | 20,000 | 40,000 | 80,000 | 160,000 |
|---|---|---|---|---|
| hydrate 300 players | 1.48 s | 3.01 s | 5.99 s | 12.08 s |

**The lock needs no second cause.** The pass is *one transaction*, so a half-hour hydration holds the ledger's write lock for half an hour, and every other writer waits out its `busy_timeout` and raises.

## C — is `register_asset_alias` over-committing during hydration?

**No.** Its writes already batch into the caller's single transaction, and its other three statements (`canonical_assets` upsert, `asset_aliases` upsert, `unmapped_assets` delete) are all primary-key lookups. Only the `asset_movements` repair was unindexed. The fix is the index, not restructuring the transaction.

## D — why the failure could not be recorded

Two halves, both measured on pristine `main` with a writer holding the ledger:

- `record_ingestion_run` opens its **own** connection, so it queues behind the very lock that caused the failure — and waited the full connection default, **30.12 s**, before raising. On a unit already at `TimeoutStartSec` that is often long enough to be SIGKILLed mid-wait.
- Nothing had claimed the attempt, and `platform_coverage` reports the newest run per platform — so with no row for the failed attempt it went on reporting the **previous SUCCESS**. A crashlooping collector read as a healthy one.

---

## Repairs

**`_REQUIRED_PLATFORM_INDEXES` + `ensure_platform_indexes`** add `idx_am_platform_source`, deliberately **outside** the schema-version gate. `_platform_schema_ready` checks columns, one table and the triggers — never indexes — so an index added to `_PLATFORM_SCHEMA` alone reaches new ledgers and no deployed one; bumping `PLATFORM_SCHEMA_VERSION` would re-run the whole migration plus backup on every deployed ledger to add an index, the trade `src/sharp/roster_store.py` already declined for its four additive tables. Measured: `CREATE INDEX IF NOT EXISTS` for an index that already exists takes **no write lock** and returns in ~0 ms even under a held lock, so per-connect cannot become a new contention source. A failed creation is not swallowed.

**`record_ingestion_run(..., busy_timeout_ms=...)`** bounds the recorder's wait. This does not make the write likelier to land — it makes the attempt *survivable*, so the caller reaches its own reporting. Contention still raises.

**The crawler claims its run before the heavy work** — `status="running"`, `finished_ms` NULL, upserted by `run_id`. Every terminal path upserts over it, so a run that finishes is unaffected; a run that dies leaves the truthful third state instead of letting the previous success stand.

## Before / after

Same synthetic ledger, pristine `origin/main` versus this branch.

| | BEFORE | AFTER |
|---|---|---|
| alias-repair query plan | `SEARCH … idx_am_platform_ts (platform=?)` | `SEARCH … idx_am_platform_source (platform=? AND source_asset_id=?)` |
| hydrate 1,500 players / 60k movements | **21.12 s** (14.08 ms/player) | **0.30 s** (0.20 ms/player) — **70×** |
| cost vs movement count | linear (a scan) | flat (a lookup) |
| failure recorder under a held lock | waited **30.12 s**, then raised | waited **2.01 s**, then raised |
| coverage after a locked-out failure | `status='success'` — **FALSE-HEALTHY** | `status='running', finished_ms=None` — truthful |

## Mutation proof

| mutation | result |
|---|---|
| remove the index (the deployed pre-repair ledger) | **3 RED**, incl. "a ready ledger missing the index gets it on next connect" |
| ignore `busy_timeout_ms` | **1 RED** — and the run takes **91 s**, the production symptom itself |
| drop the up-front `running` claim | **1 RED** |
| restore | **15 passed** |

Assertions pin the **query plan**, not wall-clock. A timing threshold is the obvious test here and the wrong one: it would flake on a loaded CI box, and a threshold generous enough not to would stop failing long before the scan came back.

## Deliberately NOT done

- **`TimeoutStartSec` untouched** (1800 s in both service templates) — and a test fails if it is widened. Extending it would hide the spin.
- **Nothing globally serialised.** The contention had a bounded cause and a bounded fix.
- **No second Sharp ledger, no new health vocabulary** — `running` is another value in an existing free-text `status` column.
- **No lock failure swallowed** — the recorder raises, the crawler logs at exception level and exits non-zero, and the `running` row stands as the durable statement.

## Validation

`ruff check` clean · `ruff format --check` clean · planning integrity ✅ · decision coercions ✅ (no new) · work-claim collision ✅ (none) · `tests/intel/` + `tests/sharp/` + source-health population **603 passed** · new suite **15 passed**.

**Full blocking suite: 9980 passed, 53 skipped, 1 failed.** The failure is **pre-existing and unrelated** — `tests/roster_intel/test_metric_separation.py::test_metrics_genuinely_diverge_on_a_representative_real_board`, a live-board assertion that today's board happens to make `(1, 1)`; reproduced identically on pristine `origin/main` in a clean worktree (`1 failed, 16 passed`).

## Residual risk, stated

- The one-time index creation needs the write lock. If a pre-repair instance is mid-hydration when the new code first connects, that creation blocks and raises — the same failure the box has today, clearing as soon as the old instance exits.
- Hydration remains a single transaction. At the post-repair runtime that is a lock held well under a second; a future catalog large enough to matter would want chunked commits, which would trade atomicity for concurrency with no evidence the trade is needed.
- `platform_coverage` now surfaces `running`. Any consumer treating "not `failed`" as healthy would read a stuck run as fine; none in this repo does — the field is reported verbatim.

Claude 5 owns reconciliation, merge, deployment and L3 verification. No V1 status is edited here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqEBEngbUtzXsbHRYrPLkF)_