### PR TITLE
V1 verification: production-auth Playwright specs (V1-27/45/56/111/131 browser halves)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ frontend/.next.old/
 frontend/.next.*/
 tests/e2e/playwright-report/
 tests/e2e/test-results/
+# prod-auth verification suite (tests/e2e/prod-auth.config.js) writes its
+# own artifact dirs so a prod run never clobbers the default suite's.
+tests/e2e/playwright-report-prod-auth/
+tests/e2e/test-results-prod-auth/
 tests/e2e/tests/
 test-results/
 

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -103,6 +103,13 @@ const backendEnv = {
 
 module.exports = defineConfig({
   testDir: "./specs",
+  // specs/prod-auth/ is the production-auth verification suite. It runs
+  // against the DEPLOYED site with a real session cookie, exclusively
+  // through tests/e2e/prod-auth.config.js — collecting it here would
+  // add permanently-skipped tests to every local/CI run (its fixture
+  // skips without PROD_ORIGIN + PROD_SESSION_COOKIE_FILE) and shift the
+  // suite-size expectations the reporter and workflows are tuned to.
+  testIgnore: "**/prod-auth/**",
   // Verifies the stack can actually serve the suite (snapshot loaded,
   // test sessions unlocked, authenticated /api/data populated) and
   // fails with a fix-it message instead of letting specs time out or

--- a/tests/e2e/prod-auth.config.js
+++ b/tests/e2e/prod-auth.config.js
@@ -1,0 +1,122 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { defineConfig } = require("@playwright/test");
+
+/**
+ * Playwright config for the PRODUCTION-AUTH verification specs
+ * (tests/e2e/specs/prod-auth/).
+ *
+ * A deliberately separate config from playwright.config.js, for three
+ * reasons:
+ *
+ *   1. **No stack.** These specs run against the deployed production
+ *      site — no webServer, no global-setup contract priming, no
+ *      test-session minting. Booting the local stack for them would be
+ *      wrong twice over (it is not the thing being verified, and the
+ *      sandbox has no production credentials).
+ *   2. **No collection overlap.** The default config's testDir is
+ *      ./specs, which contains this directory; playwright.config.js
+ *      carries a matching `testIgnore` so the default suite's size is
+ *      unchanged. This config is the ONLY way these specs are collected.
+ *   3. **No retries.** A production verification run must not launder a
+ *      flake into a pass — a spec that fails once against prod is a
+ *      finding to read, not to retry away.
+ *
+ * Runs only from the production-verification CI workflow, which supplies:
+ *   PROD_ORIGIN               e.g. https://chaseupside.com
+ *   PROD_SESSION_COOKIE_FILE  file containing ONLY the jason_session
+ *                             cookie VALUE
+ * Without both, every spec skips with an explicit message (see
+ * specs/prod-auth/helpers.js) — so an accidental local run is loudly
+ * inert, never red and never green-by-vacuity (the skip count says so).
+ */
+
+// Same pre-installed-Chromium fallback as playwright.config.js — needed
+// so `--list` (and dry runs) work in sandboxed agent containers whose
+// browser revision doesn't match this @playwright/test version. Kept as
+// a copy rather than require()-ing the default config, whose import has
+// side effects (env defaulting, directory creation) that belong to the
+// self-booted stack only.
+function resolveChromiumPath() {
+  if (process.env.E2E_CHROMIUM_PATH) return process.env.E2E_CHROMIUM_PATH;
+  const root = process.env.PLAYWRIGHT_BROWSERS_PATH;
+  if (!root || root === "0" || !fs.existsSync(root)) return undefined;
+  let candidates;
+  try {
+    candidates = fs
+      .readdirSync(root)
+      .filter((name) => /^chromium-\d+$/.test(name))
+      .map((name) => ({
+        rev: Number(name.split("-")[1]),
+        bin: path.join(root, name, "chrome-linux", "chrome"),
+      }))
+      .filter((c) => fs.existsSync(c.bin))
+      .sort((a, b) => b.rev - a.rev);
+  } catch {
+    return undefined;
+  }
+  if (!candidates.length) return undefined;
+  try {
+    const { chromium } = require("@playwright/test");
+    if (fs.existsSync(chromium.executablePath())) return undefined;
+  } catch {
+    /* not installed — fall through to the detected build */
+  }
+  return candidates[0].bin;
+}
+
+const chromiumExecutablePath = resolveChromiumPath();
+
+module.exports = defineConfig({
+  testDir: "./specs/prod-auth",
+  // Production pages carry real data over a real network; budgets are
+  // sized for that, not for the local snapshot.
+  timeout: 180_000,
+  expect: {
+    timeout: 20_000,
+  },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  // No retries, ever — see the header. failOnFlakyTests is kept anyway
+  // so a future retries edit cannot silently reintroduce laundering.
+  retries: 0,
+  failOnFlakyTests: true,
+  workers: 1,
+  // Separate output dirs so a prod-auth run never clobbers (or uploads
+  // as) the default suite's artifacts.
+  outputDir: "test-results-prod-auth",
+  reporter: [
+    ["list"],
+    ["html", { open: "never", outputFolder: "playwright-report-prod-auth" }],
+  ],
+  use: {
+    // Deliberately NO baseURL: every navigation and API call builds its
+    // absolute URL through helpers.js::prodUrl(PROD_ORIGIN), so a spec
+    // cannot accidentally hit a relative (and therefore nonexistent)
+    // origin.
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    ...(chromiumExecutablePath
+      ? { launchOptions: { executablePath: chromiumExecutablePath } }
+      : {}),
+  },
+  projects: [
+    {
+      name: "prod-desktop",
+      use: {
+        browserName: "chromium",
+        viewport: { width: 1366, height: 768 },
+      },
+    },
+    {
+      name: "prod-mobile",
+      use: {
+        browserName: "chromium",
+        viewport: { width: 390, height: 844 },
+        hasTouch: true,
+        isMobile: true,
+      },
+    },
+  ],
+});

--- a/tests/e2e/specs/prod-auth/README.md
+++ b/tests/e2e/specs/prod-auth/README.md
@@ -1,0 +1,61 @@
+# Production-auth verification specs
+
+Playwright specs that run against the **DEPLOYED production site** with a
+real authenticated session, closing the "needs a browser + a session"
+half of five V1 verification rows. They are the L3/L4 browser evidence
+the offline instruments (`scripts/verify_lineup_production.py`, the
+recipe docs) explicitly cannot produce.
+
+## What each spec proves
+
+| spec | row | proves, against the deployed SHA |
+|---|---|---|
+| `v1-131-nav-gating.spec.js` | V1-131 | `/api/auth/status` publishes a boolean `features.consensusEdge.available` that AGREES with the board endpoint, and every nav offer surface (desktop Market menu, mobile drawer at 390×844, command palette, `/more` site map, DOM-wide anchors) honours it — with the negative control that the Market group's ungated entries still render, the network invariant (zero `/api/consensus-edge/*` requests and exactly one `/api/auth/status` on a private-route reload), and direct navigation to `/consensus-edge` still rendering its own `<h1>`. Both branches are implemented; annotations record which one the deployed build exercised. Recipe: `docs/master-site-audit/evidence/V1-131/L3_PRODUCTION_RECIPE.md` steps 4-8. |
+| `v1-45-trade-surface.spec.js` | V1-45 | A trade built through the real `/trade` UI (team selected, players added via the page's own search, receiving roster chosen at the league's roster cap when one exists) produces the page's own `POST /api/trade/simulate`, and the rendered Final-roster section matches that response's `finalRosterSimulation` stamps field-for-field under the component's exact formatting — strength before/after/change, promotions/displacements, needs closed/opened, the cleanup (forced-release) count, plus the `rosterCapacity` banner's release count. The three backend states render distinguishably; only states the live league actually produced are asserted, recorded in `states-observed` annotations. Recipe: `docs/trade/V1_45_TRADE_CALCULATOR_L4_EVIDENCE_RECIPE.md` §4. |
+| `v1-111-premium-rankings.spec.js` | V1-111 | On `/rankings` (both 1366×768 and 390×844) the `.psi-editorial` premium scope is present **and active** (its token remap measurably applied), the top row is the backend's rank-1 player with the backend's value under the page's own formatting, a sample of rendered rows matches the contract's (rank, name, value) stamps exactly (no client-side re-rank), buildRows' fail-fast never fired, and any visible partial-data row renders its missing state truthfully (annotated honestly when none is visible). |
+| `v1-56-waivers-faab-strip.spec.js` | V1-56 | The `/waivers` league-FAAB context strip renders the mean/median from the page's **own** `faabAnalytics` fetch (formatting-aware equality, including a measured `$0` median rendered honestly), and a missing/empty analytics payload renders an explicit `—` unavailable state or no strip — never invented zeros. The state the live payload produced is annotated. |
+| `v1-27-lineup-render.spec.js` | V1-27 / C2-U1 §10 item 2 | On the `/` war room, the Portfolio panel's starters list equals the authenticated contract's `sleeper.teams[].optimalLineup` stamp for the displayed team — slot sequence and player set, in the stamp's own order — the split-legend starter count equals the stamp's, unpriced players are excluded from both lists (upper-bound arithmetic when the live stamp has none, annotated rather than faked), and the truth-ladder note is absent iff the stamp came from live `rosterPositions`. On `/rosters`, the "Starters only" scope renders totals with no `starter-slots-unavailable` note exactly when every team is stamped. This is the one item `scripts/verify_lineup_production.py` marks "needs a browser". |
+
+## Env contract
+
+Both variables are **required**; without them every spec skips with an
+explicit message (never fails, never silently passes):
+
+| var | meaning |
+|---|---|
+| `PROD_ORIGIN` | production origin, e.g. `https://chaseupside.com` |
+| `PROD_SESSION_COOKIE_FILE` | path to a file containing **only** the VALUE of the `jason_session` cookie, one line |
+
+The cookie value is read by the shared fixture (`helpers.js`), attached
+as an `httpOnly`/`secure`/`Lax` cookie on the browser context, verified
+live against `/api/auth/status`, and **never logged or included in any
+assertion message**. A cookie that fails to authenticate is a loud
+FAILURE, not a skip — the workflow supplied credentials and they do not
+work.
+
+## Read-only guarantee
+
+Navigation, DOM reads and network observation only. The single POST is
+`/api/trade/simulate` — a pure computation endpoint that mutates no
+league or user state. Where driving the UI would write user preferences
+(the team switcher PUTs `/api/user/state`), the spec intercepts the
+write and answers it locally so production state is never touched.
+
+## Excluded from default runs
+
+These specs are **not** part of the default local/CI e2e suite:
+
+* `tests/e2e/playwright.config.js` carries `testIgnore: "**/prod-auth/**"`,
+  so the default config's collection is unchanged by this directory;
+* they are collected exclusively by **`tests/e2e/prod-auth.config.js`**
+  (projects `prod-desktop` 1366×768, `prod-mobile` 390×844; no
+  webServer, no global-setup, `retries: 0` so a production finding is
+  never retried away), which only the production-verification CI
+  workflow invokes:
+
+```bash
+npx playwright test --config tests/e2e/prod-auth.config.js
+```
+
+Run without the env vars, that command reports every test as skipped —
+by design.

--- a/tests/e2e/specs/prod-auth/helpers.js
+++ b/tests/e2e/specs/prod-auth/helpers.js
@@ -1,0 +1,189 @@
+/**
+ * Shared fixture + helpers for the production-auth verification specs.
+ *
+ * These specs run against the DEPLOYED production site with a real
+ * session cookie.  They are read-only over the product: navigation, DOM
+ * reads and network observation only — the single POST they make is
+ * `/api/trade/simulate`, a pure computation endpoint that mutates
+ * nothing.
+ *
+ * Env contract (both required; the fixture skips cleanly otherwise):
+ *   PROD_ORIGIN               e.g. https://chaseupside.com
+ *   PROD_SESSION_COOKIE_FILE  path to a file containing ONLY the VALUE
+ *                             of the `jason_session` cookie
+ *
+ * The cookie value is never logged, never annotated, and never included
+ * in an assertion message — treat every failure path here as one that
+ * ends up in CI logs.
+ */
+const fs = require("node:fs");
+const base = require("@playwright/test");
+
+const ORIGIN = String(process.env.PROD_ORIGIN || "").replace(/\/+$/, "");
+const COOKIE_FILE = String(process.env.PROD_SESSION_COOKIE_FILE || "");
+
+/** Both env vars present — the only mode these specs run in. */
+function isConfigured() {
+  return Boolean(ORIGIN && COOKIE_FILE);
+}
+
+/**
+ * Absolute production URL for a path.  Every navigation in these specs
+ * goes through here — there is no local webServer and no baseURL split,
+ * so this is the prod-auth analogue of helpers/journey.js::pageUrl().
+ */
+function prodUrl(path) {
+  if (!ORIGIN) throw new Error("PROD_ORIGIN is not set");
+  return ORIGIN + path;
+}
+
+/** Read the cookie VALUE from the file. Never log the return value. */
+function readCookieValue() {
+  const raw = fs.readFileSync(COOKIE_FILE, "utf-8").trim();
+  if (!raw) {
+    throw new Error(
+      `PROD_SESSION_COOKIE_FILE (${COOKIE_FILE}) is empty — it must ` +
+        "contain only the jason_session cookie value.",
+    );
+  }
+  if (/\r|\n/.test(raw)) {
+    throw new Error(
+      "PROD_SESSION_COOKIE_FILE contains multiple lines — expected the " +
+        "bare cookie value on one line.",
+    );
+  }
+  return raw;
+}
+
+/**
+ * GET a JSON API endpoint with the session cookie (page.request shares
+ * the browser context's cookie jar).  Returns { status, body } — body is
+ * null when the response is not JSON.
+ */
+async function getJson(page, path) {
+  const res = await page.request.get(prodUrl(path), { timeout: 45_000 });
+  let body = null;
+  try {
+    body = await res.json();
+  } catch {
+    /* non-JSON — caller branches on status */
+  }
+  return { status: res.status(), body };
+}
+
+/** Record an observed value into the test report, visibly and durably. */
+function annotate(testInfo, type, description) {
+  testInfo.annotations.push({ type, description: String(description) });
+}
+
+/**
+ * Loose person-name normalization for cross-source joins (board display
+ * name vs Sleeper roster spelling).  Lowercase alphanumerics only, with
+ * common suffixes dropped.  Used to COMPARE, never to invent identity:
+ * callers report which matches needed it.
+ */
+function normName(name) {
+  return String(name || "")
+    .toLowerCase()
+    .replace(/\b(jr|sr|ii|iii|iv|v)\b\.?/g, "")
+    .replace(/[^a-z0-9]/g, "");
+}
+
+/**
+ * Replicas of the two display formatters SimulationPanel uses
+ * (frontend/app/trade/trade-sections.jsx).  Replicated so the spec can
+ * state the EXPECTED rendering from the backend response — the
+ * assertion is "the page shows the backend's number under the backend's
+ * formatting", so the formatter must match character-for-character
+ * (note fmtSigned's U+2212 minus).
+ */
+function fmtSigned(n) {
+  const v = Math.round(Number(n) || 0);
+  return `${v >= 0 ? "+" : "−"}${Math.abs(v).toLocaleString("en-US")}`;
+}
+
+function strengthText(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.round(n).toLocaleString("en-US") : "—";
+}
+
+/** Gate a test to one of the two prod-auth projects. */
+function desktopOnly(test, testInfo) {
+  test.skip(
+    testInfo.project.name !== "prod-desktop",
+    "desktop-viewport check — runs on the prod-desktop project only",
+  );
+}
+
+function mobileOnly(test, testInfo) {
+  test.skip(
+    testInfo.project.name !== "prod-mobile",
+    "mobile-viewport check — runs on the prod-mobile project only",
+  );
+}
+
+/**
+ * `prodPage` fixture: a page whose browser context carries the real
+ * production session cookie, verified live against /api/auth/status
+ * before any test body runs.
+ *
+ * Skip vs fail policy, deliberately split:
+ *   - env unset            → SKIP (these specs only run in the
+ *                            production-verification workflow; a default
+ *                            local/CI run must not fail on their absence)
+ *   - cookie file unreadable, or the cookie does not authenticate
+ *                          → FAIL loudly. The workflow supplied
+ *                            credentials and they do not work; reporting
+ *                            that as a skip would read as "fine".
+ */
+const test = base.test.extend({
+  prodPage: async ({ page, context }, use) => {
+    if (!isConfigured()) {
+      base.test.skip(
+        true,
+        "PROD_ORIGIN / PROD_SESSION_COOKIE_FILE not set — prod-auth " +
+          "specs run only in the production verification workflow",
+      );
+      return;
+    }
+    const value = readCookieValue();
+    await context.addCookies([
+      {
+        name: "jason_session",
+        value,
+        url: ORIGIN,
+        httpOnly: true,
+        secure: ORIGIN.startsWith("https"),
+        sameSite: "Lax",
+      },
+    ]);
+
+    const { status, body } = await getJson(page, "/api/auth/status");
+    if (status !== 200 || !body || body.authenticated !== true) {
+      throw new Error(
+        `The supplied session cookie did not authenticate against ` +
+          `${ORIGIN}/api/auth/status (HTTP ${status}, authenticated=` +
+          `${body ? body.authenticated : "n/a"}). This is a REAL failure ` +
+          "— the workflow supplied credentials and they do not work. " +
+          "(The cookie value itself is deliberately not printed.)",
+      );
+    }
+
+    await use(page);
+  },
+});
+
+module.exports = {
+  test,
+  expect: base.expect,
+  ORIGIN,
+  isConfigured,
+  prodUrl,
+  getJson,
+  annotate,
+  normName,
+  fmtSigned,
+  strengthText,
+  desktopOnly,
+  mobileOnly,
+};

--- a/tests/e2e/specs/prod-auth/v1-111-premium-rankings.spec.js
+++ b/tests/e2e/specs/prod-auth/v1-111-premium-rankings.spec.js
@@ -1,0 +1,183 @@
+/**
+ * V1-111 — the premium (`.psi-editorial`) rankings surface on the
+ * DEPLOYED production site renders backend stamps verbatim.
+ *
+ * Grounded in docs/psi/PR_A_VISUAL_VERIFICATION_2026-08-20.md ("every
+ * number traces to the contract; nothing on the page is invented") and
+ * the rankings page component:
+ *
+ *   - the `.psi-editorial` scope is present AND active (its token remap
+ *     is measurably applied, not just a class string in the DOM);
+ *   - the top row shows rank #1 with the real backend name and value —
+ *     compared against the authenticated /api/data contract, under the
+ *     page's own formatting (Math.round + toLocaleString);
+ *   - no client-side rank/value computation: the first N rendered rows'
+ *     (rank → name, value) tuples are exactly the backend's stamps, and
+ *     buildRows' zero-rank-stamps fail-fast never fired in the console;
+ *   - partial-data states render truthfully where the visible window
+ *     exhibits one (annotated honestly when it does not).
+ *
+ * Runs at BOTH 1366x768 (prod-desktop) and 390x844 (prod-mobile).
+ */
+const {
+  test,
+  expect,
+  prodUrl,
+  getJson,
+  annotate,
+} = require("./helpers");
+
+const BOARD_ROW = ".ds-table-wrap table tbody tr.rankings-row-clickable";
+
+/** rank → {name, value} from the legacy players dict the app view serves. */
+function backendRankMap(contract) {
+  const map = new Map();
+  for (const [name, row] of Object.entries(contract?.players || {})) {
+    const rank = row?._canonicalConsensusRank;
+    if (rank == null) continue;
+    map.set(Number(rank), {
+      name,
+      value: Math.round(Number(row.rankDerivedValue ?? row.values?.full ?? 0)),
+    });
+  }
+  return map;
+}
+
+test.describe("V1-111: premium rankings render backend stamps", () => {
+  test("psi-editorial is active and the board is the backend's, verbatim", async ({
+    prodPage: page,
+  }, testInfo) => {
+    // Backend truth first, over the same session.
+    const { status, body: contract } = await getJson(page, "/api/data?view=app");
+    expect(status, "/api/data must serve the session").toBe(200);
+    const rankMap = backendRankMap(contract);
+    expect(
+      rankMap.size,
+      "the contract carries no rank stamps — nothing to verify against",
+    ).toBeGreaterThan(100);
+
+    const consoleErrors = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") consoleErrors.push(msg.text().slice(0, 300));
+    });
+
+    await page.goto(prodUrl("/rankings"), { waitUntil: "domcontentloaded" });
+    const rows = page.locator(BOARD_ROW);
+    await expect(rows.first(), "rankings board should render rows").toBeVisible({
+      timeout: 90_000,
+    });
+
+    // ── The premium scope is present AND active ──────────────────────
+    const scope = page.locator("section.psi-editorial");
+    await expect(
+      scope,
+      "the rankings page section no longer carries the psi-editorial scope",
+    ).toHaveCount(1);
+    // Active = the scope's token remap is applied, not merely classed:
+    // --surface-0 is the psi cream canvas (frontend/app/tokens.css).
+    const surface0 = await scope.evaluate((el) =>
+      getComputedStyle(el).getPropertyValue("--surface-0").trim(),
+    );
+    expect(
+      surface0.toLowerCase(),
+      "psi-editorial is classed but its token layer is not applied — " +
+        "the premium surface is not actually active",
+    ).toBe("#f2ebdd");
+    annotate(testInfo, "psi-editorial", `active (--surface-0=${surface0})`);
+
+    // ── Top row: rank #1, real name, real value ──────────────────────
+    const first = rows.first();
+    const firstRankText = (
+      await first.locator('td[data-col="rank"]').innerText()
+    ).trim();
+    const firstRank = parseInt(firstRankText, 10);
+    expect(
+      firstRank,
+      `top rendered row shows rank "${firstRankText}", expected #1`,
+    ).toBe(1);
+
+    const backendTop = rankMap.get(1);
+    expect(backendTop, "backend stamps no rank-1 row").toBeTruthy();
+    const renderedName = (
+      await first.locator('td[data-col="name"] .rankings-player-name').innerText()
+    ).trim();
+    expect(
+      renderedName,
+      "the top row's player is not the backend's rank-1 player",
+    ).toBe(backendTop.name);
+
+    const renderedValue = (
+      await first.locator('td[data-col="value"] button').first().innerText()
+    ).trim();
+    expect(
+      renderedValue,
+      `top row value must be the backend's rankDerivedValue (${backendTop.value}) under the page's own formatting`,
+    ).toBe(backendTop.value.toLocaleString("en-US"));
+    annotate(
+      testInfo,
+      "top-row",
+      `#1 ${renderedName} · ${renderedValue} (API: ${backendTop.name} · ${backendTop.value})`,
+    );
+
+    // ── No client-side re-rank/re-value: sample the visible window ───
+    const sampleCount = Math.min(await rows.count(), 15);
+    let partialsSeen = 0;
+    for (let i = 0; i < sampleCount; i += 1) {
+      const row = rows.nth(i);
+      const rankText = (
+        await row.locator('td[data-col="rank"]').innerText()
+      ).trim();
+      const name = (
+        await row.locator('td[data-col="name"] .rankings-player-name').innerText()
+      ).trim();
+      if (rankText.startsWith("—")) {
+        // Partial-data state: an unranked row must really be unranked
+        // in the contract — "—" is truthful, a number would have to be.
+        partialsSeen += 1;
+        const contractRow = contract.players?.[name];
+        expect(
+          contractRow?._canonicalConsensusRank ?? null,
+          `row "${name}" renders an em-dash rank but the backend stamps one`,
+        ).toBeNull();
+        continue;
+      }
+      const rank = parseInt(rankText, 10);
+      const backendRow = rankMap.get(rank);
+      expect(
+        backendRow,
+        `rendered rank #${rank} ("${name}") does not exist in the backend's rank stamps — a client-side ordinal`,
+      ).toBeTruthy();
+      expect(
+        name,
+        `rank #${rank} renders "${name}" but the backend stamps "${backendRow.name}" — a client-side re-rank`,
+      ).toBe(backendRow.name);
+      const valueText = (
+        await row.locator('td[data-col="value"] button').first().innerText()
+      ).trim();
+      expect(
+        valueText,
+        `rank #${rank} "${name}" renders a value the backend did not stamp`,
+      ).toBe(backendRow.value.toLocaleString("en-US"));
+    }
+    annotate(
+      testInfo,
+      "rows-verified",
+      `${sampleCount} rendered rows matched backend (rank, name, value) exactly`,
+    );
+    annotate(
+      testInfo,
+      "partial-data-states",
+      partialsSeen > 0
+        ? `${partialsSeen} visible row(s) rendered explicit missing states, verified truthful`
+        : "no partial-data row visible in the sampled window — state not exercisable on this board",
+    );
+
+    // buildRows' fail-fast (zero rank stamps → empty board + console
+    // error) must not have fired; nor any other page error.
+    const failFast = consoleErrors.filter((t) => /rank stamp|buildRows/i.test(t));
+    expect(
+      failFast,
+      "buildRows reported missing backend stamps — the board would be a client-side construction",
+    ).toEqual([]);
+  });
+});

--- a/tests/e2e/specs/prod-auth/v1-131-nav-gating.spec.js
+++ b/tests/e2e/specs/prod-auth/v1-131-nav-gating.spec.js
@@ -1,0 +1,340 @@
+/**
+ * V1-131 — nav capability gating for Consensus Edge, verified against
+ * the DEPLOYED production site.
+ *
+ * Implements steps 4-8 of
+ * docs/master-site-audit/evidence/V1-131/L3_PRODUCTION_RECIPE.md:
+ * `/api/auth/status` publishes `features.consensusEdge.available` (the
+ * canonical predicate, not the raw flag), and every nav offer surface —
+ * desktop Market menu, mobile drawer, command palette, /more site map,
+ * DOM-wide anchors — honours it. The route itself stays reachable
+ * either way (gating removes the OFFER, never the page).
+ *
+ * BOTH branches are implemented; each test asserts the branch the
+ * deployed build actually reports and records it as an annotation
+ * (`branch: available=<bool>`), so the report says which invariant was
+ * exercised rather than pretending both were.
+ */
+const {
+  test,
+  expect,
+  prodUrl,
+  getJson,
+  annotate,
+  desktopOnly,
+  mobileOnly,
+} = require("./helpers");
+
+/** Recipe step 2: the capability block, asserted to be a REAL boolean. */
+async function readCapability(page, testInfo) {
+  const { status, body } = await getJson(page, "/api/auth/status");
+  expect(status, "/api/auth/status must answer 200 to a session").toBe(200);
+  const block = body?.features?.consensusEdge;
+  expect(
+    block,
+    "features.consensusEdge missing from /api/auth/status — an older " +
+      "build is deployed; the nav still fails closed but V1-131's " +
+      "capability publication is not verified",
+  ).toBeTruthy();
+  expect(
+    typeof block.available,
+    "available must be a real boolean, not a truthy stand-in",
+  ).toBe("boolean");
+  annotate(testInfo, "branch", `available=${block.available}`);
+  return block.available;
+}
+
+/** Record the deployed SHA (recipe step 1) — best-effort, annotated. */
+async function annotateDeployedSha(page, testInfo) {
+  const { body } = await getJson(page, "/api/status");
+  const sha =
+    body?.deployedSha || body?.gitSha || body?.sha || body?.version || null;
+  annotate(testInfo, "deployed-sha", sha || "not published by /api/status");
+}
+
+test.describe("V1-131: nav gating on the deployed shell", () => {
+  test("capability and the board endpoint agree (recipe step 3)", async ({
+    prodPage: page,
+  }, testInfo) => {
+    desktopOnly(test, testInfo);
+    await annotateDeployedSha(page, testInfo);
+    const available = await readCapability(page, testInfo);
+
+    const res = await page.request.get(
+      prodUrl("/api/consensus-edge/players"),
+      { timeout: 45_000 },
+    );
+    const boardStatus = res.status();
+    annotate(testInfo, "board-endpoint-status", String(boardStatus));
+
+    // Disagreement is THE defect this row exists to prevent — the one
+    // thing the recipe says cannot be waved through.
+    if (available) {
+      expect(
+        boardStatus,
+        "available=true but the board endpoint does not serve",
+      ).toBe(200);
+    } else {
+      expect(
+        boardStatus,
+        "available=false but the board endpoint is not answering 503 — " +
+          "the capability and the board disagree",
+      ).toBe(503);
+    }
+  });
+
+  test("desktop Market menu, palette, /more and DOM anchors honour the capability (recipe steps 4-5)", async ({
+    prodPage: page,
+  }, testInfo) => {
+    desktopOnly(test, testInfo);
+    const available = await readCapability(page, testInfo);
+
+    await page.goto(prodUrl("/rankings"), { waitUntil: "domcontentloaded" });
+    // Shell readiness: the top-nav search affordance renders once the
+    // client auth check resolves (helpers/journey.js documents it as
+    // the "authenticated UI is hydrated" signal).
+    await expect(page.locator(".shell-search-btn")).toBeVisible({
+      timeout: 60_000,
+    });
+
+    // ── Market menu ──────────────────────────────────────────────────
+    await page.getByRole("button", { name: "Market menu" }).click();
+    const marketMenu = page.locator('[role="menu"][aria-label="Market"]');
+    await expect(marketMenu).toBeVisible();
+    const menuItems = marketMenu.locator('[role="menuitem"]');
+    const itemTexts = await menuItems.allInnerTexts();
+    annotate(testInfo, "market-menu-items", itemTexts.join(" | "));
+
+    // Negative control FIRST, both branches: the Market group itself
+    // must be healthy, or an empty menu would "pass" the gating check.
+    for (const label of [
+      "Source Disagreement",
+      "Sharp Tracker",
+      "Sharp Roster Percentage",
+    ]) {
+      await expect(
+        marketMenu.getByRole("menuitem", { name: new RegExp(label) }),
+        `Market menu lost its "${label}" entry — the nav is broken ` +
+          "generally, so the Consensus Edge assertion below would be vacuous",
+      ).toBeVisible();
+    }
+
+    const ceMenuItem = marketMenu.getByRole("menuitem", {
+      name: /Consensus Edge/,
+    });
+    if (available) {
+      await expect(
+        ceMenuItem,
+        "available=true but the Market menu does not offer Consensus Edge",
+      ).toBeVisible();
+    } else {
+      await expect(
+        ceMenuItem,
+        "available=false but the Market menu offers Consensus Edge",
+      ).toHaveCount(0);
+    }
+
+    // DOM-wide anchor census, measured while the menu is OPEN so the
+    // zero cannot be an artifact of a collapsed menu.
+    const anchorCount = await page
+      .locator('a[href="/consensus-edge"]')
+      .count();
+    if (available) {
+      expect(
+        anchorCount,
+        "available=true but no /consensus-edge anchor exists with the Market menu open",
+      ).toBeGreaterThan(0);
+    } else {
+      expect(
+        anchorCount,
+        'available=false but a[href="/consensus-edge"] exists in the DOM',
+      ).toBe(0);
+    }
+    await page.keyboard.press("Escape");
+
+    // ── Command palette ──────────────────────────────────────────────
+    await page.locator(".shell-search-btn").click();
+    const paletteInput = page.getByLabel("Search players, picks, and pages");
+    await expect(paletteInput).toBeVisible();
+    await paletteInput.fill("consensus");
+    const ceOption = page.locator(".shell-palette-option", {
+      has: page.locator(".shell-palette-option-name", {
+        hasText: /Consensus Edge/i,
+      }),
+    });
+    if (available) {
+      await expect(
+        ceOption.first(),
+        "available=true but the palette returns no Consensus Edge target for 'consensus'",
+      ).toBeVisible({ timeout: 15_000 });
+    } else {
+      // Give the palette a moment to produce whatever it will produce,
+      // keyed on its own settled states rather than a sleep: either
+      // options render or the explicit empty state does.
+      await expect(
+        page
+          .locator(".shell-palette-option")
+          .first()
+          .or(page.locator(".shell-palette-empty")),
+      ).toBeVisible({ timeout: 15_000 });
+      await expect(
+        ceOption,
+        "available=false but the command palette offers Consensus Edge",
+      ).toHaveCount(0);
+    }
+    const paletteNames = await page
+      .locator(".shell-palette-option-name")
+      .allInnerTexts();
+    annotate(
+      testInfo,
+      "palette-results-for-consensus",
+      paletteNames.join(" | ") || "(none)",
+    );
+    await page.keyboard.press("Escape");
+
+    // ── /more site map ───────────────────────────────────────────────
+    await page.goto(prodUrl("/more"), { waitUntil: "domcontentloaded" });
+    await expect(
+      page.locator('a.shell-menu-item[href="/edge"]'),
+      "/more site map should list Source Disagreement (negative control)",
+    ).toBeVisible({ timeout: 30_000 });
+    const moreCeLinks = page.locator('a[href="/consensus-edge"]');
+    if (available) {
+      await expect(
+        moreCeLinks.first(),
+        "available=true but /more does not link Consensus Edge",
+      ).toBeVisible();
+    } else {
+      await expect(
+        moreCeLinks,
+        "available=false but /more links /consensus-edge",
+      ).toHaveCount(0);
+    }
+  });
+
+  test("hard reload of a private route: zero consensus-edge requests, exactly one auth/status (recipe step 6)", async ({
+    prodPage: page,
+  }, testInfo) => {
+    desktopOnly(test, testInfo);
+    const available = await readCapability(page, testInfo);
+    annotate(
+      testInfo,
+      "note",
+      `network invariant asserted with available=${available} — the shell ` +
+        "must never probe consensus-edge from a private route in either branch",
+    );
+
+    await page.goto(prodUrl("/rankings"), { waitUntil: "domcontentloaded" });
+    await expect(page.locator(".shell-search-btn")).toBeVisible({
+      timeout: 60_000,
+    });
+
+    // Count only from the reload onward — the recipe's step is a hard
+    // reload of an already-loaded private route.
+    const consensusEdgeRequests = [];
+    let authStatusCount = 0;
+    page.on("request", (req) => {
+      const url = req.url();
+      if (url.includes("/api/consensus-edge")) consensusEdgeRequests.push(url);
+      if (url.includes("/api/auth/status")) authStatusCount += 1;
+    });
+
+    await page.reload({ waitUntil: "domcontentloaded" });
+    // Settle on the page's own readiness markers, then let trailing
+    // shell requests drain (bounded network-idle, not a bare sleep).
+    await expect(page.locator(".shell-search-btn")).toBeVisible({
+      timeout: 60_000,
+    });
+    await expect(
+      page
+        .locator(".ds-table-wrap table tbody tr.rankings-row-clickable")
+        .first(),
+      "the rankings board should render after reload",
+    ).toBeVisible({ timeout: 60_000 });
+    await page.waitForLoadState("networkidle", { timeout: 15_000 }).catch(() => {});
+
+    expect(
+      consensusEdgeRequests,
+      "the shell made requests to /api/consensus-edge/* from a private " +
+        "route — the capability must ride /api/auth/status, not a " +
+        "per-page probe (this erodes V1-108)",
+    ).toEqual([]);
+    expect(
+      authStatusCount,
+      "/api/auth/status should be requested exactly once on a shell load",
+    ).toBe(1);
+  });
+
+  test("the /consensus-edge route itself stays reachable (recipe step 8)", async ({
+    prodPage: page,
+  }, testInfo) => {
+    desktopOnly(test, testInfo);
+    const available = await readCapability(page, testInfo);
+
+    await page.goto(prodUrl("/consensus-edge"), {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(
+      page.getByRole("heading", { level: 1, name: /^Consensus Edge$/ }),
+      "direct navigation must render the page's own <h1> — gating " +
+        "removes the offer, never the route",
+    ).toBeVisible({ timeout: 60_000 });
+    annotate(
+      testInfo,
+      "route-direct-nav",
+      `renders own h1 with available=${available}`,
+    );
+  });
+
+  test("mobile drawer honours the capability at 390x844 (recipe step 5, mobile)", async ({
+    prodPage: page,
+  }, testInfo) => {
+    mobileOnly(test, testInfo);
+    const available = await readCapability(page, testInfo);
+
+    await page.goto(prodUrl("/rankings"), { waitUntil: "domcontentloaded" });
+    const tabbar = page.locator('nav.shell-tabbar[aria-label="Primary"]');
+    await expect(tabbar).toBeVisible({ timeout: 60_000 });
+
+    await tabbar.getByRole("button", { name: /Menu/ }).click();
+    const drawerGroups = page.locator(".shell-drawer-group");
+    await expect(drawerGroups.first()).toBeVisible({ timeout: 15_000 });
+
+    // Negative control: the Market group renders with its ungated entries.
+    const marketGroup = drawerGroups.filter({
+      has: page.locator(".shell-drawer-group-label", { hasText: /^Market$/ }),
+    });
+    await expect(
+      marketGroup,
+      "mobile drawer lost its Market group — gating assertion would be vacuous",
+    ).toHaveCount(1);
+    for (const href of [
+      "/edge",
+      "/market/sharp-tracker",
+      "/market/sharp-roster-percentage",
+    ]) {
+      await expect(
+        marketGroup.locator(`a[href="${href}"]`),
+        `mobile drawer Market group lost its ${href} entry`,
+      ).toHaveCount(1);
+    }
+
+    const ceLinks = page.locator('a[href="/consensus-edge"]');
+    if (available) {
+      await expect(
+        ceLinks.first(),
+        "available=true but the mobile drawer does not offer Consensus Edge",
+      ).toBeVisible();
+    } else {
+      await expect(
+        ceLinks,
+        "available=false but the mobile drawer offers /consensus-edge",
+      ).toHaveCount(0);
+    }
+    annotate(
+      testInfo,
+      "drawer-market-links",
+      (await marketGroup.locator("a").allInnerTexts()).join(" | "),
+    );
+  });
+});

--- a/tests/e2e/specs/prod-auth/v1-27-lineup-render.spec.js
+++ b/tests/e2e/specs/prod-auth/v1-27-lineup-render.spec.js
@@ -1,0 +1,330 @@
+/**
+ * V1-27 / C2-U1 §10 item 2 — the DEPLOYED /terminal (the "/" war room)
+ * and /rosters render starters from the server-stamped
+ * `sleeper.teams[].optimalLineup`, and unpriced players are excluded
+ * from the split rather than silently benched.
+ *
+ * docs/lineup/C2_U1_CANONICAL_LINEUP.md §10 item 2 is the one checklist
+ * item `scripts/verify_lineup_production.py` cannot automate ("needs a
+ * browser"); this spec is that browser half. The render markers are
+ * read from the components themselves:
+ *   - terminal: PortfolioSummary's `.portfolio-starters` list (slot in
+ *     `.portfolio-starter-pos`, name in `.portfolio-starter-name`,
+ *     SLOT order — the stamp's own `assignments` order), the
+ *     starter/bench counts in `.portfolio-split-legend`, and the
+ *     `.portfolio-lineup-note` truth ladder disclosure;
+ *   - rosters: the "Starters only" scope's `.starter-slots-unavailable`
+ *     note, which must appear exactly when a stamp is missing.
+ *
+ * READ-ONLY GUARANTEE: driving the team switcher would PUT
+ * /api/user/state (the real user's saved selection), so every non-GET
+ * to that endpoint is intercepted and answered locally — the UI works,
+ * production state is never written.
+ */
+const {
+  test,
+  expect,
+  prodUrl,
+  getJson,
+  annotate,
+  normName,
+  desktopOnly,
+} = require("./helpers");
+
+/** Loose person-name match: exact normalized, or last token + first initial. */
+function namesMatch(a, b) {
+  const na = normName(a);
+  const nb = normName(b);
+  if (na && na === nb) return "exact";
+  const ta = String(a || "").trim().toLowerCase().split(/\s+/);
+  const tb = String(b || "").trim().toLowerCase().split(/\s+/);
+  if (
+    ta.length > 1 &&
+    tb.length > 1 &&
+    normName(ta[ta.length - 1]) === normName(tb[tb.length - 1]) &&
+    ta[0][0] === tb[0][0]
+  ) {
+    return "loose";
+  }
+  return null;
+}
+
+/** Trailing "· N" integer in a split-legend span. */
+function trailingCount(text) {
+  const m = String(text).match(/·\s*([\d,]+)\s*$/);
+  return m ? Number(m[1].replace(/,/g, "")) : NaN;
+}
+
+async function blockUserStateWrites(page) {
+  await page.route("**/api/user/state**", (route) => {
+    const req = route.request();
+    if (req.method() === "GET") return route.continue();
+    // Answer the write locally so the UI proceeds — production user
+    // state is never mutated by this read-only verification.
+    let patch = {};
+    try {
+      patch = req.postDataJSON() || {};
+    } catch {
+      /* non-JSON body — answer empty */
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ state: patch }),
+    });
+  });
+}
+
+test.describe("V1-27: lineup render consumes the optimalLineup stamp", () => {
+  test("terminal portfolio renders the stamped starter/bench split for a real team", async ({
+    prodPage: page,
+  }, testInfo) => {
+    desktopOnly(test, testInfo);
+    test.setTimeout(240_000);
+    await blockUserStateWrites(page);
+
+    // ── The stamps, from the authenticated contract ──────────────────
+    const { status, body: contract } = await getJson(page, "/api/data?view=app");
+    expect(status, "/api/data must serve the session").toBe(200);
+    const teams = contract?.sleeper?.teams || [];
+    expect(teams.length, "contract carries no Sleeper teams").toBeGreaterThan(0);
+
+    const availableTeams = teams.filter(
+      (t) => t?.optimalLineup?.available === true,
+    );
+    const slotSources = [
+      ...new Set(teams.map((t) => t?.optimalLineup?.slotSource ?? "absent")),
+    ];
+    annotate(
+      testInfo,
+      "stamp-census",
+      `${availableTeams.length}/${teams.length} teams carry ` +
+        `optimalLineup.available=true · slotSources: ${slotSources.join(",")}`,
+    );
+    expect(
+      availableTeams.length,
+      "NO team carries an available optimalLineup stamp — the §7a serving-path regression",
+    ).toBeGreaterThan(0);
+
+    // ── Load the war room and resolve which team is displayed ────────
+    await page.goto(prodUrl("/"), { waitUntil: "domcontentloaded" });
+    await expect(
+      page.locator('[aria-label="Team command bar"]'),
+    ).toBeVisible({ timeout: 90_000 });
+
+    const switcher = page.locator("button.team-switcher-toggle").first();
+    await expect(switcher).toBeVisible({ timeout: 60_000 });
+    let displayedName = (await switcher.innerText()).split("\n")[0].trim();
+    let team = teams.find((t) => t.name === displayedName) || null;
+
+    if (!team || team.optimalLineup?.available !== true) {
+      // No usable pre-selected team: pick the one with the richest
+      // stamp — the PUT this triggers is intercepted above, so the
+      // real user's saved selection is untouched.
+      const target = [...availableTeams].sort(
+        (a, b) =>
+          (b.optimalLineup.assignments || []).length -
+          (a.optimalLineup.assignments || []).length,
+      )[0];
+      await switcher.click();
+      await page
+        .locator(".team-switcher-menu")
+        .first()
+        .locator('[role="option"]', { hasText: target.name })
+        .first()
+        .click();
+      team = target;
+      displayedName = target.name;
+    }
+    const stamp = team.optimalLineup;
+    annotate(
+      testInfo,
+      "team-under-test",
+      `${team.name} · slotSource=${stamp.slotSource} · ` +
+        `${(stamp.assignments || []).length} assignments · ` +
+        `${(stamp.unpriced || []).length} unpriced`,
+    );
+
+    // ── The portfolio panel, rendered from that stamp ────────────────
+    const panel = page.locator(".panel--portfolio");
+    await expect(panel).toBeVisible({ timeout: 60_000 });
+    const startersList = panel.locator(".portfolio-starters li");
+    await expect(startersList.first(), "starters list should render").toBeVisible({
+      timeout: 60_000,
+    });
+
+    // Truth-ladder disclosure: with the live-rosterPositions rung the
+    // note must be ABSENT (the split is a measurement, not a guess).
+    if (stamp.slotSource === "sleeper_roster_positions") {
+      await expect(
+        panel.locator(".portfolio-lineup-note"),
+        "stamp is from live rosterPositions but the panel renders a fallback note",
+      ).toHaveCount(0);
+    } else {
+      annotate(
+        testInfo,
+        "lineup-note",
+        `slotSource=${stamp.slotSource} — note expected: ` +
+          (await panel.locator(".portfolio-lineup-note").allInnerTexts()).join(" "),
+      );
+    }
+
+    // ── Starter set equality, by (slot, name) in slot order ──────────
+    const renderedSlots = await panel
+      .locator(".portfolio-starters li .portfolio-starter-pos")
+      .allInnerTexts();
+    const renderedNames = await panel
+      .locator(".portfolio-starters li .portfolio-starter-name")
+      .allInnerTexts();
+    const stampAssignments = stamp.assignments || [];
+
+    expect(
+      renderedSlots.length,
+      `rendered starter count (${renderedSlots.length}) != stamped assignment count ` +
+        `(${stampAssignments.length}). Stamped: ${stampAssignments
+          .map((a) => `${a.slot}:${a.player}`)
+          .join(", ")} · Rendered: ${renderedSlots
+          .map((s, i) => `${s}:${renderedNames[i]}`)
+          .join(", ")}. A shortfall usually means a starter's board display ` +
+        "name failed to join the Sleeper roster spelling — a real render-vs-stamp gap either way.",
+    ).toBe(stampAssignments.length);
+
+    expect(
+      renderedSlots.map((s) => s.trim()),
+      "rendered slot sequence must be the stamp's own assignment order",
+    ).toEqual(stampAssignments.map((a) => String(a.slot)));
+
+    const looseMatches = [];
+    const mismatches = [];
+    stampAssignments.forEach((a, i) => {
+      const verdict = namesMatch(renderedNames[i], a.player);
+      if (verdict === "loose") {
+        looseMatches.push(`${a.slot}: "${renderedNames[i]}" ~ "${a.player}"`);
+      } else if (!verdict) {
+        mismatches.push(
+          `${a.slot}: rendered "${renderedNames[i]}" vs stamped "${a.player}"`,
+        );
+      }
+    });
+    expect(
+      mismatches,
+      "rendered starters disagree with the stamp by player",
+    ).toEqual([]);
+    annotate(
+      testInfo,
+      "name-joins",
+      looseMatches.length
+        ? `loose display-name matches (board vs Sleeper spelling): ${looseMatches.join("; ")}`
+        : "every rendered starter name matched the stamp exactly (normalized)",
+    );
+
+    // ── Split legend: counts are the stamp's, unpriced excluded ──────
+    const legendSpans = panel.locator(".portfolio-split-legend > span");
+    const starterLegend = await legendSpans
+      .filter({ hasText: /Starters/ })
+      .innerText();
+    const benchLegend = await legendSpans
+      .filter({ hasText: /Bench/ })
+      .innerText();
+    const starterCount = trailingCount(starterLegend);
+    const benchCount = trailingCount(benchLegend);
+    expect(
+      starterCount,
+      `legend starter count (${starterCount}) != stamped starters (${(stamp.starters || []).length})`,
+    ).toBe((stamp.starters || []).length);
+
+    const unpriced = stamp.unpriced || [];
+    const rosterSize = (team.players || []).length;
+    // Unpriced players are a THIRD state: in neither list. Bench can be
+    // at most roster − starters − unpriced (unresolved names shrink it
+    // further, hence ≤, never ==).
+    expect(
+      benchCount,
+      `bench count (${benchCount}) can only hold roster (${rosterSize}) − ` +
+        `starters (${starterCount}) − unpriced (${unpriced.length}) — a larger ` +
+        "bench means unpriced players were silently benched",
+    ).toBeLessThanOrEqual(rosterSize - starterCount - unpriced.length);
+    if (unpriced.length > 0) {
+      const renderedNorm = new Set(renderedNames.map(normName));
+      for (const name of unpriced) {
+        expect(
+          renderedNorm.has(normName(name)),
+          `stamped-unpriced player "${name}" is rendered as a starter`,
+        ).toBe(false);
+      }
+      annotate(
+        testInfo,
+        "unpriced-state",
+        `${unpriced.length} unpriced player(s) verified excluded from starters and from the bench count`,
+      );
+    } else {
+      annotate(
+        testInfo,
+        "unpriced-state",
+        "stamp.unpriced is empty for this team on the live board — the " +
+          "exclusion arithmetic was asserted as an upper bound only; the " +
+          "positive case was not exercisable and is not faked",
+      );
+    }
+  });
+
+  test("/rosters 'Starters only' scope is stamped-lineup-driven, with an honest unavailable state", async ({
+    prodPage: page,
+  }, testInfo) => {
+    desktopOnly(test, testInfo);
+    await blockUserStateWrites(page);
+
+    const { status, body: contract } = await getJson(page, "/api/data?view=app");
+    expect(status).toBe(200);
+    const teams = contract?.sleeper?.teams || [];
+    expect(teams.length).toBeGreaterThan(0);
+    const allStamped = teams.every((t) => t?.optimalLineup?.available === true);
+    annotate(
+      testInfo,
+      "stamp-census",
+      `${teams.filter((t) => t?.optimalLineup?.available === true).length}/${teams.length} stamped available`,
+    );
+
+    await page.goto(prodUrl("/rosters"), { waitUntil: "domcontentloaded" });
+    await expect(
+      page.getByRole("heading", { level: 1, name: /^Team Strength$/ }),
+    ).toBeVisible({ timeout: 90_000 });
+
+    await page.selectOption(
+      'select[aria-label="Assets counted in team totals"]',
+      "starters",
+    );
+
+    // Every team still renders a portfolio row under the starters scope.
+    const rows = page.locator(".roster-portfolio-table tbody tr");
+    await expect
+      .poll(() => rows.count(), {
+        message: `starters-scope portfolio should render one row per team (${teams.length})`,
+        timeout: 60_000,
+      })
+      .toBeGreaterThanOrEqual(teams.length);
+
+    const note = page.locator(".starter-slots-unavailable");
+    if (allStamped) {
+      await expect(
+        note,
+        "every team carries an available stamp, yet the page claims starter totals are unavailable",
+      ).toHaveCount(0);
+      annotate(
+        testInfo,
+        "state-observed",
+        "all stamps available → starter totals rendered, no unavailable note",
+      );
+    } else {
+      await expect(
+        note,
+        "a team's stamp is missing but the page renders starter totals as if measured",
+      ).toBeVisible();
+      annotate(
+        testInfo,
+        "state-observed",
+        "missing stamp(s) → explicit 'Starter totals unavailable' note rendered",
+      );
+    }
+  });
+});

