### PR TITLE
fix(v1-49): retry-loop health checks; fix unreachable safety-net rollback

### DIFF
--- a/.github/workflows/v1-49-host-native-scoring-activation.yml
+++ b/.github/workflows/v1-49-host-native-scoring-activation.yml
@@ -154,7 +154,24 @@ jobs:
 
       - name: Safety-net rollback (activation step failed to complete cleanly)
         id: safety_net_rollback
-        if: ${{ inputs.action == 'activate' && steps.activate.outcome == 'failure' }}
+        # `failure()` is REQUIRED here, not decorative. GitHub Actions
+        # implicitly prepends `success()` to any `if:` expression that
+        # doesn't itself call one of the status-check functions
+        # (success/failure/always/cancelled) -- a plain comparison like
+        # `steps.activate.outcome == 'failure'` does not count. Without
+        # `failure()`, the previous step (`activate`) having failed makes
+        # the job's implicit success() false, so this condition could
+        # NEVER evaluate true regardless of the rest of the expression --
+        # confirmed on two real runs (33176834694, 33192153602): activate
+        # failed (conclusion "failure") and this step still showed
+        # "skipped" both times, defeating the entire point of the safety
+        # net (catching a failure the in-script ERR trap couldn't handle,
+        # e.g. an SSH drop or runner timeout). The explicit
+        # `steps.activate.outcome == 'failure'` clause is kept alongside
+        # `failure()` so this correctly stays skipped when `preflight`
+        # itself failed and `activate` never ran (outcome "skipped", not
+        # "failure").
+        if: ${{ inputs.action == 'activate' && failure() && steps.activate.outcome == 'failure' }}
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}

--- a/deploy/diagnostics/v1_49_host_native_activation.sh
+++ b/deploy/diagnostics/v1_49_host_native_activation.sh
@@ -162,6 +162,36 @@ resolve_systemctl_bin() {
   return 1
 }
 
+# ── health check with retry, ported from deploy/verify-deploy.sh's
+#    probe_with_retries() rather than reinvented — that is the exact
+#    retry shape the real deploy pipeline already trusts, same defaults
+#    (45 attempts x 2s ~= 90s budget, 8s per-attempt curl timeout). A
+#    real production run (33192153602, 2026-08-28) proved the one-shot
+#    `sleep 3; curl` this script used before was too impatient: the
+#    curl failed with a plain connection refusal (exit 7 — nothing
+#    listening yet, not a slow response `--max-time` could have waited
+#    out) on BOTH the activate restart and the rollback restart, while
+#    an independent check of the live site showed the service had come
+#    up and served a full scrape cycle roughly 27s after the restart —
+#    comfortably past `sleep 3` but well inside this retry budget.
+wait_for_service_health() {
+  local attempts="${HEALTH_CHECK_MAX_ATTEMPTS:-45}"
+  local sleep_seconds="${HEALTH_CHECK_SLEEP_SECONDS:-2}"
+  local timeout_seconds="${HEALTH_CHECK_CURL_TIMEOUT:-8}"
+  local url="http://${APP_HOST}:${APP_PORT}/api/status"
+  local n=1
+  while (( n <= attempts )); do
+    if curl -fsS --max-time "${timeout_seconds}" "${url}" >/dev/null 2>&1; then
+      return 0
+    fi
+    if (( n < attempts )); then
+      sleep "${sleep_seconds}"
+    fi
+    n=$((n + 1))
+  done
+  return 1
+}
+
 # ── small python helpers, run against the SAME .env every production
 #    process would read (EnvironmentFile=-__APP_DIR__/.env) ───────────
 #
