### PR TITLE
fix(v1-61): stop requiring assembled export in stage profiler

### DIFF
--- a/scripts/profile_sharp_roster_percentage.py
+++ b/scripts/profile_sharp_roster_percentage.py
@@ -141,7 +141,10 @@ def _parse_args() -> argparse.Namespace:
         "--contract",
         type=Path,
         default=None,
-        help="contract JSON; defaults to newest exports/latest/dynasty_data_*.json",
+        help=(
+            "optional contract JSON; when omitted, profile build_board's canonical "
+            "contract=None path, matching the product's supported default"
+        ),
     )
     parser.add_argument(
         "--ledger-path",
@@ -163,8 +166,15 @@ def main() -> int:
     if args.timeout_seconds <= 0:
         raise SystemExit("--timeout-seconds must be > 0")
 
-    contract_path = args.contract or _latest_contract_path()
-    contract = _load_contract(contract_path)
+    # ``build_board`` explicitly supports ``contract=None``.  Production's
+    # newest exports/latest file is not guaranteed to be the assembled API
+    # contract (the 2026-08-30 Lane 4 run encountered a legitimate export with
+    # no playersArray), so treating the newest export as a mandatory input made
+    # this diagnostic fail before the canonical board ran.  Only load a
+    # contract when the operator explicitly supplied one; omission preserves
+    # the canonical default instead of fabricating or coercing an input.
+    contract_path = args.contract
+    contract = _load_contract(contract_path) if contract_path is not None else None
     recorder = StageRecorder()
     _install_stage_wrappers(recorder)
 
@@ -208,8 +218,8 @@ def main() -> int:
     report: dict[str, Any] = {
         "status": status,
         "wallMs": round(wall_ms, 3),
-        "contractPath": str(contract_path),
-        "contractPlayers": len(contract.get("playersArray") or []),
+        "contractPath": str(contract_path) if contract_path is not None else None,
+        "contractPlayers": len((contract or {}).get("playersArray") or []),
         "ledgerPath": str(args.ledger_path) if args.ledger_path else None,
         "stages": recorder.report(),
         "result": None,

--- a/tests/ops/test_v1_61_profiler_default_contract.py
+++ b/tests/ops/test_v1_61_profiler_default_contract.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from pathlib import Path
+
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "profile_sharp_roster_percentage.py"
+_SPEC = importlib.util.spec_from_file_location("profile_sharp_roster_percentage_default", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+_MOD = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MOD)
+
+
+def _ok_payload() -> dict:
+    return {
+        "status": "ok",
+        "totalQualifyingPlayers": 0,
+        "players": [],
+        "sample": {"eligibleRosters": 0},
+        "exclusions": {"storedRosters": 0},
+        "lastUpdated": None,
+    }
+
+
+def test_main_omits_contract_without_reading_latest_export(monkeypatch, capsys) -> None:
+    seen: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        _MOD,
+        "_parse_args",
+        lambda: argparse.Namespace(contract=None, ledger_path=None, timeout_seconds=5),
+    )
+    monkeypatch.setattr(
+        _MOD,
+        "_latest_contract_path",
+        lambda: (_ for _ in ()).throw(AssertionError("latest export must not be consulted")),
+    )
+    monkeypatch.setattr(_MOD, "_install_stage_wrappers", lambda recorder: None)
+
+    def fake_build_board(*, contract=None, ledger_path=None):
+        seen["contract"] = contract
+        seen["ledger_path"] = ledger_path
+        return _ok_payload()
+
+    monkeypatch.setattr(_MOD.roster_percentage, "build_board", fake_build_board)
+
+    assert _MOD.main() == 0
+    assert seen == {"contract": None, "ledger_path": None}
+    output = capsys.readouterr().out
+    assert '"contractPath": null' in output
+    assert '"contractPlayers": 0' in output
+
+
+def test_main_loads_only_an_explicit_contract(monkeypatch, tmp_path: Path) -> None:
+    contract_path = tmp_path / "contract.json"
+    contract_path.write_text(
+        '{"playersArray": [{"playerId": "42"}]}',
+        encoding="utf-8",
+    )
+    seen: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        _MOD,
+        "_parse_args",
+        lambda: argparse.Namespace(contract=contract_path, ledger_path=None, timeout_seconds=5),
+    )
+    monkeypatch.setattr(_MOD, "_install_stage_wrappers", lambda recorder: None)
+
+    def fake_build_board(*, contract=None, ledger_path=None):
+        seen["contract"] = contract
+        return _ok_payload()
+
+    monkeypatch.setattr(_MOD.roster_percentage, "build_board", fake_build_board)
+
+    assert _MOD.main() == 0
+    assert isinstance(seen["contract"], dict)
+    assert seen["contract"]["playersArray"][0]["playerId"] == "42"


### PR DESCRIPTION
## V1 traffic-control purpose

Lane 4 run 33288295756 executed on exact deployed SHA `2d89323ea4ef4f12a85b76e9933bdc0916d763fa` and failed before profiling because the newest production `exports/latest/dynasty_data_*.json` legitimately had no `playersArray`.

`src.sharp.roster_percentage.build_board()` already defines `contract=None` as a supported canonical input. The profiler had invented a stricter prerequisite by automatically selecting and requiring the newest export to be an assembled API contract.

This PR removes only that diagnostic assumption:
- omitted `--contract` now passes `contract=None` to the canonical `build_board()`;
- an explicitly supplied contract is still validated and used;
- no product implementation, methodology, auth, identity/value/lineup semantics, missing-data semantics, or V1 scope changes;
- focused tests prove the default path does not consult the latest export and explicit-contract behavior remains intact.

This is instrumentation plumbing only. It does not promote V1-61; fresh production timing evidence is still required.