### PR TITLE
V1-132: the horizon pick year blends both markets, not one

### DIFF
--- a/docs/picks/C1_U6_PICK_VALUE_COMPLETENESS.md
+++ b/docs/picks/C1_U6_PICK_VALUE_COMPLETENESS.md
@@ -233,6 +233,25 @@ assumption is named in the config (`classificationNote`) and here.
   shared structure, not an unrelated drift.  Follow-up recorded (§12): whether
   synthetic rows should be excluded from translation pools is its own measured
   decision — exclusion also moves player values.
+* **KTC-side mirror of the same coupling, measured at the V1-132 (F-34)
+  repair (2026-08-25).**  The paragraph above documents the coupling for the
+  IDPTC backbone only; the identical mechanism exists on the KTC side and was
+  measured when the horizon year gained its second market: the rookie ladder
+  (`rookie_ladder_translation_via_ktcSfTep`) is built from `ktcSfTep`'s
+  Phase-1 effective ranks, an ordinal pool that BY DESIGN contains the
+  synthetic pick rows once they carry derived `ktcSfTep` values.  Giving the
+  twelve horizon tier cells their `ktcSfTep` evidence shifts deep rookies'
+  ladder-translated votes (`dlfRookieSf` / `flockFantasySfRookies`):
+  measured **17 offense rookies moved, p50 ≈ −0.15%, max −0.78%** (Cole
+  Payton; values 1050–1900, ktcSfTep ordinals ~470–482), plus **3 tethered
+  2026 slot picks at −0.11%** — smaller than the IDPTC-side coupling
+  accepted above (max −1.3%).  Zero IDP players moved; 2027/2028 vendor
+  values byte-identical; top-200 membership unchanged; ranked 740 → 740.
+  Adjudicated by Integration as the same accepted class through the same
+  designed shared structure: there is no implementation of a two-market
+  horizon blend that leaves the ladder pool untouched, short of the §12
+  translation-pool exclusion — which stays an OPEN, separately-measured
+  methodology decision, now with symmetric evidence on both markets' pools.
 * **Cap-margin churn:** four tail players (values ≈1140, the board's ranked
   floor) fell out of the top-800 value-stamping window as repriced 2029 rows
   entered it — the same boundary churn every 2-hour refresh produces when

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -5525,8 +5525,12 @@ def _complete_synthetic_pick_sources_from_enrichment(
             continue
         year, tier, rnd = int(m.group(1)), m.group(2), int(m.group(3))
         try:
-            basis_year = int(record.get("basisYear") or 0)
-        except (TypeError, ValueError):
+            basis_year = int(record["basisYear"])
+        except (KeyError, TypeError, ValueError):
+            # No recorded basis year -> REFUSE to derive.  ``or 0`` here
+            # would fabricate gap = year - 0 and drive step**gap to ~0,
+            # stamping a 0.0 that reads as a real value — missing is
+            # never zero, and never a fabricated basis either.
             continue
         gap = year - basis_year
         if gap <= 0:

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -5336,6 +5336,13 @@ def _inject_far_future_pick_sources(
     tier entry is left untouched, so the moment vendors publish e.g.
     2029 this no-ops for that year ("pivot when sources add them").
 
+    POPULATION NOTE (V1-132 / audit F-34): this function sees the RAW
+    payload only, where just the in-JSON pick markets carry values —
+    ``ktcSfTep``'s pick values arrive through the later CSV enrichment.
+    :func:`_complete_synthetic_pick_sources_from_enrichment` runs after
+    that enrichment and extends this same derivation to the enriched
+    per-source evidence, so the horizon year blends both pick markets.
+
     Returns the per-build derivation map (canonical match key → record).
     Its length is the number of synthetic raw entries added, and its keys
     are the synthetic-name set the single-source gate allowlists.  It is
@@ -5425,6 +5432,120 @@ def _inject_far_future_pick_sources(
             added += 1
         years_with_tiers.add(year)
     return derivations
+
+
+def _complete_synthetic_pick_sources_from_enrichment(
+    players_array: list[dict[str, Any]],
+    synthetic_pick_derivations: Mapping[str, dict[str, Any]],
+) -> int:
+    """Extend the far-future derivation to CSV-enriched source evidence.
+
+    AUDIT F-34 (V1-132).  :func:`_inject_far_future_pick_sources` clones
+    the template year's entry out of ``players_by_name`` — the RAW
+    scraper payload — and that population is strictly poorer than the
+    one the canonical board blends for the same template year:
+    ``ktcSfTep``'s pick values arrive through the LATER
+    ``_enrich_from_source_csvs`` pass, which the injection structurally
+    cannot see.  So the published years (both pick markets on every tier
+    row) blended two markets while the horizon year blended
+    ``idpTradeCalc`` alone on all twelve tier cells — a single-vendor
+    dependency on exactly the rows with the least direct evidence.
+
+    The injection cannot simply move after the enrichment: it must run
+    against ``players_by_name`` BEFORE ``players_array`` is derived so
+    the synthetic rows exist as rows (and as legacy dict entries) at
+    all, and the enrichment loop itself needs those rows to exist to
+    stamp anything.  The pipeline's own structure — rows built once,
+    then enriched in place — therefore supports the converse ordering:
+    hand the injection's derivation the enriched evidence, in place, per
+    synthetic row.
+
+    Same derivation, wider population — nothing about the model changes:
+
+      * a source key present (positive) on the TEMPLATE row but absent
+        on the synthetic row is filled with ``template × step ** gap``,
+        the identical ``derivedYearModel`` cell step and compounding the
+        injection applies to the raw per-source values (through the one
+        shared :func:`_year_step_for`);
+      * a value the injection already stepped at the raw layer is left
+        alone — never re-stepped, never overwritten;
+      * a source the template row does not carry stays MISSING
+        (C1-U6-D1: a year a source did not publish is the key's
+        absence), so a source publishing no picks contributes nothing;
+      * provenance is untouched — the rows keep their
+        ``derived_year_step`` record; nothing here can promote a
+        derivation to ``direct_market_blend``.
+
+    Chained templates are processed in ascending target-year order so a
+    horizon two years past the last published year (whose template is
+    itself synthetic) reads its template's completed values.
+
+    In practice the enrichment-only pick sources are the value-signal
+    pick markets — today exactly ``ktcSfTep`` — but the rule is the
+    injection's own (every positive per-source value on the template),
+    not a source list to keep in step.
+
+    Returns the number of per-source values stamped.  Runs immediately
+    after ``_enrich_from_source_csvs`` in :func:`build_api_data_contract`
+    and mutates only the synthetic rows' ``canonicalSiteValues``;
+    ``_compute_unified_rankings`` recomputes ``sourceCount`` /
+    ``sourcePresence`` from those, and the backbone's synthetic-row
+    exclusion (C1-U6 follow-up 2) already keeps every value written here
+    out of the cross-market ladder.
+    """
+    if not synthetic_pick_derivations:
+        return 0
+    cfg = _load_pick_year_discount()
+    rows_by_key: dict[str, dict[str, Any]] = {}
+    for row in players_array:
+        if not isinstance(row, dict) or row.get("assetClass") != "pick":
+            continue
+        key = _canonical_match_key(str(row.get("canonicalName") or ""))
+        if key:
+            rows_by_key[key] = row
+
+    def _target_year(item: tuple[str, dict[str, Any]]) -> int:
+        row = rows_by_key.get(item[0])
+        if isinstance(row, dict):
+            m = _PICK_TIER_RE.match(str(row.get("canonicalName") or "").strip())
+            if m:
+                return int(m.group(1))
+        return 0
+
+    stamped = 0
+    for match_key, record in sorted(synthetic_pick_derivations.items(), key=_target_year):
+        row = rows_by_key.get(match_key)
+        if not isinstance(row, dict):
+            continue
+        template = rows_by_key.get(_canonical_match_key(str(record.get("basisName") or "")))
+        if not isinstance(template, dict):
+            continue
+        m = _PICK_TIER_RE.match(str(row.get("canonicalName") or "").strip())
+        if not m:
+            continue
+        year, tier, rnd = int(m.group(1)), m.group(2), int(m.group(3))
+        try:
+            basis_year = int(record.get("basisYear") or 0)
+        except (TypeError, ValueError):
+            continue
+        gap = year - basis_year
+        if gap <= 0:
+            continue
+        factor = _year_step_for(tier, rnd, cfg) ** gap
+        template_sites = template.get("canonicalSiteValues")
+        row_sites = row.get("canonicalSiteValues")
+        if not isinstance(template_sites, dict) or not isinstance(row_sites, dict):
+            continue
+        for source_key, template_value in template_sites.items():
+            t_num = _safe_num(template_value)
+            if t_num is None or t_num <= 0:
+                continue  # the template does not carry it → MISSING stays missing
+            existing = _safe_num(row_sites.get(source_key))
+            if existing is not None and existing > 0:
+                continue  # already derived at injection — never re-stepped
+            row_sites[source_key] = round(float(t_num) * factor, 1)
+            stamped += 1
+    return stamped
 
 
 def current_rookie_draft_year(today: date | None = None) -> int:
@@ -7722,10 +7843,14 @@ def _complete_future_pick_values(
     # scraper payload — and that population is strictly poorer than the one the
     # canonical board uses for the same template year: ``ktcSfTep``'s pick
     # values arrive through the LATER CSV enrichment, which correctly carries no
-    # far-future year to enrich a synthetic row with.  A synthetic row can
-    # therefore only ever vote on the in-JSON sources, and when those thin out
-    # it is left with no voting source at all.  No voter means no rank, no rank
-    # means no ``rankDerivedValue``.
+    # far-future year to enrich a synthetic row with.  Since V1-132 (F-34) the
+    # post-enrichment ``_complete_synthetic_pick_sources_from_enrichment`` pass
+    # steps the TEMPLATE row's enriched values onto the synthetic rows, so a
+    # synthetic row normally votes on both pick markets — but that pass can
+    # only widen what the template row carries.  When the template's evidence
+    # itself thins out (in-JSON AND CSV), a synthetic row is still left with no
+    # voting source at all.  No voter means no rank, no rank means no
+    # ``rankDerivedValue``.
     #
     # Measured 2026-08-18: the 17:11Z scrape's in-JSON ``idpTradeCalc`` pick
     # values collapsed to the round-1 tiers while BOTH vendor CSVs stayed
@@ -11245,6 +11370,14 @@ def build_api_data_contract(
     csv_index = _enrich_from_source_csvs(
         players_array, parse_errors=source_parse_errors, csv_root=csv_root
     )
+
+    # V1-132 / audit F-34: the far-future injection above ran against the
+    # RAW payload, where only the in-JSON pick markets exist; the CSV
+    # enrichment has now put ``ktcSfTep``'s pick values on the template
+    # year's rows.  Extend the SAME derivation (same cell step, same
+    # compounding, same provenance) to that enriched evidence so the
+    # horizon year blends both pick markets like every published year.
+    _complete_synthetic_pick_sources_from_enrichment(players_array, synthetic_pick_derivations)
 
     # Post-enrichment position guardrail: CSV enrichment happens AFTER
     # _derive_player_row, so the in-row guardrail there runs against an

--- a/tests/api/test_horizon_pick_two_market_injection.py
+++ b/tests/api/test_horizon_pick_two_market_injection.py
@@ -1,0 +1,302 @@
+"""V1-132 (audit F-34): the horizon pick year is not a single-vendor
+dependency.
+
+THE DEFECT
+──────────
+The published pick years blend BOTH pick markets (``idpTradeCalc`` +
+``ktcSfTep``) on their tier rows.  The HORIZON year blended
+``idpTradeCalc`` alone on all twelve tier cells, because
+``_inject_far_future_pick_sources`` derives the horizon year by cloning
+the nearest published future year's entry out of the RAW scraper
+payload — and ``ktcSfTep``'s pick values only reach a row through the
+LATER CSV enrichment step, which the injection structurally cannot see
+(and whose CSVs correctly carry no far-future year to enrich a
+synthetic row with).  F-30 made the horizon COVERAGE guarantee
+independent of the raw key set; the blended VALUE still was not.
+
+THE INVARIANT
+─────────────
+On a payload where both pick markets publish tiers through year N, the
+injected years N+1..horizon carry BOTH sources' derived entries — each
+stepped from its own vendor's published template value by the measured
+``derivedYearModel`` cell step, compounded across the gap — with
+``derived_year_step`` provenance.  And a source that publishes NO picks
+contributes nothing: missing stays missing (C1-U6-D1).
+
+These are deterministic tests through the production entry point
+(``build_api_data_contract`` with a temp ``csv_root``): no network, no
+live board, no absolute live-board counts.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import tempfile
+import unittest
+from functools import lru_cache
+from pathlib import Path
+
+from src.api.data_contract import (
+    _complete_synthetic_pick_sources_from_enrichment,
+    _load_pick_year_discount,
+    _round_suffix,
+    _year_step_for,
+    build_api_data_contract,
+)
+
+TIERS = ("Early", "Mid", "Late")
+VENDOR_ROUNDS = (1, 2, 3, 4)  # the rounds both pick markets publish
+
+CURRENT_YEAR = 2026  # pinned by the payload's own slot-pick rows
+TEMPLATE_YEAR = 2028  # nearest published future year — the injection's basis
+HORIZON_YEAR = 2029  # CURRENT_YEAR + horizonYears(3), no vendor publishes it
+
+# In-JSON pick market (the raw scraper payload carries these).
+IDPTC_TIER_VALUES: dict[str, float] = {}
+# CSV-only pick market (arrives via _enrich_from_source_csvs).
+KTC_TIER_VALUES: dict[str, float] = {}
+for _year, _base in ((2027, 5200.0), (TEMPLATE_YEAR, 4800.0)):
+    for _t_i, _tier in enumerate(TIERS):
+        for _rnd in VENDOR_ROUNDS:
+            _name = f"{_year} {_tier} {_round_suffix(_rnd)}"
+            _level = _base * (0.92**_t_i) * (0.62 ** (_rnd - 1))
+            IDPTC_TIER_VALUES[_name] = float(round(_level))
+            # A deliberately DIFFERENT number per cell, so "the horizon
+            # carries KTC's derived value" is distinguishable from "the
+            # horizon copied IDPTC's".  Integers, because the CSV parse
+            # coerces the value column to int.
+            KTC_TIER_VALUES[_name] = float(round(_level * 1.07))
+
+
+def _raw_payload() -> dict:
+    players: dict[str, dict] = {}
+
+    # An offense pool priced by both markets, so the board has a real
+    # population around the picks.
+    market = 9500
+    for i in range(1, 41):
+        sites = {"ktcSfTep": market, "idpTradeCalc": market - 20}
+        row: dict = {"_canonicalSiteValues": dict(sites), "position": "WR", "age": 25}
+        row.update(sites)
+        players[f"Pool Player {i:02d}"] = row
+        market -= 150
+
+    # Current-year SLOT picks pin the observed current draft year (the
+    # lowest year carrying slot-specific labels IS the active draft).
+    for slot, val in (("1.01", 6800), ("1.02", 6500), ("1.03", 6200)):
+        players[f"{CURRENT_YEAR} Pick {slot}"] = {"idpTradeCalc": val, "position": "PICK"}
+
+    # Future TIER picks: the in-JSON market only — exactly the raw
+    # population production hands the injection.  ``ktcSfTep`` reaches
+    # these rows via the CSV below, never via the payload.
+    for name, val in IDPTC_TIER_VALUES.items():
+        players[name] = {"idpTradeCalc": val, "position": "PICK"}
+
+    return {
+        "version": "v1-132-two-market-horizon-fixture",
+        "date": "2026-08-25",
+        "settings": {},
+        "sites": [{"key": "idpTradeCalc"}, {"key": "ktcSfTep"}, {"key": "dlfSf"}],
+        "maxValues": {},
+        "players": players,
+    }
+
+
+def _write_csvs(root: Path) -> None:
+    site_raw = root / "CSVs" / "site_raw"
+    site_raw.mkdir(parents=True)
+    # ktcSfTep: value-signal, players + published-year tier picks ONLY —
+    # the vendor publishes nothing past TEMPLATE_YEAR.
+    lines = ["name,value"]
+    lines += [f"Pool Player {i:02d},{9500 - (i - 1) * 150}" for i in range(1, 41)]
+    lines += [f"{name},{val}" for name, val in sorted(KTC_TIER_VALUES.items())]
+    (site_raw / "ktcSfTep.csv").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    # dlfSf: rank-signal, players only — a registered source that
+    # publishes NO picks at all (the missing-stays-missing control).
+    dlf = ["name,rank"] + [f"Pool Player {i:02d},{i}" for i in range(1, 21)]
+    (site_raw / "dlfSf.csv").write_text("\n".join(dlf) + "\n", encoding="utf-8")
+
+
+@lru_cache(maxsize=1)
+def _board() -> dict[str, dict]:
+    with tempfile.TemporaryDirectory() as tmp, contextlib.redirect_stdout(io.StringIO()):
+        root = Path(tmp)
+        _write_csvs(root)
+        contract = build_api_data_contract(_raw_payload(), csv_root=root)
+    return {str(r.get("canonicalName")): r for r in contract.get("playersArray") or []}
+
+
+def _positive_sites(row: dict) -> dict[str, float]:
+    return {
+        k: float(v)
+        for k, v in (row.get("canonicalSiteValues") or {}).items()
+        if isinstance(v, (int, float)) and not isinstance(v, bool) and v > 0
+    }
+
+
+def _horizon_cells() -> list[tuple[str, str, int]]:
+    return [
+        (f"{HORIZON_YEAR} {tier} {_round_suffix(rnd)}", tier, rnd)
+        for tier in TIERS
+        for rnd in VENDOR_ROUNDS
+    ]
+
+
+class TestHorizonBlendsBothMarkets(unittest.TestCase):
+    """The invariant, through the production entry point."""
+
+    def test_every_horizon_tier_cell_carries_both_markets(self) -> None:
+        board = _board()
+        cells = _horizon_cells()
+        self.assertEqual(len(cells), 12, "non-vacuity: all twelve cells checked")
+        cfg = _load_pick_year_discount()
+        gap = HORIZON_YEAR - TEMPLATE_YEAR
+        for name, tier, rnd in cells:
+            row = board.get(name)
+            self.assertIsNotNone(row, f"{name} missing — injection did not run")
+            sites = _positive_sites(row)
+            self.assertIn("idpTradeCalc", sites, f"{name} lost the in-JSON market's derived entry")
+            self.assertIn(
+                "ktcSfTep",
+                sites,
+                f"{name} carries no ktcSfTep — the horizon is a single-vendor "
+                f"dependency (F-34); positive sources: {sorted(sites)}",
+            )
+            # Each vendor's entry is that vendor's own template value
+            # stepped by the measured cell step — never the other
+            # vendor's number, never the template value verbatim.
+            step = _year_step_for(tier, rnd, cfg) ** gap
+            template = f"{TEMPLATE_YEAR} {tier} {_round_suffix(rnd)}"
+            expected_ktc = KTC_TIER_VALUES[template] * step
+            self.assertAlmostEqual(
+                sites["ktcSfTep"],
+                expected_ktc,
+                delta=1.0,
+                msg=f"{name}: ktcSfTep {sites['ktcSfTep']} != {template} × {step:.4f}",
+            )
+            expected_idp = IDPTC_TIER_VALUES[template] * step
+            self.assertAlmostEqual(
+                sites["idpTradeCalc"],
+                expected_idp,
+                delta=1.0,
+                msg=f"{name}: idpTradeCalc {sites['idpTradeCalc']} != {template} × {step:.4f}",
+            )
+            self.assertLess(
+                sites["ktcSfTep"],
+                KTC_TIER_VALUES[template],
+                f"{name}: ktcSfTep not stepped — a fabricated published-looking anchor",
+            )
+
+    def test_horizon_rows_keep_derived_provenance(self) -> None:
+        board = _board()
+        for name, _tier, _rnd in _horizon_cells():
+            row = board.get(name)
+            self.assertIsNotNone(row, name)
+            prov = row.get("pickValueProvenance") or {}
+            self.assertEqual(
+                prov.get("class"),
+                "derived_year_step",
+                f"{name}: a derivation must never present as {prov.get('class')!r}",
+            )
+
+    def test_a_source_publishing_no_picks_contributes_nothing(self) -> None:
+        """Missing stays missing (C1-U6-D1).
+
+        ``dlfSf`` covers twenty pool players and zero picks; nothing may
+        manufacture a horizon pick entry for it.  Asserted as an exact
+        set so ANY leaked key fails, not just the one control source.
+        """
+        board = _board()
+        for name, _tier, _rnd in _horizon_cells():
+            row = board.get(name)
+            self.assertIsNotNone(row, name)
+            self.assertEqual(
+                set(_positive_sites(row)),
+                {"idpTradeCalc", "ktcSfTep"},
+                f"{name}: a source that published no picks contributed",
+            )
+
+    def test_published_years_keep_vendor_values_verbatim(self) -> None:
+        """The completion widens the horizon only — a vendor-published
+        year's entries are the vendor's numbers, never stepped."""
+        board = _board()
+        checked = 0
+        for name, csv_value in KTC_TIER_VALUES.items():
+            row = board.get(name)
+            self.assertIsNotNone(row, name)
+            sites = _positive_sites(row)
+            self.assertEqual(
+                sites.get("ktcSfTep"),
+                float(csv_value),
+                f"{name}: published-year ktcSfTep moved",
+            )
+            self.assertEqual(
+                sites.get("idpTradeCalc"),
+                float(IDPTC_TIER_VALUES[name]),
+                f"{name}: published-year idpTradeCalc moved",
+            )
+            prov = row.get("pickValueProvenance") or {}
+            self.assertEqual(prov.get("class"), "direct_market_blend", name)
+            checked += 1
+        self.assertEqual(checked, 24, "non-vacuity: both published years checked")
+
+
+class TestCompletionRules(unittest.TestCase):
+    """The fine-grained rules, at the unit the fix owns."""
+
+    @staticmethod
+    def _rows_and_derivations() -> tuple[list[dict], dict[str, dict]]:
+        from src.api.data_contract import _canonical_match_key
+
+        template = {
+            "assetClass": "pick",
+            "canonicalName": f"{TEMPLATE_YEAR} Early 1st",
+            "canonicalSiteValues": {"idpTradeCalc": 5000, "ktcSfTep": 5350.0},
+        }
+        synthetic = {
+            "assetClass": "pick",
+            "canonicalName": f"{HORIZON_YEAR} Early 1st",
+            # The injection already stepped the in-JSON market.
+            "canonicalSiteValues": {"idpTradeCalc": 3926},
+        }
+        derivations = {
+            _canonical_match_key(f"{HORIZON_YEAR} Early 1st"): {
+                "factor": 0.7852,
+                "basisYear": TEMPLATE_YEAR,
+                "basisName": f"{TEMPLATE_YEAR} Early 1st",
+                "family": "measured_vendor_year_step_v1",
+                "classification": "PRIOR",
+            }
+        }
+        return [template, synthetic], derivations
+
+    def test_existing_injected_values_are_never_restepped(self) -> None:
+        rows, derivations = self._rows_and_derivations()
+        _complete_synthetic_pick_sources_from_enrichment(rows, derivations)
+        self.assertEqual(rows[1]["canonicalSiteValues"]["idpTradeCalc"], 3926)
+
+    def test_enriched_template_evidence_is_stepped_onto_the_synthetic_row(self) -> None:
+        rows, derivations = self._rows_and_derivations()
+        stamped = _complete_synthetic_pick_sources_from_enrichment(rows, derivations)
+        self.assertEqual(stamped, 1)
+        got = rows[1]["canonicalSiteValues"]["ktcSfTep"]
+        cfg = _load_pick_year_discount()
+        expected = 5350.0 * _year_step_for("Early", 1, cfg)
+        self.assertAlmostEqual(got, expected, delta=0.11)
+
+    def test_a_key_the_template_does_not_carry_stays_missing(self) -> None:
+        rows, derivations = self._rows_and_derivations()
+        _complete_synthetic_pick_sources_from_enrichment(rows, derivations)
+        self.assertNotIn("dlfSf", rows[1]["canonicalSiteValues"])
+
+    def test_empty_derivations_is_an_exact_no_op(self) -> None:
+        rows, _ = self._rows_and_derivations()
+        before = [dict(r["canonicalSiteValues"]) for r in rows]
+        stamped = _complete_synthetic_pick_sources_from_enrichment(rows, {})
+        self.assertEqual(stamped, 0)
+        self.assertEqual([r["canonicalSiteValues"] for r in rows], before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The defect (audit F-34)

Published pick years (2026/2027/2028) blend both pick markets on their tier rows; the HORIZON year (2029) blended `idpTradeCalc` **alone** on all twelve tier cells — a single-vendor dependency on exactly the rows with the least direct evidence. Cause: `_inject_far_future_pick_sources` runs against the RAW payload, and `ktcSfTep`'s pick values arrive through the LATER CSV enrichment, which the injection structurally cannot see.

## The fix

Moving the injection after enrichment is structurally impossible (it must mutate `players_by_name` before `players_array` exists), so the converse ordering: `_complete_synthetic_pick_sources_from_enrichment` runs immediately after `_enrich_from_source_csvs` and extends the SAME derivation to the enriched evidence — per synthetic row, each source positive on the template row but absent on the synthetic row is filled with `template × step**gap` through the one shared `_year_step_for` (same `derivedYearModel` cell, same compounding). Values the injection already stepped are never re-stepped; a source the template doesn't carry stays MISSING (C1-U6-D1); provenance stays `derived_year_step`; chained templates process in ascending year order. Two stale comments corrected honestly.

## Measured board effect (golden_board → board_diff, pinned inputs)

- **The repair:** all 12 horizon tier cells gain exactly `ktcSfTep` (e.g. `2029 Early 1st: {idpTradeCalc: 3952} → {idpTradeCalc: 3952, ktcSfTep: 4117.4}` = KTC's 2028 value 5244 × 0.7852 cell step). 24 `pick:2029` rows move −4.3%..+3.5% (rounds 5-6/generic follow their bases); confidence low→high where two families now agree.
- **Zero:** 2027/2028 vendor values, IDP players, newly priced/unpriced; ranked 740→740.
- **The coupling, named not hidden:** 17 offense rookies move (p50 ≈ −0.15%, max −0.78%, values 1050–1900) plus 3 tethered 2026 slot picks (−0.11%) — via the rookie ladder, whose ordinal pool is `ktcSfTep`'s Phase-1 effective ranks and by design now contains the synthetic rows. This is the **KTC-side mirror of the coupling C1-U6 §8 already measured and accepted on the IDPTC side at larger magnitude** (max −1.3%). Verified per-row: the movers' only changed votes are ladder-translated rank sources.

## Adjudication (Integration)

The implementing pass STOPPED on this diff per its instructions ("offense rows move zero"), correctly. Adjudicated ACCEPT on the records: the coupling class was accepted into production when C1-U6 shipped (same mechanism, same designed shared structure, larger magnitude on the IDPTC side); zero offense movement is unachievable by any correct two-market horizon blend without first deciding §12's translation-pool exclusion — an explicitly reserved, separately-measured methodology decision that would move MORE values and exceeds this row's authorization. Leaving a signal-independence defect live to avoid sub-1% movement on 17 deep-board rookies is the wrong trade. §8 is amended in this PR to record the KTC-side numbers; **§12 stays open**, now with symmetric evidence.

## Verification

- New `tests/api/test_horizon_pick_two_market_injection.py`: 8 passed (both-markets invariant, provenance, no-picks-source contributes nothing, published years verbatim, unit rules). **RED proven**: with the completion pass disabled, 2 fail with `'ktcSfTep' not found … the horizon is a single-vendor dependency (F-34)`. Mutation independently re-executed by the Integration Authority on this head: 2 RED, restored 8 green.
- `tests/api -k "pick"` 183 passed; picks/discount/completeness/F-30 suites 120 passed; **full `tests/api/` 2183 passed, 0 failed**; `validate_api_contract.py --lane structural` ok=True (C1-PICK-01 census green); ruff 0.6.9 clean on touched files.

No Hill/calibration/weights/tolerance change; `derivedYearModel` numbers untouched. No V1 status edit here — the row promotes in the ledger after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_