### PR TITLE
fix(v1-49): stop sourcing production .env as bash, guard empty env-args

### DIFF
--- a/deploy/diagnostics/v1_49_host_native_activation.sh
+++ b/deploy/diagnostics/v1_49_host_native_activation.sh
@@ -163,11 +163,51 @@ resolve_systemctl_bin() {
 }
 
 # ── small python helpers, run against the SAME .env every production
-#    process would source (EnvironmentFile=-__APP_DIR__/.env) ─────────
+#    process would read (EnvironmentFile=-__APP_DIR__/.env) ───────────
+#
+# Reads .env as plain KEY=VALUE lines (env_sourced_python_env_args),
+# never via bash `source`. First live activation run (2026-08-28,
+# run 33176834694) hit a real, deterministic production incident: the
+# box's actual .env contains a line that is not valid KEY=VALUE bash
+# syntax, and `source`-ing it derailed the run before any write
+# happened (a safe outcome, but not a usable one — every dispatch
+# would fail identically). `EnvironmentFile=` in the systemd unit that
+# actually loads this file is itself a plain KEY=VALUE reader, not a
+# shell interpreter, so a strict line parser here is the FAITHFUL
+# match to how production reads its own .env — bash `source` was
+# always a stricter, riskier stand-in than the real mechanism.
+# Malformed lines are silently skipped (a value there could be a
+# partial secret — never echoed), never executed as a command.
+env_sourced_python_env_args() {
+  local -a args=()
+  local line key value
+  if [[ -f "${ENV_FILE}" ]]; then
+    while IFS= read -r line || [[ -n "${line}" ]]; do
+      [[ "${line}" =~ ^[[:space:]]*(#.*)?$ ]] && continue
+      if [[ "${line}" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+        key="${BASH_REMATCH[1]}"
+        value="${BASH_REMATCH[2]}"
+        args+=("${key}=${value}")
+      fi
+    done < "${ENV_FILE}"
+  fi
+  # `printf '%s\n' "${args[@]}"` on a truly empty array still executes
+  # the format once, substituting "" for the missing operand — one
+  # blank line, not zero. mapfile below then reads that as a single
+  # empty-string element, so `env ""` gets passed a bogus argument it
+  # tries to run as a command ("env: '': No such file or directory").
+  # Guarded explicitly rather than relying on printf's argument-recycling
+  # behavior to do the right thing with zero elements.
+  if ((${#args[@]} > 0)); then
+    printf '%s\n' "${args[@]}"
+  fi
+}
+
 env_sourced_python() {
   # Usage: env_sourced_python <python -c code...>
-  ( set -a; [[ -f "${ENV_FILE}" ]] && source "${ENV_FILE}"; set +a
-    cd "${APP_DIR}" && "${PYTHON_BIN}" "$@" )
+  local -a env_args=()
+  mapfile -t env_args < <(env_sourced_python_env_args)
+  ( cd "${APP_DIR}" && env "${env_args[@]}" "${PYTHON_BIN}" "$@" )
 }
 
 read_flag_enabled() {

--- a/tests/deploy/test_v1_49_workflow_wiring.py
+++ b/tests/deploy/test_v1_49_workflow_wiring.py
@@ -147,9 +147,9 @@ def test_only_the_allowed_env_keys_are_threaded_into_the_remote_command():
         re.findall(r"([A-Z_][A-Z0-9_]*)=(?:preflight|activate|rollback|\$\(printf %q)", text)
     )
     assert keys, "expected to find at least one remote env-key assignment"
-    assert keys <= _ALLOWED_REMOTE_ENV_KEYS, (
-        f"unexpected remote env keys: {keys - _ALLOWED_REMOTE_ENV_KEYS}"
-    )
+    assert (
+        keys <= _ALLOWED_REMOTE_ENV_KEYS
+    ), f"unexpected remote env keys: {keys - _ALLOWED_REMOTE_ENV_KEYS}"
 
 
 def test_reason_is_never_interpolated_directly_as_a_bash_or_python_expression():

--- a/tests/deploy/test_v1_49_workflow_wiring.py
+++ b/tests/deploy/test_v1_49_workflow_wiring.py
@@ -147,9 +147,9 @@ def test_only_the_allowed_env_keys_are_threaded_into_the_remote_command():
         re.findall(r"([A-Z_][A-Z0-9_]*)=(?:preflight|activate|rollback|\$\(printf %q)", text)
     )
     assert keys, "expected to find at least one remote env-key assignment"
-    assert (
-        keys <= _ALLOWED_REMOTE_ENV_KEYS
-    ), f"unexpected remote env keys: {keys - _ALLOWED_REMOTE_ENV_KEYS}"
+    assert keys <= _ALLOWED_REMOTE_ENV_KEYS, (
+        f"unexpected remote env keys: {keys - _ALLOWED_REMOTE_ENV_KEYS}"
+    )
 
 
 def test_reason_is_never_interpolated_directly_as_a_bash_or_python_expression():
@@ -235,6 +235,78 @@ def test_stdin_piped_invocation_runs_main_without_unbound_variable_crash():
     assert "unbound variable" not in result.stderr, result.stderr
     assert "ACTION must be one of" in result.stderr, result.stderr
     assert result.returncode == 1
+
+
+def _source_script_and_run(app_dir: Path, bash_code: str) -> subprocess.CompletedProcess:
+    """Source the real script with APP_DIR pointed at a scratch directory,
+    then run `bash_code`. main() never auto-runs when sourced (the
+    BASH_SOURCE guard at the script's end). ENV_FILE is derived from
+    APP_DIR INSIDE the script (`ENV_FILE="${APP_DIR}/.env"`, not read
+    from a pre-set env var) — so APP_DIR is the only lever that controls
+    which .env the sourced functions see.
+    """
+    script = f'source "{_SCRIPT_PATH}" >/dev/null 2>&1; {bash_code}'
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "APP_DIR": str(app_dir)},
+        timeout=30,
+    )
+
+
+def test_env_file_is_never_sourced_as_bash(tmp_path):
+    """Regression pin for a real production incident (second live
+    activation attempt, run 33176834694, 2026-08-28): production's real
+    `.env` contains a line that is not valid `KEY=VALUE` bash syntax (a
+    bare hex string, believed to be a wrapped/partial secret), and the
+    old `source`-based loader tried to execute it as a command (exit 127,
+    `command not found`). `env_sourced_python` must parse `.env` as plain
+    KEY=VALUE text and never hand any of it to bash for execution.
+    """
+    app_dir = tmp_path / "app"
+    app_dir.mkdir()
+    (app_dir / ".env").write_text(
+        "FOO=bar\n"
+        "RISKIT_FEATURE_HOST_NATIVE_SCORING=0\n"
+        "c503b850537d737346e1f321b73ed2c9d889e0cde5636bf008985dfa1c17feaf\n"
+        "BAZ=qux with spaces\n"
+        "# a comment\n"
+        "\n"
+        "EMPTY_VALUE=\n"
+    )
+    result = _source_script_and_run(
+        app_dir,
+        'env_sourced_python -c "import os; '
+        "print('FOO=' + os.environ.get('FOO', 'MISSING')); "
+        "print('BAZ=' + os.environ.get('BAZ', 'MISSING')); "
+        "print('RISKIT=' + os.environ.get('RISKIT_FEATURE_HOST_NATIVE_SCORING', 'MISSING')); "
+        "print('EMPTY=[' + os.environ.get('EMPTY_VALUE', 'MISSING') + ']')\"",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "command not found" not in result.stderr, result.stderr
+    assert "FOO=bar" in result.stdout
+    assert "BAZ=qux with spaces" in result.stdout
+    assert "RISKIT=0" in result.stdout
+    assert "EMPTY=[]" in result.stdout
+
+
+def test_env_sourced_python_env_args_skips_malformed_lines_silently(tmp_path):
+    app_dir = tmp_path / "app"
+    app_dir.mkdir()
+    (app_dir / ".env").write_text("A=1\nnot a key value line\nB=2\n")
+    result = _source_script_and_run(app_dir, "env_sourced_python_env_args")
+    assert result.returncode == 0, result.stderr
+    lines = [line for line in result.stdout.splitlines() if line]
+    assert lines == ["A=1", "B=2"]
+
+
+def test_env_sourced_python_tolerates_a_missing_env_file(tmp_path):
+    app_dir = tmp_path / "app"
+    app_dir.mkdir()  # deliberately no .env written
+    result = _source_script_and_run(app_dir, "env_sourced_python -c \"print('ok')\"")
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
 
 
 def _run_validate_activation_id(value: str) -> subprocess.CompletedProcess:


### PR DESCRIPTION
## Incident

The second live V1-49 activation attempt (run `33176834694`, 2026-08-28) crashed with exit 127 during `Backup, activate, rebuild, measure`:

```
.env: line 108: c503b850537d737346e1f321b73ed2c9d889e0cde5636bf008985dfa1c17feaf: command not found
[v1-49][ERROR] activation step failed (exit 127)
```

Production's real `.env` contains a line that is not valid `KEY=VALUE` bash syntax (a bare 64-hex-char string, believed to be a wrapped/partial secret). `env_sourced_python()` was `source`-ing that file directly to load flags into the python subshell's environment, and bash tried to execute the malformed line as a command.

The automatic in-script rollback fired as designed and the `.env` flag was never touched (confirmed by the rollback log's own "no captured prior flag state — flag was never changed this attempt" line). Production health was independently confirmed via `/api/status` shortly after — never degraded by this run.

## Root cause and fix

`source`-ing arbitrary, not-fully-controlled `.env` content as bash is unsafe on its own terms, and it was never a faithful match to how production actually loads this file: `EnvironmentFile=` in the systemd unit (`deploy/systemd/dynasty.service.template:29`) is a plain `KEY=VALUE` reader, never a shell interpreter.

`env_sourced_python()` now parses `.env` as plain `KEY=VALUE` text (`env_sourced_python_env_args`) and passes the result to `env`, never to bash `source`. Malformed lines are silently skipped — never executed, never echoed (a value there could be a partial secret).

**Honest caveat**: an isolated local repro of "source this exact malformed line under `set -Eeuo pipefail`" did not reproduce exit 127 (bash tolerated the line and `source` returned 0) — the precise mechanics that turned it into a 127 in the real SSH session are not fully pinned down. The fix removes the risk class regardless of the exact trigger.

## Second bug caught by the new test

The new regression test (`test_env_file_is_never_sourced_as_bash`) caught a second, previously-latent bug on its first run against the fix: `printf '%s\n' "${args[@]}"` on a truly empty array still executes the format once, emitting one blank line rather than none. The caller's `mapfile` turned that into a single empty-string element, so `env ""` failed with `env: '': No such file or directory` whenever `.env` was absent or contributed zero usable lines (`test_env_sourced_python_tolerates_a_missing_env_file` caught this directly). Fixed with an explicit array-length guard before the `printf` call.

## Testing

- `bash -n deploy/diagnostics/v1_49_host_native_activation.sh` — clean
- New tests (`test_env_file_is_never_sourced_as_bash`, `test_env_sourced_python_env_args_skips_malformed_lines_silently`, `test_env_sourced_python_tolerates_a_missing_env_file`) — all pass, and were verified to actually catch both bugs before the fixes (each failed against the pre-fix / partially-fixed code first)
- `tests/deploy/ tests/scripts/` full suite: 715 passed, 4 skipped, 0 regressions
- `ruff format --check` / `ruff check` — clean
- `python3 scripts/check_planning_integrity.py` — OK
- `python3 scripts/ci_gate_classification.py` — 0 unclassified, 0 stale, 0 mismatches (no new workflow steps)

## Scope

Deliberately narrow — the one bounded repair for this incident. Two smaller follow-up items were identified but intentionally NOT bundled in here (tracked in the session's own working notes, not blocking):
- The rollback's post-restart health check (`sleep 3` then one `curl`) raced a real-but-transient connection failure during the second attempt's automatic rollback, even though production was independently confirmed healthy seconds later.
- The second activation run's "Safety-net rollback" GitHub Actions step showed `skipped` rather than a definite outcome — needs a direct read of the `if:` condition against Actions' `outcome` semantics to confirm this is expected (in-script rollback already handled it) rather than a gap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg)_