### PR TITLE
Canonical valuation: a rank cap may withhold a rank, not erase a value (#1101)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -744,6 +744,28 @@ live order (corrected 2026-07-29 audit):
     ``docs/picks/C1_U6_PICK_VALUE_COMPLETENESS.md`` §8).  Full record:
     that document.
 
+**Value availability and top-board membership are two questions** (#1101).
+``OVERALL_RANK_LIMIT`` answers only the second.  Phase 4b′ therefore stamps
+``rankDerivedValue`` on EVERY row past the cap that voted — picks (C1-U6)
+and, since #1101, PLAYERS with at least one matched trusted dynasty source
+and a positive canonical blend.  Value only: no rank, no tier, no
+percentile, no standing, so ``rankDerivedValue > 0`` beside
+``canonicalConsensusRank: None`` is the intended shape rather than an
+inconsistency to reconcile.  Off-cap player rows carry
+``offCapPlayerValue: true``; picks keep ``offCapPickValue``.
+
+The value is the one the pipeline ALREADY computed — the same
+``row_normalized`` blend the ranked path reads, never a legacy scraper
+composite, never a frontend ordinal, held at or above the canonical scale's
+own ``DISPLAY_SCALE_MIN`` so a float→int truncation cannot manufacture a 0.
+``row_normalized`` is built from ``row_source_ranks``, so arriving in this
+pass IS the evidence gate: a row nothing matched never enters it and stays
+unpriced.  MISSING IS NEVER ZERO, and never the floor either.  Confidence
+runs through the shared ``_family_evidence_for_row`` assembly and
+``assess_confidence`` — one gate, no off-cap methodology, no promotion for
+being priced.  Measured on the 2026-08-25 board: 186 players newly priced
+(155..1186), and 0 of 740 ranked rows moved value, rank or tier.
+
 Master curve constants are refit weekly by
 ``.github/workflows/refit-hill-curves.yml`` (see
 ``scripts/auto_refit_hill_curves.py``), but the refit **no longer

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -5842,6 +5842,58 @@ _TWO_WAY_PLAYERS: dict[str, str] = {
 }
 
 
+def _family_evidence_for_row(
+    *,
+    row: dict[str, Any],
+    effective_source_ranks: dict[str, Any],
+    effective_source_meta: dict[str, dict[str, Any]],
+    src_by_key: dict[str, dict[str, Any]],
+    family_by_key: dict[str, str],
+    fresh_by_source: dict[str, bool | None],
+) -> list["FamilyEvidence"]:
+    """Assemble the B11 gate's per-family evidence for one row.
+
+    ONE assembly, TWO callers: the ranked path and the off-cap player
+    value pass (#1101).  Extracted rather than transcribed, because a
+    second copy of this block would be a second confidence methodology —
+    ``src/api/confidence.py`` owns what the levels MEAN and this owns
+    what evidence it is shown, and both halves need exactly one owner.
+
+    Decides no level.  Every judgement below is about what a source
+    contribution IS, not about how good it is.
+    """
+    row_is_te = str(row.get("position") or "").strip().upper() == "TE"
+    evidence: list[FamilyEvidence] = []
+    for skey in effective_source_ranks:
+        smeta = effective_source_meta.get(skey) or {}
+        # Family-superseded members are not independent evidence;
+        # B10-T3b already excluded them from the blend.
+        if smeta.get("contributedToBlend") is False:
+            continue
+        method = str(smeta.get("method") or "")
+        src_def = src_by_key.get(skey, {})
+        evidence.append(
+            FamilyEvidence(
+                family=family_by_key.get(skey, skey),
+                source_key=skey,
+                value_contribution=smeta.get("valueContribution"),
+                fresh=fresh_by_source.get(skey),
+                # ADR-015 lifts a non-TEP source's TE row onto the
+                # TE++ basis the board is anchored on.  A measured
+                # conversion, not a native observation.
+                format_native=(not row_is_te) or bool(src_def.get("is_tep_premium")),
+                # An approximating translation — rookie ladder or
+                # backbone fallback — is a guess at where the
+                # source would have placed the player.
+                directly_observed=(
+                    method != TRANSLATION_FALLBACK
+                    and not method.startswith("rookie_ladder_translation")
+                ),
+            )
+        )
+    return evidence
+
+
 def _restate_confidence_after_override(
     players_array: list[dict[str, Any]],
     confidence_inputs: dict[int, tuple[list[FamilyEvidence], set[str]]],
@@ -10030,35 +10082,14 @@ def _compute_unified_rankings(
             # five axes over B10 family HEADS, combined by bottleneck.
             # Everything this loop does here is ASSEMBLE the evidence —
             # no level is decided in this file.
-            row_is_te = str(row.get("position") or "").strip().upper() == "TE"
-            evidence: list[FamilyEvidence] = []
-            for skey in effective_source_ranks:
-                smeta = effective_source_meta.get(skey) or {}
-                # Family-superseded members are not independent evidence;
-                # B10-T3b already excluded them from the blend.
-                if smeta.get("contributedToBlend") is False:
-                    continue
-                method = str(smeta.get("method") or "")
-                src_def = src_by_key.get(skey, {})
-                evidence.append(
-                    FamilyEvidence(
-                        family=family_by_key.get(skey, skey),
-                        source_key=skey,
-                        value_contribution=smeta.get("valueContribution"),
-                        fresh=fresh_by_source.get(skey),
-                        # ADR-015 lifts a non-TEP source's TE row onto the
-                        # TE++ basis the board is anchored on.  A measured
-                        # conversion, not a native observation.
-                        format_native=(not row_is_te) or bool(src_def.get("is_tep_premium")),
-                        # An approximating translation — rookie ladder or
-                        # backbone fallback — is a guess at where the
-                        # source would have placed the player.
-                        directly_observed=(
-                            method != TRANSLATION_FALLBACK
-                            and not method.startswith("rookie_ladder_translation")
-                        ),
-                    )
-                )
+            evidence = _family_evidence_for_row(
+                row=row,
+                effective_source_ranks=effective_source_ranks,
+                effective_source_meta=effective_source_meta,
+                src_by_key=src_by_key,
+                family_by_key=family_by_key,
+                fresh_by_source=fresh_by_source,
+            )
             # Kept so a LATER post-blend override that moves this row's
             # value can re-state its confidence against the value that
             # actually shipped.  See ``_restate_confidence_after_override``.
@@ -10145,39 +10176,127 @@ def _compute_unified_rankings(
                 if "idpTradeCalc" in source_ranks:
                     pdata["idpRank"] = source_ranks["idpTradeCalc"]
 
-    # ── Phase 4b': off-cap pick value stamping (C1-U6, RED-1) ──
+    # ── Phase 4b': off-cap VALUE stamping (C1-U6 RED-1; #1101) ──
     #
     # ``OVERALL_RANK_LIMIT`` is a RANK concept: the board publishes 800
-    # ranked rows.  For PLAYER rows past the cap, withholding the value
-    # is deliberate top-board behavior and is untouched here.  A PICK
-    # row that voted, though, is a valid tradeable asset whose canonical
-    # value must exist regardless of where it sorts (manifest
-    # C1-PICK-01: "every valid pick through 2029 has a finite canonical
-    # value") — the rookie-anchor pass already takes exactly this
-    # posture for current-year slot picks ("anchor regardless of
-    # whether the pick survived the cap").  Measured before this pass:
-    # five voted 2029 tier rows published ``rankDerivedValue: None``
-    # with their discount stamp already on the row.  Value only — no
-    # rank, no tier, no percentile: those stay capped.
+    # ranked rows.  It is NOT a claim that the 801st asset is worthless,
+    # and #1101 separates the two questions outright:
+    #
+    #   A. canonical VALUE availability   — does this asset have a price?
+    #   B. canonical TOP-BOARD membership — does it get a rank and tier?
+    #
+    # The cap answers B and only B.  So every row past it that VOTED —
+    # a pick, or a player carrying at least one matched trusted dynasty
+    # source and a positive canonical blend — keeps the value the
+    # pipeline has ALREADY computed for it.  Value only: no rank, no
+    # tier, no percentile, no standing.  A row here legitimately
+    # publishes ``rankDerivedValue > 0`` beside
+    # ``canonicalConsensusRank: None`` / ``canonicalTierId: None``, and
+    # that pairing is the intended shape, not an inconsistency.
+    #
+    # The pick half landed first (manifest C1-PICK-01: "every valid pick
+    # through 2029 has a finite canonical value"), mirroring the posture
+    # the rookie-anchor pass already took for current-year slot picks.
+    # The PLAYER half is #1101: measured on the 2026-08-25 board, 186
+    # players past the cap carried real source ranks and a positive
+    # blend (155..1186) and published ``rankDerivedValue: None`` — Trey
+    # Lance among them, with 8 sources and a blend of 1102.  A rank cap
+    # withholding a rank is top-board policy; a rank cap erasing a
+    # measured value is evidence loss.
+    #
+    # ``row_normalized`` is built from ``row_source_ranks``, so ARRIVING
+    # here is itself the evidence gate: a row nothing matched never
+    # enters this list and stays unpriced.  MISSING IS NEVER ZERO — and
+    # never ``DISPLAY_SCALE_MIN`` either.  Nothing below invents a value
+    # for a row that has none; it publishes the one already computed.
     for norm_val, row_idx in row_normalized[OVERALL_RANK_LIMIT:]:
         row = players_array[row_idx]
-        if row.get("assetClass") != "pick":
+        if norm_val <= 0:
+            # No positive canonical evidence to publish.  Leave the row
+            # unpriced rather than floor it up to 1 — a floor is what a
+            # real value is held ABOVE, not what a missing one becomes.
             continue
-        derived = int(norm_val)
-        if derived <= 0:
-            continue
-        row["rankDerivedValue"] = derived
-        row["offCapPickValue"] = True
-        is_slot_specific = _parse_pick_slot(row.get("canonicalName") or "") is not None
-        bucket, label = assess_pick_confidence(
-            row.get("canonicalSiteValues") or {},
-            is_slot_specific=is_slot_specific,
-        )
-        row["confidenceBucket"] = bucket
-        row["confidenceLabel"] = label
-        row["confidenceBasis"] = "pick_dispersion"
-        row["confidenceAxes"] = None
-        row["confidenceReasons"] = None
+        # The canonical scale's own minimum, from the scale's owner
+        # (``player_valuation.DISPLAY_SCALE_MIN``); no second literal is
+        # declared here.  The ranked path's ``int(norm_val)`` truncates,
+        # so a blend of 0.6 — real evidence, genuinely tiny — would
+        # otherwise be published as exactly the 0 this pass exists to
+        # stop manufacturing.
+        #
+        # Stated plainly: on the live board this floor is DEFENSIVE and
+        # binds nothing.  The Hill tail puts the deepest off-cap blend at
+        # 155, three orders of magnitude clear of it.  It is here because
+        # the correct rule is "positive evidence publishes at least the
+        # scale minimum", not because a row was measured needing it — and
+        # a floor that only appears once something has already been
+        # rounded to zero is a floor added too late.
+        derived = max(_CANONICAL_VALUE_MIN, int(norm_val))
+
+        if row.get("assetClass") == "pick":
+            row["rankDerivedValue"] = derived
+            row["offCapPickValue"] = True
+            is_slot_specific = _parse_pick_slot(row.get("canonicalName") or "") is not None
+            bucket, label = assess_pick_confidence(
+                row.get("canonicalSiteValues") or {},
+                is_slot_specific=is_slot_specific,
+            )
+            row["confidenceBucket"] = bucket
+            row["confidenceLabel"] = label
+            row["confidenceBasis"] = "pick_dispersion"
+            row["confidenceAxes"] = None
+            row["confidenceReasons"] = None
+        else:
+            source_ranks = row_source_ranks.get(row_idx) or {}
+            if not source_ranks:
+                # Unreachable by construction (see above); kept as the
+                # structural guard that says so, because the day the
+                # blend loop's input widens, this is the line that must
+                # refuse rather than the one that prices a stranger.
+                continue
+            source_meta = row_source_meta.get(row_idx, {})
+            dropped_set = set(row.get("droppedSources") or [])
+            effective_source_ranks = {k: v for k, v in source_ranks.items() if k not in dropped_set}
+            effective_source_meta = {k: v for k, v in source_meta.items() if k not in dropped_set}
+            row["rankDerivedValue"] = derived
+            row["offCapPlayerValue"] = True
+            # Publish the post-Hampel set the assessment below was read
+            # from.  Leaving the template's ``{}`` on a row that now
+            # carries a price would assert "no source survived" about a
+            # row priced by the survivors.
+            row["effectiveSourceRanks"] = effective_source_ranks
+            # Confidence comes from the SAME owner and the SAME evidence
+            # assembly the ranked path uses — no off-cap methodology, and
+            # nothing here promotes a row for being priced.  Whatever the
+            # gate returns is what ships: on the live board these rows
+            # answer ``low``, because coverage/agreement are genuinely
+            # thin this deep, which is the truthful answer rather than a
+            # flattering one.
+            evidence = _family_evidence_for_row(
+                row=row,
+                effective_source_ranks=effective_source_ranks,
+                effective_source_meta=effective_source_meta,
+                src_by_key=src_by_key,
+                family_by_key=family_by_key,
+                fresh_by_source=fresh_by_source,
+            )
+            # Registered so a LATER post-blend override that moves this
+            # row's value re-states its confidence against the number
+            # that actually shipped, exactly as for a ranked row.
+            row_confidence_inputs[row_idx] = (
+                evidence,
+                row_eligible_families.get(row_idx, set()),
+            )
+            assessment = assess_confidence(
+                evidence,
+                eligible_families=row_eligible_families.get(row_idx, set()),
+                consensus_value=derived,
+            )
+            row["confidenceBucket"] = assessment.overall
+            row["confidenceLabel"] = assessment.label
+            row["confidenceBasis"] = "evidence_gate"
+            row["confidenceAxes"] = dict(assessment.axes)
+            row["confidenceReasons"] = list(assessment.reasons)
+
         legacy_ref = row.get("legacyRef")
         if legacy_ref and legacy_ref in players_by_name:
             pdata = players_by_name[legacy_ref]

--- a/tests/api/test_off_cap_player_value_completeness.py
+++ b/tests/api/test_off_cap_player_value_completeness.py
@@ -1,0 +1,522 @@
+"""#1101 — a rank cap may withhold a RANK; it may not erase a VALUE.
+
+THE INVARIANT
+─────────────
+If a player is ranked or priced by any trusted dynasty source eligible to
+participate in canonical valuation, and the canonical pipeline computes a
+positive blend for that player, the board must publish a canonical
+``rankDerivedValue`` for them — whether or not they survive
+``OVERALL_RANK_LIMIT``.
+
+Two concepts, deliberately separate:
+
+  A. canonical VALUE availability   — ``rankDerivedValue``
+  B. canonical TOP-BOARD membership — ``canonicalConsensusRank`` / tier
+
+``OVERALL_RANK_LIMIT`` answers B and only B.  A row past it legitimately
+publishes ``rankDerivedValue > 0`` beside ``canonicalConsensusRank: None``
+and ``canonicalTierId: None``, and every test here asserts that pairing
+rather than treating it as an inconsistency to be smoothed over.
+
+WHAT THIS IS NOT
+────────────────
+Not a Trey Lance exception.  He is one witness (``TestTreyLance``), on
+real tracked source evidence, and his expected canonical output is NOT
+pinned to any historical number — the assertion is that legitimate
+evidence cannot disappear into "unpriced", never that it reproduces a
+particular value.  The general invariant is asserted on a synthetic board
+built to be > ``OVERALL_RANK_LIMIT`` deep, so it holds for the population
+rather than for one name.
+
+MISSING IS NEVER ZERO — AND NEVER ONE
+─────────────────────────────────────
+The floor rule runs one way only.  Positive canonical evidence must
+publish at least ``DISPLAY_SCALE_MIN``; ABSENT evidence must publish
+nothing at all.  ``TestMissingStaysMissing`` is the control that keeps
+the first half from quietly becoming "everything gets a 1".
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import tempfile
+from functools import lru_cache
+from pathlib import Path
+
+import pytest
+
+from src.api.data_contract import (
+    OVERALL_RANK_LIMIT,
+    build_api_data_contract,
+)
+from src.canonical.player_valuation import DISPLAY_SCALE_MIN
+from tests.archive_fixtures import newest_complete_raw_payload
+
+# ── Synthetic board ────────────────────────────────────────────────────
+#
+# Deep enough that the cap is genuinely exercised: ``N_PLAYERS`` sits
+# comfortably past ``OVERALL_RANK_LIMIT`` so a well-defined off-cap
+# population exists no matter how the sort resolves ties.
+#
+# Every synthetic player carries the SAME multi-source coverage, so the
+# only thing separating an on-cap row from an off-cap one is its market
+# value — which is exactly the variable the invariant is about.  A row
+# that differed in coverage as well would let a failure be explained by
+# the coverage instead of by the cap.
+
+N_PLAYERS = OVERALL_RANK_LIMIT + 220
+TARGET_OFFSET = 40
+#: The witness: far enough past the cut that no tie-break can pull it back.
+TARGET_NAME = f"Depth Player {OVERALL_RANK_LIMIT + TARGET_OFFSET:04d}"
+#: A control with no source coverage whatsoever — see TestMissingStaysMissing.
+NO_EVIDENCE_NAME = "No Evidence Player"
+
+
+def _raw_payload() -> dict:
+    players: dict[str, dict] = {}
+    # Descend in steps of 10 from 9000 so ranks are strictly ordered and
+    # no two rows tie; the deepest row still lands well above zero, so
+    # nothing here is priced by the floor rather than by its evidence.
+    market = 9000
+    for i in range(1, N_PLAYERS + 1):
+        sites = {
+            "ktcSfTep": market,
+            "idpTradeCalc": market,
+            "draftSharks": market,
+            "dlfSf": market,
+            "fantasyProsSf": market,
+        }
+        row = {"_canonicalSiteValues": dict(sites), "position": "WR", "age": 25}
+        row.update(sites)
+        players[f"Depth Player {i:04d}"] = row
+        market -= 10
+
+    # No ``_canonicalSiteValues``, no per-site keys: nothing matched this
+    # player, so no source rank exists and the row never enters the blend.
+    players[NO_EVIDENCE_NAME] = {"position": "WR", "age": 25}
+
+    return {
+        "version": "off-cap-value-fixture",
+        "date": "2026-08-25",
+        "settings": {},
+        "sites": {},
+        "maxValues": {},
+        "players": players,
+    }
+
+
+@lru_cache(maxsize=1)
+def _board() -> dict[str, dict]:
+    """Rows keyed by display name, built through the production entry point.
+
+    ``csv_root`` points at an empty directory so no site-CSV enrichment
+    runs and the fixture's own ``canonicalSiteValues`` are the whole
+    input.
+    """
+    with tempfile.TemporaryDirectory() as tmp, contextlib.redirect_stdout(io.StringIO()):
+        contract = build_api_data_contract(_raw_payload(), csv_root=Path(tmp))
+    return {str(row.get("displayName")): row for row in contract.get("playersArray") or []}
+
+
+def _off_cap_players(board: dict[str, dict]) -> dict[str, dict]:
+    return {
+        name: row
+        for name, row in board.items()
+        if row.get("assetClass") != "pick" and row.get("canonicalConsensusRank") is None
+    }
+
+
+class TestOffCapTrustedPlayerIsPriced:
+    """TEST 1 — the general invariant, asserted on the population."""
+
+    def test_the_fixture_actually_exercises_the_cap(self) -> None:
+        """Guard against a vacuous pass.
+
+        If the board ever stops producing an off-cap population, every
+        assertion below would hold over an empty set and report success
+        while testing nothing.
+        """
+        board = _board()
+        ranked = [r for r in board.values() if r.get("canonicalConsensusRank") is not None]
+        assert (
+            len(ranked) == OVERALL_RANK_LIMIT
+        ), f"expected a full {OVERALL_RANK_LIMIT}-row ranked board, got {len(ranked)}"
+        assert len(_off_cap_players(board)) >= 100
+
+    def test_target_is_off_cap_and_source_backed(self) -> None:
+        row = _board()[TARGET_NAME]
+        assert row.get("canonicalConsensusRank") is None
+        assert row.get("canonicalTierId") is None
+        source_ranks = row.get("sourceRanks") or {}
+        assert len(source_ranks) >= 2, source_ranks
+
+    def test_target_carries_a_finite_canonical_value_at_or_above_the_floor(self) -> None:
+        value = _board()[TARGET_NAME].get("rankDerivedValue")
+        assert isinstance(value, (int, float)) and not isinstance(value, bool)
+        assert value == value and value not in (float("inf"), float("-inf"))  # finite
+        assert value >= DISPLAY_SCALE_MIN
+
+    def test_every_source_backed_off_cap_player_is_priced(self) -> None:
+        """The population, not the witness.
+
+        A fix that priced only the target — or only the first N rows past
+        the cut — passes the test above and fails this one.
+        """
+        unpriced = [
+            name
+            for name, row in _off_cap_players(_board()).items()
+            if (row.get("sourceRanks") or {})
+            and not (isinstance(row.get("rankDerivedValue"), (int, float)))
+        ]
+        assert (
+            unpriced == []
+        ), f"{len(unpriced)} source-backed off-cap players unpriced: {unpriced[:5]}"
+
+    def test_priced_off_cap_players_never_fall_below_the_canonical_floor(self) -> None:
+        """The floor rule, asserted as a property rather than as teeth.
+
+        No row on any board measured so far comes near it — the Hill tail
+        puts the deepest off-cap blend around 155 — so this currently
+        discriminates nothing, and saying so is more useful than letting
+        a future reader assume it caught something.  It is the assertion
+        that stops a truncation from publishing 0 the day the tail moves.
+        """
+        below = {
+            name: row.get("rankDerivedValue")
+            for name, row in _off_cap_players(_board()).items()
+            if isinstance(row.get("rankDerivedValue"), (int, float))
+            and row["rankDerivedValue"] < DISPLAY_SCALE_MIN
+        }
+        assert below == {}, below
+
+    def test_pricing_a_row_never_promotes_it_onto_the_top_board(self) -> None:
+        """Value availability must not leak into board membership.
+
+        A priced off-cap row keeps ``None`` for every ranking field.  The
+        percentile is included because it is a STANDING within the ranked
+        pool — a row outside that pool has no standing in it, and a
+        number there would be a fabricated rank wearing another name.
+        """
+        offenders = {
+            name: (
+                row.get("canonicalConsensusRank"),
+                row.get("canonicalTierId"),
+                row.get("canonicalPercentile"),
+            )
+            for name, row in _off_cap_players(_board()).items()
+            if row.get("rankDerivedValue") is not None
+            and (
+                row.get("canonicalConsensusRank") is not None
+                or row.get("canonicalTierId") is not None
+                or row.get("canonicalPercentile") is not None
+            )
+        }
+        assert offenders == {}, offenders
+
+    def test_priced_off_cap_players_are_marked_as_such(self) -> None:
+        """Provenance: a consumer must be able to tell WHY a row has a
+        value but no rank, without inferring it from the absence."""
+        unmarked = [
+            name
+            for name, row in _off_cap_players(_board()).items()
+            if row.get("rankDerivedValue") is not None and not row.get("offCapPlayerValue")
+        ]
+        assert unmarked == [], unmarked
+
+
+class TestConfidenceIsAssessedNotAsserted:
+    """A newly priced row must not become a newly CONFIDENT row.
+
+    The gate in ``src/api/confidence.py`` is the only thing that decides a
+    level, and the off-cap pass feeds it the same evidence assembly the
+    ranked path uses.  What it may never do is claim ``high`` — or leave
+    the row saying ``unpriced`` — merely because a value now exists.
+    """
+
+    def test_a_priced_row_no_longer_claims_to_be_unpriced(self) -> None:
+        stale = {
+            name: row.get("confidenceBasis")
+            for name, row in _off_cap_players(_board()).items()
+            if row.get("rankDerivedValue") is not None
+            and row.get("confidenceBasis") in ("unpriced", "no_evidence", None)
+        }
+        assert stale == {}, stale
+
+    def test_no_off_cap_player_is_promoted_to_high_confidence(self) -> None:
+        promoted = {
+            name: row.get("confidenceBucket")
+            for name, row in _off_cap_players(_board()).items()
+            if row.get("rankDerivedValue") is not None
+            and str(row.get("confidenceBucket")) == "high"
+        }
+        assert promoted == {}, promoted
+
+    def test_the_assessment_publishes_its_own_axes_and_reasons(self) -> None:
+        """Auditable, not merely stamped: the level has to arrive with the
+        evidence it was read from."""
+        row = _board()[TARGET_NAME]
+        assert row.get("confidenceBasis") == "evidence_gate"
+        assert isinstance(row.get("confidenceAxes"), dict) and row["confidenceAxes"]
+        assert isinstance(row.get("confidenceReasons"), list) and row["confidenceReasons"]
+        # The post-Hampel set the assessment actually read, published so
+        # the level can be checked against it rather than taken on trust.
+        assert isinstance(row.get("effectiveSourceRanks"), dict)
+        assert row["effectiveSourceRanks"]
+
+
+class TestMissingStaysMissing:
+    """TEST 3 — the control.
+
+    ``MISSING IS NEVER ZERO`` and it is never ``DISPLAY_SCALE_MIN``
+    either.  A floor is what a REAL value is held above; it is not what a
+    missing one becomes.
+    """
+
+    def test_a_player_with_no_source_evidence_is_never_priced(self) -> None:
+        row = _board()[NO_EVIDENCE_NAME]
+        assert not (row.get("sourceRanks") or {}), "fixture drifted: control gained sources"
+        assert row.get("rankDerivedValue") is None
+        assert not row.get("offCapPlayerValue")
+
+    def test_the_control_is_not_priced_through_the_values_bundle_either(self) -> None:
+        """A value laundered into ``values.*`` is the same defect under a
+        different field name."""
+        values = _board()[NO_EVIDENCE_NAME].get("values") or {}
+        for key in ("overall", "finalAdjusted", "displayValue"):
+            assert values.get(key) is None, (key, values.get(key))
+
+    def test_nothing_on_the_board_is_priced_without_source_evidence(self) -> None:
+        """The population form of the control.
+
+        Picks are excluded: a derived pick is priced from the pick
+        completeness owner (year-step / round-step / generic tier EV),
+        which is a different and separately authorized evidence class.
+        """
+        fabricated = [
+            name
+            for name, row in _board().items()
+            if row.get("assetClass") != "pick"
+            and row.get("rankDerivedValue") is not None
+            and not (row.get("sourceRanks") or {})
+        ]
+        assert fabricated == [], fabricated
+
+
+class TestLegacyMirror:
+    """TEST 6 — one asset, one value, whichever shape the consumer reads.
+
+    The runtime view strips ``playersArray``, so the legacy dict is what a
+    real frontend build sees.  A value published in one and not the other
+    is the row carrying two answers.
+    """
+
+    def test_legacy_dict_agrees_with_the_canonical_row(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, contextlib.redirect_stdout(io.StringIO()):
+            contract = build_api_data_contract(_raw_payload(), csv_root=Path(tmp))
+        legacy = contract.get("players") or {}
+        rows = contract.get("playersArray") or []
+        checked = 0
+        for row in rows:
+            if row.get("assetClass") == "pick" or not row.get("offCapPlayerValue"):
+                continue
+            ref = row.get("legacyRef")
+            pdata = legacy.get(ref)
+            if not isinstance(pdata, dict):
+                continue
+            assert pdata.get("rankDerivedValue") == row.get("rankDerivedValue"), ref
+            checked += 1
+        assert checked > 0, "no off-cap player reached the legacy dict — test is vacuous"
+
+
+class TestTopBoardIsInert:
+    """TEST 4 — this repair ADDS values below the cap; it reprices nothing.
+
+    Measured out-of-band on the pinned 2026-08-25 archive board
+    (``dynasty_export_20260825_073239.zip``), before vs after: 0 of 740
+    ranked rows moved value, 0 moved rank, 0 moved tier, and 186 off-cap
+    players were newly priced in the range 155..1186.
+
+    What is asserted HERE is the structural property that MAKES that true
+    and keeps it true: the off-cap pass iterates
+    ``row_normalized[OVERALL_RANK_LIMIT:]``, a slice positionally disjoint
+    from the ``[:OVERALL_RANK_LIMIT]`` the ranked pass enumerates, so no
+    ranked row is reachable from it.  A future edit that widened the slice
+    would break the disjointness these tests check.
+    """
+
+    def test_no_ranked_row_was_written_by_the_off_cap_pass(self) -> None:
+        board = _board()
+        touched = {
+            name: row.get("canonicalConsensusRank")
+            for name, row in board.items()
+            if row.get("canonicalConsensusRank") is not None
+            and (row.get("offCapPlayerValue") or row.get("offCapPickValue"))
+        }
+        assert touched == {}, touched
+
+    def test_the_ranked_board_is_contiguous_and_complete(self) -> None:
+        """If the off-cap pass had promoted or displaced anything, the
+        ranked ordinals would not still be exactly 1..N."""
+        ranks = sorted(
+            row["canonicalConsensusRank"]
+            for row in _board().values()
+            if row.get("canonicalConsensusRank") is not None
+        )
+        assert ranks == list(range(1, len(ranks) + 1))
+
+    def test_every_ranked_row_still_carries_a_value(self) -> None:
+        missing = [
+            name
+            for name, row in _board().items()
+            if row.get("canonicalConsensusRank") is not None and row.get("rankDerivedValue") is None
+        ]
+        assert missing == [], missing
+
+    def test_off_cap_values_never_exceed_the_deepest_ranked_value(self) -> None:
+        """Ordering sanity: a row past the cut cannot be worth more than
+        the last row that made it.  A violation would mean the off-cap
+        pass read a different quantity than the sort did.
+        """
+        board = _board()
+        ranked = [
+            (row["canonicalConsensusRank"], row.get("rankDerivedValue"))
+            for row in board.values()
+            if row.get("canonicalConsensusRank") is not None and row.get("assetClass") != "pick"
+        ]
+        deepest = min(v for _, v in ranked if v is not None)
+        over = {
+            name: row.get("rankDerivedValue")
+            for name, row in _off_cap_players(board).items()
+            if isinstance(row.get("rankDerivedValue"), (int, float))
+            and row["rankDerivedValue"] > deepest
+        }
+        assert over == {}, (deepest, over)
+
+
+class TestNoSecondOwner:
+    """TEST 7 — the value comes from the canonical pipeline, and from
+    nowhere else.
+
+    The banned fallbacks are the legacy scraper composite family.  They
+    live on a different scale, so splicing one in would be a second board
+    wearing the canonical field name — the defect class W29-F001 closed.
+    """
+
+    BANNED = ("_composite", "_rawComposite", "_finalAdjusted", "composite")
+
+    def test_off_cap_value_is_not_any_banned_composite(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, contextlib.redirect_stdout(io.StringIO()):
+            contract = build_api_data_contract(_raw_payload(), csv_root=Path(tmp))
+        legacy = contract.get("players") or {}
+        checked = 0
+        for row in contract.get("playersArray") or []:
+            if not row.get("offCapPlayerValue"):
+                continue
+            pdata = legacy.get(row.get("legacyRef")) or {}
+            value = row.get("rankDerivedValue")
+            for field in self.BANNED:
+                raw = pdata.get(field) if isinstance(pdata, dict) else None
+                if raw is None:
+                    continue
+                assert value != raw, f"{row.get('displayName')}: value came from {field}"
+            checked += 1
+        assert checked > 0
+
+    def test_the_off_cap_value_is_the_pipeline_blend_the_row_already_carried(self) -> None:
+        """``_blendedValueUncapped`` is the pre-cap blend the pipeline
+        stamped on every row.  The published off-cap value must be that
+        number (subject only to the canonical floor), not a second
+        computation of it.
+        """
+        mismatched = {}
+        for name, row in _off_cap_players(_board()).items():
+            value = row.get("rankDerivedValue")
+            if value is None:
+                continue
+            blend = row.get("_blendedValueUncapped")
+            if blend is None:
+                mismatched[name] = ("no blend stamp", value)
+                continue
+            # The ranked path truncates; the floor lifts a sub-1 blend.
+            if abs(value - blend) > 1:
+                mismatched[name] = (blend, value)
+        assert mismatched == {}, mismatched
+
+    def test_the_frontend_materializer_declares_no_value_fallback(self) -> None:
+        """Structural: the repair is backend-only by construction.
+
+        ``buildRows`` may assign a local DISPLAY ORDINAL to rows the
+        backend left unranked (documented, and unchanged here).  What it
+        must never do is turn that ordinal — or any other client-side
+        quantity — into a canonical VALUE.
+        """
+        js = (
+            Path(__file__).resolve().parents[2] / "frontend" / "lib" / "dynasty-data.js"
+        ).read_text(encoding="utf-8")
+        # A frontend value owner would have to WRITE the canonical field.
+        for pattern in ("rankDerivedValue =", "rankDerivedValue:"):
+            for line in js.splitlines():
+                if pattern not in line:
+                    continue
+                stripped = line.strip()
+                # Reads and pass-throughs are fine; a computed assignment
+                # from a local ordinal is not.
+                assert "computedConsensusRank" not in stripped, stripped
+
+
+class TestTreyLance:
+    """TEST 5 — the reported symptom, on real tracked source evidence.
+
+    Deliberately NOT pinned to 896 / 1095 / 1123.  Those numbers
+    established that source coverage exists and what the board used to
+    show; they are not a methodology, and asserting them would convert a
+    truthfulness invariant into a snapshot of one day's blend.
+
+    The claim under test is only this: evidence this broad cannot
+    disappear into "unpriced".
+    """
+
+    NAME = "Trey Lance"
+
+    @staticmethod
+    @lru_cache(maxsize=1)
+    def _real_board() -> tuple[dict | None, str | None]:
+        payload, archive = newest_complete_raw_payload()
+        if payload is None:
+            return None, None
+        with contextlib.redirect_stdout(io.StringIO()):
+            contract = build_api_data_contract(payload)
+        rows = {
+            str(row.get("canonicalName") or row.get("displayName")): row
+            for row in contract.get("playersArray") or []
+        }
+        return rows, archive
+
+    def _row(self) -> dict:
+        rows, _ = self._real_board()
+        if rows is None:
+            pytest.skip("no complete archived scrape available")
+        row = rows.get(self.NAME)
+        if row is None:
+            pytest.skip(f"{self.NAME} is not on the archived board")
+        return row
+
+    def test_he_carries_qualifying_dynasty_source_evidence(self) -> None:
+        source_ranks = self._row().get("sourceRanks") or {}
+        assert len(source_ranks) >= 2, source_ranks
+
+    def test_his_canonical_value_is_positive(self) -> None:
+        value = self._row().get("rankDerivedValue")
+        assert isinstance(value, (int, float)) and not isinstance(value, bool)
+        assert value >= DISPLAY_SCALE_MIN
+        assert value > 0
+
+    def test_a_missing_top_board_rank_is_acceptable_and_a_missing_value_is_not(self) -> None:
+        """States the ruling explicitly so a future reader does not
+        'repair' the null rank back into a fabricated one."""
+        row = self._row()
+        if row.get("canonicalConsensusRank") is None:
+            assert row.get("canonicalTierId") is None
+            assert row.get("offCapPlayerValue") is True
+        assert row.get("rankDerivedValue") is not None


### PR DESCRIPTION
Closes #1101.

## The defect

`OVERALL_RANK_LIMIT` is a RANK concept, but it was deciding two questions at once: whether an asset gets a top-board rank **and** whether it gets a canonical value at all. Phase 4b′ already made that separation for **picks** (C1-U6, manifest C1-PICK-01); it had never been made for **players**, and the code comment said so explicitly — "for PLAYER rows past the cap, withholding the value is deliberate top-board behavior".

That policy is superseded by the owner directive: if a player is ranked or priced by any trusted dynasty source eligible to participate in canonical valuation, they must have a non-zero canonical value.

Measured on the pinned 2026-08-25 archive board **before** the change: **186 players** past the cap carried real matched source ranks and a positive canonical blend (155..1186) and published `rankDerivedValue: null`. Trey Lance — the reported symptom — sat there with **8 sources** and a blend of **1102**, stamped `confidenceBasis: "unpriced"`.

Withholding his *rank* is top-board policy. Erasing his *measured value* is evidence loss.

## What changed

`src/api/data_contract.py::_compute_unified_rankings`, Phase 4b′ — now stamps every row past the cap that VOTED, pick or player. **Value only**: no rank, no tier, no percentile, no standing. A row here publishes `rankDerivedValue > 0` beside `canonicalConsensusRank: None` / `canonicalTierId: None`, and that pairing is the intended shape rather than an inconsistency to reconcile.

Four properties are load-bearing:

- **The value is the one the pipeline already computed** — the same `row_normalized` blend the ranked path reads. No second computation, and none of the banned fallbacks (`_composite`, `_rawComposite`, `_finalAdjusted`, a raw source rank, a frontend ordinal).
- **The floor comes from the scale's owner.** `max(DISPLAY_SCALE_MIN, int(norm_val))`, imported from `src/canonical/player_valuation.py`; no second literal is declared. It stops a float→int truncation from manufacturing a 0. Stated plainly in the code and the tests: on the live board this floor is **defensive and binds nothing** — the Hill tail puts the deepest off-cap blend at 155.
- **MISSING IS NEVER ZERO — and never the floor either.** `row_normalized` is built from `row_source_ranks`, so *arriving in this pass IS the evidence gate*: a row nothing matched never enters it and stays unpriced. 61 such rows on the live board are untouched. Nothing here invents a value for a row that has none.
- **Confidence is ASSESSED, not asserted.** The evidence assembly the ranked path used inline is extracted to `_family_evidence_for_row` and shared, so there is one assembly feeding one gate rather than an off-cap methodology beside the ranked one. Nothing is promoted for being priced: the 186 rows answer **166 low / 20 medium**, zero high, all `confidenceBasis: "evidence_gate"`. `effectiveSourceRanks` is published on those rows so the level can be audited against the set it was read from — leaving the template's `{}` on a now-priced row would assert "no source survived" about a row priced by the survivors.

`OVERALL_RANK_LIMIT` itself is unchanged, as is every item on the do-not-touch list: source weights, family dedup, Hill constants and promotion, percentile-tail policy, the cross-position bridge, IDP translation, TE premium, Hampel thresholds, the single-source retention factor, source acquisition. Pick methodology is untouched beyond sharing the minimum-floor invariant, and that sharing is **measurably inert** — 0 pick values changed.

No frontend change. `buildRows`' local display ordinal for unranked rows is an adjacent known issue and is not used here; the value comes entirely from the backend.

## Measured, pinned inputs

`dynasty_export_20260825_073239.zip`, same payload before and after:

**Top-800**

| | |
|---|---|
| values moved | **0** |
| ranks moved | **0** |
| tiers moved | **0** |

(0 board-wide rank or tier changes either — the 740 ranked rows and their ordinals are byte-identical.)

**Off-cap player population**

| | |
|---|---|
| source-backed players past the cap | 186 |
| previously unpriced | 186 |
| newly receiving canonical value | 186 |
| minimum newly published value | 155 |
| maximum newly published value | 1186 |
| picks newly priced or changed | 0 |
| legacy-dict mirror agreement | 186 / 186 |

**Trey Lance**

| | before | after |
|---|---|---|
| source coverage | 8 (`ktcSfTep`, `fantasyProsSf`, `otcffbSf`, `yahooBoone`, `fantasyNavigatorSf`, `pfkDynasty`, `idpShowCombined`, `idpTradeCalc`) | unchanged |
| `rankDerivedValue` | `null` | **1101** |
| `canonicalConsensusRank` | `null` | `null` (outside the top 800 — acceptable and intended) |
| `canonicalTierId` | `null` | `null` |
| `confidenceBasis` | `unpriced` | `evidence_gate` (`low`) |
| legacy dict | `null` | 1101 |

**Missing/no-evidence control:** 61 non-pick rows with no matched canonical source stay unpriced, and their `values.overall` / `finalAdjusted` / `displayValue` stay `null`. The 12 remaining unpriced source-backed rows are the deliberately alias-suppressed generic tier picks (`pickGenericSuppressed`) — pre-existing pick methodology, unchanged.

## Tests

New: `tests/api/test_off_cap_player_value_completeness.py` (24 tests). It asserts the **general invariant on a synthetic board deeper than the cap**, not a Trey Lance exception:

- off-cap trusted player is priced — target has source ranks, `canonicalConsensusRank`/`canonicalTierId` absent, value finite and `>= DISPLAY_SCALE_MIN`; plus the population form, so a fix that priced only the target fails
- a non-vacuity guard, so the suite cannot pass over an empty off-cap set
- confidence is assessed not asserted — no `high`, no lingering `unpriced` basis, axes/reasons/`effectiveSourceRanks` published
- **missing stays missing** — a zero-evidence control is never priced, including through `values.*`
- legacy-dict mirror agreement, with its own vacuity guard
- top-board disjointness: no ranked row is written by the off-cap pass, ordinals stay contiguous `1..N`, and no off-cap value exceeds the deepest ranked value
- no second owner: the value is not any banned composite, it equals the row's own `_blendedValueUncapped`, and `dynasty-data.js` declares no client-side value fallback
- Trey Lance on real tracked archive evidence — deliberately **not** pinned to 896 / 1095 / 1123, which establish coverage and prior behavior rather than methodology. The claim under test is only that evidence this broad cannot disappear into "unpriced".

**Mutation-checked.** Bypassing the off-cap player stamp turns **7 of the 24 RED** (target pricing, population pricing, the confidence assessment, the legacy mirror, the no-second-owner check, and both Trey value assertions). Restoring turns them GREEN.

## Validation

| gate | result |
|---|---|
| `pytest tests/ -m "not livedata"` (full hard gate) | **10051 passed**, 42 skipped, 398 subtests |
| new regression module | 24 passed |
| `tests/api/test_data_contract.py` | 39 passed |
| `test_ranking_coherence` / `test_valuation_pipeline_stages` / `test_single_source_resolution` / `test_valuation_degraded_inputs` / `test_percentile_tail_policy` | 134 passed, 4 subtests |
| `ruff check .` | clean |
| `ruff format --check .` | clean |
| `scripts/validate_api_contract.py --lane structural` | ok=True, 0 errors, 0 warnings, 1114 players |
| `scripts/check_planning_integrity.py` | rc 0 |
| `scripts/check_decision_coercions.py` | rc 0 — no new coercions |
| `scripts/check_work_claims.py` (changed files + branch) | no overlapping claim |

## Docs

`CLAUDE.md` gains a short paragraph in the Live Value Pipeline section stating the two-question separation, the evidence gate, the floor rule and the measured numbers — the runbook previously described Phase 4b′ as picks-only, which this makes stale.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNyrWMPCsDwQavHvBEFFFQ)_