### PR TITLE
V1-109: fix the two remaining mobile roster-view defects

### DIFF
--- a/docs/master-site-audit/evidence/V1-109/REPAIR_2026-08-25.md
+++ b/docs/master-site-audit/evidence/V1-109/REPAIR_2026-08-25.md
@@ -1,0 +1,110 @@
+# V1-109 — the two remaining W26-F017 defects, repaired at 390×844
+
+**Follows:** `RE_MEASUREMENT_2026-08-24.md` (which fixed the tray↔FAB occlusion,
+found /draft stacking closed-by-later-work, and left these two measured but
+unrepaired).
+**Instrument:** `frontend/scripts/measure-mobile-usability.mjs` (unchanged, control
+passed on every run below).
+**Raw output:** `mobile-390-2026-08-25-pre-repair.json` /
+`mobile-390-2026-08-25-post-repair.json` — production build, real backend,
+authenticated session, 390×844 / `isMobile` / `hasTouch` / DPR 3.
+
+## Why these two are now repairable
+
+The re-measurement pass declined both repairs for stated reasons, and both
+reasons have since resolved:
+
+- **Type scale** was gated on owner decision `OD-05` (V1-110). `OD-05` is
+  **RESOLVED 2026-08-18** (`docs/DESIGN-SYSTEM.md`) and V1-110 is `VERIFIED`:
+  the shipped ramp has an explicit floor — `--font-size-2xs` = 11px, "no
+  micro-type below `--font-size-2xs`". The token to raise onto now exists and
+  is canonical.
+- **Touch targets** needed hit-area instrumentation, because the correct repair
+  (pseudo-element hit-area expansion; growing the box would change row height,
+  which V1-106's windowing froze) is invisible to `getBoundingClientRect`.
+  That instrumentation now exists: `tests/e2e/specs/mobile-touch-targets.spec.js`
+  measures the effective hit region with `document.elementFromPoint`.
+
+## Defect 1 — watchlist stars at 17×13px (worst target on /rankings)
+
+Reproduced pre-repair: every per-row watchlist star button at **17×13px** —
+under WCAG 2.5.8 AA (24×24) in both dimensions, repeated once per mounted row
+(30 of the top-10 worst-target slots on the measured board).
+
+**Repair** (`frontend/app/rankings/board.module.css` `.watchStar`): a centered,
+invisible 44×44 `::after` pseudo-element carries the touch target at
+`max-width: 768px`. No laid-out box moves — row height is untouched (V1-106).
+Mobile-only because on a desktop pointer an invisible 44px halo would steal
+precise clicks aimed at the player-name button beside it.
+
+**Measured with the new hit-area instrument** (`elementFromPoint` walk from the
+visual center):
+
+| | effective hit area |
+|---|---|
+| pre-repair | **18×14px** → RED (`effective hit width 18px < 24px (border box 17x13)`) |
+| post-repair | **44 wide × 33–44 tall** (measured on four stars; vertical extent clipped by the adjacent row's zone exactly as predicted) → GREEN at the 24×24 AA bar |
+
+The guaranteed floor is 24×24 (AA), not 44×44, because rows repeat every ~37px:
+two 44px zones on adjacent rows necessarily overlap and the later row wins the
+contested strip. Asserting 44 effective would demand taller rows — the exact
+change V1-106 forbids. Cross-row integrity is asserted too: each star's own
+center must resolve to that star.
+
+The rect-based instrument still counts the star "under 44px" post-repair
+(160/167 on /rankings) — expected and documented in the instrument's own
+header: it measures border boxes and is a triage list, not a verdict on hit
+areas.
+
+## Defect 2 — type as small as 9.0px on three pages
+
+Reproduced pre-repair (smallest visible type): /rankings **9.0px**
+(value-band chips ×30, badge chips; 9.2px position ranks ×30), /rosters
+**9.0px** (portfolio bar labels ×54, roster-count subtext, buy/sell counts,
+legend), /draft **9.3px** ("NEED" chips ×72).
+
+**Repair:** every live sub-10px size on the three routes raised onto the
+design-system floor `var(--font-size-2xs)` (11px):
+
+| file | what |
+|---|---|
+| `frontend/app/globals.css` | `.rankings-value-band` (base rule — the one that wins on source order — AND the ≤768px duplicate), `.rankings-chip`, `.rankings-mobile-source-label`, `.rankings-mobile-sources` (≤420px), `.action-label` |
+| `frontend/app/rankings/board.module.css` | `.posRank` (was `0.85em` → 9.2px inside the pos badge) |
+| `frontend/app/draft/draft.css` | `.draft-need-chip-row` |
+| `frontend/app/draft/page.jsx` | inline "mine" tag |
+| `frontend/app/rosters/rosters.css` | `.team-strength-facets dt`, `.team-strength-unranked-note` |
+| `frontend/app/rosters/page.jsx` | all nine sub-10px inline sizes (`FONT_2XS` const) |
+
+**Measured:** smallest type 9.0 / 9.0 / 9.3 → **10.9 / 10.6 / 10.6** px.
+Everything repaired sits at 11px; the remaining 10.6/10.9px are the app-wide
+legacy `0.66rem`/`0.68rem` sizes whose migration onto the ramp is V1-110's
+per-page R-phase scope — the same band as /trade's 10.2px, which the audit
+accepted. The E2E bar is therefore **10px** (the audit's own defect line — it
+named the ~9px band on exactly these three pages), not 11px, so the assertion
+pins the defect this row owns without pre-claiming the R-phase migration.
+
+## Mutation proof (both specs, real production builds)
+
+Fixes reverted (`git stash`), rebuilt, both specs run at 390×844:
+
+```
+✘ mobile-touch-targets /rankings — effective hit width 18px < 24px (border box 17x13)
+✘ mobile-type-floor /rankings   — 9px x15 rankings-value-band, 9.2px x30 posRank, …
+✘ mobile-type-floor /rosters    — 9px x54 "QB 25k", 9.3px x12, 9.6px x24, 9.9px …
+✘ mobile-type-floor /draft      — 9.3px x72 draft-need-chip-row "NEED"
+✓ control (probe flags known-bad geometry) — the instrument itself stays valid
+```
+
+Fixes restored, rebuilt: **5/5 GREEN**. One wrinkle found by the mutation run
+and fixed in the spec rather than papered over: /draft's NEED chips mount
+*after* the first table renders, so a scan at first-table-visible measured a
+page state where the offenders did not yet exist — the spec now settles the way
+the instrument does (network idle + a best-effort wait for the chips) before
+scanning.
+
+## Status
+
+Both remaining named defects of `V1-109` now repaired with mutation-proved E2E
+coverage. Status column untouched; the row's required level is L4 (a production
+consumer), which no local measurement can satisfy — promotion is Integration's
+call.

--- a/docs/master-site-audit/evidence/V1-109/mobile-390-2026-08-25-post-repair.json
+++ b/docs/master-site-audit/evidence/V1-109/mobile-390-2026-08-25-post-repair.json
@@ -1,0 +1,620 @@
+{
+  "measuredAt": "2026-08-25T19:07:45.708Z",
+  "viewport": "390x844",
+  "minTargetPx": 44,
+  "minFontPx": 12,
+  "control": {
+    "ok": true,
+    "targetsSeen": 3,
+    "undersizedSeen": 1,
+    "smallestFontPx": 9,
+    "expected": {
+      "targetsSeen": 3,
+      "undersizedSeen": 1,
+      "smallestFontPx": 9
+    }
+  },
+  "routes": {
+    "/rankings": {
+      "status": 200,
+      "hasMain": true,
+      "h1": "Rankings",
+      "viewportWidth": 390,
+      "documentScrollWidth": 390,
+      "horizontalOverflowPx": 0,
+      "targets": {
+        "total": 167,
+        "under": 160,
+        "worst": [
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Brock Bowers to watchlist"
+          },
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Josh Allen to watchlist"
+          },
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Bijan Robinson to watchlist"
+          },
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Jahmyr Gibbs to watchlist"
+          },
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Ja'Marr Chase to watchlist"
+          },
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Drake Maye to watchlist"
+          },
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Jaxon Smith-Njigba to watchlist"
+          },
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Trey McBride to watchlist"
+          },
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Puka Nacua to watchlist"
+          },
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Jayden Daniels to watchlist"
+          }
+        ]
+      },
+      "fonts": {
+        "distinctSizes": [
+          {
+            "px": 10.9,
+            "count": 37,
+            "sample": "QB"
+          },
+          {
+            "px": 11,
+            "count": 132,
+            "sample": "Chase Upside Consensus / Updated 15m ago"
+          },
+          {
+            "px": 11.2,
+            "count": 120,
+            "sample": "1"
+          },
+          {
+            "px": 11.5,
+            "count": 2,
+            "sample": "Risk It To Get The Brisket"
+          },
+          {
+            "px": 12,
+            "count": 20,
+            "sample": "Hide edge"
+          },
+          {
+            "px": 13,
+            "count": 9,
+            "sample": "Skip to content"
+          },
+          {
+            "px": 14,
+            "count": 2,
+            "sample": "Rankings"
+          },
+          {
+            "px": 18,
+            "count": 6,
+            "sample": "983"
+          },
+          {
+            "px": 28,
+            "count": 1,
+            "sample": "Rankings"
+          }
+        ],
+        "smallestPx": 10.9,
+        "underCount": 291
+      },
+      "wideElements": [
+        {
+          "tag": "table",
+          "cls": "ds-table ds-table--compact",
+          "w": 557
+        },
+        {
+          "tag": "colgroup",
+          "cls": "",
+          "w": 557
+        },
+        {
+          "tag": "thead",
+          "cls": "",
+          "w": 557
+        },
+        {
+          "tag": "tr",
+          "cls": "",
+          "w": 557
+        },
+        {
+          "tag": "tbody",
+          "cls": "",
+          "w": 557
+        },
+        {
+          "tag": "tr",
+          "cls": "ds-table__row--interactive rankings-row-clickable",
+          "w": 557
+        }
+      ],
+      "pinnedCount": 8,
+      "pinnedOverlaps": []
+    },
+    "/rosters": {
+      "status": 200,
+      "hasMain": true,
+      "h1": "Team Strength",
+      "viewportWidth": 390,
+      "documentScrollWidth": 390,
+      "horizontalOverflowPx": 0,
+      "targets": {
+        "total": 48,
+        "under": 31,
+        "worst": [
+          {
+            "tag": "button",
+            "w": 82.9,
+            "h": 16.7,
+            "label": "Jonas Sanker"
+          },
+          {
+            "tag": "button",
+            "w": 76,
+            "h": 16.7,
+            "label": "Cyrus Allen"
+          },
+          {
+            "tag": "button",
+            "w": 89.8,
+            "h": 16.7,
+            "label": "Derrick Moore"
+          },
+          {
+            "tag": "button",
+            "w": 76,
+            "h": 16.7,
+            "label": "Mack Wilson"
+          },
+          {
+            "tag": "button",
+            "w": 82.9,
+            "h": 16.7,
+            "label": "Marlin Klein"
+          },
+          {
+            "tag": "button",
+            "w": 89.8,
+            "h": 16.7,
+            "label": "Tanner Koziol"
+          },
+          {
+            "tag": "button",
+            "w": 89.8,
+            "h": 16.7,
+            "label": "Charlie Kolar"
+          },
+          {
+            "tag": "button",
+            "w": 103.7,
+            "h": 16.7,
+            "label": "Milton Williams"
+          },
+          {
+            "tag": "button",
+            "w": 103.7,
+            "h": 16.7,
+            "label": "Jer'Zhan Newton"
+          },
+          {
+            "tag": "button",
+            "w": 76,
+            "h": 16.7,
+            "label": "RJ Maryland"
+          }
+        ]
+      },
+      "fonts": {
+        "distinctSizes": [
+          {
+            "px": 10.6,
+            "count": 1,
+            "sample": "Every asset the filters below admit, at "
+          },
+          {
+            "px": 10.9,
+            "count": 1,
+            "sample": "Players not on any roster with meaningfu"
+          },
+          {
+            "px": 11,
+            "count": 163,
+            "sample": "QB"
+          },
+          {
+            "px": 11.2,
+            "count": 27,
+            "sample": "Team"
+          },
+          {
+            "px": 11.5,
+            "count": 54,
+            "sample": "Risk It To Get The Brisket"
+          },
+          {
+            "px": 11.7,
+            "count": 12,
+            "sample": "Ty"
+          },
+          {
+            "px": 12,
+            "count": 1,
+            "sample": "Pass ?team=<ownerId>. It could not be in"
+          },
+          {
+            "px": 12.2,
+            "count": 1,
+            "sample": "Roster value portfolio"
+          },
+          {
+            "px": 13,
+            "count": 1,
+            "sample": "Skip to content"
+          },
+          {
+            "px": 13.1,
+            "count": 3,
+            "sample": "Team Strength"
+          },
+          {
+            "px": 13.4,
+            "count": 8,
+            "sample": "QB"
+          },
+          {
+            "px": 14,
+            "count": 1,
+            "sample": "Team Strength"
+          },
+          {
+            "px": 14.7,
+            "count": 1,
+            "sample": "Choose a team"
+          },
+          {
+            "px": 15.2,
+            "count": 1,
+            "sample": "Team Strength"
+          }
+        ],
+        "smallestPx": 10.6,
+        "underCount": 258
+      },
+      "wideElements": [
+        {
+          "tag": "table",
+          "cls": "roster-portfolio-table",
+          "w": 586
+        },
+        {
+          "tag": "tbody",
+          "cls": "",
+          "w": 586
+        },
+        {
+          "tag": "tr",
+          "cls": "",
+          "w": 586
+        },
+        {
+          "tag": "tr",
+          "cls": "",
+          "w": 586
+        },
+        {
+          "tag": "tr",
+          "cls": "",
+          "w": 586
+        },
+        {
+          "tag": "tr",
+          "cls": "",
+          "w": 586
+        },
+        {
+          "tag": "tr",
+          "cls": "",
+          "w": 586
+        },
+        {
+          "tag": "tr",
+          "cls": "",
+          "w": 586
+        },
+        {
+          "tag": "tr",
+          "cls": "",
+          "w": 586
+        },
+        {
+          "tag": "tr",
+          "cls": "",
+          "w": 586
+        }
+      ],
+      "pinnedCount": 6,
+      "pinnedOverlaps": []
+    },
+    "/draft": {
+      "status": 200,
+      "hasMain": true,
+      "h1": "Draft Board",
+      "viewportWidth": 390,
+      "documentScrollWidth": 390,
+      "horizontalOverflowPx": 0,
+      "targets": {
+        "total": 580,
+        "under": 422,
+        "worst": [
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          },
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          },
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          },
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          },
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          },
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          },
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          },
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          },
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          },
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          }
+        ]
+      },
+      "fonts": {
+        "distinctSizes": [
+          {
+            "px": 10.6,
+            "count": 110,
+            "sample": "Mine"
+          },
+          {
+            "px": 10.9,
+            "count": 236,
+            "sample": "(sparkline populates after first pick)"
+          },
+          {
+            "px": 11,
+            "count": 142,
+            "sample": "My Team"
+          },
+          {
+            "px": 11.2,
+            "count": 665,
+            "sample": "— how much of the budget advantage to sp"
+          },
+          {
+            "px": 11.5,
+            "count": 177,
+            "sample": "Risk It To Get The Brisket"
+          },
+          {
+            "px": 11.8,
+            "count": 4,
+            "sample": "All72"
+          },
+          {
+            "px": 12,
+            "count": 57,
+            "sample": "How this works"
+          },
+          {
+            "px": 12.2,
+            "count": 31,
+            "sample": "—"
+          },
+          {
+            "px": 12.5,
+            "count": 78,
+            "sample": "$0"
+          },
+          {
+            "px": 12.8,
+            "count": 2,
+            "sample": "Aggression — how much of the budget adva"
+          },
+          {
+            "px": 13,
+            "count": 2,
+            "sample": "Skip to content"
+          },
+          {
+            "px": 13.1,
+            "count": 2,
+            "sample": "Live sync: OFF"
+          },
+          {
+            "px": 14,
+            "count": 10,
+            "sample": "Draft Board"
+          },
+          {
+            "px": 14.1,
+            "count": 2,
+            "sample": "$54"
+          },
+          {
+            "px": 14.4,
+            "count": 169,
+            "sample": "+"
+          },
+          {
+            "px": 18,
+            "count": 12,
+            "sample": "1.00×"
+          },
+          {
+            "px": 22,
+            "count": 1,
+            "sample": "Draft Board"
+          }
+        ],
+        "smallestPx": 10.6,
+        "underCount": 1334
+      },
+      "wideElements": [
+        {
+          "tag": "div",
+          "cls": "draft-team-row draft-team-row-head",
+          "w": 599
+        },
+        {
+          "tag": "table",
+          "cls": "ds-table",
+          "w": 543
+        },
+        {
+          "tag": "thead",
+          "cls": "",
+          "w": 543
+        },
+        {
+          "tag": "tr",
+          "cls": "",
+          "w": 543
+        },
+        {
+          "tag": "tbody",
+          "cls": "",
+          "w": 543
+        },
+        {
+          "tag": "table",
+          "cls": "draft-table",
+          "w": 1065
+        },
+        {
+          "tag": "thead",
+          "cls": "",
+          "w": 1065
+        },
+        {
+          "tag": "tr",
+          "cls": "",
+          "w": 1065
+        },
+        {
+          "tag": "tbody",
+          "cls": "",
+          "w": 1065
+        },
+        {
+          "tag": "tr",
+          "cls": "draft-row",
+          "w": 1065
+        }
+      ],
+      "pinnedCount": 21,
+      "pinnedOverlaps": [
+        {
+          "a": "th.",
+          "b": "th.",
+          "overlapPx": {
+            "x": 1,
+            "y": 41
+          },
+          "area": 41
+        },
+        {
+          "a": "th.",
+          "b": "th.",
+          "overlapPx": {
+            "x": 1,
+            "y": 41
+          },
+          "area": 41
+        }
+      ]
+    }
+  }
+}

