### PR TITLE
fix: blend-hull check compared differently-quantized integers — repo-wide structural CI red

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -607,7 +607,16 @@ Steps:
     ``blendIntegrityViolation`` and left alone, because coercing an
     impossible number to a plausible one hides a pipeline fault.  No
     asset-class exemption, no confidence dependency, no tunable band —
-    ``_BLEND_HULL_EPSILON`` (1e-9) is float slack, not policy.
+    ``_BLEND_HULL_EPSILON`` (1e-9) is float slack, and
+    ``_BLEND_HULL_QUANTIZATION_BELOW`` / ``…_ABOVE`` (1.5 / 0.5, added
+    2026-08-25) are the exact worst-case skew of comparing a truncated
+    ``int(norm_val)`` against ``int(round())`` contribution stamps —
+    both numerical precision, not policy.  Without the latter the check
+    manufactured a violation whenever the two pick markets nearly agreed
+    at a rounding boundary (measured: "2027 Mid 2nd" 2026-08-25, and the
+    "2027 Late 1st" transient of 2026-08-22/#1063 — the same class,
+    previously closed as an upstream blip because it self-cleared when
+    the next scrape moved a value).
 
     **Not clamping is only half of abstaining.**  The other half is that
     the value stops counting as an ordinary canonical number, and that is

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -1814,7 +1814,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # provider being one we otherwise trust.  UNKNOWN fails closed.
         "game_type": GAME_TYPE_DYNASTY,
         "game_type_evidence": (
-            "Play for Keeps pfk_dynasty_rankings Supabase table — the table name is the " "product"
+            "Play for Keeps pfk_dynasty_rankings Supabase table — the table name is the product"
         ),
         "display_name": "Play for Keeps Dynasty",
         "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
@@ -1849,7 +1849,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # provider being one we otherwise trust.  UNKNOWN fails closed.
         "game_type": GAME_TYPE_DYNASTY,
         "game_type_evidence": (
-            "dynasty-daddy.com/api/v1/player/all/today — Dynasty Daddy is a dynasty-only " "product"
+            "dynasty-daddy.com/api/v1/player/all/today — Dynasty Daddy is a dynasty-only product"
         ),
         "display_name": "Dynasty Daddy Superflex",
         "scope": SOURCE_SCOPE_OVERALL_OFFENSE,
@@ -2172,7 +2172,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # provider being one we otherwise trust.  UNKNOWN fails closed.
         "game_type": GAME_TYPE_DYNASTY,
         "game_type_evidence": (
-            "same draftsharks.com dynasty-rankings page as draftSharks, IDP slice of the " "one DOM"
+            "same draftsharks.com dynasty-rankings page as draftSharks, IDP slice of the one DOM"
         ),
         "correlation_group": "draftSharks",
         "display_name": "Draft Sharks IDP Dynasty",
@@ -5682,6 +5682,32 @@ def _parse_pick_tier(name: str) -> tuple[int, str, int] | None:
 #: W02-F016.
 _BLEND_HULL_EPSILON: float = 1e-9
 
