### PR TITLE
FAAB bid predictor: learn manager tendencies from resolved losing bids

### DIFF
--- a/frontend/components/waivers/FaabRecommendation.jsx
+++ b/frontend/components/waivers/FaabRecommendation.jsx
@@ -22,8 +22,8 @@
  *          the ceiling, because bidding the ceiling captures zero
  *          surplus by construction.
  *   2. Warnings ("likely outbid", pacing, marginal upgrade) as Banners.
- *   3. Contention — the FAAB v2 sealed-auction read: the clearing price,
- *      the projected top rival, and the per-opponent estimate table.
+ *   3. FAAB Bid Predictor — the sealed-auction read: clearing price,
+ *      projected top rival, and the per-opponent estimate table.
  *   4. Everything else behind disclosures: the factor breakdown (the
  *      user does not need eleven rows of arithmetic by default) and the
  *      league's historical FAAB context.
@@ -214,7 +214,7 @@ const RIVAL_COLUMNS = [
     hideBelow: "lg",
     accessor: (r) => r.aggression,
     render: (r) => `${Number(r.aggression ?? 1).toFixed(2)}×`,
-    headerInfo: "Their average winning bid ÷ the league median, clamped to 0.5-2.0×.",
+    headerInfo: "Historical waiver-bid tendency from resolved attempts when available; older history falls back to winning bids. Clamped to 0.5–2.0×.",
   },
 ];
 
