### PR TITLE
V1-96 residuals: the archives index covers the rows it indexes; leagueVitals counts the directory it sits beside

### DIFF
--- a/src/public_league/archives.py
+++ b/src/public_league/archives.py
@@ -245,7 +245,11 @@ def _season_result_archives(
 
 def _manager_index(snapshot: PublicLeagueSnapshot) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
-    for manager in snapshot.managers.ordered_managers():
+    # Archives are historical record sets: the season-result rows include
+    # retirees' real past seasons (C9-HIST-01), so the index must cover the
+    # rows it indexes — this is an all-time directory, not a forward-facing
+    # one (C9-HIST-01 residual).
+    for manager in snapshot.managers.ordered_managers(include_retired=True):
         rows.append(
             {
                 "kind": "manager",

--- a/src/public_league/overview.py
+++ b/src/public_league/overview.py
@@ -385,7 +385,11 @@ def _league_vitals(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
                 total_scored_weeks += 1
     return {
         "seasonsCovered": len(snapshot.seasons),
-        "managers": len(snapshot.managers.by_owner_id),
+        # Current-state vital ("At a glance") — must match the forward-facing
+        # ``league.managers`` directory in the same payload (to_public_list()).
+        # The all-time count including retirees is a DIFFERENT quantity and
+        # would need its own label (V1-96 residual).
+        "managers": len(snapshot.managers.ordered_managers()),
         "totalTrades": total_trades,
         "totalWaivers": total_waivers,
         "totalScoredWeeks": total_scored_weeks,

--- a/tests/public_league/test_overview.py
+++ b/tests/public_league/test_overview.py
@@ -64,6 +64,38 @@ class OverviewTests(unittest.TestCase):
         vitals = self.overview["leagueVitals"]
         self.assertEqual(vitals["seasonsCovered"], 2)
         self.assertGreaterEqual(vitals["totalTrades"], 2)
+        self.assertEqual(vitals["managers"], len(self.snapshot.managers.ordered_managers()))
+
+    def test_league_vitals_managers_matches_directory_with_retiree_present(self) -> None:
+        """V1-96 residual: leagueVitals is the CURRENT-STATE "At a glance"
+        card and renders beside the same payload's ``league.managers``
+        directory (``to_public_list()``, retirees excluded).  Its count
+        must therefore be the directory's count — the all-time count
+        including retirees is a different quantity and would need its own
+        label.  A retiree is present so the assertion discriminates:
+        counting ``by_owner_id`` (pre-fix) gives directory + retirees.
+        """
+        snapshot = build_test_snapshot()
+        # owner-X held a roster in 2024 only — flag them retired the way
+        # build_manager_registry models it (Manager.is_retired).
+        snapshot.managers.by_owner_id["owner-X"].is_retired = True
+
+        directory_count = len(snapshot.managers.ordered_managers())
+        # Discrimination guard: with the retiree flagged, the all-time
+        # count and the directory count genuinely differ.
+        self.assertEqual(len(snapshot.managers.by_owner_id), directory_count + 1)
+
+        payload = build_section_payload(snapshot, "overview")
+        vitals = payload["data"]["leagueVitals"]
+        self.assertEqual(
+            vitals["managers"],
+            directory_count,
+            msg=(
+                "leagueVitals.managers must count the forward-facing manager "
+                "directory it renders beside, not by_owner_id (which includes "
+                "retirees)"
+            ),
+        )
 
     def test_most_decorated_franchise(self) -> None:
         top = self.overview["mostDecoratedFranchise"]

--- a/tests/public_league/test_public_contract.py
+++ b/tests/public_league/test_public_contract.py
@@ -265,6 +265,43 @@ class SectionCoverageTests(unittest.TestCase):
         ):
             self.assertIn(block, s)
 
+    def test_archives_manager_index_covers_every_season_result_owner(self) -> None:
+        """V1-96 residual (C9-HIST-01): the archives manager index must
+        cover the rows it indexes.
+
+        ``seasonResults`` emits every historical standings row, including
+        retirees' real past seasons.  A manager index built from the
+        forward-facing directory (``ordered_managers()`` default,
+        retirees excluded) therefore cannot find owners its own archive
+        contains.  The invariant — not a count literal: every ownerId
+        appearing in seasonResults appears in the manager index.
+        """
+        from src.public_league import archives
+
+        install_stubs(build_stub_client())
+        snapshot = build_public_snapshot("L2025", max_seasons=2)
+        # owner-X held roster 4 in 2024 only — exactly the retiree shape.
+        # Flag them retired the way build_manager_registry models it
+        # (Manager.is_retired), so the fixture contains a retired manager
+        # WITH historical season rows.
+        snapshot.managers.by_owner_id["owner-X"].is_retired = True
+
+        section = archives.build_section(snapshot)
+        season_result_owners = {row["ownerId"] for row in section["seasonResults"]}
+        index_owners = {row["ownerId"] for row in section["managers"]}
+
+        # Guard against vacuity: the retiree really is in the archive rows.
+        self.assertIn("owner-X", season_result_owners)
+        self.assertLessEqual(
+            season_result_owners,
+            index_owners,
+            msg=(
+                "archives.seasonResults contains owners the archives manager "
+                "index cannot find: "
+                f"{sorted(season_result_owners - index_owners)}"
+            ),
+        )
+
     def test_luck_section(self) -> None:
         s = self.contract["sections"]["luck"]
         for block in (


### PR DESCRIPTION
Two bounded one-line residual defects adjacent to V1-96 (historical franchise continuity), found live in production and recorded in the ledger's V1-96 row. One commit per defect, each with its own mutation evidence.

## Defect 1 — /archives manager index excludes retirees while its own rows include them

`src/public_league/archives.py::_manager_index` called `ordered_managers()` with the default `include_retired=False`, while `_season_result_archives` emits ALL historical standings rows — including both retirees' 2024 seasons. The archive contained seasons its own index could not find (set difference = exactly the two retiree owner ids). The registry's own docstring (`identity.py`) names archives among the callers that need historical participation and says retirement filters "forward-facing manager directories only" (C9-HIST-01).

**Fix:** `ordered_managers(include_retired=True)` in `_manager_index`, with a comment naming why — archives are historical record sets; the index must cover the rows it indexes.

**Test (was vacuous):** `test_archives_indices` only asserted the `managers` key existed. New `test_archives_manager_index_covers_every_season_result_owner` pins the invariant — every ownerId appearing in `seasonResults` appears in the archives manager index (a set-coverage assertion, not a count literal) — against a snapshot with a retired manager who has historical season rows, plus a vacuity guard that the retiree really is in the archive rows.

**Mutation proof (executed, restored):** reverting the fix alone → test FAILS (`seasonResults contains owners the archives manager index cannot find: ['owner-X']`); restored → passes.

## Defect 2 — leagueVitals.managers says 14 while the same payload's directory says 12

`src/public_league/overview.py::_league_vitals` counted `len(snapshot.managers.by_owner_id)`, which post-#965 includes retirees (kept in the registry, flagged `is_retired`). leagueVitals is the "At a glance" **current-state** card and renders beside the same payload's `league.managers` directory (`to_public_list()` → retirees excluded → 12). Two unlabelled numbers disagreeing on one page.

**Fix:** `"managers": len(snapshot.managers.ordered_managers())` — the current-state vital must match the forward-facing directory it sits beside. The all-time count including retirees is a different quantity and would need its own label.

**Test (was missing):** `test_league_vitals_totals_match_snapshot` now also asserts `vitals["managers"] == len(ordered_managers())`; new discriminating `test_league_vitals_managers_matches_directory_with_retiree_present` flags a fixture manager retired (the `Manager.is_retired` shape `build_manager_registry` produces) and guards that `by_owner_id == directory + 1`, so pre-fix ≠ post-fix.

**Mutation proof (executed, restored):** reverting the fix alone → test FAILS (`AssertionError: 5 != 4`); restored → passes.

## Not touched, deliberately

The other `by_owner_id` consumers (history.py, streaks.py, awards.py, metrics.py, franchise.py, conduct.py, snapshot_store.py, api/team_assignment.py, ros/power_v2.py) are correctly unfiltered — historical participation. `server.py` ops metrics untouched. No WORK_CLAIMS.md or V1 status edits.

## Validation

- `python -m pytest tests/public_league/ -q` — **424 passed, 50 subtests passed**
- `tests/api/` public tests (7 files) — **73 passed, 12 skipped, 7 subtests passed**
- `ruff check` + `ruff format --check` clean on the 4 touched files only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_