### PR TITLE
fix(V1-131): keep mobile drawer open through shell hydration

### DIFF
--- a/frontend/components/shell/MobileChrome.jsx
+++ b/frontend/components/shell/MobileChrome.jsx
@@ -16,7 +16,7 @@
  */
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Drawer, Icon } from "@/components/ds";
 import TeamSwitcher from "@/components/TeamSwitcher";
 import LeagueSwitcher from "@/components/LeagueSwitcher";
@@ -84,10 +84,16 @@ export function MobileTopBar({ authenticated, onSearch, searchEnabled = true }) 
 export function MobileTabBar({ authenticated, isAdmin, capabilities, isPublic, onLogout }) {
   const pathname = usePathname();
   const [menuOpen, setMenuOpen] = useState(false);
+  const previousPathnameRef = useRef(pathname);
 
-  // Close the drawer whenever navigation lands.
+  // Close the drawer only when navigation ACTUALLY lands somewhere else.
+  // A late shell mount/hydration effect must not race the Menu click and
+  // immediately close a drawer that was just opened (V1-131 mobile L4).
   useEffect(() => {
-    setMenuOpen(false);
+    if (previousPathnameRef.current !== pathname) {
+      previousPathnameRef.current = pathname;
+      setMenuOpen(false);
+    }
   }, [pathname]);
 
   // Logged out, the authed tab set filtered by "is this public" left


### PR DESCRIPTION
## V1 traffic-control repair

Fresh branch from current `main` (`0a6f6b43559b5eacaf2df035bfacccd666f5dd11`).

The authenticated production L4 run proves V1-131's API/desktop branches but fails the 390x844 mobile-drawer step because clicking **Menu** leaves no `.shell-drawer-group` in the DOM. The implementation currently runs an unconditional `setMenuOpen(false)` whenever the pathname effect fires. This patch preserves the intended close-on-navigation behavior but only closes on a real pathname transition, avoiding a late mount/hydration effect racing the click.

No capability semantics, auth, route gating, nav ownership, or V1 methodology are changed. The existing `v1-131-nav-gating.spec.js` remains the acceptance authority; this PR is not itself verification. After merge/deploy, rerun authenticated production verification and promote V1-131 only if the complete recipe passes.