### PR TITLE
fix(sharp): remove O(N^2) percentile scans from score_managers (V1-61)

### DIFF
--- a/src/sharp/score.py
+++ b/src/sharp/score.py
@@ -66,6 +66,7 @@ Design rules, each guarding a specific failure
 
 from __future__ import annotations
 
+import bisect
 import json
 import math
 from dataclasses import dataclass, field
@@ -214,6 +215,31 @@ def percentile_rank(value: float, population: Sequence[float]) -> float:
     return (below + 0.5 * equal) / len(pop)
 
 
+def _percentile_rank_sorted(value: float, sorted_population: Sequence[float]) -> float:
+    """Same statistic as :func:`percentile_rank`, in O(log N) instead of O(N).
+
+    Callers must hand in a population that is ALREADY sorted and already
+    cleaned to plain floats (no filtering or casting happens here) — this
+    is the hot-path twin used by :func:`score_managers`, which precomputes
+    one sorted array per population axis ONCE rather than re-scanning a raw
+    list on every one of the N managers being scored. ``percentile_rank``
+    itself is untouched and stays the correct choice for any caller holding
+    an unsorted or unvalidated population.
+
+    ``bisect_left`` counts population members strictly below ``value`` on a
+    sorted array; ``bisect_right - bisect_left`` counts members equal to
+    it — together they reproduce ``percentile_rank``'s
+    ``(below + 0.5 * equal) / len(pop)`` exactly, including the empty- and
+    all-tied-population cases.
+    """
+    n = len(sorted_population)
+    if n == 0:
+        return 0.5
+    below = bisect.bisect_left(sorted_population, value)
+    equal = bisect.bisect_right(sorted_population, value) - below
+    return (below + 0.5 * equal) / n
+
+
 def _shrunk_rate(successes: int, trials: int, base_rate: float, prior_n: float) -> float:
     """Beta-binomial shrink toward ``base_rate``.  With few trials the
     result sits near the base rate; it only departs with real volume."""
@@ -284,6 +310,11 @@ def _performance_component(
     population: dict[str, list[float]],
     cfg: dict[str, Any],
 ) -> tuple[float, list[str]]:
+    """``population`` must be pre-sorted, pre-cleaned float arrays (see
+    ``score_managers``'s ``sorted_population`` — every lookup here goes
+    through ``_percentile_rank_sorted``, not ``percentile_rank``, because
+    this runs once per manager and a fresh O(N) scan per call was the
+    dominant cost of ``score_managers`` in production (V1-61)."""
     block = cfg.get("performance") or {}
     sub = block.get("subWeights") or {}
     notes: list[str] = []
