### PR TITLE
Lane 4 verifier: V1-65 census, V1-58 in-process cohort, V1-87 flag blast-radius — three on-box checks

### DIFF
--- a/scripts/verify_lane4_production.py
+++ b/scripts/verify_lane4_production.py
@@ -1609,16 +1609,128 @@ def check_league_population_difference(report: Report, *, ledger_path: Path | No
     )
 
 
-def record_blocked_rows(report: Report, unauth_detail: str | None) -> None:
+def check_cohort_population_onbox(report: Report, *, ledger_path: Path | None = None) -> None:
+    """V1-58 — the sharp cohort, resolved in-process from the deployed stores.
+
+    Over HTTPS this row needs an authenticated ``/api/sharp/cohort`` read.
+    On the box the SAME population is resolvable in-process through the one
+    canonical owner — ``src/sharp/cohort.py::cohort_members`` — which is the
+    identical pattern ``run_onbox`` already trusts when it builds the market
+    and roster-percentage boards from the deployed stores for C1-C3.
+
+    Two honesty rules, both structural:
+
+    * A population of ZERO with the stores PRESENT is a REAL measured
+      answer.  It is reported as PASS with ``populated: false`` — the check
+      verifies MEASURABILITY and reports the population truthfully.  It is
+      never converted to FAILED (an empty cohort is a finding, not a broken
+      verifier) and never presented as a populated cohort.
+    * Absent stores are BLOCKED.  Empty-here is only evidence when the
+      store is actually here.
+    """
+    check = report.add(
+        Check("V58", "V1-58", "sharp cohort resolved in-process from the deployed stores")
+    )
+    try:
+        from src.intel import ledger as intel_ledger
+        from src.sharp.cohort import cohort_members, load_ffpc_config
+    except Exception as exc:  # pragma: no cover - deployment shape
+        check.status = ERROR
+        check.detail = f"could not import the cohort owner: {exc!r}"
+        return
+
+    path = Path(ledger_path) if ledger_path else intel_ledger.default_path()
+    if not path.exists():
+        # ``ledger.connect`` (which the cohort owner reaches through
+        # ``ensure_platform_schema``) CREATES an absent file, so presence is
+        # decided here first — this script is read-only.
+        check.status = BLOCKED
+        check.detail = (
+            f"no platform ledger at {path}, so there is no store to resolve the "
+            "cohort from. This is the sandbox/undeployed state — run on the box. "
+            "Not to be closed by manufacturing a cohort."
+        )
+        check.evidence = {"ledgerPresent": False, "ledgerPath": str(path)}
+        return
+
+    try:
+        # The same config-loading path market_payload uses for its own
+        # in-process cohort resolution.
+        members, coverage = cohort_members(
+            qualification="all", ledger_path=path, ffpc_config=load_ffpc_config()
+        )
+    except Exception as exc:
+        check.status = ERROR
+        check.detail = f"cohort_members raised: {exc!r}"
+        return
+
+    by_method: dict[str, int] = {}
+    by_platform: dict[str, int] = {}
+    for member in members:
+        by_method[member.qualification_method] = by_method.get(member.qualification_method, 0) + 1
+        by_platform[member.platform] = by_platform.get(member.platform, 0) + 1
+
+    # Deliberately NOT a population denominator: this check verifies that
+    # the cohort is MEASURABLE here and reports the population truthfully,
+    # and a truthful zero must not be downgraded by the vacuous-pass guard
+    # in ``Check.finalize`` — zero members over present stores is the
+    # measured answer, not an uninspected one.
+    check.denominator = None
+    check.evidence = {
+        "ledgerPresent": True,
+        "memberCount": len(members),
+        "populated": bool(members),
+        "byQualificationMethod": by_method,
+        "byPlatform": by_platform,
+        "coverage": coverage,
+    }
+    check.status = PASS
+    if members:
+        check.detail = (
+            f"cohort resolves in-process to {len(members)} member(s) ({by_method}; "
+            f"platforms {by_platform}); methodology "
+            f"{coverage.get('methodologyVersion')!r}."
+        )
+    else:
+        check.detail = (
+            "the stores are present and the cohort truthfully resolves to ZERO "
+            "members — a real measured answer, reported as populated: false "
+            f"(evidenceManagers={coverage.get('evidenceManagers')}, "
+            f"automated={coverage.get('automatedQualifiedManagers')}, "
+            f"curated={coverage.get('curatedManagers')}, "
+            f"provisional={coverage.get('provisionalManagers')}). Not converted to a "
+            "failure: an empty cohort is a finding about the deployed data, not "
+            "about this check."
+        )
+
+
+def record_blocked_rows(report: Report, unauth_detail: str | None, *, mode: str = "remote") -> None:
     """V1-58 / V1-59 — recorded as BLOCKED, with the credential named.
+
+    V1-59 (a clean journalctl run of the three-pass crawl chain) is blocked
+    in BOTH modes — nothing in this script can observe systemd journals
+    remotely, and the on-box run still needs a human-readable journal pass.
+
+    V1-58 is blocked only in REMOTE mode.  On the box the cohort is resolved
+    IN-PROCESS by :func:`check_cohort_population_onbox`, through the same
+    canonical owner and the same deployed stores that ``run_onbox`` already
+    uses to build the market and roster boards for C1-C3 — so recording the
+    row as blocked there would deny a measurement the run just made.
+    Whether an in-process resolution satisfies the row's L3 (whose wording
+    names an authenticated ``/api/sharp/cohort`` read) is an adjudication
+    call recorded at the contract ledger, not decided by this script; the
+    check reports the measurement and claims nothing about the row's level.
 
     Never closed by standing up a synthetic cohort: a manufactured population
     would verify the manufacture.
     """