--- a/docs/master-site-audit/evidence/V1-109/mobile-390-2026-08-25-pre-repair.json
+++ b/docs/master-site-audit/evidence/V1-109/mobile-390-2026-08-25-pre-repair.json
@@ -1,0 +1,615 @@
+{
+  "measuredAt": "2026-08-25T18:54:06.899Z",
+  "viewport": "390x844",
+  "minTargetPx": 44,
+  "minFontPx": 12,
+  "control": {
+    "ok": true,
+    "targetsSeen": 3,
+    "undersizedSeen": 1,
+    "smallestFontPx": 9,
+    "expected": {
+      "targetsSeen": 3,
+      "undersizedSeen": 1,
+      "smallestFontPx": 9
+    }
+  },
+  "routes": {
+    "/rankings": {
+      "status": 200,
+      "hasMain": true,
+      "h1": "Rankings",
+      "viewportWidth": 390,
+      "documentScrollWidth": 390,
+      "horizontalOverflowPx": 0,
+      "targets": {
+        "total": 167,
+        "under": 160,
+        "worst": [
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Brock Bowers to watchlist"
+          },
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Josh Allen to watchlist"
+          },
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Bijan Robinson to watchlist"
+          },
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Jahmyr Gibbs to watchlist"
+          },
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Ja'Marr Chase to watchlist"
+          },
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Drake Maye to watchlist"
+          },
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Jaxon Smith-Njigba to watchlist"
+          },
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Trey McBride to watchlist"
+          },
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Puka Nacua to watchlist"
+          },
+          {
+            "tag": "button",
+            "w": 17,
+            "h": 13,
+            "label": "Add Jayden Daniels to watchlist"
+          }
+        ]
+      },
+      "fonts": {
+        "distinctSizes": [
+          {
+            "px": 9,
+            "count": 35,
+            "sample": "S+"
+          },
+          {
+            "px": 9.2,
+            "count": 30,
+            "sample": "1"
+          },
+          {
+            "px": 10.9,
+            "count": 37,
+            "sample": "QB"
+          },
+          {
+            "px": 11,
+            "count": 67,
+            "sample": "Chase Upside Consensus / Updated 1m ago"
+          },
+          {
+            "px": 11.2,
+            "count": 120,
+            "sample": "1"
+          },
+          {
+            "px": 11.5,
+            "count": 2,
+            "sample": "Risk It To Get The Brisket"
+          },
+          {
+            "px": 12,
+            "count": 20,
+            "sample": "Hide edge"
+          },
+          {
+            "px": 13,
+            "count": 9,
+            "sample": "Skip to content"
+          },
+          {
+            "px": 14,
+            "count": 2,
+            "sample": "Rankings"
+          },
+          {
+            "px": 18,
+            "count": 6,
+            "sample": "983"
+          },
+          {
+            "px": 28,
+            "count": 1,
+            "sample": "Rankings"
+          }
+        ],
+        "smallestPx": 9,
+        "underCount": 291
+      },
+      "wideElements": [
+        {
+          "tag": "table",
+          "cls": "ds-table ds-table--compact",
+          "w": 552
+        },
+        {
+          "tag": "colgroup",
+          "cls": "",
+          "w": 552
+        },
+        {
+          "tag": "thead",
+          "cls": "",
+          "w": 552
+        },
+        {
+          "tag": "tr",
+          "cls": "",
+          "w": 552
+        },
+        {
+          "tag": "tbody",
+          "cls": "",
+          "w": 552
+        },
+        {
+          "tag": "tr",
+          "cls": "ds-table__row--interactive rankings-row-clickable",
+          "w": 552
+        }
+      ],
+      "pinnedCount": 8,
+      "pinnedOverlaps": []
+    },
+    "/rosters": {
+      "status": 200,
+      "hasMain": true,
+      "h1": "Team Strength",
+      "viewportWidth": 390,
+      "documentScrollWidth": 390,
+      "horizontalOverflowPx": 0,
+      "targets": {
+        "total": 48,
+        "under": 31,
+        "worst": [
+          {
+            "tag": "button",
+            "w": 82.9,
+            "h": 16.7,
+            "label": "Jonas Sanker"
+          },
+          {
+            "tag": "button",
+            "w": 76,
+            "h": 16.7,
+            "label": "Cyrus Allen"
+          },
+          {
+            "tag": "button",
+            "w": 89.8,
+            "h": 16.7,
+            "label": "Derrick Moore"
+          },
+          {
+            "tag": "button",
+            "w": 76,
+            "h": 16.7,
+            "label": "Mack Wilson"
+          },
+          {
+            "tag": "button",
+            "w": 82.9,
+            "h": 16.7,
+            "label": "Marlin Klein"
+          },
+          {
+            "tag": "button",
+            "w": 89.8,
+            "h": 16.7,
+            "label": "Tanner Koziol"
+          },
+          {
+            "tag": "button",
+            "w": 89.8,
+            "h": 16.7,
+            "label": "Charlie Kolar"
+          },
+          {
+            "tag": "button",
+            "w": 103.7,
+            "h": 16.7,
+            "label": "Milton Williams"
+          },
+          {
+            "tag": "button",
+            "w": 103.7,
+            "h": 16.7,
+            "label": "Jer'Zhan Newton"
+          },
+          {
+            "tag": "button",
+            "w": 76,
+            "h": 16.7,
+            "label": "RJ Maryland"
+          }
+        ]
+      },
+      "fonts": {
+        "distinctSizes": [
+          {
+            "px": 9,
+            "count": 54,
+            "sample": "QB 25k"
+          },
+          {
+            "px": 9.3,
+            "count": 12,
+            "sample": "58 players, 54 picks"
+          },
+          {
+            "px": 9.6,
+            "count": 24,
+            "sample": "21 sell"
+          },
+          {
+            "px": 9.9,
+            "count": 67,
+            "sample": "QB"
+          },
+          {
+            "px": 10.6,
+            "count": 1,
+            "sample": "Every asset the filters below admit, at "
+          },
+          {
+            "px": 10.9,
+            "count": 1,
+            "sample": "Players not on any roster with meaningfu"
+          },
+          {
+            "px": 11,
+            "count": 6,
+            "sample": "Home"
+          },
+          {
+            "px": 11.2,
+            "count": 27,
+            "sample": "Team"
+          },
+          {
+            "px": 11.5,
+            "count": 54,
+            "sample": "Risk It To Get The Brisket"
+          },
+          {
+            "px": 11.7,
+            "count": 12,
+            "sample": "Ty"
+          },
+          {
+            "px": 12,
+            "count": 1,
+            "sample": "Pass ?team=<ownerId>. It could not be in"
+          },
+          {
+            "px": 12.2,
+            "count": 1,
+            "sample": "Roster value portfolio"
+          },
+          {
+            "px": 13,
+            "count": 1,
+            "sample": "Skip to content"
+          },
+          {
+            "px": 13.1,
+            "count": 3,
+            "sample": "Team Strength"
+          },
+          {
+            "px": 13.4,
+            "count": 8,
+            "sample": "QB"
+          },
+          {
+            "px": 14,
+            "count": 1,
+            "sample": "Team Strength"
+          },
+          {
+            "px": 14.7,
+            "count": 1,
+            "sample": "Choose a team"
+          },
+          {
+            "px": 15.2,
+            "count": 1,
+            "sample": "Team Strength"
+          }
+        ],
+        "smallestPx": 9,
+        "underCount": 258
+      },
+      "wideElements": [
+        {
+          "tag": "table",
+          "cls": "roster-portfolio-table",
+          "w": 508
+        },
+        {
+          "tag": "tbody",
+          "cls": "",
+          "w": 508
+        }
+      ],
+      "pinnedCount": 6,
+      "pinnedOverlaps": []
+    },
+    "/draft": {
+      "status": 200,
+      "hasMain": true,
+      "h1": "Draft Board",
+      "viewportWidth": 390,
+      "documentScrollWidth": 390,
+      "horizontalOverflowPx": 0,
+      "targets": {
+        "total": 580,
+        "under": 422,
+        "worst": [
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          },
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          },
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          },
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          },
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          },
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          },
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          },
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          },
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          },
+          {
+            "tag": "input",
+            "w": 13,
+            "h": 13,
+            "label": ""
+          }
+        ]
+      },
+      "fonts": {
+        "distinctSizes": [
+          {
+            "px": 9.3,
+            "count": 72,
+            "sample": "NEED"
+          },
+          {
+            "px": 10.6,
+            "count": 110,
+            "sample": "Mine"
+          },
+          {
+            "px": 10.9,
+            "count": 236,
+            "sample": "(sparkline populates after first pick)"
+          },
+          {
+            "px": 11,
+            "count": 70,
+            "sample": "My Team"
+          },
+          {
+            "px": 11.2,
+            "count": 665,
+            "sample": "— how much of the budget advantage to sp"
+          },
+          {
+            "px": 11.5,
+            "count": 177,
+            "sample": "Risk It To Get The Brisket"
+          },
+          {
+            "px": 11.8,
+            "count": 4,
+            "sample": "All72"
+          },
+          {
+            "px": 12,
+            "count": 57,
+            "sample": "How this works"
+          },
+          {
+            "px": 12.2,
+            "count": 31,
+            "sample": "—"
+          },
+          {
+            "px": 12.5,
+            "count": 78,
+            "sample": "$0"
+          },
+          {
+            "px": 12.8,
+            "count": 2,
+            "sample": "Aggression — how much of the budget adva"
+          },
+          {
+            "px": 13,
+            "count": 2,
+            "sample": "Skip to content"
+          },
+          {
+            "px": 13.1,
+            "count": 2,
+            "sample": "Live sync: OFF"
+          },
+          {
+            "px": 14,
+            "count": 10,
+            "sample": "Draft Board"
+          },
+          {
+            "px": 14.1,
+            "count": 2,
+            "sample": "$54"
+          },
+          {
+            "px": 14.4,
+            "count": 169,
+            "sample": "+"
+          },
+          {
+            "px": 18,
+            "count": 12,
+            "sample": "1.00×"
+          },
+          {
+            "px": 22,
+            "count": 1,
+            "sample": "Draft Board"
+          }
+        ],
+        "smallestPx": 9.3,
+        "underCount": 1334
+      },
+      "wideElements": [
+        {
+          "tag": "div",
+          "cls": "draft-team-row draft-team-row-head",
+          "w": 599
+        },
+        {
+          "tag": "table",
+          "cls": "ds-table",
+          "w": 543
+        },
+        {
+          "tag": "thead",
+          "cls": "",
+          "w": 543
+        },
+        {
+          "tag": "tr",
+          "cls": "",
+          "w": 543
+        },
+        {
+          "tag": "tbody",
+          "cls": "",
+          "w": 543
+        },
+        {
+          "tag": "table",
+          "cls": "draft-table",
+          "w": 1061
+        },
+        {
+          "tag": "thead",
+          "cls": "",
+          "w": 1061
+        },
+        {
+          "tag": "tr",
+          "cls": "",
+          "w": 1061
+        },
+        {
+          "tag": "tbody",
+          "cls": "",
+          "w": 1061
+        },
+        {
+          "tag": "tr",
+          "cls": "draft-row",
+          "w": 1061
+        }
+      ],
+      "pinnedCount": 21,
+      "pinnedOverlaps": [
+        {
+          "a": "th.",
+          "b": "th.",
+          "overlapPx": {
+            "x": 1,
+            "y": 41
+          },
+          "area": 41
+        },
+        {
+          "a": "th.",
+          "b": "th.",
+          "overlapPx": {
+            "x": 1,
+            "y": 41
+          },
+          "area": 41
+        }
+      ]
+    }
+  }
+}

