### PR TITLE
fix(v1-49): repair BASH_SOURCE unbound-variable crash in the SSH invocation path

### DIFF
--- a/deploy/diagnostics/v1_49_host_native_activation.sh
+++ b/deploy/diagnostics/v1_49_host_native_activation.sh
@@ -563,10 +563,24 @@ main() {
   esac
 }
 
-# Run main only when EXECUTED, not when sourced — mirrors
-# deploy/rollback.sh's own guard. Sourcing is how a test can call
-# individual functions (e.g. validate_activation_id) in isolation
-# without dispatching a real preflight/activate/rollback.
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+# Run main only when EXECUTED, not when sourced. Sourcing is how a
+# test can call individual functions (e.g. validate_activation_id) in
+# isolation without dispatching a real preflight/activate/rollback.
+#
+# ``${BASH_SOURCE[0]:-${0}}`` rather than deploy/rollback.sh's bare
+# ``${BASH_SOURCE[0]}``: that script is always invoked as
+# ``bash /path/to/rollback.sh`` (a named file), which populates
+# BASH_SOURCE. This one is piped over SSH via
+# ``ssh ... "bash -s" < deploy/diagnostics/v1_49_host_native_activation.sh``
+# — bash reading a script from stdin with no named file does not push
+# anything onto BASH_SOURCE at all, so under `set -u` the bare form
+# throws "BASH_SOURCE[0]: unbound variable" before main() ever runs,
+# and every real dispatch fails at this line. The default-expansion
+# form falls back to ``$0`` when BASH_SOURCE has no entry, making the
+# comparison trivially true (never sourced in that shape, so main()
+# is always the right call) while leaving the sourced-for-testing case
+# unchanged (BASH_SOURCE[0] is the sourced file's real path there,
+# which does not equal $0).
+if [[ "${BASH_SOURCE[0]:-${0}}" == "${0}" ]]; then
   main "$@"
 fi

--- a/tests/deploy/test_v1_49_workflow_wiring.py
+++ b/tests/deploy/test_v1_49_workflow_wiring.py
@@ -26,6 +26,7 @@ flag/backup logic lives in ``tests/scripts/test_prod_env_flag_ops.py``,
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -203,6 +204,37 @@ def test_do_rollback_is_called_from_exactly_the_two_expected_sites():
 def test_script_syntax_is_valid_bash():
     result = subprocess.run(["bash", "-n", str(_SCRIPT_PATH)], capture_output=True, text=True)
     assert result.returncode == 0, result.stderr
+
+
+def test_stdin_piped_invocation_runs_main_without_unbound_variable_crash():
+    """Regression pin for a real production incident (first live activation
+    dispatch, 2026-08-28): piping the script via stdin into `bash -s` — the
+    exact shape
+    `ssh ... "bash -s" < deploy/diagnostics/v1_49_host_native_activation.sh`
+    uses in the real workflow — leaves BASH_SOURCE with no entry at all
+    (no named file is involved), and the bare `${BASH_SOURCE[0]}` guard
+    threw "unbound variable" under `set -u` before main() ever ran. Every
+    real dispatch failed at that line regardless of ACTION or inputs; the
+    bug was invisible to `bash -n` (syntax-valid) and to the sourced-file
+    unit tests below (a real named path populates BASH_SOURCE correctly,
+    so sourcing never exercised this branch).
+
+    Reproduces the exact invocation shape here — stdin, no filename — and
+    asserts main() actually reaches its own dispatch logic rather than
+    crashing on the unset guard variable.
+    """
+    with open(_SCRIPT_PATH, "rb") as script_file:
+        result = subprocess.run(
+            ["bash", "-s"],
+            stdin=script_file,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "ACTION": ""},
+            timeout=30,
+        )
+    assert "unbound variable" not in result.stderr, result.stderr
+    assert "ACTION must be one of" in result.stderr, result.stderr
+    assert result.returncode == 1
 
 
 def _run_validate_activation_id(value: str) -> subprocess.CompletedProcess:


### PR DESCRIPTION
## Summary

The first live `action: activate` dispatch of the V1-49 controlled-activation workflow (run [33168603289](https://github.com/jasonleetucker-code/riskittogetthebrisket/actions/runs/33168603289), 2026-08-28T11:49Z) refused cleanly at the preflight step — no production write happened, exactly as designed. But the actual cause was not a stale `expected_sha`, it was a real bug:

```
bash: line 570: BASH_SOURCE[0]: unbound variable
```

`deploy/diagnostics/v1_49_host_native_activation.sh`'s sourced-vs-executed guard (`if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then main "$@"; fi`) was modeled on `deploy/rollback.sh`'s identical-looking pattern — but that script is always invoked as `bash /path/to/rollback.sh` (a named file). This script is instead piped over SSH via `ssh ... "bash -s" < deploy/diagnostics/v1_49_host_native_activation.sh`, and bash reading a script from stdin with no named file pushes nothing onto `BASH_SOURCE` at all. Under `set -u`, the bare form therefore threw "unbound variable" before `main()` ever ran — **every real dispatch would have failed at that line regardless of ACTION or inputs.**

The bug was invisible to `bash -n` (syntax-valid — referencing an unset variable is not a parse error) and to the existing sourced-file unit tests (`source /real/path/to/script.sh` populates `BASH_SOURCE` correctly, so sourcing never exercised the stdin-piped branch that's actually used in production).

## Fix

`${BASH_SOURCE[0]:-${0}}` — falls back to `$0` when `BASH_SOURCE` has no entry, making the comparison trivially true for the stdin-piped shape (so `main()` always runs there, which is correct — that invocation is never a "sourced for testing" case) while leaving the sourced-for-testing case unchanged (`BASH_SOURCE[0]` is the sourced file's real path there, which does not equal `$0`).

Verified against all three invocation shapes locally before pushing:
1. `bash -s < script` (the real SSH shape) — `main()` now runs ✓
2. `bash script.sh` (direct execution) — `main()` runs ✓ (already worked)
3. `source script.sh` from another script (the test harness shape) — `main()` does NOT auto-run ✓ (already worked)

## Test plan

- [x] Reproduced the original crash locally (`bash -s < script` under `set -u`) before writing the fix
- [x] Added `test_stdin_piped_invocation_runs_main_without_unbound_variable_crash` — pipes the real script via stdin into `bash -s` (the exact production shape) and asserts `main()` reaches its own dispatch logic rather than crashing
- [x] Mutation-verified: reverted to the bare `${BASH_SOURCE[0]}` form and confirmed the new test's underlying reproduction still crashes identically
- [x] `bash -n` syntax check clean
- [x] `pytest tests/deploy/ tests/scripts/` — 712 passed, 4 skipped (no regressions)
- [x] `ruff format --check` / `ruff check` clean
- [x] `python3 scripts/check_planning_integrity.py` — OK
- [x] `python3 scripts/ci_gate_classification.py` — 0 unclassified, 0 stale (no new workflow steps, classification untouched)
- [ ] Exact-head PR CI green (pending)

No production write happened during the failed attempt — preflight refused before any state was captured or mutated. V1-49 remains `IMPLEMENTED_UNVERIFIED`; the controlled activation will be re-dispatched against a freshly-confirmed deployed SHA once this fix lands and deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg)_