--- a/tests/e2e/specs/prod-auth/v1-45-trade-surface.spec.js
+++ b/tests/e2e/specs/prod-auth/v1-45-trade-surface.spec.js
@@ -1,0 +1,413 @@
+/**
+ * V1-45 — the Trade Calculator consumes the canonical
+ * `finalRosterSimulation` block truthfully, verified on the DEPLOYED
+ * production site.
+ *
+ * Implements §4 steps 2-3 of
+ * docs/trade/V1_45_TRADE_CALCULATOR_L4_EVIDENCE_RECIPE.md against the
+ * merged render (frontend/app/trade/trade-sections.jsx SimulationPanel,
+ * PR #1120): build a trade through the deployed UI whose receiving
+ * roster sits at the league's roster cap, capture the page's OWN
+ * POST /api/trade/simulate, and assert the rendered Final-roster
+ * section matches the response's stamps field-for-field on what is
+ * rendered.
+ *
+ * Honesty rules, per the task brief:
+ *   - only states the live league actually produces are asserted;
+ *     `states-observed` annotations record which branch ran;
+ *   - the spec replicates the component's formatters exactly
+ *     (helpers.js::fmtSigned / strengthText) so "matches" means
+ *     character-for-character, not approximately;
+ *   - nothing here computes trade math — every expectation is a
+ *     restatement of a backend-stamped number.
+ *
+ * Read-only over the site: /api/trade/simulate is a pure computation
+ * endpoint (it mutates no league state) and is the one POST made.
+ */
+const {
+  test,
+  expect,
+  prodUrl,
+  getJson,
+  annotate,
+  fmtSigned,
+  strengthText,
+  desktopOnly,
+} = require("./helpers");
+
+/** Board display names (the trade search pool), lowercased → exact. */
+function boardNames(contract) {
+  const names = new Map();
+  for (const key of Object.keys(contract?.players || {})) {
+    names.set(key.toLowerCase(), key);
+  }
+  if (Array.isArray(contract?.playersArray)) {
+    for (const p of contract.playersArray) {
+      if (p?.displayName) names.set(p.displayName.toLowerCase(), p.displayName);
+    }
+  }
+  return names;
+}
+
+const PICK_TOKEN = /\d{4}/;
+
+test.describe("V1-45: /trade renders finalRosterSimulation from the page's own simulate call", () => {
+  test("SimulationPanel matches POST /api/trade/simulate field-for-field", async ({
+    prodPage: page,
+  }, testInfo) => {
+    desktopOnly(test, testInfo);
+    test.setTimeout(300_000); // real UI drive over the network
+
+    // ── Pick an at-cap receiving team + real players, from the API ──
+    const { status: dataStatus, body: contract } = await getJson(
+      page,
+      "/api/data?view=app",
+    );
+    expect(dataStatus, "/api/data must serve the authenticated session").toBe(
+      200,
+    );
+    const teams = contract?.sleeper?.teams || [];
+    expect(teams.length, "contract carries no Sleeper teams").toBeGreaterThan(
+      0,
+    );
+
+    const { body: leaguesBody } = await getJson(page, "/api/leagues");
+    const leagueList = Array.isArray(leaguesBody)
+      ? leaguesBody
+      : leaguesBody?.leagues || [];
+    const contractLeagueKey =
+      contract?.meta?.leagueKey || contract?.leagueKey || null;
+    const leagueEntry =
+      leagueList.find((l) => l?.key === contractLeagueKey) ||
+      leagueList[0] ||
+      null;
+    const rosterLimit = Number(leagueEntry?.rosterSettings?.rosterSize) || null;
+    annotate(testInfo, "league", `${contractLeagueKey} rosterLimit=${rosterLimit}`);
+
+    const board = boardNames(contract);
+    // My team: prefer a roster AT the cap (so the +1-player trade forces
+    // a release), else the largest roster — annotated either way, and
+    // the assertions below follow what the backend actually stamps
+    // rather than assuming the forced-release branch.
+    const bySizeDesc = [...teams].sort(
+      (a, b) => (b.players || []).length - (a.players || []).length,
+    );
+    const myTeam =
+      bySizeDesc.find(
+        (t) => rosterLimit != null && (t.players || []).length >= rosterLimit,
+      ) || bySizeDesc[0];
+    const myTeamIdx = teams.indexOf(myTeam);
+    const atCap =
+      rosterLimit != null && (myTeam.players || []).length >= rosterLimit;
+    annotate(
+      testInfo,
+      "receiving-team",
+      `${myTeam.name} (${(myTeam.players || []).length} players, atCap=${atCap})`,
+    );
+
+    // Side A (my side, giving): ONE player whose Sleeper spelling is an
+    // EXACT board row name — that exact match is what the page's
+    // "which side is mine" scorer keys on (trade/page.jsx
+    // teamRosterNames → rowByName.has), so it guarantees side A is
+    // treated as the sending side.
+    const myRosterSet = new Set(myTeam.players || []);
+    const giveName = (myTeam.players || []).find(
+      (p) => p && !PICK_TOKEN.test(p) && board.get(p.toLowerCase()) === p,
+    );
+    expect(
+      giveName,
+      "no player on the chosen roster resolves to an identically-spelled board row — cannot drive the UI deterministically",
+    ).toBeTruthy();
+
+    // Side B (their side, my team receives): TWO players from another
+    // roster, on the board, not on my roster. Net +1 player to an
+    // at-cap roster → the forced-release path.
+    const donor = teams.find(
+      (t) =>
+        t !== myTeam &&
+        (t.players || []).filter(
+          (p) =>
+            p &&
+            !PICK_TOKEN.test(p) &&
+            board.get(p.toLowerCase()) === p &&
+            !myRosterSet.has(p),
+        ).length >= 2,
+    );
+    expect(donor, "no donor roster with two board-resolvable players").toBeTruthy();
+    const receiveNames = (donor.players || [])
+      .filter(
+        (p) =>
+          p &&
+          !PICK_TOKEN.test(p) &&
+          board.get(p.toLowerCase()) === p &&
+          !myRosterSet.has(p) &&
+          p !== giveName,
+      )
+      .slice(0, 2);
+    annotate(
+      testInfo,
+      "trade",
+      `give [${giveName}] · receive [${receiveNames.join(", ")}] from ${donor.name}`,
+    );
+
+    // ── Drive the deployed UI ────────────────────────────────────────
+    await page.goto(prodUrl("/trade"), { waitUntil: "domcontentloaded" });
+    await expect(
+      page.getByRole("heading", { level: 1, name: /^Trade Calculator$/ }),
+    ).toBeVisible({ timeout: 60_000 });
+    await page.waitForFunction(
+      () => !document.body.innerText.includes("Loading player pool..."),
+      null,
+      { timeout: 90_000 },
+    );
+
+    // Select my team (the SuggestionsDesk selector is what feeds
+    // `selectedTeam`, which both gates the Simulate button and names
+    // the team in the request).
+    await page.selectOption("#suggest-team", String(myTeamIdx));
+    await expect(
+      page.getByText(/^Loaded \d+ players/),
+      "team selection should load the roster",
+    ).toBeVisible({ timeout: 30_000 });
+
+    // Add assets through the page's own search-and-pick flow.
+    async function addToSide(sideLabel, name) {
+      const input = page.getByLabel(
+        `Search to add a player to Side ${sideLabel}`,
+      );
+      await input.click();
+      await input.fill(name);
+      const result = page
+        .locator(".trade-side-search-result")
+        .filter({
+          has: page.locator(".trade-side-search-result-name", {
+            hasText: new RegExp(
+              `^${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`,
+            ),
+          }),
+        })
+        .first();
+      await expect(
+        result,
+        `search should surface "${name}" verbatim`,
+      ).toBeVisible({ timeout: 15_000 });
+      await result.click();
+      await expect(
+        page.getByRole("button", {
+          name: `Remove ${name} from Side ${sideLabel}`,
+        }),
+        `"${name}" should land on Side ${sideLabel}`,
+      ).toBeVisible({ timeout: 15_000 });
+    }
+
+    await addToSide("A", giveName);
+    for (const name of receiveNames) await addToSide("B", name);
+
+    // ── (a) capture the page's OWN simulate round-trip ───────────────
+    const responsePromise = page.waitForResponse(
+      (res) =>
+        res.url().includes("/api/trade/simulate") &&
+        !res.url().includes("simulate-mc") &&
+        res.request().method() === "POST",
+      { timeout: 60_000 },
+    );
+    const simulateBtn = page.getByRole("button", { name: /^Simulate impact$/ });
+    await expect(simulateBtn).toBeEnabled({ timeout: 15_000 });
+    await simulateBtn.click();
+
+    const simResponse = await responsePromise;
+    const requestBody = simResponse.request().postDataJSON() || {};
+    expect(
+      requestBody.teamName,
+      "the page's simulate request must name the selected team",
+    ).toBe(myTeam.name);
+    expect(requestBody.playersOut).toContain(giveName);
+    for (const name of receiveNames) {
+      expect(requestBody.playersIn).toContain(name);
+    }
+    expect(
+      simResponse.status(),
+      `simulate answered ${simResponse.status()}`,
+    ).toBe(200);
+    const sim = await simResponse.json();
+
+    // ── (b) rendered Final-roster section === response stamps ────────
+    const frs = sim.finalRosterSimulation;
+    expect(
+      frs,
+      "response carries no finalRosterSimulation — the V1-45 render " +
+        "(PR #1120) has nothing to consume; is the deployed SHA behind?",
+    ).toBeTruthy();
+    const rc = sim.rosterCapacity;
+    annotate(
+      testInfo,
+      "response-shape",
+      `finalRosterSimulation keys: ${Object.keys(frs).join(",")} · ` +
+        `rosterCapacity.requiresDrops=${rc ? rc.requiresDrops : "absent"}`,
+    );
+
+    const panel = page
+      .locator(".ds-panel")
+      .filter({
+        has: page.getByRole("heading", { level: 2, name: /^Impact on / }),
+      })
+      .first();
+    await expect(panel).toBeVisible({ timeout: 30_000 });
+
+    // Roster-capacity banner — the forced-release COUNT, rendered vs
+    // stamped (rc.forcedDrops), when the backend says drops are forced.
+    if (rc && rc.requiresDrops === true) {
+      const nDrops = (rc.forcedDrops || []).length;
+      await expect(
+        panel.getByText(
+          new RegExp(`Forces ${nDrops} release${nDrops === 1 ? "" : "s"}`),
+        ),
+        `rendered forced-release count must equal rosterCapacity.forcedDrops.length (${nDrops})`,
+      ).toBeVisible();
+      for (const d of rc.forcedDrops || []) {
+        await expect(
+          panel.getByText(new RegExp(`${d.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} \\(${d.position}\\)`)),
+          `forced drop "${d.name}" must be named in the capacity banner`,
+        ).toBeVisible();
+      }
+      annotate(testInfo, "states-observed", `rosterCapacity forces ${nDrops} release(s)`);
+    } else {
+      annotate(
+        testInfo,
+        "states-observed",
+        `rosterCapacity.requiresDrops=${rc ? rc.requiresDrops : "absent"} — no forced-release banner expected`,
+      );
+    }
+
+    // The Final-roster section itself, branch by what the backend stamped.
+    const stat = (label) =>
+      panel
+        .locator("div.ds-stat")
+        .filter({
+          has: page.locator(".ds-stat__label", {
+            hasText: new RegExp(`^${label}$`),
+          }),
+        })
+        .locator(".ds-stat__value");
+
+    if (frs.available === true) {
+      annotate(testInfo, "states-observed", "finalRosterSimulation: populated");
+
+      await expect(
+        panel.getByText(/^Final roster$/),
+        "populated state must render the Final roster section",
+      ).toBeVisible();
+
+      // Strength tiles — the BACKEND's numbers under the component's
+      // exact formatting (strengthText / fmtSigned replicas).
+      await expect(stat("Strength before")).toHaveText(
+        strengthText(frs.strengthBefore?.total),
+      );
+      await expect(stat("Strength after")).toHaveText(
+        strengthText(frs.strengthAfter?.total),
+      );
+      const expectedDelta = Number.isFinite(Number(frs.strengthDelta))
+        ? fmtSigned(frs.strengthDelta)
+        : "—";
+      await expect(
+        stat("Strength change"),
+        `Strength change must render the backend's strengthDelta (${frs.strengthDelta}) verbatim`,
+      ).toHaveText(expectedDelta);
+
+      // Promotions / displacements — count parity plus every stamped
+      // name present, as rendered.
+      const promoted = panel.locator("li", { hasText: /^Promoted:/ });
+      await expect(promoted).toHaveCount((frs.promotions || []).length);
+      for (const m of frs.promotions || []) {
+        await expect(
+          promoted.filter({ hasText: m.name }),
+          `promotion "${m.name}" missing from the rendered list`,
+        ).toHaveCount(1);
+      }
+      const displaced = panel.locator("li", { hasText: /^Displaced:/ });
+      await expect(displaced).toHaveCount((frs.displacements || []).length);
+      for (const m of frs.displacements || []) {
+        await expect(
+          displaced.filter({ hasText: m.name }),
+          `displacement "${m.name}" missing from the rendered list`,
+        ).toHaveCount(1);
+      }
+
+      // Needs — both directions, rendered iff stamped non-empty.
+      const needsClosed = panel.locator("li", { hasText: /^Needs closed:/ });
+      if ((frs.needsFixed || []).length > 0) {
+        await expect(needsClosed).toHaveText(
+          `Needs closed: ${frs.needsFixed.join(", ")}`,
+        );
+      } else {
+        await expect(needsClosed).toHaveCount(0);
+      }
+      const needsOpened = panel.locator("li", { hasText: /^Needs opened:/ });
+      if ((frs.needsCreated || []).length > 0) {
+        await expect(needsOpened).toHaveText(
+          `Needs opened: ${frs.needsCreated.join(", ")}`,
+        );
+      } else {
+        await expect(needsOpened).toHaveCount(0);
+      }
+
+      // Cleanup line — the forced-release count INSIDE the final-roster
+      // section, which must agree with the stamp it renders.
+      const nCleanup = (frs.cleanupApplied || []).length;
+      if (nCleanup > 0) {
+        await expect(
+          panel.getByText(
+            new RegExp(
+              `Solved after ${nCleanup} required release${nCleanup === 1 ? "" : "s"}`,
+            ),
+          ),
+          `cleanup line must carry cleanupApplied.length (${nCleanup})`,
+        ).toBeVisible();
+      }
+      if (frs.cleanupIsUpperBound) {
+        await expect(
+          panel.getByText(/worst case, so this final\s+roster is one of a range/),
+        ).toBeVisible();
+      }
+
+      // Distinguishability: the populated section must NOT carry the
+      // refusal copy.
+      await expect(panel.getByText(/Not simulated/)).toHaveCount(0);
+    } else if (frs.unavailableReason === "capacity_uncertain") {
+      annotate(
+        testInfo,
+        "states-observed",
+        "finalRosterSimulation: capacity_uncertain",
+      );
+      // The capacity_uncertain copy is its own sentence — "taxi
+      // occupancy" wording — distinct from both the populated section
+      // and the generic error refusal.
+      await expect(
+        panel.getByText(
+          /Not simulated — taxi occupancy is unknown, so the forced-drop set is a range/,
+        ),
+      ).toBeVisible();
+      // The refusal banner reuses the "Final roster" title, so absence
+      // of the POPULATED section is asserted on its tiles, not the title.
+      await expect(stat("Strength change")).toHaveCount(0);
+    } else {
+      const reason = frs.unavailableReason || frs.unavailable || "unreported";
+      annotate(
+        testInfo,
+        "states-observed",
+        `finalRosterSimulation: unavailable (${reason})`,
+      );
+      await expect(
+        panel.getByText(new RegExp(`Not simulated — .*${reason}`)),
+        "the refusal must be rendered with its own reason, not collapsed",
+      ).toBeVisible();
+      await expect(stat("Strength change")).toHaveCount(0);
+      // ...and it must not read like the capacity_uncertain state.
+      if (reason !== "capacity_uncertain") {
+        await expect(panel.getByText(/taxi occupancy is unknown/)).toHaveCount(
+          0,
+        );
+      }
+    }
+  });
+});