@@ -338,7 +368,7 @@ do_rollback() {
     failures+=("could not resolve systemctl to restart the service")
   fi
 
-  if ! curl -fsS --max-time 10 "http://${APP_HOST}:${APP_PORT}/api/status" >/dev/null; then
+  if ! wait_for_service_health; then
     failures+=("health check (/api/status) failed after rollback")
   fi
 
@@ -442,7 +472,7 @@ do_activate() {
   sudo -n "${systemctl_bin}" restart "${SERVICE_NAME}"
   sleep 3
   sudo -n "${systemctl_bin}" is-active --quiet "${SERVICE_NAME}"
-  curl -fsS --max-time 10 "http://${APP_HOST}:${APP_PORT}/api/status" >/dev/null
+  wait_for_service_health || { warn "Service did not become healthy within the retry budget."; false; }
   log "Service restarted and healthy."
 
   # 5. Paranoia check: the flag now reads enabled.

--- a/tests/deploy/test_v1_49_workflow_wiring.py
+++ b/tests/deploy/test_v1_49_workflow_wiring.py
@@ -349,6 +349,97 @@ def test_do_activate_and_do_rollback_action_both_validate_activation_id():
     assert "validate_activation_id" in do_rollback_action_body
 
 
+def _run_wait_for_service_health(
+    tmp_path, curl_body: str, env_overrides: dict
+) -> tuple[subprocess.CompletedProcess, Path]:
+    """Source the real script with a stubbed `curl` on PATH ahead of the
+    real one, then call `wait_for_service_health` in isolation. Returns
+    the completed process plus the path to a counter file the stub
+    increments on every invocation, so a test can assert exactly how
+    many attempts were made.
+    """
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    counter_file = tmp_path / "attempts"
+    counter_file.write_text("0")
+    curl_stub = fake_bin / "curl"
+    curl_stub.write_text(f"#!/usr/bin/env bash\n{curl_body}\n")
+    curl_stub.chmod(0o755)
+
+    script = f'source "{_SCRIPT_PATH}" >/dev/null 2>&1; wait_for_service_health'
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+            "APP_DIR": str(tmp_path),
+            **env_overrides,
+        },
+        timeout=30,
+    )
+    return result, counter_file
+
+
+def test_wait_for_service_health_retries_until_success(tmp_path):
+    """Regression pin for a real production incident (third live activation
+    attempt, run 33192153602, 2026-08-28): the health check after a
+    `systemctl restart` failed with a plain connection refusal (curl exit 7)
+    on both the activate and the rollback restart, while the service was
+    independently confirmed to come up ~27s later — well past the old
+    one-shot `sleep 3; curl` this replaced, but inside this retry budget.
+    """
+    counter_file = tmp_path / "attempts"
+    curl_body = f"""
+n=$(cat "{counter_file}")
+n=$((n + 1))
+echo "$n" > "{counter_file}"
+if (( n < 3 )); then
+  exit 7
+fi
+exit 0
+"""
+    result, counter_file = _run_wait_for_service_health(
+        tmp_path,
+        curl_body,
+        {"HEALTH_CHECK_MAX_ATTEMPTS": "5", "HEALTH_CHECK_SLEEP_SECONDS": "0"},
+    )
+    assert result.returncode == 0, result.stderr
+    assert counter_file.read_text().strip() == "3"
+
+
+def test_wait_for_service_health_fails_after_exhausting_attempts(tmp_path):
+    curl_body = f"""
+n=$(cat "{tmp_path / 'attempts'}")
+n=$((n + 1))
+echo "$n" > "{tmp_path / 'attempts'}"
+exit 7
+"""
+    result, counter_file = _run_wait_for_service_health(
+        tmp_path,
+        curl_body,
+        {"HEALTH_CHECK_MAX_ATTEMPTS": "3", "HEALTH_CHECK_SLEEP_SECONDS": "0"},
+    )
+    assert result.returncode != 0
+    assert counter_file.read_text().strip() == "3"
+
+
+def test_both_health_checks_route_through_the_retry_helper():
+    """Exactly one `wait_for_service_health` definition, called from both
+    do_activate() and do_rollback() -- and no bare one-shot `curl ...
+    /api/status` survives anywhere else in the file (the shape the two
+    call sites used before this fix, and the shape the false
+    ROLLBACK_FAILED alarm on run 33192153602 was caused by).
+    """
+    script_text = _SCRIPT_PATH.read_text()
+    definitions = re.findall(r"^wait_for_service_health\(\)\s*\{", script_text, flags=re.MULTILINE)
+    assert len(definitions) == 1
+    # def + do_activate call + do_rollback call
+    assert script_text.count("wait_for_service_health") == 3
+    assert script_text.count("curl -fsS") == 1
+
+
 def test_workflow_only_references_the_established_ssh_secrets():
     text = _WORKFLOW_PATH.read_text()
     expected_secrets = {
@@ -360,6 +451,36 @@ def test_workflow_only_references_the_established_ssh_secrets():
     }
     used_secrets = set(re.findall(r"secrets\.([A-Z_]+)", text))
     assert used_secrets == expected_secrets
+
+
+def test_safety_net_rollback_condition_calls_a_status_check_function():
+    """GitHub Actions implicitly prepends `success()` to any `if:` expression
+    that doesn't itself call one of success()/failure()/always()/cancelled().
+    A plain comparison like `steps.activate.outcome == 'failure'` does NOT
+    count -- so without an explicit status-check function, this step could
+    never run when the step it exists to safety-net for actually fails
+    (the previous step failing makes the implicit success() false, which
+    ANDs the whole condition to false regardless of the rest).
+
+    Confirmed on two real runs (33176834694, 33192153602): `activate`
+    failed and "Safety-net rollback" showed `skipped` both times --
+    defeating the entire point of the safety net (catching a failure the
+    in-script ERR trap can't handle, e.g. an SSH drop or runner timeout).
+    """
+    document = _load_workflow()
+    job = _job(document)
+    safety_net = next(step for step in job["steps"] if step.get("id") == "safety_net_rollback")
+    condition = safety_net["if"]
+    assert re.search(r"\b(failure|always)\s*\(\s*\)", condition), (
+        "safety-net rollback's `if:` has no failure()/always() call, so "
+        "GitHub Actions' implicit success() prepend makes it unreachable "
+        "whenever the step it exists to catch actually fails"
+    )
+    # The explicit outcome check must survive alongside failure() -- it is
+    # what keeps this correctly skipped when `activate` never ran at all
+    # (preflight failed, so activate's own outcome is "skipped", not
+    # "failure").
+    assert "steps.activate.outcome" in condition
 
 
 def test_merging_this_workflow_never_dispatches_it():


