### PR TITLE
test(v1-56): select a real team before production FAAB strip assertion

### DIFF
--- a/tests/e2e/specs/prod-auth/v1-56-waivers-faab-strip.spec.js
+++ b/tests/e2e/specs/prod-auth/v1-56-waivers-faab-strip.spec.js
@@ -50,6 +50,32 @@ test.describe("V1-56: /waivers league-FAAB context strip", () => {
       page.getByRole("heading", { level: 1, name: /^Waivers$/ }),
     ).toBeVisible({ timeout: 90_000 });
 
+    // FaabHeaderStat intentionally lives inside ManualAddDrop's
+    // selected-team branch because the strip includes "Your FAAB" as
+    // well as the league-wide numbers. The ephemeral guest-pass account
+    // has no persisted Sleeper team identity, so merely loading /waivers
+    // leaves selectedTeam null and the strip correctly absent. Older
+    // versions of this production spec asserted the strip immediately
+    // and therefore failed on a legitimate teamless state even while the
+    // page had fetched populated league analytics. Select a REAL team
+    // through the deployed TeamSwitcher before asserting the consumer.
+    const teamToggle = page.locator(".team-switcher-toggle").first();
+    await expect(
+      teamToggle,
+      "the deployed shell must expose the canonical TeamSwitcher before V1-56 can exercise the team-scoped FAAB strip",
+    ).toBeVisible({ timeout: 60_000 });
+    await teamToggle.click();
+    const teamOptions = page.locator(".team-switcher-option");
+    await expect(
+      teamOptions.first(),
+      "TeamSwitcher opened but exposed no real league teams",
+    ).toBeVisible({ timeout: 30_000 });
+    const selectedTeamName = (
+      await teamOptions.first().locator(".team-switcher-option-name").innerText()
+    ).trim();
+    await teamOptions.first().click();
+    annotate(testInfo, "team-selected", selectedTeamName || "first available team");
+
     const analyticsRes = await analyticsPromise;
     let data = null;
     if (analyticsRes) {


### PR DESCRIPTION
## Why
Fresh authenticated production verification run `33121548528` exposed a verifier/setup gap, not a product/value defect: the ephemeral guest session has no persisted Sleeper team identity, while `FaabHeaderStat` intentionally renders inside `ManualAddDrop`'s `selectedTeam` branch because the strip includes both league-wide bid context and `Your FAAB`.

The prior production spec loaded `/waivers`, captured populated `faabAnalytics`, then asserted the strip without ever selecting a team. That can correctly leave the strip absent and still produce a false failure.

## Change
- Drive the deployed canonical `TeamSwitcher` after `/waivers` loads.
- Select the first real league team exposed by the page.
- Preserve the existing comparison against the page's own captured `GET /api/public/league/faabAnalytics` response.
- Preserve missing != zero semantics, including measured `$0` vs unavailable `—`.

No product code, FAAB methodology, valuation, auth, V1 scope, or completion tally changes.

## Acceptance
- Exact-head CI must pass before merge.
- After merge, a fresh authenticated production verification run is still required to confirm the corrected browser consumer proof. This PR itself is not production verification.