-    for row, title in (
+    rows = [
         ("V1-58", "Sharp cohort proven populated in production"),
         ("V1-59", "Sharp bootstrap stops failing"),
-    ):
+    ]
+    if mode == "onbox":
+        rows = [entry for entry in rows if entry[0] != "V1-58"]
+    for row, title in rows:
         check = report.add(Check(f"B{row[-2:]}", row, title))
         check.status = UNVERIFIABLE if unauth_detail else BLOCKED
         check.detail = (
@@ -1787,7 +1899,7 @@ def run_remote(report: Report, args: argparse.Namespace) -> None:
     check_crowd_refusal_reasons(report, faab, source)
     check_faab_recommendation_effect(report, faab, source)
 
-    record_blocked_rows(report, unauth)
+    record_blocked_rows(report, unauth, mode="remote")
 
 
 def run_onbox(report: Report, args: argparse.Namespace) -> None:
@@ -1895,7 +2007,8 @@ def run_onbox(report: Report, args: argparse.Namespace) -> None:
     check_ffpc_lane_is_honest(report)
     check_single_cohort_owner(report)
     check_league_population_difference(report)
-    record_blocked_rows(report, None)
+    check_cohort_population_onbox(report)
+    record_blocked_rows(report, None, mode="onbox")
 
 
 def _git_head() -> str | None:

--- a/scripts/verify_lane4_production.py
+++ b/scripts/verify_lane4_production.py
@@ -1463,6 +1463,152 @@ def check_single_cohort_owner(report: Report) -> None:
         check.detail = f"expected one definition in src/sharp/cohort.py, found {hits}."
 
 
+def check_league_population_difference(report: Report, *, ledger_path: Path | None = None) -> None:
+    """V1-65 (L2) — the two admitted league populations, from the deployed ledger.
+
+    The row's L2 needs the CENSUS, not just the single-owner property that
+    ``check_single_cohort_owner`` pins: how many discovered leagues the
+    Insider (signal) gate admits, how many the strictly-narrower Sharp gate
+    admits, and an explicit accounting of the difference.  All of it is read
+    from the intel ledger through the existing read-only primitives
+    (``discovery.signal_eligible_league_ids`` / ``sharp_eligible_league_ids``
+    / ``graph_stats``); nothing is re-decided here.
+
+    The one thing this check ASSERTS rather than reports: sharp is defined as
+    strictly narrower than signal (dynasty-only, no keeper, >= 2 seasons —
+    ``src/intel/league_filter.py``), so a sharp-admitted league outside the
+    signal set means the two gates disagreed about the same stored evidence.
+
+    The signal-but-not-sharp difference is EXPLAINED, not just counted: each
+    league's stored ``settings_json`` evidence (type / bestBall / ageSeasons)
+    is re-run through the canonical ``league_filter.sharp_exclusion_reason``
+    ladder — never a second rule — and the reasons are published as a
+    histogram.
+    """
+    check = report.add(
+        Check(
+            "V65b",
+            "V1-65",
+            "signal- vs sharp-admitted league populations, censused from the deployed ledger",
+        )
+    )
+    try:
+        from src.intel import league_filter
+        from src.intel import ledger as intel_ledger
+        from src.sharp import discovery
+    except Exception as exc:  # pragma: no cover - deployment shape
+        check.status = ERROR
+        check.detail = f"could not import the discovery/ledger owners: {exc!r}"
+        return
+
+    path = Path(ledger_path) if ledger_path else intel_ledger.default_path()
+    if not path.exists():
+        # ``ledger.connect`` CREATES an absent file (schema write), and this
+        # script is read-only — so presence is decided before any connect.
+        check.status = BLOCKED
+        check.detail = (
+            f"no intel ledger at {path}, so there is no discovered-league store to "
+            "census. This is the sandbox/undeployed state — the ledger is gitignored "
+            "and prod-only. Run on the box; do not synthesise leagues."
+        )
+        check.evidence = {"ledgerPresent": False, "ledgerPath": str(path)}
+        return
+
+    conn = intel_ledger.connect(path)
+    try:
+        league_rows = conn.execute("SELECT league_id, settings_json FROM leagues").fetchall()
+        ms_sharp_complete = conn.execute(
+            "SELECT COUNT(DISTINCT league_id) AS n FROM manager_seasons "
+            "WHERE sharp_eligible=1 AND is_complete=1"
+        ).fetchone()["n"]
+    finally:
+        conn.close()
+
+    if not league_rows:
+        check.status = UNMEASURABLE
+        check.detail = (
+            "ledger carries no discovered leagues here — an environment artifact "
+            "(the discovery crawl runs only on the deployed box), not a statement "
+            "about the production graph. Empty-here is not evidence of anything."
+        )
+        check.evidence = {"ledgerPresent": True, "observedLeagues": 0}
+        return
+
+    signal = set(discovery.signal_eligible_league_ids(ledger_path=path))
+    sharp = set(discovery.sharp_eligible_league_ids(ledger_path=path))
+    stats = discovery.graph_stats(ledger_path=path)
+    sharp_only = sorted(sharp - signal)
+    signal_only = sorted(signal - sharp)
+
+    stored = {str(r["league_id"]): r["settings_json"] for r in league_rows}
+    histogram: dict[str, int] = {}
+    for lid in signal_only:
+        try:
+            settings = json.loads(stored.get(lid) or "{}")
+        except (TypeError, ValueError):
+            settings = None
+        if not isinstance(settings, dict):
+            histogram["unparseable_settings"] = histogram.get("unparseable_settings", 0) + 1
+            continue
+        age_recorded = "ageSeasons" in settings
+        # Faithful inverse of what discovery stored, not a guess:
+        # ``league_age_seasons`` answers 2 iff ``previous_league_id`` was
+        # truthy at crawl time, and ``ageSeasons`` recorded exactly that.
+        reconstructed = {
+            "settings": {"type": settings.get("type"), "best_ball": settings.get("bestBall")},
+            "previous_league_id": (
+                "recorded-chain" if (settings.get("ageSeasons") or 0) >= 2 else ""
+            ),
+        }
+        reason = league_filter.sharp_exclusion_reason(reconstructed)
+        if reason == "too_new" and not age_recorded:
+            # An unrecorded age is UNKNOWN, and unknown must not read as a
+            # measured "too new" — missing is never a value.
+            reason = "age_unrecorded"
+        if reason is None:
+            # Re-derivation admits a league the stored sharpEligible flag
+            # refused. Publish the drift; coerce neither side.
+            reason = "stored_flag_disagrees_with_rederivation"
+        histogram[reason] = histogram.get(reason, 0) + 1
+
+    check.denominator = len(league_rows)
+    check.evidence = {
+        "ledgerPresent": True,
+        "observedLeagues": len(league_rows),
+        "signalAdmitted": len(signal),
+        "sharpAdmitted": len(sharp),
+        "signalOnlyCount": len(signal_only),
+        "signalOnlySample": signal_only[:10],
+        "sharpOnlyCount": len(sharp_only),
+        "sharpOnlySample": sharp_only[:10],
+        "sharpExclusionReasons": histogram,
+        # Cross-check from an independent table: leagues whose crawled
+        # season RECORDS are marked sharp-eligible and complete. Reported,
+        # not asserted against the discovery flags — the records crawl
+        # legitimately lags discovery.
+        "managerSeasonsSharpCompleteLeagues": ms_sharp_complete,
+        "graphStats": {
+            key: stats.get(key) for key in ("observedUsers", "memberships", "discoveryOnlyLeagues")
+        },
+    }
+    if sharp_only:
+        check.status = FAIL
+        check.detail = (
+            f"{len(sharp_only)} league(s) are sharp-admitted but NOT signal-admitted "
+            f"(sample {sharp_only[:10]}). Sharp is defined as strictly narrower than "
+            "signal (dynasty-only, >= 2 seasons), so this set must be empty — a member "
+            "here means the two gates disagree about the same stored evidence."
+        )
+        return
+    check.status = PASS
+    check.detail = (
+        f"signal admits {len(signal)} of {len(league_rows)} discovered leagues, sharp "
+        f"admits {len(sharp)}; the {len(signal_only)}-league difference is explained by "
+        f"{histogram}. manager_seasons cross-check: {ms_sharp_complete} distinct "
+        "league(s) carry sharp-eligible complete season records."
+    )
+
+
 def record_blocked_rows(report: Report, unauth_detail: str | None) -> None:
     """V1-58 / V1-59 — recorded as BLOCKED, with the credential named.
 
@@ -1748,6 +1894,7 @@ def run_onbox(report: Report, args: argparse.Namespace) -> None:
     check_faab_history_artifact(report, args.league)
     check_ffpc_lane_is_honest(report)
     check_single_cohort_owner(report)
+    check_league_population_difference(report)
     record_blocked_rows(report, None)
 
 

--- a/scripts/verify_lane4_production.py
+++ b/scripts/verify_lane4_production.py
@@ -1704,6 +1704,141 @@ def check_cohort_population_onbox(report: Report, *, ledger_path: Path | None = 
         )
 
 
+def check_ledger_rank_change_flag(report: Report, *, ledger_path: Path | None = None) -> None:
+    """V1-87 — the measured ON/OFF blast radius of RISKIT_FEATURE_LEDGER_RANK_CHANGE.
+
+    The row is blocked on exactly one input: a temporal ledger with real
+    ``canonical_board`` rows, which only production has —
+    ``src/history/record.py`` writes that lane at the fresh-scrape promotion
+    site.  ``data_contract._stamp_rank_changes`` documents why the number
+    cannot be taken anywhere else: with no ledger BOTH flag branches stamp
+    ``None``, so an ON/OFF diff reports a vacuous "0 rows changed" that
+    would read as evidence.
+
+    The measurement is the NARROW read, deliberately.  Flag OFF stamps
+    ``None`` on every row structurally (``_stamp_rank_changes`` never
+    touches the ledger on that branch), so its non-null count is 0 by
+    construction and rebuilding the whole contract to observe it would
+    prove nothing the source does not already state.  Flag ON derives
+    ``rankChange`` from ``asof.previous_board_ranks`` — called here with
+    the same arguments ``data_contract`` passes — joined against the
+    newest recorded canonical board, which IS the served board's recorded
+    ranks.  A full double contract rebuild on the box would answer the
+    same question at far greater cost; ``measurementBasis`` in the
+    evidence says so.
+    """
+    check = report.add(
+        Check(
+            "V87",
+            "V1-87",
+            "ledger rank-change flag ON/OFF blast radius over the recorded canonical_board lane",
+        )
+    )
+    try:
+        from src.history import asof as history_asof
+        from src.history import store as history_store
+    except Exception as exc:  # pragma: no cover - deployment shape
+        check.status = ERROR
+        check.detail = f"could not import the temporal-history owner: {exc!r}"
+        return
+
+    path = Path(ledger_path) if ledger_path else history_store.DB_PATH
+    coverage = history_store.coverage(path)
+    lane_counts = coverage.get("byLane") or {}
+    canonical_rows = int(lane_counts.get(history_store.LANE_CANONICAL, 0) or 0)
+    check.evidence = {
+        "ledgerPath": str(path),
+        "ledgerPresent": bool(coverage.get("exists")),
+        "laneRowCounts": lane_counts,
+        "canonicalBoardRows": canonical_rows,
+    }
+    if not coverage.get("exists") or canonical_rows == 0:
+        check.status = UNMEASURABLE
+        check.detail = (
+            "the temporal ledger holds no canonical_board rows here — an environment "
+            "artifact, not a measurement: only production records that lane "
+            "(src/history/record.py, at the fresh-scrape promotion site in server.py). "
+            "With no ledger BOTH flag branches stamp None, so an ON/OFF diff taken "
+            "here would report a vacuous '0 rows changed' and must not be recorded as "
+            "evidence. Run this on the box."
+        )
+        return
+
+    conn = history_store.connect(path)
+    try:
+        dates = [
+            str(r[0])
+            for r in conn.execute(
+                "SELECT DISTINCT observed_date FROM observations "
+                "WHERE lane=? ORDER BY observed_date",
+                (history_store.LANE_CANONICAL,),
+            ).fetchall()
+        ]
+        newest = dates[-1] if dates else None
+        # The newest recorded board's ranked rows, corrections excluded —
+        # the same exclusion previous_board_ranks applies to the comparator.
+        ranked_keys = {
+            str(r[0])
+            for r in conn.execute(
+                "SELECT DISTINCT asset_key FROM observations "
+                "WHERE lane=? AND observed_date=? AND rank IS NOT NULL "
+                "AND id NOT IN (SELECT superseded_id FROM corrections)",
+                (history_store.LANE_CANONICAL, newest),
+            ).fetchall()
+        }
+    finally:
+        conn.close()
+
+    check.evidence.update({"canonicalBoardDates": len(dates), "newestBoardDate": newest})
+    if len(dates) < 2:
+        check.status = UNMEASURABLE
+        check.detail = (
+            f"the canonical_board lane holds only {len(dates)} distinct board date(s), "
+            "and rankChange needs a strictly-prior comparator date — the flag's ON "
+            "branch cannot be measured from this ledger yet. Not a pass: re-run after "
+            "the next recorded board."
+        )
+        return
+
+    # The same function, with the same arguments, that
+    # data_contract._stamp_rank_changes calls when the flag is ON.
+    previous = history_asof.previous_board_ranks(before_date=newest, path=path)
+    comparator_keys = {key for key, (_d, rank) in previous.items() if rank > 0}
+    on_non_null = len(ranked_keys & comparator_keys)
+    comparator_date = next(iter(sorted({d for d, _r in previous.values()})), None)
+
+    check.denominator = len(ranked_keys)
+    check.evidence.update(
+        {
+            "comparatorDate": comparator_date,
+            "comparatorRankedAssets": len(previous),
+            "rankedRowsOnNewestBoard": len(ranked_keys),
+            "nonNullRankChangeOn": on_non_null,
+            # OFF stamps None on every row before the ledger is ever read —
+            # structural, per _stamp_rank_changes' flag branch, so 0 here is
+            # a statement about the code, not an observation of this ledger.
+            "nonNullRankChangeOff": 0,
+            "offIsStructural": True,
+            "delta": on_non_null,
+            "measurementBasis": (
+                "narrow read through src/history's own reader: the newest recorded "
+                "canonical_board (the served board's recorded ranks) joined against "
+                "asof.previous_board_ranks — the same call data_contract."
+                "_stamp_rank_changes makes with the flag ON. OFF is structurally "
+                "all-None, so a full double contract rebuild would answer the same "
+                "question at far greater cost and was deliberately not run."
+            ),
+        }
+    )
+    check.status = PASS
+    check.detail = (
+        f"flag ON derives a non-null rankChange for {on_non_null} of {len(ranked_keys)} "
+        f"ranked rows on the {newest} board (comparator {comparator_date}, "
+        f"{len(previous)} ranked assets); flag OFF stamps None on all of them "
+        f"structurally, so the blast radius is exactly {on_non_null} rows."
+    )
+
+
 def record_blocked_rows(report: Report, unauth_detail: str | None, *, mode: str = "remote") -> None:
     """V1-58 / V1-59 — recorded as BLOCKED, with the credential named.
 
@@ -2008,6 +2143,7 @@ def run_onbox(report: Report, args: argparse.Namespace) -> None:
     check_single_cohort_owner(report)
     check_league_population_difference(report)
     check_cohort_population_onbox(report)
+    check_ledger_rank_change_flag(report)
     record_blocked_rows(report, None, mode="onbox")
 
 

--- a/tests/ops/test_lane4_verification.py
+++ b/tests/ops/test_lane4_verification.py
@@ -860,3 +860,114 @@ class TestLeaguePopulationCensus:
         assert check.status == verify.BLOCKED
         assert check.evidence["ledgerPresent"] is False
         assert not path.exists()
+
+
+# ── V1-58: the in-process cohort resolution ────────────────────────
+
+
+class TestCohortPopulationOnbox:
+    """On the box the cohort is resolvable in-process through the canonical
+    owner — the same pattern run_onbox uses for the market and roster
+    boards. Two honesty rules: a measured zero over present stores is a
+    truthful pass-with-populated-false, and absent stores are blocked."""
+
+    def test_an_absent_store_is_blocked_and_is_not_created(self, tmp_path):
+        path = tmp_path / "absent" / "ledger.sqlite3"
+        report = _report()
+        verify.check_cohort_population_onbox(report, ledger_path=path)
+        check = report.checks[0]
+        assert check.status == verify.BLOCKED
+        assert check.evidence["ledgerPresent"] is False
+        assert not path.exists()
+
+    def test_a_measured_zero_over_present_stores_is_a_truthful_pass(self, tmp_path, monkeypatch):
+        """Zero members with the stores present is a REAL measured answer.
+
+        Not converted to FAILED (an empty cohort is a finding about the
+        deployed data, not about the check), not presented as populated,
+        and not downgraded by the vacuous-pass guard — this check verifies
+        measurability, so its denominator is deliberately None.
+        """
+        from src.sharp import cohort
+
+        path = _intel_ledger(tmp_path, monkeypatch)
+        monkeypatch.setattr(cohort, "load_ffpc_config", lambda path=None: {})
+        # The curated-industry population reads a separate store that may or
+        # may not exist in a dev checkout; pin it empty so this test measures
+        # the automated path over the tmp ledger deterministically.
+        monkeypatch.setattr(cohort, "curated_industry_members", lambda qualification: [])
+        report = _report()
+        verify.check_cohort_population_onbox(report, ledger_path=path)
+        report.finalize()
+        check = report.checks[0]
+        assert check.status == verify.PASS, check.detail
+        assert check.evidence["populated"] is False
+        assert check.evidence["memberCount"] == 0
+        assert "ZERO" in check.detail and "measured" in check.detail
+
+    def test_a_populated_cohort_reports_the_qualification_and_platform_split(
+        self, tmp_path, monkeypatch
+    ):
+        from src.sharp import cohort
+
+        path = _intel_ledger(tmp_path, monkeypatch)
+        members = [
+            cohort.CohortMember("sleeper:u1", "sleeper", "automated_qualified", 0.9),
+            cohort.CohortMember("ffpc:m1", "ffpc", "curated_high_stakes", 0.75),
+        ]
+        coverage = {
+            "automatedQualifiedManagers": 1,
+            "curatedManagers": 1,
+            "provisionalManagers": 0,
+            "evidenceManagers": 5,
+            "methodologyVersion": "sharp-v2-test",
+        }
+        monkeypatch.setattr(cohort, "cohort_members", lambda **kw: (members, coverage))
+        report = _report()
+        verify.check_cohort_population_onbox(report, ledger_path=path)
+        check = report.checks[0]
+        assert check.status == verify.PASS
+        assert check.evidence["populated"] is True
+        assert check.evidence["memberCount"] == 2
+        assert check.evidence["byQualificationMethod"] == {
+            "automated_qualified": 1,
+            "curated_high_stakes": 1,
+        }
+        assert check.evidence["byPlatform"] == {"sleeper": 1, "ffpc": 1}
+        assert check.evidence["coverage"]["methodologyVersion"] == "sharp-v2-test"
+
+
+class TestBlockedRowsModeSplit:
+    """B58 stays blocked only where nothing measured it: REMOTE mode.
+
+    On the box check_cohort_population_onbox resolves the cohort in-process,
+    so recording the row as blocked there would deny a measurement the run
+    just made. B59 stays blocked in both modes.
+    """
+
+    def test_remote_mode_records_both_rows_blocked(self):
+        report = _report()
+        verify.record_blocked_rows(report, None, mode="remote")
+        assert [c.row for c in report.checks] == ["V1-58", "V1-59"]
+        assert all(c.status == verify.BLOCKED for c in report.checks)
+
+    def test_remote_mode_with_a_401_records_both_rows_unverifiable(self):
+        report = _report()
+        verify.record_blocked_rows(report, "401 from /api/sharp/cohort", mode="remote")
+        assert [c.row for c in report.checks] == ["V1-58", "V1-59"]
+        assert all(c.status == verify.UNVERIFIABLE for c in report.checks)
+
+    def test_onbox_mode_keeps_only_b59(self):
+        report = _report()
+        verify.record_blocked_rows(report, None, mode="onbox")
+        assert [c.row for c in report.checks] == ["V1-59"]
+        assert report.checks[0].status == verify.BLOCKED
+
+    def test_run_onbox_actually_registers_the_in_process_check(self):
+        """Non-vacuity: the mode split is only honest if the on-box run
+        REPLACES the blocked row with a measurement rather than dropping it."""
+        import inspect
+
+        source = inspect.getsource(verify.run_onbox)
+        assert "check_cohort_population_onbox(report)" in source
+        assert 'record_blocked_rows(report, None, mode="onbox")' in source

--- a/tests/ops/test_lane4_verification.py
+++ b/tests/ops/test_lane4_verification.py
@@ -724,3 +724,139 @@ class TestTheRequiredListsCannotBeSilentlyEmptied:
         turned on. If one stops being guarded, the correction it protects can
         silently rot back."""
         assert field in verify.REQUIRED_FIELDS
+
+
+# ── V1-65: the league-population census ────────────────────────────
+
+
+def _intel_ledger(tmp_path, monkeypatch):
+    """A tmp intel ledger, schema applied — the test_discovery pattern."""
+    from src.intel import ledger, store
+
+    monkeypatch.setattr(store, "DATA_DIR", tmp_path / "intel")
+    ledger.reset_setup_cache()
+    path = tmp_path / "intel" / ledger.LEDGER_FILENAME
+    ledger.connect(path).close()
+    return path
+
+
+def _league_row(league_id, *, type_=2, best_ball=0, signal=True, sharp=True, age=2, omit_age=False):
+    import json
+
+    settings = {
+        "type": type_,
+        "bestBall": best_ball,
+        "signalEligible": signal,
+        "sharpEligible": sharp,
+        "ageSeasons": age,
+    }
+    if omit_age:
+        settings.pop("ageSeasons")
+    return {
+        "league_id": league_id,
+        "season": "2026",
+        "previous_league_id": "prev" if age >= 2 else "",
+        "name": f"League {league_id}",
+        "total_rosters": 12,
+        "settings_json": json.dumps(settings),
+    }
+
+
+class TestLeaguePopulationCensus:
+    """V1-65's L2 census: signal- vs sharp-admitted, with the difference
+    explained rather than merely counted."""
+
+    def test_a_populated_ledger_yields_the_census_and_the_reason_histogram(
+        self, tmp_path, monkeypatch
+    ):
+        from src.intel import ledger
+
+        path = _intel_ledger(tmp_path, monkeypatch)
+        ledger.upsert_leagues(
+            [
+                # signal AND sharp: dynasty, 2 seasons.
+                _league_row("DYN_OLD", type_=2, signal=True, sharp=True, age=2),
+                # signal only: keeper (dynasty-adjacent, never sharp).
+                _league_row("KEEP", type_=1, signal=True, sharp=False, age=2),
+                # signal only: first-year dynasty.
+                _league_row("DYN_NEW", type_=2, signal=True, sharp=False, age=1),
+                # neither: best-ball and redraft.
+                _league_row("BB", type_=2, best_ball=1, signal=False, sharp=False),
+                _league_row("RED", type_=0, signal=False, sharp=False),
+            ],
+            path=path,
+        )
+        conn = ledger.connect(path)
+        try:
+            conn.execute(
+                "INSERT INTO manager_seasons (league_id, season, user_id, is_complete, "
+                "sharp_eligible) VALUES ('DYN_OLD', '2025', 'u1', 1, 1)"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        report = _report()
+        verify.check_league_population_difference(report, ledger_path=path)
+        check = report.checks[0]
+        assert check.status == verify.PASS, check.detail
+        assert check.evidence["signalAdmitted"] == 3
+        assert check.evidence["sharpAdmitted"] == 1
+        assert check.evidence["sharpOnlyCount"] == 0
+        assert check.evidence["signalOnlyCount"] == 2
+        assert sorted(check.evidence["signalOnlySample"]) == ["DYN_NEW", "KEEP"]
+        assert check.evidence["sharpExclusionReasons"] == {"keeper": 1, "too_new": 1}
+        assert check.evidence["managerSeasonsSharpCompleteLeagues"] == 1
+        assert check.denominator == 5
+
+    def test_a_sharp_league_outside_the_signal_set_fails(self, tmp_path, monkeypatch):
+        """Sharp is strictly narrower by definition; a member here means the
+        two gates disagreed about the same stored evidence."""
+        from src.intel import ledger
+
+        path = _intel_ledger(tmp_path, monkeypatch)
+        ledger.upsert_leagues(
+            [_league_row("WEIRD", type_=2, signal=False, sharp=True, age=2)], path=path
+        )
+        report = _report()
+        verify.check_league_population_difference(report, ledger_path=path)
+        check = report.checks[0]
+        assert check.status == verify.FAIL
+        assert check.evidence["sharpOnlySample"] == ["WEIRD"]
+
+    def test_an_unrecorded_age_is_not_reported_as_too_new(self, tmp_path, monkeypatch):
+        """Missing is never a value: a league whose stored settings carry no
+        ageSeasons must not read as a measured 'too new'."""
+        from src.intel import ledger
+
+        path = _intel_ledger(tmp_path, monkeypatch)
+        ledger.upsert_leagues(
+            [_league_row("NOAGE", type_=2, signal=True, sharp=False, age=1, omit_age=True)],
+            path=path,
+        )
+        report = _report()
+        verify.check_league_population_difference(report, ledger_path=path)
+        check = report.checks[0]
+        assert check.status == verify.PASS
+        assert check.evidence["sharpExclusionReasons"] == {"age_unrecorded": 1}
+
+    def test_an_empty_leagues_table_is_unmeasurable_never_pass(self, tmp_path, monkeypatch):
+        path = _intel_ledger(tmp_path, monkeypatch)
+        report = _report()
+        verify.check_league_population_difference(report, ledger_path=path)
+        check = report.checks[0]
+        assert check.status == verify.UNMEASURABLE
+        assert "carries no discovered leagues here" in check.detail
+        assert check.evidence["ledgerPresent"] is True
+
+    def test_an_absent_ledger_is_blocked_and_is_not_created(self, tmp_path):
+        """Read-only: probing for the store must not mint one — an empty
+        ledger this check created would be indistinguishable from a real
+        empty crawl on the next run."""
+        path = tmp_path / "absent" / "ledger.sqlite3"
+        report = _report()
+        verify.check_league_population_difference(report, ledger_path=path)
+        check = report.checks[0]
+        assert check.status == verify.BLOCKED
+        assert check.evidence["ledgerPresent"] is False
+        assert not path.exists()

--- a/tests/ops/test_lane4_verification.py
+++ b/tests/ops/test_lane4_verification.py
@@ -971,3 +971,118 @@ class TestBlockedRowsModeSplit:
         source = inspect.getsource(verify.run_onbox)
         assert "check_cohort_population_onbox(report)" in source
         assert 'record_blocked_rows(report, None, mode="onbox")' in source
+
+
+# ── V1-87: the rank-change flag's blast radius ─────────────────────
+
+
+def _temporal_ledger(tmp_path):
+    from src.history import store
+
+    store._reset_setup_cache_for_tests()
+    path = tmp_path / "temporal_ledger.sqlite"
+    store.connect(path).close()
+    return path
+
+
+def _record_board(path, observed_date, ranks_by_player):
+    """One canonical_board date: ``{player_suffix: rank}``."""
+    from src.history import store
+
+    result = store.write_observations(
+        [
+            {
+                "asset_key": f"player:{suffix}",
+                "asset_class": "offense",
+                "lane": store.LANE_CANONICAL,
+                "source_key": "",
+                "observed_date": observed_date,
+                "rank": rank,
+                "value": 1000.0 - rank,
+                "origin": "test",
+            }
+            for suffix, rank in ranks_by_player.items()
+        ],
+        path=path,
+    )
+    assert not result["rejected"], result["rejected"]
+    return result
+
+
+class TestLedgerRankChangeFlag:
+    """V1-87: the flag's ON/OFF blast radius, measured against a ledger with
+    real canonical_board rows — and honestly unmeasurable without one, since
+    with no ledger BOTH branches stamp None and the diff is vacuous."""
+
+    def test_two_board_dates_yield_the_measured_blast_radius(self, tmp_path):
+        path = _temporal_ledger(tmp_path)
+        _record_board(path, "2026-08-01", {"1": 10, "2": 20, "3": 30})
+        # player:4 is new on the second board: ranked, but no comparator,
+        # so the ON branch stamps None for it — it must not count.
+        _record_board(path, "2026-08-02", {"2": 15, "3": 35, "4": 40})
+        report = _report()
+        verify.check_ledger_rank_change_flag(report, ledger_path=path)
+        report.finalize()
+        check = report.checks[0]
+        assert check.status == verify.PASS, check.detail
+        assert check.evidence["canonicalBoardRows"] == 6
+        assert check.evidence["canonicalBoardDates"] == 2
+        assert check.evidence["newestBoardDate"] == "2026-08-02"
+        assert check.evidence["comparatorDate"] == "2026-08-01"
+        assert check.evidence["rankedRowsOnNewestBoard"] == 3
+        assert check.evidence["nonNullRankChangeOn"] == 2
+        assert check.evidence["nonNullRankChangeOff"] == 0
+        assert check.evidence["offIsStructural"] is True
+        assert check.evidence["delta"] == 2
+        assert check.denominator == 3
+
+    def test_a_single_board_date_is_unmeasurable_not_zero(self, tmp_path):
+        """One date has no strictly-prior comparator. Reporting a blast
+        radius of 0 there would present 'cannot measure' as 'measured
+        nothing moved'."""
+        path = _temporal_ledger(tmp_path)
+        _record_board(path, "2026-08-01", {"1": 10, "2": 20})
+        report = _report()
+        verify.check_ledger_rank_change_flag(report, ledger_path=path)
+        check = report.checks[0]
+        assert check.status == verify.UNMEASURABLE
+        assert "strictly-prior comparator" in check.detail
+        assert check.evidence["canonicalBoardDates"] == 1
+
+    def test_an_absent_ledger_is_unmeasurable_and_is_not_created(self, tmp_path):
+        path = tmp_path / "absent" / "temporal_ledger.sqlite"
+        report = _report()
+        verify.check_ledger_rank_change_flag(report, ledger_path=path)
+        check = report.checks[0]
+        assert check.status == verify.UNMEASURABLE
+        assert "environment artifact" in check.detail
+        assert check.evidence["ledgerPresent"] is False
+        assert not path.exists()
+
+    def test_a_ledger_without_canonical_board_rows_is_unmeasurable(self, tmp_path):
+        """Other lanes are not the served board; their presence must not
+        make the flag's blast radius look measurable."""
+        from src.history import store
+
+        path = _temporal_ledger(tmp_path)
+        result = store.write_observations(
+            [
+                {
+                    "asset_key": "player:1",
+                    "asset_class": "offense",
+                    "lane": store.LANE_SOURCE,
+                    "source_key": "ktcSfTep",
+                    "observed_date": "2026-08-01",
+                    "value": 5000.0,
+                    "origin": "test",
+                }
+            ],
+            path=path,
+        )
+        assert result["written"] == 1
+        report = _report()
+        verify.check_ledger_rank_change_flag(report, ledger_path=path)
+        check = report.checks[0]
+        assert check.status == verify.UNMEASURABLE
+        assert check.evidence["canonicalBoardRows"] == 0
+        assert check.evidence["laneRowCounts"].get(store.LANE_SOURCE) == 1


### PR DESCRIPTION
Three new read-only checks in `scripts/verify_lane4_production.py`, one commit each, all registered in `run_onbox` beside `check_single_cohort_owner`. Production runs this on the box against real gitignored stores; the sandbox stores are empty, so every check's first obligation is to degrade honestly — blocked/unmeasurable with the input named, never a false pass, never empty-here read as evidence. No workflow file changes; `run_onbox` already reaches everything.

## Commit 1 — V1-65 L2 census (`check_league_population_difference`, id `V65b`)

The existing `V65` check pins the single-owner property; the row's L2 needs the **census**. Read entirely through the existing read-only primitives — `discovery.signal_eligible_league_ids()` / `sharp_eligible_league_ids()` / `graph_stats()` — plus two direct SELECTs, it emits:

- `signalAdmitted` / `sharpAdmitted` counts and the explicit set difference (`signalOnly` / `sharpOnly` counts + samples capped at 10 ids);
- a `sharp_exclusion_reason` histogram over the signal-but-not-sharp leagues, **re-derived from each league's stored `settings_json` evidence** (`type` / `bestBall` / `ageSeasons`) through the canonical `league_filter.sharp_exclusion_reason` ladder — a faithful reconstruction of the crawl-time input, never a second rule. An unrecorded age reports `age_unrecorded` (missing is never a measured `too_new`); a stored-flag/re-derivation drift is published as `stored_flag_disagrees_with_rederivation`, coercing neither side;
- an independent cross-check: `SELECT COUNT(DISTINCT league_id) FROM manager_seasons WHERE sharp_eligible=1 AND is_complete=1` — reported, not asserted, since the records crawl legitimately lags discovery.

One thing it asserts rather than reports: sharp is *defined* strictly narrower than signal, so a non-empty `sharpOnly` set is a FAIL (the two gates disagreed about the same stored evidence).

Degradation: absent ledger → **BLOCKED** and the file is *not created* (`ledger.connect` would mint one — presence is decided before any connect); present-but-empty leagues table → **UNMEASURABLE** with "ledger carries no discovered leagues here" (environment artifact wording).

## Commit 2 — V1-58 measured in-process (`check_cohort_population_onbox`, id `V58`)

`record_blocked_rows` hardcoded B58 as "needs an authenticated /api/sharp/cohort read" even in onbox mode — while `run_onbox` was already building the market and roster-percentage boards **in-process from the same deployed stores** for C1–C3. The new check resolves the cohort through the one canonical owner, with the exact call `market_payload` makes (`cohort_members(qualification="all", ledger_path=…, ffpc_config=load_ffpc_config())`), and emits member count, the qualification-method split, per-member platform counts, and the owner's own coverage block.

Two honesty rules, both structural:

- **population 0 with stores present is a REAL measured answer**: PASS with `populated: false`. Never converted to FAILED (an empty cohort is a finding about the deployed data, not the check), never presented as populated — and its denominator is deliberately `None` so `Check.finalize`'s vacuous-pass guard cannot downgrade a truthful zero;
- **absent stores → BLOCKED**, and the probe creates nothing.

`record_blocked_rows` now takes `mode`: B58 is recorded blocked only in **remote** mode; B59 (journalctl over the three-pass chain) stays blocked in both, unchanged. Whether an in-process resolution satisfies the row's L3 — whose wording names the authenticated endpoint read — is an adjudication call recorded at the contract ledger, not decided by this script; the docstring says exactly that.

## Commit 3 — V1-87 flag blast radius (`check_ledger_rank_change_flag`, id `V87`)

Measures what `RISKIT_FEATURE_LEDGER_RANK_CHANGE` actually decides, against the one input the blocked row named: a temporal ledger with real `canonical_board` rows (only production has them — `src/history/record.py` writes that lane at the fresh-scrape promotion site).

**The narrow read, deliberately, and the check says why.** Flag OFF stamps `None` on every row *structurally* (`_stamp_rank_changes` never opens the ledger on that branch), so its non-null count is 0 by construction — rebuilding the full contract twice on the box would prove nothing the source doesn't already state. Flag ON is measured by calling `asof.previous_board_ranks` — the same function, same arguments, `data_contract` makes — joined against the newest recorded canonical board (the served board's recorded ranks, corrections excluded with the comparator's own rule). Emitted: per-lane row counts, distinct board dates, newest/comparator dates, `nonNullRankChangeOn`, structurally-0 `nonNullRankChangeOff`, the delta, and a `measurementBasis` note.

Degradation follows `_stamp_rank_changes`' own F-24 warning verbatim: with no ledger BOTH branches stamp `None`, so an ON/OFF diff there is a vacuous "0 rows changed" that must not become evidence. Absent ledger, no `canonical_board` rows, or a single board date (no strictly-prior comparator) → **UNMEASURABLE** with the environment artifact named. The absent-ledger probe goes through `store.coverage` and creates nothing.

## Overlap with #1077

Checked `#1077` ("Lane 4 flag posture + two stale blocker premises") file by file before starting: it touches `docs/lane4/*`, `tests/api/test_feature_flag_endpoint_reachability.py`, and a different region of `tests/ops/test_lane4_verification.py` (a `_routes_named_in` extraction refactor of the procedures-doc guard). **It implements none of these three checks**, so nothing here duplicates it. The shared test file is touched in disjoint regions — this PR only appends new test classes at the end — so a merge with #1077 should be conflict-free or trivially resolvable. Note #1077's V1-62/V1-89 analysis is complementary to (and unchanged by) this work.

## Verification

- `python -m pytest tests/ops/ -q` → **104 passed** (89 before this PR's additions in the file's baseline run of 70 for the verifier suite; 15 new tests across the three commits, plus the other ops files).
- `python -m pytest tests/sharp/test_discovery.py -q` → 20 passed (discovery consumed read-only; not modified).
- `python -m pytest tests/history/test_temporal_ledger.py -q` → 58 passed.
- `ruff check` clean on both touched files; `ruff format` applied to added code only — the local ruff is newer than CI's and wants to rewrite one pre-existing line in the verifier, which was deliberately left byte-identical (no drive-by reformatting).
- Sandbox smoke of `--mode onbox`: exit 3 (INCOMPLETE, correctly), `V65b` unmeasurable ("ledger carries no discovered leagues here"), `V58` truthful pass with `populated: false` over the present-but-empty store, `V87` unmeasurable naming the environment artifact, `B59` blocked, `B58` no longer emitted in onbox mode — and no store file created by any probe.

Constraints held: read-only checks only (SELECTs, file reads, the same reader APIs production code uses); no workflow changes; no `WORK_CLAIMS.md`; no V1 status edits; no existing check weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_