### PR TITLE
fix(trade): the opponent-fit label no longer encodes the interpreter's hash seed

### DIFF
--- a/src/trade/suggestions.py
+++ b/src/trade/suggestions.py
@@ -1122,7 +1122,13 @@ def _opponent_fit_label(
     if not fitting_teams:
         return None
     if len(fitting_teams) == 1:
-        return f"Strong bilateral fit: {fitting_teams[0]} needs {', '.join(give_positions)} and could deal."
+        # sorted(): ``give_positions`` is a set, and joining a set puts the
+        # process's hash seed into an API response — measured: four distinct
+        # labels for one suggestion across PYTHONHASHSEED 0/1/7/42.
+        return (
+            f"Strong bilateral fit: {fitting_teams[0]} needs "
+            f"{', '.join(sorted(give_positions))} and could deal."
+        )
     return f"Potential trade partners ({len(fitting_teams)}): {', '.join(fitting_teams[:3])}"
 
 

--- a/tests/trade/test_suggestions_determinism.py
+++ b/tests/trade/test_suggestions_determinism.py
@@ -1,0 +1,89 @@
+"""The suggestions API is deterministic across interpreter hash seeds.
+
+``_opponent_fit_label`` built its "needs POS, POS, POS" clause by joining a
+SET, so one suggestion produced different `/api/trade/suggestions` bytes in
+different processes — measured before the repair: four distinct labels for
+the same input across ``PYTHONHASHSEED`` 0/1/7/42.  Sets are the right
+container for the membership checks above the join; the JOIN is where an
+order must be chosen, and it must be chosen by the data, not the seed.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from src.trade.suggestions import PlayerAsset, TradeSuggestion, _opponent_fit_label
+
+REPO = Path(__file__).resolve().parents[2]
+
+_PROBE = """
+from types import SimpleNamespace
+from src.trade.suggestions import _opponent_fit_label, TradeSuggestion, PlayerAsset
+mk = lambda n, p, v: PlayerAsset(name=n, position=p, display_value=v, calibrated_value=v)
+s = TradeSuggestion(
+    type="sell_high",
+    give=[mk("A", "WR", 100), mk("B", "RB", 100), mk("C", "TE", 100)],
+    receive=[mk("D", "QB", 300)],
+    give_total=300, receive_total=300, gap=0, fairness="even",
+    rationale="", why_this_helps="", confidence=0.5, strategy="balanced",
+)
+opp = SimpleNamespace(need_positions={"WR", "RB", "TE"}, surplus_positions=set())
+print(_opponent_fit_label(s, {"Team Z": opp}))
+"""
+
+
+def _mk(name: str, pos: str, val: int) -> PlayerAsset:
+    return PlayerAsset(name=name, position=pos, display_value=val, calibrated_value=val)
+
+
+def _suggestion() -> TradeSuggestion:
+    return TradeSuggestion(
+        type="sell_high",
+        give=[_mk("A", "WR", 100), _mk("B", "RB", 100), _mk("C", "TE", 100)],
+        receive=[_mk("D", "QB", 300)],
+        give_total=300,
+        receive_total=300,
+        gap=0,
+        fairness="even",
+        rationale="",
+        why_this_helps="",
+        confidence=0.5,
+        strategy="balanced",
+    )
+
+
+def test_the_needs_clause_is_sorted_not_seed_ordered():
+    opp = SimpleNamespace(need_positions={"WR", "RB", "TE"}, surplus_positions=set())
+    label = _opponent_fit_label(_suggestion(), {"Team Z": opp})
+    assert label == "Strong bilateral fit: Team Z needs RB, TE, WR and could deal."
+
+
+def test_the_label_is_identical_across_hash_seeds():
+    """The property, proven the only way it can be: separate interpreters.
+
+    In-process assertions cannot exercise hash randomisation — every call in
+    one process shares one seed.  Before the repair this test fails with
+    multiple distinct labels; after it, one.
+    """
+    outputs = set()
+    for seed in ("0", "1", "7", "42"):
+        env = dict(os.environ)
+        env["PYTHONHASHSEED"] = seed
+        result = subprocess.run(
+            [sys.executable, "-c", _PROBE],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(REPO),
+            timeout=120,
+        )
+        assert result.returncode == 0, result.stderr[-2000:]
+        outputs.add(result.stdout.strip())
+    assert len(outputs) == 1, (
+        f"one suggestion produced {len(outputs)} distinct labels across hash "
+        f"seeds: {sorted(outputs)}"
+    )


### PR DESCRIPTION
## The defect, measured before touching anything

`_opponent_fit_label` (`src/trade/suggestions.py`) built its *"needs POS, POS, POS"* clause by joining a **set**, so `/api/trade/suggestions` published different bytes for the same suggestion in different processes:

```
PYTHONHASHSEED=0  → …needs RB, TE, WR and could deal.
PYTHONHASHSEED=1  → …needs TE, WR, RB and could deal.
PYTHONHASHSEED=7  → …needs RB, WR, TE and could deal.
PYTHONHASHSEED=42 → …needs TE, RB, WR and could deal.
```

Four distinct labels, one input. Found and routed during the V1-36 guard analysis (recorded in that row); proven pre-existing.

## Fix

`sorted()` at the join. The sets stay — the membership checks above the join are what they exist for; the join is where an order must be chosen, and it's now chosen by the data instead of the seed.

## Pinned two ways

- an exact-label assertion;
- a **subprocess test across four hash seeds** — the only honest way to exercise hash randomisation, since every call inside one process shares one seed.

**Mutation:** reverting the `sorted()` turns both RED; restored, GREEN.

## Validation

| | |
|---|---|
| `tests/trade/test_suggestions_determinism.py` | 2 passed |
| V1-36 guard suite (`test_suggestions_package_identity.py`) | 29 passed |
| full `tests/trade/` | **818 passed** |
| ruff check / format on touched files | clean |

One production line + one test file. No V1 status edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_