### PR DESCRIPTION
## Incident

The third live V1-49 activation attempt (run `33192153602`, dispatched against `42ce5b2`) got further than either prior attempt — preflight, PBP backup, the BDVM pre-activation snapshot build, and the flag flip all succeeded (proving the `.env`-sourcing fix from #1164 works end-to-end against production's real `.env`) — then hit two real, confirmed, bounded infra defects. Neither touches scoring behavior.

### 1. Health-check impatience

Both `do_activate()`'s and `do_rollback()`'s post-restart health check were a one-shot `sleep 3; curl` with no retry. Both failed with `curl: (7) Failed to connect to 127.0.0.1 port 8000 after 0 ms` — nothing listening yet, not a slow response `--max-time` could have waited out.

Verified via a live `WebFetch` against `https://chaseupside.com/api/status` immediately after: production was fully healthy, and a real scrape cycle started at `16:55:45Z` and completed normally at `16:59:45Z` — the rollback's restart was issued at `16:55:18.37Z`, so the service was genuinely up and serving within ~27s. That's well past the `sleep 3` + instant-probe window both checks used, but comfortably inside a real retry budget.

This is the same symptom the second incident's rollback hit (noted then as "worth a follow-up if it recurs") — it has now recurred, confirming a systematic under-budget (this app's real cold-start — canonical valuation engine, BDVM, ~250 modules — genuinely exceeds a few seconds) rather than a one-off flake.

**Fix**: ported the exact retry pattern the real deploy pipeline already trusts — `deploy/verify-deploy.sh::probe_with_retries()` (45 attempts × 2s ≈ 90s budget, 8s per-attempt timeout) — into a new `wait_for_service_health()` helper, used at both call sites in place of the one-shot check. Reused, not reinvented.

### 2. "Safety-net rollback" step's `if:` condition is structurally unreachable

Its condition (`inputs.action == 'activate' && steps.activate.outcome == 'failure'`) never calls one of GitHub Actions' status-check functions (`success()`/`failure()`/`always()`/`cancelled()`). GitHub Actions implicitly prepends `success()` to any `if:` expression that omits one — so whenever the immediately prior step (`activate`) itself fails, the job's implicit `success()` is false and the whole condition is unreachable regardless of the rest.

Confirmed on **two** real runs (`33176834694`, `33192153602`): `activate` failed (conclusion `"failure"`, "Process completed with exit code 3") and "Safety-net rollback" showed `skipped` both times. The safety net — designed to catch a failure the in-script `ERR` trap can't handle (an SSH drop, a runner timeout) — has never once been able to fire.

**Fix**: added `failure()` to the condition, keeping the explicit `steps.activate.outcome == 'failure'` clause so it still correctly stays skipped when `activate` never ran at all (preflight failed).

### Production impact: none

The flag was correctly restored to its prior `ABSENT` state (verified by the script's own deterministic env-file read, independent of the flaky HTTP timing check), and `/api/status` confirmed a fully healthy, normally-operating service throughout. The workflow's own `ROLLBACK FAILED — MANUAL INTERVENTION REQUIRED` status on run `33192153602` was a false alarm produced entirely by defect #1 — no actual manual intervention was needed.

## Testing

- `bash -n` on the script — clean
- New tests: `wait_for_service_health` retry/exhaustion behavior (stubbed `curl`), both health checks route through the one helper (no bare `curl` survives), and the safety-net `if:` condition calls a status-check function — **all four mutation-verified**: failed against the pre-fix code (git-stashed), pass against the fix
- Full `tests/deploy/ tests/scripts/` suite: 719 passed, 4 skipped, 0 regressions
- `ruff format --check` / `ruff check` — clean
- `python3 scripts/check_planning_integrity.py` — OK
- `python3 scripts/ci_gate_classification.py` — 0 unclassified/stale/mismatches (no new workflow steps)

## Scope

Both fixes come from the same run's evidence and are pure reliability/orchestration repairs with zero scoring-methodology impact — bundled in one PR rather than two for that reason.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg)_