--- a/tests/e2e/specs/prod-auth/v1-56-waivers-faab-strip.spec.js
+++ b/tests/e2e/specs/prod-auth/v1-56-waivers-faab-strip.spec.js
@@ -1,0 +1,146 @@
+/**
+ * V1-56 — the /waivers league-FAAB context strip on the DEPLOYED
+ * production site renders the analytics API's numbers, and renders
+ * missing data as an explicit unavailable state, never as zeros.
+ *
+ * The strip is FaabHeaderStat (frontend/components/waivers/
+ * ManualAddDrop.jsx): three StatTiles — "Your FAAB", "League average
+ * bid", "League median bid" — fed by
+ * GET /api/public/league/faabAnalytics?leagueKey=… (the page's own
+ * fetch, captured here rather than re-derived, so the comparison is
+ * against exactly the payload the page consumed).
+ *
+ * MISSING IS NEVER ZERO, both directions:
+ *   - with bid history (`totalBidsAnalyzed > 0`), the tiles must equal
+ *     `$${Math.round(v)}` of the API's mean/median — including a
+ *     MEASURED $0 median, which is this league's most common answer
+ *     and must render as "$0", not be hidden;
+ *   - without bid history, the tiles must read "—" (or the strip be
+ *     absent), never "$0".
+ * The spec asserts whichever state the live payload produces and
+ * annotates it.
+ */
+const {
+  test,
+  expect,
+  prodUrl,
+  annotate,
+  desktopOnly,
+} = require("./helpers");
+
+test.describe("V1-56: /waivers league-FAAB context strip", () => {
+  test("the strip equals the faabAnalytics payload the page fetched", async ({
+    prodPage: page,
+  }, testInfo) => {
+    desktopOnly(test, testInfo);
+
+    // Capture the page's OWN analytics fetch. Registered before goto so
+    // the response cannot land first.
+    const analyticsPromise = page
+      .waitForResponse(
+        (res) =>
+          res.url().includes("/api/public/league/faabAnalytics") &&
+          res.request().method() === "GET",
+        { timeout: 60_000 },
+      )
+      .catch(() => null);
+
+    await page.goto(prodUrl("/waivers"), { waitUntil: "domcontentloaded" });
+    await expect(
+      page.getByRole("heading", { level: 1, name: /^Waivers$/ }),
+    ).toBeVisible({ timeout: 90_000 });
+
+    const analyticsRes = await analyticsPromise;
+    let data = null;
+    if (analyticsRes) {
+      annotate(
+        testInfo,
+        "analytics-fetch",
+        `${analyticsRes.status()} ${new URL(analyticsRes.url()).pathname}${new URL(analyticsRes.url()).search}`,
+      );
+      if (analyticsRes.status() === 200) {
+        const json = await analyticsRes.json().catch(() => null);
+        // The strip reads one level down (`json.data`) — the nesting
+        // ManualAddDrop.jsx documents.
+        data = json?.data ?? null;
+      }
+    } else {
+      annotate(
+        testInfo,
+        "analytics-fetch",
+        "no faabAnalytics request observed within 60s",
+      );
+    }
+
+    const tileValue = (label) =>
+      page
+        .locator("div.ds-stat")
+        .filter({
+          has: page.locator(".ds-stat__label", {
+            hasText: new RegExp(`^${label}$`),
+          }),
+        })
+        .locator(".ds-stat__value");
+
+    const avgTile = tileValue("League average bid");
+    const medianTile = tileValue("League median bid");
+
+    if (data && (data.leagueAvgWinningBid != null || data.leagueMedianWinningBid != null)) {
+      // ── Populated payload: formatting-aware equality ───────────────
+      const avg = data.leagueAvgWinningBid;
+      const median = data.leagueMedianWinningBid;
+      const analyzed = data.totalBidsAnalyzed;
+      // Replica of the component's own evidence gate (MISSING != ZERO):
+      // a zero with no observation count must render unknown, a zero
+      // WITH observations is a real $0.
+      const hasBidHistory =
+        analyzed != null
+          ? analyzed > 0
+          : (avg != null && avg > 0) || (median != null && median > 0);
+      const expected = (v) =>
+        hasBidHistory && v != null ? `$${Math.round(v)}` : "—";
+
+      await expect(
+        avgTile,
+        `League average bid must render the API's mean (${avg}, analyzed=${analyzed})`,
+      ).toHaveText(expected(avg), { timeout: 30_000 });
+      await expect(
+        medianTile,
+        `League median bid must render the API's median (${median}, analyzed=${analyzed})`,
+      ).toHaveText(expected(median));
+      annotate(
+        testInfo,
+        "state-observed",
+        hasBidHistory
+          ? `populated: avg=${expected(avg)} median=${expected(median)} over ${analyzed} bids` +
+            (median === 0 ? " (measured $0 median rendered honestly)" : "")
+          : "payload present but zero evidence — em-dash unavailable state verified",
+      );
+    } else {
+      // ── Missing/absent analytics: explicit unavailable, never $0 ───
+      const stripTiles = await avgTile.count();
+      if (stripTiles > 0) {
+        await expect(
+          avgTile,
+          "analytics unavailable but the average tile renders a figure — missing must not read as a number",
+        ).toHaveText("—");
+        await expect(medianTile).toHaveText("—");
+        annotate(
+          testInfo,
+          "state-observed",
+          "analytics absent: strip rendered with explicit em-dash unavailable state",
+        );
+      } else {
+        annotate(
+          testInfo,
+          "state-observed",
+          "analytics absent and no team context: strip absent entirely (its documented null state)",
+        );
+      }
+      // Whichever shape, "$0" must not have been invented anywhere in
+      // the bid tiles.
+      await expect(avgTile.filter({ hasText: /^\$0$/ })).toHaveCount(0);
+      await expect(medianTile.filter({ hasText: /^\$0$/ })).toHaveCount(0);
+    }
+  });
+});


