### PR TITLE
V1-103 M-parts: operator actions gate on the admin allowlist; login gets a failure throttle

### DIFF
--- a/server.py
+++ b/server.py
@@ -11609,6 +11609,30 @@ async def auth_login(request: Request):
 
     username = str(payload.get("username") or "").strip()
     password = str(payload.get("password") or "")
+
+    # W22-F003: the login endpoint gets its own failure throttle —
+    # exponential backoff per client IP and per (client IP, username)
+    # after repeated failed attempts.  Checked BEFORE any credential
+    # comparison so a blocked caller learns nothing about validity.
+    # Design, constants and the never-key-on-username-alone invariant
+    # live in ``src/api/rate_limit.py`` (the ``login_*`` functions) —
+    # one throttle owner, no second in-server implementation.
+    from src.api import rate_limit as _rl
+
+    client_ip = _client_ip_from_request(request)
+    throttled, retry_after = _rl.login_throttle_check(client_ip, username)
+    if throttled:
+        return JSONResponse(
+            status_code=429,
+            content={
+                "ok": False,
+                "error": "too_many_attempts",
+                "message": "Too many failed login attempts — try again shortly.",
+                "retryAfterSeconds": retry_after,
+            },
+            headers={"Retry-After": str(retry_after), "Cache-Control": "no-store"},
+        )
+
     # Post-login default lands users on "/" (the Brisket Home
     # dashboard — Team Value + Top Movers + Risers/Fallers).  An
     # explicit ``next`` from the form preserves deep-link return,
@@ -11617,6 +11641,7 @@ async def auth_login(request: Request):
 
     # Owner login: full session, max-age = JASON_AUTH_COOKIE_MAX_AGE.
     if username == JASON_LOGIN_USERNAME and password == JASON_LOGIN_PASSWORD:
+        _rl.login_record_success(client_ip, username)
         session_id = _create_auth_session(username, auth_method="password")
         response = JSONResponse(content={"ok": True, "redirect": next_path})
         response.set_cookie(
@@ -11644,10 +11669,12 @@ async def auth_login(request: Request):
         if remaining < 1.0:
             # Expired during the millisecond between fetch and now —
             # treat as invalid.
+            _rl.login_record_failure(client_ip, username)
             return JSONResponse(
                 status_code=401,
                 content={"ok": False, "error": "Invalid username or password."},
             )
+        _rl.login_record_success(client_ip, username)
         session_id = _create_auth_session(
             "guest",
             auth_method="guest_pass",
@@ -11678,6 +11705,7 @@ async def auth_login(request: Request):
         )
         return response
 
+    _rl.login_record_failure(client_ip, username)
     return JSONResponse(
         status_code=401,
         content={"ok": False, "error": "Invalid username or password."},

--- a/server.py
+++ b/server.py
@@ -11458,6 +11458,14 @@ async def trigger_scrape(request: Request, background_tasks: BackgroundTasks):
     ``not_implemented`` because multi-league scraping isn't wired up
     yet (that's a future refactor of Dynasty Scraper.py).
     """
+    # W22-F007: triggering the production scrape (or force-refreshing
+    # a league's Sleeper overlay) is an operator-grade action, not a
+    # product feature — gate on the admin allowlist, never on mere
+    # session presence.  A guest-pass session gets 403 here.
+    session_or_err = _require_admin_session(request)
+    if isinstance(session_or_err, JSONResponse):
+        return session_or_err
+
     # Validate the key first.  Non-default leagues don't run the
     # full ranking scrape (the pipeline is single-league) — instead
     # they refresh the on-demand Sleeper overlay (rosters + trades
@@ -11545,8 +11553,13 @@ async def trigger_scrape(request: Request, background_tasks: BackgroundTasks):
 
 
 @app.post("/api/test-alert")
-async def test_alert():
+async def test_alert(request: Request):
     """Send a test alert email to verify configuration."""
+    # W22-F007: sends an outbound email — operator-grade, so it gates
+    # on the admin allowlist, not on session presence.
+    session_or_err = _require_admin_session(request)
+    if isinstance(session_or_err, JSONResponse):
+        return session_or_err
     if not ALERT_ENABLED:
         return JSONResponse(
             status_code=400,
@@ -14404,13 +14417,16 @@ async def post_intel_refresh(request: Request):
     sequentially (the cron's mode); any other key resolves through
     the standard league resolver."""
     is_cron = _intel_bearer_auth_ok(request)
-    session = None if is_cron else _get_auth_session(request)
-    if not is_cron and not session:
-        return JSONResponse(
-            status_code=401,
-            content={"error": "auth_required", "message": "Sign-in or bearer token required."},
-            headers={"Cache-Control": "no-store"},
-        )
+    session = None
+    if not is_cron:
+        # W22-F007: a crawl is minutes of budgeted Sleeper calls — an
+        # operator-grade action, so the browser path gates on the admin
+        # allowlist rather than session presence (a guest-pass session
+        # gets 403).  The bearer path (the daily cron) is unchanged.
+        session_or_err = _require_admin_session(request)
+        if isinstance(session_or_err, JSONResponse):
+            return session_or_err
+        session = session_or_err
 
     # D13: per-user cooldown on MANUAL triggers.  The cron (bearer) is
     # exempt — it is the intended scheduled driver.  A crawl is minutes

--- a/src/api/rate_limit.py
+++ b/src/api/rate_limit.py
@@ -20,6 +20,7 @@ _MAX_TRACKED_IPS — keeps memory bounded.
 from __future__ import annotations
 
 import logging
+import math
 import os
 import threading
 import time
@@ -138,3 +139,166 @@ def snapshot() -> dict[str, Any]:
 def reset_for_tests() -> None:
     with _lock:
         _buckets.clear()
+    login_reset_for_tests()
+
+
+# ── Login failure throttle (W22-F003) ────────────────────────────────
+#
+# ``POST /api/auth/login`` had no throttle of its own, no lockout and
+# no failure backoff — 200 wrong-password attempts landed at 223 req/s
+# with zero 429.  This is a dedicated FAILURE throttle, separate from
+# the public token buckets above: it counts failed credential checks
+# and imposes an exponential delay once the free attempts are spent.
+#
+# Keying — INVARIANT: a lockout is NEVER keyed on username alone.  An
+# attacker must not be able to lock the real owner out remotely by
+# spraying failures at the owner's username from anywhere on the
+# internet; the per-username component is therefore always scoped
+# WITHIN the client IP.  Each failure is charged to two keys:
+#
+#   * ``ip:<ip>``             — throttles username rotation from one host
+#   * ``ipuser:<ip>|<user>``  — throttles password guessing on one account
+#
+# Failures from IP A never throttle IP B (test-pinned in
+# tests/api/test_login_throttle.py).  With no usable client IP nothing
+# is keyed at all — falling back to the bare username would break the
+# invariant.
+#
+# All constants live here, once:
+_LOGIN_FREE_ATTEMPTS = 5  # failures per window before the backoff starts
+_LOGIN_BACKOFF_BASE_SECONDS = 1.0  # first delay; then 2s, 4s, ... doubling
+_LOGIN_BACKOFF_CAP_SECONDS = 60.0  # the doubling caps here
+_LOGIN_FAILURE_WINDOW_SECONDS = 15 * 60  # cool-off: state expires after this
+#                                          long with no new failure
+_MAX_TRACKED_LOGIN_KEYS = 5000
+
+
+@dataclass
+class _LoginFailureState:
+    failures: int
+    last_failure_at: float
+    blocked_until: float
+
+
+_login_failures: dict[str, _LoginFailureState] = {}
+_login_lock = threading.Lock()
+
+
+def _login_now() -> float:
+    """The login throttle's single clock read — a seam so tests can
+    drive the backoff without sleeping."""
+    return time.time()
+
+
+def _login_keys(ip: str, username: str) -> list[str]:
+    """The keys one attempt is charged to.  Never the bare username —
+    see the invariant in the section comment above."""
+    keys: list[str] = []
+    ip = (ip or "").strip()
+    if not ip:
+        return keys
+    keys.append(f"ip:{ip}")
+    user = (username or "").strip().lower()
+    if user:
+        keys.append(f"ipuser:{ip}|{user}")
+    return keys
+
+
+def _login_state_expired(state: _LoginFailureState, now: float) -> bool:
+    return now - state.last_failure_at >= _LOGIN_FAILURE_WINDOW_SECONDS
+
+
+def login_throttle_check(ip: str, username: str) -> tuple[bool, int]:
+    """``(is_blocked, retry_after_seconds)`` for one login attempt.
+
+    Call BEFORE any credential comparison, so a blocked caller learns
+    nothing about validity.  Never blocks a first attempt (no recorded
+    failures → no state → not blocked).
+    """
+    now = _login_now()
+    worst = 0.0
+    with _login_lock:
+        for key in _login_keys(ip, username):
+            state = _login_failures.get(key)
+            if state is None:
+                continue
+            if _login_state_expired(state, now):
+                # Cool-off elapsed — the window resets.
+                _login_failures.pop(key, None)
+                continue
+            worst = max(worst, state.blocked_until - now)
+    if worst > 0:
+        return (True, max(1, math.ceil(worst)))
+    return (False, 0)
+
+
+def login_record_failure(ip: str, username: str) -> None:
+    """Record one FAILED credential check against both keys.
+
+    The first ``_LOGIN_FREE_ATTEMPTS`` failures in a window carry no
+    delay; from then on the next attempt is pushed out exponentially
+    (1s, 2s, 4s, ... capped at ``_LOGIN_BACKOFF_CAP_SECONDS``).
+    """
+    now = _login_now()
+    with _login_lock:
+        for key in _login_keys(ip, username):
+            state = _login_failures.get(key)
+            if state is None or _login_state_expired(state, now):
+                state = _LoginFailureState(failures=0, last_failure_at=now, blocked_until=0.0)
+                _login_failures[key] = state
+            state.failures += 1
+            state.last_failure_at = now
+            if state.failures >= _LOGIN_FREE_ATTEMPTS:
+                delay = min(
+                    _LOGIN_BACKOFF_CAP_SECONDS,
+                    _LOGIN_BACKOFF_BASE_SECONDS * (2.0 ** (state.failures - _LOGIN_FREE_ATTEMPTS)),
+                )
+                state.blocked_until = max(state.blocked_until, now + delay)
+        _maybe_evict_login_keys()
+
+
+def login_record_success(ip: str, username: str) -> None:
+    """A successful login clears the ``(ip, username)`` failure state.
+
+    Deliberately NOT the bare-IP key: an attacker holding one valid
+    credential (e.g. a guest pass) must not be able to reset the
+    IP-wide counter between guessing bursts.  The IP key expires on its
+    own via the cool-off window.
+    """
+    ip = (ip or "").strip()
+    user = (username or "").strip().lower()
+    if not ip or not user:
+        return
+    with _login_lock:
+        _login_failures.pop(f"ipuser:{ip}|{user}", None)
+
+
+def _maybe_evict_login_keys() -> None:
+    """Bound memory: drop the oldest 10% when the cap is hit.  Called
+    under ``_login_lock``."""
+    if len(_login_failures) <= _MAX_TRACKED_LOGIN_KEYS:
+        return
+    target = max(1, _MAX_TRACKED_LOGIN_KEYS // 10)
+    oldest = sorted(
+        _login_failures.items(),
+        key=lambda kv: kv[1].last_failure_at,
+    )[:target]
+    for key, _ in oldest:
+        _login_failures.pop(key, None)
+
+
+def login_throttle_snapshot() -> dict[str, Any]:
+    """Summary stats for observability."""
+    with _login_lock:
+        return {
+            "trackedKeys": len(_login_failures),
+            "freeAttempts": _LOGIN_FREE_ATTEMPTS,
+            "backoffBaseSeconds": _LOGIN_BACKOFF_BASE_SECONDS,
+            "backoffCapSeconds": _LOGIN_BACKOFF_CAP_SECONDS,
+            "failureWindowSeconds": _LOGIN_FAILURE_WINDOW_SECONDS,
+        }
+
+
+def login_reset_for_tests() -> None:
+    with _login_lock:
+        _login_failures.clear()

--- a/tests/api/test_login_throttle.py
+++ b/tests/api/test_login_throttle.py
@@ -1,0 +1,192 @@
+"""W22-F003 — the login endpoint's own failure throttle.
+
+The finding: login had no throttle of its own, no lockout and no
+failure backoff — 200 wrong-password attempts landed at 223 req/s with
+zero 429.  The repair is a dedicated failure throttle in
+``src/api/rate_limit.py`` (``login_*`` — one owner, beside the public
+token buckets), wired into ``POST /api/auth/login``:
+
+* failures are keyed by client IP AND by (client IP, username) —
+  NEVER by username alone, so failures from elsewhere cannot lock the
+  real owner out (the isolation test below pins the invariant);
+* ``_LOGIN_FREE_ATTEMPTS`` failures per window are free, then the next
+  attempt is delayed exponentially (1s → 2s → 4s ... capped), served
+  as 429 + ``retryAfterSeconds``;
+* the throttle is checked BEFORE credential comparison (a blocked
+  caller learns nothing), and success clears the (ip, username) state.
+
+Tests drive the clock through ``rate_limit._login_now`` — no sleeps.
+Both ``X-Forwarded-For`` and ``X-Real-IP`` are set to the same single
+IP so the tests hold under either resolution order of
+``_client_ip_from_request`` (this branch reads XFF-first; #1112 moves
+to X-Real-IP-first).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+import server
+from src.api import rate_limit
+
+
+OWNER = "owneruser"
+OWNER_PW = "correct-horse-not-a-real-secret"
+
+
+def _hdrs(ip: str) -> dict[str, str]:
+    return {"X-Forwarded-For": ip, "X-Real-IP": ip}
+
+
+def _login(client, ip: str, username: str, password: str):
+    return client.post(
+        "/api/auth/login",
+        json={"username": username, "password": password},
+        headers=_hdrs(ip),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _login_env(monkeypatch):
+    monkeypatch.setattr(server, "JASON_LOGIN_USERNAME", OWNER)
+    monkeypatch.setattr(server, "JASON_LOGIN_PASSWORD", OWNER_PW)
+    # Keep wrong-password attempts away from the guest-pass SQLite —
+    # only the throttle is under test here.
+    monkeypatch.setattr(server._guest_passes, "validate", lambda pw: None)
+    rate_limit.reset_for_tests()
+    yield
+    rate_limit.reset_for_tests()
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """Deterministic clock for the login throttle only."""
+
+    class _Clock:
+        now = 1_000_000.0
+
+        def advance(self, seconds: float) -> None:
+            _Clock.now += seconds
+
+    monkeypatch.setattr(rate_limit, "_login_now", lambda: _Clock.now)
+    return _Clock()
+
+
+# ── The invariant, pinned structurally ─────────────────────────────
+
+
+def test_keys_never_contain_a_bare_username_component():
+    """A lockout keyed on username alone would let an attacker lock the
+    real owner out remotely.  The per-username key is always scoped
+    within the client IP, and no usable IP means no keys at all."""
+    assert rate_limit._login_keys("1.2.3.4", "Bob") == [
+        "ip:1.2.3.4",
+        "ipuser:1.2.3.4|bob",
+    ]
+    assert rate_limit._login_keys("", "bob") == []
+    assert rate_limit._login_keys("   ", "bob") == []
+
+
+def test_failures_from_one_ip_do_not_throttle_another_ip(clock):
+    """The isolation half of the invariant, end to end: a burst from
+    IP A neither throttles nor locks out the same username at IP B."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        for _ in range(6):
+            _login(c, "10.0.0.1", OWNER, "wrong")
+        # IP A is now backed off.
+        res_a = _login(c, "10.0.0.1", OWNER, "wrong")
+        assert res_a.status_code == 429
+        # IP B, same username: a wrong attempt is a plain 401 ...
+        res_b = _login(c, "10.0.0.2", OWNER, "wrong")
+        assert res_b.status_code == 401, res_b.text
+        # ... and the real owner still signs in.
+        res_ok = _login(c, "10.0.0.2", OWNER, OWNER_PW)
+        assert res_ok.status_code == 200, res_ok.text
+        assert res_ok.json()["ok"] is True
+
+
+# ── Backoff behavior ───────────────────────────────────────────────
+
+
+def test_first_attempt_is_never_throttled(clock):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = _login(c, "10.1.0.1", OWNER, "wrong")
+    assert res.status_code == 401
+    assert res.json() == {"ok": False, "error": "Invalid username or password."}
+
+
+def test_burst_gets_429_with_growing_retry_after(clock):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        # The free attempts are plain 401s.
+        for i in range(rate_limit._LOGIN_FREE_ATTEMPTS):
+            res = _login(c, "10.1.0.2", OWNER, "wrong")
+            assert res.status_code == 401, f"attempt {i + 1} throttled early"
+        # The next attempt is backed off.
+        first = _login(c, "10.1.0.2", OWNER, "wrong")
+        assert first.status_code == 429, first.text
+        body = first.json()
+        assert body["error"] == "too_many_attempts"
+        retry_1 = body["retryAfterSeconds"]
+        assert retry_1 >= 1
+        assert first.headers["Retry-After"] == str(retry_1)
+        # Wait out the delay: the attempt lands (401) and doubles the
+        # backoff for the one after it.
+        clock.advance(retry_1 + 0.1)
+        res = _login(c, "10.1.0.2", OWNER, "wrong")
+        assert res.status_code == 401
+        second = _login(c, "10.1.0.2", OWNER, "wrong")
+        assert second.status_code == 429
+        retry_2 = second.json()["retryAfterSeconds"]
+        assert retry_2 > retry_1, f"backoff did not grow: {retry_1} -> {retry_2}"
+
+
+def test_backoff_caps_at_the_declared_ceiling(clock):
+    ip, user = "10.1.0.6", "someone"
+    for _ in range(60):
+        rate_limit.login_record_failure(ip, user)
+    blocked, retry_after = rate_limit.login_throttle_check(ip, user)
+    assert blocked
+    assert retry_after <= int(rate_limit._LOGIN_BACKOFF_CAP_SECONDS)
+
+
+def test_correct_password_is_blocked_during_backoff_then_works_after(clock):
+    """The check runs BEFORE credential comparison — a blocked caller
+    learns nothing about validity — and expiry restores access."""
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        for _ in range(rate_limit._LOGIN_FREE_ATTEMPTS):
+            _login(c, "10.1.0.3", OWNER, "wrong")
+        res = _login(c, "10.1.0.3", OWNER, OWNER_PW)
+        assert res.status_code == 429, "correct password must not bypass the backoff"
+        clock.advance(2.0)
+        res = _login(c, "10.1.0.3", OWNER, OWNER_PW)
+        assert res.status_code == 200, res.text
+        assert res.json()["ok"] is True
+
+
+def test_success_resets_the_ip_username_state(clock):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        for _ in range(rate_limit._LOGIN_FREE_ATTEMPTS):
+            _login(c, "10.1.0.4", OWNER, "wrong")
+        clock.advance(2.0)
+        ok = _login(c, "10.1.0.4", OWNER, OWNER_PW)
+        assert ok.status_code == 200
+        # The (ip, username) failure state is gone ...
+        with rate_limit._login_lock:
+            assert f"ipuser:10.1.0.4|{OWNER}" not in rate_limit._login_failures
+        # ... so the next mistake is a plain 401, not a 429.
+        res = _login(c, "10.1.0.4", OWNER, "wrong")
+        assert res.status_code == 401
+
+
+def test_cooloff_window_forgets_old_failures(clock):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        for _ in range(6):
+            _login(c, "10.1.0.5", OWNER, "wrong")
+        assert _login(c, "10.1.0.5", OWNER, "wrong").status_code == 429
+        # A full cool-off later the window has reset: free attempts again.
+        clock.advance(rate_limit._LOGIN_FAILURE_WINDOW_SECONDS + 1)
+        res = _login(c, "10.1.0.5", OWNER, "wrong")
+        assert res.status_code == 401
+        res = _login(c, "10.1.0.5", OWNER, OWNER_PW)
+        assert res.status_code == 200

--- a/tests/api/test_operator_admin_gate.py
+++ b/tests/api/test_operator_admin_gate.py
@@ -1,0 +1,212 @@
+"""W22-F007 — operator-grade actions gate on the admin allowlist.
+
+The finding: operator-grade endpoints (production scrape trigger,
+outbound email send, intel crawl trigger) were gated on session
+PRESENCE only, so a guest-pass holder could trigger them.  The repair
+routes each through ``_require_admin_session`` (session + the
+``PRIVATE_APP_ALLOWED_USERNAMES`` allowlist).
+
+Per endpoint, three states are pinned:
+
+  (a) no session          → 401 (unchanged — middleware or handler)
+  (b) non-allowlisted     → 403 ``admin_required``  ← the RED→GREEN
+      session               discriminator: pre-fix this succeeded or
+                            attempted the action
+  (c) allowlisted admin   → neither 401 nor 403; the heavy action runs
+                            (mocked — ONLY the side-effecting action is
+                            mocked, never the gate)
+
+The action spies double as proof that a rejected request never reaches
+the side effect.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+import server
+
+
+@pytest.fixture(autouse=True)
+def _stub_allowlist(monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "PRIVATE_APP_ALLOWED_USERNAMES",
+        frozenset({"jasonleetucker"}),
+    )
+    yield
+
+
+def _authed_admin(monkeypatch):
+    monkeypatch.setattr(server, "_is_authenticated", lambda r: True)
+    monkeypatch.setattr(
+        server,
+        "_get_auth_session",
+        lambda r: {"username": "jasonleetucker"},
+    )
+
+
+def _authed_guest(monkeypatch):
+    """A session that exists but is NOT allowlisted — the guest-pass
+    shape the finding is about (guest sessions carry username
+    ``"guest"``, which is never in the allowlist)."""
+    monkeypatch.setattr(server, "_is_authenticated", lambda r: True)
+    monkeypatch.setattr(
+        server,
+        "_get_auth_session",
+        lambda r: {"username": "guest", "auth_method": "guest_pass"},
+    )
+
+
+# ── POST /api/scrape ───────────────────────────────────────────────
+
+
+def _stub_scrape_environment(monkeypatch, calls):
+    """Mock ONLY the side-effecting pieces of the scrape path: the
+    scraper itself plus the league/status plumbing needed to reach it
+    deterministically in a bare test env."""
+    cfg = SimpleNamespace(key="dynasty_main", sleeper_league_id="111")
+    monkeypatch.setattr(server, "_resolve_league_for_request", lambda *a, **k: cfg)
+    monkeypatch.setattr(server._league_registry, "get_default_league", lambda: cfg)
+    monkeypatch.setattr(server, "_scrape_status_payload", lambda: {"is_running": False})
+    monkeypatch.setattr(server, "_record_scrape_event", lambda *a, **k: None)
+
+    async def fake_run_scraper(trigger: str = "manual"):
+        calls.append(trigger)
+        return None
+
+    monkeypatch.setattr(server, "run_scraper", fake_run_scraper)
+
+
+def test_scrape_no_session_is_401():
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post("/api/scrape")
+    assert res.status_code == 401
+    assert res.json().get("error") == "auth_required"
+
+
+def test_scrape_guest_session_is_403_and_never_scrapes(monkeypatch):
+    calls: list[str] = []
+    _stub_scrape_environment(monkeypatch, calls)
+    _authed_guest(monkeypatch)
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post("/api/scrape")
+    assert res.status_code == 403, res.text
+    assert res.json().get("error") == "admin_required"
+    assert calls == [], "a 403'd request must never start the scraper"
+
+
+def test_scrape_admin_session_starts_the_scrape(monkeypatch):
+    calls: list[str] = []
+    _stub_scrape_environment(monkeypatch, calls)
+    _authed_admin(monkeypatch)
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post("/api/scrape")
+    assert res.status_code not in (401, 403), res.text
+    assert res.status_code == 200
+    # TestClient runs background tasks before returning.
+    assert calls == ["manual_api"]
+
+
+# ── POST /api/test-alert ───────────────────────────────────────────
+
+
+def _stub_alert_environment(monkeypatch, sent):
+    monkeypatch.setattr(server, "ALERT_ENABLED", True)
+    monkeypatch.setattr(server, "ALERT_TO", "ops@example.invalid")
+    monkeypatch.setattr(server, "send_alert", lambda subject, body: sent.append((subject, body)))
+
+
+def test_test_alert_no_session_is_401():
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post("/api/test-alert")
+    assert res.status_code == 401
+    assert res.json().get("error") == "auth_required"
+
+
+def test_test_alert_guest_session_is_403_and_never_sends(monkeypatch):
+    sent: list[tuple[str, str]] = []
+    _stub_alert_environment(monkeypatch, sent)
+    _authed_guest(monkeypatch)
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post("/api/test-alert")
+    assert res.status_code == 403, res.text
+    assert res.json().get("error") == "admin_required"
+    assert sent == [], "a 403'd request must never send email"
+
+
+def test_test_alert_admin_session_sends(monkeypatch):
+    sent: list[tuple[str, str]] = []
+    _stub_alert_environment(monkeypatch, sent)
+    _authed_admin(monkeypatch)
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post("/api/test-alert")
+    assert res.status_code not in (401, 403), res.text
+    assert res.status_code == 200
+    assert len(sent) == 1
+
+
+# ── POST /api/intel/refresh ────────────────────────────────────────
+
+
+def _stub_intel_environment(monkeypatch, calls):
+    server._intel_refresh_reset_for_tests()
+    cfg = SimpleNamespace(key="dynasty_main", sleeper_league_id="111")
+    monkeypatch.setattr(server, "_resolve_league_for_request", lambda *a, **k: cfg)
+    monkeypatch.setattr(server._intel_service, "refresh_status", lambda: {"isRunning": False})
+
+    def fake_start(**kwargs):
+        calls.append(kwargs)
+        return {"isRunning": True}
+
+    monkeypatch.setattr(server._intel_service, "start_refresh_async", fake_start)
+
+
+def test_intel_refresh_no_session_is_401(monkeypatch):
+    # Self-authed path: the middleware defers, the handler's own gate
+    # answers.  No bearer header and no session → 401.
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post("/api/intel/refresh")
+    assert res.status_code == 401
+    assert res.json().get("error") == "auth_required"
+
+
+def test_intel_refresh_guest_session_is_403_and_never_crawls(monkeypatch):
+    calls: list[dict] = []
+    _stub_intel_environment(monkeypatch, calls)
+    _authed_guest(monkeypatch)
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post("/api/intel/refresh")
+    assert res.status_code == 403, res.text
+    assert res.json().get("error") == "admin_required"
+    assert calls == [], "a 403'd request must never start a crawl"
+
+
+def test_intel_refresh_admin_session_starts_the_crawl(monkeypatch):
+    calls: list[dict] = []
+    _stub_intel_environment(monkeypatch, calls)
+    _authed_admin(monkeypatch)
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post("/api/intel/refresh")
+    assert res.status_code not in (401, 403), res.text
+    assert res.status_code == 202
+    assert len(calls) == 1
+
+
+def test_intel_refresh_bearer_cron_path_is_unchanged(monkeypatch):
+    """The cron authenticates with a bearer token and no session; the
+    admin gate must not apply to it (it is not a browser session at
+    all).  Pins that W22-F007 did not break the scheduled driver."""
+    calls: list[dict] = []
+    _stub_intel_environment(monkeypatch, calls)
+    monkeypatch.setattr(server, "INTEL_REFRESH_TOKEN", "sekrit")
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post(
+            "/api/intel/refresh",
+            headers={"Authorization": "Bearer sekrit"},
+        )
+    assert res.status_code == 202, res.text
+    assert len(calls) == 1

--- a/tests/intel/test_endpoints.py
+++ b/tests/intel/test_endpoints.py
@@ -25,6 +25,11 @@ LEAGUE_KEY = "dynasty_main"
 def authed(monkeypatch):
     monkeypatch.setattr(server, "_is_authenticated", lambda r: True)
     monkeypatch.setattr(server, "_get_auth_session", lambda r: {"username": "jason"})
+    # POST /api/intel/refresh now gates its session path on the admin
+    # allowlist (W22-F007), so the stub identity is allowlisted
+    # explicitly rather than depending on the env default.  Read-only
+    # intel endpoints ignore this.
+    monkeypatch.setattr(server, "PRIVATE_APP_ALLOWED_USERNAMES", frozenset({"jason"}))
 
 
 @pytest.fixture


### PR DESCRIPTION
Implements the two remaining M-sized V1-103 security repairs: **W22-F007** (operator-grade actions gated on session presence, not the admin allowlist) and **W22-F003** (login had no throttle of its own, no lockout, no failure backoff).

Deliberately does NOT touch the regions PR #1112 (fix/v1-103-s-parts) is changing: `_client_ip_from_request` is called as it exists on the base, and `_PUBLIC_API_EXACT` / `_SELF_AUTHED_API_EXACT` are unmodified.

---

## Commit 1 — W22-F007: operator-grade actions gate on `_require_admin_session`

### Census of every mutating endpoint in `server.py` (`@app.post` / `@app.put`; no `@app.delete` exists)

| Endpoint | Classification | Notes |
|---|---|---|
| `POST /api/scrape` | **newly gated** | triggers the production scrape / force-refreshes a league's Sleeper overlay |
| `POST /api/test-alert` | **newly gated** | sends an outbound email (the email-send endpoint from the finding) |
| `POST /api/intel/refresh` | **newly gated** (session path only) | intel crawl — minutes of budgeted Sleeper calls; the bearer cron path is unchanged and test-pinned |
| `POST /api/admin/nfl-data/flush` | already admin-gated | `_require_admin_session` |
| `POST /api/admin/sessions/force-logout-all` | already admin-gated | `_require_admin_session` |
| `POST /api/admin/guest-pass` (+ list GET) | already admin-gated | `_require_admin_session` |
| `POST /api/admin/guest-pass/{id}/revoke` | already admin-gated | `_require_admin_session` |
| `POST /api/admin/signal-state/migrate` | already admin-gated | `_require_admin_session` |
| `POST /api/league/articles/generate` | already admin-gated | `_require_admin_session` |
| `POST /api/signal-alerts/run` | already operator-gated (different mechanism) | bearer cron token OR password-session (`auth_method == "password"` is mintable only by the owner login; guest passes mint `guest_pass`). Left as-is — not session-presence-only, and converting it would touch the cron path |
| `POST /api/custom-alerts/run` | already operator-gated (different mechanism) | same bearer-or-password model as signal-alerts |
| `POST /api/test/create-session` | E2E-only | invisible (404) unless `E2E_TEST_MODE` + secret; unchanged |
| `POST /api/rankings/overrides` | left user-level | ordinary product feature |
| `POST /api/waiver/suggestions`, `POST /api/waiver/faab-recommend` | left user-level | product features |
| `POST /api/trade/suggestions`, `finder`, `simulate`, `simulate-mc`, `analyze`, `import-ktc`, `export-ktc` | left user-level | product features |
| `POST /api/angle/find`, `POST /api/angle/packages` | left user-level | product features |
| `POST /api/bdvm/trade-eval` | left user-level | product feature |
| `POST /api/intel/leads` | left user-level | read-shaped ranking computation, no production mutation |
| `POST /api/auth/login`, `POST /api/auth/logout` | left as-is | the auth surface itself (login gains the Commit-2 throttle) |
| `PUT /api/user/state`, `PUT /api/custom-alerts` | left user-level | the user's own state/rules |
| `POST /api/push/subscribe`, `POST /api/push/unsubscribe` | left user-level | the user's own push subscriptions |
| `POST /api/user/signals/dismiss`, `POST /api/user/signals/restore` | left user-level | the user's own signal state |

Adjudication-needed: none — every mutating endpoint classified cleanly into one of the rows above.

### Design
The correct gate already existed (`server.py::_require_admin_session` — session + `PRIVATE_APP_ALLOWED_USERNAMES`, 401/403 JSON conventions). Each newly gated endpoint now runs it first, using the established `session_or_err` caller pattern; endpoint behavior past the gate is unchanged. For `/api/intel/refresh` only the browser/session path is upgraded — the bearer token remains the cron's credential and is pinned by a new test.

### Tests (10 new in `tests/api/test_operator_admin_gate.py`)
Per endpoint: (a) no session → 401 (unchanged), (b) non-allowlisted session → 403 `admin_required` **with the side-effecting action proven un-run** (the RED→GREEN discriminator — pre-fix the guest request succeeded/attempted the action), (c) allowlisted admin → the action runs. Only the side-effecting action is mocked (scraper, `send_alert`, `start_refresh_async`), never the gate. Plus the bearer-cron-unchanged pin.

`tests/intel/test_endpoints.py`'s `authed` stub is now explicitly allowlisted (its refresh-lifecycle tests trigger the crawl through the session path).

### E2E check
The only E2E spec touching a newly gated path is `tests/e2e/specs/multi-league.spec.js`, which asserts the **unauthenticated 401** on `POST /api/scrape` — unchanged (middleware fires first). No authenticated E2E spec exercises any newly gated endpoint, so no test-session adjustment was needed (`E2E_TEST_USERNAME=e2e-test-user` never hits them).

### Mutation proof 1 (executed, restored)
Dropped the gate from `POST /api/scrape` → `test_scrape_guest_session_is_403_and_never_scrapes` **FAILED** (guest got 200 and the scraper spy fired); restored → green.

---

## Commit 2 — W22-F003: login failure throttle with exponential backoff

### Design
One owner: the `login_*` functions in `src/api/rate_limit.py`, beside the existing public token buckets — no second in-server implementation.

* Failures keyed by **client IP** (`ip:<ip>`) and **(client IP, username-lowercased)** (`ipuser:<ip>|<user>`). **Invariant, stated in the module comment and pinned by test: a lockout is NEVER keyed on username alone** — an attacker must not be able to lock the real owner out remotely; failures from IP A do not throttle IP B for the same username. No usable client IP → nothing keyed (never a bare-username fallback).
* **5 free attempts** per **15-minute** cool-off window, then the next attempt is delayed exponentially (**1s → 2s → 4s … capped at 60s**), answered as **429** with `retryAfterSeconds` + `Retry-After`. Constants declared once in `rate_limit.py`.
* Checked **before** any credential comparison, so a blocked caller learns nothing about validity. Every 401 path records a failure; success clears the `(ip, username)` state — deliberately not the bare-IP key, so one valid credential (e.g. a guest pass) cannot reset the IP-wide counter between guessing bursts.
* Client identity via the existing `_client_ip_from_request` (called as it exists on base; not modified — #1112 owns it).

### Tests (8 new in `tests/api/test_login_throttle.py`, clock-driven via the `_login_now` seam — no sleeps)
First attempt never throttled; wrong-password burst → 429 with **growing** `retryAfterSeconds`; correct password blocked during backoff, works after expiry; success resets the (ip, username) state; cool-off window forgets old failures; backoff caps at the declared ceiling; **different-IP isolation** for the same username (the invariant); the structural key-shape pin. Tests set both `X-Forwarded-For` and `X-Real-IP` identically so they hold before and after #1112's client-IP resolution change.

### Mutation proof 2 (executed, restored)
No-op'd `login_record_failure` → 5 tests **FAILED**, including `test_burst_gets_429_with_growing_retry_after` (zero 429s ever); restored → green.

---

## Validation

* `python -m pytest tests/api/ -q -k "auth or rate or admin or login"` → **141 passed, 3 skipped**
* `python -m pytest tests/api/test_private_auth.py -q` → **33 passed**
* Full `python -m pytest tests/api/ -q -m "not livedata"` → **2193 passed, 29 skipped, 193 subtests passed**
* `tests/intel/test_endpoints.py` + `tests/api/test_operator_admin_gate.py` → **54 passed**
* ruff **0.6.9** (CI pin) check + format clean on every touched file; no untouched files reformatted

Nothing added to `_PUBLIC_API_EXACT` / `_SELF_AUTHED_API_EXACT`; no existing auth path weakened; no E2E_TEST_MODE semantics in prod paths; no credentials in code or tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_