### PR TITLE
V1-103 S-parts: the rate limiter keys on an unspoofable identity; /api/scaffold/status leaves the anonymous allowlist

### DIFF
--- a/server.py
+++ b/server.py
@@ -3368,7 +3368,13 @@ _PUBLIC_API_EXACT = frozenset(
         "/api/auth/status",
         "/api/auth/login",
         "/api/auth/logout",
-        "/api/scaffold/status",
+        # /api/scaffold/status was REMOVED from this list 2026-08-25
+        # (W22-F005 / V1-103): it hands the full source inventory and
+        # pipeline internals to anonymous callers, and a caller census
+        # found nothing anonymous reading it — no frontend caller, no
+        # bridge route, no workflow curl, no deploy script. The other
+        # /api/scaffold/* endpoints were already private
+        # (tests/api/test_private_auth.py).
         # /league page is a public view — its draft-capital tab reads
         # this endpoint.  Payload is public Sleeper data (team names,
         # pick dollar values, owners) already viewable on Sleeper.

--- a/server.py
+++ b/server.py
@@ -3521,14 +3521,32 @@ async def _request_context_middleware(request: Request, call_next):
 
 
 def _client_ip_from_request(request: Request) -> str:
-    """Prefer ``X-Forwarded-For`` (nginx sets it for us in prod);
-    fall back to ``request.client.host``."""
+    """The client identity the RATE LIMITER keys on — attacker-fixed, not
+    attacker-chosen (W22-F002 / V1-103).
+
+    ``X-Real-IP`` first: nginx sets it with ``proxy_set_header X-Real-IP
+    $remote_addr`` (deploy/nginx/chaseupside-proxy.conf), which REPLACES
+    anything the client sent — through the proxy it is always the TCP
+    peer nginx actually saw.
+
+    ``X-Forwarded-For`` is different: nginx uses
+    ``$proxy_add_x_forwarded_for``, which APPENDS the real address to
+    whatever the client supplied.  Taking the FIRST entry — what this
+    function did until 2026-08-25 — therefore keyed the limiter on an
+    attacker-chosen string: rotate one header value per request and every
+    public endpoint's limit dissolves.  The one entry our own trusted
+    proxy wrote is the LAST, so the fallback takes that.
+
+    Bare ``request.client.host`` remains for direct (dev/E2E) access.
+    """
+    real_ip = request.headers.get("x-real-ip", "").strip()
+    if real_ip:
+        return real_ip
     xff = request.headers.get("x-forwarded-for", "")
     if xff:
-        # First entry in the chain is the original client.
-        first = xff.split(",")[0].strip()
-        if first:
-            return first
+        last = xff.split(",")[-1].strip()
+        if last:
+            return last
     client = request.client
     return client.host if client else ""
 

--- a/src/api/error_responses.py
+++ b/src/api/error_responses.py
@@ -108,8 +108,16 @@ def install_exception_handler(app: FastAPI) -> None:
         # Never let a handler crash silently; always log with full
         # context that correlates to the request.
         rid = current_request_id()
-        client_ip = request.headers.get("x-forwarded-for") or (
-            request.client.host if request.client else ""
+        # Same trust order as server._client_ip_from_request (W22-F002):
+        # X-Real-IP is REPLACED by nginx so it is the peer nginx saw;
+        # X-Forwarded-For is APPENDED to, so only its LAST entry is ours.
+        # This is log context, but a log that records an attacker-chosen
+        # string as "ip=" poisons the incident trail the same way.
+        _xff = request.headers.get("x-forwarded-for", "")
+        client_ip = (
+            request.headers.get("x-real-ip", "").strip()
+            or (_xff.split(",")[-1].strip() if _xff else "")
+            or (request.client.host if request.client else "")
         )
         tb = traceback.format_exc()
         _LOGGER.error(

--- a/tests/api/test_client_ip_trust.py
+++ b/tests/api/test_client_ip_trust.py
@@ -1,0 +1,80 @@
+"""W22-F002 / V1-103 — the rate limiter keys on an identity the client cannot choose.
+
+nginx (deploy/nginx/chaseupside-proxy.conf) sets two headers with different
+trust semantics:
+
+* ``X-Real-IP $remote_addr`` — REPLACED: whatever the client sent is gone,
+  the value is the TCP peer nginx saw.
+* ``X-Forwarded-For $proxy_add_x_forwarded_for`` — APPENDED: the client's
+  own header survives in front, nginx adds the real address at the END.
+
+Until 2026-08-25 ``server._client_ip_from_request`` took the FIRST
+``X-Forwarded-For`` entry, so every public endpoint's rate limit keyed on
+an attacker-chosen string — rotate one header value per request and the
+limiter sees a new "client" every time.  These tests pin the repaired
+trust order: X-Real-IP, then the LAST X-Forwarded-For entry, then the
+socket peer.
+"""
+
+from __future__ import annotations
+
+from starlette.requests import Request
+
+import server
+
+
+def _request(headers: dict[str, str] | None = None, client_host: str | None = "127.0.0.1"):
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/status",
+        "query_string": b"",
+        "headers": [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()],
+        "client": (client_host, 12345) if client_host else None,
+    }
+    return Request(scope)
+
+
+class TestProxiedRequests:
+    def test_rotating_the_forwarded_for_header_does_not_change_the_key(self):
+        """The defect, pinned: through nginx, the spoofable prefix of
+        X-Forwarded-For must not move the limiter's key."""
+        keys = set()
+        for i in range(5):
+            req = _request(
+                {
+                    "X-Real-IP": "203.0.113.7",
+                    "X-Forwarded-For": f"junk-{i}, 203.0.113.7",
+                }
+            )
+            keys.add(server._client_ip_from_request(req))
+        assert keys == {"203.0.113.7"}, (
+            "five requests differing only in the client-supplied X-Forwarded-For "
+            f"prefix produced {len(keys)} distinct limiter keys: {sorted(keys)} — "
+            "the limit is bypassable by rotating one header (W22-F002)"
+        )
+
+    def test_first_forwarded_entry_is_never_the_answer_when_a_proxy_appended(self):
+        req = _request({"X-Forwarded-For": "attacker-chosen, 198.51.100.9"})
+        assert server._client_ip_from_request(req) == "198.51.100.9"
+
+    def test_real_ip_wins_over_everything(self):
+        req = _request(
+            {"X-Real-IP": "203.0.113.7", "X-Forwarded-For": "spoof-a, spoof-b"},
+            client_host="10.0.0.1",
+        )
+        assert server._client_ip_from_request(req) == "203.0.113.7"
+
+
+class TestDirectRequests:
+    def test_no_headers_falls_back_to_the_socket_peer(self):
+        req = _request({}, client_host="192.0.2.4")
+        assert server._client_ip_from_request(req) == "192.0.2.4"
+
+    def test_empty_header_values_fall_through(self):
+        req = _request({"X-Real-IP": "  ", "X-Forwarded-For": ""}, client_host="192.0.2.4")
+        assert server._client_ip_from_request(req) == "192.0.2.4"
+
+    def test_no_client_and_no_headers_answers_empty_never_raises(self):
+        req = _request({}, client_host=None)
+        assert server._client_ip_from_request(req) == ""

--- a/tests/api/test_private_auth.py
+++ b/tests/api/test_private_auth.py
@@ -40,6 +40,10 @@ PRIVATE_API_PATHS = [
     "/api/scaffold/identity",
     "/api/scaffold/validation",
     "/api/scaffold/report",
+    # De-allowlisted 2026-08-25 (W22-F005 / V1-103): pipeline internals
+    # and the full source inventory are operator data, and the caller
+    # census found no anonymous consumer.
+    "/api/scaffold/status",
     "/api/user/state",
     "/api/player/12345/realized",  # Phase 11 follow-on — realized points
     "/api/admin/nfl-data/flush",


### PR DESCRIPTION
Two bounded security repairs from V1-103's scope (W22-F002 + W22-F005), each its own commit with an executed mutation.

## W22-F002 — the rate limiter keyed on an attacker-chosen string

`server.py::_client_ip_from_request` took the **first** `X-Forwarded-For` entry. nginx sets that header with `$proxy_add_x_forwarded_for` (deploy/nginx/chaseupside-proxy.conf:59), which **appends** the real peer to whatever the client sent — so through the proxy, the first entry is whatever the attacker typed, and every public endpoint's rate limit dissolves by rotating one header value per request.

Repaired trust order:
1. **`X-Real-IP`** — nginx sets it with `$remote_addr`, which **replaces** the client's value; through the proxy it is always the TCP peer nginx saw.
2. The **last** `X-Forwarded-For` entry — the one our own trusted proxy wrote.
3. The socket peer (direct dev/E2E access).

The unhandled-exception log context in `src/api/error_responses.py` takes the same order, so `ip=` in the incident trail can no longer record a spoofed value.

`tests/api/test_client_ip_trust.py` (new, 6 tests) pins rotation invariance (5 requests differing only in the spoofable XFF prefix → exactly 1 limiter key), the never-first rule, X-Real-IP precedence, and the direct fallbacks. **Mutation** (restore the first-entry read): 3 RED; restored: 6 green.

## W22-F005 — `/api/scaffold/status` de-allowlisted

The endpoint hands the full source inventory and pipeline internals to anonymous callers. Caller census before removal: no frontend caller, no bridge route (`frontend/app/api/` has no scaffold route), no workflow curl, no deploy-script read — and the four other `/api/scaffold/*` endpoints were already private. It now requires a session like they do.

Pinned by adding it to `PRIVATE_API_PATHS` in `tests/api/test_private_auth.py`. **Mutation** (re-allowlist it): `test_private_api_paths_require_auth[/api/scaffold/status]` RED; restored green.

Deliberately NOT touched: the login throttle (W22-F003, M-sized) and the admin-allowlist gating of operator actions (W22-F007, M-sized) — both remain open on the V1-103 row; no allowlist entry was **added** anywhere.

## Validation

`tests/api/test_client_ip_trust.py` + `tests/api/test_private_auth.py`: **40 passed**. ruff clean on touched files. No V1 status edit here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_