### PR TITLE
fix(sharp): reuse one SQLite connection in Sharp Roster Percentage build

### DIFF
--- a/src/intel/platform_ledger.py
+++ b/src/intel/platform_ledger.py
@@ -1688,10 +1688,19 @@ def query_movements(
     asset_type: str | None = None,
     canonical_only: bool = True,
     path: Path | None = None,
+    conn: sqlite3.Connection | None = None,
 ) -> list[dict[str, Any]]:
+    """``conn`` lets a caller that already holds a connection to this same
+    ledger (e.g. ``roster_percentage.build_board()``, which already opens
+    one for ``roster_store``) reuse it instead of paying for another
+    ``ensure_platform_schema`` round trip. Ownership stays with the
+    caller when supplied — mirrors ``ensure_platform_schema``'s own
+    ``own = conn is None`` pattern.
+    """
     if not manager_keys:
         return []
-    conn = ensure_platform_schema(path)
+    own = conn is None
+    connection = conn if conn is not None else ensure_platform_schema(path)
     clauses = [
         f"m.manager_key IN ({','.join('?' for _ in manager_keys)})",
         "m.tx_type='trade'",
@@ -1728,7 +1737,7 @@ def query_movements(
          ORDER BY m.ts DESC, m.movement_key
     """
     try:
-        rows = conn.execute(sql, params).fetchall()
+        rows = connection.execute(sql, params).fetchall()
         return [
             {
                 "platform": r["platform"],
@@ -1754,7 +1763,8 @@ def query_movements(
             for r in rows
         ]
     finally:
-        conn.close()
+        if own:
+            connection.close()
 
 
 def audit_asset(

--- a/src/sharp/roster_percentage.py
+++ b/src/sharp/roster_percentage.py
@@ -44,6 +44,7 @@ leaving a caller to infer intent from rank alone.
 from __future__ import annotations
 
 import logging
+import sqlite3
 import time
 from collections import Counter
 from dataclasses import dataclass
@@ -322,7 +323,9 @@ def build_player_index(contract: dict[str, Any] | None) -> dict[str, dict[str, A
     return index
 
 
-def _catalog_metadata(ledger_path: Path | None) -> dict[str, dict[str, Any]]:
+def _catalog_metadata(
+    ledger_path: Path | None, *, conn: sqlite3.Connection | None = None
+) -> dict[str, dict[str, Any]]:
     """``{canonicalAssetId: {displayName, position, nflTeam}}`` from the ledger.
 
     ``canonical_assets`` is the platform's own asset catalog, hydrated
@@ -334,9 +337,14 @@ def _catalog_metadata(ledger_path: Path | None) -> dict[str, dict[str, Any]]:
 
     Degrades to an empty map — a name is cosmetic and must never cost a
     board its numbers.
+
+    ``conn`` lets the caller (``build_board``) reuse the same connection
+    it already opened for ``roster_store`` instead of paying for a
+    second ``ensure_roster_schema`` round trip.
     """
+    own = conn is None
     try:
-        conn = roster_store.ensure_roster_schema(ledger_path)
+        connection = conn if conn is not None else roster_store.ensure_roster_schema(ledger_path)
     except Exception:  # noqa: BLE001
         log.exception("sharp roster %%: asset catalog unavailable")
         return {}
@@ -347,7 +355,7 @@ def _catalog_metadata(ledger_path: Path | None) -> dict[str, dict[str, Any]]:
                 "position": (str(row["position"] or "").strip().upper() or None),
                 "nflTeam": (str(row["nfl_team"] or "").strip().upper() or None),
             }
-            for row in conn.execute(
+            for row in connection.execute(
                 """
                 SELECT canonical_asset_id, display_name, position, nfl_team
                   FROM canonical_assets
@@ -359,7 +367,8 @@ def _catalog_metadata(ledger_path: Path | None) -> dict[str, dict[str, Any]]:
         log.exception("sharp roster %%: asset catalog read failed")
         return {}
     finally:
-        conn.close()
+        if own:
+            connection.close()
 
 
 def _fallback_metadata(asset_id: str, catalog: dict[str, dict[str, Any]] | None = None) -> dict:
@@ -580,52 +589,70 @@ def build_board(
     )
     cohort_keys = {m.manager_key for m in members}
 
-    stored = roster_store.load_rosters(path=ledger_path)
-    usable, exclusions = eligible_rosters(
-        stored,
-        cohort_manager_keys=cohort_keys,
-        now_ms=now,
-        max_age_days=max_age_days,
-    )
-    filtered = [r for r in usable if _roster_passes(r, filters)]
-    filtered_out = len(usable) - len(filtered)
+    # One connection for every DB-backed call below (load_rosters, each
+    # holdings_as_of baseline, and the buy/sell join), instead of each
+    # opening and closing its own. Every one of these already accepted an
+    # optional ``conn`` for exactly this reuse; nothing here threaded one
+    # through, so a single board request paid for
+    # ensure_roster_schema/ensure_platform_schema (a schema-readiness
+    # check plus a commit) six separate times against the same file. This
+    # is the real cost behind the >60s timeouts measured against this
+    # endpoint in production (V1-61) — /api/sharp/cohort's sibling defect
+    # (redundant build_manager_records() calls, #1150) was a different
+    # function; this one was never touched.
+    db_conn = roster_store.ensure_roster_schema(ledger_path)
+    try:
+        stored = roster_store.load_rosters(path=ledger_path, conn=db_conn)
+        usable, exclusions = eligible_rosters(
+            stored,
+            cohort_manager_keys=cohort_keys,
+            now_ms=now,
+            max_age_days=max_age_days,
+        )
+        filtered = [r for r in usable if _roster_passes(r, filters)]
+        filtered_out = len(usable) - len(filtered)
 
-    roster_keys = {str(r["rosterKey"]) for r in filtered}
-    holders, slot_counts = _tally(filtered)
-    denominators, unknown_format = _denominators(filtered)
-    # W15-F009 (inv 4.6): every ``filtered`` roster already passed the
-    # cohort-membership gate in ``eligible_rosters``, so its ``managerKey``
-    # is guaranteed present — this map is total over ``roster_keys``, not
-    # a best-effort join, and needs no "unknown manager" fallback bucket.
-    roster_manager = {str(r["rosterKey"]): str(r["managerKey"]) for r in filtered}
+        roster_keys = {str(r["rosterKey"]) for r in filtered}
+        holders, slot_counts = _tally(filtered)
+        denominators, unknown_format = _denominators(filtered)
+        # W15-F009 (inv 4.6): every ``filtered`` roster already passed the
+        # cohort-membership gate in ``eligible_rosters``, so its ``managerKey``
+        # is guaranteed present — this map is total over ``roster_keys``, not
+        # a best-effort join, and needs no "unknown manager" fallback bucket.
+        roster_manager = {str(r["rosterKey"]): str(r["managerKey"]) for r in filtered}
 
-    player_index = build_player_index(contract)
-    asset_catalog = _catalog_metadata(ledger_path)
-    buy_sell = _buy_sell_index(
-        members=members,
-        ledger_path=ledger_path,
-        window=buy_sell_window,
-        now_ms=now,
-    )
+        player_index = build_player_index(contract)
+        asset_catalog = _catalog_metadata(ledger_path, conn=db_conn)
+        buy_sell = _buy_sell_index(
+            members=members,
+            ledger_path=ledger_path,
+            window=buy_sell_window,
+            now_ms=now,
+            conn=db_conn,
+        )
 
-    # The owner's stated windows are 7 / 14 / 30 day; season-to-date is kept
-    # alongside them because it answers a different question (how ownership
-    # moved over the whole season, not over a recent window).
-    #
-    # Adding a window costs one ``holdings_as_of`` read and NOTHING else: the
-    # population-overlap guard in ``_trend`` applies to every baseline
-    # identically, so a cohort that grew between the endpoints still cannot
-    # masquerade as players gaining ownership on the new window either.
-    baselines = {
-        "sevenDay": now - 7 * DAY_MS,
-        "fourteenDay": now - 14 * DAY_MS,
-        "thirtyDay": now - 30 * DAY_MS,
-        "seasonToDate": _season_start_ms(now),
-    }
-    baseline_holdings = {
-        name: roster_store.holdings_as_of(as_of, roster_keys=sorted(roster_keys), path=ledger_path)
-        for name, as_of in baselines.items()
-    }
+        # The owner's stated windows are 7 / 14 / 30 day; season-to-date is kept
+        # alongside them because it answers a different question (how ownership
+        # moved over the whole season, not over a recent window).
+        #
+        # Adding a window costs one ``holdings_as_of`` read and NOTHING else: the
+        # population-overlap guard in ``_trend`` applies to every baseline
+        # identically, so a cohort that grew between the endpoints still cannot
+        # masquerade as players gaining ownership on the new window either.
+        baselines = {
+            "sevenDay": now - 7 * DAY_MS,
+            "fourteenDay": now - 14 * DAY_MS,
+            "thirtyDay": now - 30 * DAY_MS,
+            "seasonToDate": _season_start_ms(now),
+        }
+        baseline_holdings = {
+            name: roster_store.holdings_as_of(
+                as_of, roster_keys=sorted(roster_keys), path=ledger_path, conn=db_conn
+            )
+            for name, as_of in baselines.items()
+        }
+    finally:
+        db_conn.close()
 
     market_pct = _market_ownership(sorted(holders))
     rows: list[dict[str, Any]] = []
@@ -823,6 +850,7 @@ def _buy_sell_index(
     ledger_path: Path | None,
     window: str,
     now_ms: int,
+    conn: sqlite3.Connection | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Recent Sharp Buy/Sell Tracker activity, keyed by canonical asset.
 
@@ -830,6 +858,11 @@ def _buy_sell_index(
     the ledger, so "3 sharp buys" means exactly what it means on
     ``/market/sharp-tracker``.  A failure here degrades to no activity
     column; it never takes the roster board down.
+
+    ``conn`` lets the caller (``build_board``, which already holds one
+    connection for ``roster_store``) reuse it here instead of paying for
+    a second ``ensure_platform_schema`` round trip against the same
+    underlying ledger file.
     """
     try:
         from src.intel import platform_ledger, signals
@@ -842,6 +875,7 @@ def _buy_sell_index(
             until_ms=until,
             canonical_only=True,
             path=ledger_path,
+            conn=conn,
         )
         quality = {m.manager_key: m.quality for m in members}
         aggregated = sharp_market._aggregate_window(movements, quality)

--- a/tests/sharp/test_roster_percentage.py
+++ b/tests/sharp/test_roster_percentage.py
@@ -811,3 +811,75 @@ def test_the_roster_board_defines_no_qualification_of_its_own():
         assert (
             forbidden not in source
         ), f"roster_percentage must not re-derive qualification: {forbidden}"
+
+
+# ── connection reuse (V1-61) ────────────────────────────────────────────
+#
+# Every DB-backed call inside build_board() (load_rosters, one
+# holdings_as_of per baseline window, the buy/sell join) already accepted
+# an optional ``conn`` to reuse a caller's connection, but build_board()
+# never threaded one through -- each call paid for its own
+# ensure_roster_schema/ensure_platform_schema round trip (a schema
+# readiness check plus a commit) against the same underlying file. This
+# is the real cost behind the >60s timeouts measured against this
+# endpoint in production.
+
+
+def test_build_board_opens_exactly_one_connection(ledger, cohort_of, monkeypatch):
+    """Regression pin: one board request must open the ledger file once,
+    not once per internal call. Counts real ``sqlite3.connect`` calls
+    through ``src.intel.ledger.connect`` -- the one primitive every
+    schema-readiness helper in this chain bottoms out at -- rather than
+    trusting call counts on the higher-level wrappers, which would not
+    catch a wrapper that opens its own connection internally.
+    """
+    from src.intel import ledger as ledger_module
+
+    cohort_of(["sleeper:u1", "sleeper:u2"])
+    rs.record_rosters(
+        [
+            roster("sleeper:u1", "sleeper:L1", assets=["wr1", "rb1"]),
+            roster("sleeper:u2", "sleeper:L2", assets=["wr1"]),
+        ],
+        path=ledger,
+    )
+
+    real_connect = ledger_module.connect
+    calls = []
+
+    def _counting_connect(path=None):
+        calls.append(path)
+        return real_connect(path)
+
+    monkeypatch.setattr(ledger_module, "connect", _counting_connect)
+    board(ledger)
+    assert len(calls) == 1, f"expected exactly one connection, opened {len(calls)}"
+
+
+def test_query_movements_does_not_close_a_caller_supplied_connection(tmp_path):
+    """A caller-supplied connection must survive the call (ownership
+    stays with the caller) -- mirrors the same ``own = conn is None``
+    contract ``ensure_platform_schema``/``ensure_roster_schema`` already
+    honour. Without this, threading one shared connection through
+    ``build_board`` would close it after the FIRST ``_buy_sell_index``
+    call and break every subsequent read on it.
+    """
+    from src.intel import ledger as ledger_module
+    from src.intel import platform_ledger
+
+    db_path = tmp_path / "ledger.sqlite3"
+    conn = ledger_module.connect(db_path)
+    try:
+        platform_ledger.ensure_platform_schema(conn=conn)
+        result = platform_ledger.query_movements(
+            manager_keys=["sleeper:u1"],
+            since_ms=0,
+            until_ms=NOW,
+            path=db_path,
+            conn=conn,
+        )
+        assert result == []
+        # Still usable -- a closed connection would raise ProgrammingError.
+        conn.execute("SELECT 1").fetchone()
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

- V1-61's contract row documents a real >60s production timeout on `/api/sharp/roster-percentage`.
- Root cause: `src/sharp/roster_percentage.py::build_board()` opened 5-6 separate SQLite connections per request (`load_rosters`, four `holdings_as_of` baseline calls, `_buy_sell_index` → `platform_ledger.query_movements`, `_catalog_metadata`), each paying its own schema-check-and-commit round trip.
- Fix: thread one shared connection through the whole request, using the `own = conn is None` reuse pattern already established elsewhere in this codebase (`ensure_roster_schema`, `ensure_platform_schema`, `load_rosters`, `holdings_as_of`). `query_movements()` and `_catalog_metadata()` now accept an optional `conn`; `build_board()` opens one connection and closes it in a `finally`.
- No behavior change to what the board reports — no missing→zero coercion, no dropped managers/exclusion reasons, no auth change.

## Test plan

- [x] `tests/sharp/test_roster_percentage.py` — 47/47 passing, including two new regression tests (connection-count assertion across a full `build_board()` call; confirms `query_movements()` never closes a caller-supplied connection). Both mutation-verified against the pre-fix code (reverting either fix reproduces a real failure).
- [x] Broader suite: `tests/sharp/`, `tests/intel/test_platform_ledger.py`, `tests/intel/test_platform_ledger_hydration_contention.py` — 344/344 passing.
- [x] `ruff check` clean on changed files; `ruff format --diff` on changed files shows only pre-existing, untouched-by-this-diff drift (confirmed present on `origin/main` before this branch).
- [x] `python3 scripts/check_planning_integrity.py` — OK.
- [ ] Real production timing recipe against `/api/sharp/roster-percentage` post-deploy (V1-61's row stays `IMPLEMENTED_UNVERIFIED` until this is re-run — this PR is the engineering fix, not the production verification).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg)_