### PR TITLE
V1-52: all_play binds to the missing-value path recent already uses

### DIFF
--- a/src/ros/power_v2.py
+++ b/src/ros/power_v2.py
@@ -370,7 +370,17 @@ def _score_state(
         wins = s["wins"]
         games = s["games"] or 1
         wl = wins / games  # already in [0, 1]
-        all_play = state["allplay"].get(oid, 0.0)
+        # UNMEASURED IS None, NOT 0.0 -- the same owner invariant recent
+        # binds to above (missing != zero).  ``last_season_allplay_share``
+        # only holds keys for owners who appeared in the last SCORED
+        # season's weeks, and all_play is an expected share on [0, 1]
+        # consumed raw (never percentiled), so the retired ``.get(oid,
+        # 0.0)`` default scored an absent owner as the league's WORST
+        # all-play performer -- a confident bottom value, at weight 0.08,
+        # for a component nothing measured.  ``None`` propagates to a
+        # dropped weight and a null component through the same per-owner
+        # renormalisation recent already uses.
+        all_play = state["allplay"].get(oid)
         streak = _streak_score_from_outcomes(state["outcomes"].get(oid, []))
         # Luck regression: a team whose actualWins lag expectedWins
         # gets a small boost (regression toward expected).  Clamp to
@@ -403,6 +413,12 @@ def _score_state(
     ppg_values = [inputs[o]["ppg"] for o in owner_ids]
     recent_values = [inputs[o]["recent"] for o in owner_ids]
     recent_available = any(v is not None for v in recent_values)
+    # all_play is already a 0-1 share and is consumed raw -- unlike
+    # ``recent_values`` this list feeds no ``_percentile`` call.  It
+    # exists only to answer whether ANYONE was measured, so league-wide
+    # absence can renormalise the weight away below.
+    all_play_values = [inputs[o]["all_play"] for o in owner_ids]
+    all_play_available = any(v is not None for v in all_play_values)
 
     # Renormalise weights when missing inputs are present so the score
     # stays in [0, 100] instead of being deflated by the unfilled
@@ -420,6 +436,13 @@ def _score_state(
     # scored at a stand-in value.
     if not recent_available:
         missing_inputs.append("recent")
+    # Same rule, same mechanism, for all_play (owner invariant: missing
+    # != zero).  With no scored weeks anywhere in the snapshot,
+    # ``last_season_allplay_share`` is empty, so the component is
+    # unmeasurable league-wide and drops out of the weight budget rather
+    # than being scored at a stand-in 0.0 for every owner.
+    if not all_play_available:
+        missing_inputs.append("all_play")
 
     # THE PRESEASON SUPPRESSION BELONGS TO ONE LENS, NOT BOTH.
     #
@@ -503,7 +526,7 @@ def _score_state(
                             else round(_percentile(recent_values, i["recent"]), 4)
                         ),
                         "wl_record": round(i["wl_record"], 4),
-                        "all_play": round(i["all_play"], 4),
+                        "all_play": (None if i["all_play"] is None else round(i["all_play"], 4)),
                         "streak": round(i["streak"], 4),
                         "luck_regression": round(i["luck_regression"], 4),
                         "pointsPerGame": round(i["ppg"], 2),

--- a/tests/ros/test_power_v2_season_scoping.py
+++ b/tests/ros/test_power_v2_season_scoping.py
@@ -427,11 +427,24 @@ class TestRecentFormSurvivesAScorelessCurrentSeason:
 
     def test_all_play_also_survives_the_scoreless_season(self):
         """``last_season_allplay_share`` resets alongside it, so the two
-        cannot disagree about which season they describe."""
+        cannot disagree about which season they describe.
+
+        Non-vacuity (V1-52 residual): BOTH of this fixture's owners hold
+        an ``allplay`` key, so the bravo>alpha comparison alone survived
+        the retired ``.get(oid, 0.0)`` default untouched.  The
+        absent-owner fixture is what actually exercises the default arm:
+        carol has no key in the last scored season's share map, and
+        unmeasured must surface as None -- never the 0.0 the default
+        would coerce."""
         out = power_v2.build_section(_preseason_shape_snapshot(), lens=power_v2.LENS_RESULTS_ONLY)
         rows = out["currentRanking"]
         shares = {r["ownerId"]: r["components"]["all_play"] for r in rows}
         assert shares["bravo"] > shares["alpha"]
+        absent = power_v2.build_section(
+            _owner_absent_from_last_scored_season_snapshot(), lens=power_v2.LENS_RESULTS_ONLY
+        )
+        carol = _row(absent["currentRanking"], "carol")["components"]
+        assert carol["all_play"] is None, carol["all_play"]
 
     def test_recent_still_carries_its_declared_weight(self):
         """Guards the other direction: a fix that silently dropped the
@@ -591,6 +604,100 @@ class TestUnmeasuredRecentFormStaysUnknown:
         for row in out["currentRanking"]:
             for key in row["weightsApplied"]:
                 assert row["components"].get(key) is not None, (row["ownerId"], key)
+
+
+class TestUnmeasuredAllPlayStaysUnknown:
+    """Owner invariant, all_play edition (V1-52 residual): the ``recent``
+    repair above left its four-lines-later neighbour coerced --
+    ``state["allplay"].get(oid, 0.0)``.  all_play is an expected share on
+    [0, 1] consumed raw (never percentiled), so the 0.0 default did not
+    even get recent's every-owner-ties-at-0.5 camouflage: it scored a
+    missing owner as the league's WORST all-play performer, at weight
+    0.08.  Same two cases as recent, resolved through the same two
+    mechanisms."""
+
+    # ── (a) nothing measured anywhere ──────────────────────────────────
+
+    def test_no_scored_weeks_drops_all_play_from_the_weight_budget(self):
+        out = power_v2.build_section(_no_scored_weeks_snapshot(), lens=power_v2.LENS_RESULTS_ONLY)
+        assert "all_play" not in (out["effectiveWeights"] or {}), (
+            "an input nothing can supply must renormalise away, not be "
+            "scored at a stand-in value"
+        )
+        assert "all_play" in out["missingInputs"]
+
+    def test_no_scored_weeks_publishes_null_not_zero(self):
+        out = power_v2.build_section(_no_scored_weeks_snapshot(), lens=power_v2.LENS_RESULTS_ONLY)
+        for row in out["currentRanking"]:
+            assert row["components"]["all_play"] is None, row["components"]["all_play"]
+
+    # ── (b) one owner absent from the last scored season ───────────────
+
+    def test_the_absent_owners_all_play_is_null_not_zero(self):
+        out = power_v2.build_section(
+            _owner_absent_from_last_scored_season_snapshot(), lens=power_v2.LENS_RESULTS_ONLY
+        )
+        rows = out["currentRanking"]
+        carol = _row(rows, "carol")["components"]
+        assert carol["all_play"] is None, carol["all_play"]
+        # The measured owners keep real shares -- the null is carol's,
+        # not a league-wide wipe.
+        assert _row(rows, "alpha")["components"]["all_play"] is not None
+        assert _row(rows, "bravo")["components"]["all_play"] is not None
+
+    def test_the_absent_owner_does_not_inherit_a_stale_prior_season(self):
+        """carol dominated 2024's all-play (900 vs 100/110 every week,
+        expectedShare 1.0); none of that may resurface as 2025 form."""
+        out = power_v2.build_section(
+            _owner_absent_from_last_scored_season_snapshot(), lens=power_v2.LENS_RESULTS_ONLY
+        )
+        assert _row(out["currentRanking"], "carol")["components"]["all_play"] != 1.0
+
+    def test_the_absent_owner_is_scored_without_the_unknown_component(self):
+        """Not deflated by a worst-in-league zero -- the weight is simply
+        not applied to this row."""
+        out = power_v2.build_section(
+            _owner_absent_from_last_scored_season_snapshot(), lens=power_v2.LENS_RESULTS_ONLY
+        )
+        rows = out["currentRanking"]
+        carol = _row(rows, "carol")
+        assert "all_play" not in carol["weightsApplied"]
+        assert carol["powerScore"] is not None
+        # The component IS measurable league-wide, so it stays in the
+        # section budget and the owners who have it keep their weight.
+        assert "all_play" in out["effectiveWeights"]
+        assert "all_play" in _row(rows, "alpha")["weightsApplied"]
+
+    def test_a_null_all_play_never_reaches_the_weighted_sum(self):
+        """Mirror of recent's structural sweep, made discriminating for
+        all_play: that sweep passed on the PRE-fix code because the
+        coerced 0.0 is not None -- the weight WAS applied, to a stand-in.
+        This version additionally pins that the absent owner applies no
+        all_play weight at all, so there is no value, real or invented,
+        for it to multiply."""
+        out = power_v2.build_section(
+            _owner_absent_from_last_scored_season_snapshot(), lens=power_v2.LENS_RESULTS_ONLY
+        )
+        for row in out["currentRanking"]:
+            for key in row["weightsApplied"]:
+                assert row["components"].get(key) is not None, (row["ownerId"], key)
+        assert "all_play" not in _row(out["currentRanking"], "carol")["weightsApplied"]
+
+    def test_the_refusal_path_serialises_the_unknown_share_as_null(self):
+        """Forward-looking + preseason with no team-strength file is the
+        every-component-dropped refusal state (the same reachable shape
+        tests/ros/test_power_unrankable.py pins).  carol's unmeasured
+        share must serialise as null there too: the pre-fix ``round()``
+        call would TypeError on None, and a coerced 0.0 would publish a
+        confident worst-in-league share inside the branch whose whole
+        point is refusing to invent numbers."""
+        out = power_v2.build_section(
+            _owner_absent_from_last_scored_season_snapshot(), lens=power_v2.LENS_FORWARD_LOOKING
+        )
+        assert out.get("unrankable"), "fixture must land on the refusal path"
+        rows = out["currentRanking"]
+        assert _row(rows, "carol")["components"]["all_play"] is None
+        assert _row(rows, "alpha")["components"]["all_play"] is not None
 
 
 # ── All three season resets, pinned on one three-season fixture ────────


### PR DESCRIPTION
## Defect (V1-52 residual, adjudicated in `docs/VERSION_1_COMPLETION_CONTRACT.md`'s V1-52 row)

`src/ros/power_v2.py::_score_state` read

```python
all_play = state["allplay"].get(oid, 0.0)
```

four lines below the line that gets `recent` right (`recent = sum(rb) / len(rb) if rb else None`, under the owner-invariant comment "UNMEASURED IS None, NOT 0.0").

`last_season_allplay_share` only holds keys for owners who appeared in the **last SCORED season's** weeks (reset at the top of each scored season, written per week), so an owner absent from that season — mid-rejoin, expansion, departed-and-returned — had no key, and the default coerced that missing measurement to a confident `0.0`.

Worse than recent's version of the same bug: `all_play` is an expected share on [0, 1] consumed **raw** (it never goes through `_percentile`), so the coercion did not even get recent's every-owner-ties-at-0.5 camouflage. A missing owner was scored as the league's **worst** all-play performer, at weight 0.08 of `WEIGHTS`, with the weight applied as though something had been measured.

## Fix

`all_play = None` now flows exactly the way `recent = None` already flows — same mechanisms, no new rule:

- `.get(oid)` with no default, so unmeasured propagates as `None`;
- `all_play_values` / `all_play_available` beside recent's, appending `"all_play"` to `missing_inputs` when **nobody** was measured, so league-wide absence renormalises the weight away via the same `dropped_components` mechanism (case a);
- the per-owner renormalisation already filters a present-but-`None` component out of `owner_weights` — verified, not changed: `components.get(k, 0.0) is not None` sees the `None` **value** because the `all_play` key is always present on the ranked path, so the `0.0` default arm never fires and a single absent owner drops the weight for their row only (case b); serialisation is already None-generic;
- the unrankable/refusal branch's `round(i["all_play"], 4)` is guarded the same way its `recent` neighbour is (`None if ... is None else round(...)`) — it would `TypeError` on `None`, and a refusal branch must not invent a worst-in-league share either.

`all_play` is deliberately **not** routed through `_percentile`: it is already a 0-1 share. `WEIGHTS`, lenses, refusal contracts, `career_state` untouched.

## Tests (`tests/ros/test_power_v2_season_scoping.py`)

New `TestUnmeasuredAllPlayStaysUnknown` mirrors recent's `TestUnmeasuredRecentFormStaysUnknown` over the existing fixtures:

- no scored weeks anywhere → `"all_play"` in `missingInputs`, dropped from `effectiveWeights`, every row's component null (case a);
- carol absent from the last scored season (`_owner_absent_from_last_scored_season_snapshot`) → her `components["all_play"]` is null, never 0.0; her `weightsApplied` excludes `all_play` while alpha/bravo keep theirs and the section budget retains it (case b);
- her 2024 all-play dominance does not resurface as 2025 form;
- structural: no applied weight lacks a real value, **plus** the discriminating half the generic sweep missed — pre-fix the coerced 0.0 *is* not-None, so the sweep passed while the weight multiplied a stand-in; the mirrored version pins that carol applies no `all_play` weight at all;
- the refusal path (forward-looking + preseason, no team-strength file) serialises her share as null.

`test_all_play_also_survives_the_scoreless_season` is strengthened with the absent-owner fixture: its previous both-owners-have-keys shape never exercised the `.get` default arm, so it passed under the mutation.

## Mutation proof

Reverting the one line to `.get(oid, 0.0)`:

```
7 failed, 28 passed  (e.g. `assert 0.0 is None`)
FAILED ...::test_all_play_also_survives_the_scoreless_season
FAILED ...::TestUnmeasuredAllPlayStaysUnknown::test_no_scored_weeks_drops_all_play_from_the_weight_budget
FAILED ...::TestUnmeasuredAllPlayStaysUnknown::test_no_scored_weeks_publishes_null_not_zero
FAILED ...::TestUnmeasuredAllPlayStaysUnknown::test_the_absent_owners_all_play_is_null_not_zero
FAILED ...::TestUnmeasuredAllPlayStaysUnknown::test_the_absent_owner_is_scored_without_the_unknown_component
FAILED ...::TestUnmeasuredAllPlayStaysUnknown::test_a_null_all_play_never_reaches_the_weighted_sum
FAILED ...::TestUnmeasuredAllPlayStaysUnknown::test_the_refusal_path_serialises_the_unknown_share_as_null
```

Restored: `35 passed` in the file. Working tree returned to the clean diff before commit.

## Test results

- `python -m pytest tests/ros/ tests/public_league/ -q` → **691 passed, 1 skipped, 50 subtests passed**
- `tests/ros/test_power_unrankable.py` + `tests/ros/test_power_lenses.py` + this file → **54 passed** (18 passed, 1 skipped for the first two alone)
- `ruff format --check` + `ruff check` pass on both touched files under **CI's pinned ruff 0.6.9** (verified with that exact version, not just the newer local one); a pre-existing assert message the local 0.15.x formatter wanted to collapse was hand-restored so no untouched code is reformatted.

Frontend confirmed safe downstream: `ros-power.jsx`'s `ComponentBar` returns null for a weight the row did not apply, so an unmeasured share's bar vanishes instead of rendering a fabricated 0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_