### PR TITLE
V1-25: league-config consistency — W18-F005/F011 residual drift closed

### DIFF
--- a/src/trade/suggestions.py
+++ b/src/trade/suggestions.py
@@ -349,6 +349,14 @@ class RosterAnalysis:
     #: Whether a constraint set was consulted at all.  "Nothing is protected"
     #: and "nobody asked" are different claims and this keeps them apart.
     constraints_applied: bool = False
+    #: The starter-demand model this analysis was computed with (W30-F006 /
+    #: V1-25).  ``analyze_roster`` stores the LEAGUE'S resolved needs here so
+    #: every downstream consumer — the four generators, ``rank_score``, the
+    #: balancer-candidate picker — reads the same lineup the rooms were split
+    #: with.  ``DEFAULT_STARTER_NEEDS`` (dynasty_main's demand) is the
+    #: FALLBACK default only: reading the module constant directly inside a
+    #: generator is the hardcode that told the 1-TE league to keep its TE2.
+    starter_needs: dict[str, int] = field(default_factory=lambda: dict(DEFAULT_STARTER_NEEDS))
 
     def __post_init__(self) -> None:
         """An analysis built without constraints has consulted none.
@@ -877,6 +885,7 @@ def analyze_roster(
         sendable_keys=sendable_keys,
         constrained_out=tuple(blocked),
         constraints_applied=True,
+        starter_needs=dict(needs),
     )
 
 
@@ -1000,7 +1009,7 @@ def rank_score(
         for p in s.receive:
             if p.position in roster.need_positions:
                 starter_ct = roster.starter_counts.get(p.position, 0)
-                needed = DEFAULT_STARTER_NEEDS.get(p.position, 1)
+                needed = roster.starter_needs.get(p.position, 1)
                 if starter_ct == 0:
                     need_sev = max(need_sev, 2.0)
                 elif starter_ct < needed:
@@ -1039,7 +1048,7 @@ def rank_score_breakdown(
         for p in s.receive:
             if p.position in roster.need_positions:
                 starter_ct = roster.starter_counts.get(p.position, 0)
-                needed = DEFAULT_STARTER_NEEDS.get(p.position, 1)
+                needed = roster.starter_needs.get(p.position, 1)
                 if starter_ct == 0:
                     need_sev = max(need_sev, 2.0)
                 elif starter_ct < needed:
@@ -1146,7 +1155,7 @@ def _generate_sell_high(
         players = roster.by_position.get(pos, [])
         if len(players) < 2:
             continue
-        need = DEFAULT_STARTER_NEEDS.get(pos, 1)
+        need = roster.starter_needs.get(pos, 1)
         # Depth is measured on the FULL room (a protected player is still
         # depth); the candidates we may offer come from the sendable view.
         sell_candidates = [
@@ -1226,7 +1235,7 @@ def _generate_buy_low(
         for target in targets[:5]:
             for surplus_pos in roster.surplus_positions:
                 depth = roster.by_position.get(surplus_pos, [])
-                need = DEFAULT_STARTER_NEEDS.get(surplus_pos, 1)
+                need = roster.starter_needs.get(surplus_pos, 1)
                 tradeable = [
                     p
                     for p in depth[need:]
@@ -1282,7 +1291,7 @@ def _generate_consolidation(
     tradeable: list[PlayerAsset] = []
     for pos in roster.surplus_positions:
         players = roster.by_position.get(pos, [])
-        need = DEFAULT_STARTER_NEEDS.get(pos, 1)
+        need = roster.starter_needs.get(pos, 1)
         for p in players[need:]:
             if p.display_value >= MIN_RELEVANT_VALUE and roster.can_send(p):
                 tradeable.append(p)
@@ -1375,16 +1384,15 @@ def _generate_positional_upgrades(
 ) -> list[TradeSuggestion]:
     suggestions: list[TradeSuggestion] = []
 
-    for pos in DEFAULT_STARTER_NEEDS:
+    for pos in roster.starter_needs:
         players = roster.by_position.get(pos, [])
         if len(players) < 2:
             continue
-        need = DEFAULT_STARTER_NEEDS.get(pos, 1)
+        need = roster.starter_needs.get(pos, 1)
         if need < 1:
             continue
 
         starters = players[:need]
-        # pos is always an offense position in DEFAULT_STARTER_NEEDS; using
         depth = [
             p
             for p in players[need:]
@@ -1428,7 +1436,7 @@ def _generate_positional_upgrades(
                 surplus_tol = int(FAIRNESS_TOLERANCE * UPGRADE_SWEETENER_SURPLUS_MULTIPLIER)
                 for sp in roster.surplus_positions:
                     sp_depth = roster.by_position.get(sp, [])
-                    sp_need = DEFAULT_STARTER_NEEDS.get(sp, 1)
+                    sp_need = roster.starter_needs.get(sp, 1)
                     for p in sp_depth[sp_need:]:
                         sp_ev = p.display_value
                         if sp_ev >= MIN_RELEVANT_VALUE and abs(sp_ev - gap_needed) < surplus_tol:
@@ -1582,9 +1590,9 @@ def _roster_balancer_candidates(
     candidates: list[PlayerAsset] = []
 
     # Prefer surplus-position depth, then any non-starter depth
-    for pos in list(roster.surplus_positions) + list(DEFAULT_STARTER_NEEDS.keys()):
+    for pos in list(roster.surplus_positions) + list(roster.starter_needs.keys()):
         players = roster.by_position.get(pos, [])
-        need = DEFAULT_STARTER_NEEDS.get(pos, 1)
+        need = roster.starter_needs.get(pos, 1)
         for p in players[need:]:
             # The equalizer is spec §2.3's "trade equalizers / counteroffer
             # suggestions" bullet: it puts a FURTHER outgoing asset into the
@@ -1955,7 +1963,7 @@ def generate_suggestions_from_pool(
             # reads as "no trades exist" rather than "you protect these".
             "constraintsBlockedOutgoing": len(roster.constrained_out),
             "constraintsBlockedReasons": sorted({r for _a, r in roster.constrained_out}),
-            "starterNeeds": starter_needs or DEFAULT_STARTER_NEEDS,
+            "starterNeeds": roster.starter_needs,
             "opponentRostersProvided": len(league_rosters) if league_rosters else 0,
             "opponentRostersAnalyzed": len(opponent_analyses),
         },

--- a/tests/trade/test_starter_needs_league_scoped.py
+++ b/tests/trade/test_starter_needs_league_scoped.py
@@ -1,0 +1,200 @@
+"""V1-25 — league-config consistency: the suggestion engine's starter
+demand follows the LEAGUE, never the ``dynasty_main`` constant.
+
+Residual drift behind W18-F005/W18-F011 (finding W30-F006): the entry
+point threaded ``starter_needs_for_league`` into ``analyze_roster`` and
+nothing else.  Every generator, both rank scorers and the
+balancer-candidate picker read ``DEFAULT_STARTER_NEEDS`` — dynasty_main's
+lineup — unconditionally, so in the 1-TE league the engine flagged a TE
+surplus and then never offered the TE2 it had just called surplus
+(``players[2:]`` with the other league's ``need = 2``).
+
+The repair stores the resolved demand on ``RosterAnalysis.starter_needs``
+and every consumer reads it from there.  These tests go RED if any of the
+historical hardcodes is reintroduced:
+
+* behavioral — a 1-TE-demand league's sell-high offers the TE2;
+  ``rank_score`` grades need severity against the league's own demand;
+* structural — ``DEFAULT_STARTER_NEEDS`` is private to the declared
+  fallback sites (the W30-F006 required repair, stated as an AST guard
+  in the same style as ``test_finder_va_is_not_bypassable``).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from src.trade.suggestions import (
+    DEFAULT_STARTER_NEEDS,
+    PlayerAsset,
+    RosterAnalysis,
+    TradeSuggestion,
+    _generate_sell_high,
+    _identity_key,
+    _roster_balancer_candidates,
+    analyze_roster,
+    generate_suggestions_from_pool,
+    rank_score_breakdown,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+SUGGESTIONS_PATH = REPO / "src" / "trade" / "suggestions.py"
+
+#: dynasty_new's derived demand (host truth, W18-F011: 10-team, 1 TE,
+#: FLEX + WR/RB-only WRRB_FLEX, superflex, no IDP).  Passed explicitly so
+#: these tests stay hermetic — the threading is what is under test, not
+#: the registry read (that is pinned in
+#: tests/league_intel/test_registry_consumers.py).
+ONE_TE_NEEDS = {"QB": 2, "RB": 4, "WR": 3, "TE": 1}
+
+
+def _player(name: str, pos: str, value: int) -> PlayerAsset:
+    return PlayerAsset(
+        name=name,
+        position=pos,
+        display_value=value,
+        calibrated_value=value,
+        source_count=3,
+    )
+
+
+def _one_te_league_pool() -> tuple[list[str], list[PlayerAsset]]:
+    """A roster with a genuine TE surplus under 1-TE demand, plus an
+    unrostered QB target priced inside FAIRNESS_TOLERANCE of the TE2."""
+    rostered = [
+        _player("Te One", "TE", 7000),
+        _player("Te Two", "TE", 6800),
+        _player("Te Three", "TE", 6600),
+        _player("Qb One", "QB", 5000),
+        _player("Rb One", "RB", 4000),
+        _player("Wr One", "WR", 4000),
+    ]
+    pool = rostered + [
+        _player("Qb Target", "QB", 6700),
+        _player("Wr Target", "WR", 6500),
+    ]
+    roster_names = [p.name for p in rostered]
+    return roster_names, pool
+
+
+class TestSellHighFollowsLeagueDemand:
+    def test_te2_is_a_sell_candidate_when_the_league_starts_one_te(self):
+        """The exact W30-F006 numeric proof: under 1-TE demand the sell
+        window is ``players[1:]``, so the TE2 must be offerable.  The
+        retired hardcode sliced ``players[2:]`` (dynasty_main's TE 2) and
+        the TE2 could never be offered in the league that starts one."""
+        roster_names, pool = _one_te_league_pool()
+        roster = analyze_roster(roster_names, pool, ONE_TE_NEEDS)
+        assert "TE" in roster.surplus_positions  # premise, not the claim
+        suggestions = _generate_sell_high(roster, pool, {_identity_key(n) for n in roster_names})
+        given = {p.name for s in suggestions for p in s.give}
+        assert "Te Two" in given, (
+            "TE2 not offered from a surplus room in a 1-TE league — the "
+            "generator is slicing with a demand model that is not this "
+            "league's (W30-F006 reintroduced)"
+        )
+
+    def test_end_to_end_entry_point_threads_the_league_demand(self):
+        roster_names, pool = _one_te_league_pool()
+        out = generate_suggestions_from_pool(
+            roster_names=roster_names,
+            pool=pool,
+            starter_needs=ONE_TE_NEEDS,
+            board_top_n=0,
+        )
+        assert out["metadata"]["starterNeeds"] == ONE_TE_NEEDS
+        given = {p["name"] for s in out["sellHigh"] for p in s["give"]}
+        assert "Te Two" in given
+
+
+class TestRankScoreFollowsLeagueDemand:
+    def test_need_severity_is_graded_on_the_leagues_own_demand(self):
+        """A roster holding its league's ONE required TE starter has no
+        TE need severity.  Grading it against dynasty_main's TE 2 (the
+        retired hardcode) manufactures severity 1.0."""
+        te = _player("Te Incoming", "TE", 6000)
+        suggestion = TradeSuggestion(
+            type="buy_low",
+            give=[_player("Rb Out", "RB", 6000)],
+            receive=[te],
+            give_total=6000,
+            receive_total=6000,
+            gap=0,
+            fairness="even",
+            rationale="",
+            why_this_helps="",
+            confidence="high",
+            strategy="neutral",
+        )
+        roster = RosterAnalysis(
+            roster_size=10,
+            by_position={},
+            surplus_positions=[],
+            need_positions=["TE"],
+            starter_counts={"TE": 1},
+            depth_counts={},
+            starter_needs=dict(ONE_TE_NEEDS),
+        )
+        breakdown = rank_score_breakdown(suggestion, roster)
+        assert breakdown["need_severity"] == 0.0
+
+    def test_default_analysis_still_carries_the_dynasty_main_fallback(self):
+        """No-op guard for the live league: an analysis built without
+        explicit needs must behave exactly as before the threading —
+        ``RosterAnalysis.starter_needs`` IS the constant then."""
+        roster_names, pool = _one_te_league_pool()
+        roster = analyze_roster(roster_names, pool)
+        assert roster.starter_needs == DEFAULT_STARTER_NEEDS
+
+
+class TestBalancerCandidatesFollowLeagueDemand:
+    def test_te2_is_an_offerable_balancer_in_a_one_te_league(self):
+        roster_names, pool = _one_te_league_pool()
+        roster = analyze_roster(roster_names, pool, ONE_TE_NEEDS)
+        candidates = _roster_balancer_candidates(roster, set())
+        names = {c.name for c in candidates}
+        assert "Te Two" in names, (
+            "balancer eligibility protected a 'starter' slot this league "
+            "does not have (W30-F006 reintroduced)"
+        )
+
+
+class TestDefaultNeedsPrivateToFallback:
+    """The W30-F006 required repair, structurally: ``DEFAULT_STARTER_NEEDS``
+    may be read only where the FALLBACK is decided.  Any new read inside a
+    generator, scorer or balancer helper is the historical drift coming
+    back, whatever it is named at that point."""
+
+    ALLOWED_SCOPES = {
+        None,  # module level: the definition itself
+        "starter_needs_for_league",  # registry-empty fallback
+        "analyze_roster",  # caller-passed-nothing fallback
+        "RosterAnalysis",  # dataclass default_factory
+    }
+
+    def test_default_starter_needs_is_read_only_at_fallback_sites(self):
+        tree = ast.parse(SUGGESTIONS_PATH.read_text(encoding="utf-8"))
+
+        offenders: list[str] = []
+
+        def walk(node: ast.AST, scope: str | None) -> None:
+            for child in ast.iter_child_nodes(node):
+                child_scope = scope
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                    child_scope = child.name
+                if (
+                    isinstance(child, ast.Name)
+                    and child.id == "DEFAULT_STARTER_NEEDS"
+                    and scope not in self.ALLOWED_SCOPES
+                ):
+                    offenders.append(f"{scope}:{child.lineno}")
+                walk(child, child_scope)
+
+        walk(tree, None)
+        assert offenders == [], (
+            "DEFAULT_STARTER_NEEDS (dynasty_main's demand model) is read "
+            f"outside its declared fallback sites: {offenders}. Consumers "
+            "must read RosterAnalysis.starter_needs — the league's own "
+            "demand — instead (W30-F006 / V1-25)."
+        )


### PR DESCRIPTION
# V1-25 — League-config consistency (inv 7.8), residual drift W18-F005/F011

## What was verified vs what was fixed

Each claim from the earlier session's plan was re-verified against the current tree before acting:

| claim | verdict at head |
|---|---|
| `config/league_comparison.json` benchmarks a league not in the registry | **Already closed** (#1056/#1114). "My league" resolves through `league_registry.get_default_league()` and fails closed when the registry is empty; `baseline_league` is a documented benchmark **vessel** card, deliberately not "my league". Pinned by `tests/league_comparison/test_service.py` + `tests/api/test_gameplan_league_config_consistency.py`. |
| hardcoded per-position sample sizes | **Already closed** (#1056/#1114). `_sample_sizes_from_roster_settings` derives QB/RB/WR/TE/IDP_TOTAL from the registry's own `rosterSettings` and **overwrites** any config value; FLEX stays an explicit config value with no silent default (its `get(..., 96)` escape hatch is deleted and pinned). |
| registry `dynasty_new` wrong on roster fields (missing WRRB_FLEX + IR) | **Already closed** (#1114). Registry carries rosterSize 27 / taxiSize 3 / FLEX 1 + `WRRB_FLEX` 1 (`wrrbFlexEligible: [RB, WR]`), matching the committed host snapshot `config/league_intel/dynasty_new/sleeper_league_snapshot_2026-08-25.json`. `reserve_slots: 3` is deliberately snapshot-pinned rather than a dead registry field (no consumer vocabulary for IR yet — pinned by test). **No config data was changed here and nothing unverifiable was guessed.** |
| hardcoded `dynasty_main` call sites | **Still live — fixed in this PR** (W30-F006 shape). |

## The fix

`generate_suggestions_from_pool` threaded the league's `starter_needs_for_league()` demand into `analyze_roster` **only**. Seven consumers read `DEFAULT_STARTER_NEEDS` — dynasty_main's 2-TE / 9-IDP lineup — unconditionally: `_generate_sell_high`, `_generate_buy_low`, `_generate_consolidation`, `_generate_positional_upgrades`, `rank_score`, `rank_score_breakdown`, `_roster_balancer_candidates`. Measured consequence (the audit's numeric proof): in the 1-TE league the engine flagged a TE surplus and then never offered the TE2 it had just called surplus (`players[2:]` with the other league's `need = 2`), and need severity everywhere was graded against the wrong lineup.

Smallest correct closure, per the finding's required repair:

- `analyze_roster` stamps the resolved demand on **`RosterAnalysis.starter_needs`**; every consumer reads it from there — the same demand the rooms were split with, one owner, no second table.
- `DEFAULT_STARTER_NEEDS` is now **private to the declared fallback sites** (`starter_needs_for_league`'s registry-empty fallback, `analyze_roster`'s caller-passed-nothing fallback, the dataclass default) — enforced structurally by an AST guard.
- `metadata.starterNeeds` now reports the demand the analysis actually used.
- **dynasty_main is an exact no-op**: the derived needs reproduce the constant (already pinned by `test_derived_needs_reproduce_the_constant_for_dynasty_main`).

## RED→GREEN proof

`tests/trade/test_starter_needs_league_scoped.py` (6 tests): behavioral pins (TE2 offerable in a 1-TE league at the generator and through the entry point; need severity graded on the league's own demand; balancer eligibility; dynasty_main fallback no-op) plus the AST guard. Mutation-verified: reintroducing the sell-high hardcode at head turns **3 tests RED**; at this head all 6 pass.

## Validation

- `tests/trade/` + `tests/league_intel/test_registry_consumers.py` + `tests/league_comparison/` + `tests/api/test_gameplan_league_config_consistency.py`: **1001 passed**
- league-scoped `tests/api` (`-k league`, incl. `test_league_registry.py`, `test_league_routing.py`, `test_league_isolation_invariants.py`): **205 passed, 12 skipped**
- `ruff format` / `ruff check`: clean
- `scripts/check_planning_integrity.py` + `scripts/check_decision_coercions.py`: clean

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_