### PR TITLE
V1-104: human review control for sharp identities

### DIFF
--- a/src/sharp/curated_service.py
+++ b/src/sharp/curated_service.py
@@ -31,8 +31,12 @@ def _int_param(value: Any, default: int, *, minimum: int = 0, maximum: int = 100
         return default
 
 
-def _require_admin(request: Request) -> JSONResponse | None:
-    """Return an error response when the caller is not an allowlisted admin.
+def _admin_session(request: Request) -> JSONResponse | dict[str, Any]:
+    """Resolve the caller's admin session, or an error response.
+
+    Returns the SESSION DICT on success so callers can attribute the action
+    to the authenticated admin (the audit trail's "who" must come from the
+    session, never from a caller-supplied body field).
 
     Resolved through the running server module rather than imported, because
     ``server.py`` imports THIS module -- a module-level import back into it
@@ -45,8 +49,17 @@ def _require_admin(request: Request) -> JSONResponse | None:
         require_admin = getattr(module, "_require_admin_session", None)
         if require_admin is not None:
             result = require_admin(request)
-            return result if isinstance(result, JSONResponse) else None
+            if isinstance(result, JSONResponse):
+                return result
+            return result if isinstance(result, dict) else {}
     return _error(503, "admin_gate_unavailable", "Admin authorization is unavailable.")
+
+
+def _require_admin(request: Request) -> JSONResponse | None:
+    """Gate-only view of :func:`_admin_session` for routes that need no
+    attribution. Same fail-closed contract."""
+    result = _admin_session(request)
+    return result if isinstance(result, JSONResponse) else None
 
 
 def _error(status: int, code: str, message: str) -> JSONResponse:
@@ -126,9 +139,14 @@ def _register_http_routes() -> None:
         # model -- it is what turns a curated person into a Super Sharp whose
         # trades vote. The private-API gate only proves *a* logged-in user, so
         # this needs the allowlist on top.
-        guard = _require_admin(request)
-        if guard is not None:
-            return guard
+        session = _admin_session(request)
+        if isinstance(session, JSONResponse):
+            return session
+        # The audit trail's "who" is the authenticated admin, taken from the
+        # session. A body-supplied ``reviewer`` is a caller claim and is
+        # deliberately ignored -- before 2026-08-25 it defaulted to the
+        # constant "admin", so every recorded decision had the same author.
+        reviewer = str(session.get("username") or "").strip() or "admin"
         try:
             body = await request.json()
         except Exception:  # noqa: BLE001
@@ -138,7 +156,7 @@ def _register_http_routes() -> None:
                 curated.review_candidate,
                 candidate_id,
                 str((body or {}).get("decision") or ""),
-                reviewer=str((body or {}).get("reviewer") or "admin"),
+                reviewer=reviewer,
                 reason=str((body or {}).get("reason") or "") or None,
             )
         except KeyError:

