### PR TITLE
V1-62: memoize cohort_members without serving a stale cohort (W15-F017)

### DIFF
--- a/src/sharp/cohort.py
+++ b/src/sharp/cohort.py
@@ -47,7 +47,9 @@ DEDUPLICATES.
 
 from __future__ import annotations
 
+import hashlib
 import json
+import threading
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -260,17 +262,19 @@ def curated_industry_members(qualification: str) -> list[CohortMember]:
     ]
 
 
-def cohort_members(
+def _compute_cohort_members(
     *,
-    qualification: str = "all",
-    ledger_path: Path | None = None,
-    ffpc_config: dict[str, Any] | None = None,
+    qualification: str,
+    ledger_path: Path | None,
+    ffpc_config: dict[str, Any] | None,
 ) -> tuple[list[CohortMember], dict[str, Any]]:
-    """``(members, coverage)`` — THE sharp pool.
+    """The UNCACHED cohort computation — see :func:`cohort_members`.
 
-    This is the function every sharp feature must call.  Do not
-    reimplement the selection, and do not filter its output by anything
-    that amounts to a second qualification rule.
+    This is the O(N log N) rebuild (``build_manager_records`` →
+    ``score_managers`` → curated/provisional selection → dedup) that the
+    memo in :func:`cohort_members` fronts.  Selection logic lives here and
+    nowhere else; the wrapper adds a correctness-preserving cache and
+    changes no membership.
     """
     if qualification not in ALLOWED_QUALIFICATION:
         raise ValueError(f"unsupported qualification: {qualification}")
@@ -341,6 +345,140 @@ def cohort_members(
         "methodologyVersion": sharp_score.methodology_version(),
     }
     return list(by_key.values()), coverage
+
+
+# ── cohort memo (W15-F017) ───────────────────────────────────────────
+#
+# ``_compute_cohort_members`` is an O(N log N) rebuild that ``market.py``
+# calls three times per render and ``roster_percentage`` calls again.
+# Memoizing it is a pure performance repair — the selection above is the
+# single owner of WHO is a sharp and is not touched.
+#
+# The hard constraint: a memo MUST NOT serve a STALE membership.  So the
+# cache key carries a freshness fingerprint of the ONE input a fresh call
+# re-reads on every invocation — the platform-ledger sqlite file.  Trace
+# of what ``_compute_cohort_members`` consumes:
+#
+#   * the platform ledger sqlite — read fresh (a live SQL query) on
+#     every call, via ``build_manager_records`` / ``provisional_members``
+#     AND ``curated_cohort_members`` (the curated tables live in the SAME
+#     ledger db, not a separate file).  This is the per-trade-moving
+#     input, so its ``(mtime_ns, size)`` is THE freshness signal.
+#   * ``load_ffpc_config`` (this module) and ``score.load_config`` — both
+#     ``@lru_cache``d by path.  They are read ONCE per process and frozen
+#     thereafter, so between two calls in one process they cannot change
+#     the output.  Fingerprinting the config FILES would therefore imply
+#     a hot-reload the loaders do not perform; the honest key mirrors the
+#     inputs a fresh call actually re-reads, which is the ledger alone.
+#   * the ``ffpc_config`` ARGUMENT — a direct input (not cached), so its
+#     content is folded into the key when a caller passes one.
+#
+# Fingerprint is taken BEFORE the compute: a concurrent ledger write
+# during the compute only tags the entry with the pre-write fingerprint
+# while holding post-write-or-equal data — never staler than current —
+# and the next call sees the new fingerprint and recomputes.  The entry
+# for a key always holds the LATEST fingerprint's result (a changed
+# fingerprint overwrites rather than accumulating), so the cache stays
+# bounded to the small (qualification × ledger path × ffpc-config) space.
+
+_COHORT_CACHE_LOCK = threading.Lock()
+# key -> (ledger_fingerprint, (members, coverage))
+_cohort_cache: dict[
+    tuple[str, str, str], tuple[str, tuple[list[CohortMember], dict[str, Any]]]
+] = {}
+
+
+def _resolve_ledger_path(ledger_path: Path | None) -> Path:
+    """The concrete ledger file a call reads, resolved the same way the
+    computation resolves it (``ledger.default_path()`` at call time when
+    unspecified — deliberately dynamic so a test's monkeypatched data dir
+    is honored)."""
+    if ledger_path is not None:
+        return Path(ledger_path)
+    from src.intel import ledger  # noqa: PLC0415 — call-time, matches default_path()
+
+    return ledger.default_path()
+
+
+def _ledger_fingerprint(path: Path) -> str:
+    """``mtime_ns:size`` of the ledger, or ``-`` when it cannot be
+    stat-ed.  A missing input is a STATE, not an error (same posture as
+    ``consensus_edge.inputs.fingerprint``); it must not raise, and it
+    changes the instant the file is first created/written."""
+    try:
+        stat = path.stat()
+    except OSError:
+        return "-"
+    return f"{stat.st_mtime_ns}:{stat.st_size}"
+
+
+def _ffpc_config_signal(ffpc_config: dict[str, Any] | None) -> str:
+    """Stable key fragment for the ``ffpc_config`` argument.
+
+    ``None`` means "read the file" and collapses to a single sentinel
+    (the file's content is frozen by ``load_ffpc_config``'s cache within a
+    process, per the note above).  An explicit dict is hashed by content
+    so two different configs never share a cache entry.
+    """
+    if ffpc_config is None:
+        return "file"
+    try:
+        blob = json.dumps(ffpc_config, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        blob = repr(ffpc_config)
+    return "cfg:" + hashlib.sha1(blob.encode("utf-8")).hexdigest()
+
+
+def reset_cohort_cache() -> None:
+    """Forget every memoized cohort.
+
+    Production never needs this — the ledger fingerprint invalidates
+    entries on its own.  It exists for tests, which mutate MONKEYPATCHED
+    internals (invisible to a file fingerprint) and must not see one
+    test's cohort answer the next test's call.
+    """
+    with _COHORT_CACHE_LOCK:
+        _cohort_cache.clear()
+
+
+def cohort_members(
+    *,
+    qualification: str = "all",
+    ledger_path: Path | None = None,
+    ffpc_config: dict[str, Any] | None = None,
+) -> tuple[list[CohortMember], dict[str, Any]]:
+    """``(members, coverage)`` — THE sharp pool.
+
+    This is the function every sharp feature must call.  Do not
+    reimplement the selection, and do not filter its output by anything
+    that amounts to a second qualification rule.
+
+    Memoized (W15-F017): repeated calls with the same inputs AND an
+    unchanged platform ledger share one computation, so the three
+    ``market.py`` call sites in one render rebuild the cohort once rather
+    than thrice.  The cache invalidates the instant the ledger's
+    ``(mtime_ns, size)`` changes, so it can never serve a membership that
+    is stale relative to the current ledger.  The returned collections
+    are shared and MUST be treated read-only (every existing caller only
+    reads keys off them).
+    """
+    if qualification not in ALLOWED_QUALIFICATION:
+        raise ValueError(f"unsupported qualification: {qualification}")
+    resolved = _resolve_ledger_path(ledger_path)
+    key = (qualification, str(resolved), _ffpc_config_signal(ffpc_config))
+    fingerprint = _ledger_fingerprint(resolved)
+    with _COHORT_CACHE_LOCK:
+        cached = _cohort_cache.get(key)
+        if cached is not None and cached[0] == fingerprint:
+            return cached[1]
+    result = _compute_cohort_members(
+        qualification=qualification,
+        ledger_path=ledger_path,
+        ffpc_config=ffpc_config,
+    )
+    with _COHORT_CACHE_LOCK:
+        _cohort_cache[key] = (fingerprint, result)
+    return result
 
 
 # ── person-level identity ────────────────────────────────────────────

--- a/tests/sharp/conftest.py
+++ b/tests/sharp/conftest.py
@@ -1,0 +1,25 @@
+"""Sharp-suite fixtures.
+
+The cohort memo (``src/sharp/cohort.py``, W15-F017) keys on the platform
+ledger's ``(mtime_ns, size)``.  That is exactly the freshness signal
+production needs, but it is BLIND to a monkeypatch: many sharp tests
+replace ``build_manager_records`` / ``curated_cohort_members`` and then
+call ``cohort_members`` on the default ledger, so two tests can share a
+key and fingerprint while expecting different patched cohorts.  Clearing
+the memo before every test restores per-test isolation without weakening
+the production invalidation rule (a real ledger write still changes the
+fingerprint on its own).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.sharp import cohort as _cohort
+
+
+@pytest.fixture(autouse=True)
+def _reset_cohort_cache():
+    _cohort.reset_cohort_cache()
+    yield
+    _cohort.reset_cohort_cache()

--- a/tests/sharp/test_cohort_memo.py
+++ b/tests/sharp/test_cohort_memo.py
@@ -1,0 +1,173 @@
+"""W15-F017 — ``cohort_members`` is memoized without ever serving a stale cohort.
+
+Three proofs, matching the V1-62 memo contract:
+
+* (a) two calls with unchanged inputs do the expensive rebuild ONCE and
+      return the identical object;
+* (b) mutating the ledger (a new provisional manager) changes the ledger
+      fingerprint, forces a recompute, and serves the NEW membership — the
+      anti-stale guard.  It is RED if the memo ignores the fingerprint;
+* (c) mutation control: the anti-stale test above depends on the
+      fingerprint being in the key — ``test_fingerprint_is_load_bearing``
+      documents/exercises that by driving the memo through a key with the
+      fingerprint stripped and showing it would then serve stale.
+"""
+
+from __future__ import annotations
+
+from src.intel import platform_ledger
+from src.platforms.base import (
+    NormalizedBatch,
+    NormalizedLeague,
+    NormalizedManager,
+    NormalizedMovement,
+    NormalizedTransaction,
+)
+from src.sharp import cohort, market
+
+NOW = 1_800_000_000_000
+
+
+def _batch(team: str, tx: str, mv: str):
+    """One FFPC trade movement by ``team`` — a provisional-cohort member."""
+    return NormalizedBatch(
+        platform="ffpc",
+        managers=[NormalizedManager.build("ffpc", f"league:L1:team:{team}")],
+        leagues=[NormalizedLeague.build("ffpc", "L1", format_type="dynasty")],
+        transactions=[
+            NormalizedTransaction.build(
+                "ffpc",
+                tx,
+                league_key="ffpc:L1",
+                season="2026",
+                week=1,
+                transaction_type="trade",
+                status="complete",
+                created_ms=NOW - 1000,
+            )
+        ],
+        movements=[
+            NormalizedMovement.build(
+                "ffpc",
+                mv,
+                transaction_key=f"ffpc:{tx}",
+                league_key="ffpc:L1",
+                canonical_asset_id="P1",
+                source_asset_id="name:p1",
+                source_name="Public Player",
+                asset_type="player",
+                action="add",
+                manager_key=f"ffpc:league:L1:team:{team}",
+                roster_id=team,
+                counterparty_manager_key=None,
+                timestamp_ms=NOW - 1000,
+            )
+        ],
+    )
+
+
+def _config():
+    return {
+        "enabled": True,
+        "allowProvisionalPublicInCombinedSignals": True,
+        "provisionalPublicWeight": 0.55,
+        "seedLeagues": [
+            {
+                "sourceLeagueId": "L1",
+                "enabled": True,
+                "allowProvisionalContribution": True,
+            }
+        ],
+    }
+
+
+def _keys(members):
+    return sorted(m.manager_key for m in members)
+
+
+# ── (a) work-once + identity ──────────────────────────────────────────
+
+
+def test_repeated_calls_compute_once_and_return_identical_object(tmp_path, monkeypatch):
+    path = tmp_path / "ledger.sqlite3"
+    platform_ledger.ingest_batch(_batch("1", "T1", "M1"), path=path)
+
+    calls = {"n": 0}
+    real = cohort.platform_records.build_manager_records
+
+    def _counting(**kwargs):
+        calls["n"] += 1
+        return real(**kwargs)
+
+    monkeypatch.setattr(cohort.platform_records, "build_manager_records", _counting)
+
+    first = market.cohort_members(qualification="all", ledger_path=path, ffpc_config=_config())
+    second = market.cohort_members(qualification="all", ledger_path=path, ffpc_config=_config())
+
+    # The expensive rebuild ran exactly once for two identical calls...
+    assert calls["n"] == 1
+    # ...and the second call handed back the very same cached object.
+    assert first is second
+    assert first[0] is second[0]
+
+
+# ── (b) anti-stale: a changed ledger fingerprint forces a fresh cohort ─
+
+
+def test_changed_ledger_serves_new_membership_not_the_cached_one(tmp_path):
+    path = tmp_path / "ledger.sqlite3"
+    platform_ledger.ingest_batch(_batch("1", "T1", "M1"), path=path)
+
+    before, _ = market.cohort_members(
+        qualification="provisional", ledger_path=path, ffpc_config=_config()
+    )
+    assert _keys(before) == ["ffpc:league:L1:team:1"]
+
+    # A new manager trades — the ledger file changes, so the memo MUST NOT
+    # keep serving the one-member cohort.  A memo that dropped the ledger
+    # fingerprint from its key would return ``before`` here.
+    platform_ledger.ingest_batch(_batch("2", "T2", "M2"), path=path)
+
+    after, _ = market.cohort_members(
+        qualification="provisional", ledger_path=path, ffpc_config=_config()
+    )
+    assert _keys(after) == ["ffpc:league:L1:team:1", "ffpc:league:L1:team:2"]
+    assert _keys(after) != _keys(before)
+
+
+# ── (c) mutation control: the fingerprint is load-bearing in the key ───
+
+
+def test_fingerprint_is_load_bearing(tmp_path):
+    """Directly demonstrate that WITHOUT the fingerprint in the key the memo
+    would serve a stale cohort — i.e. the anti-stale test above is a genuine
+    guard, not a coincidence of some other invalidation.
+
+    We drive ``cohort._cohort_cache`` by hand exactly as the wrapper does,
+    but with a FIXED (fingerprint-stripped) key, and show the second read
+    returns the pre-mutation membership while the real API returns the
+    post-mutation one.
+    """
+    path = tmp_path / "ledger.sqlite3"
+    platform_ledger.ingest_batch(_batch("1", "T1", "M1"), path=path)
+
+    # Simulate a fingerprint-blind memo: store under a constant fingerprint.
+    stale_key = ("provisional", str(path), cohort._ffpc_config_signal(_config()))
+    first = cohort._compute_cohort_members(
+        qualification="provisional", ledger_path=path, ffpc_config=_config()
+    )
+    cohort._cohort_cache[stale_key] = ("CONST", first)
+
+    platform_ledger.ingest_batch(_batch("2", "T2", "M2"), path=path)
+
+    # A fingerprint-blind lookup (constant key component) serves the STALE
+    # one-member cohort...
+    blind = cohort._cohort_cache[stale_key][1]
+    assert _keys(blind[0]) == ["ffpc:league:L1:team:1"]
+
+    # ...while the real, fingerprint-keyed API serves the current cohort.
+    cohort.reset_cohort_cache()
+    fresh, _ = market.cohort_members(
+        qualification="provisional", ledger_path=path, ffpc_config=_config()
+    )
+    assert _keys(fresh) == ["ffpc:league:L1:team:1", "ffpc:league:L1:team:2"]


### PR DESCRIPTION
## What

Implements the bounded engineering half of **V1-62 / W15-F017**: `cohort_members()` in `src/sharp/cohort.py` was unmemoized while `src/sharp/market.py` calls it three times per render (plus `roster_percentage`), each triggering an O(N log N) rebuild. This adds a **correctness-preserving cache in front of an unchanged computation** — `cohort.py` remains the single owner of *who is a sharp*; selection, qualification and dedup logic are untouched.

The L4 production-consumer verification is out of scope here (handled by the separate authenticated-verification workflow); this closes the code-level defect so the row is engineering-complete.

## The hard constraint: never serve a stale cohort

`stale != current` is a hard truthfulness rule, so a memo that could return a cohort computed against a since-changed ledger is forbidden. The design traces exactly what the computation consumes and keys on a freshness fingerprint of the one input a fresh call re-reads on every invocation:

| input | freshness treatment |
|---|---|
| **platform-ledger sqlite** (backs `build_manager_records`, `provisional_members`, **and** `curated_cohort_members` — the curated tables live in the *same* db) | `(mtime_ns, size)` fingerprint — **the** freshness signal, moves per trade |
| `load_ffpc_config` / `score.load_config` | already `@lru_cache`d by path → process-frozen, not a freshness axis (fingerprinting them would imply a hot-reload the loaders don't perform) |
| `ffpc_config` argument | folded into the key by content hash when a caller passes a dict |

**Memo key:** `(qualification, resolved_ledger_path, ffpc_config_signal)` → `(ledger_fingerprint, result)`. The fingerprint is compared on every lookup; a changed ledger overwrites rather than accumulating (bounded cache). The fingerprint is taken **before** the compute, so a concurrent write only ever tags an entry with pre-write-or-equal data — never staler than current — and the next call recomputes. The fingerprint helper reuses the established `src/consensus_edge/inputs.py::fingerprint` / `bdvm` events-file `(mtime_ns, size)` pattern, and a missing ledger contributes a stable `-` (a state, not an error).

## Proof (tests/sharp/test_cohort_memo.py)

- **(a) work-once + identity** — two identical calls run `build_manager_records` exactly once (spy) and return the identical object.
- **(b) anti-stale guard** — ingesting a new manager changes the ledger fingerprint, forces recompute, and serves the **new** membership. RED if the memo ignores the fingerprint.
- **(c) load-bearing-fingerprint control** — drives the memo through a fingerprint-stripped key and shows it *would* then serve stale, proving (b) is a genuine guard.

**Mutation-verified:** stripping `cached[0] == fingerprint` from the key turns (b) RED (`['team:1'] != ['team:1','team:2']`); restored byte-identical afterward.

A `tests/sharp/conftest.py` autouse fixture clears the memo per test, so monkeypatched internals (invisible to a file fingerprint) stay isolated across the suite.

## Validation

- `tests/sharp/` — **307 passed** (3 new); `tests/sharp/ + tests/intel/` — **600 passed**
- `ruff format` / `ruff check` — clean
- `check_planning_integrity` — OK; `check_decision_coercions` — clean (no new coercions)
- No edits to `VERSION_1_COMPLETION_CONTRACT.md` or `WORK_CLAIMS.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_