### PR DESCRIPTION
# Production-auth verification specs

Adds `tests/e2e/specs/prod-auth/` — five Playwright specs that run against the **deployed production site** with a real session cookie, producing the browser half of the evidence five V1 rows explicitly could not get from offline instruments. Test code only: no workflow files, no auth/minting logic, no server changes.

## What each spec proves (and what it only annotates)

| spec | row | asserts | annotates honestly |
|---|---|---|---|
| `v1-131-nav-gating.spec.js` | V1-131 | `features.consensusEdge.available` is a real boolean AND agrees with the board endpoint (200↔true, 503↔false — the recipe's non-waivable invariant); desktop Market menu, mobile drawer (390×844), command palette, `/more`, and DOM-wide `a[href="/consensus-edge"]` all honour it; negative control that Source Disagreement / Sharp Tracker / Sharp Roster Percentage still render; hard reload of `/rankings` makes **zero** `/api/consensus-edge/*` requests and **exactly one** `/api/auth/status`; direct `/consensus-edge` navigation still renders its own `<h1>` | which branch ran (`branch: available=<bool>`), deployed SHA, menu/palette/drawer contents — both branches are implemented, only the deployed one is exercised |
| `v1-45-trade-surface.spec.js` | V1-45 | drives the real `/trade` UI (team selected via the page's own selector, players added via its search, receiving roster chosen **at the cap** when one exists), captures the page's **own** `POST /api/trade/simulate`, then asserts the rendered Final-roster section equals the response's `finalRosterSimulation` stamps field-for-field under the component's exact formatters (strength before/after/change incl. the U+2212 sign convention, promotions/displacements by count and name, needs closed/opened, `cleanupApplied` forced-release count) plus the `rosterCapacity` banner's release count and named drops; the observed state must not carry the other states' copy (`capacity_uncertain` "taxi occupancy" wording vs populated vs "Not simulated — <reason>") | `states-observed` records exactly which backend states the live league produced — unobserved states are never faked; trade composition and at-cap status recorded |
| `v1-111-premium-rankings.spec.js` | V1-111 | `.psi-editorial` scope present **and active** (its `--surface-0` token remap measurably applied, not just a class string); top row is rank #1 with the backend's rank-1 player name and `rankDerivedValue` under the page's own formatting; a 15-row sample of the visible window matches backend (rank → name, value) exactly — a client-side re-rank or re-value fails with a precise diff; buildRows' zero-rank-stamps fail-fast never fired; runs on both 1366×768 and 390×844 | partial-data states: any visible `—` rank is verified truthful against the contract; when the sampled window exhibits none, that is annotated rather than claimed |
| `v1-56-waivers-faab-strip.spec.js` | V1-56 | the league-FAAB strip's "League average bid" / "League median bid" tiles equal the payload from the page's **own** `faabAnalytics` fetch (formatting-aware `$${Math.round(v)}`), replicating the component's evidence gate so a **measured** $0 median must render as `$0` while a zero with no observations must render `—`; absent analytics ⇒ explicit `—` state or absent strip, and never an invented `$0` | which state the live payload produced (`state-observed`), the analytics request/status observed |
| `v1-27-lineup-render.spec.js` | V1-27 / C2-U1 §10 item 2 | terminal Portfolio starters list equals `sleeper.teams[].optimalLineup` for the displayed team — slot **sequence** identical to the stamp's assignment order, player set equal (normalized; loose display-name joins annotated, real mismatches fail with a diff); split-legend starter count equals `stamp.starters.length`; bench count bounded so stamped-unpriced players cannot be silently benched, and no stamped-unpriced player renders as a starter; truth-ladder note absent iff `slotSource === "sleeper_roster_positions"`; `/rosters` "Starters only" renders all team rows with the `starter-slots-unavailable` note appearing exactly when a stamp is missing | stamp census (available/slotSource per team), name-join quality, and — when the live board has `unpriced: []` — that the positive exclusion case was not exercisable and is not faked |

## Read-only guarantee

Navigation, DOM reads, network observation. The single POST is `/api/trade/simulate` (pure computation). Where driving the UI would write user preferences (team switcher → `PUT /api/user/state`), the spec intercepts the write and answers it locally, so the real user's saved state is never touched. The cookie value is read from the file, attached to the browser context, and never logged or embedded in any assertion message.

## Isolation from the default suite

* New dedicated config **`tests/e2e/prod-auth.config.js`** (projects `prod-desktop` 1366×768 + `prod-mobile` 390×844; no webServer, no global-setup, `retries: 0` so a production finding is never retried away; separate artifact dirs, gitignored).
* `tests/e2e/playwright.config.js` gains `testIgnore: "**/prod-auth/**"`.

Verified:

```
# default config — unchanged before and after this PR
npx playwright test -c tests/e2e/playwright.config.js --list
Total: 516 tests in 22 files            # identical pre/post

# dedicated config
npx playwright test --config tests/e2e/prod-auth.config.js --list
Total: 20 tests in 5 files              # 5 specs × 2 projects

# run WITHOUT credentials (this sandbox has none) — clean skip, exit 0
npx playwright test --config tests/e2e/prod-auth.config.js
  20 skipped
```

`tests/e2e/test_e2e_harness_guards.py`: 14 passed (the new files satisfy the bare-goto and retired-name guards).

## Env contract (supplied by the CI workflow, not this PR)

| var | meaning |
|---|---|
| `PROD_ORIGIN` | e.g. `https://chaseupside.com` |
| `PROD_SESSION_COOKIE_FILE` | file containing ONLY the `jason_session` cookie value |

Unset ⇒ every spec skips with an explicit message. Set but non-authenticating ⇒ loud failure (credentials were supplied and do not work), never a skip.

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_