--- a/tests/sharp/test_identity_review_admin_control.py
+++ b/tests/sharp/test_identity_review_admin_control.py
@@ -1,0 +1,259 @@
+"""V1-104 — the human-review control over sharp identity mappings.
+
+Inventory 6.9's V1-required scope (narrow: sharp identities only): a human
+admin must be able to review/approve/reject identity candidates, the decision
+must actually move the canonical cohort owner, and every decision must leave
+an audit trail naming WHO decided and WHEN.
+
+What this file pins beyond ``test_curated_wiring.py`` (which tests the gate
+helper in isolation) and ``test_curated_model.py`` (which tests the model):
+
+* the REAL route enforces the gate — deleting the guard from
+  ``decide_candidate`` or ``refresh_curated`` turns these RED, because the
+  spies prove a refused request never reaches the decision or the refresh;
+* the audit trail's "who" is the AUTHENTICATED session identity, never a
+  body-supplied claim — before 2026-08-25 the route read ``reviewer`` from
+  the request body with a constant ``"admin"`` default, and the admin UI
+  never sends one, so every real decision was recorded under the same name;
+* an approval changes what the canonical cohort selection
+  (``curated_cohort_members`` — the function ``src/sharp/cohort.py``
+  consumes) returns, and a rejection never does;
+* both decisions land in ``sharp_review_decisions`` with reviewer, reason
+  and a real ``decided_ms``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+import server
+from src.sharp import curated, curated_service
+
+SNAPSHOT = Path(__file__).parents[2] / "config" / "sharp" / "curated_universe.json"
+
+
+def _snapshot():
+    return json.loads(SNAPSHOT.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(autouse=True)
+def _stub_allowlist(monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "PRIVATE_APP_ALLOWED_USERNAMES",
+        frozenset({"jasonleetucker"}),
+    )
+    yield
+
+
+def _authed_admin(monkeypatch):
+    monkeypatch.setattr(server, "_is_authenticated", lambda r: True)
+    monkeypatch.setattr(
+        server,
+        "_get_auth_session",
+        lambda r: {"username": "jasonleetucker"},
+    )
+
+
+def _authed_guest(monkeypatch):
+    """A session that exists but is NOT allowlisted — the guest-pass shape."""
+    monkeypatch.setattr(server, "_is_authenticated", lambda r: True)
+    monkeypatch.setattr(
+        server,
+        "_get_auth_session",
+        lambda r: {"username": "guest", "auth_method": "guest_pass"},
+    )
+
+
+# ── the route gate, exercised through the real app ─────────────────
+
+
+def test_review_decision_no_session_is_401():
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post("/api/sharp/review/some-candidate", json={"decision": "approve"})
+    assert res.status_code == 401
+    assert res.json().get("error") == "auth_required"
+
+
+def test_review_decision_guest_session_is_403_and_never_decides(monkeypatch):
+    calls: list[tuple] = []
+
+    def spy(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {"candidateId": "x", "decision": "approve", "status": "verified"}
+
+    monkeypatch.setattr(curated_service.curated, "review_candidate", spy)
+    _authed_guest(monkeypatch)
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post("/api/sharp/review/some-candidate", json={"decision": "approve"})
+    assert res.status_code == 403, res.text
+    assert res.json().get("error") == "admin_required"
+    assert calls == [], "a 403'd request must never record a review decision"
+
+
+def test_curated_refresh_guest_session_is_403_and_never_refreshes(monkeypatch):
+    calls: list[dict] = []
+
+    def spy(**kwargs):
+        calls.append(kwargs)
+        return {}
+
+    monkeypatch.setattr(curated_service, "_refresh_pipeline", spy)
+    _authed_guest(monkeypatch)
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post("/api/sharp/curated/refresh", json={})
+    assert res.status_code == 403, res.text
+    assert res.json().get("error") == "admin_required"
+    assert calls == [], "a 403'd request must never spend the refresh budget"
+
+
+def test_admin_decision_is_attributed_to_the_session_not_the_body(monkeypatch):
+    """The audit "who" comes from the authenticated session.
+
+    The body carries a spoofed ``reviewer`` claim; the recorded reviewer must
+    be the allowlisted session's username. Pre-fix this recorded the body
+    claim (or the constant "admin" — the admin UI sends no reviewer at all).
+    """
+    captured: list[dict] = []
+
+    def spy(candidate_id, decision, *, reviewer="admin", reason=None, **kwargs):
+        captured.append(
+            {
+                "candidateId": candidate_id,
+                "decision": decision,
+                "reviewer": reviewer,
+                "reason": reason,
+            }
+        )
+        return {"candidateId": candidate_id, "decision": decision, "status": "rejected_match"}
+
+    monkeypatch.setattr(curated_service.curated, "review_candidate", spy)
+    _authed_admin(monkeypatch)
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post(
+            "/api/sharp/review/some-candidate",
+            json={"decision": "reject", "reviewer": "somebody_else", "reason": "not them"},
+        )
+    assert res.status_code == 200, res.text
+    assert len(captured) == 1
+    assert captured[0]["reviewer"] == "jasonleetucker"
+    assert captured[0]["reviewer"] != "somebody_else"
+    assert captured[0]["reason"] == "not them"
+
+
+# ── the decision moves the canonical cohort owner ──────────────────
+
+
+def _prepare_candidate(ledger, *, user_id="900001"):
+    """Import the workbook and walk one Sleeper candidate to a stable
+    platform id (the precondition for approval), without deciding it."""
+    curated.import_snapshot(_snapshot(), ledger_path=ledger)
+    conn = curated.ensure_schema(ledger)
+    try:
+        row = conn.execute(
+            """
+            SELECT candidate_id, person_id, candidate_username
+              FROM sharp_identity_candidates
+             WHERE platform='sleeper'
+             ORDER BY confidence DESC, candidate_id
+             LIMIT 1
+            """
+        ).fetchone()
+        candidate_id = str(row["candidate_id"])
+        person_id = str(row["person_id"])
+        username = str(row["candidate_username"])
+    finally:
+        conn.close()
+    curated.inspect_sleeper_candidates(
+        ledger_path=ledger,
+        fetch_json=lambda _url: (200, {"user_id": user_id, "username": username}),
+        request_sleep=0,
+        budget=1,
+    )
+    return {"candidate_id": candidate_id, "person_id": person_id, "user_id": user_id}
+
+
+def _decision_rows(ledger, candidate_id):
+    conn = curated.ensure_schema(ledger)
+    try:
+        return [
+            dict(row)
+            for row in conn.execute(
+                """
+                SELECT decision, reviewer, reason, decided_ms
+                  FROM sharp_review_decisions
+                 WHERE candidate_id=?
+                 ORDER BY decided_ms
+                """,
+                (candidate_id,),
+            ).fetchall()
+        ]
+    finally:
+        conn.close()
+
+
+def test_approval_promotes_the_identity_into_the_curated_cohort(tmp_path):
+    ledger = tmp_path / "intel.sqlite"
+    prepared = _prepare_candidate(ledger)
+
+    # Before any human decision the behavioral cohort is empty — candidate
+    # existence, API existence and name resemblance verify nothing.
+    assert curated.curated_cohort_members(mode="curated_industry", ledger_path=ledger) == []
+
+    curated.review_candidate(
+        prepared["candidate_id"],
+        "approve",
+        reviewer="jasonleetucker",
+        reason="ownership corroborated",
+        ledger_path=ledger,
+    )
+
+    members = curated.curated_cohort_members(mode="curated_industry", ledger_path=ledger)
+    keys = {member.manager_key: member for member in members}
+    assert f"sleeper:{prepared['user_id']}" in keys
+    assert keys[f"sleeper:{prepared['user_id']}"].person_id == prepared["person_id"]
+
+    # ...and the decision is in the audit trail with who + when.
+    rows = _decision_rows(ledger, prepared["candidate_id"])
+    assert [row["decision"] for row in rows] == ["approve"]
+    assert rows[0]["reviewer"] == "jasonleetucker"
+    assert rows[0]["reason"] == "ownership corroborated"
+    assert int(rows[0]["decided_ms"]) > 0
+
+
+def test_rejection_is_audited_and_never_creates_a_cohort_member(tmp_path):
+    ledger = tmp_path / "intel.sqlite"
+    prepared = _prepare_candidate(ledger)
+
+    curated.review_candidate(
+        prepared["candidate_id"],
+        "reject",
+        reviewer="jasonleetucker",
+        reason="handle collision",
+        ledger_path=ledger,
+    )
+
+    assert curated.curated_cohort_members(mode="curated_industry", ledger_path=ledger) == []
+    conn = curated.ensure_schema(ledger)
+    try:
+        status = conn.execute(
+            "SELECT verification_status FROM sharp_identity_candidates WHERE candidate_id=?",
+            (prepared["candidate_id"],),
+        ).fetchone()["verification_status"]
+        verified_accounts = conn.execute(
+            "SELECT COUNT(*) FROM sharp_platform_accounts WHERE platform='sleeper' AND verification_status='verified'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert status == "rejected_match"
+    assert verified_accounts == 0
+
+    rows = _decision_rows(ledger, prepared["candidate_id"])
+    assert [row["decision"] for row in rows] == ["reject"]
+    assert rows[0]["reviewer"] == "jasonleetucker"
+    assert rows[0]["reason"] == "handle collision"
+    assert int(rows[0]["decided_ms"]) > 0


### PR DESCRIPTION
## Scope

`docs/VERSION_1_COMPLETION_CONTRACT.md` §3.8 row **V1-104** (inventory 6.9, "Human review / admin controls"), at its stated V1 boundary: **narrow today — sharp identities only**. No general admin system is built; the control feeds the existing owners (`src/sharp/curated.py::review_candidate`, `sharp_review_decisions`, `curated_cohort_members`) and adds no second store or second cohort rule.

## Defect

The review layer (`/api/sharp/review*`, `src/sharp/curated_service.py`) existed but was not L1-verifiable, and one part of it was genuinely wrong:

- **The audit trail's "who" was a caller claim.** `decide_candidate` read `reviewer` from the request body with a constant `"admin"` default. The admin UI (`frontend/app/admin/sharp-identities/page.jsx`) sends only `{decision, reason}`, so **every real decision was recorded as `"admin"`** — the who/when audit requirement's "who" was a constant, and a caller could stamp any name it liked.
- **The route gate had no bypass-proof test.** `tests/sharp/test_curated_wiring.py` pins the `_require_admin` helper in isolation; deleting the guard lines from `decide_candidate` or `refresh_curated` left every existing test green.

## Repair

- `curated_service._admin_session(request)` resolves the caller's admin session (same fail-closed resolution through the running server module; `_require_admin` becomes a thin gate-only wrapper over it, so the existing wiring tests and their contract are unchanged).
- `decide_candidate` attributes the decision to the **authenticated session's username**; the body's `reviewer` field is deliberately ignored. Frontend needs no change.

## Mutation-proofing (`tests/sharp/test_identity_review_admin_control.py`, 6 tests)

Through the **real** `server.app`, in the `test_operator_admin_gate.py` pattern:

| test | mutation it turns RED on |
|---|---|
| guest session → 403, `review_candidate` spy never called | guard removed from `decide_candidate` — **verified RED** |
| guest session → 403, `_refresh_pipeline` spy never called | guard removed from `refresh_curated` — **verified RED** |
| no session → 401 | private-API middleware bypass |
| admin decision recorded under session identity, body claim `somebody_else` ignored | pre-fix head — **verified RED at exact head before the fix** |
| approval promotes the identity into `curated_cohort_members` (the selection `cohort.py` consumes), with the audit row (`approve`, reviewer, reason, `decided_ms > 0`) | approval no longer feeding the cohort owner, or the audit write dropped |
| rejection audited, flips to `rejected_match`, mints **no** verified account and **no** cohort member | rejection silently verifying |

## Validation

- `tests/sharp/` + `tests/api/test_operator_admin_gate.py` + `tests/api/test_admin_endpoints.py`: **336 passed**
- `ruff format` / `ruff check` clean on both touched files
- `scripts/check_planning_integrity.py` clean; `scripts/check_decision_coercions.py` clean (no new coercions)
- No planning documents edited (`VERSION_1_COMPLETION_CONTRACT.md` / `WORK_CLAIMS.md` untouched — status promotion is Integration's call)

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_