@@ -291,14 +322,14 @@ def _performance_component(
 
     win = rec.win_pct
     if win is not None:
-        p = percentile_rank(win, population.get("winPct") or [])
+        p = _percentile_rank_sorted(win, population.get("winPct") or [])
         parts.append((float(sub.get("winPct", 0.30)), p))
         if p >= 0.9:
             notes.append(f"Top-{round((1 - p) * 100)}% multi-season win rate")
 
     playoff = rec.playoff_rate
     if playoff is not None:
-        p = percentile_rank(playoff, population.get("playoffRate") or [])
+        p = _percentile_rank_sorted(playoff, population.get("playoffRate") or [])
         parts.append((float(sub.get("playoffRate", 0.25)), p))
         if rec.playoff_appearances and rec.completed_seasons:
             notes.append(
@@ -310,7 +341,7 @@ def _performance_component(
     base = _mean(population.get("championshipRate") or []) or 0.08
     prior_n = float((block.get("championshipShrinkage") or {}).get("priorN", 6.0))
     shrunk = _shrunk_rate(rec.championships, rec.completed_seasons, base, prior_n)
-    p = percentile_rank(shrunk, population.get("championshipRateShrunk") or [])
+    p = _percentile_rank_sorted(shrunk, population.get("championshipRateShrunk") or [])
     parts.append((float(sub.get("championshipRate", 0.20)), p))
     if rec.championships >= 2:
         notes.append(f"{rec.championships} championships across observed leagues")
@@ -337,6 +368,10 @@ def _roster_quality_component(
 ) -> tuple[float | None, list[str]]:
     """Roster strength percentile, or **None** when there is no evidence.
 
+    ``population`` must be pre-sorted, pre-cleaned float arrays (see
+    ``_performance_component``'s note — same ``score_managers`` caller,
+    same reason).
+
     Returns None rather than 0.0 for "nothing to score", and that
     distinction is the whole point. The four ``ManagerRecord`` fields
     this reads — ``roster_value_ratios``, ``age_adjusted_value_ratio``,
@@ -362,7 +397,7 @@ def _roster_quality_component(
     ratio = _mean(rec.roster_value_ratios)
     if ratio is not None:
         clamped = _clamp(ratio, float(lo), float(hi))
-        p = percentile_rank(clamped, population.get("rosterValueRatio") or [])
+        p = _percentile_rank_sorted(clamped, population.get("rosterValueRatio") or [])
         parts.append((float(sub.get("valueVsLeagueAverage", 0.45)), p))
         if p >= 0.9:
             notes.append(
@@ -379,7 +414,7 @@ def _roster_quality_component(
         if val is None:
             continue
         clamped = _clamp(float(val), float(lo), float(hi))
-        p = percentile_rank(clamped, population.get(pop_key) or [])
+        p = _percentile_rank_sorted(clamped, population.get(pop_key) or [])
         parts.append((float(sub.get(weight_key, 0.2)), p))
 
     if not parts:
@@ -577,6 +612,20 @@ def score_managers(
     qual = cfg.get("qualification") or {}
     population = build_population(records, cfg)
 
+    # Precomputed ONCE per axis, not once per manager: `_performance_component`
+    # and `_roster_quality_component` used to call `percentile_rank`, which
+    # rebuilds and rescans its population argument from scratch on every
+    # call. With ~N managers each doing several such lookups against the
+    # same N-sized population, that is O(N^2) — measured as the dominant
+    # cost (~196 of ~297 total seconds) of a real production Sharp Roster
+    # Percentage build (V1-61). Sorting each axis once here and looking
+    # values up with `_percentile_rank_sorted` (binary search) makes the
+    # per-manager cost O(log N) instead, with no change to the statistic.
+    sorted_population = {
+        key: sorted(float(v) for v in vals if isinstance(v, (int, float)))
+        for key, vals in population.items()
+    }
+
     scored: list[ManagerScore] = []
     raw_scores: list[float] = []
 
@@ -606,8 +655,8 @@ def score_managers(
             )
             continue
 
-        perf, perf_notes = _performance_component(rec, population, cfg)
-        roster, roster_notes = _roster_quality_component(rec, population, cfg)
+        perf, perf_notes = _performance_component(rec, sorted_population, cfg)
+        roster, roster_notes = _roster_quality_component(rec, sorted_population, cfg)
         consistency, cons_notes = _consistency_component(rec, cfg)
         longevity = _longevity_component(rec, cfg)
         activity = _activity_component(rec, cfg)
@@ -702,10 +751,14 @@ def score_managers(
     max_size = int(qual.get("maxCohortSize", 2500))
 
     qualified: list[ManagerScore] = []
+    # Same O(N^2) -> O(N log N) repair as the sorted_population precompute
+    # above: this loop calls the percentile lookup once per evaluable
+    # manager against the same `raw_scores` population every time.
+    sorted_raw_scores = sorted(raw_scores)
     for entry in scored:
         if not entry.evaluable or entry.score is None:
             continue
-        entry.score_percentile = round(percentile_rank(entry.score, raw_scores), 4)
+        entry.score_percentile = round(_percentile_rank_sorted(entry.score, sorted_raw_scores), 4)
         # BOTH bars. A high score on thin evidence does not qualify.
         if entry.score_percentile >= min_pct and entry.confidence >= min_conf:
             entry.qualified = True

--- a/tests/sharp/test_score.py
+++ b/tests/sharp/test_score.py
@@ -3,6 +3,9 @@ separation of score from confidence."""
 
 from __future__ import annotations
 
+import random
+import time
+
 import pytest
 
 from src.sharp import score as S
@@ -264,6 +267,46 @@ class TestPercentileRank:
         assert S.percentile_rank(0.05, pop) < S.percentile_rank(0.45, pop)
 
 
+class TestPercentileRankSorted:
+    """``_percentile_rank_sorted`` is the O(log N) hot-path twin of
+    ``percentile_rank``, used inside ``score_managers`` (V1-61: calling
+    ``percentile_rank`` fresh per manager rescans the whole population on
+    every call, which measured as ~196 of ~297 total seconds of a real
+    production Sharp Roster Percentage build). It must be exactly
+    interchangeable with ``percentile_rank`` on the same underlying
+    values — every property already proven of ``percentile_rank`` in
+    ``TestPercentileRank`` above is re-proven here for the sorted/binary
+    -search path, plus a broader equivalence sweep.
+    """
+
+    def test_identical_population_scores_midpoint_not_elite(self):
+        assert S._percentile_rank_sorted(1.0, sorted([1.0] * 10)) == 0.5
+
+    def test_empty_population_is_neutral(self):
+        assert S._percentile_rank_sorted(0.9, []) == 0.5
+
+    def test_monotone(self):
+        pop = sorted([0.1, 0.2, 0.3, 0.4, 0.5])
+        assert S._percentile_rank_sorted(0.05, pop) < S._percentile_rank_sorted(0.45, pop)
+
+    def test_matches_percentile_rank_across_populations_and_probes(self):
+        populations = [
+            [],
+            [1.0],
+            [1.0] * 10,
+            [0.1, 0.2, 0.3, 0.4, 0.5],
+            [0.1, 0.1, 0.3, 0.3, 0.3, 0.9],
+            [round((i * 37 % 401) * 0.0025, 4) for i in range(400)],  # duplicates + gaps
+        ]
+        probes = [-5.0, 0.0, 0.1, 0.13, 0.3, 0.5, 0.9, 1.0, 5.0]
+        for pop in populations:
+            sorted_pop = sorted(pop)
+            for value in probes:
+                assert S._percentile_rank_sorted(value, sorted_pop) == pytest.approx(
+                    S.percentile_rank(value, pop)
+                ), (pop, value)
+
+
 def test_manager_score_to_dict_preserves_unknown_components_and_nested_weights():
     scored = S.ManagerScore(
         user_id="serializer",
@@ -284,3 +327,87 @@ def test_manager_score_to_dict_preserves_unknown_components_and_nested_weights()
         "performance": 0.4615,
         "rosterQuality": 0.0,
     }
+
+
+class TestScoreManagersPercentileWiring:
+    """The V1-61 perf fix changed WHERE percentiles get computed
+    (``score_managers`` now precomputes one sorted array per population
+    axis and looks values up with ``_percentile_rank_sorted``, instead of
+    ``_performance_component``/``_roster_quality_component``/the
+    qualification loop each calling ``percentile_rank`` fresh per
+    manager) but must not change WHAT gets computed. The equivalence
+    classes in ``TestPercentileRankSorted`` above prove the primitive
+    itself is correct; this proves the wiring — which population gets
+    threaded into which call — was not scrambled in the process, by
+    substituting the original, untouched ``percentile_rank`` back into
+    every call site the fix touched and confirming the full
+    ``score_managers`` output is unchanged.
+
+    (Manually verified once, outside the committed suite, with the actual
+    pre-fix implementation via ``git stash`` at N=800 and N=6000: byte-
+    identical ``ManagerScore.to_dict()`` output both times, real-code not
+    reasoning-only. This test is the permanent, automated form of that
+    check.)
+    """
+
+    def test_matches_reference_percentile_rank_at_every_call_site(self, monkeypatch):
+        # Deliberately SHUFFLED: the `population()` helper builds records
+        # in monotonically increasing win_pct/finish/roster-ratio order, so
+        # `records` (and therefore the internal `raw_scores`, built by
+        # appending each manager's total score in iteration order) comes
+        # out already ascending by coincidence. A prior version of this
+        # test used the unshuffled population and passed even when the
+        # `score_percentile` call site was mutated to read the raw
+        # (unsorted-by-construction) `raw_scores` list directly instead of
+        # `sorted_raw_scores` -- bisect on an already-sorted-by-luck input
+        # happens to still be correct. Shuffling breaks that coincidence
+        # and is what actually proves the call site sorts before it binary
+        # -searches. Verified: this exact mutation (drop `sorted(...)`,
+        # feed `_percentile_rank_sorted` the unsorted `raw_scores`) makes
+        # ~90 of 94 evaluated managers' scorePercentile disagree with the
+        # reference on this shuffled input, and 0 disagree on the
+        # unshuffled one -- keep the shuffle.
+        records = population(150)
+        rng = random.Random(20260830)
+        rng.shuffle(records)
+
+        fast = [entry.to_dict() for entry in S.score_managers(records)]
+
+        # Delegate the fast path back to the original O(N) primitive.
+        # Sorting doesn't change a multiset, so percentile_rank produces
+        # the identical number whether or not its input happens to be
+        # pre-sorted -- this is a faithful reference, not an approximation.
+        monkeypatch.setattr(S, "_percentile_rank_sorted", S.percentile_rank)
+
+        reference = [entry.to_dict() for entry in S.score_managers(records)]
+
+        assert fast == reference
+        # Sanity check the swap actually exercised real evaluable managers,
+        # not an early-exit no-op that would make the equality above
+        # vacuous.
+        evaluated = [e for e in fast if e.get("evaluable") and e.get("score") is not None]
+        assert len(evaluated) > 50
+
+
+class TestScoreManagersScaleGuard:
+    """Regression guard against re-introducing an O(N^2) percentile scan
+    in ``score_managers`` (V1-61). Measured directly against the real
+    pre-fix implementation via ``git stash`` before writing this bound:
+    at N=8000, the O(N^2) code took 13.8s and the O(N log N) fix takes
+    1.8s. The bound below sits well above the fixed code's real time
+    (headroom for a slow CI runner) and well below the quadratic code's
+    real time, so a reintroduced rescan-per-manager fails this loudly
+    without making routine test runs slow.
+    """
+
+    def test_large_population_scores_well_within_the_quadratic_gap(self):
+        records = population(8000)
+        start = time.perf_counter()
+        S.score_managers(records)
+        elapsed = time.perf_counter() - start
+        assert elapsed < 6.0, (
+            f"score_managers took {elapsed:.2f}s for 8000 managers — "
+            "this is the V1-61 quadratic-percentile regression guard; "
+            "if this is genuinely slow again, check for a percentile_rank "
+            "call reintroduced inside the per-manager loop"
+        )


### PR DESCRIPTION
## Summary

V1-61's production timeout (`/api/sharp/roster-percentage` > 60s) survived
both #1169 (SQLite connection reuse) and #1175 (batched `holdings_as_of`
reads) — both landed and correct, but neither touched the actual dominant
cost. The Lane 4 on-box stage profiler (run `33292910657`, deployed SHA
`00f0b3766002`, a descendant containing #1175/#1176) measured it directly:

```
"wallMs": 296629.074,
"stages": {
  "cohort_members":       {"calls": 1, "totalMs": 195605.09, "maxMs": 195605.09},
  "load_rosters":         {"totalMs": 29820.088},
  "holdings_as_of_multi": {"totalMs": 9182.092},
  ... (everything else negligible)
}
```

`cohort_members()` — 66% of the wall time — is a function neither prior fix
touched.

## Root cause

`src/sharp/score.py::score_managers()` calls `percentile_rank(value,
population)` per manager (up to 4x per manager between
`_performance_component` and the qualification loop's `score_percentile`
assignment). `percentile_rank()` itself is O(N): it rebuilds a filtered
float list and does two more full linear scans on every call. Called fresh,
from scratch, once per manager, against the *same* population every time —
classic O(N²). This directly contradicts `cohort.py`'s own docstring claim
that `_compute_cohort_members` (which calls `score_managers`) is "the
O(N log N) rebuild" — it wasn't, because of this one function.

## Fix

Added `_percentile_rank_sorted()`, a `bisect`-based twin of
`percentile_rank()` that takes an already-sorted, already-cleaned float
array and returns the identical statistic in O(log N). `score_managers()`
now sorts each population axis and `raw_scores` **once**, before the
per-manager loop, instead of `percentile_rank()` rescanning them per call.
`percentile_rank()` itself is untouched — it has no callers outside this
module (confirmed via `grep`) and stays correct for any future caller
holding an unsorted list. No weight, threshold, shrinkage, confidence, or
qualification logic changed — this only changes *how* the same numbers get
computed, not what they are.

## Verification

- **Exact equivalence against the real pre-fix code**, via `git stash`,
  not just reasoning: at N=800, byte-identical `ManagerScore.to_dict()`
  output, 0.171s → 0.035s. At N=6000, byte-identical output, 6.72s → 0.96s.
  At N=8000, 13.8s → 1.8s.
- **`TestPercentileRankSorted`** (new): equivalence sweep of
  `_percentile_rank_sorted` vs `percentile_rank` across several populations
  (empty, single-element, all-tied, duplicates+gaps) and probes, plus the
  same pinned edge cases (`TestPercentileRank`) re-proven for the sorted
  path.
- **`TestScoreManagersPercentileWiring`** (new): monkeypatches the fast
  path back to the original `percentile_rank` and diffs the full
  `score_managers()` output — on a **shuffled** population, deliberately,
  because the existing `population()` test helper builds records in
  already-ascending order, which silently hides a missing `sorted(...)` at
  the `raw_scores` call site. Confirmed by mutation: dropping the sort
  there breaks 90/94 shuffled results and 0/94 unshuffled ones — the
  shuffle is load-bearing, not decoration.
- **`TestScoreManagersScaleGuard`** (new): timing bound calibrated against
  the real pre-fix measurement (13.8s at N=8000), asserting the fixed path
  stays well under it — a regression guard against reintroducing a
  per-manager rescan.
- Both fix sites independently mutation-verified: reverting either one
  breaks its respective new test.
- `tests/sharp/` full suite: 330 passed.
- `ruff format --check` / `ruff check`: clean.
- `python3 scripts/check_planning_integrity.py`: OK.

## What this does NOT resolve yet

If production timing is still over the 60s bar after this deploys, the
next-largest measured stage was `load_rosters` (29.8s) — that's the next
lever, decided from fresh Lane 4 numbers post-deploy, not guessed at here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg)_