### PR TITLE
V1-80: the critical-source gate can fire for DLF

### DIFF
--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -1114,6 +1114,40 @@ _CRITICAL_PRIMARY_SOURCES: tuple[str, ...] = (
 )
 
 
+def critical_primary_for_run_source(run_source: str) -> str | None:
+    """The critical primary source a scraper RUN name reports for, or ``None``.
+
+    The scraper's run registries name a source by its transport, not only
+    by its identity — ``source_enabled_map`` in ``Dynasty Scraper.py``
+    reads ``SITES.get("DLF")`` and registers the result as
+    ``"DLF_LocalCSV"`` — so the name that reaches
+    ``sourceRunSummary.failedSources`` is the primary source name,
+    optionally qualified with an underscore suffix (``DLF_LocalCSV``,
+    historically ``KTC_TradeDB`` / ``KTC_WaiverDB``).  Matching run names
+    against :data:`_CRITICAL_PRIMARY_SOURCES` verbatim therefore could not
+    fire for DLF at all: a DLF failure arrived as ``DLF_LocalCSV``, matched
+    nothing, and fell through to the ``partial_run_unknown`` WARNING for
+    one of the four sources this file declares critical (audit F-17 /
+    V1-80).
+
+    This is the ONE derivation rule from run name to critical primary —
+    exact match, or ``<primary>_<qualifier>`` — deliberately NOT a fourth
+    hand-maintained name list (F-17 rules that out as the defect, not the
+    fix).  ``IDPTradeCalc`` keeps its historical bare-prefix match so any
+    unqualified sub-endpoint name it ever emitted stays critical.
+
+    The qualifier separator is ``_`` because that is the scraper's own
+    naming convention; run names whose primary is NOT critical resolve to
+    ``None`` and stay warnings (``DraftSharks_IDP``, ``FantasyPros_IDP``).
+    """
+    for primary in _CRITICAL_PRIMARY_SOURCES:
+        if run_source == primary or run_source.startswith(primary + "_"):
+            return primary
+    if run_source.startswith("IDPTradeCalc"):
+        return "IDPTradeCalc"
+    return None
+
+
 def _build_source_timestamps() -> dict[str, dict[str, Any]]:
     """Return per-source freshness block with mtimes + staleness flags.
 
@@ -13077,10 +13111,10 @@ def validate_api_data_contract(payload: dict[str, Any]) -> dict[str, Any]:
                 if src in TOLERABLE_PARTIAL_SOURCES:
                     warnings.append(f"partial_run_tolerable:{src}")
                     continue
-                # Critical match: exact name of a primary source, or a
-                # prefix match for IDPTradeCalc's sub-endpoints.
-                is_critical = src in _CRITICAL_PRIMARY_SOURCES or src.startswith("IDPTradeCalc")
-                if is_critical:
+                # Critical match: the run name resolves to a critical
+                # primary source (exact, or ``<primary>_<qualifier>`` —
+                # the scraper reports DLF as ``DLF_LocalCSV``; F-17).
+                if critical_primary_for_run_source(src) is not None:
                     errors.append(f"partial_run_critical:{src}")
                 else:
                     warnings.append(f"partial_run_unknown:{src}")

--- a/tests/api/test_dlf_critical_gate.py
+++ b/tests/api/test_dlf_critical_gate.py
@@ -1,0 +1,220 @@
+"""The critical-source gate can fire for DLF (audit F-17 / V1-80).
+
+THE DEFECT THIS PINS
+────────────────────
+``_CRITICAL_PRIMARY_SOURCES`` declares ``"DLF"`` critical, but the name
+that reaches the gate is never ``"DLF"``: ``Dynasty Scraper.py``'s
+``source_enabled_map`` reads ``SITES.get("DLF")`` and registers the
+result under the RUN name ``"DLF_LocalCSV"``, which is what
+``sourceRunSummary.failedSources`` carries.  Matched verbatim,
+``"DLF_LocalCSV"`` is not in the critical tuple, so a failed DLF run was
+emitted as ``partial_run_unknown:DLF_LocalCSV`` — a WARNING — for one of
+the four sources the repo declares critical.  Latent today
+(``SITES["DLF"] = False``; DLF reaches the board via
+``scripts/fetch_dlf.py``), but re-enabling DLF in ``SITES`` looks like a
+one-line change and would have shipped with its critical gate disabled.
+
+THE REPAIR
+──────────
+``critical_primary_for_run_source`` — one derivation rule from run name
+to critical primary (exact match, or ``<primary>_<qualifier>``), NOT a
+fourth hand-maintained name list; F-17 explicitly rules the latter out
+as the defect rather than the fix.
+
+Every test here builds its own SYNTHETIC payload — never the live board,
+per the CLAUDE.md rule for hard-gate tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.api import data_contract
+from src.api.data_contract import (
+    build_api_data_contract,
+    critical_primary_for_run_source,
+    validate_api_data_contract,
+)
+
+
+def _healthy_payload() -> dict:
+    """A synthetic scrape whose run summary reports a clean run."""
+    return {
+        "players": {
+            "Josh Allen": {
+                "_composite": 8500,
+                "_rawComposite": 8500,
+                "_finalAdjusted": 8400,
+                "_canonicalSiteValues": {"ktcSfTep": 8500},
+                "_sites": 6,
+                "position": "QB",
+                "team": "BUF",
+            },
+            "Ja'Marr Chase": {
+                "_composite": 9200,
+                "_rawComposite": 9200,
+                "_finalAdjusted": 9100,
+                "_canonicalSiteValues": {"ktcSfTep": 9200},
+                "_sites": 7,
+                "position": "WR",
+                "team": "CIN",
+            },
+        },
+        "sites": [{"key": "ktcSfTep"}, {"key": "idpTradeCalc"}],
+        "maxValues": {"ktcSfTep": 9999},
+        "sleeper": {"positions": {"Josh Allen": "QB", "Ja'Marr Chase": "WR"}},
+        "settings": {
+            "sourceRunSummary": {
+                "overallStatus": "ok",
+                "partialRun": False,
+                "completeSources": ["KTC", "IDPTradeCalc", "DLF_LocalCSV"],
+                "partialSources": [],
+                "failedSources": [],
+                "timedOutSources": [],
+            }
+        },
+    }
+
+
+def _dlf_failed_payload() -> dict:
+    """The same scrape with DLF failed — under the SCRAPER'S name for it.
+
+    ``DLF_LocalCSV`` is the exact string ``source_enabled_map`` registers
+    for ``SITES["DLF"]``, i.e. the name a real DLF failure arrives under.
+    """
+    payload = _healthy_payload()
+    payload["settings"]["sourceRunSummary"] = {
+        "overallStatus": "partial",
+        "partialRun": True,
+        "completeSources": ["KTC", "IDPTradeCalc"],
+        "partialSources": [],
+        "failedSources": ["DLF_LocalCSV"],
+        "timedOutSources": [],
+        "sources": {
+            "DLF_LocalCSV": {
+                "source": "DLF_LocalCSV",
+                "state": "failed",
+                "error": "DLF local CSV missing/unreadable",
+                "valueCount": 0,
+            }
+        },
+    }
+    return payload
+
+
+class TestTheGateFiresForDlf:
+    """The RED half of F-17: before the repair this exact payload
+    produced ``partial_run_unknown:DLF_LocalCSV`` — a warning — and
+    ``ok: True``."""
+
+    def test_a_failed_dlf_run_is_a_critical_error(self):
+        report = validate_api_data_contract(build_api_data_contract(_dlf_failed_payload()))
+        assert report["ok"] is False
+        assert report["status"] == "invalid"
+        assert any("partial_run_critical:DLF_LocalCSV" in e for e in report["errors"])
+
+    def test_it_is_not_downgraded_to_an_unknown_warning(self):
+        report = validate_api_data_contract(build_api_data_contract(_dlf_failed_payload()))
+        assert not any("partial_run_unknown:DLF_LocalCSV" in w for w in report["warnings"]), report[
+            "warnings"
+        ]
+
+    def test_it_lands_in_the_source_health_lane_and_only_there(self):
+        """A DLF failure is a provider condition, never a structural one —
+        the lane split must classify it with the other criticals."""
+        report = validate_api_data_contract(build_api_data_contract(_dlf_failed_payload()))
+        assert any("partial_run_critical:DLF_LocalCSV" in e for e in report["sourceHealthErrors"])
+        assert not [e for e in report["structuralErrors"] if "partial_run_critical" in e], report[
+            "structuralErrors"
+        ]
+        assert report["sourceHealthOk"] is False
+        assert report["structurallyOk"] is True
+
+    def test_the_allowlist_still_precedes_the_critical_match(self):
+        """Mechanism ordering pin: a recorded allowlist decision wins over
+        the critical derivation, exactly as it does for exact names."""
+        from unittest import mock
+
+        with mock.patch.object(
+            data_contract, "TOLERABLE_PARTIAL_SOURCES", frozenset({"DLF_LocalCSV"})
+        ):
+            report = validate_api_data_contract(build_api_data_contract(_dlf_failed_payload()))
+        assert any("partial_run_tolerable:DLF_LocalCSV" in w for w in report["warnings"])
+        assert not [e for e in report["errors"] if "DLF_LocalCSV" in e]
+
+
+class TestNonCriticalRunNamesStayWarnings:
+    """The derivation must not promote sources the repo does not declare
+    critical — their primaries are not in the tuple."""
+
+    @pytest.mark.parametrize("run_name", ["DraftSharks_IDP", "FantasyPros_IDP", "Flock"])
+    def test_a_failed_non_critical_source_stays_a_warning(self, run_name):
+        payload = _healthy_payload()
+        payload["settings"]["sourceRunSummary"] = {
+            "overallStatus": "partial",
+            "partialRun": True,
+            "completeSources": ["KTC", "IDPTradeCalc"],
+            "partialSources": [],
+            "failedSources": [run_name],
+            "timedOutSources": [],
+        }
+        report = validate_api_data_contract(build_api_data_contract(payload))
+        assert any(f"partial_run_unknown:{run_name}" in w for w in report["warnings"])
+        assert not [e for e in report["errors"] if run_name in e]
+
+
+class TestTheDerivationRuleItself:
+    """One rule, not a name list: run name → critical primary."""
+
+    @pytest.mark.parametrize(
+        ("run_name", "primary"),
+        [
+            ("DLF", "DLF"),
+            ("DLF_LocalCSV", "DLF"),
+            ("KTC", "KTC"),
+            ("KTC_TradeDB", "KTC"),
+            ("DynastyNerds", "DynastyNerds"),
+            ("IDPTradeCalc", "IDPTradeCalc"),
+            ("IDPTradeCalc_Picks", "IDPTradeCalc"),
+            # historical bare-prefix sub-endpoint shape, preserved:
+            ("IDPTradeCalcPicks", "IDPTradeCalc"),
+        ],
+    )
+    def test_critical_run_names_resolve_to_their_primary(self, run_name, primary):
+        assert critical_primary_for_run_source(run_name) == primary
+
+    @pytest.mark.parametrize(
+        "run_name",
+        [
+            "DraftSharks_IDP",
+            "FantasyPros_IDP",
+            "FantasyCalc",
+            "Flock",
+            # a primary name as a bare prefix without the ``_`` qualifier
+            # separator is a DIFFERENT source, not a qualified run name:
+            "DLFX",
+            "KTCClone",
+            "",
+        ],
+    )
+    def test_everything_else_resolves_to_none(self, run_name):
+        assert critical_primary_for_run_source(run_name) is None
+
+
+class TestTheGateIsValidationOnly:
+    """The gate reports; it never reprices.  The ONLY difference between
+    these two payloads is the upstream run summary, so every published
+    value must be identical."""
+
+    def test_a_dlf_failure_moves_no_value_and_no_rank(self):
+        healthy = build_api_data_contract(_healthy_payload())
+        degraded = build_api_data_contract(_dlf_failed_payload())
+        healthy_rows = {
+            r.get("displayName"): (r.get("rankDerivedValue"), r.get("canonicalConsensusRank"))
+            for r in healthy["playersArray"]
+        }
+        degraded_rows = {
+            r.get("displayName"): (r.get("rankDerivedValue"), r.get("canonicalConsensusRank"))
+            for r in degraded["playersArray"]
+        }
+        assert healthy_rows == degraded_rows

