### PR TITLE
CI: raise the PR-validation job timeout to 30 minutes

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -55,7 +55,15 @@ jobs:
     # aspirational until this date — no vitest step existed in any
     # workflow.  It does now (see "Frontend unit tests" below), so the
     # comment is finally accurate.  vitest adds ~20s.
-    timeout-minutes: 20
+    #
+    # 20 → 30 (2026-08-25): the suite legitimately grew past the old
+    # ceiling — ten green runs that day measured 12.5-19.5 minutes, and
+    # TWO runs were killed at exactly ~20m ("cancelled", which reads
+    # like a supersede and cost an hour of diagnosis each time). 30
+    # keeps a real hang detectable while leaving headroom for a suite
+    # that adds tests every merge. This bounds WALL CLOCK only — no
+    # test, gate or tolerance is affected.
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
## Two runs were killed today at exactly the ceiling, and it read as something else

`pr-validation.yml`'s job carried `timeout-minutes: 20`. The suite has legitimately grown past it: ten green runs today measured **12.5–19.5 minutes**, and two runs were killed at almost exactly 20m — #1105's first Validate PR (started 09:51:51, killed 10:11:58 = 20m07s) and #1115's (started 10:44:30, killed 11:04:40 = 20m10s). GitHub records the kill as conclusion **"cancelled"**, which is indistinguishable at a glance from a concurrency supersede — both incidents cost a diagnosis pass before the pattern (both at ~20m) gave it away.

## Change

`timeout-minutes: 20 → 30`, with the measurement recorded in the comment above it (following the file's own convention — the 10→20 bump has the same style of note). 30 keeps a genuine hang detectable while leaving headroom for a suite that adds tests on most merges.

Wall-clock bound only: no test, gate, tolerance, or validator is affected. A `pull_request` run uses the PR's own workflow version, so this PR's validation already runs under the raised budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_