--- a/frontend/app/draft/draft.css
+++ b/frontend/app/draft/draft.css
@@ -1207,7 +1207,10 @@
   border: 1px solid var(--blush);
   border-radius: 3px;
   padding: 1px 5px;
-  font-size: 0.58rem;
+  /* V1-109 / W26-F017: was 0.58rem — the 9.3px "NEED" chips were
+     /draft's smallest shipped type at 390x844 (x72 on the measured
+     board). 11px design-system floor (docs/DESIGN-SYSTEM.md). */
+  font-size: var(--font-size-2xs, 0.6875rem);
   font-weight: 700;
   letter-spacing: 0.05em;
   margin-left: 4px;

--- a/frontend/app/draft/page.jsx
+++ b/frontend/app/draft/page.jsx
@@ -3047,7 +3047,11 @@ function DraftReviewPanel({ workspace, stats, onClose }) {
                         {t.isMine && (
                           <span
                             className="draft-tag draft-tag-mine"
-                            style={{ marginLeft: 6, fontSize: "0.62rem" }}
+                            style={{
+                              marginLeft: 6,
+                              // V1-109 / W26-F017: 11px type floor (was 0.62rem).
+                              fontSize: "var(--font-size-2xs, 0.6875rem)",
+                            }}
                           >
                             mine
                           </span>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2019,7 +2019,12 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   .rankings-player-cell { gap: 4px; }
   .rankings-player-meta { font-size: 0.62rem; }
   .rankings-value { font-size: 0.74rem; }
-  .rankings-value-band { font-size: 0.52rem; }
+  /* V1-109 / W26-F017: was 0.52rem. NOTE this mobile rule loses to the
+     identically-specific base .rankings-value-band rule further down the
+     file on source order (the same trap the FAB fix documents at
+     .screenshot-fab) — both now carry the 11px design-system floor so
+     the pair cannot disagree. */
+  .rankings-value-band { font-size: var(--font-size-2xs, 0.6875rem); }
   .edge-rail-grid { grid-template-columns: 1fr 1fr; }
   .edge-rail-name { max-width: 120px; }
   .edge-rail-item { font-size: 0.66rem; }
@@ -2070,7 +2075,8 @@ input[type="range"]:focus-visible::-moz-range-thumb {
   .rankings-mobile-source-label {
     font-weight: 700;
     color: var(--cyan, #4fc3f7);
-    font-size: 0.6rem;
+    /* V1-109 / W26-F017: was 0.6rem (9.6px) — 11px floor. */
+    font-size: var(--font-size-2xs, 0.6875rem);
     letter-spacing: 0.02em;
   }
   .rankings-mobile-source-val {
@@ -2183,7 +2189,9 @@ input[type="range"]:focus-visible::-moz-range-thumb {
      padding lets 3 chips fit per row at 288px instead of 2. */
   .rankings-mobile-sources {
     max-width: calc(100vw - 20px);
-    font-size: 0.6rem;
+    /* V1-109 / W26-F017: was 0.6rem (9.6px, inherited by every chip
+       value in the expanded-row source strip) — 11px floor. */
+    font-size: var(--font-size-2xs, 0.6875rem);
     gap: 3px 5px;
   }
   .rankings-mobile-source-chip {
@@ -2373,7 +2381,8 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 }
 
 .rankings-chip {
-  font-size: 0.56rem;
+  /* V1-109 / W26-F017: was 0.56rem (9px) — 11px design-system floor. */
+  font-size: var(--font-size-2xs, 0.6875rem);
   padding: 1px 5px;
 }
 
@@ -2416,7 +2425,10 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 
 .rankings-value-band {
   display: block;
-  font-size: 0.56rem;
+  /* V1-109 / W26-F017: was 0.56rem — this base rule is the one that
+     actually wins at 390px (source order beats the mobile block above);
+     it shipped 9.0px type on every Value cell. 11px floor. */
+  font-size: var(--font-size-2xs, 0.6875rem);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -2508,7 +2520,11 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 /* ── Action-frame labels (Signal column) ─────────────────────────── */
 .action-label {
   display: inline-block;
-  font-size: 0.58rem;
+  /* V1-109 / W26-F017: was 0.58rem (9.3px) — 11px floor. Renders in the
+     /rankings Signal column (and /edge), so it is part of the
+     three-page micro-type defect even when the current board happens to
+     surface no signals. */
+  font-size: var(--font-size-2xs, 0.6875rem);
   font-weight: 600;
   padding: 1px 6px;
   border-radius: 3px;

--- a/frontend/app/rankings/board.module.css
+++ b/frontend/app/rankings/board.module.css
@@ -420,6 +420,35 @@
   color: var(--text-tertiary);
   display: inline-flex;
   padding: 0 2px;
+  /* Anchor for the mobile hit-area pseudo below. Positioning the button
+     itself changes no layout — the pseudo is the only absolute box. */
+  position: relative;
+}
+/* V1-109 / W26-F017 — the watchlist star measured 17x13px at 390x844,
+   the worst interactive target on /rankings (repeated once per row).
+   The repair is HIT-AREA EXPANSION, not growing the box: row height is
+   load-bearing for the V1-106 windowing (useRowWindow measures real row
+   blocks), so the visual star stays 13px and an invisible, centered
+   pseudo-element carries the touch target instead. 44x44 is the WCAG
+   2.5.5 / iOS HIG target; rows repeat every ~34px, so the topmost-paint
+   rule clips neighbouring zones to roughly row height vertically — the
+   guaranteed floor is WCAG 2.5.8 AA (24x24), which
+   tests/e2e/specs/mobile-touch-targets.spec.js measures with
+   elementFromPoint (a getBoundingClientRect instrument cannot see this
+   repair — see the V1-109 re-measurement doc).
+   Mobile-only on purpose: on a desktop pointer an invisible 44px halo
+   would steal precise clicks aimed at the tail of the player-name
+   button beside it. */
+@media (max-width: 768px) {
+  .watchStar::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 44px;
+    height: 44px;
+    transform: translate(-50%, -50%);
+  }
 }
 .watchStar:hover {
   color: var(--text-primary);
@@ -443,7 +472,10 @@
      depends on what's rendered behind it. */
   color: var(--text-secondary, inherit);
   font-family: var(--font-data);
-  font-size: 0.85em;
+  /* V1-109 / W26-F017: was 0.85em, which computed to 9.2px inside the
+     position badge — below the design system's 11px floor
+     (docs/DESIGN-SYSTEM.md: "no micro-type below --font-size-2xs"). */
+  font-size: var(--font-size-2xs);
 }
 .consensusCell {
   font-family: var(--font-data);

--- a/frontend/app/rosters/page.jsx
+++ b/frontend/app/rosters/page.jsx
@@ -36,6 +36,12 @@ const PAGE_SURFACE = "#131519";
 const POS_TEXT_COLORS = Object.fromEntries(
   Object.entries(POS_GROUP_COLORS).map(([g, c]) => [g, textSafe(c, PAGE_SURFACE)]),
 );
+// V1-109 / W26-F017: /rosters shipped micro-type down to 9.0px at
+// 390x844 — the smallest type of any route in the mobile audit. Every
+// inline size that sat below the design-system floor now rides the token
+// (docs/DESIGN-SYSTEM.md: "no micro-type below --font-size-2xs" = 11px).
+// Pinned by tests/e2e/specs/mobile-type-floor.spec.js.
+const FONT_2XS = "var(--font-size-2xs, 0.6875rem)";
 import AgeCurveOverlay from "@/components/graphs/AgeCurveOverlay";
 import TeamStrengthCard from "@/components/TeamStrengthCard";
 import { useRosterIntelligence } from "@/components/useRosterIntelligence";
@@ -315,7 +321,7 @@ export default function RostersPage() {
         {/* Legend */}
         <div style={{ display: "flex", gap: 10, marginBottom: 10, flexWrap: "wrap" }}>
           {POS_GROUPS.filter((g) => activeGroups.has(g)).map((g) => (
-            <div key={g} style={{ display: "flex", alignItems: "center", gap: 4, fontSize: "0.62rem" }}>
+            <div key={g} style={{ display: "flex", alignItems: "center", gap: 4, fontSize: FONT_2XS }}>
               <div style={{ width: 10, height: 10, borderRadius: 2, background: POS_GROUP_COLORS[g] }} />
               {g}
             </div>
@@ -367,7 +373,7 @@ export default function RostersPage() {
                   <tr key={team.name} style={isMe ? { background: "rgba(200, 56, 3, 0.06)" } : undefined}>
                     <td style={{ fontWeight: 700, ...(isMe ? { color: "var(--cyan)" } : {}) }}>
                       {team.name}
-                      <div style={{ fontSize: "0.58rem", color: "var(--subtext)", fontWeight: 400 }}>
+                      <div style={{ fontSize: FONT_2XS, color: "var(--subtext)", fontWeight: 400 }}>
                         {team.playerCount} players{team.pickCount ? `, ${team.pickCount} picks` : ""}
                       </div>
                     </td>
@@ -390,7 +396,7 @@ export default function RostersPage() {
                                 display: "flex",
                                 alignItems: "center",
                                 justifyContent: "center",
-                                fontSize: "0.56rem",
+                                fontSize: FONT_2XS,
                                 // Same rule as the chips above: the label
                                 // sits ON the mark colour, so the readable
                                 // foreground is computed rather than
@@ -569,7 +575,7 @@ function TradeTargetsCard({ myTeam, teams, groupAvg, onPlayerClick }) {
                   name={t.name}
                   size={22}
                 />
-                <span style={{ color: POS_TEXT_COLORS[needPos], fontFamily: "var(--mono)", fontWeight: 700, width: 28, fontSize: "0.62rem" }}>
+                <span style={{ color: POS_TEXT_COLORS[needPos], fontFamily: "var(--mono)", fontWeight: 700, width: 28, fontSize: FONT_2XS }}>
                   {t.pos}
                 </span>
                 <PlayerNameButton
@@ -606,7 +612,7 @@ function TradeTargetsCard({ myTeam, teams, groupAvg, onPlayerClick }) {
                 name={p.name}
                 size={22}
               />
-              <span style={{ color: POS_TEXT_COLORS[p.group], fontFamily: "var(--mono)", fontWeight: 700, width: 28, fontSize: "0.62rem" }}>
+              <span style={{ color: POS_TEXT_COLORS[p.group], fontFamily: "var(--mono)", fontWeight: 700, width: 28, fontSize: FONT_2XS }}>
                 {p.pos}
               </span>
               <span style={{ flex: 1, fontWeight: 600 }}>{p.name}</span>
@@ -664,7 +670,7 @@ function LeagueEdgeCard({ edges }) {
                   }}
                   title={`Market overvalues ${t.sellCount} of their players`}
                 />
-                <span style={{ fontSize: "0.6rem", color: "var(--red)", fontFamily: "var(--mono)", minWidth: 40 }}>
+                <span style={{ fontSize: FONT_2XS, color: "var(--red)", fontFamily: "var(--mono)", minWidth: 40 }}>
                   {t.sellCount} sell
                 </span>
                 <div
@@ -677,13 +683,13 @@ function LeagueEdgeCard({ edges }) {
                   }}
                   title={`Market undervalues ${t.buyCount} of their players`}
                 />
-                <span style={{ fontSize: "0.6rem", color: "var(--green)", fontFamily: "var(--mono)" }}>
+                <span style={{ fontSize: FONT_2XS, color: "var(--green)", fontFamily: "var(--mono)" }}>
                   {t.buyCount} buy
                 </span>
               </div>
             </div>
             {(t.topSells.length > 0 || t.topBuys.length > 0) && (
-              <div style={{ fontSize: "0.62rem", color: "var(--subtext)", paddingLeft: 100 }}>
+              <div style={{ fontSize: FONT_2XS, color: "var(--subtext)", paddingLeft: 100 }}>
                 {t.topSells.length > 0 && (
                   <span style={{ color: "var(--red)" }}>
                     Overvalued: {t.topSells.map((p) => `${p.name} +${p.pct}%`).join(", ")}
@@ -732,7 +738,7 @@ function WaiverWireCard({ gems, onPlayerClick }) {
               name={p.name}
               size={20}
             />
-            <span style={{ color: POS_TEXT_COLORS[p.pos] || "var(--subtext)", fontWeight: 700, fontFamily: "var(--mono)", fontSize: "0.62rem" }}>
+            <span style={{ color: POS_TEXT_COLORS[p.pos] || "var(--subtext)", fontWeight: 700, fontFamily: "var(--mono)", fontSize: FONT_2XS }}>
               {p.pos}
             </span>
             <PlayerNameButton

--- a/frontend/app/rosters/rosters.css
+++ b/frontend/app/rosters/rosters.css
@@ -80,7 +80,8 @@
 }
 
 .team-strength-facets dt {
-  font-size: 0.62rem;
+  /* V1-109 / W26-F017: was 0.62rem (9.9px) — 11px design-system floor. */
+  font-size: var(--font-size-2xs, 0.6875rem);
   color: var(--subtext);
   text-transform: uppercase;
   letter-spacing: 0.03em;
@@ -129,7 +130,8 @@
 }
 
 .team-strength-unranked-note {
-  font-size: 0.58rem;
+  /* V1-109 / W26-F017: was 0.58rem (9.3px) — 11px design-system floor. */
+  font-size: var(--font-size-2xs, 0.6875rem);
   font-weight: 400;
   color: var(--subtext);
   text-transform: uppercase;

--- a/tests/e2e/specs/mobile-touch-targets.spec.js
+++ b/tests/e2e/specs/mobile-touch-targets.spec.js
@@ -1,0 +1,155 @@
+/**
+ * V1-109 / W26-F017 — the /rankings watchlist star is actually tappable.
+ *
+ * THE DEFECT, measured at 390x844 (evidence/V1-109/RE_MEASUREMENT_2026-08-24.md,
+ * re-reproduced 2026-08-25 on the current tree): the per-row watchlist
+ * star buttons render at 17x13px — the worst interactive targets on
+ * /rankings, repeated once per row, failing not just WCAG 2.5.5 (44x44)
+ * but WCAG 2.5.8 AA (24x24) in BOTH dimensions.
+ *
+ * WHY THE REPAIR IS INVISIBLE TO getBoundingClientRect. Growing the
+ * button would change row height, and row height is load-bearing for the
+ * V1-106 windowing (useRowWindow measures real row blocks) — that row is
+ * VERIFIED and frozen. So the repair is hit-area expansion: a centered,
+ * invisible ::after pseudo-element on the button (board.module.css
+ * .watchStar), which enlarges what a finger can hit without moving a
+ * single laid-out box. The border box stays 17x13, which is exactly why
+ * the V1-109 re-measurement pass declined to ship this without hit-area
+ * instrumentation: a rect-based instrument cannot tell the repair from a
+ * no-op.
+ *
+ * THE INSTRUMENT, therefore: document.elementFromPoint. From each star's
+ * visual center we walk outward 1px at a time along both axes and count
+ * the contiguous span of points that still hit-test to that button (a
+ * point over the pseudo-element resolves to its originating element).
+ * That is the browser's own answer to "where can a tap land", and it sees
+ * pseudo-element hit areas, sibling occlusion and stacking — everything a
+ * rect cannot.
+ *
+ * THE BAR is WCAG 2.5.8 AA (24x24), not 44x44, and that is honest rather
+ * than lenient: board rows repeat every ~34px, so two 44px-tall zones on
+ * adjacent rows necessarily overlap and the later row's zone wins the
+ * contested strip. The pseudo-element is 44x44; the GUARANTEED effective
+ * area is 44 wide by ~row-height tall. Asserting 44x44 effective would
+ * demand taller rows — the exact change V1-106 forbids.
+ *
+ * Cross-row integrity travels with the expansion: each star's own center
+ * must still resolve to that star, so one row's enlarged zone may never
+ * swallow its neighbour's control (the failure mode where every tap
+ * toggles the wrong player).
+ */
+const { test, expect } = require("../helpers/auth-fixture");
+const { gotoRankingsBoard } = require("../helpers/journey");
+
+const MOBILE = { width: 390, height: 844 };
+const MIN_HIT_PX = 24; // WCAG 2.5.8 AA — see header for why not 44.
+const STARS_TO_MEASURE = 3;
+
+/**
+ * Runs IN the page. For up to `max` watchlist-star buttons fully inside
+ * the viewport, measures the contiguous hit-test extent through the
+ * button's visual center along both axes.
+ */
+const MEASURE_STARS = (max) => {
+  const hits = (btn, x, y) => {
+    const el = document.elementFromPoint(x, y);
+    return el === btn || btn.contains(el);
+  };
+  const stars = Array.from(
+    document.querySelectorAll('button[aria-label$="watchlist"]'),
+  ).filter((btn) => {
+    const r = btn.getBoundingClientRect();
+    // Fully on-screen with margin for the probe walk, and below any
+    // pinned header chrome.
+    return (
+      r.width > 0 &&
+      r.height > 0 &&
+      r.left > 50 &&
+      r.right < window.innerWidth - 50 &&
+      r.top > 150 &&
+      r.bottom < window.innerHeight - 150
+    );
+  });
+  const out = [];
+  for (const btn of stars.slice(0, max)) {
+    const r = btn.getBoundingClientRect();
+    const cx = r.left + r.width / 2;
+    const cy = r.top + r.height / 2;
+    const centerHits = hits(btn, cx, cy);
+    let left = 0;
+    let right = 0;
+    let up = 0;
+    let down = 0;
+    if (centerHits) {
+      // Contiguous runs, capped at 40px per direction (the pseudo is 44).
+      while (left < 40 && hits(btn, cx - (left + 1), cy)) left++;
+      while (right < 40 && hits(btn, cx + (right + 1), cy)) right++;
+      while (up < 40 && hits(btn, cx, cy - (up + 1))) up++;
+      while (down < 40 && hits(btn, cx, cy + (down + 1))) down++;
+    }
+    out.push({
+      label: (btn.getAttribute("aria-label") || "").slice(0, 50),
+      rect: { w: Math.round(r.width), h: Math.round(r.height) },
+      centerHits,
+      hitW: left + right + 1,
+      hitH: up + down + 1,
+    });
+  }
+  return out;
+};
+
+test.describe("mobile 390px: rankings watchlist stars have a real hit area", () => {
+  test.use({ viewport: MOBILE, isMobile: true, hasTouch: true });
+
+  test("/rankings — each star's effective (elementFromPoint) hit area is at least 24x24", async ({
+    authedPage,
+  }) => {
+    await authedPage.setViewportSize(MOBILE);
+    await gotoRankingsBoard(authedPage);
+
+    // At 390px the header + controls fill the first screen and the board's
+    // rows start below the fold (measured: first star at y=1161 in an
+    // 844px viewport). elementFromPoint only answers for on-screen points,
+    // so bring the rows to the middle of the viewport first, then give the
+    // V1-106 windowing a beat to settle the newly mounted rows.
+    await authedPage.evaluate(() => {
+      const el = document.querySelector('button[aria-label$="watchlist"]');
+      if (el) el.scrollIntoView({ block: "center" });
+    });
+    await authedPage.waitForTimeout(600);
+
+    const stars = await authedPage.evaluate(MEASURE_STARS, STARS_TO_MEASURE);
+
+    // Non-vacuity: a board with no measurable stars proves nothing. The
+    // windowed board mounts ~40 rows, each with a star; if none qualify
+    // the page (or the selector) has changed and this test must say so
+    // rather than pass on an empty sample.
+    expect(
+      stars.length,
+      "expected at least " +
+        `${STARS_TO_MEASURE} watchlist star buttons fully in the viewport — ` +
+        "an empty sample would make this test vacuous",
+    ).toBeGreaterThanOrEqual(STARS_TO_MEASURE);
+
+    for (const s of stars) {
+      // Specificity: the star's own center resolves to that star. This is
+      // both the non-vacuous half of the probe and the guard against one
+      // row's expanded zone swallowing its neighbour's control.
+      expect(
+        s.centerHits,
+        `${s.label}: the button's own center does not hit-test to it — ` +
+          "something is stacked over the control",
+      ).toBe(true);
+      expect(
+        s.hitW,
+        `${s.label}: effective hit width ${s.hitW}px < ${MIN_HIT_PX}px ` +
+          `(border box ${s.rect.w}x${s.rect.h}) — the 17x13 star defect (W26-F017)`,
+      ).toBeGreaterThanOrEqual(MIN_HIT_PX);
+      expect(
+        s.hitH,
+        `${s.label}: effective hit height ${s.hitH}px < ${MIN_HIT_PX}px ` +
+          `(border box ${s.rect.w}x${s.rect.h}) — the 17x13 star defect (W26-F017)`,
+      ).toBeGreaterThanOrEqual(MIN_HIT_PX);
+    }
+  });
+});

--- a/tests/e2e/specs/mobile-type-floor.spec.js
+++ b/tests/e2e/specs/mobile-type-floor.spec.js
@@ -1,0 +1,177 @@
+/**
+ * V1-109 / W26-F017 — "type as small as 9.0px ships on three pages".
+ *
+ * THE DEFECT, measured at 390x844 (evidence/V1-109/RE_MEASUREMENT_2026-08-24.md,
+ * re-reproduced 2026-08-25 on the current tree):
+ *
+ *   /rankings  9.0px x~36 (value bands, chips) + 9.2px (position ranks)
+ *   /rosters   9.0-9.9px (portfolio bar labels, legend, buy/sell counts)
+ *   /draft     9.3px x72 ("NEED" chips)
+ *
+ * The re-measurement pass recorded this WITHOUT repairing it because the
+ * type scale was a token decision gated on owner decision OD-05. OD-05 is
+ * RESOLVED (2026-08-18, docs/DESIGN-SYSTEM.md) and V1-110 shipped the
+ * ramp: an 8-step scale whose floor is --font-size-2xs = 11px, with the
+ * explicit rule "no micro-type below --font-size-2xs". The repair raises
+ * every sub-10px size on these three routes onto that token.
+ *
+ * THE ASSERTION BAR is 10px, not 11px, and the difference is deliberate:
+ * the audit's own verdict drew the defect line at the ~9px band — /trade
+ * ships 10.2px type and was NOT named a type-floor defect page. The
+ * legacy 0.66/0.68rem sizes (10.56/10.88px) are app-wide conventions
+ * whose migration onto the ramp is V1-110's per-page R-phase work, not
+ * this defect. Everything this repair TOUCHED sits at 11px; what this
+ * test forbids is any visible text below 10px — i.e. the micro-type
+ * class the audit named — ever shipping on these routes again.
+ *
+ * THE CONTROL: the probe is exercised against known geometry first (a
+ * page with one 9px span). An instrument that cannot see a 9px span
+ * would make every route below pass vacuously — the repo has been burned
+ * by an instrument measuring itself before (#760), so the self-check is
+ * not optional. Same posture as measure-mobile-usability.mjs.
+ */
+const { test, expect } = require("../helpers/auth-fixture");
+const {
+  pageUrl,
+  gotoRankingsBoard,
+  awaitStreamSettled,
+} = require("../helpers/journey");
+
+const MOBILE = { width: 390, height: 844 };
+const MIN_FONT_PX = 10; // the audit's defect line — see header.
+
+/**
+ * Runs IN the page. Returns every visible element that renders its own
+ * text below `minPx`, plus the count of text elements checked (so a page
+ * that never rendered cannot read as clean — MISSING IS NEVER ZERO).
+ */
+const SCAN_TYPE = (minPx) => {
+  const isHidden = (el) => {
+    if (el.closest('[aria-hidden="true"]')) return true;
+    const s = getComputedStyle(el);
+    if (s.display === "none" || s.visibility === "hidden" || Number(s.opacity) === 0)
+      return true;
+    const r = el.getBoundingClientRect();
+    return r.width === 0 || r.height === 0;
+  };
+  const offenders = [];
+  let checked = 0;
+  for (const el of document.querySelectorAll("body *")) {
+    if (isHidden(el)) continue;
+    const hasOwnText = Array.from(el.childNodes).some(
+      (n) => n.nodeType === 3 && n.textContent.trim().length > 0,
+    );
+    if (!hasOwnText) continue;
+    checked += 1;
+    const px = parseFloat(getComputedStyle(el).fontSize);
+    if (!Number.isFinite(px) || px >= minPx) continue;
+    offenders.push({
+      px: Math.round(px * 10) / 10,
+      el: `${el.tagName.toLowerCase()}.${String(el.className || "")
+        .trim()
+        .split(/\s+/)
+        .slice(0, 2)
+        .join(".")}`,
+      sample: el.textContent.trim().slice(0, 30),
+    });
+  }
+  // Collapse per (px, el) so a per-row offender reports once with a count.
+  const grouped = new Map();
+  for (const o of offenders) {
+    const key = `${o.px}|${o.el}`;
+    if (!grouped.has(key)) grouped.set(key, { ...o, count: 0 });
+    grouped.get(key).count += 1;
+  }
+  return { checked, offenders: Array.from(grouped.values()) };
+};
+
+function offendersMessage(route, result) {
+  const lines = result.offenders
+    .map((o) => `  ${o.px}px x${o.count}  ${o.el}  "${o.sample}"`)
+    .join("\n");
+  return (
+    `${route} ships text below ${MIN_FONT_PX}px at 390x844 (W26-F017):\n` +
+    `${lines}\n` +
+    "The design-system floor is --font-size-2xs (11px, docs/DESIGN-SYSTEM.md); " +
+    "raise the offending size onto the token."
+  );
+}
+
+async function scanRoute(page, route) {
+  const result = await page.evaluate(SCAN_TYPE, MIN_FONT_PX);
+  // Non-vacuity: every one of these routes renders hundreds of text
+  // elements; a near-empty scan means the page never reached a useful
+  // state, and "0 offenders on a page that did not render" must not read
+  // as a clean result.
+  expect(
+    result.checked,
+    `${route}: only ${result.checked} text elements were measurable — ` +
+      "the page did not render enough to make this scan meaningful",
+  ).toBeGreaterThan(50);
+  expect(result.offenders, offendersMessage(route, result)).toEqual([]);
+}
+
+test.describe("mobile 390px: no micro-type below the audit's defect line", () => {
+  test.use({ viewport: MOBILE, isMobile: true, hasTouch: true });
+
+  test("the probe flags known-bad geometry (control)", async ({ page }) => {
+    // The viewport meta matters: without it, mobile-emulated Chromium
+    // lays the page out at 980px and text autosizing can inflate the 9px
+    // span past the threshold — the control would then fail for a reason
+    // that says nothing about the probe (same meta the
+    // measure-mobile-usability.mjs control carries).
+    await page.setContent(
+      '<meta name="viewport" content="width=device-width">' +
+        '<main><span style="font-size:9px">tiny</span><p>normal text</p>' +
+        `${'<p>filler</p>'.repeat(60)}</main>`,
+    );
+    const result = await page.evaluate(SCAN_TYPE, MIN_FONT_PX);
+    expect(result.checked).toBeGreaterThan(50);
+    expect(result.offenders).toHaveLength(1);
+    expect(result.offenders[0].px).toBe(9);
+  });
+
+  test("/rankings — no visible text below 10px", async ({ authedPage }) => {
+    await authedPage.setViewportSize(MOBILE);
+    await gotoRankingsBoard(authedPage);
+    await scanRoute(authedPage, "/rankings");
+  });
+
+  test("/rosters — no visible text below 10px", async ({ authedPage }) => {
+    await authedPage.setViewportSize(MOBILE);
+    await authedPage.goto(pageUrl("/rosters"), { waitUntil: "domcontentloaded" });
+    await awaitStreamSettled(authedPage);
+    await expect(authedPage.locator("main table").first()).toBeVisible({
+      timeout: 60_000,
+    });
+    await scanRoute(authedPage, "/rosters");
+  });
+
+  test("/draft — no visible text below 10px", async ({ authedPage }) => {
+    await authedPage.setViewportSize(MOBILE);
+    await authedPage.goto(pageUrl("/draft"), { waitUntil: "domcontentloaded" });
+    await awaitStreamSettled(authedPage);
+    await expect(authedPage.locator("main table").first()).toBeVisible({
+      timeout: 60_000,
+    });
+    // The page's smallest type (the per-row "NEED" chips, 9.3px x72 in the
+    // pre-repair measurement) mounts AFTER the first table renders, once
+    // the roster-need computation lands. Scanning at first-table-visible
+    // measured a page state where the offenders did not exist yet — a
+    // pass that proves nothing. Settle the way the mobile-usability
+    // instrument does (network idle + a beat), then best-effort wait for
+    // the chips themselves; the .catch keeps a board that legitimately
+    // has no roster needs from failing the wait, since the scan below is
+    // still a valid (if weaker) statement about whatever rendered.
+    await authedPage
+      .waitForLoadState("networkidle", { timeout: 30_000 })
+      .catch(() => {});
+    await authedPage
+      .locator(".draft-need-chip-row")
+      .first()
+      .waitFor({ timeout: 15_000 })
+      .catch(() => {});
+    await authedPage.waitForTimeout(1200);
+    await scanRoute(authedPage, "/draft");
+  });
+});


### PR DESCRIPTION
## What

`V1-109` (inventory 9.3 / MFB-67 / MFB-93) inherited four named mobile defects. `#1086` closed two (/trade tray↔FAB occlusion fixed and mutation-proved; /draft stacking no longer reproduces). This PR fixes the remaining two, both re-reproduced on the current tree before repair (`docs/master-site-audit/evidence/V1-109/mobile-390-2026-08-25-pre-repair.json`, production build, real backend, 390×844).

Both blockers the 2026-08-24 re-measurement recorded have resolved since: **OD-05 is decided** (`docs/DESIGN-SYSTEM.md`, V1-110 `VERIFIED` with the 11px `--font-size-2xs` floor), and the **hit-area instrumentation** the touch-target repair needed now exists in this PR's E2E spec.

## Defect 1 — /rankings watchlist stars at 17×13px (W26-F017)

The worst interactive targets on the page — per-row, under WCAG 2.5.8 AA (24×24) in both dimensions. Growing the button would change row height, which `V1-106`'s windowing froze, so the repair is **hit-area expansion**: an invisible, centered 44×44 `::after` on `.watchStar` at ≤768px (`frontend/app/rankings/board.module.css`). No laid-out box moves.

Measured with `document.elementFromPoint` (the browser's own answer to "where can a tap land" — a rect instrument structurally cannot see this repair): effective hit area **18×14px → 44 wide × 33–44 tall** (vertical extent clipped by the adjacent row's zone, which is why the spec's guaranteed bar is the 24×24 AA floor, plus a cross-row integrity check that each star's center still resolves to its own star).

Pinned by `tests/e2e/specs/mobile-touch-targets.spec.js`.

## Defect 2 — type as small as 9.0px on /rankings, /rosters, /draft (W26-F017)

Every live sub-10px size on the three routes raised onto the design-system floor `var(--font-size-2xs)` (11px): rankings value bands (both the mobile rule and the base rule that actually wins on source order), chips, `posRank` (0.85em → 9.2px), the expanded-row mobile source strip, `.action-label`; draft `NEED` chips and the inline "mine" tag; the nine sub-10px inline sizes plus two CSS rules on /rosters.

Measured smallest visible type: **9.0 / 9.0 / 9.3 → 10.9 / 10.6 / 10.6 px**. The remainder is the app-wide legacy 0.66/0.68rem band — same as /trade's 10.2px, which the audit accepted — whose migration onto the ramp is V1-110 R-phase scope. The spec therefore asserts the audit's own 10px defect line (with a known-geometry control so a probe that cannot see a 9px span voids the run).

Pinned by `tests/e2e/specs/mobile-type-floor.spec.js`.

## Mutation proof (real production builds, both directions)

Fixes reverted → rebuild → run:

```
✘ mobile-touch-targets /rankings — effective hit width 18px < 24px (border box 17x13)
✘ mobile-type-floor /rankings   — 9px x15 rankings-value-band, 9.2px x30 posRank, …
✘ mobile-type-floor /rosters    — 9px x54 "QB 25k", 9.3px x12, 9.6px x24, 9.9px …
✘ mobile-type-floor /draft      — 9.3px x72 draft-need-chip-row "NEED"
✓ control — the probe itself stays valid
```

Fixes restored → rebuild → **5/5 GREEN**, in both `mobile-chromium` and `desktop-1366` projects. The red run caught a vacuity in the /draft leg (NEED chips mount after the first table renders; the spec now settles the way `measure-mobile-usability.mjs` does before scanning) — fixed in the spec, re-proved red, then green.

## Gates run locally

- Frontend vitest: **2363/2363** across 160 files
- New E2E: **5/5** in both projects; existing `mobile-pinned-overlap` + `mobile-smoke`: 4/4; `a11y-axe`: 10/10
- Production build green, **all 14 bundle budgets under**
- Full record: `docs/master-site-audit/evidence/V1-109/REPAIR_2026-08-25.md` + pre/post instrument JSONs

No status column edited; V1-109's required L4 is a production-consumer statement and stays Integration's call.

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_