--- a/tests/archive_fixtures.py
+++ b/tests/archive_fixtures.py
@@ -45,7 +45,7 @@ def _degraded_critical_sources(payload: dict) -> list[str]:
     """
     from src.api.data_contract import (
         TOLERABLE_PARTIAL_SOURCES,
-        _CRITICAL_PRIMARY_SOURCES,
+        critical_primary_for_run_source,
     )
 
     settings = payload.get("settings") if isinstance(payload.get("settings"), dict) else {}
@@ -58,7 +58,7 @@ def _degraded_critical_sources(payload: dict) -> list[str]:
             name = str(src)
             if name in TOLERABLE_PARTIAL_SOURCES:
                 continue
-            if name in _CRITICAL_PRIMARY_SOURCES or name.startswith("IDPTradeCalc"):
+            if critical_primary_for_run_source(name) is not None:
                 degraded.append(name)
     return degraded
 


### PR DESCRIPTION
Implements **V1-80** (`docs/VERSION_1_COMPLETION_CONTRACT.md`) — audit finding **F-17** (`docs/audit/POST_MERGE_C_SERIES_AUDIT_2026-08-18.md`), verification level **L2**.

## The defect

`_CRITICAL_PRIMARY_SOURCES` (`src/api/data_contract.py`) declares `"DLF"` critical, but the name that reaches the gate never is `"DLF"`: `Dynasty Scraper.py::source_enabled_map` reads `SITES.get("DLF")` and registers the result under the run name **`DLF_LocalCSV`**, which is what `sourceRunSummary.failedSources` / `timedOutSources` carry. Matched verbatim, `"DLF_LocalCSV"` is in neither the critical tuple nor the `startswith("IDPTradeCalc")` clause, so a failed DLF run was emitted as `partial_run_unknown:DLF_LocalCSV` — a **warning** — for one of the four sources the repo declares critical. Latent today (`SITES["DLF"] = False`; DLF reaches the board via `scripts/fetch_dlf.py`), but re-enabling DLF in `SITES` looks like a one-line change and would have shipped with its critical gate disabled.

## The repair

`critical_primary_for_run_source(run_source)` — **one derivation rule** from scraper run name to critical primary: exact match, or `<primary>_<qualifier>` (the scraper's own underscore convention), with `IDPTradeCalc` keeping its historical bare-prefix match. Deliberately **not** a fourth hand-maintained name list — F-17 explicitly rules "add `DLF_LocalCSV` to the tuple" out as the defect, not the fix. The gate in `validate_api_data_contract` and `tests/archive_fixtures.py::_degraded_critical_sources` (which had its own inline copy of the old rule) now share the one owner, so the two can no longer disagree.

Non-critical qualified run names (`DraftSharks_IDP`, `FantasyPros_IDP`, `Flock`, `FantasyCalc`) still resolve to `None` and stay warnings; a bare-prefix collision without the `_` separator (`DLFX`, `KTCClone`) does not match. The `TOLERABLE_PARTIAL_SOURCES` allowlist still precedes the critical match, unchanged.

## RED-proof

`tests/api/test_dlf_critical_gate.py` injects the DLF failure into a **synthetic** payload (never the live board, per the hard-gate rule) and asserts `partial_run_critical:DLF_LocalCSV` appears as an error, in the source-health lane only, with `ok: False`. Verified by temporarily reverting the gate wiring to the old verbatim match: the three gate-behavior tests go **red** (`3 failed, 20 passed` — the failure was the DLF error string absent and the payload validating `ok: True`), and go green again with the repair restored.

## L2 measured statement

Built the contract from `exports/latest/dynasty_data_2026-08-25.json` via `build_api_data_contract`, with the repair and with it reverted:

* **1116 rows built either way; 0 rows changed value, rank or tier.** The classifier runs only inside `validate_api_data_contract`; it is on no value path. The gate is validation-only.
* The live run summary is `overallStatus: complete`, `partialRun: false`, with **zero** degraded run names — so the reclassification changes **0 error strings** on the live board, and `contractHealth` is `ok: true / healthy` (0 errors, both lanes empty) before and after.

## Validation

* `tests/api/test_dlf_critical_gate.py` — 23 passed
* `tests/api/test_contract_health_lanes.py` — 23 passed
* Full `tests/api/` (`-m "not livedata"`) — 2277 passed, 29 skipped, 193 subtests passed
* `ruff format` + `ruff check` clean on touched files
* `python scripts/check_planning_integrity.py` — clean
* `python scripts/check_decision_coercions.py` — clean (no new coercions)

No source-weight changes, no methodology changes; missing is never zero (a non-reporting source stays exactly as visible as before — only the severity of a *reported* critical failure is corrected).

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_