### PR TITLE
V1-76: one canonical failure-attribution vocabulary

### DIFF
--- a/frontend/__tests__/components/source-health-strip.test.jsx
+++ b/frontend/__tests__/components/source-health-strip.test.jsx
@@ -349,3 +349,120 @@ describe("SourceHealthStrip · run failures it cannot attribute (F-12)", () => {
     expect(document.body.textContent).toMatch(/matched by key/);
   });
 });
+
+// The server now speaks ONE vocabulary (F-12 / census S-2 / V1-76).
+//
+// ``server._source_health`` resolves each run-named failure to the
+// registry keys it concerns via its single
+// ``registry_keys_for_run_source`` owner, and publishes them as
+// ``source_failures[].registryKeys`` plus the ``*_source_keys``
+// registry-key projections of the run-state lists.  The frontend needed
+// no mapping of its own — it consumes the resolved keys.  A failure that
+// round-trips to a rendered row now LIGHTS THAT ROW (not the
+// unattributable panel); a failure that resolves to nothing (an
+// unverified run name, fail-closed) is still shown verbatim as
+// unattributable.
+describe("SourceHealthStrip · server-resolved attribution (F-12 / V1-76)", () => {
+  /** The resolved shape: run-named failures carry their registry keys,
+      and run-state lists carry a registry-key projection. */
+  const RESOLVED = {
+    source_health: {
+      source_runtime: {
+        overall_status: "partial",
+        enabled_sources: ["KTC", "IDPTradeCalc"],
+        failed_sources: ["KTC"],
+        failed_source_keys: ["ktcSfTep"],
+        partial_sources: ["DLF_LocalCSV"],
+        partial_source_keys: ["dlfSf"],
+        timed_out_sources: [],
+        timed_out_source_keys: [],
+        finished_at: new Date().toISOString(),
+      },
+      registered_sources: ["ktcSfTep", "idpTradeCalc", "dlfSf"],
+      source_counts: { ktcSfTep: 502, idpTradeCalc: 911, dlfSf: 400 },
+      unmeasured_sources: [],
+      sources: {
+        ktcSfTep: { lastFetched: new Date().toISOString(), ageHours: 0.2 },
+        idpTradeCalc: { lastFetched: new Date().toISOString(), ageHours: 0.2 },
+        dlfSf: { lastFetched: new Date().toISOString(), ageHours: 0.2 },
+      },
+      source_failures: [
+        {
+          source: "KTC",
+          reason: "failed",
+          registryKeys: ["ktcSfTep"],
+          details: { message: "KTC blocked: cloudflare challenge" },
+        },
+        {
+          source: "DLF_LocalCSV",
+          reason: "partial",
+          registryKeys: ["dlfSf"],
+          details: { message: "source completed with zero mapped values" },
+        },
+      ],
+      missing_sources: [],
+    },
+  };
+
+  it("lights the resolved rows instead of stranding the failures", async () => {
+    mockStatus({ body: RESOLVED });
+    const { container } = render(<SourceHealthStrip variant="page" />);
+    await waitFor(() => expect(screen.getByRole("region")).toBeTruthy());
+    screen.getByRole("button").click();
+
+    // KTC failed -> ktcSfTep row down; DLF_LocalCSV partial -> dlfSf row warn.
+    await waitFor(() =>
+      expect(container.querySelectorAll(".source-health-row--down").length).toBe(1),
+    );
+    expect(container.querySelectorAll(".source-health-row--warn").length).toBe(1);
+    // ...and the resolved failure reason reaches the row it lit up.
+    expect(document.body.textContent).toMatch(/cloudflare challenge/);
+    expect(document.body.textContent).toMatch(/zero mapped values/);
+  });
+
+  it("does not double-report a resolved failure as unattributable", async () => {
+    mockStatus({ body: RESOLVED });
+    const { container } = render(<SourceHealthStrip variant="page" />);
+    await waitFor(() => expect(screen.getByRole("region")).toBeTruthy());
+    screen.getByRole("button").click();
+
+    await waitFor(() =>
+      expect(container.querySelectorAll(".source-health-row").length).toBe(3),
+    );
+    // Every failure attributed to a row -> the unattributable panel is empty.
+    expect(
+      container.querySelectorAll(".source-health-unattributed-row").length,
+    ).toBe(0);
+  });
+
+  it("still strands a failure that resolves to no registered row", async () => {
+    // Fail-closed: an unverified run name carries empty registryKeys and
+    // no key projection, so it cannot be pinned to a row and stays
+    // visible under its own name.
+    const body = JSON.parse(JSON.stringify(RESOLVED));
+    body.source_health.source_runtime.failed_sources = ["SomethingWeNeverRan"];
+    body.source_health.source_runtime.failed_source_keys = [];
+    body.source_health.source_runtime.partial_sources = [];
+    body.source_health.source_runtime.partial_source_keys = [];
+    body.source_health.source_failures = [
+      {
+        source: "SomethingWeNeverRan",
+        reason: "failed",
+        registryKeys: [],
+        details: { message: "mystery outage" },
+      },
+    ];
+    mockStatus({ body });
+    const { container } = render(<SourceHealthStrip variant="page" />);
+    await waitFor(() => expect(screen.getByRole("region")).toBeTruthy());
+    screen.getByRole("button").click();
+
+    await waitFor(() =>
+      expect(
+        container.querySelectorAll(".source-health-unattributed-row").length,
+      ).toBe(1),
+    );
+    expect(container.querySelectorAll(".source-health-row--down").length).toBe(0);
+    expect(document.body.textContent).toMatch(/mystery outage/);
+  });
+});

