### PR TITLE
V1-85: pickAnchorsProvenance describes the anchors the export actually emits

### DIFF
--- a/Dynasty Scraper.py
+++ b/Dynasty Scraper.py
@@ -5717,6 +5717,10 @@ async def run(progress_callback=None):
 
     rebuilt_pick_entries = {}  # players_json labels -> entry
     rebuilt_pick_anchors = {}  # site -> canonical pick key (no "Pick")
+    # (site, canonical key) pairs whose exported anchor is the MODEL's
+    # composite, not a vendor quote — provenance reconciliation names
+    # them instead of letting them wear a vendor class (V1-85).
+    _model_injected_pick_keys = set()
 
     def _put_pick(label, canonical_key, value, site_vals):
         v = max(1, int(round(float(value))))
@@ -5756,6 +5760,7 @@ async def run(progress_callback=None):
         if vendor_priced and "ktc" not in e:
             e["ktc"] = v
             rebuilt_pick_anchors.setdefault("ktc", {})[canonical_key] = v
+            _model_injected_pick_keys.add(("ktc", canonical_key))
         e["_composite"] = v
         # The TRUE count.  ``max(1, ...)`` claimed one source for a row
         # with none, which is the same conflation in a second field.
@@ -5873,6 +5878,15 @@ async def run(progress_callback=None):
     # anchor (C1-U6-D1, 2026-08-17).  Raw now means raw.
     players_json.update(rebuilt_pick_entries)
     pick_anchors = rebuilt_pick_anchors
