### PR TITLE
ops(v1-61): align Lane 4 triggers with executed scripts

### DIFF
--- a/.github/workflows/lane4-onbox-verification.yml
+++ b/.github/workflows/lane4-onbox-verification.yml
@@ -50,8 +50,13 @@ on:
   push:
     branches:
       - main
+    # Keep the production evidence lane coupled to the scripts it executes.
+    # A profiler/verifier repair that lands without changing this workflow
+    # must still produce fresh on-box evidence from that exact merged tree.
     paths:
       - '.github/workflows/lane4-onbox-verification.yml'
+      - 'scripts/profile_sharp_roster_percentage.py'
+      - 'scripts/verify_lane4_production.py'
   workflow_dispatch:
     inputs:
       league:


### PR DESCRIPTION
V1-61 traffic-control repair. The Lane 4 on-box workflow executes the Sharp stage profiler and Lane 4 verifier, but its push trigger currently watches only the workflow YAML. That allowed #1179's profiler import-path repair to deploy without producing fresh on-box evidence.

This PR only couples the existing read-only evidence lane to the two scripts it already executes:
- `scripts/profile_sharp_roster_percentage.py`
- `scripts/verify_lane4_production.py`

No product output, Sharp methodology, auth rule, canonical ownership, missing/stale semantics, or V1 scope changes. On merge, the workflow-file change itself will trigger one fresh exact-tree production evidence run; future repairs to either executed script will do the same.