@@ -248,9 +248,9 @@ function ContentionSection({ contention }) {
           meta={rivals.length ? `of ${rivals.length} rivals` : "no rivals modeled"}
         />
         <StatTile
-          label="Rival read"
+          label="FAAB bid predictor"
           value="Estimate"
-          meta="winning bids only"
+          meta="resolved history + roster context"
         />
       </div>
 

--- a/scripts/fetch_faab_history.py
+++ b/scripts/fetch_faab_history.py
@@ -2,8 +2,13 @@
 """Fetch and persist a league's historical FAAB bid history.
 
 Walks the Sleeper league chain backwards through ``previous_league_id``
-and stores every completed waiver / free-agent add with its winning
-bid under ``data/faab/bid_history_<leagueKey>.json``.
+and stores completed waiver / free-agent winning prices plus resolved
+failed waiver bids under ``data/faab/bid_history_<leagueKey>.json``.
+
+Winning prices remain the clearing-price sample.  Resolved waiver wins
++ failed bids form a separate manager-tendency sample, so a losing bid
+can teach the predictor how aggressive an owner is without being
+mistaken for the price that actually cleared.
 
 The FAAB engine's market model reads the persisted file; it never
 makes network calls itself.  Run this on a cadence (or by hand after
@@ -75,6 +80,8 @@ def main() -> int:
             continue
 
         total = payload.get("totalAdds") or 0
+        attempts = payload.get("totalBidAttempts") or 0
+        failed = payload.get("totalFailedWaiverBids") or 0
         if not total:
             print("  no completed adds with a bid found")
             continue
@@ -82,11 +89,16 @@ def main() -> int:
 
         priors = summarize_bid_history(payload)
         print(
-            f"  {total} adds across {len(payload.get('seasons') or [])} season(s): "
+            f"  {total} winning adds across {len(payload.get('seasons') or [])} season(s): "
             f"median {priors.median_pct:.2f}% of budget, "
             f"p90 {priors.p90_pct:.2f}%, max {priors.max_pct:.2f}%, "
             f"{priors.zero_bid_share:.0%} at $0"
         )
+        if attempts:
+            print(
+                f"  owner-tendency sample: {attempts} resolved waiver bids "
+                f"({failed} failed/lower bids)"
+            )
         if args.summary_only:
             print(json.dumps(priors.to_dict(), indent=2))
             continue

--- a/src/trade/faab_history.py
+++ b/src/trade/faab_history.py
@@ -1,11 +1,22 @@
 """Historical FAAB bid history — fetch, persist, and summarise.
 
 The FAAB engine's market model needs to know how THIS league actually
-bids, not how a generic league bids.  Sleeper exposes every completed
-``waiver`` / ``free_agent`` transaction with its winning
-``settings.waiver_bid``, and leagues chain backwards through
-``previous_league_id``, so a dynasty league's whole bidding history is
-reachable.
+bids, not how a generic league bids.  Sleeper exposes resolved waiver
+transactions after processing, including completed winning claims and
+failed claims with their submitted ``settings.waiver_bid``.  Leagues
+also chain backwards through ``previous_league_id``, so a dynasty
+league's bidding history is reachable without pretending pending blind
+bids are visible before waivers run.
+
+Two distributions deliberately stay separate:
+
+* **winning prices** — completed waiver / free-agent adds.  These answer
+  what claims actually cleared for and remain the source for the league
+  median, percentiles, zero-bid share and week priors;
+* **resolved waiver attempts** — completed + failed waiver claims.  These
+  answer how aggressively each manager is willing to bid.  Failed/lower
+  bids improve owner-tendency estimation without being mistaken for a
+  market-clearing price.
 
 What this module deliberately does differently from
 ``src/api/faab_analytics.py``
@@ -68,8 +79,19 @@ def fetch_bid_history(
     *,
     max_seasons: int = 10,
 ) -> dict[str, Any]:
-    """Walk the league chain backwards and collect every completed
-    waiver / free-agent add with its winning bid.
+    """Walk the league chain backwards and collect resolved FAAB bids.
+
+    Completed waiver / free-agent adds are retained as winning-price
+    observations.  Failed **waiver** claims are retained too because,
+    after the waiver run, their submitted bid is observable willingness
+    to pay even though it did not clear.  Failed free-agent transactions
+    are excluded: they are not sealed-bid waiver attempts and can fail
+    for unrelated transaction mechanics.
+
+    The returned season key remains ``adds`` for backwards compatibility;
+    v2 rows stamp ``status`` and ``won`` so summarisation can keep winning
+    prices separate from all resolved waiver attempts.  Legacy v1 rows
+    without those keys are interpreted as completed wins.
 
     Network-bound and slow (one request per league-week), so callers
     should persist the result rather than calling this per request.
@@ -144,24 +166,37 @@ def fetch_bid_history(
             for tx in txs:
                 if not isinstance(tx, dict):
                     continue
-                if tx.get("type") not in ("waiver", "free_agent"):
+                tx_type = str(tx.get("type") or "")
+                status = str(tx.get("status") or "")
+                if tx_type not in ("waiver", "free_agent"):
                     continue
-                if tx.get("status") != "complete":
+                is_win = status == "complete"
+                is_resolved_losing_waiver = tx_type == "waiver" and status == "failed"
+                if not is_win and not is_resolved_losing_waiver:
+                    # Pending claims are intentionally invisible to the model;
+                    # only resolved history may teach future predictions.
                     continue
                 bid = (tx.get("settings") or {}).get("waiver_bid")
                 adds = tx.get("adds") or {}
                 if bid is None or not isinstance(adds, dict) or not adds:
+                    continue
+                try:
+                    bid_int = int(bid)
+                except (TypeError, ValueError):
                     continue
                 roster_ids = tx.get("roster_ids") or []
                 for player_id in adds:
                     rows.append(
                         {
                             "playerId": str(player_id),
-                            "bid": int(bid),
-                            "bidPct": 100.0 * float(bid) / float(budget),
+                            "bid": bid_int,
+                            "bidPct": 100.0 * float(bid_int) / float(budget),
                             "week": week,
                             "rosterId": roster_ids[0] if roster_ids else None,
-                            "type": str(tx.get("type")),
+                            "type": tx_type,
+                            "status": status,
+                            "won": is_win,
+                            "transactionId": str(tx.get("transaction_id") or "") or None,
                             "createdAt": int(tx.get("status_updated") or tx.get("created") or 0),
                         }
                     )
@@ -188,11 +223,22 @@ def fetch_bid_history(
         )
         league_id = league.get("previous_league_id")
 
+    all_rows = [row for season in seasons for row in season.get("adds") or []]
+    wins = [row for row in all_rows if row.get("status", "complete") == "complete"]
+    attempts = [
+        row
+        for row in all_rows
+        if row.get("type") == "waiver" and row.get("status", "complete") in ("complete", "failed")
+    ]
+    failed_attempts = [row for row in attempts if row.get("status") == "failed"]
     return {
-        "schemaVersion": 1,
+        "schemaVersion": 2,
         "sleeperLeagueId": str(sleeper_league_id),
         "seasons": seasons,
-        "totalAdds": sum(len(s["adds"]) for s in seasons),
+        # Backwards-compatible: totalAdds still means completed acquisitions.
+        "totalAdds": len(wins),
+        "totalBidAttempts": len(attempts),
+        "totalFailedWaiverBids": len(failed_attempts),
     }
 
 
@@ -223,9 +269,13 @@ def load_bid_history(league_key: str) -> dict[str, Any] | None:
 class MarketPriors:
     """League-fitted market parameters.
 
-    Every field is a percentage of the ORIGINAL budget, so a league
-    that changed its budget between seasons still aggregates
-    correctly.
+    Every percentage is against the ORIGINAL budget, so a league that
+    changed its budget between seasons still aggregates correctly.
+
+    ``sample_size`` and the price percentiles remain **winning-price**
+    statistics. ``bid_attempt_sample_size`` / ``owner_attempt_*`` are a
+    separate sealed-bid tendency layer built from resolved waiver wins
+    plus failed claims when a v2 history snapshot contains them.
     """
 
     sample_size: int = 0
@@ -238,6 +288,10 @@ class MarketPriors:
     nonzero_median_pct: float = 0.0
     owner_aggression: dict[str, float] = field(default_factory=dict)
     owner_sample: dict[str, int] = field(default_factory=dict)
+    bid_attempt_sample_size: int = 0
+    failed_bid_sample_size: int = 0
+    owner_attempt_aggression: dict[str, float] = field(default_factory=dict)
+    owner_attempt_sample: dict[str, int] = field(default_factory=dict)
     by_week: dict[int, float] = field(default_factory=dict)
     seasons: list[str] = field(default_factory=list)
 
@@ -253,6 +307,12 @@ class MarketPriors:
             "nonzeroMedianPct": round(self.nonzero_median_pct, 3),
             "ownerAggression": {k: round(v, 3) for k, v in self.owner_aggression.items()},
             "ownerSample": self.owner_sample,
+            "bidAttemptSampleSize": self.bid_attempt_sample_size,
+            "failedBidSampleSize": self.failed_bid_sample_size,
+            "ownerAttemptAggression": {
+                k: round(v, 3) for k, v in self.owner_attempt_aggression.items()
+            },
+            "ownerAttemptSample": self.owner_attempt_sample,
             "seasons": self.seasons,
         }
 
@@ -265,7 +325,14 @@ def _percentile(sorted_vals: list[float], q: float) -> float:
 
 
 def summarize_bid_history(payload: dict[str, Any] | None) -> MarketPriors:
-    """Fit the market priors.
+    """Fit winning-price priors plus manager bid-attempt tendencies.
+
+    Legacy v1 snapshots contain completed wins only; rows without a
+    ``status`` key are therefore treated as wins and still produce the
+    exact same winning-price priors.  V2 snapshots additionally retain
+    failed waiver claims.  Those losing bids are **not** admitted to
+    ``median_pct`` / percentiles / by-week clearing priors; they only
+    expand the owner-attempt tendency sample.
 
     Unlike the legacy analytics summariser this KEEPS $0 bids — they
     are the modal outcome and dropping them is what made the old
@@ -275,8 +342,10 @@ def summarize_bid_history(payload: dict[str, Any] | None) -> MarketPriors:
     if not isinstance(payload, dict):
         return priors
 
-    all_pct: list[float] = []
-    by_owner: dict[str, list[float]] = {}
+    winning_pct: list[float] = []
+    winning_by_owner: dict[str, list[float]] = {}
+    waiver_attempt_pct: list[float] = []
+    attempts_by_owner: dict[str, list[float]] = {}
     by_week: dict[int, list[float]] = {}
     seasons: list[str] = []
 
@@ -292,37 +361,57 @@ def summarize_bid_history(payload: dict[str, Any] | None) -> MarketPriors:
                 pct = float(row.get("bidPct"))
             except (TypeError, ValueError):
                 continue
-            all_pct.append(pct)
+            status = str(row.get("status") or "complete")
+            tx_type = str(row.get("type") or "waiver")
             owner = str(row.get("ownerId") or "")
-            if owner:
-                by_owner.setdefault(owner, []).append(pct)
-            try:
-                by_week.setdefault(int(row.get("week") or 0), []).append(pct)
-            except (TypeError, ValueError):
-                pass
 
-    if not all_pct:
+            if status == "complete":
+                winning_pct.append(pct)
+                if owner:
+                    winning_by_owner.setdefault(owner, []).append(pct)
+                try:
+                    by_week.setdefault(int(row.get("week") or 0), []).append(pct)
+                except (TypeError, ValueError):
+                    pass
+
+            if tx_type == "waiver" and status in ("complete", "failed"):
+                waiver_attempt_pct.append(pct)
+                if owner:
+                    attempts_by_owner.setdefault(owner, []).append(pct)
+                if status == "failed":
+                    priors.failed_bid_sample_size += 1
+
+    if not winning_pct:
         return priors
 
-    all_pct.sort()
-    nonzero = [p for p in all_pct if p > 0]
+    winning_pct.sort()
+    nonzero = [p for p in winning_pct if p > 0]
 
-    priors.sample_size = len(all_pct)
-    priors.zero_bid_share = 1.0 - (len(nonzero) / len(all_pct))
-    priors.median_pct = statistics.median(all_pct)
-    priors.mean_pct = statistics.fmean(all_pct)
-    priors.p75_pct = _percentile(all_pct, 0.75)
-    priors.p90_pct = _percentile(all_pct, 0.90)
-    priors.max_pct = all_pct[-1]
+    priors.sample_size = len(winning_pct)
+    priors.zero_bid_share = 1.0 - (len(nonzero) / len(winning_pct))
+    priors.median_pct = statistics.median(winning_pct)
+    priors.mean_pct = statistics.fmean(winning_pct)
+    priors.p75_pct = _percentile(winning_pct, 0.75)
+    priors.p90_pct = _percentile(winning_pct, 0.90)
+    priors.max_pct = winning_pct[-1]
     priors.nonzero_median_pct = statistics.median(nonzero) if nonzero else 0.0
     priors.seasons = sorted(set(seasons), reverse=True)
 
-    league_mean = priors.mean_pct or 1.0
-    for owner, vals in by_owner.items():
+    winning_league_mean = priors.mean_pct or 1.0
+    for owner, vals in winning_by_owner.items():
         priors.owner_sample[owner] = len(vals)
         priors.owner_aggression[owner] = (
-            (statistics.fmean(vals) / league_mean) if league_mean else 1.0
+            (statistics.fmean(vals) / winning_league_mean) if winning_league_mean else 1.0
         )
+
+    priors.bid_attempt_sample_size = len(waiver_attempt_pct)
+    if waiver_attempt_pct:
+        attempt_league_mean = statistics.fmean(waiver_attempt_pct) or 1.0
+        for owner, vals in attempts_by_owner.items():
+            priors.owner_attempt_sample[owner] = len(vals)
+            priors.owner_attempt_aggression[owner] = (
+                (statistics.fmean(vals) / attempt_league_mean) if attempt_league_mean else 1.0
+            )
 
     for week, vals in by_week.items():
         priors.by_week[week] = statistics.fmean(vals)
@@ -789,12 +878,23 @@ def owner_aggression_factor(
 ) -> tuple[float, bool]:
     """``(factor, low_sample)`` for one manager.
 
-    Below ``min_sample`` observed adds the manager defaults to neutral
-    with ``low_sample=True`` — the engine surfaces that rather than
-    pretending to know a tendency from two claims.
+    Prefer the resolved-waiver-attempt fit when at least ``min_sample``
+    blind bids exist for this owner.  That fit includes completed wins
+    and failed/lower claims after the waiver run, so it measures actual
+    willingness to spend instead of conditioning only on bids that won.
+
+    Older v1 history files have no losing-attempt sample; they fall back
+    to the legacy winning-bid fit.  Below the sample floor either way,
+    the manager defaults to neutral with ``low_sample=True``.
     """
-    n = priors.owner_sample.get(str(owner_id), 0)
-    if n < min_sample:
+    key = str(owner_id)
+    attempt_n = priors.owner_attempt_sample.get(key, 0)
+    if attempt_n >= min_sample:
+        factor = priors.owner_attempt_aggression.get(key, 1.0)
+        return max(clamp[0], min(clamp[1], float(factor))), False
+
+    win_n = priors.owner_sample.get(key, 0)
+    if win_n < min_sample:
         return 1.0, True
-    factor = priors.owner_aggression.get(str(owner_id), 1.0)
+    factor = priors.owner_aggression.get(key, 1.0)
     return max(clamp[0], min(clamp[1], float(factor))), False

--- a/tests/trade/test_faab_bid_attempts.py
+++ b/tests/trade/test_faab_bid_attempts.py
@@ -1,0 +1,177 @@
+"""Resolved losing waiver bids improve owner-tendency prediction safely.
+
+Sleeper does not expose another manager's pending blind bid before the
+waiver run.  After processing, however, a failed waiver transaction can
+carry the submitted ``settings.waiver_bid``.  That is useful evidence of
+willingness to spend, but it is NOT a clearing price.
+
+These tests pin the separation:
+
+* completed wins continue to own the market-clearing distribution;
+* completed + failed waiver claims own the manager-tendency sample;
+* pending claims never enter history;
+* legacy v1 rows without status metadata remain completed wins.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.trade import faab_history
+
+
+def _league(budget=100):
+    return {
+        "settings": {"num_teams": 12, "waiver_budget": budget},
+        "season": "2026",
+        "previous_league_id": None,
+    }
+
+
+def _tx(*, bid, status="complete", tx_type="waiver", player="p1", roster_id=1):
+    return {
+        "transaction_id": f"{status}-{tx_type}-{player}-{bid}",
+        "type": tx_type,
+        "status": status,
+        "settings": {"waiver_bid": bid},
+        "adds": {player: roster_id},
+        "roster_ids": [roster_id],
+        "status_updated": 1_700_000_000,
+    }
+
+
+def _install(monkeypatch, transactions):
+    rosters = [
+        {"roster_id": 1, "owner_id": "owner-a"},
+        {"roster_id": 2, "owner_id": "owner-b"},
+    ]
+
+    def fake_get(url: str):
+        if "/transactions/" in url:
+            week = int(url.rsplit("/", 1)[-1])
+            return transactions if week == 1 else []
+        if url.endswith("/rosters"):
+            return rosters
+        return _league()
+
+    monkeypatch.setattr(faab_history, "_get", fake_get)
+
+
+def _row(pct, *, owner, status="complete", tx_type="waiver", week=1):
+    return {
+        "bidPct": float(pct),
+        "ownerId": owner,
+        "status": status,
+        "type": tx_type,
+        "week": week,
+    }
+
+
+def test_fetch_keeps_resolved_failed_waiver_bids_but_not_pending_or_failed_free_agents(monkeypatch):
+    _install(
+        monkeypatch,
+        [
+            _tx(bid=18, status="complete", tx_type="waiver", player="won", roster_id=1),
+            _tx(bid=31, status="failed", tx_type="waiver", player="lost", roster_id=2),
+            _tx(bid=44, status="pending", tx_type="waiver", player="secret", roster_id=2),
+            _tx(bid=12, status="failed", tx_type="free_agent", player="fa-fail", roster_id=2),
+        ],
+    )
+
+    out = faab_history.fetch_bid_history("L1")
+    rows = out["seasons"][0]["adds"]
+
+    assert {(r["playerId"], r["status"], r["bid"]) for r in rows} == {
+        ("won", "complete", 18),
+        ("lost", "failed", 31),
+    }
+    assert out["schemaVersion"] == 2
+    assert out["totalAdds"] == 1, "legacy totalAdds must still mean completed acquisitions"
+    assert out["totalBidAttempts"] == 2
+    assert out["totalFailedWaiverBids"] == 1
+    assert next(r for r in rows if r["playerId"] == "lost")["ownerId"] == "owner-b"
+
+
+def test_losing_bids_expand_owner_sample_without_polluting_clearing_prices():
+    payload = {
+        "schemaVersion": 2,
+        "seasons": [
+            {
+                "season": "2026",
+                "adds": [
+                    _row(10, owner="a", status="complete"),
+                    _row(20, owner="b", status="complete"),
+                    _row(90, owner="a", status="failed"),
+                    _row(80, owner="a", status="failed"),
+                ],
+            }
+        ],
+    }
+
+    priors = faab_history.summarize_bid_history(payload)
+
+    # Clearing-price statistics are wins only: [10, 20].
+    assert priors.sample_size == 2
+    assert priors.median_pct == pytest.approx(15.0)
+    assert priors.mean_pct == pytest.approx(15.0)
+    assert priors.max_pct == pytest.approx(20.0)
+
+    # Manager tendency sees all resolved blind waiver attempts.
+    assert priors.bid_attempt_sample_size == 4
+    assert priors.failed_bid_sample_size == 2
+    assert priors.owner_attempt_sample["a"] == 3
+    assert priors.owner_sample["a"] == 1
+    assert priors.owner_attempt_aggression["a"] > 1.0
+
+
+def test_owner_aggression_prefers_three_resolved_attempts_over_one_winning_bid():
+    payload = {
+        "schemaVersion": 2,
+        "seasons": [
+            {
+                "season": "2026",
+                "adds": [
+                    _row(10, owner="a", status="complete"),
+                    _row(20, owner="a", status="failed"),
+                    _row(30, owner="a", status="failed"),
+                    _row(0, owner="b", status="complete"),
+                    _row(0, owner="b", status="failed"),
+                    _row(0, owner="b", status="failed"),
+                ],
+            }
+        ],
+    }
+
+    priors = faab_history.summarize_bid_history(payload)
+    factor, low_sample = faab_history.owner_aggression_factor(priors, "a", min_sample=3)
+
+    # Attempt means: owner A = 20, owner B = 0, league = 10 => 2.0x.
+    # The old wins-only path would have seen just one A win and returned
+    # neutral/low-sample instead.
+    assert factor == pytest.approx(2.0)
+    assert low_sample is False
+
+
+def test_v1_rows_without_status_keep_the_legacy_winning_bid_behavior():
+    payload = {
+        "schemaVersion": 1,
+        "seasons": [
+            {
+                "season": "2025",
+                "adds": [
+                    {"bidPct": 5.0, "ownerId": "a", "type": "waiver", "week": 1},
+                    {"bidPct": 10.0, "ownerId": "a", "type": "waiver", "week": 2},
+                    {"bidPct": 15.0, "ownerId": "a", "type": "waiver", "week": 3},
+                    {"bidPct": 10.0, "ownerId": "b", "type": "waiver", "week": 1},
+                ],
+            }
+        ],
+    }
+
+    priors = faab_history.summarize_bid_history(payload)
+    assert priors.sample_size == 4
+    assert priors.bid_attempt_sample_size == 4
+    assert priors.failed_bid_sample_size == 0
+    factor, low_sample = faab_history.owner_aggression_factor(priors, "a", min_sample=3)
+    assert low_sample is False
+    assert factor == pytest.approx(priors.owner_attempt_aggression["a"])


### PR DESCRIPTION
## What changed
- keep completed winning claims as the canonical clearing-price distribution
- ingest resolved failed Sleeper waiver bids after processing as owner-tendency evidence
- never ingest pending claims, so the model does not imply blind bids are visible before waivers run
- prefer resolved-attempt aggression when a manager has at least 3 observations, with automatic fallback to legacy winning-bid history
- preserve schema-v1 history compatibility and the legacy `totalAdds` meaning
- report resolved-attempt / failed-bid coverage in the history refresh script
- add regression tests for pending-bid exclusion, failed-bid ingestion, clearing-price isolation, tendency preference, and v1 fallback

## Why
A losing $40 bid is strong evidence that an owner was willing to spend $40, but it is not evidence that the player cleared at $40. Separating those samples lets the existing FAAB engine make better opponent-bid predictions without corrupting its clearing-price priors.

## Safety / truthfulness
This uses only **resolved historical waiver transactions after the run**. It does not expose or claim access to other managers' pending blind bids.