### PR TITLE
V1-87 / F-24: the ledger rank-change flag joins the operator inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ snapshots). This line said "Private repo" while `SECURITY.md` and
   Sleeper-login allowlist; public routes hit `/api/public/league/*`.
 - **Feature flags** (`src/api/feature_flags.py`): every new
   capability from the 2026-04 upgrade ships flag-gated. Defaults are
-  **per-flag**: 8 of the 18 in `_DEFAULTS` ship enabled (`bdvm_engine`,
+  **per-flag**: 9 of the 19 in `_DEFAULTS` ship enabled (`ledger_rank_change`, `bdvm_engine`,
   `te_basis_conversion`, `monte_carlo_trade`, `idp_scoring_fit`,
   `reception_scoring_fit`, `nfl_data_ingest`, `realized_points_api`,
   `perfect_draft`),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,8 +26,10 @@ Browser ─► Nginx ─► Next.js (port 3000) ─► FastAPI (port 8000) ─�
    `src/api/feature_flags.py`. Env override via `RISKIT_FEATURE_<NAME>=1`
    (or `=0` to disable).
 
-   **Defaults are per-flag.** As of 2026-08-05, 8 of the 18 entries in
-   `_DEFAULTS` ship enabled — `bdvm_engine`, `te_basis_conversion`
+   **Defaults are per-flag.** As of 2026-08-25, 9 of the 19 entries in
+   `_DEFAULTS` ship enabled — `ledger_rank_change` (registered closing
+   F-24: the ledger-derived `rankChange` derivation, previously an
+   invisible direct env read), `bdvm_engine`, `te_basis_conversion`
    (which reprices every tight end on the live board),
    `monte_carlo_trade`, `idp_scoring_fit`, `reception_scoring_fit`,
    `nfl_data_ingest`, `realized_points_api`, `perfect_draft` — several

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -5874,32 +5874,25 @@ def _stamp_rank_changes(
     # it either.  The rollback lever CLAUDE.md documents is real; the
     # inventory that would tell an operator it exists is not.
     #
-    # Registering it in ``_DEFAULTS`` is the obvious repair and was attempted.
-    # It is refused by ``tests/api/test_feature_flags.py``, which requires
-    # every defaulted-ON flag to be classified either ``safe_on`` (additive,
-    # inert, cannot move a number) or ``value_moving_on`` (with a MEASURED
-    # blast radius).  This flag is neither cheaply: it MUTATES THE CONTRACT —
-    # ON stamps ledger-derived ``rankChange``, OFF stamps ``None`` — so the
-    # ``safe_on`` standard ``perfect_draft`` meets ("writes no value, mutates
-    # no contract") does not hold, and ``value_moving_on`` demands a
-    # measurement.
-    #
-    # That measurement needs the temporal ledger and a built board.  With no
-    # ``data/temporal_ledger.sqlite`` present BOTH branches stamp ``None``,
-    # so an on/off diff taken without it reports "0 rows changed" — a vacuous
-    # figure that would read as evidence.  Recording that would be worse than
-    # recording nothing.
-    #
-    # To close F-24: measure ON vs OFF over a real board with the ledger
-    # present (which rows' ``rankChange`` becomes ``None``, and the
-    # distribution of the non-null values), then register the flag carrying
-    # that blast radius.  Until then this direct read stays, documented.
-    import os as _os
+    # F-24 CLOSED 2026-08-25 (V1-87).  The paragraph above records why the
+    # flag could not be registered without a measurement, and the
+    # measurement now exists: Lane 4 on-box run 32843495391 (deployed
+    # ``8537aa4c2``, ledger present, 37 recorded board dates) measured ON
+    # deriving a non-null ``rankChange`` for 743 of 749 ranked rows on the
+    # 2026-08-25 board (comparator 2026-08-24) against a structurally
+    # all-None OFF.  The flag is registered in ``feature_flags._DEFAULTS``
+    # carrying that blast radius, classified ``value_moving_on``, and this
+    # site now reads through the ONE registry owner rather than the
+    # environment directly — so /api/status, ``snapshot()`` and the
+    # reachability test finally see the rollback lever CLAUDE.md documents.
+    # Registry reads are cached per process (same convention as
+    # ``bdvm_engine``); tests that flip the env mid-process call
+    # ``feature_flags.reload()``.
+    from src.api import feature_flags as _feature_flags
 
-    flag = _os.environ.get("RISKIT_FEATURE_LEDGER_RANK_CHANGE", "1").strip().lower()
     previous: dict[str, tuple[str, int]] = {}
     _history_keys = None
-    if flag not in ("0", "false", "off"):
+    if _feature_flags.is_enabled("ledger_rank_change"):
         # Every src.history touch — the keys import included — sits
         # inside one guard: a history failure (or the rollback flag)
         # must not break the contract build, and the degraded stamp is

--- a/src/api/feature_flags.py
+++ b/src/api/feature_flags.py
@@ -87,6 +87,22 @@ _DEFAULTS: Final[dict[str, bool]] = {
     # label, and with the flag off it uses the first usable bridge, which
     # reproduces the incumbent ladder integer for integer.
     "multi_bridge_ladder": False,
+    # C1-U4 — ledger-derived rankChange on the canonical contract.  ON
+    # derives each ranked row's rankChange from the temporal ledger's
+    # previous recorded board; OFF stamps None on every row (deliberately
+    # not the retired self-referential cache).  Registered 2026-08-25,
+    # closing audit F-24 (V1-87): the flag was read directly from the
+    # environment in data_contract and was invisible to this inventory,
+    # snapshot(), /api/status and the reachability test.  Blast radius
+    # MEASURED on the production box (Lane 4 run 32843495391, deployed
+    # 8537aa4c2, ledger present with 37 recorded board dates): ON derives
+    # a non-null rankChange for 743 of 749 ranked rows on the 2026-08-25
+    # board (comparator 2026-08-24, 1342 ranked assets); OFF is
+    # structurally all-None, so the blast radius is exactly those 743
+    # rankChange stamps — no VALUE, rank, or tier moves under either
+    # setting.  Rollback: RISKIT_FEATURE_LEDGER_RANK_CHANGE=0 (and
+    # restart — registry reads are cached per process).
+    "ledger_rank_change": True,
     "unified_id_mapper": False,
     # Phase 2 — nfl_data_py pipeline
     # Activated with the 2026-04-25 deploy that adds nfl_data_py to
@@ -471,6 +487,12 @@ NO_GATE: Final[str] = "NO_GATE"
 _GATE_STATUS: Final[dict[str, str]] = {
     # ── Reachable from server.py; toggling changes a response ──
     "nfl_data_ingest": LIVE,
+    # ledger_rank_change gates the temporal-ledger rankChange derivation in
+    # ``data_contract._stamp_rank_changes``, which reaches a request through
+    # ``/api/data``: on → each ranked row's rankChange derives from the
+    # ledger's previous recorded board (743 of 749 rows non-null on the
+    # measured production board), off → None on every row.
+    "ledger_rank_change": LIVE,
     "realized_points_api": LIVE,
     "monte_carlo_trade": LIVE,
     "te_basis_conversion": LIVE,

--- a/src/api/feature_flags.py
+++ b/src/api/feature_flags.py
@@ -8,21 +8,21 @@ proves itself.
 enabled.**  This docstring, ``README.md`` and ``docs/ARCHITECTURE.md``
 all used to assert a blanket disabled-by-default rule, and
 ARCHITECTURE built a stronger claim on top of it about production
-behaviour being frozen until a flag was flipped.  Both were false: 8 of
-the 16 entries in ``_DEFAULTS`` below are ``True`` — ``bdvm_engine``,
-``te_basis_conversion`` (which reprices every tight end on the live
-board), ``monte_carlo_trade``, ``idp_scoring_fit``,
-``reception_scoring_fit``, ``nfl_data_ingest``, ``realized_points_api``
-and ``perfect_draft`` — several with comments recording that the
-enabled default is deliberate.
+behaviour being frozen until a flag was flipped.  Both were false:
+9 of the 19 entries in ``_DEFAULTS`` below are ``True`` —
+``bdvm_engine``, ``te_basis_conversion`` (which reprices every tight
+end on the live board), ``monte_carlo_trade``, ``idp_scoring_fit``,
+``reception_scoring_fit``, ``nfl_data_ingest``, ``realized_points_api``,
+``perfect_draft`` and ``ledger_rank_change`` — several with comments
+recording that the enabled default is deliberate.
 
-**One live gate is deliberately NOT in this registry**, and it is the
-sharpest illustration of why the paragraph above matters:
-``RISKIT_FEATURE_LEDGER_RANK_CHANGE`` is read directly in
-``data_contract._stamp_rank_changes``, defaults ON, and therefore appears
-in no operator surface at all.  Audit **F-24** proposed registering it;
-that is blocked, not abandoned, and the reason is recorded at the read
-site.
+**No live gate sits outside this registry any more.**  The last one —
+``RISKIT_FEATURE_LEDGER_RANK_CHANGE``, read directly in
+``data_contract._stamp_rank_changes`` and therefore visible in no
+operator surface at all — was registered as ``ledger_rank_change`` on
+2026-08-25, closing audit **F-24** (V1-87).  The read site now routes
+through ``is_enabled``; the measured blast radius that unblocked the
+registration is recorded at its ``_DEFAULTS`` entry.
 
 For a flag that ships enabled, the env var is a ROLLBACK lever, not an
 opt-in.  Read ``_DEFAULTS`` for the flag you care about rather than

--- a/tests/api/test_feature_flags.py
+++ b/tests/api/test_feature_flags.py
@@ -92,6 +92,16 @@ def test_every_flag_defaults_off_except_safe_additive():
         # QB/RB/WR/IDP value changes.  Rank displacement median 7, p90
         # 22.  Rollback: RISKIT_FEATURE_TE_BASIS_CONVERSION=0.
         "te_basis_conversion",
+        # C1-U4 / F-24 (V1-87).  Ledger-derived rankChange on the
+        # canonical contract.  Blast radius MEASURED on the production
+        # box (Lane 4 run 32843495391, deployed 8537aa4c2, temporal
+        # ledger present with 37 recorded board dates): ON derives a
+        # non-null rankChange for 743 of 749 ranked rows on the
+        # 2026-08-25 board (comparator 2026-08-24, 1342 ranked assets);
+        # OFF stamps None on every row structurally.  The moved field is
+        # rankChange ONLY — no value, rank or tier differs between the
+        # settings.  Rollback: RISKIT_FEATURE_LEDGER_RANK_CHANGE=0.
+        "ledger_rank_change",
         # IDP positional scoring fit.  Blast radius RE-measured against
         # the 2026-07-28 live board (1,094 rows) on the complete scoring
         # card:

--- a/tests/history/test_temporal_ledger.py
+++ b/tests/history/test_temporal_ledger.py
@@ -28,6 +28,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from src.api import data_contract
+from src.api import feature_flags as _ff
 from src.history import asof, backfill, keys, migrate, record, store
 
 FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "temporal_live_subset.json"
@@ -575,10 +576,12 @@ class TestRankChangeDeterministic(_LedgerCase):
         fx = _fx()
         _record_fixture_board(self.ledger, "2026-08-15", rows=_prior_rows(fx))
         os.environ["RISKIT_FEATURE_LEDGER_RANK_CHANGE"] = "0"
+        _ff.reload()
         try:
             stamps = self._stamp(_rows(fx), "2026-08-16")
         finally:
             del os.environ["RISKIT_FEATURE_LEDGER_RANK_CHANGE"]
+            _ff.reload()
         self.assertTrue(all(v is None for v in stamps.values()))
 
 
@@ -801,10 +804,12 @@ class TestValuationInertness(unittest.TestCase):
 
         # Build 1 — derivation off.
         os.environ["RISKIT_FEATURE_LEDGER_RANK_CHANGE"] = "0"
+        _ff.reload()
         try:
             baseline = data_contract.build_api_data_contract(json.loads(json.dumps(raw)))
         finally:
             os.environ.pop("RISKIT_FEATURE_LEDGER_RANK_CHANGE", None)
+            _ff.reload()
 
         # Seed a ledger with the SAME board recorded under the prior
         # date, then build again with the derivation on and the default


### PR DESCRIPTION
## The blocked repair, unblocked by the measurement it was waiting for

F-24: `RISKIT_FEATURE_LEDGER_RANK_CHANGE` was read directly from the environment in `data_contract` (default ON) and absent from `feature_flags._DEFAULTS` — invisible to `snapshot()`, `effective_flags()`, `/api/status`, and the reachability test. A live gate on the canonical board's `rankChange` derivation whose documented rollback lever no operator surface could see.

Registration was correctly refused until measured: the `value_moving_on` gate demands a blast radius, and a no-ledger ON/OFF diff is vacuously "0 rows changed" (both branches stamp None). The `data_contract` comment recorded the exact closure recipe — *"measure ON vs OFF over a real board with the ledger present, then register the flag carrying that blast radius."*

**The measurement now exists** — Lane 4 on-box run 32843495391 (deployed `8537aa4c2`, temporal ledger present with 37 recorded board dates): ON derives a non-null `rankChange` for **743 of 749** ranked rows on the 2026-08-25 board (comparator 2026-08-24, 1,342 ranked assets); OFF is structurally all-None. The moved field is `rankChange` only — no value, rank, or tier differs between settings.

## Changes

- `feature_flags._DEFAULTS` gains `ledger_rank_change: True` carrying the measured blast radius; `_GATE_STATUS` classifies it `LIVE` (gates `_stamp_rank_changes`, reachable through `/api/data`).
- `data_contract`'s read goes through the ONE registry owner (`is_enabled("ledger_rank_change")`); the env override `RISKIT_FEATURE_LEDGER_RANK_CHANGE` keeps working identically via the registry's `_env_read`. Registry reads are cached per process (same convention as `bdvm_engine`); the F-24 comment block records closure.
- `tests/api/test_feature_flags.py::value_moving_on` gains the entry with the measurement.
- The two mid-process env-flip sites in `tests/history/test_temporal_ledger.py` call `feature_flags.reload()` — the registry's own mechanism.

## Validation

54 flag tests + 38 temporal-ledger tests passed (the reachability suite's per-flag import-graph checks now cover this flag); coercion gate clean; ruff 0.6.9 check + format clean on the four touched files. No default changed, no gate weakened — the flag was ON before and is ON now; only its visibility and ownership moved.

No V1 status edit here — V1-87 promotes in the ledger after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_