### PR TITLE
fix(ops): honor each unit's own SuccessExitStatus in the V1-59 chain check

### DIFF
--- a/scripts/verify_v1_onbox.py
+++ b/scripts/verify_v1_onbox.py
@@ -592,9 +592,13 @@ def check_v59() -> None:
             ["systemctl", "list-timers", f"{unit}.timer", "--all", "--no-pager"], timeout=30
         )
         results[unit] = {"unit": info, "timer": timers.strip().splitlines()[:4]}
-        if info.get("Result") not in ("success", "exit-code") or info.get("ExecMainStatus") not in (
-            "0",
-        ):
+        # systemd's own Result= already applies each unit's SuccessExitStatus=
+        # directive (dynasty-sharp-{discovery,records,rosters}.service.template
+        # all declare "SuccessExitStatus=0 2" — exit 2 is a documented
+        # nothing-to-do outcome, not a failure). Re-deriving pass/fail from a
+        # raw ExecMainStatus == "0" check ignores that contract and flags a
+        # genuinely healthy run as failed.
+        if info.get("Result") not in ("success", "exit-code"):
             problems.append(
                 f"{unit}: Result={info.get('Result')} ExecMainStatus={info.get('ExecMainStatus')}"
             )
@@ -618,7 +622,8 @@ def check_v59() -> None:
     else:
         c.record(
             "pass",
-            "all three chain units last exited 0 with no lock crashes or timeout "
+            "all three chain units last reported Result=success (per each unit's "
+            "own SuccessExitStatus contract) with no lock crashes or timeout "
             "kills in 48h of journal",
             chain=results,
         )

--- a/tests/ops/test_v1_verification_primitives.py
+++ b/tests/ops/test_v1_verification_primitives.py
@@ -393,3 +393,73 @@ def test_c1u8_item7_targets_the_acquisition_store_not_the_intel_ledger():
     assert "acquisition_store" in head
     assert "pick_lineage" in head
     assert "event_type = 'TRADE'" in head
+
+
+# ── V59 chain check honors each unit's own SuccessExitStatus contract ──
+
+
+def _fake_run_v59_chain(exec_main_status: str):
+    """Build a fake onbox._run that answers exactly the calls check_v59()
+    makes, for all three chain units plus the ffpc unit, with the given
+    ExecMainStatus on the chain units. Result=success on every unit,
+    matching what systemd itself reports once SuccessExitStatus=0 2 has
+    been applied — real production evidence (2026-08-29 on-box run)."""
+
+    def fake_run(cmd, timeout=300):
+        if cmd[:2] == ["systemctl", "show"] and "chaseupside-ffpc-sharp.service" in cmd:
+            return 0, "Result=success\nExecMainStatus=0\nNRestarts=0\n", ""
+        if cmd[:2] == ["systemctl", "show"]:
+            return (
+                0,
+                f"Result=success\nExecMainStatus={exec_main_status}\n"
+                "ExecMainExitTimestamp=Sat 2026-08-29 10:47:16 CEST\n"
+                "ActiveEnterTimestamp=\n",
+                "",
+            )
+        if cmd[:2] == ["systemctl", "list-timers"]:
+            return 0, "NEXT LEFT LAST PASSED UNIT ACTIVATES\n", ""
+        if cmd[:1] == ["journalctl"]:
+            return 0, "", ""
+        raise AssertionError(f"unexpected command in test: {cmd}")
+
+    return fake_run
+
+
+def test_v59_chain_exit_2_is_pass_not_fail(monkeypatch):
+    """Regression pin for a real false-fail found during the 2026-08-29
+    on-box harvest: dynasty-sharp-discovery.service.template and
+    dynasty-sharp-rosters.service.template both declare
+    SuccessExitStatus=0 2 (exit 2 is a documented nothing-to-do outcome,
+    not a failure) and systemd's own Result= property already reflects
+    that. The old check ignored Result and independently required
+    ExecMainStatus == "0", so a genuinely healthy Result=success run
+    with ExecMainStatus=2 was reported as a chain failure."""
+    monkeypatch.setattr(onbox, "_run", _fake_run_v59_chain("2"))
+    onbox.check_v59()
+    chain_check = [c for c in onbox.CHECKS if c.check_id == "V59"]
+    assert len(chain_check) == 1
+    assert chain_check[0].status == "pass", chain_check[0].detail
+
+
+def test_v59_chain_still_fails_on_a_real_bad_result(monkeypatch):
+    """The fix must not become a rubber stamp: a unit whose Result is
+    genuinely not success/exit-code (e.g. a real timeout/failed unit)
+    still fails the check."""
+
+    def fake_run(cmd, timeout=300):
+        if cmd[:2] == ["systemctl", "show"] and "chaseupside-ffpc-sharp.service" in cmd:
+            return 0, "Result=success\nExecMainStatus=0\nNRestarts=0\n", ""
+        if cmd[:2] == ["systemctl", "show"]:
+            return 0, "Result=failed\nExecMainStatus=15\n", ""
+        if cmd[:2] == ["systemctl", "list-timers"]:
+            return 0, "NEXT LEFT LAST PASSED UNIT ACTIVATES\n", ""
+        if cmd[:1] == ["journalctl"]:
+            return 0, "", ""
+        raise AssertionError(f"unexpected command in test: {cmd}")
+
+    monkeypatch.setattr(onbox, "_run", fake_run)
+    onbox.check_v59()
+    chain_check = [c for c in onbox.CHECKS if c.check_id == "V59"]
+    assert len(chain_check) == 1
+    assert chain_check[0].status == "fail"
+    assert "Result=failed" in chain_check[0].detail


### PR DESCRIPTION
## Summary

- Found during a fresh 2026-08-29 on-box harvest run (`v1-onbox-checklists.yml`, run `33244230463`): `check_v59()` reported the discovery → records → rosters chain as **FAILED** even though systemd's own `Result=` property said `success` for every unit.
- `dynasty-sharp-discovery.service.template`, `dynasty-sharp-records.service.template` and `dynasty-sharp-rosters.service.template` all declare `SuccessExitStatus=0 2` (exit 2 is a documented nothing-to-do outcome, not a failure — systemd itself already applies this when computing `Result=`). The check independently re-derived pass/fail by requiring `ExecMainStatus == "0"`, ignoring both `Result=` and the units' own documented exit-code contract.
- Fix: trust `Result` (`success`/`exit-code`), which already accounts for each unit's `SuccessExitStatus` directive, instead of independently requiring `ExecMainStatus == "0"`.
- Does **not** change V1-59's own contract status — it's already `VERIFIED` on separate, correctly-interpreted production evidence from `#1144`. This corrects the checklist tool so future harvests read this chain accurately.

## Test plan

- [x] Two new regression tests in `tests/ops/test_v1_verification_primitives.py`, mutation-verified against the pre-fix code: one confirms `Result=success` with `ExecMainStatus=2` now passes, the other confirms a genuinely failed unit (`Result=failed`) still fails.
- [x] `tests/ops/` — 139/139 passing.
- [x] `ruff check` / `ruff format --diff` clean on changed files.
- [x] `python3 scripts/check_planning_integrity.py` — OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg)_