### PR TITLE
V1 verifier corrections from the first production harvest run

### DIFF
--- a/.github/workflows/v1-authenticated-verification.yml
+++ b/.github/workflows/v1-authenticated-verification.yml
@@ -315,5 +315,6 @@ jobs:
             v1-auth-report.json
             lane4-remote.txt
             prod-auth-browser.txt
+            tests/e2e/test-results-prod-auth/
           if-no-files-found: warn
           retention-days: 30

--- a/scripts/verify_v1_authenticated.py
+++ b/scripts/verify_v1_authenticated.py
@@ -461,6 +461,25 @@ def emit_free_agent(contract: dict | None, out_path: str | None) -> None:
 # ────────────────────────────── driver ──────────────────────────────
 
 
+def _isolated(label: str, fn, *args):
+    """Run one check so its crash costs THAT check, never the suite.
+
+    The first production run proved why this exists: check_v61's uncaught
+    read timeout (a cold /api/sharp/roster-percentage taking >60 s right
+    after a deploy restart) aborted main() before the report was written
+    or the free agent picked — every downstream check silently vanished
+    and the run proved nothing about them.  A network timeout is a
+    legitimate measurement to RECORD (status "error"), not a reason to
+    lose the rest of the evidence.
+    """
+    try:
+        return fn(*args)
+    except Exception as exc:  # noqa: BLE001 — recorded, not raised
+        c = _check(f"{label}:crash", "-", f"{label} raised instead of recording")
+        c.record("error", f"{type(exc).__name__}: {exc}")
+        return None
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--origin", required=True)
@@ -476,18 +495,18 @@ def main() -> int:
         cookie_value = fh.read().strip()
     client = Client(args.origin, cookie_value)
 
-    session_ok = check_auth0(client)
-    check_v102(args.expected_duration_seconds, args.observed_expires_epoch)
+    session_ok = _isolated("AUTH0", check_auth0, client)
+    _isolated("V102A", check_v102, args.expected_duration_seconds, args.observed_expires_epoch)
     if session_ok:
-        contract = _fetch_contract(client)
-        check_v61(client)
-        check_v56(client)
-        check_v131(client)
-        check_v11_item8(client)
-        check_v11_item3_fresh(contract)
-        check_v27_item3(client, contract, args.league)
-        check_v45(client, contract, args.league)
-        emit_free_agent(contract, args.free_agent_out)
+        contract = _isolated("CONTRACT", _fetch_contract, client)
+        _isolated("V61A", check_v61, client)
+        _isolated("V56A", check_v56, client)
+        _isolated("V131A", check_v131, client)
+        _isolated("V11-8", check_v11_item8, client)
+        _isolated("V11-3", check_v11_item3_fresh, contract)
+        _isolated("V27-3", check_v27_item3, client, contract, args.league)
+        _isolated("V45A", check_v45, client, contract, args.league)
+        _isolated("FA-PICK", emit_free_agent, contract, args.free_agent_out)
 
     report = {
         "utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),

--- a/scripts/verify_v1_onbox.py
+++ b/scripts/verify_v1_onbox.py
@@ -243,9 +243,18 @@ def check_v89() -> None:
                     shutil.copy(cfg_src, troot / "config" / "source_staleness.json")
                 # Two synthetic archives, 40 days apart, identical
                 # DraftSharks bytes — unambiguously beyond any budget.
+                # The names MUST follow the production convention
+                # (dynasty_export_%Y%m%d_%H%M%S.zip, Dynasty Scraper.py's
+                # writer): measure_content_staleness timestamps archives
+                # via _ARCHIVE_STAMP_RE (\d{8})_(\d{6}) and SILENTLY
+                # SKIPS any archive whose name does not parse.  The
+                # first control used dashed dates, both archives were
+                # skipped, and the resulting {} read as "detector cannot
+                # see DraftSharks staleness" — a false FAIL against a
+                # sound detector (root-caused 2026-08-25).
                 frozen = b"name,value\nFrozen Player,1000\n"
-                for day in ("2026-07-01", "2026-08-10"):
-                    zp = troot / "exports" / "archive" / f"dynasty_data_{day}.zip"
+                for stamp in ("20260701_000000", "20260810_000000"):
+                    zp = troot / "exports" / "archive" / f"dynasty_export_{stamp}.zip"
                     with zipfile.ZipFile(zp, "w") as zf:
                         zf.writestr(
                             "manifest.json",
@@ -359,7 +368,20 @@ def check_c1u8(allow_writes: bool) -> None:
         rc, out, err = _run([sys.executable, "scripts/acquisition_status.py"])
         holdings_unknown = re.search(r"holdingsImportUnknown[\"'=:\s]+(\d+)", out)
         events = re.search(r"events[\"'=:\s]+(\d+)", out)
-        if rc != 0:
+        if rc == 2 and "ABSENT" in out:
+            # Exit 2 is the script's DEFINED "ledger absent" semantic
+            # (acquisition_status returns 2 iff coverage()["present"] is
+            # false).  The store is created only by the §8 items 2/3 live
+            # builder, so its absence is a blocked dependency, never a
+            # code failure — adjudicated 2026-08-25 after this check
+            # recorded a false FAIL against an unrun builder.
+            c.record(
+                "blocked",
+                "acquisition ledger absent — §8 items 2/3 (the live builder) "
+                "have not run; dispatch with run_live_builder=true first",
+                stdout=out[-400:],
+            )
+        elif rc != 0:
             c.record("fail", f"status script exited {rc}", stderr=err[-500:])
         elif events and int(events.group(1)) > 0:
             c.record(
@@ -378,83 +400,163 @@ def check_c1u8(allow_writes: bool) -> None:
     except Exception as exc:  # noqa: BLE001
         c.record("error", str(exc))
 
-    # Item 5 — the store holds more than trades (waiver rows).
+    # Item 5 — the store holds more than trades (waiver rows).  The
+    # retention store's table is league_transactions (there has never
+    # been a league_events TABLE — the first run of this check asked for
+    # one and recorded a false unmeasurable; the file is just NAMED
+    # league_events.sqlite).  §8 item 5 is operationally "the trades
+    # count must stop equalling the transactions count": Sleeper's type
+    # vocabulary is trade / waiver / free_agent.
     c = _check("C1U8-5", "V1-16", "§8 item 5: waiver rows exist (trades != transactions)")
     try:
         with _sqlite_ro(retention) as conn:
             tables = {
                 r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
             }
-            if "league_events" not in tables:
-                c.record("unmeasurable", f"no league_events table; tables={sorted(tables)}")
+            if "league_transactions" not in tables:
+                c.record("unmeasurable", f"no league_transactions table; tables={sorted(tables)}")
             else:
-                cols = [r[1] for r in conn.execute("PRAGMA table_info(league_events)")]
-                type_col = next((k for k in ("event_type", "type", "kind") if k in cols), None)
-                if type_col is None:
-                    c.record("unmeasurable", f"no recognizable type column; columns={cols}")
+                rows = dict(
+                    conn.execute(
+                        "SELECT type, COUNT(*) FROM league_transactions GROUP BY type"
+                    ).fetchall()
+                )
+                total = sum(rows.values())
+                non_trade = {k: v for k, v in rows.items() if str(k).lower() != "trade"}
+                if total == 0:
+                    c.record("unmeasurable", "league_transactions is empty", by_type=rows)
+                elif non_trade:
+                    c.record("pass", "store holds non-trade transactions", by_type=rows)
                 else:
-                    rows = dict(
-                        conn.execute(
-                            f"SELECT {type_col}, COUNT(*) FROM league_events GROUP BY {type_col}"
-                        ).fetchall()
-                    )
-                    non_trade = {k: v for k, v in rows.items() if "trade" not in str(k).lower()}
-                    if non_trade:
-                        c.record("pass", "store holds non-trade events", by_type=rows)
-                    else:
-                        c.record("fail", "store still holds trades and nothing else", by_type=rows)
+                    c.record("fail", "store still holds trades and nothing else", by_type=rows)
     except Exception as exc:  # noqa: BLE001
         c.record("error", str(exc))
 
-    # Item 6 — the nightly backup carries the ledger.
+    # Item 6 — the nightly backup carries the ACQUISITION ledger.  Real
+    # roots per deploy/backup/backup_root_lib.sh (the one owner of the
+    # backup location): /var/backups/riskit-state primary,
+    # /home/dynasty/backups/riskit-state fallback, generations under
+    # <root>/daily/YYYY-MM-DD/ with sqlite gz copies under sqlite/.  The
+    # first run of this check inspected two paths the backup owner never
+    # writes and grepped for names that miss item 6's actual target,
+    # sqlite/acquisition.sqlite.gz.  Three honest states beyond
+    # pass/fail: the root is root-owned 0700 so an unprivileged run is
+    # blocked-unreadable; and until §8 items 2/3 create the source store
+    # the backup legitimately logs "skip (absent)" — item 6 is the
+    # TRANSITION to a real snapshot, so gz-absent while the source store
+    # is absent is blocked-on-2/3, not fail.
     c = _check("C1U8-6", "V1-15", "§8 item 6: nightly backup includes the ledger")
-    backup_roots = [Path("/var/backups/riskit/daily"), REPO_ROOT / "backups" / "daily"]
-    root = next((p for p in backup_roots if p.exists()), None)
-    if root is None:
-        c.record("unmeasurable", f"no backup dir at {[str(p) for p in backup_roots]}")
-    else:
-        snaps = sorted(root.iterdir())
-        if not snaps:
-            c.record("fail", f"backup dir {root} is empty")
-        else:
-            newest = snaps[-1]
-            hits = [
-                str(p) for p in newest.rglob("*") if "league_events" in p.name or "ledger" in p.name
-            ]
-            if hits:
-                c.record("pass", f"newest backup {newest.name} carries the ledger", files=hits)
-            else:
-                c.record("fail", f"newest backup {newest.name} does NOT carry the ledger")
-
-    # Item 7 — one trade end to end: event → two holding periods → lineage.
-    c = _check("C1U8-7", "V1-17", "§8 item 7: one trade resolves end to end")
+    acquisition_store = REPO_ROOT / "data" / "retention" / "acquisition.sqlite"
+    backup_roots = [
+        Path("/var/backups/riskit-state"),
+        Path.home() / "backups" / "riskit-state",
+    ]
     try:
-        with _sqlite_ro(intel) as conn:
-            tables = {
-                r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
-            }
-            holding = next((t for t in tables if "holding" in t), None)
-            lineage = next((t for t in tables if "lineage" in t or "pick" in t), None)
-            if not holding:
-                c.record("unmeasurable", f"no holdings table found; tables={sorted(tables)}")
-            else:
-                n_holdings = conn.execute(f"SELECT COUNT(*) FROM {holding}").fetchone()[0]
-                n_lineage = (
-                    conn.execute(f"SELECT COUNT(*) FROM {lineage}").fetchone()[0]
-                    if lineage
-                    else None
+        root = next((p for p in backup_roots if p.exists()), None)
+        if root is None:
+            c.record("unmeasurable", f"no backup root at {[str(p) for p in backup_roots]}")
+        else:
+            try:
+                daily = root / "daily"
+                snaps = sorted(daily.iterdir()) if daily.exists() else []
+            except PermissionError:
+                snaps = None
+            if snaps is None:
+                c.record(
+                    "blocked",
+                    f"backup root {root} unreadable by this user (root-owned 0700) — "
+                    "same posture as retention_backup_restore_proof.sh",
                 )
-                if n_holdings and n_holdings >= 2:
+            elif not snaps:
+                c.record("fail", f"backup root {root} has no daily generations")
+            else:
+                newest = snaps[-1]
+                gz = newest / "sqlite" / "acquisition.sqlite.gz"
+                if gz.exists():
                     c.record(
                         "pass",
-                        "holdings and lineage populated from real events",
-                        holdings_table=holding,
-                        holdings=n_holdings,
-                        lineage_table=lineage,
-                        lineage_rows=n_lineage,
+                        f"newest generation {newest.name} carries acquisition.sqlite.gz",
+                        file=str(gz),
+                        size=gz.stat().st_size,
+                    )
+                elif not acquisition_store.exists():
+                    c.record(
+                        "blocked",
+                        "acquisition.sqlite.gz absent, but the SOURCE store is absent "
+                        "too — blocked on §8 items 2/3 (the backup logs 'skip (absent)' "
+                        "until the builder creates the store)",
+                        generation=str(newest),
                     )
                 else:
-                    c.record("fail", f"holdings table {holding} has {n_holdings} rows")
+                    c.record(
+                        "fail",
+                        f"source store exists but newest generation {newest.name} "
+                        "does NOT carry sqlite/acquisition.sqlite.gz",
+                    )
+    except PermissionError:
+        c.record("blocked", "backup root unreadable by this user (root-owned 0700)")
+
+    # Item 7 — one trade end to end: event → two holding periods → lineage.
+    # The holdings/pick_lineage tables live in the C1-U8 ACQUISITION
+    # store data/retention/acquisition.sqlite (src/acquisition/store.py),
+    # NOT the intel ledger — the intel ledger is "members' other leagues,
+    # wrong population" per the C1-U8 record, and the first run of this
+    # check searched it, recording a false unmeasurable.  Until §8 items
+    # 2/3 create the store this item is blocked, same as item 4.
+    c = _check("C1U8-7", "V1-17", "§8 item 7: one trade resolves end to end")
+    try:
+        if not acquisition_store.exists():
+            c.record(
+                "blocked",
+                f"acquisition store absent at {acquisition_store} — blocked on "
+                "§8 items 2/3 (the live builder)",
+            )
+        else:
+            with _sqlite_ro(acquisition_store) as conn:
+                trade = conn.execute(
+                    "SELECT league_key, asset_id FROM acquisition_events "
+                    "WHERE event_type = 'TRADE' LIMIT 1"
+                ).fetchone()
+                if trade is None:
+                    c.record("fail", "store exists but holds no TRADE acquisition event")
+                else:
+                    lk, aid = trade
+                    holdings = conn.execute(
+                        "SELECT owner_rid, basis_value, basis_missing_reason FROM holdings "
+                        "WHERE league_key = ? AND asset_id = ? ORDER BY sequence_num",
+                        (lk, aid),
+                    ).fetchall()
+                    basis_ok = any(h[1] is not None or h[2] is not None for h in holdings)
+                    lineage_hops = conn.execute(
+                        "SELECT COUNT(*) FROM pick_lineage WHERE league_key = ?", (lk,)
+                    ).fetchone()[0]
+                    pick_trades = conn.execute(
+                        "SELECT COUNT(*) FROM acquisition_events WHERE league_key = ? "
+                        "AND event_type = 'TRADE' AND asset_id LIKE 'pick:%'",
+                        (lk,),
+                    ).fetchone()[0]
+                    if len(holdings) >= 2 and basis_ok and (pick_trades == 0 or lineage_hops >= 1):
+                        c.record(
+                            "pass",
+                            "a TRADE event resolves to both holding periods with an "
+                            "explicit basis-or-reason, and traded picks carry lineage",
+                            league_key=lk,
+                            asset_id=aid,
+                            holding_periods=len(holdings),
+                            pick_trades=pick_trades,
+                            lineage_hops=lineage_hops,
+                        )
+                    else:
+                        c.record(
+                            "fail",
+                            "trade does not resolve end to end",
+                            league_key=lk,
+                            asset_id=aid,
+                            holding_periods=len(holdings),
+                            basis_present=basis_ok,
+                            pick_trades=pick_trades,
+                            lineage_hops=lineage_hops,
+                        )
     except Exception as exc:  # noqa: BLE001
         c.record("error", str(exc))
 

--- a/tests/ops/test_v1_verification_primitives.py
+++ b/tests/ops/test_v1_verification_primitives.py
@@ -203,3 +203,76 @@ def test_onbox_workflow_gates_the_only_write_behind_a_flag():
     # The write path (--allow-writes) is only produced when run_live_builder
     # is true.
     assert "run_live_builder && '--allow-writes' || ''" in wf
+
+
+def test_v89_control_archive_names_parse_under_the_detector_grammar():
+    """The step-8 control must speak the detector's filename dialect.
+
+    measure_content_staleness stamps archives via (\\d{8})_(\\d{6}) and
+    silently skips names that do not parse.  The first control used
+    dashed dates, both archives were skipped, and {} read as 'the
+    detector cannot see DraftSharks staleness' — a false FAIL against a
+    sound detector.  Pin: every archive filename the verifier constructs
+    for the control matches the real detector's stamp regex.
+    """
+    from scripts.check_source_health import _ARCHIVE_STAMP_RE
+
+    src = Path(onbox.__file__).read_text(encoding="utf-8")
+    names = re.findall(r'f"(dynasty_[a-z]+_\{[a-z]+\}\.zip)"', src)
+    assert names, "the control's archive-name f-string moved — update this pin"
+    stamps = re.findall(r"for stamp in \(([^)]*)\)", src)
+    assert stamps, "the control's stamp tuple moved — update this pin"
+    for stamp in re.findall(r'"([^"]+)"', stamps[0]):
+        rendered = names[0].replace("{stamp}", stamp)
+        assert _ARCHIVE_STAMP_RE.search(rendered), (
+            f"control archive name {rendered!r} does not parse under "
+            "_ARCHIVE_STAMP_RE — the detector will silently skip it and the "
+            "control will fail falsely again"
+        )
+
+
+def test_isolated_records_a_crash_as_that_checks_error(_reset_checks):
+    """A check's crash costs that check, never the suite.
+
+    The first production run lost the report file, the free-agent pick
+    and every downstream check to one uncaught read timeout in
+    check_v61.
+    """
+
+    def boom():
+        raise TimeoutError("the read operation timed out")
+
+    out = auth._isolated("V61A", boom)
+    assert out is None
+    crash = [c for c in auth.CHECKS if c.check_id == "V61A:crash"]
+    assert len(crash) == 1
+    assert crash[0].status == "error"
+    assert "TimeoutError" in crash[0].detail
+
+    def fine():
+        return "value"
+
+    assert auth._isolated("OK", fine) == "value"
+    assert not [c for c in auth.CHECKS if c.check_id == "OK:crash"]
+
+
+def test_c1u8_item4_absent_store_is_blocked_not_fail():
+    """acquisition_status exit 2 + ABSENT is the script's defined
+    'ledger absent' semantic — a blocked dependency on the unrun §8
+    items 2/3 builder, never a code failure."""
+    src = Path(onbox.__file__).read_text(encoding="utf-8")
+    m = re.search(r'rc == 2 and "ABSENT" in out', src)
+    assert m, "the item-4 absent-store branch is gone — exit 2 would read as FAIL again"
+    seg = src[m.start() : m.start() + 1500]
+    assert '"blocked"' in seg, "the absent-store branch must record blocked"
+
+
+def test_c1u8_item7_targets_the_acquisition_store_not_the_intel_ledger():
+    """holdings/pick_lineage live in data/retention/acquisition.sqlite;
+    the intel ledger is the wrong population by design."""
+    src = Path(onbox.__file__).read_text(encoding="utf-8")
+    item7 = src[src.index('"C1U8-7"') :]
+    head = item7[:3000]
+    assert "acquisition_store" in head
+    assert "pick_lineage" in head
+    assert "event_type = 'TRADE'" in head


### PR DESCRIPTION
## What the first on-box + authenticated harvest runs actually proved

Five harness defects, adjudicated against production reality (root-caused with citations; none is a production defect):

1. **V89-8 false FAIL** — the stale-content control named its synthetic archives `dynasty_data_2026-07-01.zip`; `measure_content_staleness` timestamps archives via `(\d{8})_(\d{6})` and silently skips names that don't parse, so the detector was never handed the frozen bytes and `{}` read as "the detector cannot see DraftSharks staleness". Reproduced with correctly-named archives (`dynasty_export_%Y%m%d_%H%M%S.zip`, the sole real writer's convention): `daysSinceChange: 40`, warning fires. The detector is sound; the control now speaks its filename dialect.
2. **C1U8-4** — `acquisition_status.py` exit 2 + "ABSENT" is that script's *defined* ledger-absent semantic. Absent-because-the-§8-items-2/3-builder-never-ran is a blocked dependency, now recorded `blocked`, not `fail`.
3. **C1U8-5** — the retention store's table is `league_transactions` (the file is merely *named* league_events.sqlite); the check now runs the type census (`trade`/`waiver`/`free_agent`) the §8 item actually means.
4. **C1U8-6** — real backup roots per `deploy/backup/backup_root_lib.sh` (`/var/backups/riskit-state`, fallback `~/backups/riskit-state`), real target `sqlite/acquisition.sqlite.gz`, plus two honest states: `blocked` when the root is root-owned 0700, and `blocked`-on-2/3 while the source store doesn't exist (the backup legitimately logs "skip (absent)" until then).
5. **C1U8-7** — holdings/`pick_lineage` live in `data/retention/acquisition.sqlite` (`src/acquisition/store.py`), not the intel ledger ("wrong population" per the C1-U8 record). The check now resolves one `TRADE` event to ≥2 holding periods with an explicit basis-or-reason and pick lineage when pick trades exist.

Plus one authenticated-suite repair: **`_isolated()` wraps every check** so a crash costs that check, never the suite — the observed failure was `check_v61`'s uncaught >60 s read timeout (cold `/api/sharp/roster-percentage` right after a deploy restart) aborting `main()` before the report was written or the free agent picked, silently losing every downstream check.

## Tests

4 new pins in `tests/ops/test_v1_verification_primitives.py` (control filenames parse under the real detector grammar; `_isolated` records a crash as that check's error; item-4 absent-store is blocked; item-7 targets the acquisition store) — 21/21 green. `ruff check` + `format` clean; planning integrity clean.

Production findings from the same runs are handled separately: the real V1-59 sqlite lock contention is #1134, and the heavy-endpoint cold-start timeouts are recorded for re-dispatch at a quiet interval.

---
_Generated by [Claude Code](https://claude.ai/code/session_013xYrhCNgmyCYSCw6KuHhKe)_