--- a/frontend/components/SourceHealthStrip.jsx
+++ b/frontend/components/SourceHealthStrip.jsx
@@ -55,16 +55,21 @@ function ageLabel(iso) {
 
 // Per-row tone.
 //
-// The two membership tests are kept and are CORRECT — they simply do not
-// fire on today's payload, because the two sides speak different
-// vocabularies (see attributionSplit below).  Left in place rather than
-// deleted so that the day run state is published in registry keys, rows
-// light up without touching this component.  What must not happen is a
-// reader assuming they work now: they are pinned by a test either way.
+// ``source`` is a registry key (a rendered row).  Run state arrives from
+// the scraper in run-name space, so the server (F-12 / V1-76) now
+// projects each run-state list into registry-key space beside the
+// run-name original — ``failed_source_keys`` alongside ``failed_sources``
+// — using its single ``registry_keys_for_run_source`` owner.  We consult
+// the KEY-space list first (the join that actually fires on real data)
+// and keep the run-name list as a fallback for the forward-compatible
+// case where the backend already publishes run state in registry keys.
 function toneFor(source, runtime, ageHours) {
-  // Hard signals first.
+  // Hard signals first — key-space projection, then the run-name list.
+  if (runtime?.failed_source_keys?.includes(source)) return "down";
   if (runtime?.failed_sources?.includes(source)) return "down";
+  if (runtime?.partial_source_keys?.includes(source)) return "warn";
   if (runtime?.partial_sources?.includes(source)) return "warn";
+  if (runtime?.timed_out_source_keys?.includes(source)) return "down";
   if (runtime?.timed_out_sources?.includes(source)) return "down";
   // Age-based fallback.  NOTE this is FRESHNESS, not run state: a failed
   // fetch normally leaves the previous CSV in place, so a recent file
@@ -95,20 +100,36 @@ function toneFor(source, runtime, ageHours) {
 // both vocabularies (``server._source_health``) — inventing one here
 // would make this component a second owner of it.
 //
-// So this does the part that needs no mapping: it stops throwing the
-// unmatched failures away.  They are reported under their own names,
-// with the run's own reason, and labelled as unattributable — which is
-// the honest state, and is not the same as "everything is fine".
+// So this does the part that needs no mapping IN THE FRONTEND: the
+// server (F-12 / V1-76) resolves each run-named failure to the registry
+// keys it concerns and stamps them as ``registryKeys``, using its single
+// ``registry_keys_for_run_source`` owner.  A failure whose resolved keys
+// name a rendered row is ATTRIBUTED — it lights that row up via
+// ``toneFor`` and is dropped from this panel.  A failure that resolves to
+// nothing (an unverified run name, fail-closed) still cannot be pinned to
+// a row, so it is reported under its own name, with the run's own reason,
+// and labelled unattributable — the honest state, not "everything fine".
 function attributionSplit(health, runtime, rowSources) {
   const known = new Set(rowSources);
+  const attributable = (keys) =>
+    Array.isArray(keys) && keys.some((k) => known.has(k));
   const failures = Array.isArray(health?.source_failures)
     ? health.source_failures
     : [];
   const seen = new Set();
+  // Run names the server DID attribute to a rendered row — recorded so
+  // the belt-and-braces pass below does not re-report them as orphans.
+  const attributed = new Set();
   const unattributed = [];
   for (const f of failures) {
     const name = f?.source;
-    if (!name || known.has(name) || seen.has(name)) continue;
+    // Attributed when the run name itself is a rendered row, OR the
+    // server resolved it to registry keys that are.
+    if (name && (known.has(name) || attributable(f?.registryKeys))) {
+      attributed.add(name);
+      continue;
+    }
+    if (!name || seen.has(name)) continue;
     // The field is ``reason``, not ``kind``.  ``server._push_failure``
     // appends ``{source, reason, details}`` — reading ``kind`` meant the
     // fallback fired on EVERY row, so a PARTIAL source rendered as a hard
@@ -133,7 +154,8 @@ function attributionSplit(health, runtime, rowSources) {
     ["partial_sources", "partial"],
   ]) {
     for (const name of Array.isArray(runtime?.[key]) ? runtime[key] : []) {
-      if (!name || known.has(name) || seen.has(name)) continue;
+      if (!name || known.has(name) || attributed.has(name) || seen.has(name))
+        continue;
       seen.add(name);
       unattributed.push({ source: name, kind, reason: null });
     }
@@ -227,8 +249,14 @@ export default function SourceHealthStrip({ variant = "inline" }) {
         ageLabel: ageLbl,
         ageHours: srcAgeHours,
         failedReason:
+          // ``src`` is a registry key; a failure names a run source and
+          // (F-12 / V1-76) carries the registry keys it resolved to, so
+          // match on either — otherwise a DLF_LocalCSV failure's reason
+          // never reaches the ``dlfSf`` row it lit up.
           (health.source_failures || []).find(
-            (f) => f.source === src,
+            (f) =>
+              f.source === src ||
+              (Array.isArray(f.registryKeys) && f.registryKeys.includes(src)),
           )?.details?.message || null,
       };
     });

--- a/server.py
+++ b/server.py
@@ -1738,6 +1738,30 @@ def _build_source_health_snapshot(
         else:
             missing.append(key)
 
+    # F-12 / V1-76: the ONE resolver from a scraper RUN name to the
+    # canonical registry keys it concerns.  Failures arrive named in the
+    # scraper's run-name vocabulary (``KTC``, ``DLF_LocalCSV`` …) while
+    # every population/coverage field here is registry-keyed
+    # (``ktcSfTep``, ``dlfSf`` …), so a failure could not be joined back
+    # to its rows.  Resolving here — the one seam that holds both
+    # vocabularies — is what the health surface delegates to rather than
+    # inventing a second owner of source identity.  Fails closed: an
+    # unrecognised run name resolves to ``[]`` and stays unattributed.
+    try:
+        from src.api.data_contract import registry_keys_for_run_source
+    except Exception:  # pragma: no cover - resolver import failure
+
+        def registry_keys_for_run_source(_run_source: str) -> list[str]:
+            return []
+
+    def _registry_keys_for_run_names(names: list) -> list[str]:
+        out: list[str] = []
+        for n in names:
+            for k in registry_keys_for_run_source(str(n)):
+                if k not in out:
+                    out.append(k)
+        return out
+
     failures: list[dict] = []
     seen_failures: set[tuple[str, str, str]] = set()
 
@@ -1755,6 +1779,11 @@ def _build_source_health_snapshot(
                 "source": src,
                 "reason": rsn,
                 "details": d,
+                # The canonical registry keys this run-named failure
+                # concerns, so the health surface can join it back to its
+                # rows.  Empty when the run name resolves to nothing —
+                # fail closed, do not guess a row.
+                "registryKeys": registry_keys_for_run_source(src),
             }
         )
 
@@ -1857,6 +1886,16 @@ def _build_source_health_snapshot(
             "partial_sources": sorted([str(s) for s in partial_sources]),
             "timed_out_sources": sorted([str(s) for s in timed_out_sources]),
             "failed_sources": sorted([str(s) for s in failed_sources]),
+            # F-12 / V1-76: the same lists projected into registry-key
+            # space, so a health row (registry-keyed) can light up from
+            # run state on its own.  Additive — the run-name lists above
+            # are retained as provenance.  Empty entries fail closed: a
+            # run name that resolves to no registered key contributes
+            # nothing here and stays visible under its own name in
+            # ``source_failures``.
+            "failed_source_keys": sorted(_registry_keys_for_run_names(failed_sources)),
+            "partial_source_keys": sorted(_registry_keys_for_run_names(partial_sources)),
+            "timed_out_source_keys": sorted(_registry_keys_for_run_names(timed_out_sources)),
         }
 
     if not partial_run:

--- a/src/api/data_contract.py
+++ b/src/api/data_contract.py
@@ -1148,6 +1148,59 @@ def critical_primary_for_run_source(run_source: str) -> str | None:
     return None
 
 
+def _run_source_names_match(reported: str, declared: str) -> bool:
+    """True if a REPORTED run name and a DECLARED one are the same identity.
+
+    The same qualifier rule :func:`critical_primary_for_run_source` uses —
+    exact match, or ``<primary>_<qualifier>`` in EITHER direction — so a
+    primary name (``DLF``) and its transport-qualified form
+    (``DLF_LocalCSV``) are never two incomparable labels.
+    """
+    if not reported or not declared:
+        return False
+    if reported == declared:
+        return True
+    return reported.startswith(declared + "_") or declared.startswith(reported + "_")
+
+
+def registry_keys_for_run_source(run_source: str) -> list[str]:
+    """Registry keys a scraper RUN name governs, in registry order.
+
+    The single resolver from a ``sourceRunSummary`` run name to the
+    canonical ranking-registry keys it concerns (F-12 / census S-2 /
+    V1-76).  Where :func:`critical_primary_for_run_source` answers "is
+    this run name a CRITICAL primary" for the contract-health gate, this
+    answers "which registry ROWS does this run name concern" for the
+    health surface — the same vocabulary problem, one step further.
+
+    The mapping is DECLARED on each :data:`_RANKING_SOURCES` entry's
+    ``run_source`` field — the registry is the source-identity owner, so
+    this reads that owner rather than keeping a second parallel table.
+    It is declared only where the in-process Dynasty Scraper run governs
+    the source (the only run names that can reach
+    ``sourceRunSummary``): ``KTC`` → ``ktcSfTep``, ``IDPTradeCalc`` →
+    ``idpTradeCalc``, and ``DLF_LocalCSV`` → the four DLF boards it loads
+    from local CSVs (V1-80 / F-17).  A registry key fetched by its own
+    ``scripts/`` timer declares no ``run_source`` and a scrape-run
+    failure can never name it.
+
+    Returns ``[]`` when no registered source declares this run name: the
+    fail-closed state, so an unverified failure stays unattributed rather
+    than being pinned to a guessed row.  MISSING IS NEVER a wrong guess.
+    """
+    name = str(run_source or "").strip()
+    if not name:
+        return []
+    out: list[str] = []
+    for src in _RANKING_SOURCES:
+        declared = str(src.get("run_source") or "").strip()
+        if declared and _run_source_names_match(name, declared):
+            key = str(src.get("key") or "")
+            if key and key not in out:
+                out.append(key)
+    return out
+
+
 def _build_source_timestamps() -> dict[str, dict[str, Any]]:
     """Return per-source freshness block with mtimes + staleness flags.
 
@@ -1348,6 +1401,12 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # finder + per-source winner row on /trade can keep displaying
         # both values side-by-side.  Only the blend vote was removed.
         "key": "ktcSfTep",
+        # F-12 / V1-76: the Dynasty Scraper run name that governs this
+        # board, so a ``sourceRunSummary`` failure round-trips to this
+        # registry key (``registry_keys_for_run_source``).  Declared only
+        # where the in-process scraper run produces the source; keys
+        # fetched by their own ``scripts/`` timer omit it and fail closed.
+        "run_source": "KTC",
         # C1-SRC-02: DYNASTY is PROVEN per endpoint, never inferred from the
         # provider being one we otherwise trust.  UNKNOWN fails closed.
         "game_type": GAME_TYPE_DYNASTY,
@@ -1381,6 +1440,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # row sets (offense vs IDP positions), so sourceRanks["idpTradeCalc"]
         # is written exactly once per row.
         "key": "idpTradeCalc",
+        "run_source": "IDPTradeCalc",  # F-12 / V1-76 (see ktcSfTep)
         # C1-SRC-02: DYNASTY is PROVEN per endpoint, never inferred from the
         # provider being one we otherwise trust.  UNKNOWN fails closed.
         "game_type": GAME_TYPE_DYNASTY,
@@ -1435,6 +1495,10 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # preventing false 1-src flags on fringe offense players
         # that DLF SF was never going to list.
         "key": "dlfSf",
+        # F-12 / V1-76: the scraper loads all four DLF boards under the
+        # single run name ``DLF_LocalCSV`` (V1-80 / F-17), so a DLF run
+        # failure round-trips to every DLF registry key.
+        "run_source": "DLF_LocalCSV",
         # C1-SRC-02: DYNASTY is PROVEN per endpoint, never inferred from the
         # provider being one we otherwise trust.  UNKNOWN fails closed.
         "game_type": GAME_TYPE_DYNASTY,
@@ -1480,6 +1544,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # weight scales contribution down so the rookie board never
         # overwhelms the veteran-rich retail/expert blend.
         "key": "dlfRookieSf",
+        "run_source": "DLF_LocalCSV",  # F-12 / V1-76 (see dlfSf)
         # C1-SRC-02: DYNASTY is PROVEN per endpoint, never inferred from the
         # provider being one we otherwise trust.  UNKNOWN fails closed.
         "game_type": GAME_TYPE_DYNASTY,
@@ -1529,6 +1594,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # the best IDP in the shared market (typically ~30-50), which
         # correctly calibrates DLF against the retail offense market.
         "key": "dlfIdp",
+        "run_source": "DLF_LocalCSV",  # F-12 / V1-76 (see dlfSf)
         # C1-SRC-02: DYNASTY is PROVEN per endpoint, never inferred from the
         # provider being one we otherwise trust.  UNKNOWN fails closed.
         "game_type": GAME_TYPE_DYNASTY,
@@ -1567,6 +1633,7 @@ _RANKING_SOURCES: list[dict[str, Any]] = [
         # translated against IDPTC's ladder.  depth=50 matches the
         # typical export size.
         "key": "dlfRookieIdp",
+        "run_source": "DLF_LocalCSV",  # F-12 / V1-76 (see dlfSf)
         # C1-SRC-02: DYNASTY is PROVEN per endpoint, never inferred from the
         # provider being one we otherwise trust.  UNKNOWN fails closed.
         "game_type": GAME_TYPE_DYNASTY,

--- a/tests/api/test_failure_attribution_vocabulary.py
+++ b/tests/api/test_failure_attribution_vocabulary.py
@@ -1,0 +1,165 @@
+"""Failure attribution speaks ONE vocabulary (F-12 / census S-2 / V1-76).
+
+The scraper's ``sourceRunSummary`` names a source by its RUN name — the
+``source_enabled_map`` key in ``Dynasty Scraper.py`` (``KTC``,
+``IDPTradeCalc``, ``DLF_LocalCSV`` …).  Every population/coverage surface
+in ``data_contract`` speaks the ranking-registry KEY (``ktcSfTep``,
+``idpTradeCalc``, ``dlfSf`` …).  The two vocabularies are disjoint on
+real data — ``"DLF_LocalCSV" != "dlfSf"`` — so a run-level failure could
+not be joined back to the registry rows it concerns.  The health surface
+therefore misattributed or dropped it (audit F-12).
+
+The refuted design (``playerCount: null`` to distinguish "reported zero"
+from "did not report") is NOT resurrected here: it raised ``TypeError``
+at the scrape-promotion ``site_count`` computation and would have marked
+whole scrapes FAILED.  See ``docs/VERSION_1_COMPLETION_CONTRACT.md`` §8.1.
+
+The repair is a single DECLARED mapping owned by the registry (each
+``_RANKING_SOURCES`` entry's ``run_source`` field, resolved by
+``registry_keys_for_run_source``), so a failure disposition ROUND-TRIPS
+from its run name to its canonical registry keys.  Unverified fails
+closed: a run name no registered source declares resolves to ``[]`` and
+stays unattributed rather than being pinned to a guessed row.
+"""
+
+from __future__ import annotations
+
+import server as srv
+from src.api.data_contract import (
+    get_ranking_source_keys,
+    registry_keys_for_run_source,
+)
+
+
+# The verifiable scraper-run sources — the only run names that can appear
+# in ``sourceRunSummary`` today — and the registry keys each governs.
+DLF_KEYS = ["dlfSf", "dlfRookieSf", "dlfIdp", "dlfRookieIdp"]
+
+
+class TestRunNameResolvesToRegistryKeys:
+    def test_ktc_run_name_round_trips_to_its_registry_key(self):
+        assert registry_keys_for_run_source("KTC") == ["ktcSfTep"]
+
+    def test_idptradecalc_run_name_round_trips(self):
+        assert registry_keys_for_run_source("IDPTradeCalc") == ["idpTradeCalc"]
+
+    def test_dlf_local_csv_run_name_governs_every_dlf_registry_key(self):
+        # The exact defect in the finding: a DLF failure arrives under the
+        # transport-qualified run name ``DLF_LocalCSV`` and must resolve to
+        # ALL four DLF registry boards, none of which is spelled
+        # ``DLF_LocalCSV``.
+        assert sorted(registry_keys_for_run_source("DLF_LocalCSV")) == sorted(DLF_KEYS)
+
+    def test_resolved_keys_are_all_real_registry_keys(self):
+        registered = set(get_ranking_source_keys())
+        for run_name in ("KTC", "IDPTradeCalc", "DLF_LocalCSV"):
+            for key in registry_keys_for_run_source(run_name):
+                assert key in registered
+
+    def test_unverified_run_name_fails_closed(self):
+        # A run name no registered source declares must resolve to nothing
+        # — the failure stays unattributed, never pinned to a guessed row.
+        assert registry_keys_for_run_source("SomeSourceWeNeverRan") == []
+        assert registry_keys_for_run_source("") == []
+        assert registry_keys_for_run_source(None) == []  # type: ignore[arg-type]
+
+    def test_primary_and_transport_qualified_forms_agree(self):
+        # V1-80's qualifier tolerance: a bare ``DLF`` and the scraper's
+        # ``DLF_LocalCSV`` resolve to the same keys, so a primary name and
+        # its transport-qualified form are never two incomparable labels.
+        assert sorted(registry_keys_for_run_source("DLF")) == sorted(DLF_KEYS)
+
+
+def _payload_with_dlf_failure() -> dict:
+    """A complete-shaped run in which DLF_LocalCSV hard-failed.
+
+    Anchor ``sites`` carry real integer ``playerCount`` values — the
+    refuted design's ``playerCount: null`` is deliberately NOT emitted.
+    """
+    return {
+        "sites": [
+            {"key": "ktc", "playerCount": 500},
+            {"key": "idpTradeCalc", "playerCount": 900},
+        ],
+        "settings": {
+            "sourceRunSummary": {
+                "overallStatus": "partial",
+                "partialRun": True,
+                "enabledSources": ["KTC", "IDPTradeCalc", "DLF_LocalCSV"],
+                "completeSources": ["KTC", "IDPTradeCalc"],
+                "partialSources": [],
+                "timedOutSources": [],
+                "failedSources": ["DLF_LocalCSV"],
+                "sources": {
+                    "DLF_LocalCSV": {
+                        "error": "local CSV missing",
+                        "message": "DLF local CSV not found",
+                        "valueCount": 0,
+                    }
+                },
+            }
+        },
+    }
+
+
+class TestSnapshotRoundTrip:
+    def test_failure_record_carries_its_registry_keys(self):
+        snap = srv._build_source_health_snapshot(_payload_with_dlf_failure())
+        dlf_fail = [f for f in snap["source_failures"] if f["source"] == "DLF_LocalCSV"]
+        assert len(dlf_fail) == 1, "the DLF run failure must be reported once"
+        assert sorted(dlf_fail[0]["registryKeys"]) == sorted(DLF_KEYS), (
+            "a run-named failure must round-trip to the registry rows it "
+            f"concerns; got {dlf_fail[0].get('registryKeys')}"
+        )
+
+    def test_runtime_publishes_key_space_projection(self):
+        snap = srv._build_source_health_snapshot(_payload_with_dlf_failure())
+        runtime = snap["source_runtime"]
+        # Run-name provenance is retained...
+        assert runtime["failed_sources"] == ["DLF_LocalCSV"]
+        # ...and the registry-key projection is published beside it so the
+        # health rows (registry-keyed) can light up on their own.
+        assert sorted(runtime["failed_source_keys"]) == sorted(DLF_KEYS)
+        assert runtime["partial_source_keys"] == []
+        assert runtime["timed_out_source_keys"] == []
+
+    def test_the_two_vocabularies_now_share_a_join_key(self):
+        # The census S-2 statement made executable: the failure vocabulary
+        # and the population vocabulary intersect where they should.
+        snap = srv._build_source_health_snapshot(_payload_with_dlf_failure())
+        registered = set(snap["registered_sources"])
+        failed_keys = set(snap["source_runtime"]["failed_source_keys"])
+        assert failed_keys, "a real failure must project into key space"
+        assert failed_keys <= registered, (
+            "every projected failure key must be a member of the registry "
+            "population — otherwise it is still a second vocabulary"
+        )
+
+
+class TestRefutedDesignIsNotResurrected:
+    """The refuted ``playerCount: null`` design broke the scrape promoter.
+
+    Guard the two facts §8.1 pinned: our output introduces no ``None``
+    ``playerCount``, and the ``site_count`` computation the promoter runs
+    still works on a payload our snapshot rode alongside.
+    """
+
+    def test_snapshot_introduces_no_null_player_count(self):
+        snap = srv._build_source_health_snapshot(_payload_with_dlf_failure())
+        # anchor_row_counts is the only place playerCount is read; a real
+        # integer count must not have become None.
+        for key, count in snap["anchor_row_counts"].items():
+            assert count is not None, (
+                f"{key} carried a real playerCount and must not be nulled — "
+                "that is the refuted design that raised TypeError at the "
+                "scrape promoter"
+            )
+
+    def test_promoter_site_count_expression_still_works(self):
+        # Replicates server.py's scrape-promotion guard verbatim to prove
+        # our failure-attribution shape never reaches it with a null
+        # playerCount.  ``None > 0`` would raise TypeError.
+        result = _payload_with_dlf_failure()
+        result["players"] = {"a": {}, "b": {}}
+        site_count = len([s for s in result.get("sites", []) if s.get("playerCount", 0) > 0])
+        assert site_count == 2  # ktc + idpTradeCalc, both positive


### PR DESCRIPTION
## V1-76 — Failure attribution compares one vocabulary (audit F-12 / census S-2)

Required level **L2** (RED→GREEN deterministic test + measured board/contract effect). The previously proposed `playerCount: null` design is **refuted** (`docs/VERSION_1_COMPLETION_CONTRACT.md` §8.1) and is **not** resurrected here.

### The real defect (F-12)
The source-health surface compared scraper **run names** (`KTC`, `IDPTradeCalc`, `DLF_LocalCSV`) against ranking-**registry keys** (`ktcSfTep`, `idpTradeCalc`, `dlfSf`). The two vocabularies are disjoint on real data (`"DLF_LocalCSV" != "dlfSf"`), so a run-level failure disposition could not round-trip to the registry rows it concerns — a hard-failed source was misattributed or dropped and rendered green off its stale-but-recent CSV. `frontend/components/SourceHealthStrip.jsx` already documented that its per-row run-state lookups were structurally dead and explicitly punted the mapping to the backend seam (`server._source_health`).

### The fix — one DECLARED mapping, owned by the registry
- `_RANKING_SOURCES` entries gain a `run_source` field, declared **only** where the in-process Dynasty Scraper run governs the source — the only run names that can reach `sourceRunSummary`: `KTC → ktcSfTep`, `IDPTradeCalc → idpTradeCalc`, `DLF_LocalCSV →` the four DLF boards it loads (aligns with V1-80 / F-17, #1126). Keys fetched by their own `scripts/` timer omit it and **fail closed**. Identity metadata only — decides no value.
- `registry_keys_for_run_source()` resolves a run name to its registry keys, **reusing V1-80's `critical_primary_for_run_source` qualifier rule** (exact, or `<primary>_<qualifier>`) rather than inventing a second table.
- `_build_source_health_snapshot` stamps `registryKeys` on each failure and publishes `failed_source_keys` / `partial_source_keys` / `timed_out_source_keys` beside the run-name lists — additive, provenance retained.
- `SourceHealthStrip` consumes the resolved keys: a failure that round-trips to a rendered row lights it up; one that resolves to nothing stays shown verbatim as unattributable.

### Refuted-design avoidance
No `sites[].playerCount` is nulled and the scrape-promoter `site_count = len([s for s in result.get("sites", []) if s.get("playerCount", 0) > 0])` expression is guarded by a dedicated test. The change is additive to `/api/status` only; it never reaches the promotion path.

### L2 measured effect
`exports/latest/dynasty_data_2026-08-25.json` via `build_api_data_contract`: **1116 rows built with and without the change — 0 rows moved value, rank, or tier.** Attribution is a health-surface concern, not a valuation one.

### Tests
- **RED→GREEN**: `tests/api/test_failure_attribution_vocabulary.py` (11) fails to import `registry_keys_for_run_source` at HEAD; green after. Covers the run-name→keys round-trip, fail-closed on unverified names, the snapshot round-trip, and the two refuted-design guards.
- 3 new frontend cases pin row-lighting on the resolved shape and the fail-closed unattributable panel; the 13 existing F-12 cases stay green.
- `tests/api/` (2485 passed), `tests/deploy/` (376 passed), source-registry parity, contract-health lanes, DLF critical gate all green. `check_planning_integrity` + `check_decision_coercions` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_