### PR TITLE
fix(e2e): scope V1-45's forced-drop locator to the capacity banner

### DIFF
--- a/tests/e2e/specs/prod-auth/v1-45-trade-surface.spec.js
+++ b/tests/e2e/specs/prod-auth/v1-45-trade-surface.spec.js
@@ -256,17 +256,28 @@ test.describe("V1-45: /trade renders finalRosterSimulation from the page's own s
 
     // Roster-capacity banner — the forced-release COUNT, rendered vs
     // stamped (rc.forcedDrops), when the backend says drops are forced.
+    //
+    // Scoped to the "Roster capacity" alert region specifically, not the
+    // whole panel: a forced-drop player can ALSO appear in the Final-roster
+    // section's own "Displaced: <name> (<pos>) — ..." line further down
+    // the same panel (a real production case, e.g. Budda Baker), and a
+    // panel-wide text search hits both — a Playwright strict-mode
+    // violation on a locator that was never meant to be unique panel-wide.
     if (rc && rc.requiresDrops === true) {
+      const capacityBanner = panel
+        .locator('[role="alert"], [role="status"]')
+        .filter({ has: page.getByText("Roster capacity", { exact: true }) })
+        .first();
       const nDrops = (rc.forcedDrops || []).length;
       await expect(
-        panel.getByText(
+        capacityBanner.getByText(
           new RegExp(`Forces ${nDrops} release${nDrops === 1 ? "" : "s"}`),
         ),
         `rendered forced-release count must equal rosterCapacity.forcedDrops.length (${nDrops})`,
       ).toBeVisible();
       for (const d of rc.forcedDrops || []) {
         await expect(
-          panel.getByText(new RegExp(`${d.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} \\(${d.position}\\)`)),
+          capacityBanner.getByText(new RegExp(`${d.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} \\(${d.position}\\)`)),
           `forced drop "${d.name}" must be named in the capacity banner`,
         ).toBeVisible();
       }


### PR DESCRIPTION
## Summary

- Found on a real production run (`v1-authenticated-verification.yml` run `33243332875`, 2026-08-29): the SimulationPanel spec failed with a Playwright strict-mode violation — `getByText(/Budda Baker \(DB\)/)` resolved to 2 elements within the same panel.
- **Not a product defect.** A forced-drop player can legitimately also appear in the Final-roster section's own `Displaced: <name> (<pos>) — ...` line further down the same `.ds-panel` — a real production case. The test searched the whole panel with a bare text locator instead of scoping to the "Roster capacity" alert region specifically.
- Fix: scope the forced-release count and per-drop name assertions to the `Banner`'s own `[role="alert"]` region (title "Roster capacity"), which `frontend/components/ds/Banner.jsx` always renders uniquely for this state — only one of the `requiresDrops===true` / `requiresDrops===null` banners is ever mounted at a time.

## Test plan

- [x] `node --check` — syntax clean.
- [x] DOM structure confirmed by reading `Banner.jsx`: the new locator is structurally unique (each banner's title is wrapped in its own `role="alert"`/`role="status"` container).
- [ ] This environment cannot execute Playwright against production directly (confirmed `ERR_CONNECTION_RESET` through the configured proxy) — pending confirmation on the next real authenticated production run (`v1-authenticated-verification.yml`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg)_