### PR TITLE
V1-59: commit per league in the sharp transactions crawl (writer-lock window)

### DIFF
--- a/src/sharp/transactions.py
+++ b/src/sharp/transactions.py
@@ -314,6 +314,7 @@ def crawl_transactions(
                 result.leagues_failed += 1
                 result.errors[lid] = "transactions_fetch_failed"
                 _save_fetch_state(conn, lid, state, error="transactions_fetch_failed")
+                conn.commit()
                 continue
 
             new_boundary = {
@@ -334,6 +335,18 @@ def crawl_transactions(
                 },
                 error=None,
             )
+            # Commit PER LEAGUE, not once for the whole crawl.  Every
+            # iteration does network I/O, so a single end-of-crawl commit
+            # held the SQLite writer lock across the entire budget — the
+            # same contention records.py repaired per season (V1-59): in a
+            # quiet period most leagues yield zero new events, nothing
+            # else commits, and the implicit transaction opened by the
+            # first _save_fetch_state upsert starves every concurrent
+            # sharp unit past its 30 s busy_timeout.  Movements dedupe on
+            # movement_id and fetch state upserts on league_id, so
+            # per-league durability changes no outcome — only the lock
+            # window.
+            conn.commit()
             result.leagues_fetched += 1
 
         conn.commit()

--- a/tests/sharp/test_transactions.py
+++ b/tests/sharp/test_transactions.py
@@ -298,9 +298,9 @@ class TestCoverageHonesty:
         stamps = _fetch_stamps(db)
         assert len(stamps) == 3, "the fixture must crawl three leagues or it proves nothing"
         assert cov["oldestCrawlMs"] == min(stamps)
-        assert cov["oldestCrawlMs"] != max(
-            stamps
-        ), "min and max coincide, so this fixture cannot tell them apart"
+        assert cov["oldestCrawlMs"] != max(stamps), (
+            "min and max coincide, so this fixture cannot tell them apart"
+        )
         # ...and the denominator behaviour already pinned above is untouched.
         assert cov["sharpEligibleLeagues"] == 3
         assert cov["leaguesCrawled"] == 3
@@ -386,3 +386,64 @@ class TestCursorPersistence:
         result, _ = _crawl(later, ledger_path=db)
         assert result.movements_ingested == 2
         assert ledger.counts(path=db)["tradeCount"] == 2
+
+
+class TestWriterLockWindows:
+    def test_each_league_commits_before_the_next_network_call(self, db):
+        """V1-59: the crawl must never hold the SQLite writer lock across
+        network I/O.
+
+        A single end-of-crawl commit left the implicit transaction opened
+        by the FIRST league's ``_save_fetch_state`` upsert pending for the
+        whole budgeted run — on production, minutes of writer lock in a
+        quiet period (no new events, so ``ingest_events`` never commits),
+        starving every concurrent sharp unit past its 30 s busy_timeout
+        (measured 2026-08-25: discovery, records and rosters all raising
+        ``database is locked``).  The observable property, mirrored from
+        ``test_records.TestWriterLockWindows``: by the time the crawl asks
+        Sleeper about the SECOND league, the FIRST league's fetch-state row
+        is already visible to an independent connection.  Under the retired
+        single-commit shape this count is 0 until the crawl returns.
+        """
+        import sqlite3
+
+        observed: list[int] = []
+        responses = {
+            f"{BASE}/state/nfl": {"week": 2},
+            f"{BASE}/league/L1/rosters": [roster(1, "A"), roster(2, "B")],
+            f"{BASE}/league/L2/rosters": [roster(1, "A"), roster(2, "B")],
+            # No transactions entries on purpose: FakeHttp answers [] for
+            # every transactions week, which is the quiet-period shape —
+            # nothing but _save_fetch_state writes, so only the per-league
+            # commit can make the row visible.
+        }
+
+        class SpyingHttp(FakeHttp):
+            def __call__(self, url):
+                if url == f"{BASE}/league/L2/rosters":
+                    probe = sqlite3.connect(db)
+                    try:
+                        n = probe.execute(
+                            "SELECT COUNT(*) FROM sharp_league_fetch WHERE league_id='L1'"
+                        ).fetchone()[0]
+                    finally:
+                        probe.close()
+                    observed.append(n)
+                return super().__call__(url)
+
+        http = SpyingHttp(responses)
+        transactions.crawl_transactions(
+            league_ids=["L1", "L2"],
+            budget=100,
+            sleep_s=0.0,
+            http_get=http,
+            now_ms=NOW,
+            ledger_path=db,
+        )
+
+        assert observed, "the crawl never reached the second league — vacuous"
+        assert observed[0] > 0, (
+            "the first league's fetch state was invisible to an independent "
+            "reader while the crawl performed its next network call — the "
+            "writer transaction is still spanning network I/O (V1-59)"
+        )

--- a/tests/sharp/test_transactions.py
+++ b/tests/sharp/test_transactions.py
@@ -298,9 +298,9 @@ class TestCoverageHonesty:
         stamps = _fetch_stamps(db)
         assert len(stamps) == 3, "the fixture must crawl three leagues or it proves nothing"
         assert cov["oldestCrawlMs"] == min(stamps)
-        assert cov["oldestCrawlMs"] != max(stamps), (
-            "min and max coincide, so this fixture cannot tell them apart"
-        )
+        assert cov["oldestCrawlMs"] != max(
+            stamps
+        ), "min and max coincide, so this fixture cannot tell them apart"
         # ...and the denominator behaviour already pinned above is untouched.
         assert cov["sharpEligibleLeagues"] == 3
         assert cov["leaguesCrawled"] == 3


### PR DESCRIPTION
## The production defect (found by the V1 on-box checklist harvest, 2026-08-25)

The scheduled sharp chain failed with `sqlite3.OperationalError: database is locked`: `dynasty-sharp-discovery` (ExecMainStatus=1, 06:47), `dynasty-sharp-rosters` (ExecMainStatus=1, 11:28 + Aug 24 13:13), and three lock lines in `dynasty-sharp-records`' journal — six lock events across three units in two days.

## Root cause

Not a missing-PRAGMA problem: every path already routes through the single connection factory `src/intel/ledger.py::connect` (30 s `busy_timeout`, WAL persistent in the production file). The cause is `src/sharp/transactions.py::crawl_transactions` holding one **implicit write transaction across its entire budgeted network crawl**: the first `_save_fetch_state` upsert opens it, and the only commit was the single end-of-crawl `conn.commit()`. In a quiet period most leagues yield zero new events, so `ledger.ingest_events` (which commits internally) never fires and the WAL writer lock is held for the length of the run — minutes up to `TimeoutStartSec=1800` — while every other sharp unit waits out its 30 s `busy_timeout` and raises. Timer overlap is routine, not hypothetical: `Persistent=true` catch-ups and `OnActiveSec=30min` re-fires produce runs far outside the staggered slots (journal: 00:01 / 07:02 / 11:28 / 13:13 / 16:23 / 22:27).

This is the exact defect class already found, fixed and test-pinned for the records crawl (`records.py` per-season commit, `tests/sharp/test_records.py::TestWriterLockWindows`) — the transactions crawl never received the same repair.

## The fix

Commit per league in `crawl_transactions` — one `conn.commit()` on the failure path, one on the success path, mirroring `records.py`. Correctness is unchanged by construction: movements dedupe on `movement_id` (`INSERT OR IGNORE`) and fetch state upserts on `league_id`, so per-league durability changes no outcome — only the lock window. After this change no code path in the repo holds a ledger write transaction across network I/O.

Deliberately NOT done, with reasons: no retry-on-locked wrapper (contention-raises is pinned repo policy — `tests/intel/test_ledger_lock_safety.py`); no new PRAGMAs (the factory is already the one owner); no timer serialization (the journal proves the stagger already fails to serialize, and the write pattern must be safe under overlap).

## Evidence

- **RED→GREEN**: new `tests/sharp/test_transactions.py::TestWriterLockWindows` — a spying HTTP fake probes an independent connection when the crawl reaches the SECOND league and asserts the FIRST league's fetch-state row is already visible (non-vacuous: asserts the probe fired). Fails under the retired single-commit shape (re-verified by mutation), passes with the fix.
- `tests/sharp/` + `tests/intel/` — 607 passed, 0 failed.
- `ruff check` + `ruff format --check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_