### PR TITLE
V1-49: controlled production activation/rollback workflow for host_native_scoring

### DIFF
--- a/.github/workflows/v1-49-host-native-scoring-activation.yml
+++ b/.github/workflows/v1-49-host-native-scoring-activation.yml
@@ -1,0 +1,268 @@
+name: V1-49 Host-Native Scoring — Controlled Activation
+
+# Narrowly-scoped, reviewed production write for exactly ONE thing:
+# flipping RISKIT_FEATURE_HOST_NATIVE_SCORING in production, rebuilding
+# the PBP-weekly artifact, and measuring the result — with automatic,
+# verified rollback on any failure.
+#
+# This is deliberately NOT a general production-mutation framework:
+#   * the flag key is hard-coded inside
+#     deploy/diagnostics/v1_49_host_native_activation.sh, never taken
+#     from a workflow input;
+#   * the only typed inputs are `action` (activate|rollback),
+#     `confirm_activation`, `expected_sha`, `bdvm_season`,
+#     `activation_id`, and a free-text `reason` used only as an audit
+#     note — there is no free-text command input anywhere;
+#   * there is exactly one rollback code path
+#     (deploy/diagnostics/v1_49_host_native_activation.sh::do_rollback),
+#     invoked both by the automatic in-script failure handler and by an
+#     explicit `action: rollback` dispatch.
+#
+# Merging this workflow does NOT activate anything — it must be
+# separately dispatched with `action: activate` once this PR's CI is
+# green. See docs/scoring/HOST_NATIVE_SCORING_VALIDATION.md and V1-49 in
+# docs/VERSION_1_COMPLETION_CONTRACT.md for the governing conditions.
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "activate = flip the flag, rebuild, measure. rollback = restore a prior activation attempt."
+        required: true
+        type: choice
+        options:
+          - activate
+          - rollback
+      confirm_activation:
+        description: "Must be true to run action=activate. Guards against a fat-fingered dispatch."
+        required: false
+        default: false
+        type: boolean
+      expected_sha:
+        description: "Exact commit SHA production must currently be running. Preflight refuses on mismatch. Required for activate; ignored for rollback."
+        required: true
+        type: string
+      bdvm_season:
+        description: "Season scripts/bdvm_build_baseline.py targets for the pre/post snapshot diff (e.g. 2026). Required for activate; ignored for rollback."
+        required: false
+        type: string
+      activation_id:
+        description: "For action=rollback: the activation id (GitHub Actions run id) to restore. Empty = most recent activation attempt."
+        required: false
+        type: string
+      reason:
+        description: "Audit note: why this is being run."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  # Shares deploy.yml's group deliberately: a real deploy and a flag
+  # activation must never race on the same box.
+  group: production-deploy
+  cancel-in-progress: false
+
+jobs:
+  v1-49-activation:
+    name: V1-49 host-native-scoring controlled activation
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Validate inputs
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          if [[ "${{ inputs.action }}" == "activate" ]]; then
+            if [[ "${{ inputs.confirm_activation }}" != "true" ]]; then
+              echo "::error::action=activate requires confirm_activation=true. Refusing to proceed."
+              exit 1
+            fi
+            if [[ -z "${{ inputs.bdvm_season }}" ]]; then
+              echo "::error::bdvm_season is required for action=activate."
+              exit 1
+            fi
+          fi
+
+      - name: Configure production SSH
+        env:
+          DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          install -d -m 700 "$HOME/.ssh"
+          printf '%s\n' "$DEPLOY_SSH_PRIVATE_KEY" | sed 's/\r$//' > "$HOME/.ssh/id_ed25519"
+          printf '%s\n' "$DEPLOY_KNOWN_HOSTS" | sed 's/\r$//' > "$HOME/.ssh/known_hosts"
+          chmod 600 "$HOME/.ssh/id_ed25519"
+          chmod 644 "$HOME/.ssh/known_hosts"
+          ssh-keygen -y -f "$HOME/.ssh/id_ed25519" >/dev/null
+          echo "PORT=${DEPLOY_PORT:-22}" >> "$GITHUB_ENV"
+
+      - name: Preflight (read-only)
+        id: preflight
+        if: ${{ inputs.action == 'activate' }}
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          APP_DIR: ${{ vars.PROD_APP_DIR || '/home/dynasty/trade-calculator' }}
+          PYTHON_BIN: ${{ vars.PROD_PYTHON_BIN || '' }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          set -o pipefail
+          rc=0
+          ssh -i "$HOME/.ssh/id_ed25519" \
+            -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+            -o ConnectTimeout=15 -o ServerAliveInterval=15 \
+            -p "$PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "ACTION=preflight APP_DIR=$(printf %q "$APP_DIR") PYTHON_BIN=$(printf %q "$PYTHON_BIN") EXPECTED_SHA=$(printf %q "${{ inputs.expected_sha }}") bash -s" \
+            < deploy/diagnostics/v1_49_host_native_activation.sh 2>&1 | tee preflight.txt || rc=$?
+          echo "Preflight exit code: ${rc}"
+          exit "${rc}"
+
+      - name: Backup, activate, rebuild, measure
+        id: activate
+        if: ${{ inputs.action == 'activate' && steps.preflight.outcome == 'success' }}
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          APP_DIR: ${{ vars.PROD_APP_DIR || '/home/dynasty/trade-calculator' }}
+          PYTHON_BIN: ${{ vars.PROD_PYTHON_BIN || '' }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          set -o pipefail
+          rc=0
+          ssh -i "$HOME/.ssh/id_ed25519" \
+            -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+            -o ConnectTimeout=15 -o ServerAliveInterval=30 \
+            -p "$PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "ACTION=activate APP_DIR=$(printf %q "$APP_DIR") PYTHON_BIN=$(printf %q "$PYTHON_BIN") EXPECTED_SHA=$(printf %q "${{ inputs.expected_sha }}") ACTIVATION_ID=$(printf %q "${{ github.run_id }}") BDVM_SEASON=$(printf %q "${{ inputs.bdvm_season }}") REASON=$(printf %q "${{ inputs.reason }}") bash -s" \
+            < deploy/diagnostics/v1_49_host_native_activation.sh 2>&1 | tee activation.txt || rc=$?
+          echo "Activation exit code: ${rc}"
+          echo "activation_exit=${rc}" >> "$GITHUB_OUTPUT"
+          exit "${rc}"
+
+      - name: Safety-net rollback (activation step failed to complete cleanly)
+        id: safety_net_rollback
+        if: ${{ inputs.action == 'activate' && steps.activate.outcome == 'failure' }}
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          APP_DIR: ${{ vars.PROD_APP_DIR || '/home/dynasty/trade-calculator' }}
+          PYTHON_BIN: ${{ vars.PROD_PYTHON_BIN || '' }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          set -o pipefail
+          rc=0
+          # Covers what the in-script ERR trap cannot see (an SSH drop,
+          # or the runner killing the previous step on timeout). Calling
+          # this even when the in-script trap already rolled back is
+          # safe: every restore it performs is idempotent.
+          ssh -i "$HOME/.ssh/id_ed25519" \
+            -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+            -o ConnectTimeout=15 -o ServerAliveInterval=15 \
+            -p "$PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "ACTION=rollback APP_DIR=$(printf %q "$APP_DIR") PYTHON_BIN=$(printf %q "$PYTHON_BIN") ACTIVATION_ID=$(printf %q "${{ github.run_id }}") REASON=$(printf %q "safety-net: activate step did not complete cleanly, run ${{ github.run_id }}") bash -s" \
+            < deploy/diagnostics/v1_49_host_native_activation.sh 2>&1 | tee safety-net-rollback.txt || rc=$?
+          echo "Safety-net rollback exit code: ${rc}"
+          if [[ "${rc}" != "0" ]]; then
+            echo "::error::Safety-net rollback FAILED (exit ${rc}) — MANUAL INTERVENTION REQUIRED."
+          fi
+          exit "${rc}"
+
+      - name: Explicit rollback dispatch
+        id: explicit_rollback
+        if: ${{ inputs.action == 'rollback' }}
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          APP_DIR: ${{ vars.PROD_APP_DIR || '/home/dynasty/trade-calculator' }}
+          PYTHON_BIN: ${{ vars.PROD_PYTHON_BIN || '' }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          set -o pipefail
+          rc=0
+          ssh -i "$HOME/.ssh/id_ed25519" \
+            -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+            -o ConnectTimeout=15 -o ServerAliveInterval=15 \
+            -p "$PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "ACTION=rollback APP_DIR=$(printf %q "$APP_DIR") PYTHON_BIN=$(printf %q "$PYTHON_BIN") ACTIVATION_ID=$(printf %q "${{ inputs.activation_id }}") REASON=$(printf %q "${{ inputs.reason }}") bash -s" \
+            < deploy/diagnostics/v1_49_host_native_activation.sh 2>&1 | tee rollback.txt || rc=$?
+          echo "Rollback exit code: ${rc}"
+          exit "${rc}"
+
+      - name: Job summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## V1-49 host-native-scoring — action: ${{ inputs.action }}"
+            echo ""
+            echo "- Reason: ${{ inputs.reason }}"
+            echo "- Run id (activation id): ${{ github.run_id }}"
+            echo "- Expected SHA: ${{ inputs.expected_sha }}"
+            echo ""
+            if [[ "${{ inputs.action }}" == "activate" ]]; then
+              if [[ "${{ steps.preflight.outcome }}" == "failure" ]]; then
+                echo "### RESULT: PREFLIGHT_REFUSED — nothing was written."
+              else
+                exit_code="${{ steps.activate.outputs.activation_exit }}"
+                case "${exit_code}" in
+                  0) echo "### RESULT: ACTIVATED" ;;
+                  2) echo "### RESULT: ROLLED_BACK — this is a FAILED V1-49 verification attempt, not VERIFIED." ;;
+                  *)
+                    if [[ "${{ steps.safety_net_rollback.outcome }}" == "success" ]]; then
+                      echo "### RESULT: ROLLED_BACK (via safety net) — this is a FAILED V1-49 verification attempt, not VERIFIED."
+                    else
+                      echo "### RESULT: ROLLBACK_FAILED — MANUAL INTERVENTION REQUIRED."
+                    fi
+                    ;;
+                esac
+              fi
+            else
+              if [[ "${{ steps.explicit_rollback.outcome }}" == "success" ]]; then
+                echo "### RESULT: ROLLED_BACK"
+              else
+                echo "### RESULT: ROLLBACK_FAILED — MANUAL INTERVENTION REQUIRED."
+              fi
+            fi
+            echo ""
+            for f in preflight.txt activation.txt safety-net-rollback.txt rollback.txt; do
+              if [[ -s "${f}" ]]; then
+                echo "<details><summary>${f}</summary>"
+                echo ""
+                echo '```'
+                tail -c 40000 "${f}"
+                echo '```'
+                echo "</details>"
+                echo ""
+              fi
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: v1-49-activation-report
+          path: |
+            preflight.txt
+            activation.txt
+            safety-net-rollback.txt
+            rollback.txt
+          if-no-files-found: ignore
+          retention-days: 90

--- a/config/ci/release_gate_classification.json
+++ b/config/ci/release_gate_classification.json
@@ -683,6 +683,33 @@
     "temporal-ledger-diagnostics.yml::ledger-status::Probe temporal ledger on production": {
       "category": "blocking"
     },
+    "v1-49-host-native-scoring-activation.yml::v1-49-activation::Backup, activate, rebuild, measure": {
+      "category": "blocking"
+    },
+    "v1-49-host-native-scoring-activation.yml::v1-49-activation::Checkout": {
+      "category": "blocking"
+    },
+    "v1-49-host-native-scoring-activation.yml::v1-49-activation::Configure production SSH": {
+      "category": "blocking"
+    },
+    "v1-49-host-native-scoring-activation.yml::v1-49-activation::Explicit rollback dispatch": {
+      "category": "blocking"
+    },
+    "v1-49-host-native-scoring-activation.yml::v1-49-activation::Job summary": {
+      "category": "blocking"
+    },
+    "v1-49-host-native-scoring-activation.yml::v1-49-activation::Preflight (read-only)": {
+      "category": "blocking"
+    },
+    "v1-49-host-native-scoring-activation.yml::v1-49-activation::Safety-net rollback (activation step failed to complete cleanly)": {
+      "category": "blocking"
+    },
+    "v1-49-host-native-scoring-activation.yml::v1-49-activation::Upload the reports": {
+      "category": "blocking"
+    },
+    "v1-49-host-native-scoring-activation.yml::v1-49-activation::Validate inputs": {
+      "category": "blocking"
+    },
     "v1-authenticated-verification.yml::v1-authenticated::API verification suite": {
       "category": "blocking"
     },

--- a/deploy/diagnostics/v1_49_host_native_activation.sh
+++ b/deploy/diagnostics/v1_49_host_native_activation.sh
@@ -1,0 +1,572 @@
+#!/usr/bin/env bash
+#
+# v1_49_host_native_activation.sh — controlled production activation and
+# rollback for ONE feature flag: RISKIT_FEATURE_HOST_NATIVE_SCORING.
+#
+# WHAT THIS IS, AND IS NOT
+# ─────────────────────────
+# This script does exactly three things, selected by $ACTION: (1) a
+# read-only preflight that refuses to proceed on any unexpected state,
+# (2) a controlled activation — backup, flag flip, restart, PBP rebuild,
+# post-activation measurement — that automatically rolls itself back on
+# any failure, and (3) an explicit rollback that restores a prior
+# activation attempt's captured state. It is deliberately NOT a general
+# remote-command runner: the flag key is a hard-coded constant
+# ($FLAG_KEY below), never taken from an argument, and there is no path
+# by which caller-supplied text becomes a shell command.
+#
+# THE SINGLE ROLLBACK PATH
+# ─────────────────────────
+# do_rollback() is the ONLY code that ever touches the flag or the PBP
+# artifacts to undo something. It runs from two callers only: the ERR
+# trap installed inside do_activate() (automatic rollback on any failure
+# during activation), and the $ACTION=rollback branch (an explicit,
+# later dispatch — including one run in a fresh SSH session after this
+# script's own process died, e.g. an SSH drop or a runner timeout). Both
+# callers pass it the SAME on-disk state directory, so there are not two
+# rollback implementations to keep in sync — there is one, and it reads
+# its inputs from files, never from in-memory state that a dropped
+# connection could lose.
+#
+# do_rollback() is idempotent: every restore it performs
+# (scripts/prod_env_flag_ops.py restore, scripts/pbp_artifact_backup.py
+# restore) is itself idempotent, so running it twice — e.g. the ERR trap
+# fires, and a later explicit $ACTION=rollback dispatch is also run
+# against the same activation id — converges to the same state and is
+# not an error.
+#
+# WHAT NEVER TRIGGERS A ROLLBACK
+# ────────────────────────────────
+# The post-activation "league-comparison rerun" probe
+# (GET /api/league-comparison?refresh=1) is an OBSERVATION, not a
+# pass/fail gate — a 503 there is a documented, normal condition of that
+# endpoint (Sleeper transiently unreachable) and is recorded as such,
+# never treated as evidence the activation itself is broken. Every other
+# step (flag flip, restart, health check, PBP rebuild, PBP schema
+# validation, BDVM pre/post build and diff) is a hard requirement: any
+# failure trips automatic rollback.
+#
+# STATE LAYOUT
+# ─────────────
+#   $APP_DIR/.deploy/v1-49-host-native-activation/<activation_id>/
+#     prior_flag_state.txt          raw .env value captured before the
+#                                    flip ("ABSENT" if the key was unset)
+#     prior_flag_enabled_bool.txt   is_enabled() result captured before
+#                                    the flip, for the post-rollback
+#                                    sanity check
+#     pbp_backup_manifest_path.txt  path to the pbp_artifact_backup.py
+#                                    manifest for this attempt
+#     bdvm_pre_snapshot_path.txt / bdvm_post_snapshot_path.txt
+#     report.json                   final structured report
+#     result.txt                    ACTIVATED | ROLLED_BACK | ROLLBACK_FAILED
+#   $APP_DIR/.deploy/v1-49-host-native-activation/LATEST
+#     the most recent activation_id — used by $ACTION=rollback when no
+#     --activation-id / ACTIVATION_ID is supplied
+#
+# Inputs (environment):
+#   ACTION            preflight | activate | rollback   (required)
+#   APP_DIR           deployed app tree
+#   SERVICE_NAME      systemd unit to restart (default: dynasty)
+#   PYTHON_BIN        venv interpreter (falls back through candidates)
+#   APP_HOST/APP_PORT local health-check target (default 127.0.0.1:8000)
+#   EXPECTED_SHA      required for preflight/activate — refuses on mismatch
+#   ACTIVATION_ID     required for activate; for rollback, empty = LATEST
+#   REASON            free-text audit note (never used as a command)
+#   BDVM_SEASON       required for activate — the season bdvm_build_baseline.py
+#                     targets (this script does not derive it; the
+#                     dispatching human states it explicitly)
+#
+# Exit codes:
+#   0  preflight passed / activation succeeded / rollback succeeded
+#   1  preflight refused (nothing was written) / rollback found nothing
+#      to roll back
+#   2  activation failed and automatic rollback SUCCEEDED — this is a
+#      FAILED V1-49 verification attempt, not a success
+#   3  activation failed and automatic rollback ALSO FAILED, or an
+#      explicit rollback dispatch failed — manual intervention required
+
+set -Eeuo pipefail
+
+FLAG_KEY="RISKIT_FEATURE_HOST_NATIVE_SCORING"
+FLAG_GATE_NAME="host_native_scoring"
+PBP_SEASONS=(2021 2022 2023 2024 2025)
+
+APP_DIR="${APP_DIR:-/home/dynasty/trade-calculator}"
+SERVICE_NAME="${SERVICE_NAME:-dynasty}"
+APP_HOST="${APP_HOST:-127.0.0.1}"
+APP_PORT="${APP_PORT:-8000}"
+ENV_FILE="${APP_DIR}/.env"
+ACTION="${ACTION:-}"
+EXPECTED_SHA="${EXPECTED_SHA:-}"
+ACTIVATION_ID="${ACTIVATION_ID:-}"
+REASON="${REASON:-unspecified}"
+BDVM_SEASON="${BDVM_SEASON:-}"
+
+STATE_ROOT="${APP_DIR}/.deploy/v1-49-host-native-activation"
+LATEST_POINTER="${STATE_ROOT}/LATEST"
+
+log()  { printf '[v1-49] %s\n' "$*"; }
+warn() { printf '[v1-49][WARN] %s\n' "$*" >&2; }
+
+fail_preflight() {
+  printf '[v1-49][PREFLIGHT REFUSED] %s\n' "$*" >&2
+  exit 1
+}
+
+# ACTIVATION_ID becomes a path segment (${STATE_ROOT}/${ACTIVATION_ID}).
+# For `activate` it is always github.run_id (numeric, not caller-chosen),
+# but for `rollback` it is free-text operator input
+# (inputs.activation_id) — unvalidated, "../../etc" would point
+# do_rollback at a directory outside $STATE_ROOT entirely. Enforced
+# before ANY use, on both paths, so there is one gate rather than one
+# per caller.
+validate_activation_id() {
+  local id="$1"
+  if [[ -z "${id}" || ! "${id}" =~ ^[A-Za-z0-9_.-]+$ || "${id}" == "." || "${id}" == ".." ]]; then
+    echo "[v1-49][ERROR] invalid activation id (must match ^[A-Za-z0-9_.-]+\$, not '.' or '..'): '${id}'" >&2
+    exit 1
+  fi
+}
+
+# ── interpreter / systemctl resolution (mirrors the fallback chain
+#    already established in lane4-onbox-verification.yml + deploy.sh,
+#    kept local here rather than sourced — this script's rollback path
+#    must not depend on another script's tree state) ─────────────────
+resolve_python_bin() {
+  if [[ -n "${PYTHON_BIN:-}" && -x "${PYTHON_BIN}" ]]; then
+    printf '%s\n' "${PYTHON_BIN}"
+    return 0
+  fi
+  local candidate
+  for candidate in \
+    "${APP_DIR}/.venv/bin/python" \
+    "${APP_DIR}/venv/bin/python" \
+    "/home/dynasty/.venvs/trade-calculator/bin/python"
+  do
+    [[ -x "${candidate}" ]] && { printf '%s\n' "${candidate}"; return 0; }
+  done
+  command -v python3
+}
+PYTHON_BIN="$(resolve_python_bin)"
+
+resolve_systemctl_bin() {
+  local candidate
+  for candidate in /bin/systemctl /usr/bin/systemctl; do
+    [[ -x "${candidate}" ]] || continue
+    if sudo -n "${candidate}" --version >/dev/null 2>&1; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+  warn "No NOPASSWD sudo permission for systemctl (checked /bin, /usr/bin)."
+  return 1
+}
+
+# ── small python helpers, run against the SAME .env every production
+#    process would source (EnvironmentFile=-__APP_DIR__/.env) ─────────
+env_sourced_python() {
+  # Usage: env_sourced_python <python -c code...>
+  ( set -a; [[ -f "${ENV_FILE}" ]] && source "${ENV_FILE}"; set +a
+    cd "${APP_DIR}" && "${PYTHON_BIN}" "$@" )
+}
+
+read_flag_enabled() {
+  env_sourced_python -c "
+import sys
+sys.path.insert(0, '.')
+from src.api.feature_flags import is_enabled
+print(is_enabled('${FLAG_GATE_NAME}'))
+"
+}
+
+# ── preflight: read-only, refuses on any surprise ─────────────────────
+run_preflight_checks() {
+  log "Preflight: expected SHA, flag state, service, PBP script, artifact state."
+
+  [[ -n "${EXPECTED_SHA}" ]] || fail_preflight "EXPECTED_SHA was not supplied."
+  [[ -d "${APP_DIR}/.git" ]] || fail_preflight "APP_DIR is not a git checkout: ${APP_DIR}"
+
+  local actual_sha
+  actual_sha="$(git -C "${APP_DIR}" rev-parse HEAD)" || fail_preflight "could not read HEAD in ${APP_DIR}"
+  if [[ "${actual_sha}" != "${EXPECTED_SHA}" ]]; then
+    fail_preflight "deployed SHA (${actual_sha}) does not match expected (${EXPECTED_SHA})."
+  fi
+  log "SHA confirmed: ${actual_sha}"
+
+  local current_enabled
+  current_enabled="$(read_flag_enabled)" || fail_preflight "could not read current ${FLAG_GATE_NAME} state."
+  log "Current ${FLAG_KEY} state: enabled=${current_enabled}"
+
+  local systemctl_bin
+  systemctl_bin="$(resolve_systemctl_bin)" || fail_preflight "cannot resolve a usable systemctl."
+  sudo -n "${systemctl_bin}" cat "${SERVICE_NAME}" >/dev/null 2>&1 \
+    || fail_preflight "systemd unit not found: ${SERVICE_NAME}"
+  log "Service unit confirmed: ${SERVICE_NAME}"
+
+  [[ -f "${APP_DIR}/scripts/build_pbp_weekly.py" ]] \
+    || fail_preflight "missing scripts/build_pbp_weekly.py"
+  # ast.parse rather than py_compile: preflight is read-only, and
+  # py_compile would write a __pycache__/*.pyc as a side effect.
+  "${PYTHON_BIN}" -c "
+import ast
+import sys
+with open(sys.argv[1]) as fh:
+    ast.parse(fh.read())
+" "${APP_DIR}/scripts/build_pbp_weekly.py" \
+    || fail_preflight "scripts/build_pbp_weekly.py fails to parse"
+  [[ -f "${APP_DIR}/scripts/bdvm_build_baseline.py" ]] \
+    || fail_preflight "missing scripts/bdvm_build_baseline.py"
+
+  log "Current PBP artifact state (data/nfl_data/actuals/):"
+  local season
+  for season in "${PBP_SEASONS[@]}"; do
+    local artifact="${APP_DIR}/data/nfl_data/actuals/pbp_weekly_${season}.jsonl"
+    if [[ -f "${artifact}" ]]; then
+      local schema
+      schema="$(env_sourced_python -c "
+import json
+import sys
+with open(sys.argv[1]) as fh:
+    first = fh.readline()
+try:
+    print(json.loads(first).get('schemaVersion', '<none>'))
+except Exception:
+    print('<unparseable>')
+" "${artifact}" 2>/dev/null || echo '<error>')"
+      log "  ${season}: exists, schemaVersion=${schema}, mtime=$(date -u -r "${artifact}" +%Y-%m-%dT%H:%M:%SZ)"
+    else
+      log "  ${season}: does not exist yet"
+    fi
+  done
+
+  log "Preflight OK."
+}
+
+# ── the single rollback path ───────────────────────────────────────────
+do_rollback() {
+  local state_dir="$1"
+  local trigger_reason="$2"
+  local failures=()
+
+  log "ROLLBACK: starting (state dir: ${state_dir}; trigger: ${trigger_reason})"
+
+  if [[ ! -d "${state_dir}" ]]; then
+    warn "ROLLBACK: no state directory at ${state_dir} — nothing captured to roll back."
+    return 1
+  fi
+
+  local prior_flag_file="${state_dir}/prior_flag_state.txt"
+  local prior_bool_file="${state_dir}/prior_flag_enabled_bool.txt"
+  local pbp_manifest_pointer="${state_dir}/pbp_backup_manifest_path.txt"
+
+  if [[ -f "${prior_flag_file}" ]]; then
+    local prior_state
+    if prior_state="$(cat "${prior_flag_file}")"; then
+      log "ROLLBACK: restoring ${FLAG_KEY} to captured prior state: ${prior_state}"
+      "${PYTHON_BIN}" "${APP_DIR}/scripts/prod_env_flag_ops.py" restore \
+        --env-file "${ENV_FILE}" --key "${FLAG_KEY}" --prior-state "${prior_state}" \
+        || failures+=("env flag restore failed")
+    else
+      failures+=("could not read captured prior flag state from ${prior_flag_file}")
+    fi
+  else
+    log "ROLLBACK: no captured prior flag state — flag was never changed this attempt."
+  fi
+
+  if [[ -f "${pbp_manifest_pointer}" ]]; then
+    local manifest_path
+    if manifest_path="$(cat "${pbp_manifest_pointer}")"; then
+      log "ROLLBACK: restoring PBP artifacts from manifest: ${manifest_path}"
+      "${PYTHON_BIN}" "${APP_DIR}/scripts/pbp_artifact_backup.py" restore \
+        --manifest "${manifest_path}" \
+        || failures+=("pbp artifact restore failed")
+    else
+      failures+=("could not read captured pbp backup manifest path from ${pbp_manifest_pointer}")
+    fi
+  else
+    log "ROLLBACK: no PBP backup manifest captured — nothing to restore there."
+  fi
+
+  local systemctl_bin
+  if systemctl_bin="$(resolve_systemctl_bin)"; then
+    log "ROLLBACK: restarting ${SERVICE_NAME} to pick up restored .env"
+    sudo -n "${systemctl_bin}" restart "${SERVICE_NAME}" || failures+=("service restart failed")
+    sleep 3
+    sudo -n "${systemctl_bin}" is-active --quiet "${SERVICE_NAME}" \
+      || failures+=("service not active after rollback restart")
+  else
+    failures+=("could not resolve systemctl to restart the service")
+  fi
+
+  if ! curl -fsS --max-time 10 "http://${APP_HOST}:${APP_PORT}/api/status" >/dev/null; then
+    failures+=("health check (/api/status) failed after rollback")
+  fi
+
+  if [[ -f "${prior_bool_file}" ]]; then
+    local expected_bool actual_bool
+    if expected_bool="$(cat "${prior_bool_file}")"; then
+      actual_bool="$(read_flag_enabled || echo '<error>')"
+      if [[ "${actual_bool}" != "${expected_bool}" ]]; then
+        failures+=("post-rollback flag state (${actual_bool}) does not match pre-activation state (${expected_bool})")
+      else
+        log "ROLLBACK: verified flag state matches pre-activation (${actual_bool})."
+      fi
+    else
+      failures+=("could not read captured prior flag boolean from ${prior_bool_file}")
+    fi
+  fi
+
+  if (( ${#failures[@]} > 0 )); then
+    printf '[v1-49][ROLLBACK FAILED] MANUAL INTERVENTION REQUIRED:\n' >&2
+    local f
+    for f in "${failures[@]}"; do
+      printf '  - %s\n' "${f}" >&2
+    done
+    echo "ROLLBACK_FAILED" > "${state_dir}/result.txt"
+    return 1
+  fi
+
+  log "ROLLBACK: complete and verified."
+  echo "ROLLED_BACK" > "${state_dir}/result.txt"
+  return 0
+}
+
+# ── controlled activation ──────────────────────────────────────────────
+do_activate() {
+  [[ -n "${ACTIVATION_ID}" ]] || fail_preflight "ACTIVATION_ID was not supplied."
+  validate_activation_id "${ACTIVATION_ID}"
+  [[ -n "${BDVM_SEASON}" ]] || fail_preflight "BDVM_SEASON was not supplied."
+
+  run_preflight_checks
+
+  local state_dir="${STATE_ROOT}/${ACTIVATION_ID}"
+  mkdir -p "${state_dir}"
+  mkdir -p "${STATE_ROOT}"
+  printf '%s\n' "${ACTIVATION_ID}" > "${LATEST_POINTER}"
+  printf '%s\n' "${REASON}" > "${state_dir}/reason.txt"
+  printf '%s\n' "${EXPECTED_SHA}" > "${state_dir}/expected_sha.txt"
+  date -u +%Y-%m-%dT%H:%M:%SZ > "${state_dir}/started_at_utc.txt"
+
+  local activation_failed=0
+  on_activation_error() {
+    local exit_code=$?
+    trap - ERR
+    printf '[v1-49][ERROR] activation step failed (exit %s); invoking automatic rollback.\n' "${exit_code}" >&2
+    if do_rollback "${state_dir}" "automatic (activation step failed, exit ${exit_code})"; then
+      log "Automatic rollback succeeded. This remains a FAILED V1-49 verification attempt."
+      exit 2
+    else
+      exit 3
+    fi
+  }
+  trap on_activation_error ERR
+
+  # 1. Backup current PBP artifacts BEFORE anything else changes.
+  log "Backing up current PBP artifacts."
+  local backup_json manifest_path
+  backup_json="$("${PYTHON_BIN}" "${APP_DIR}/scripts/pbp_artifact_backup.py" backup \
+    --actuals-dir "${APP_DIR}/data/nfl_data/actuals" \
+    --seasons "${PBP_SEASONS[@]}")"
+  manifest_path="$(env_sourced_python -c "import json,sys; print(json.loads(sys.argv[1])['manifestPath'])" "${backup_json}")"
+  printf '%s\n' "${manifest_path}" > "${state_dir}/pbp_backup_manifest_path.txt"
+  log "PBP backup manifest: ${manifest_path}"
+
+  # 2. BDVM baseline BEFORE the flip — captures champion-scoring output.
+  local bdvm_pre_label="v149_pre_${ACTIVATION_ID}"
+  log "Building BDVM pre-activation snapshot (label=${bdvm_pre_label})."
+  env_sourced_python "${APP_DIR}/scripts/bdvm_build_baseline.py" \
+    --season "${BDVM_SEASON}" --label "${bdvm_pre_label}"
+  local bdvm_pre_path
+  bdvm_pre_path="$(find "${APP_DIR}/data/bdvm/projections/${BDVM_SEASON}" -name "projections_*_${bdvm_pre_label}.json" -newer "${state_dir}/started_at_utc.txt" -print -quit)"
+  [[ -n "${bdvm_pre_path}" ]] || bdvm_pre_path="$(find "${APP_DIR}/data/bdvm/projections/${BDVM_SEASON}" -name "projections_*_${bdvm_pre_label}.json" -print -quit)"
+  [[ -n "${bdvm_pre_path}" ]] || { warn "could not locate the BDVM pre-activation snapshot on disk"; false; }
+  printf '%s\n' "${bdvm_pre_path}" > "${state_dir}/bdvm_pre_snapshot_path.txt"
+  log "BDVM pre-activation snapshot: ${bdvm_pre_path}"
+
+  # 3. Capture prior flag state and flip.
+  local prior_bool
+  prior_bool="$(read_flag_enabled)"
+  printf '%s\n' "${prior_bool}" > "${state_dir}/prior_flag_enabled_bool.txt"
+
+  local set_json prior_state
+  set_json="$("${PYTHON_BIN}" "${APP_DIR}/scripts/prod_env_flag_ops.py" set \
+    --env-file "${ENV_FILE}" --key "${FLAG_KEY}" --value "1")"
+  prior_state="$(env_sourced_python -c "import json,sys; print(json.loads(sys.argv[1])['prior_state'])" "${set_json}")"
+  printf '%s\n' "${prior_state}" > "${state_dir}/prior_flag_state.txt"
+  log "Flag flipped. Prior raw state: ${prior_state} (enabled=${prior_bool})"
+
+  # 4. Restart the ONLY service that needs it, then health-check.
+  local systemctl_bin
+  systemctl_bin="$(resolve_systemctl_bin)"
+  log "Restarting ${SERVICE_NAME}."
+  sudo -n "${systemctl_bin}" restart "${SERVICE_NAME}"
+  sleep 3
+  sudo -n "${systemctl_bin}" is-active --quiet "${SERVICE_NAME}"
+  curl -fsS --max-time 10 "http://${APP_HOST}:${APP_PORT}/api/status" >/dev/null
+  log "Service restarted and healthy."
+
+  # 5. Paranoia check: the flag now reads enabled.
+  local now_bool
+  now_bool="$(read_flag_enabled)"
+  if [[ "${now_bool}" != "True" ]]; then
+    warn "Flag does not read enabled after restart (got: ${now_bool})."
+    false
+  fi
+  log "Confirmed ${FLAG_KEY} is now enabled."
+
+  # 6. Rebuild the PBP artifact for the full named season set.
+  log "Rebuilding PBP weekly artifacts for seasons: ${PBP_SEASONS[*]}"
+  local pbp_rc=0
+  env_sourced_python "${APP_DIR}/scripts/build_pbp_weekly.py" \
+    --seasons "${PBP_SEASONS[@]}" || pbp_rc=$?
+  # Exit 2 ("nothing to do / already current") is a healthy outcome per
+  # the script's own systemd unit (SuccessExitStatus=0 2); exit 1 (a
+  # season that should exist produced no plays) is a real failure.
+  if [[ "${pbp_rc}" != "0" && "${pbp_rc}" != "2" ]]; then
+    warn "build_pbp_weekly.py exited ${pbp_rc}"
+    false
+  fi
+  log "PBP rebuild finished (exit ${pbp_rc})."
+
+  # 7. Validate every rebuilt artifact against the CURRENT schema via the
+  #    canonical loader — never a re-implementation of its refusal rule.
+  log "Validating rebuilt PBP artifacts against the current schema."
+  env_sourced_python -c "
+import sys
+sys.path.insert(0, '.')
+from src.nfl_data.pbp_weekly import load_pbp_weekly
+seasons = [${PBP_SEASONS[*]/%/,}]
+refused = [s for s in seasons if load_pbp_weekly(s) is None]
+if refused:
+    print('REFUSED or missing after rebuild:', refused, file=sys.stderr)
+    sys.exit(1)
+print('All seasons loaded and validated against the current schema:', seasons)
+"
+
+  # 8. BDVM baseline AFTER the flip — captures challenger-scoring output.
+  local bdvm_post_label="v149_post_${ACTIVATION_ID}"
+  log "Building BDVM post-activation snapshot (label=${bdvm_post_label})."
+  env_sourced_python "${APP_DIR}/scripts/bdvm_build_baseline.py" \
+    --season "${BDVM_SEASON}" --label "${bdvm_post_label}"
+  local bdvm_post_path
+  bdvm_post_path="$(find "${APP_DIR}/data/bdvm/projections/${BDVM_SEASON}" -name "projections_*_${bdvm_post_label}.json" -print -quit)"
+  [[ -n "${bdvm_post_path}" ]] || { warn "could not locate the BDVM post-activation snapshot on disk"; false; }
+  printf '%s\n' "${bdvm_post_path}" > "${state_dir}/bdvm_post_snapshot_path.txt"
+  log "BDVM post-activation snapshot: ${bdvm_post_path}"
+
+  # 9. Diff the two BDVM snapshots — item 1 of the promotion gate.
+  log "Diffing BDVM pre/post snapshots."
+  local bdvm_diff_json="${state_dir}/bdvm_diff.json"
+  "${PYTHON_BIN}" "${APP_DIR}/scripts/diff_bdvm_snapshots.py" \
+    --before "${bdvm_pre_path}" --after "${bdvm_post_path}" > "${bdvm_diff_json}"
+  log "BDVM diff written: ${bdvm_diff_json}"
+  cat "${bdvm_diff_json}"
+
+  # 10. League-comparison OBSERVATION — item 2 of the promotion gate.
+  #     Deliberately does NOT trigger rollback on a non-200: this
+  #     endpoint's own contract treats upstream unavailability (503) as
+  #     normal, and conflating that with an activation failure would be
+  #     exactly the "reinterpret failure as success" mistake in reverse
+  #     — turning an unrelated upstream hiccup into a false activation
+  #     failure. Recorded honestly either way.
+  log "Probing GET /api/league-comparison?refresh=1 (uncontrolled in-season observation — see header notes)."
+  local lc_http_code lc_body_file="${state_dir}/league_comparison_response.json"
+  lc_http_code="$(curl -sS --max-time 30 -o "${lc_body_file}" -w '%{http_code}' \
+    "http://${APP_HOST}:${APP_PORT}/api/league-comparison?refresh=1" || echo "curl_error")"
+  log "league-comparison probe HTTP status: ${lc_http_code}"
+
+  # 11. Write the final structured report and mark success.
+  #
+  # Every dynamic value here — REASON above all, which is free-text
+  # operator input from the workflow_dispatch form — is passed through
+  # the environment and read via os.environ, never interpolated into
+  # the Python source text. String-interpolating REASON into a
+  # triple-quoted literal would let its content break out of the string
+  # and execute as Python; os.environ has no such boundary to escape.
+  trap - ERR
+  REPORT_ACTIVATION_ID="${ACTIVATION_ID}" \
+  REPORT_EXPECTED_SHA="${EXPECTED_SHA}" \
+  REPORT_REASON="${REASON}" \
+  REPORT_PRIOR_FLAG_RAW="${prior_state}" \
+  REPORT_PRIOR_FLAG_BOOL="${prior_bool}" \
+  REPORT_PBP_MANIFEST="${manifest_path}" \
+  REPORT_PBP_RC="${pbp_rc}" \
+  REPORT_BDVM_PRE="${bdvm_pre_path}" \
+  REPORT_BDVM_POST="${bdvm_post_path}" \
+  REPORT_LC_HTTP="${lc_http_code}" \
+  REPORT_STATE_DIR="${state_dir}" \
+  env_sourced_python -c "
+import json
+import os
+
+report = {
+    'activationId': os.environ['REPORT_ACTIVATION_ID'],
+    'expectedSha': os.environ['REPORT_EXPECTED_SHA'],
+    'reason': os.environ['REPORT_REASON'],
+    'priorFlagRawState': os.environ['REPORT_PRIOR_FLAG_RAW'],
+    'priorFlagEnabled': os.environ['REPORT_PRIOR_FLAG_BOOL'],
+    'pbpBackupManifest': os.environ['REPORT_PBP_MANIFEST'],
+    'pbpRebuildExitCode': int(os.environ['REPORT_PBP_RC']),
+    'bdvmPreSnapshot': os.environ['REPORT_BDVM_PRE'],
+    'bdvmPostSnapshot': os.environ['REPORT_BDVM_POST'],
+    'item2LeagueComparisonHttpStatus': os.environ['REPORT_LC_HTTP'],
+    'item2Label': 'uncontrolled in-season observation, not a controlled diff -- see script header',
+    'item3Label': (
+        'no dedicated historical-backtest script exists in this repo; '
+        'treated as satisfied by the item 1 (BDVM) and item 4 (PBP) '
+        'measured deltas above, per HOST_NATIVE_SCORING_VALIDATION.md '
+        'own framing of item 3 as downstream of items 1+4'
+    ),
+}
+state_dir = os.environ['REPORT_STATE_DIR']
+with open(os.path.join(state_dir, 'report.json'), 'w') as fh:
+    json.dump(report, fh, indent=2)
+print(json.dumps(report, indent=2))
+"
+  echo "ACTIVATED" > "${state_dir}/result.txt"
+  log "Activation complete."
+}
+
+do_rollback_action() {
+  local activation_id="${ACTIVATION_ID}"
+  if [[ -z "${activation_id}" ]]; then
+    [[ -f "${LATEST_POINTER}" ]] || { echo "[v1-49][ERROR] no ACTIVATION_ID given and no LATEST pointer exists." >&2; exit 1; }
+    activation_id="$(cat "${LATEST_POINTER}")" \
+      || { echo "[v1-49][ERROR] could not read LATEST pointer: ${LATEST_POINTER}" >&2; exit 1; }
+    log "No ACTIVATION_ID supplied; using LATEST: ${activation_id}"
+  fi
+  validate_activation_id "${activation_id}"
+  local state_dir="${STATE_ROOT}/${activation_id}"
+  [[ -d "${state_dir}" ]] || { echo "[v1-49][ERROR] no state directory for activation id: ${activation_id}" >&2; exit 1; }
+  if do_rollback "${state_dir}" "explicit rollback dispatch (${REASON})"; then
+    exit 0
+  else
+    exit 3
+  fi
+}
+
+main() {
+  case "${ACTION}" in
+    preflight)
+      run_preflight_checks
+      ;;
+    activate)
+      do_activate
+      ;;
+    rollback)
+      do_rollback_action
+      ;;
+    *)
+      echo "[v1-49][ERROR] ACTION must be one of: preflight, activate, rollback (got: '${ACTION}')" >&2
+      exit 1
+      ;;
+  esac
+}
+
+# Run main only when EXECUTED, not when sourced — mirrors
+# deploy/rollback.sh's own guard. Sourcing is how a test can call
+# individual functions (e.g. validate_activation_id) in isolation
+# without dispatching a real preflight/activate/rollback.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/diff_bdvm_snapshots.py
+++ b/scripts/diff_bdvm_snapshots.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Diff two BDVM projection snapshots (``projections_<date>[_<label>].json``,
+written by ``scripts/bdvm_build_baseline.py``).
+
+Built for the V1-49 controlled-activation workflow's "BDVM rerun against
+challenger output" measurement
+(``docs/scoring/HOST_NATIVE_SCORING_VALIDATION.md`` §4 item 1): a
+pre-activation snapshot (``--label v149_pre``) is compared against a
+post-activation snapshot (``--label v149_post``) of the same season, and
+this tool reports exactly what moved.
+
+This is a COMPARISON tool only — it never recomputes fantasy points or
+any scoring value. It diffs the already-published, already-scored scalar
+fields each record carries (``games``, ``fpg``, ``fpts``, ``projHigh``,
+``projLow``) plus provenance flags (``isProxy``, ``statBasis``,
+``scoringNative``). Recomputing a value here would duplicate the
+canonical scoring engine and risk drifting from it; reporting the raw
+delta between two already-canonical numbers does not.
+
+Records are matched by ``(playerKey, season, source)`` — the same
+identity a snapshot file already keys its rows on.
+
+Exit codes: 0 success (a report was produced, regardless of whether any
+differences were found — this tool never judges pass/fail), 2 usage/IO
+error (missing file, malformed JSON).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_COMPARABLE_NUMERIC_FIELDS = ("games", "fpg", "fpts", "projHigh", "projLow")
+_PROVENANCE_FIELDS = ("isProxy", "statBasis", "scoringNative")
+
+
+class SnapshotDiffError(Exception):
+    """Raised on invalid input; callers should exit 2."""
+
+
+def load_snapshot_payload(path: Path) -> dict:
+    if not path.is_file():
+        raise SnapshotDiffError(f"snapshot not found: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SnapshotDiffError(f"malformed snapshot JSON at {path}: {exc}") from exc
+    if "records" not in payload:
+        raise SnapshotDiffError(f"snapshot at {path} has no 'records' key")
+    return payload
+
+
+def _record_key(record: dict) -> tuple[str, int, str]:
+    return (record["playerKey"], int(record["season"]), record["source"])
+
+
+def _summarize(key: tuple[str, int, str], record: dict) -> dict:
+    return {
+        "playerKey": key[0],
+        "season": key[1],
+        "source": key[2],
+        "fpg": record.get("fpg"),
+        "fpts": record.get("fpts"),
+        "isProxy": record.get("isProxy"),
+    }
+
+
+def _numeric_delta(before_value: Any, after_value: Any) -> float | None:
+    if isinstance(before_value, (int, float)) and isinstance(after_value, (int, float)):
+        return after_value - before_value
+    return None
+
+
+def _max_abs_field_delta(changed_entry: dict) -> float:
+    magnitudes = [
+        abs(d["delta"]) for d in changed_entry["fieldDeltas"].values() if d.get("delta") is not None
+    ]
+    return max(magnitudes) if magnitudes else 0.0
+
+
+def diff_records(before: list[dict], after: list[dict]) -> dict:
+    """Compare two lists of raw snapshot records (as loaded from JSON).
+
+    Returns a dict with full added/removed/changed lists (unsorted
+    counts are exact; ``changed`` is sorted by the largest absolute
+    numeric-field delta first) plus summary counts.
+    """
+    before_by_key = {_record_key(r): r for r in before}
+    after_by_key = {_record_key(r): r for r in after}
+    all_keys = set(before_by_key) | set(after_by_key)
+
+    added: list[dict] = []
+    removed: list[dict] = []
+    changed: list[dict] = []
+    unchanged_count = 0
+
+    for key in sorted(all_keys):
+        before_rec = before_by_key.get(key)
+        after_rec = after_by_key.get(key)
+        if before_rec is None:
+            added.append(_summarize(key, after_rec))
+            continue
+        if after_rec is None:
+            removed.append(_summarize(key, before_rec))
+            continue
+
+        field_deltas: dict[str, dict] = {}
+        for field in _COMPARABLE_NUMERIC_FIELDS:
+            before_value, after_value = before_rec.get(field), after_rec.get(field)
+            if before_value != after_value:
+                field_deltas[field] = {
+                    "before": before_value,
+                    "after": after_value,
+                    "delta": _numeric_delta(before_value, after_value),
+                }
+
+        provenance_deltas: dict[str, dict] = {}
+        for field in _PROVENANCE_FIELDS:
+            before_value, after_value = before_rec.get(field), after_rec.get(field)
+            if before_value != after_value:
+                provenance_deltas[field] = {"before": before_value, "after": after_value}
+
+        if field_deltas or provenance_deltas:
+            changed.append(
+                {
+                    "playerKey": key[0],
+                    "season": key[1],
+                    "source": key[2],
+                    "fieldDeltas": field_deltas,
+                    "provenanceDeltas": provenance_deltas,
+                }
+            )
+        else:
+            unchanged_count += 1
+
+    changed.sort(key=_max_abs_field_delta, reverse=True)
+
+    return {
+        "beforeRecordCount": len(before),
+        "afterRecordCount": len(after),
+        "addedCount": len(added),
+        "removedCount": len(removed),
+        "changedCount": len(changed),
+        "unchangedCount": unchanged_count,
+        "added": added,
+        "removed": removed,
+        "changed": changed,
+    }
+
+
+def diff_snapshots(before_path: Path, after_path: Path, *, top_n: int | None = None) -> dict:
+    before_payload = load_snapshot_payload(before_path)
+    after_payload = load_snapshot_payload(after_path)
+    report = diff_records(before_payload["records"], after_payload["records"])
+    report["beforePath"] = str(before_path)
+    report["afterPath"] = str(after_path)
+    report["beforeSeason"] = before_payload.get("season")
+    report["afterSeason"] = after_payload.get("season")
+    report["beforeAsOf"] = before_payload.get("asOf")
+    report["afterAsOf"] = after_payload.get("asOf")
+    if top_n is not None:
+        report["added"] = report["added"][:top_n]
+        report["removed"] = report["removed"][:top_n]
+        report["changed"] = report["changed"][:top_n]
+        report["truncatedToTopN"] = top_n
+    return report
+
+
+def _cmd_diff(args: argparse.Namespace) -> int:
+    report = diff_snapshots(Path(args.before), Path(args.after), top_n=args.top_n)
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--before", required=True, help="pre-activation snapshot path")
+    parser.add_argument("--after", required=True, help="post-activation snapshot path")
+    parser.add_argument(
+        "--top-n",
+        type=int,
+        default=25,
+        help="cap added/removed/changed lists to the top N entries (default 25); "
+        "pass 0 to disable truncation",
+    )
+    parser.set_defaults(func=_cmd_diff)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.top_n is not None and args.top_n <= 0:
+        args.top_n = None
+    try:
+        return args.func(args)
+    except SnapshotDiffError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pbp_artifact_backup.py
+++ b/scripts/pbp_artifact_backup.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Backup and restore the production PBP-weekly artifacts.
+
+Built for the V1-49 controlled-activation workflow
+(``.github/workflows/v1-49-host-native-scoring-activation.yml``), which
+rebuilds ``data/nfl_data/actuals/pbp_weekly_<season>.jsonl`` (written by
+``scripts/build_pbp_weekly.py``) as part of activating
+``RISKIT_FEATURE_HOST_NATIVE_SCORING``, and must be able to restore the
+prior artifact state deterministically if anything downstream fails.
+
+A backup captures, for each requested season, whether the file existed
+BEFORE the rebuild (``existedBefore``) — not just its content. That
+distinction is what lets restore correctly UNDO a rebuild that created a
+season file from nothing: overwriting-only would leave behind an
+artifact the pre-activation production state never had. Existing files
+are archived into one timestamped ``.tar.gz``; a manifest JSON records
+per-season existence plus the tar location, and is the single input
+``restore`` needs.
+
+Backups never collide: the timestamp used in both filenames is checked
+against the backup directory and disambiguated if a prior backup from
+the same second is already there, so running the workflow twice in a
+row without an intervening restore cannot clobber the previous backup.
+
+Subcommands:
+
+* ``backup``  — archive the named seasons' current artifacts (only the
+  ones that exist) and write a manifest. Prints the manifest path.
+* ``restore`` — replay a manifest: extract files that existed before the
+  backup, and delete files the manifest says did not.
+
+Exit codes: 0 success, 2 usage/IO error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tarfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class PbpBackupError(Exception):
+    """Raised on invalid input or a corrupt/missing backup; callers exit 2."""
+
+
+def default_actuals_dir() -> Path:
+    return REPO_ROOT / "data" / "nfl_data" / "actuals"
+
+
+def default_backup_dir(actuals_dir: Path) -> Path:
+    return actuals_dir / ".backups"
+
+
+def pbp_weekly_filename(season: int) -> str:
+    return f"pbp_weekly_{int(season)}.jsonl"
+
+
+def _unique_backup_stamp(backup_dir: Path) -> str:
+    base = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    stamp = base
+    suffix = 1
+    while (backup_dir / f"pbp_weekly_backup_{stamp}.manifest.json").exists():
+        suffix += 1
+        stamp = f"{base}-{suffix}"
+    return stamp
+
+
+def create_backup(actuals_dir: Path, seasons: list[int], backup_dir: Path) -> dict:
+    """Archive the current artifacts for ``seasons`` and write a manifest.
+
+    Returns the manifest dict (also written to disk). Seasons whose file
+    does not currently exist are recorded as ``existedBefore: False`` and
+    are NOT an error — that is the expected state for a season no
+    previous rebuild has ever covered.
+    """
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    stamp = _unique_backup_stamp(backup_dir)
+    manifest_path = backup_dir / f"pbp_weekly_backup_{stamp}.manifest.json"
+    tar_path = backup_dir / f"pbp_weekly_backup_{stamp}.tar.gz"
+
+    seasons_info: dict[str, dict] = {}
+    existing_files: list[Path] = []
+    for season in seasons:
+        filename = pbp_weekly_filename(season)
+        file_path = actuals_dir / filename
+        existed = file_path.is_file()
+        seasons_info[str(int(season))] = {"filename": filename, "existedBefore": existed}
+        if existed:
+            existing_files.append(file_path)
+
+    with tarfile.open(tar_path, "w:gz") as tar:
+        for file_path in existing_files:
+            tar.add(file_path, arcname=file_path.name)
+
+    manifest = {
+        "capturedAtUtc": datetime.now(timezone.utc).isoformat(),
+        "actualsDir": str(actuals_dir),
+        "tarPath": str(tar_path),
+        "seasons": seasons_info,
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    return {"manifestPath": str(manifest_path), **manifest}
+
+
+def restore_backup(manifest_path: Path, actuals_dir: Path | None = None) -> dict:
+    """Replay ``manifest_path``: restore files that existed before the
+    backup, and delete files the manifest says did not exist before it.
+
+    ``actuals_dir`` overrides the manifest-recorded directory (used only
+    when restoring against a different checkout than the one that took
+    the backup); defaults to the manifest's own recorded path.
+    """
+    if not manifest_path.is_file():
+        raise PbpBackupError(f"manifest not found: {manifest_path}")
+    manifest = json.loads(manifest_path.read_text())
+    target_dir = actuals_dir if actuals_dir is not None else Path(manifest["actualsDir"])
+    tar_path = Path(manifest["tarPath"])
+    seasons_info: dict[str, dict] = manifest["seasons"]
+
+    to_restore = [info["filename"] for info in seasons_info.values() if info["existedBefore"]]
+    to_delete = [info["filename"] for info in seasons_info.values() if not info["existedBefore"]]
+
+    restored: list[str] = []
+    if to_restore:
+        if not tar_path.is_file():
+            raise PbpBackupError(f"backup archive missing, cannot restore: {tar_path}")
+        target_dir.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(tar_path, "r:gz") as tar:
+            members = [tar.getmember(name) for name in to_restore]
+            extract_kwargs = {"filter": "data"} if sys.version_info >= (3, 12) else {}
+            tar.extractall(path=str(target_dir), members=members, **extract_kwargs)
+        restored = list(to_restore)
+
+    deleted: list[str] = []
+    for filename in to_delete:
+        file_path = target_dir / filename
+        if file_path.exists():
+            file_path.unlink()
+            deleted.append(filename)
+
+    return {"restored": restored, "deleted": deleted}
+
+
+def _cmd_backup(args: argparse.Namespace) -> int:
+    actuals_dir = Path(args.actuals_dir)
+    backup_dir = Path(args.backup_dir) if args.backup_dir else default_backup_dir(actuals_dir)
+    result = create_backup(actuals_dir, args.seasons, backup_dir)
+    print(json.dumps(result))
+    return 0
+
+
+def _cmd_restore(args: argparse.Namespace) -> int:
+    manifest_path = Path(args.manifest)
+    actuals_dir = Path(args.actuals_dir) if args.actuals_dir else None
+    result = restore_backup(manifest_path, actuals_dir=actuals_dir)
+    print(json.dumps(result))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    backup = sub.add_parser("backup", help="archive the current PBP weekly artifacts")
+    backup.add_argument("--actuals-dir", default=str(default_actuals_dir()))
+    backup.add_argument("--backup-dir", default=None)
+    backup.add_argument("--seasons", type=int, nargs="+", required=True)
+    backup.set_defaults(func=_cmd_backup)
+
+    restore = sub.add_parser("restore", help="restore from a backup manifest")
+    restore.add_argument("--manifest", required=True)
+    restore.add_argument("--actuals-dir", default=None)
+    restore.set_defaults(func=_cmd_restore)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except PbpBackupError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/prod_env_flag_ops.py
+++ b/scripts/prod_env_flag_ops.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Idempotent single-key edits to a production ``.env`` file.
+
+Built for the V1-49 controlled-activation workflow
+(``.github/workflows/v1-49-host-native-scoring-activation.yml``), which
+flips exactly one ``RISKIT_FEATURE_*`` flag in production's
+``<PROD_APP_DIR>/.env`` (loaded via ``EnvironmentFile=-__APP_DIR__/.env``
+in ``deploy/systemd/dynasty.service.template``) and must be able to
+restore the prior state deterministically on any failure. This module is
+intentionally general (it edits one ``KEY=value`` line, nothing else) so
+the same code path serves both the forward flip and the rollback restore
+— there is exactly one write function
+(:func:`atomic_write_env_lines`) and exactly one line-mutation pair
+(:func:`upsert_line` / :func:`remove_line`).
+
+Every write is atomic (temp file + ``os.replace``) and every operation is
+idempotent: applying ``set`` twice with the same value, or ``restore``
+twice with the same prior state, converges to one line and never
+duplicates or corrupts the file. No other keys in the file are ever
+touched.
+
+Subcommands:
+
+* ``show``    — print the current raw value for a key (or ``ABSENT``).
+* ``set``     — upsert ``key=value``; prints the PRIOR value (or
+  ``ABSENT``) as JSON so a caller can capture it for later restore in
+  the same call that performs the write.
+* ``restore`` — set the key back to a previously captured value, or
+  remove the line entirely if the captured prior state was ``ABSENT``.
+
+Exit codes: 0 success, 2 usage/IO error (missing/unwritable file,
+invalid key, value containing a newline).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+ABSENT_SENTINEL = "ABSENT"
+
+_KEY_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+
+
+class EnvOpsError(Exception):
+    """Raised on invalid input; callers should exit 2."""
+
+
+def _validate_key(key: str) -> None:
+    if not _KEY_RE.match(key):
+        raise EnvOpsError(f"invalid env key (must match {_KEY_RE.pattern!r}): {key!r}")
+
+
+def _validate_value(value: str) -> None:
+    if "\n" in value or "\r" in value:
+        raise EnvOpsError("value must not contain a newline")
+
+
+def read_env_lines(path: Path) -> list[str]:
+    """Read an ``.env`` file as a list of lines (with trailing newlines).
+
+    A missing file reads as empty content — matches the systemd
+    ``EnvironmentFile=-...`` convention where a leading ``-`` tolerates
+    an absent file.
+    """
+    if not path.exists():
+        return []
+    return path.read_text().splitlines(keepends=True)
+
+
+def read_current_value(lines: list[str], key: str) -> str:
+    """Return the raw value string for ``key=...``, or ``ABSENT_SENTINEL``."""
+    _validate_key(key)
+    pattern = re.compile(rf"^{re.escape(key)}=(.*)$")
+    for line in lines:
+        match = pattern.match(line.rstrip("\n\r"))
+        if match:
+            return match.group(1)
+    return ABSENT_SENTINEL
+
+
+def upsert_line(lines: list[str], key: str, value: str) -> list[str]:
+    """Return ``lines`` with ``key=value`` set: rewrite the existing line
+    in place, or append a new one if absent. Idempotent — reapplying with
+    the same value produces byte-identical output.
+    """
+    _validate_key(key)
+    _validate_value(value)
+    pattern = re.compile(rf"^{re.escape(key)}=")
+    new_lines: list[str] = []
+    replaced = False
+    for line in lines:
+        stripped = line.rstrip("\n\r")
+        if pattern.match(stripped):
+            new_lines.append(f"{key}={value}\n")
+            replaced = True
+        else:
+            new_lines.append(line if line.endswith("\n") else line + "\n")
+    if not replaced:
+        if new_lines and not new_lines[-1].endswith("\n"):
+            new_lines[-1] += "\n"
+        new_lines.append(f"{key}={value}\n")
+    return new_lines
+
+
+def remove_line(lines: list[str], key: str) -> list[str]:
+    """Return ``lines`` with any ``key=...`` line removed. Idempotent —
+    removing an already-absent key is a no-op.
+    """
+    _validate_key(key)
+    pattern = re.compile(rf"^{re.escape(key)}=")
+    return [line for line in lines if not pattern.match(line.rstrip("\n\r"))]
+
+
+def atomic_write_env_lines(path: Path, lines: list[str]) -> None:
+    """Write ``lines`` to ``path`` atomically (temp file + rename)."""
+    tmp_path = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+    tmp_path.write_text("".join(lines))
+    tmp_path.replace(path)
+
+
+def apply_set(path: Path, key: str, value: str) -> str:
+    """Upsert ``key=value`` in the env file at ``path``; return the prior
+    value (or :data:`ABSENT_SENTINEL`) so the caller can capture it.
+    """
+    lines = read_env_lines(path)
+    prior = read_current_value(lines, key)
+    new_lines = upsert_line(lines, key, value)
+    atomic_write_env_lines(path, new_lines)
+    return prior
+
+
+def apply_restore(path: Path, key: str, prior_state: str) -> None:
+    """Restore ``key`` to ``prior_state`` (or remove it if ``prior_state``
+    is :data:`ABSENT_SENTINEL`). Idempotent.
+    """
+    _validate_key(key)
+    lines = read_env_lines(path)
+    if prior_state == ABSENT_SENTINEL:
+        new_lines = remove_line(lines, key)
+    else:
+        new_lines = upsert_line(lines, key, prior_state)
+    atomic_write_env_lines(path, new_lines)
+
+
+def _cmd_show(args: argparse.Namespace) -> int:
+    path = Path(args.env_file)
+    value = read_current_value(read_env_lines(path), args.key)
+    print(json.dumps({"key": args.key, "value": value}))
+    return 0
+
+
+def _cmd_set(args: argparse.Namespace) -> int:
+    path = Path(args.env_file)
+    prior = apply_set(path, args.key, args.value)
+    print(json.dumps({"key": args.key, "prior_state": prior, "new_value": args.value}))
+    return 0
+
+
+def _cmd_restore(args: argparse.Namespace) -> int:
+    path = Path(args.env_file)
+    apply_restore(path, args.key, args.prior_state)
+    print(json.dumps({"key": args.key, "restored_to": args.prior_state}))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    show = sub.add_parser("show", help="print the current value for a key")
+    show.add_argument("--env-file", required=True)
+    show.add_argument("--key", required=True)
+    show.set_defaults(func=_cmd_show)
+
+    set_cmd = sub.add_parser("set", help="upsert key=value, printing the prior state")
+    set_cmd.add_argument("--env-file", required=True)
+    set_cmd.add_argument("--key", required=True)
+    set_cmd.add_argument("--value", required=True)
+    set_cmd.set_defaults(func=_cmd_set)
+
+    restore = sub.add_parser("restore", help="restore a key to a captured prior state")
+    restore.add_argument("--env-file", required=True)
+    restore.add_argument("--key", required=True)
+    restore.add_argument("--prior-state", required=True)
+    restore.set_defaults(func=_cmd_restore)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except EnvOpsError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/deploy/test_v1_49_workflow_wiring.py
+++ b/tests/deploy/test_v1_49_workflow_wiring.py
@@ -1,0 +1,263 @@
+"""Structural pins for the V1-49 host-native-scoring activation workflow.
+
+Two things are load-bearing and easy to break silently while editing
+either the YAML or the remote script, so this test is a structural
+guard rather than a functional one (functional coverage for the actual
+flag/backup logic lives in ``tests/scripts/test_prod_env_flag_ops.py``,
+``tests/scripts/test_pbp_artifact_backup.py`` and
+``tests/scripts/test_diff_bdvm_snapshots.py``):
+
+1. This workflow must never become a general remote-command runner. The
+   only thing ever piped over SSH is the ONE fixed, checked-in script
+   (``deploy/diagnostics/v1_49_host_native_activation.sh``), and the
+   only values threaded into its environment are a small, named,
+   non-command set (ACTION, APP_DIR, PYTHON_BIN, EXPECTED_SHA,
+   ACTIVATION_ID, BDVM_SEASON, REASON). REASON in particular is
+   free-text operator input — it must reach the remote script only as
+   an environment value, never concatenated into the command string
+   itself or into inline Python source.
+2. There is exactly one rollback code path
+   (``do_rollback()`` in the shell script), called from exactly the two
+   places the design requires: the automatic in-script failure handler,
+   and the explicit ``ACTION=rollback`` dispatch branch. A second
+   rollback implementation appearing anywhere would mean the two could
+   drift out of sync with each other.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import yaml
+
+_REPO = Path(__file__).resolve().parents[2]
+_WORKFLOW_PATH = _REPO / ".github" / "workflows" / "v1-49-host-native-scoring-activation.yml"
+_SCRIPT_PATH = _REPO / "deploy" / "diagnostics" / "v1_49_host_native_activation.sh"
+
+_ALLOWED_REMOTE_ENV_KEYS = {
+    "ACTION",
+    "APP_DIR",
+    "PYTHON_BIN",
+    "EXPECTED_SHA",
+    "ACTIVATION_ID",
+    "BDVM_SEASON",
+    "REASON",
+}
+_EXPECTED_INPUT_NAMES = {
+    "action",
+    "confirm_activation",
+    "expected_sha",
+    "bdvm_season",
+    "activation_id",
+    "reason",
+}
+
+
+def _load_workflow() -> dict:
+    return yaml.safe_load(_WORKFLOW_PATH.read_text())
+
+
+def _on_block(document: dict) -> dict:
+    # ``on:`` is a YAML 1.1 boolean, so safe_load keys it as True. Accept
+    # either in case a future loader is configured differently — same
+    # idiom as tests/deploy/test_e2e_workflow_triggers.py::_triggers.
+    return document.get("on", document.get(True))
+
+
+def _inputs(document: dict) -> dict:
+    return _on_block(document)["workflow_dispatch"]["inputs"]
+
+
+def _job(document: dict) -> dict:
+    jobs = document["jobs"]
+    assert len(jobs) == 1, f"expected exactly one job, found {list(jobs)}"
+    return next(iter(jobs.values()))
+
+
+def test_workflow_file_exists_and_parses():
+    assert _WORKFLOW_PATH.is_file()
+    document = _load_workflow()
+    assert "jobs" in document
+
+
+def test_concurrency_shares_the_production_deploy_group():
+    document = _load_workflow()
+    concurrency = document["concurrency"]
+    assert concurrency["group"] == "production-deploy"
+    assert concurrency["cancel-in-progress"] is False
+
+
+def test_job_runs_in_the_production_environment():
+    document = _load_workflow()
+    job = _job(document)
+    assert job["environment"] == "production"
+
+
+def test_typed_inputs_are_exactly_the_expected_set():
+    document = _load_workflow()
+    inputs = _inputs(document)
+    assert set(inputs.keys()) == _EXPECTED_INPUT_NAMES
+
+
+def test_action_input_is_a_closed_choice_with_no_default():
+    document = _load_workflow()
+    inputs = _inputs(document)
+    action_input = inputs["action"]
+    assert action_input["type"] == "choice"
+    assert set(action_input["options"]) == {"activate", "rollback"}
+    assert action_input["required"] is True
+    assert "default" not in action_input
+
+
+def test_no_input_looks_like_a_generic_command_field():
+    document = _load_workflow()
+    inputs = _inputs(document)
+    for name, spec in inputs.items():
+        lowered = f"{name} {spec.get('description', '')}".lower()
+        assert "command" not in lowered, f"input {name!r} looks like a generic command field"
+        assert "shell" not in lowered, f"input {name!r} looks like a generic shell field"
+
+
+def test_every_remote_ssh_invocation_pipes_the_one_fixed_script():
+    """Every SSH call must end in `bash -s" < deploy/diagnostics/v1_49_host_native_activation.sh`
+    — never a caller-constructed command string.
+    """
+    text = _WORKFLOW_PATH.read_text()
+    ssh_invocations = re.findall(r'"\$DEPLOY_USER@\$DEPLOY_HOST"\s*\\\n(.*?)\n', text)
+    assert ssh_invocations, "expected at least one SSH invocation in the workflow"
+    fixed_script_pipes = re.findall(
+        r'bash -s"\s*\\\n\s*< deploy/diagnostics/v1_49_host_native_activation\.sh',
+        text,
+    )
+    # One pipe-in per SSH step (preflight, activate, safety-net rollback,
+    # explicit rollback) — never a bare `bash -s"` with no fixed script
+    # following it, and never a second script path.
+    assert len(fixed_script_pipes) >= 4
+    assert "deploy/diagnostics/v1_49_host_native_activation.sh" in text
+    other_scripts = re.findall(r"< deploy/diagnostics/(\S+\.sh)", text)
+    assert set(other_scripts) == {"v1_49_host_native_activation.sh"}
+
+
+def test_only_the_allowed_env_keys_are_threaded_into_the_remote_command():
+    text = _WORKFLOW_PATH.read_text()
+    keys = set(
+        re.findall(r"([A-Z_][A-Z0-9_]*)=(?:preflight|activate|rollback|\$\(printf %q)", text)
+    )
+    assert keys, "expected to find at least one remote env-key assignment"
+    assert (
+        keys <= _ALLOWED_REMOTE_ENV_KEYS
+    ), f"unexpected remote env keys: {keys - _ALLOWED_REMOTE_ENV_KEYS}"
+
+
+def test_reason_is_never_interpolated_directly_as_a_bash_or_python_expression():
+    """REASON is free-text operator input. It must only ever appear as a
+    shell-quoted environment VALUE (via `printf %q`) — never spliced
+    directly into a command string or Python source, which is exactly
+    what would let it break out and execute as code.
+    """
+    workflow_text = _WORKFLOW_PATH.read_text()
+    assert 'REASON=$(printf %q "${{ inputs.reason }}")' in workflow_text
+    # No other raw appearance of the reason input outside the guarded
+    # printf-%q assignment and the human-readable job-summary echo.
+    raw_reason_uses = re.findall(r"\$\{\{\s*inputs\.reason\s*\}\}", workflow_text)
+    assert len(raw_reason_uses) <= 3  # printf %q, safety-net synthetic reason text, job summary
+
+    script_text = _SCRIPT_PATH.read_text()
+    assert "'''${REASON}'''" not in script_text
+    assert "REPORT_REASON" in script_text
+    assert "os.environ['REPORT_REASON']" in script_text
+
+
+def test_flag_key_is_a_hardcoded_constant_not_an_input():
+    script_text = _SCRIPT_PATH.read_text()
+    assert 'FLAG_KEY="RISKIT_FEATURE_HOST_NATIVE_SCORING"' in script_text
+
+    # The flag name may appear in the workflow's prose comments (it does,
+    # in the header) but must never appear in anything that actually
+    # executes: no input, and no `env:` value on any step.
+    document = _load_workflow()
+    inputs = _inputs(document)
+    assert not any("RISKIT_FEATURE" in name for name in inputs)
+    job = _job(document)
+    for step in job["steps"]:
+        for value in (step.get("env") or {}).values():
+            assert "RISKIT_FEATURE" not in str(value)
+
+
+def test_exactly_one_rollback_implementation():
+    script_text = _SCRIPT_PATH.read_text()
+    definitions = re.findall(r"^do_rollback\(\)\s*\{", script_text, flags=re.MULTILINE)
+    assert len(definitions) == 1, "there must be exactly one do_rollback() implementation"
+
+
+def test_do_rollback_is_called_from_exactly_the_two_expected_sites():
+    script_text = _SCRIPT_PATH.read_text()
+    calls = re.findall(r'do_rollback "\$\{state_dir\}"', script_text)
+    # Once from the automatic ERR trap handler, once from the explicit
+    # rollback action branch.
+    assert len(calls) == 2
+
+
+def test_script_syntax_is_valid_bash():
+    result = subprocess.run(["bash", "-n", str(_SCRIPT_PATH)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+def _run_validate_activation_id(value: str) -> subprocess.CompletedProcess:
+    """Source the script (never runs main(), see the BASH_SOURCE guard at
+    its end) and call validate_activation_id in isolation — the actual
+    behavioral check for the path-traversal guard on ACTIVATION_ID,
+    which for `action=rollback` is free-text operator input threaded
+    straight into a filesystem path (STATE_ROOT/${ACTIVATION_ID}).
+    """
+    script = f'source "{_SCRIPT_PATH}" && validate_activation_id "$1" && echo VALID'
+    return subprocess.run(
+        ["bash", "-c", script, "bash", value],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_validate_activation_id_accepts_realistic_ids():
+    for value in ["33066619784", "v149_pre_123", "activation-id.2026", "A"]:
+        result = _run_validate_activation_id(value)
+        assert result.returncode == 0, f"{value!r}: {result.stderr}"
+        assert "VALID" in result.stdout
+
+
+def test_validate_activation_id_rejects_path_traversal_and_empty_values():
+    for value in ["../../etc", "..", ".", "foo/bar", "foo bar", "", "$(rm -rf /)"]:
+        result = _run_validate_activation_id(value)
+        assert result.returncode != 0, f"expected rejection for {value!r}"
+        assert "VALID" not in result.stdout
+
+
+def test_do_activate_and_do_rollback_action_both_validate_activation_id():
+    script_text = _SCRIPT_PATH.read_text()
+    do_activate_body = script_text.split("do_activate() {", 1)[1].split(
+        "\ndo_rollback_action()", 1
+    )[0]
+    do_rollback_action_body = script_text.split("do_rollback_action() {", 1)[1]
+    assert "validate_activation_id" in do_activate_body
+    assert "validate_activation_id" in do_rollback_action_body
+
+
+def test_workflow_only_references_the_established_ssh_secrets():
+    text = _WORKFLOW_PATH.read_text()
+    expected_secrets = {
+        "DEPLOY_SSH_PRIVATE_KEY",
+        "DEPLOY_KNOWN_HOSTS",
+        "DEPLOY_PORT",
+        "DEPLOY_HOST",
+        "DEPLOY_USER",
+    }
+    used_secrets = set(re.findall(r"secrets\.([A-Z_]+)", text))
+    assert used_secrets == expected_secrets
+
+
+def test_merging_this_workflow_never_dispatches_it():
+    document = _load_workflow()
+    assert set(_on_block(document).keys()) == {"workflow_dispatch"}

--- a/tests/scripts/test_diff_bdvm_snapshots.py
+++ b/tests/scripts/test_diff_bdvm_snapshots.py
@@ -1,0 +1,192 @@
+"""Unit tests for ``scripts/diff_bdvm_snapshots.py``.
+
+Pins the properties the V1-49 activation workflow's "BDVM rerun against
+challenger output" measurement depends on:
+
+1. Records are matched by (playerKey, season, source); an added/removed
+   player is reported, not silently dropped or fabricated as a zero
+   delta.
+2. Numeric field deltas are computed only from already-published
+   numbers — this tool never recomputes a fantasy-points value.
+3. Provenance flips (e.g. a proxy record superseded by a real one) are
+   reported even when the point totals happen to match.
+4. Unchanged records are counted, not listed, and excluded from
+   "changed".
+5. `changed` is sorted by the largest absolute numeric delta first.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "diff_bdvm_snapshots.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("diff_bdvm_snapshots", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+_mod = _load_module()
+
+
+def _record(player_key, source="idpShow", season=2026, **overrides):
+    base = {
+        "source": source,
+        "playerKey": player_key,
+        "position": "LB",
+        "season": season,
+        "asOf": "2026-08-28",
+        "games": 17,
+        "statLine": None,
+        "statBasis": "season",
+        "fpg": 10.0,
+        "fpts": 170.0,
+        "scoringNative": True,
+        "isProxy": False,
+        "projHigh": None,
+        "projLow": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_snapshot(path: Path, records: list[dict], season=2026, as_of="2026-08-28"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {"asOf": as_of, "season": season, "recordCount": len(records), "records": records}
+        )
+    )
+
+
+def test_added_and_removed_players_are_reported(tmp_path):
+    before = [_record("player-a")]
+    after = [_record("player-a"), _record("player-b")]
+    report = _mod.diff_records(before, after)
+    assert report["addedCount"] == 1
+    assert report["added"][0]["playerKey"] == "player-b"
+    assert report["removedCount"] == 0
+
+
+def test_removed_player_is_reported_not_dropped(tmp_path):
+    before = [_record("player-a"), _record("player-b")]
+    after = [_record("player-a")]
+    report = _mod.diff_records(before, after)
+    assert report["removedCount"] == 1
+    assert report["removed"][0]["playerKey"] == "player-b"
+
+
+def test_numeric_field_delta_is_computed_correctly(tmp_path):
+    before = [_record("player-a", fpg=10.0, fpts=170.0)]
+    after = [_record("player-a", fpg=12.5, fpts=212.5)]
+    report = _mod.diff_records(before, after)
+    assert report["changedCount"] == 1
+    changed = report["changed"][0]
+    assert changed["fieldDeltas"]["fpg"]["delta"] == 2.5
+    assert changed["fieldDeltas"]["fpts"]["delta"] == 42.5
+
+
+def test_unchanged_records_are_counted_not_listed(tmp_path):
+    rec = _record("player-a")
+    report = _mod.diff_records([rec], [dict(rec)])
+    assert report["unchangedCount"] == 1
+    assert report["changedCount"] == 0
+    assert report["changed"] == []
+
+
+def test_provenance_flip_is_reported_even_with_identical_points(tmp_path):
+    before = [_record("player-a", isProxy=True, fpg=10.0, fpts=170.0)]
+    after = [_record("player-a", isProxy=False, fpg=10.0, fpts=170.0)]
+    report = _mod.diff_records(before, after)
+    assert report["changedCount"] == 1
+    changed = report["changed"][0]
+    assert changed["fieldDeltas"] == {}
+    assert changed["provenanceDeltas"]["isProxy"] == {"before": True, "after": False}
+
+
+def test_changed_is_sorted_by_largest_absolute_delta_first(tmp_path):
+    before = [
+        _record("small-move", fpg=10.0, fpts=170.0),
+        _record("big-move", fpg=10.0, fpts=170.0),
+    ]
+    after = [
+        _record("small-move", fpg=10.5, fpts=178.5),
+        _record("big-move", fpg=20.0, fpts=340.0),
+    ]
+    report = _mod.diff_records(before, after)
+    assert [c["playerKey"] for c in report["changed"]] == ["big-move", "small-move"]
+
+
+def test_different_sources_for_the_same_player_are_distinct_records(tmp_path):
+    before = [_record("player-a", source="idpShow"), _record("player-a", source="mikeClay")]
+    after = [_record("player-a", source="idpShow", fpg=15.0, fpts=255.0)]
+    report = _mod.diff_records(before, after)
+    assert report["changedCount"] == 1
+    assert report["removedCount"] == 1
+    assert report["removed"][0]["source"] == "mikeClay"
+
+
+def test_diff_snapshots_reads_files_and_stamps_metadata(tmp_path):
+    before_path = tmp_path / "projections_2026-08-27_v149_pre.json"
+    after_path = tmp_path / "projections_2026-08-28_v149_post.json"
+    _write_snapshot(before_path, [_record("player-a", fpg=10.0, fpts=170.0)], as_of="2026-08-27")
+    _write_snapshot(after_path, [_record("player-a", fpg=12.0, fpts=204.0)], as_of="2026-08-28")
+
+    report = _mod.diff_snapshots(before_path, after_path)
+    assert report["beforeAsOf"] == "2026-08-27"
+    assert report["afterAsOf"] == "2026-08-28"
+    assert report["changedCount"] == 1
+
+
+def test_top_n_truncates_lists_but_not_counts(tmp_path):
+    before = [_record(f"player-{i}", fpg=10.0, fpts=170.0) for i in range(5)]
+    after = [_record(f"player-{i}", fpg=10.0 + i + 1, fpts=170.0 + i + 1) for i in range(5)]
+    report = _mod.diff_records(before, after)
+    assert report["changedCount"] == 5
+
+    before_path = tmp_path / "before.json"
+    after_path = tmp_path / "after.json"
+    _write_snapshot(before_path, before)
+    _write_snapshot(after_path, after)
+    truncated = _mod.diff_snapshots(before_path, after_path, top_n=2)
+    assert truncated["changedCount"] == 5
+    assert len(truncated["changed"]) == 2
+
+
+def test_missing_snapshot_file_raises(tmp_path):
+    try:
+        _mod.load_snapshot_payload(tmp_path / "nope.json")
+        raise AssertionError("expected SnapshotDiffError")
+    except _mod.SnapshotDiffError:
+        pass
+
+
+def test_malformed_json_raises(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not valid json")
+    try:
+        _mod.load_snapshot_payload(bad)
+        raise AssertionError("expected SnapshotDiffError")
+    except _mod.SnapshotDiffError:
+        pass
+
+
+def test_cli_diff(tmp_path, capsys):
+    before_path = tmp_path / "before.json"
+    after_path = tmp_path / "after.json"
+    _write_snapshot(before_path, [_record("player-a", fpg=10.0, fpts=170.0)])
+    _write_snapshot(after_path, [_record("player-a", fpg=12.0, fpts=204.0)])
+
+    rc = _mod.main(["--before", str(before_path), "--after", str(after_path)])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["changedCount"] == 1

--- a/tests/scripts/test_pbp_artifact_backup.py
+++ b/tests/scripts/test_pbp_artifact_backup.py
@@ -1,0 +1,162 @@
+"""Unit tests for ``scripts/pbp_artifact_backup.py``.
+
+Pins the properties the V1-49 activation/rollback workflow depends on:
+
+1. Backup records ``existedBefore`` per season, not just content.
+2. Restore correctly puts back a file that existed, and DELETES a file
+   that a rebuild created from nothing (the case a plain "overwrite from
+   backup" would miss, since there is nothing to overwrite from).
+3. Two backups run back-to-back never collide/clobber each other.
+4. A season the backup never covered at all is untouched by restore.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "pbp_artifact_backup.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("pbp_artifact_backup", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+_mod = _load_module()
+
+
+def _write_season_file(actuals_dir: Path, season: int, content: str) -> Path:
+    actuals_dir.mkdir(parents=True, exist_ok=True)
+    path = actuals_dir / _mod.pbp_weekly_filename(season)
+    path.write_text(content)
+    return path
+
+
+def test_backup_records_existed_before_per_season(tmp_path):
+    actuals_dir = tmp_path / "actuals"
+    _write_season_file(actuals_dir, 2024, '{"schemaVersion": "x"}\n')
+    # 2025 deliberately not created.
+    manifest = _mod.create_backup(actuals_dir, [2024, 2025], tmp_path / "backups")
+    assert manifest["seasons"]["2024"]["existedBefore"] is True
+    assert manifest["seasons"]["2025"]["existedBefore"] is False
+
+
+def test_restore_puts_back_a_file_that_existed(tmp_path):
+    actuals_dir = tmp_path / "actuals"
+    original = '{"schemaVersion": "old"}\n'
+    _write_season_file(actuals_dir, 2024, original)
+    manifest = _mod.create_backup(actuals_dir, [2024], tmp_path / "backups")
+
+    # Simulate a rebuild overwriting the file with new content.
+    (actuals_dir / _mod.pbp_weekly_filename(2024)).write_text('{"schemaVersion": "new"}\n')
+
+    result = _mod.restore_backup(Path(manifest["manifestPath"]))
+    assert result["restored"] == [_mod.pbp_weekly_filename(2024)]
+    assert result["deleted"] == []
+    assert (actuals_dir / _mod.pbp_weekly_filename(2024)).read_text() == original
+
+
+def test_restore_deletes_a_file_the_rebuild_created_from_nothing(tmp_path):
+    actuals_dir = tmp_path / "actuals"
+    # 2025 does not exist before the backup.
+    _write_season_file(actuals_dir, 2024, "{}\n")
+    manifest = _mod.create_backup(actuals_dir, [2024, 2025], tmp_path / "backups")
+
+    # Simulate a rebuild that creates 2025 from nothing.
+    (actuals_dir / _mod.pbp_weekly_filename(2025)).write_text('{"schemaVersion": "brand-new"}\n')
+    assert (actuals_dir / _mod.pbp_weekly_filename(2025)).exists()
+
+    result = _mod.restore_backup(Path(manifest["manifestPath"]))
+    assert _mod.pbp_weekly_filename(2025) in result["deleted"]
+    assert not (actuals_dir / _mod.pbp_weekly_filename(2025)).exists()
+    # 2024 (which existed before) is untouched by the delete branch.
+    assert (actuals_dir / _mod.pbp_weekly_filename(2024)).exists()
+
+
+def test_restore_deleting_an_already_absent_created_file_is_a_noop(tmp_path):
+    actuals_dir = tmp_path / "actuals"
+    manifest = _mod.create_backup(actuals_dir, [2025], tmp_path / "backups")
+    # 2025 was never created by anything downstream either.
+    result = _mod.restore_backup(Path(manifest["manifestPath"]))
+    assert result["deleted"] == []
+
+
+def test_two_backups_in_a_row_do_not_collide(tmp_path, monkeypatch):
+    actuals_dir = tmp_path / "actuals"
+    _write_season_file(actuals_dir, 2024, "{}\n")
+    backup_dir = tmp_path / "backups"
+
+    # Force the same wall-clock second for both calls to exercise the
+    # disambiguation path deterministically.
+    from datetime import datetime, timezone
+
+    fixed_now = datetime(2026, 8, 28, 1, 0, 0, tzinfo=timezone.utc)
+
+    class _FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now
+
+    monkeypatch.setattr(_mod, "datetime", _FixedDatetime)
+
+    manifest_1 = _mod.create_backup(actuals_dir, [2024], backup_dir)
+    manifest_2 = _mod.create_backup(actuals_dir, [2024], backup_dir)
+
+    assert manifest_1["manifestPath"] != manifest_2["manifestPath"]
+    assert manifest_1["tarPath"] != manifest_2["tarPath"]
+    assert Path(manifest_1["manifestPath"]).exists()
+    assert Path(manifest_2["manifestPath"]).exists()
+
+
+def test_manifest_is_valid_json_on_disk(tmp_path):
+    actuals_dir = tmp_path / "actuals"
+    _write_season_file(actuals_dir, 2024, "{}\n")
+    manifest = _mod.create_backup(actuals_dir, [2024], tmp_path / "backups")
+    on_disk = json.loads(Path(manifest["manifestPath"]).read_text())
+    assert on_disk["seasons"]["2024"]["existedBefore"] is True
+
+
+def test_restore_missing_manifest_raises(tmp_path):
+    try:
+        _mod.restore_backup(tmp_path / "nope.manifest.json")
+        raise AssertionError("expected PbpBackupError")
+    except _mod.PbpBackupError:
+        pass
+
+
+def test_cli_backup_then_restore_round_trip(tmp_path, capsys):
+    actuals_dir = tmp_path / "actuals"
+    original = '{"schemaVersion": "old"}\n'
+    _write_season_file(actuals_dir, 2024, original)
+
+    rc = _mod.main(
+        [
+            "backup",
+            "--actuals-dir",
+            str(actuals_dir),
+            "--backup-dir",
+            str(tmp_path / "backups"),
+            "--seasons",
+            "2024",
+            "2025",
+        ]
+    )
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    manifest_path = out["manifestPath"]
+
+    (actuals_dir / _mod.pbp_weekly_filename(2024)).write_text("clobbered")
+    (actuals_dir / _mod.pbp_weekly_filename(2025)).write_text("clobbered")
+
+    rc = _mod.main(["restore", "--manifest", manifest_path])
+    assert rc == 0
+    assert (actuals_dir / _mod.pbp_weekly_filename(2024)).read_text() == original
+    assert not (actuals_dir / _mod.pbp_weekly_filename(2025)).exists()

--- a/tests/scripts/test_prod_env_flag_ops.py
+++ b/tests/scripts/test_prod_env_flag_ops.py
@@ -1,0 +1,181 @@
+"""Unit tests for ``scripts/prod_env_flag_ops.py``.
+
+Pins the properties the V1-49 activation/rollback workflow depends on:
+
+1. ``set`` is idempotent — applying the same value twice converges to
+   one line, never duplicates it.
+2. ``set`` correctly captures the prior state, including ``ABSENT``
+   when the key did not exist.
+3. ``restore`` round-trips exactly: restoring a captured real value
+   reproduces the original line; restoring a captured ``ABSENT``
+   removes the key entirely, even if something else set it in between.
+4. No other line in the file is ever touched.
+5. Writes are atomic (no partial file left behind on the happy path).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "prod_env_flag_ops.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("prod_env_flag_ops", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+_mod = _load_module()
+
+ABSENT = _mod.ABSENT_SENTINEL
+KEY = "RISKIT_FEATURE_HOST_NATIVE_SCORING"
+
+
+def test_set_on_missing_file_creates_it_and_prior_is_absent(tmp_path):
+    env_file = tmp_path / ".env"
+    prior = _mod.apply_set(env_file, KEY, "1")
+    assert prior == ABSENT
+    assert env_file.read_text() == f"{KEY}=1\n"
+
+
+def test_set_is_idempotent(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("OTHER_KEY=unchanged\n")
+    _mod.apply_set(env_file, KEY, "1")
+    first = env_file.read_text()
+    prior_second = _mod.apply_set(env_file, KEY, "1")
+    second = env_file.read_text()
+    assert first == second
+    assert prior_second == "1"
+    assert first.count(f"{KEY}=") == 1
+
+
+def test_set_captures_prior_real_value_and_preserves_other_lines(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(f"BEFORE=1\n{KEY}=0\nAFTER=2\n")
+    prior = _mod.apply_set(env_file, KEY, "1")
+    assert prior == "0"
+    content = env_file.read_text()
+    assert "BEFORE=1" in content
+    assert "AFTER=2" in content
+    assert f"{KEY}=1" in content
+    assert content.count(f"{KEY}=") == 1
+
+
+def test_restore_to_absent_removes_the_key(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(f"BEFORE=1\n{KEY}=1\nAFTER=2\n")
+    _mod.apply_restore(env_file, KEY, ABSENT)
+    content = env_file.read_text()
+    assert KEY not in content
+    assert "BEFORE=1" in content
+    assert "AFTER=2" in content
+
+
+def test_restore_to_absent_is_idempotent_when_key_already_gone(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("BEFORE=1\nAFTER=2\n")
+    _mod.apply_restore(env_file, KEY, ABSENT)
+    content = env_file.read_text()
+    assert content == "BEFORE=1\nAFTER=2\n"
+
+
+def test_restore_to_prior_real_value_round_trips_exactly(tmp_path):
+    env_file = tmp_path / ".env"
+    original = f"BEFORE=1\n{KEY}=0\nAFTER=2\n"
+    env_file.write_text(original)
+    prior = _mod.apply_set(env_file, KEY, "1")
+    assert env_file.read_text() != original
+    _mod.apply_restore(env_file, KEY, prior)
+    assert env_file.read_text() == original
+
+
+def test_capture_then_restore_round_trip_survives_an_intervening_set(tmp_path):
+    """The rollback scenario: set captures prior, something else (a
+    retry, or the activation's own restart-and-recheck) sets it again,
+    and restore still lands on the ORIGINAL captured value.
+    """
+    env_file = tmp_path / ".env"
+    env_file.write_text(f"{KEY}=0\n")
+    prior = _mod.apply_set(env_file, KEY, "1")
+    assert prior == "0"
+    _mod.apply_set(env_file, KEY, "1")  # idempotent re-set, e.g. a retry
+    _mod.apply_restore(env_file, KEY, prior)
+    assert env_file.read_text() == f"{KEY}=0\n"
+
+
+def test_show_reports_absent_for_missing_key(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("OTHER=1\n")
+    lines = _mod.read_env_lines(env_file)
+    assert _mod.read_current_value(lines, KEY) == ABSENT
+
+
+def test_show_reports_absent_for_missing_file(tmp_path):
+    env_file = tmp_path / "does_not_exist.env"
+    lines = _mod.read_env_lines(env_file)
+    assert _mod.read_current_value(lines, KEY) == ABSENT
+
+
+def test_set_appends_trailing_newline_before_new_key_if_missing(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("NO_TRAILING_NEWLINE=1")
+    _mod.apply_set(env_file, KEY, "1")
+    content = env_file.read_text()
+    assert content == f"NO_TRAILING_NEWLINE=1\n{KEY}=1\n"
+
+
+def test_invalid_key_is_rejected(tmp_path):
+    env_file = tmp_path / ".env"
+    try:
+        _mod.apply_set(env_file, "not a valid key!", "1")
+        raise AssertionError("expected EnvOpsError")
+    except _mod.EnvOpsError:
+        pass
+
+
+def test_value_with_newline_is_rejected(tmp_path):
+    env_file = tmp_path / ".env"
+    try:
+        _mod.apply_set(env_file, KEY, "1\nINJECTED=1")
+        raise AssertionError("expected EnvOpsError")
+    except _mod.EnvOpsError:
+        pass
+
+
+def test_atomic_write_leaves_no_temp_file_behind(tmp_path):
+    env_file = tmp_path / ".env"
+    _mod.apply_set(env_file, KEY, "1")
+    leftovers = list(tmp_path.glob(".env.tmp.*"))
+    assert leftovers == []
+
+
+def test_cli_set_then_restore_round_trips(tmp_path, capsys):
+    env_file = tmp_path / ".env"
+    env_file.write_text(f"{KEY}=0\n")
+
+    rc = _mod.main(["set", "--env-file", str(env_file), "--key", KEY, "--value", "1"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert '"prior_state": "0"' in out
+    assert env_file.read_text() == f"{KEY}=1\n"
+
+    rc = _mod.main(["restore", "--env-file", str(env_file), "--key", KEY, "--prior-state", "0"])
+    assert rc == 0
+    assert env_file.read_text() == f"{KEY}=0\n"
+
+
+def test_cli_show(tmp_path, capsys):
+    env_file = tmp_path / ".env"
+    env_file.write_text(f"{KEY}=1\n")
+    rc = _mod.main(["show", "--env-file", str(env_file), "--key", KEY])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert '"value": "1"' in out


### PR DESCRIPTION
## Summary

Builds the narrowly-scoped `workflow_dispatch` mechanism required before `RISKIT_FEATURE_HOST_NATIVE_SCORING` can be safely flipped in production, per the owner-authorized controlled-activation conditions recorded on V1-49 in `docs/VERSION_1_COMPLETION_CONTRACT.md` (exact-head CI green, blast radius measured first, rollback ready, any unexpected scoring behavior triggers rollback, no scoring-methodology change).

**This PR does not activate anything.** Merging it only makes the mechanism available; V1-49 stays `IMPLEMENTED_UNVERIFIED` until a real `action: activate` dispatch is run separately and its results are measured.

### What it does, end to end

1. **Preflight (read-only)** — confirms the exact expected commit SHA, current flag state, `dynasty.service` exists, `scripts/build_pbp_weekly.py` is present and parses, and records current PBP artifact/schema state. Refuses (no write) on any surprise.
2. **Backup → activate → rebuild → measure** — backs up the current PBP-weekly artifacts (tracking which seasons existed before, so a rollback can *delete* a file a rebuild created from nothing, not just overwrite it), captures the prior `.env` flag state, flips only `RISKIT_FEATURE_HOST_NATIVE_SCORING` via the existing `.env`/`EnvironmentFile=` mechanism, restarts only `dynasty.service` (the frontend never reads this flag), rebuilds the PBP-weekly artifact for the five vendor-priced seasons, validates each rebuilt artifact through the canonical `load_pbp_weekly` loader, builds BDVM pre/post projection snapshots and diffs them, and probes `GET /api/league-comparison?refresh=1` as an observation.
3. **Automatic rollback on any failure** — a single `do_rollback()` function, invoked both by an in-script `ERR` trap and by an explicit `action: rollback` dispatch, restores the captured `.env` state and PBP artifacts, restarts the service, and verifies recovery. Every restore it performs is idempotent, so it's safe to call twice (e.g. the trap fires *and* a safety-net dispatch also runs after an SSH drop).
4. **Reports, never fabricates evidence.** Two of the four promotion-gate measurements in `docs/scoring/HOST_NATIVE_SCORING_VALIDATION.md` §4 have no existing controlled-comparison tooling anywhere in this repo: the league-comparison challenger path only differs from champion behavior for the *current* in-season year (nflverse already covers every historical season), so flag-change and live-data-change are confounded there; and no dedicated historical-backtest script exists at all. Per owner direction this session, the workflow reports this honestly — an explicitly-labeled uncontrolled observation for item 2, and item 3 treated as satisfied by the item 1 (BDVM) + item 4 (PBP) measured deltas, per the validation doc's own framing — rather than inventing new backtest methodology to fill the gap.

### Security / scope boundary

- The flag key (`RISKIT_FEATURE_HOST_NATIVE_SCORING`) is a hard-coded constant in the shell script, never a workflow input.
- The only typed inputs are `action` (closed `activate`/`rollback` choice), `confirm_activation`, `expected_sha`, `bdvm_season`, `activation_id`, and a free-text `reason` used only as an audit note (passed to Python via `os.environ`, never string-interpolated into source — closes a real injection vector I found and fixed during self-review).
- `ACTIVATION_ID` becomes a filesystem path segment; for `action=rollback` it's free-text operator input, so it's validated against `^[A-Za-z0-9_.-]+$` before use (path-traversal guard, also found and fixed during self-review, now with direct test coverage).
- Uses the existing `DEPLOY_*` secrets / production `environment:` / SSH pattern already established by `lane4-onbox-verification.yml` and `retention-backup-proof.yml`. Shares `deploy.yml`'s `production-deploy` concurrency group so a real deploy and an activation attempt can never race.
- No secrets or `.env` contents are ever printed — only the single captured flag line (a boolean) is logged.

### New files

- `scripts/prod_env_flag_ops.py` — idempotent single-key `.env` upsert/capture/restore, atomic writes
- `scripts/pbp_artifact_backup.py` — timestamped backup/restore of the PBP-weekly artifacts
- `scripts/diff_bdvm_snapshots.py` — pure comparison of two BDVM projection snapshots (never recomputes a scoring value)
- `deploy/diagnostics/v1_49_host_native_activation.sh` — the remote orchestrator
- `.github/workflows/v1-49-host-native-scoring-activation.yml` — the typed dispatch entry point
- `tests/scripts/test_{prod_env_flag_ops,pbp_artifact_backup,diff_bdvm_snapshots}.py`, `tests/deploy/test_v1_49_workflow_wiring.py`
- `config/ci/release_gate_classification.json` — classification entries for the new workflow's 9 steps

## Test plan

- [x] `pytest tests/scripts/test_prod_env_flag_ops.py tests/scripts/test_pbp_artifact_backup.py tests/scripts/test_diff_bdvm_snapshots.py tests/deploy/test_v1_49_workflow_wiring.py tests/deploy/test_release_gate_classification.py` — 57 passed
- [x] `bash -n deploy/diagnostics/v1_49_host_native_activation.sh` — syntax clean
- [x] `ruff format --check` / `ruff check` — clean on all new Python files
- [x] `python3 scripts/check_planning_integrity.py` — OK
- [x] `python3 scripts/ci_gate_classification.py` — 0 unclassified, 0 stale
- [x] Full `tests/deploy/ tests/scripts/` suite (708 passed, 4 skipped) — no regressions
- [ ] Exact-head PR CI green (pending this PR's own run)
- [ ] Not run against production as part of this PR — activation is a separate, later dispatch after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg)_