### PR TITLE
fix(v1-61): bootstrap profiler repo import path

### DIFF
--- a/scripts/profile_sharp_roster_percentage.py
+++ b/scripts/profile_sharp_roster_percentage.py
@@ -33,6 +33,16 @@ from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Callable
 
+# When invoked as ``python scripts/profile_sharp_roster_percentage.py``, Python
+# places ``scripts/`` rather than the repository root at sys.path[0].  The
+# production Lane 4 runner executes the profiler in exactly that form, so make
+# the repository root explicit before importing the canonical ``src`` package.
+# This changes import plumbing only; it does not alter product inputs, outputs,
+# auth, methodology, or missing-data semantics.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
 from src.sharp import cohort as sharp_cohort
 from src.sharp import roster_percentage as roster_percentage
 from src.sharp import roster_store

--- a/scripts/profile_sharp_roster_percentage.py
+++ b/scripts/profile_sharp_roster_percentage.py
@@ -43,9 +43,9 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from src.sharp import cohort as sharp_cohort
-from src.sharp import roster_percentage as roster_percentage
-from src.sharp import roster_store
+from src.sharp import cohort as sharp_cohort  # noqa: E402
+from src.sharp import roster_percentage as roster_percentage  # noqa: E402
+from src.sharp import roster_store  # noqa: E402
 
 
 class ProfileTimeout(RuntimeError):


### PR DESCRIPTION
V1-61 production profiler plumbing repair only.

The first post-#1178 Lane 4 run failed immediately with `ModuleNotFoundError: No module named 'src'` when executing `python scripts/profile_sharp_roster_percentage.py`. This change makes the profiler self-bootstrap the repository root on `sys.path` before importing the existing canonical `src.sharp` owners.

No product result, auth rule, methodology, identity/value/lineup invariant, missing-data behavior, V1 scope, or denominator changes. The profiler remains read-only and still calls canonical `build_board()` exactly once.