+# The two quantities the hull check compares are INTEGERS quantized from
+# floats by two different rules, and the allowance below is the exact
+# worst-case skew of that quantization — numerical precision, not policy:
+#
+# * ``rankDerivedValue`` is ``int(norm_val)`` — truncation, so the
+#   published integer sits as much as (just under) 1.0 BELOW the float
+#   blend and never above it;
+# * each ``sourceRankMeta[*].valueContribution`` stamp is
+#   ``int(round(value))`` — within 0.5 of its float contribution in
+#   either direction.
+#
+# A float blend sitting exactly on the hull floor can therefore publish
+# up to 1.5 below the stamped minimum (1.0 truncation + 0.5 stamp
+# rounding), and up to 0.5 above the stamped maximum (stamp rounding
+# only — truncation never raises a value). Anything outside THOSE bounds
+# is a genuine impossibility. Measured incident, 2026-08-25 ("2027 Mid
+# 2nd"): votes 3459.692 (ktc 3459 x 9999/9997) and 3460.0 (idpTradeCalc
+# 3460/9999 x 9999), float blend ~3459.85 inside the true hull, published
+# ``int()`` -> 3459, stamps ``int(round())`` -> [3460, 3460] — flagged as
+# "below" a hull the blend never left. The 2026-08-22 "2027 Late 1st"
+# transient (#1063) is the same class: it fires whenever the two pick
+# markets nearly agree at a rounding boundary, and "self-corrects" when
+# the next scrape moves either value a hair.
+_BLEND_HULL_QUANTIZATION_BELOW: float = 1.5
+_BLEND_HULL_QUANTIZATION_ABOVE: float = 0.5
+
 
 def _detect_blend_integrity_violations(
     players_array: list[dict[str, Any]],
@@ -5730,10 +5756,23 @@ def _detect_blend_integrity_violations(
     the nearest boundary would turn pipeline corruption into a clean,
     plausible-looking number. The row is marked instead, so the failure
     stays visible. There is no tolerance dial: the check is exact up to
-    floating-point representation, and ``_BLEND_HULL_EPSILON`` is a
-    numerical-precision allowance, NOT a policy band — measured across
-    5,931 historical rows the violation count is 0 at every tolerance from
-    0% to 10%, so no policy slack is doing any work.
+    the representation of its inputs, and both allowances are
+    numerical-precision, NOT policy bands — measured across 5,931
+    historical rows the violation count is 0 at every tolerance from 0%
+    to 10%, so no policy slack is doing any work.
+
+    "Representation of its inputs" is doing real work in that sentence,
+    and this check got it wrong until 2026-08-25: the two quantities
+    compared here are integers quantized from floats by DIFFERENT rules
+    (``rankDerivedValue`` truncates; the ``valueContribution`` stamps
+    round), so a float blend genuinely inside its hull can publish up to
+    1.5 below the stamped minimum and 0.5 above the stamped maximum.
+    ``_BLEND_HULL_EPSILON`` alone manufactured a "violation" out of that
+    skew whenever the stamped hull was under a unit wide — see the
+    derivation and the measured 2027 Mid 2nd incident at
+    ``_BLEND_HULL_QUANTIZATION_BELOW``. The additive allowance covers
+    exactly the quantization worst case and nothing else: a fault that
+    moves a value by even two units past the hull still fires.
 
     Rows resting on fewer than two contributions are skipped: a hull needs
     two points, and "missing" is not "violating".
@@ -5771,7 +5810,9 @@ def _detect_blend_integrity_violations(
             continue
 
         lo, hi = min(contributions.values()), max(contributions.values())
-        if lo * (1.0 - _BLEND_HULL_EPSILON) <= value <= hi * (1.0 + _BLEND_HULL_EPSILON):
+        lo_bound = lo * (1.0 - _BLEND_HULL_EPSILON) - _BLEND_HULL_QUANTIZATION_BELOW
+        hi_bound = hi * (1.0 + _BLEND_HULL_EPSILON) + _BLEND_HULL_QUANTIZATION_ABOVE
+        if lo_bound <= value <= hi_bound:
             continue
 
         stamp = {
@@ -6821,8 +6862,7 @@ def _validate_source_game_types_invariant(
         )
     if unknown_value:
         problems.append(
-            f"declare a game_type outside GAME_TYPES: {unknown_value}. "
-            f"Valid: {sorted(GAME_TYPES)}"
+            f"declare a game_type outside GAME_TYPES: {unknown_value}. Valid: {sorted(GAME_TYPES)}"
         )
     if not_dynasty:
         problems.append(

--- a/tests/api/test_blend_integrity.py
+++ b/tests/api/test_blend_integrity.py
@@ -198,6 +198,64 @@ class TestTheInvariantDetectsImpossibility(unittest.TestCase):
             self.assertIsNone(row.get("blendIntegrityViolation"), f"boundary {v} flagged")
 
 
+class TestQuantizationSkewIsNotViolation(unittest.TestCase):
+    """The 2026-08-25 "2027 Mid 2nd" false positive, pinned.
+
+    The two quantities the detector compares are integers quantized from
+    floats by DIFFERENT rules: ``rankDerivedValue`` is ``int(norm_val)``
+    (truncation — up to 1.0 below the float blend), while each
+    ``valueContribution`` stamp is ``int(round(value))`` (within 0.5
+    either way). A blend genuinely inside its float hull can therefore
+    publish up to 1.5 below the stamped minimum and up to 0.5 above the
+    stamped maximum — and when the stamped hull is under a unit wide,
+    the old float-epsilon check manufactured a violation out of pure
+    rounding. Measured live: ktc voted 3459 x 9999/9997 = 3459.692,
+    idpTradeCalc voted 3460.0, the blend was ~3459.85 (inside), the
+    published truncation was 3459, and both stamps rounded to 3460 —
+    flagged "below" a hull the blend never left, quarantining the row
+    and turning the structural CI lane red on every open PR. The
+    2026-08-22 "2027 Late 1st" transient (#1063) was the same class.
+    """
+
+    def _detect(self, value, contributions):
+        row = {
+            "displayName": "X",
+            "canonicalConsensusRank": 134,
+            "rankDerivedValue": value,
+            "sourceRankMeta": {k: {"valueContribution": v} for k, v in contributions.items()},
+        }
+        dc._detect_blend_integrity_violations([row], {})
+        return row
+
+    def test_the_live_incident_shape_is_not_flagged(self):
+        """Truncated value one below a degenerate rounded hull."""
+        row = self._detect(3459, {"ktcSfTep": 3460, "idpTradeCalc": 3460})
+        self.assertIsNone(row.get("blendIntegrityViolation"))
+
+    def test_truncation_skew_below_a_narrow_hull_is_not_flagged(self):
+        """Same skew on a hull one unit wide."""
+        row = self._detect(3459, {"a": 3460, "b": 3461})
+        self.assertIsNone(row.get("blendIntegrityViolation"))
+
+    def test_below_beyond_the_quantization_bound_still_fires(self):
+        """Two whole units below the stamped floor cannot be rounding."""
+        row = self._detect(3458, {"a": 3460, "b": 3460})
+        self.assertEqual(row["blendIntegrityViolation"]["direction"], "below")
+
+    def test_above_beyond_the_quantization_bound_still_fires(self):
+        """Truncation never raises: one unit above the stamped ceiling
+        is already impossible, and must still be detected."""
+        row = self._detect(3461, {"a": 3460, "b": 3460})
+        self.assertEqual(row["blendIntegrityViolation"]["direction"], "above")
+
+    def test_the_allowance_is_quantization_scale_not_a_band(self):
+        """Both allowances must stay below 2 units on a 1-9999 scale —
+        wide enough for integer quantization, structurally too narrow to
+        act as the corridor's policy band."""
+        self.assertLessEqual(dc._BLEND_HULL_QUANTIZATION_BELOW, 1.5)
+        self.assertLessEqual(dc._BLEND_HULL_QUANTIZATION_ABOVE, 0.5)
+
+
 class TestMissingEvidenceStaysExplicit(unittest.TestCase):
     """ "Missing" is not "violating" — a hull needs two points."""
 


### PR DESCRIPTION
## What broke

Every open PR's Validate run went red at the blocking "API data contract check (structural lane)" step at ~17:00 UTC today:

```
blend_integrity_violation:1 row(s) hold a value outside the range of their own source contributions (2027 Mid 2nd)
```

Reproduced on clean `main` (`aa8896fc7`) — the condition lives in the tracked payload, not any PR's diff. #1077, #1120 and #1121 all failed on exactly this step with all 10,261 unit tests green.

## Root cause — a false positive in the detector, not a pipeline fault

`_detect_blend_integrity_violations` compares two integers quantized from floats by **different rules**, with only a 1e-9 float epsilon:

- `rankDerivedValue` is `int(norm_val)` — **truncation** (`data_contract.py:10074`), up to 1.0 below the float blend;
- each `sourceRankMeta[*].valueContribution` stamp is `int(round(value))` — within 0.5 either way.

A blend genuinely inside its float hull can therefore publish up to **1.5 below the stamped minimum** and **0.5 above the stamped maximum**. When the stamped hull is under a unit wide, the check manufactures a violation out of pure rounding.

Measured on the live row: ktc voted `3459 × 9999/9997 = 3459.692`, idpTradeCalc voted `3460.0`; the blend (~3459.85) sits inside the true hull; the published truncation is `3459`; both stamps round to `3460` — flagged "below" a hull the blend never left. The row was quarantined (Consensus Edge WITHHELD, BDVM skip) on a correct value.

The 2026-08-22 "2027 Late 1st" transient (#1063) is the same class — it was closed as an upstream blip because it self-cleared when the next scrape moved a value by a hair. This class fires whenever the two pick markets nearly agree at a rounding boundary.

## The fix

Additive allowance `_BLEND_HULL_QUANTIZATION_BELOW = 1.5` / `_ABOVE = 0.5` — the exact worst-case skew of the two quantizers, derived in the code comment. Numerical precision, not a policy band: a fault two units past the hull still fires, no value is moved, the abstain/quarantine machinery is untouched.

- `tests/api/test_blend_integrity.py` — new `TestQuantizationSkewIsNotViolation`: the live incident shape must not flag; two units below / one unit above must still flag; allowances pinned at quantization scale (≤1.5 / ≤0.5).
- `CLAUDE.md` detector section updated — its "no tunable band, epsilon is float slack" sentence would otherwise have gone stale.

## Verification

- `tests/api/` full non-livedata sweep: **2254 passed**, 0 failed
- `scripts/validate_api_contract.py --lane structural` on the tracked payload: `ok=True errors=0` (was `ok=False errors=1`)
- `check_planning_integrity` / `check_decision_coercions`: clean
- `ruff format` / `ruff check`: clean

No source-weight, Hill/calibration, clamp, or validator-lane changes. No value moves on any row; the only behavioral change is that the false detection (and the quarantine it caused) stops.

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_