+    # ``pick_anchors_provenance`` must describe the map the export
+    # EMITS, not the stage-1 vendor builds the model board replaced.
+    # Unreconciled it stamped a whole site (``ktcSfTep``) and ~96 keys
+    # per source that ``pickAnchors`` does not contain, and said
+    # nothing true about the model-injected composites it does
+    # (F-22 / V1-85 — reporting only, no value moves here).
+    pick_anchors_provenance = _pickmap.reconcile_emitted_anchor_provenance(
+        rebuilt_pick_anchors, pick_anchors_provenance, _model_injected_pick_keys
+    )
     _disc_str = ", ".join(
         f"y+{int(y) - int(_pick_model_year)}={discount_by_year.get(y, 0):.3f}"
         for y in _future_pick_years
@@ -6563,10 +6577,11 @@ async def run(progress_callback=None):
         "pickAnchors": pick_anchors,
         "pickAnchorsRaw": pick_anchors_raw,
         # What each emitted anchor key actually IS, per source — a
-        # published observation or a within-year derivation.  Additive
-        # and read by nothing yet; it exists so "derived" and "observed"
-        # are distinguishable in the export at all, which they were not
-        # (C1-U6-D1).
+        # published observation, a within-year derivation, a vendor
+        # value carried on a model row, or the model's own injected
+        # composite.  Reconciled against the EMITTED map above, so its
+        # site/key sets match ``pickAnchors`` exactly (C1-U6-D1; F-22 /
+        # V1-85).  Additive and read by nothing yet.
         "pickAnchorsProvenance": pick_anchors_provenance,
         "coverageAudit": coverage_audit,
         "poolAudit": _pool_audit.to_dict() if _pool_audit else None,

--- a/src/picks/site_pick_map.py
+++ b/src/picks/site_pick_map.py
@@ -41,6 +41,7 @@ from dataclasses import dataclass, field
 from typing import Any, Mapping, Sequence
 
 __all__ = [
+    "MODEL_INJECTED_PROVENANCE",
     "PICK_TIERS",
     "SitePickMap",
     "build_site_pick_map",
@@ -48,8 +49,10 @@ __all__ = [
     "parse_pick_label",
     "pick_suffix",
     "pick_value",
+    "reconcile_emitted_anchor_provenance",
     "slot_to_tier",
     "slot_tier_ranges",
+    "VENDOR_ROW_PROVENANCE",
 ]
 
 #: Tier vocabulary, in board order.
@@ -393,3 +396,57 @@ def build_site_pick_map(
                     values[key] = fmt_pick_value(s_val)
                     provenance[key] = s_class
     return SitePickMap(values=values, provenance=provenance)
+
+
+# ── Emitted-anchor provenance reconciliation (F-22 / V1-85) ──────────
+
+#: The scraper's model composite, published under a vendor key on a row
+#: that vendor did not price (the deliberate C1-U6 follow-up 3 branch).
+MODEL_INJECTED_PROVENANCE = "model_injected_composite"
+
+#: A value that rode a model row's per-site values — vendor evidence —
+#: but whose (site, key) has no recorded stage-1 evidence class.
+VENDOR_ROW_PROVENANCE = "vendor_row_value"
+
+
+def reconcile_emitted_anchor_provenance(
+    emitted: Mapping[str, Any],
+    stage1_provenance: Mapping[str, Any],
+    model_injected: Sequence[tuple[str, str]] | set[tuple[str, str]] | None = None,
+) -> dict[str, dict[str, str]]:
+    """Provenance for exactly the anchors a payload EMITS.
+
+    ``SitePickMap``'s contract — a key absent from ``values`` is absent
+    from ``provenance`` too — holds per source at build time, but the
+    scraper's export replaces the built anchor maps with the model's
+    rebuilt board while carrying the stage-1 provenance forward
+    unchanged (F-22 / V1-85).  Measured on the 2026-08-25 payload: the
+    export stamped provenance for ``ktcSfTep`` (180 keys) while
+    ``pickAnchors`` carried no ``ktcSfTep`` at all, and stamped 180
+    ``ktc`` keys against 84 emitted — two surfaces describing the same
+    anchors differently, which is the audit's F-22 exactly.
+
+    This reconciles the descriptions: the returned mapping's site and
+    key sets equal the emitted map's, exactly.  A value that rode a
+    model row's site values keeps its stage-1 evidence class when one
+    was recorded (else ``VENDOR_ROW_PROVENANCE``); a model-injected
+    composite is named ``MODEL_INJECTED_PROVENANCE`` rather than
+    wearing a vendor class.  Reporting only — no anchor value is read,
+    written, or moved here.
+    """
+    injected = {(str(s), str(k)) for s, k in (model_injected or ())}
+    out: dict[str, dict[str, str]] = {}
+    for site, site_map in emitted.items():
+        if not isinstance(site_map, Mapping):
+            continue
+        stage1 = stage1_provenance.get(site)
+        stage1 = stage1 if isinstance(stage1, Mapping) else {}
+        site_prov: dict[str, str] = {}
+        for key in site_map:
+            k = str(key)
+            if (str(site), k) in injected:
+                site_prov[k] = MODEL_INJECTED_PROVENANCE
+            else:
+                site_prov[k] = str(stage1.get(k) or VENDOR_ROW_PROVENANCE)
+        out[str(site)] = site_prov
+    return out

--- a/tests/picks/test_anchor_provenance_reconciliation.py
+++ b/tests/picks/test_anchor_provenance_reconciliation.py
@@ -1,0 +1,178 @@
+"""F-22 / V1-85 — pickAnchors provenance describes the anchors the export EMITS.
+
+``SitePickMap``'s own contract is that a key absent from ``values`` is
+absent from ``provenance`` too.  The scraper's export broke exactly that
+invariant at the payload level: ``pick_anchors = rebuilt_pick_anchors``
+replaces the stage-1 vendor anchor maps with the model's rebuilt board,
+while ``pick_anchors_provenance`` sailed on describing the stage-1
+builds.  Measured on the live 2026-08-25 payload:
+
+    pickAnchors            → ktc: 84, idpTradeCalc: 84   (no ktcSfTep)
+    pickAnchorsProvenance  → ktc: 180, ktcSfTep: 180, idpTradeCalc: 180
+
+Two surfaces describing the same anchors differently — the audit's F-22,
+reclassified P2 (reporting; the served values were never implicated,
+because the contract reads the vendor CSVs independently).
+
+``reconcile_emitted_anchor_provenance`` is the repair's owner half; the
+scraper wiring is pinned structurally below (this file cannot run a full
+scrape, and a wiring assertion that cannot observe its subject would
+read exactly like one that passed — the F-8/F-23 lesson).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from src.picks.site_pick_map import (
+    MODEL_INJECTED_PROVENANCE,
+    VENDOR_ROW_PROVENANCE,
+    reconcile_emitted_anchor_provenance,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRAPER = REPO_ROOT / "Dynasty Scraper.py"
+
+
+def _live_shaped_fixture():
+    """The measured live inconsistency, in miniature.
+
+    Stage-1 provenance covers two sites and a superset of keys; the
+    emitted model board carries one site, a subset of its keys, plus one
+    model-injected composite the stage-1 build never saw.
+    """
+    emitted = {
+        "ktc": {
+            "2026 1.01": 6726,
+            "2026 Early 1st": 5605,
+            "2027 Mid 4th": 310,  # model-injected composite
+        },
+        "idpTradeCalc": {"2026 1.01": 8013},
+    }
+    stage1 = {
+        "ktc": {
+            "2026 1.01": "derived_slot_from_tier",
+            "2026 Early 1st": "published_tier",
+            "2026 Late 3rd": "published_tier",  # not emitted
+        },
+        # A whole site the emitted map does not carry — the live payload's
+        # ktcSfTep exactly.
+        "ktcSfTep": {"2026 Early 1st": "published_tier"},
+    }
+    injected = {("ktc", "2027 Mid 4th")}
+    return emitted, stage1, injected
+
+
+class TestReconciledProvenanceDescribesTheEmittedMap:
+    def test_stage1_provenance_violates_the_invariant_the_reconciler_restores(self):
+        """The defect, stated as the invariant it breaks.
+
+        Pass the stage-1 provenance through unreconciled — the pre-fix
+        export behaviour — and it names a site and keys the emitted map
+        does not contain.  Reconciled, site and key sets match exactly.
+        """
+        emitted, stage1, injected = _live_shaped_fixture()
+
+        def violations(prov):
+            out = []
+            for site, site_prov in prov.items():
+                if site not in emitted:
+                    out.append(f"site:{site}")
+                    continue
+                for key in site_prov:
+                    if key not in emitted[site]:
+                        out.append(f"{site}:{key}")
+            for site, site_map in emitted.items():
+                for key in site_map:
+                    if key not in (prov.get(site) or {}):
+                        out.append(f"missing:{site}:{key}")
+            return out
+
+        # Pre-fix behaviour: provenance for anchors that are not there.
+        assert violations(stage1), "fixture must reproduce the live inconsistency"
+
+        reconciled = reconcile_emitted_anchor_provenance(emitted, stage1, injected)
+        assert violations(reconciled) == []
+        assert set(reconciled) == set(emitted)
+        for site in emitted:
+            assert set(reconciled[site]) == set(emitted[site])
+
+    def test_a_dropped_site_is_dropped_not_carried(self):
+        emitted, stage1, injected = _live_shaped_fixture()
+        reconciled = reconcile_emitted_anchor_provenance(emitted, stage1, injected)
+        assert "ktcSfTep" not in reconciled
+
+    def test_stage1_evidence_class_is_carried_for_vendor_values(self):
+        emitted, stage1, injected = _live_shaped_fixture()
+        reconciled = reconcile_emitted_anchor_provenance(emitted, stage1, injected)
+        assert reconciled["ktc"]["2026 1.01"] == "derived_slot_from_tier"
+        assert reconciled["ktc"]["2026 Early 1st"] == "published_tier"
+
+    def test_model_injection_is_named_not_dressed_as_a_vendor(self):
+        emitted, stage1, injected = _live_shaped_fixture()
+        reconciled = reconcile_emitted_anchor_provenance(emitted, stage1, injected)
+        assert reconciled["ktc"]["2027 Mid 4th"] == MODEL_INJECTED_PROVENANCE
+
+    def test_unrecorded_vendor_value_gets_the_honest_fallback_class(self):
+        emitted, stage1, injected = _live_shaped_fixture()
+        # idpTradeCalc has no stage-1 provenance in the fixture at all.
+        reconciled = reconcile_emitted_anchor_provenance(emitted, stage1, injected)
+        assert reconciled["idpTradeCalc"]["2026 1.01"] == VENDOR_ROW_PROVENANCE
+
+    def test_non_mapping_site_values_are_skipped_not_crashed(self):
+        reconciled = reconcile_emitted_anchor_provenance(
+            {"ktc": {"a": 1}, "broken": None}, {}, None
+        )
+        assert set(reconciled) == {"ktc"}
+
+
+class TestScraperWiring:
+    """Structural pin: the export path actually reconciles.
+
+    The scraper cannot be executed here, so the wiring is asserted over
+    its AST — the same posture as ``test_finder_va_is_not_bypassable``.
+    """
+
+    def _tree(self):
+        return ast.parse(SCRAPER.read_text(encoding="utf-8"))
+
+    def test_provenance_is_reassigned_from_the_owner_reconciler(self):
+        found = False
+        for node in ast.walk(self._tree()):
+            if not isinstance(node, ast.Assign):
+                continue
+            targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            if "pick_anchors_provenance" not in targets:
+                continue
+            call = node.value
+            if (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Attribute)
+                and call.func.attr == "reconcile_emitted_anchor_provenance"
+            ):
+                found = True
+        assert found, (
+            "the scraper must reassign pick_anchors_provenance from "
+            "reconcile_emitted_anchor_provenance after replacing pick_anchors "
+            "with the rebuilt model board — otherwise the export stamps "
+            "provenance for anchors it does not emit (F-22 / V1-85)"
+        )
+
+    def test_model_injected_keys_are_recorded_at_the_injection_branch(self):
+        src = SCRAPER.read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        found = False
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "add"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "_model_injected_pick_keys"
+            ):
+                found = True
+        assert found, (
+            "the e['ktc'] = v model-injection branch must record its "
+            "(site, key) so provenance can name it MODEL_INJECTED_PROVENANCE"
+        )


### PR DESCRIPTION
## The inconsistency, measured on the live payload (F-22 / V1-85)

`exports/latest/dynasty_data_2026-08-25.json`:

| surface | ktc | ktcSfTep | idpTradeCalc |
|---|---|---|---|
| `pickAnchors` (emitted) | 84 | **absent** | 84 |
| `pickAnchorsProvenance` | **180** | **180** | **180** |

The provenance block's own comment claims it describes "each **emitted** anchor key" — but it describes the stage-1 vendor builds, which `pick_anchors = rebuilt_pick_anchors` (the model board) replaces at export time while the provenance sails on unchanged. A whole site (`ktcSfTep`) and ~96 keys per source are described that the payload does not contain, and the model-injected composites it *does* contain are described by nothing (or falsely, by a vendor class). This is the audit's F-22 exactly: *"two surfaces describe the same anchors differently; the served values are not implicated"* — reclassified P2, because the contract reads the vendor CSVs independently (all 36 rows confirmed).

## Fix — reporting only, value-inert

- `src/picks/site_pick_map.py` (the pick-map **owner**) gains `reconcile_emitted_anchor_provenance`: the returned provenance's site/key sets equal the emitted map's exactly; vendor-carried values keep their stage-1 evidence class (else `vendor_row_value`); the deliberate C1-U6-follow-up-3 model injection is named `model_injected_composite` instead of wearing a vendor class. This extends `SitePickMap`'s own stated contract ("a key absent from `values` is absent from `provenance` too") to the payload level.
- `Dynasty Scraper.py` (the **adapter**, per the C1-U6-D1 arrangement) records the injection branch's `(site, key)` pairs and reconciles at the exact replacement site. No anchor value is read, written, or moved — `pickAnchors` and `pickAnchorsRaw` are byte-identical in behavior.
- The `pickAnchorsProvenance` export comment now tells the truth.

Deliberately NOT done here: stamping `pickAnchors` under `ktcSfTep` to widen the pick anchor set (W05-F006's recommendation #4) — that is a **value-affecting** change requiring coordination with pick tethering, and this row is the P2 reporting half only.

## Tests + mutations

- `tests/picks/test_anchor_provenance_reconciliation.py`: the invariant test proves the stage-1 fixture *violates* the emitted-key-set invariant (the pre-fix behavior) and the reconciled map satisfies it; per-class tests for carried/injected/fallback provenance; AST wiring pins on the scraper (same posture as `test_finder_va_is_not_bypassable` — a wiring assertion that cannot observe its subject reads exactly like one that passed).
- **Mutation 1** (function passes stage-1 through): 5 RED. **Mutation 2** (scraper reconcile assignment removed): AST wiring test RED. Both restored; `tests/picks/` 65 passed, 16 subtests.
- `ruff check` + `ruff format --check` clean on the three touched files.

No V1 status edit here — promotion happens in the ledger after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_