### PR TITLE
Lane 4 on-box: make the verifier's output survive a kill (-u), and widen the budget

### DIFF
--- a/.github/workflows/lane4-onbox-verification.yml
+++ b/.github/workflows/lane4-onbox-verification.yml
@@ -66,7 +66,12 @@ jobs:
   lane4-onbox:
     name: Lane 4 on-box verification
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 15 was too short to distinguish "hung" from "slow": the box is
+    # spending ~29.5 min of CPU per half-hour on the crashlooping
+    # chaseupside-ffpc-sharp.service (V1-59), so everything on it is slow.
+    # 30 gives a genuinely stuck check somewhere to fail rather than
+    # racing the budget.
+    timeout-minutes: 30
     environment: production
     steps:
       - name: Configure production SSH
@@ -119,7 +124,18 @@ jobs:
           [ -x "$PY" ] || PY="$APP_DIR/venv/bin/python"
           [ -x "$PY" ] || PY=python3
           # No --out: nothing is written to production disk.
-          exec "$PY" scripts/verify_lane4_production.py \
+          #
+          # -u is LOAD-BEARING, not hygiene.  Python's stdout is
+          # block-buffered when it is not a TTY, and this runs through
+          # `ssh | tee` -- no TTY at any hop.  The first dispatch (run
+          # 32826823646) was killed by the step timeout and the artifact
+          # came back 274 bytes: the header echoes only, with every check
+          # this script had emitted still sitting unflushed in the buffer
+          # when the process died.  `if: always()` on the upload guarantees
+          # the FILE arrives, not that it has anything in it.  That made a
+          # hang and a slow-but-working run indistinguishable, which is the
+          # one thing an instrument must never do.
+          exec "$PY" -u scripts/verify_lane4_production.py \
             --mode onbox --league "$LEAGUE_KEY"
           REMOTE
           echo "verifier_exit=$rc" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## The first dispatch failed, and the failure was mine

Run `32826823646` produced this and nothing else:

```
08:34:30  ### deployed_sha: 4cba78eae…
          ### app_dir: /home/…/trade-calculator
          ### league: …_main
          ### utc: 2026-08-25T08:34:30Z
08:49:38  ##[error]The operation was canceled.
```

Uploaded artifact: **274 bytes** — the header echoes, nothing else.

**That artifact cannot distinguish the two explanations, and that is the defect:**

1. the verifier hung on its first check; or
2. the verifier was running normally and every line it printed was still sitting in an unflushed stdout buffer when the process died.

Python **block-buffers stdout when it is not a TTY**, and this runs through `ssh | tee` — no TTY at any hop. So (2) isn't a remote possibility, it's the *default behaviour*.

In #1099 I wrote that `if: always()` on the upload meant "a killed run still yields its partial output". **That was wrong.** `if: always()` guarantees the *file* is uploaded, not that the file has anything in it. An instrument whose failure mode is indistinguishable from its success mode is the one thing this lane exists to prevent, and I shipped one.

## The fix

- **`-u` on the interpreter** — load-bearing, not hygiene. Each check reaches the artifact as it's produced, so a kill *truncates* the record instead of erasing it.
- **`timeout-minutes` 15 → 30.** Fifteen was too short to tell *hung* from *slow*: the box is burning ~29.5 min of CPU per half-hour on the crashlooping `chaseupside-ffpc-sharp.service` (the V1-59 defect measured earlier today), so everything on it is slow. Thirty lets a genuinely stuck check fail rather than race the budget.

Nothing about the verifier, its checks, its exit codes, or its read-only posture changes. `tests/deploy/` classification guard still passes — the step names are unchanged, so the manifest entries still resolve.

## One real datum did survive

From the on-box `git rev-parse HEAD` the workflow prints before running:

```
deployed_sha: 4cba78eae   (measured on-box 2026-08-25T08:34:30Z)
```

That **confirms production is three merges behind `main`** — #1081, #1078, #1099 — after those deploys were superseded in the `production-deploy` concurrency group. Previously that was inference from GitHub run states; now it's measured on the box.

## Scope

One workflow file. **Promotes no V1 row, edits no status — tally stays 89 / 136.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_