### PR TITLE
V1-59 residual: the records crawl commits per season, not per crawl

### DIFF
--- a/src/sharp/records.py
+++ b/src/sharp/records.py
@@ -335,6 +335,15 @@ def crawl_records(
                 for row in rows:
                     touched_managers.add(row["user_id"])
                 _store_rows(rows, conn=conn)
+                # Commit PER SEASON, not once for the whole crawl.  Every
+                # iteration of this loop does network I/O, so a single
+                # end-of-crawl commit held the SQLite writer lock across
+                # the entire budget — measured on prod as an hour-long
+                # write transaction overlapping the 05:20 FFPC ingestion
+                # window, the same lock contention V1-59 names.  Rows
+                # upsert on (league_id, season, user_id), so per-season
+                # durability changes no outcome — only the lock window.
+                conn.commit()
 
                 current = str(league.get("previous_league_id") or "")
         conn.commit()

--- a/tests/sharp/test_records.py
+++ b/tests/sharp/test_records.py
@@ -287,3 +287,52 @@ class TestFinishPercentiles:
         assert recs["top"].finish_percentiles == [1.0]
         assert recs["bot"].finish_percentiles == [0.0]
         assert recs["mid"].finish_percentiles == [0.5]
+
+
+class TestWriterLockWindows:
+    def test_each_season_commits_before_the_next_network_call(self, db):
+        """V1-59 residual: the crawl must never hold the SQLite writer
+        lock across network I/O.
+
+        A single end-of-crawl commit kept one write transaction open for
+        the whole budget — on production, an hour-long writer lock
+        overlapping the 05:20 FFPC ingestion window.  The observable
+        property: by the time the crawl asks Sleeper about the SECOND
+        chain hop, the FIRST hop's rows are already visible to an
+        independent connection.  Under the retired single-commit shape
+        this count is 0 until the crawl returns.
+        """
+        import sqlite3
+
+        observed: list[int] = []
+        responses = {
+            f"{BASE}/league/L2026": league("L2026", "2026", previous="L2025"),
+            f"{BASE}/league/L2026/rosters": [roster(1, "a"), roster(2, "b")],
+            f"{BASE}/league/L2026/winners_bracket": bracket(1, 2),
+            f"{BASE}/league/L2025": league("L2025", "2025", previous="0"),
+            f"{BASE}/league/L2025/rosters": [roster(1, "a"), roster(2, "b")],
+            f"{BASE}/league/L2025/winners_bracket": bracket(2, 1),
+        }
+
+        class SpyingSleeper(FakeSleeper):
+            def __call__(self, url):
+                if url == f"{BASE}/league/L2025":
+                    probe = sqlite3.connect(db)
+                    try:
+                        n = probe.execute(
+                            "SELECT COUNT(*) FROM manager_seasons WHERE league_id='L2026'"
+                        ).fetchone()[0]
+                    finally:
+                        probe.close()
+                    observed.append(n)
+                return super().__call__(url)
+
+        http = SpyingSleeper(responses)
+        records.crawl_records(league_ids=["L2026"], http_get=http, ledger_path=db, sleep_s=0)
+
+        assert observed, "the crawl never reached the second chain hop — vacuous"
+        assert observed[0] > 0, (
+            "the first season's rows were invisible to an independent reader "
+            "while the crawl performed its next network call — the writer "
+            "transaction is still spanning network I/O (V1-59)"
+        )


### PR DESCRIPTION
## The bounded follow-up #1102 named

`crawl_records` (`src/sharp/records.py`) held **one SQLite write transaction across its entire network budget** — a single `conn.commit()` after the whole chain walk, with every loop iteration doing Sleeper HTTP calls inside that open transaction. On production this is the hour-long writer lock overlapping the 05:20 FFPC ingestion window — the same `database is locked` contention V1-59 names, on the side #1102 did not touch (its fixes were the ingestion index, `busy_timeout`, and the pre-claimed running row).

## Fix

Commit after each stored season. Rows upsert on `(league_id, season, user_id)`, so per-season durability changes **no outcome** — only the lock window, which shrinks from the whole crawl to one row batch. The end-of-crawl commit stays (covers the no-rows path).

## Pinned behaviorally, not structurally

`TestWriterLockWindows::test_each_season_commits_before_the_next_network_call`: an independent sqlite connection opened *inside the stubbed fetch of the second chain hop* must already see the first hop's rows. Under the retired single-commit shape that count is 0 until the crawl returns — **mutation executed**: dropping the per-season commit turns it RED; restored, `tests/sharp/test_records.py` 16 passed. A vacuity guard asserts the crawl actually reached the second hop.

One production file, one test file. No V1 status edit; the V1-59 row promotes only on a clean scheduled bootstrap run in production journald.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_