### PR TITLE
perf(sharp): hoist per-baseline trend structures out of the row loop (V1-61)

### DIFF
--- a/src/sharp/roster_percentage.py
+++ b/src/sharp/roster_percentage.py
@@ -49,7 +49,7 @@ import time
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Iterable, Sequence
+from typing import Any, Callable, Collection, Iterable, Sequence
 
 from src.sharp import cohort as sharp_cohort
 from src.sharp import roster_store
@@ -76,6 +76,14 @@ MIN_PLAYER_DENOMINATOR = 5
 # substantially the same rosters.  Below this overlap the sample moved
 # too much for the delta to mean anything, and we say so instead.
 MIN_TREND_POPULATION_OVERLAP = 0.80
+
+# An asset nothing held at a given baseline.  A shared immutable empty is safe
+# because ``_trend`` only ever iterates ``baseline_holders``; it never mutates
+# it.  "Held by no roster then" is a real measurement, not missing evidence —
+# ``_trend`` still reports rosterPctThen 0.0 against a real shared population,
+# and withholds the delta on its own population-overlap rule when the
+# populations moved too much.
+_NO_ROSTER_KEYS: frozenset[str] = frozenset()
 
 DAY_MS = 86_400_000
 
@@ -492,7 +500,7 @@ def _trend(
     asset_id: str,
     *,
     current_holders: set[str],
-    baseline_holders: dict[str, set[str]],
+    baseline_holders: Collection[str],
     current_roster_keys: set[str],
     baseline_roster_keys: set[str],
 ) -> dict[str, Any]:
@@ -502,6 +510,14 @@ def _trend(
     cohort that grew between the endpoints cannot masquerade as players
     gaining ownership.  When the overlap is too small the delta is
     withheld and the reason is returned in its place.
+
+    ``baseline_holders`` is the ROSTER KEYS that held this asset at the
+    baseline.  It is only ever iterated (``{k for k in baseline_holders
+    ...}``), never subscripted, so a bare set of keys and a
+    ``{roster_key: assets}`` mapping are interchangeable here — iterating
+    a mapping yields exactly its keys.  ``build_board`` passes a set from
+    a per-baseline inverted index; the older per-asset filtered mapping
+    produced the identical iteration at O(rosters) cost per asset.
     """
     shared = current_roster_keys & baseline_roster_keys
     union = current_roster_keys | baseline_roster_keys
@@ -664,6 +680,38 @@ def build_board(
         db_conn.close()
 
     market_pct = _market_ownership(sorted(holders))
+
+    # Loop-invariant baseline structures, computed ONCE per baseline rather
+    # than rebuilt for every (asset x baseline) pair in the row loop below
+    # (V1-61).  The trend block used to build, per asset per baseline, both a
+    # filtered copy of that baseline's whole holdings map and a fresh set of
+    # its roster keys -- each O(rosters).  At the measured production shape
+    # (2,379 qualifying assets x 4 baselines x 9,544 eligible rosters) that
+    # was the single largest remaining cost in build_board: 57.4s of a 128.1s
+    # wall on the 2026-08-30 Lane 4 profile (run 33303611063), and the only
+    # part of it the profiler did not attribute to a named stage.
+    #
+    # Nothing _trend receives changes value:
+    #   * it only ITERATES baseline_holders, and only for roster keys, so an
+    #     inverted asset -> roster-keys index yields the identical iteration
+    #     as the filtered mapping did (see its docstring).
+    #   * baseline_roster_keys KEEPS its per-asset intersection with
+    #     ``applicable``.  That is load-bearing and deliberately not hoisted:
+    #     _trend's ``union`` is ``current_roster_keys | baseline_roster_keys``,
+    #     so passing the unintersected baseline set would widen the union and
+    #     silently change populationOverlap -- the guard that stops a cohort
+    #     that grew between endpoints reading as ownership gain.
+    baseline_key_sets: dict[str, set[str]] = {
+        name: set(baseline_holdings[name] or {}) for name in baselines
+    }
+    baseline_asset_rosters: dict[str, dict[str, set[str]]] = {}
+    for _name in baselines:
+        _inverted: dict[str, set[str]] = {}
+        for _roster_key, _held_assets in (baseline_holdings[_name] or {}).items():
+            for _held_asset in _held_assets:
+                _inverted.setdefault(_held_asset, set()).add(_roster_key)
+        baseline_asset_rosters[_name] = _inverted
+
     rows: list[dict[str, Any]] = []
     unpriced = 0
     for asset_id, held_by in holders.items():
@@ -738,13 +786,9 @@ def build_board(
                 name: _trend(
                     asset_id,
                     current_holders=counted,
-                    baseline_holders={
-                        key: assets
-                        for key, assets in (baseline_holdings[name] or {}).items()
-                        if asset_id in assets
-                    },
+                    baseline_holders=baseline_asset_rosters[name].get(asset_id, _NO_ROSTER_KEYS),
                     current_roster_keys=applicable,
-                    baseline_roster_keys=set(baseline_holdings[name] or {}) & applicable,
+                    baseline_roster_keys=baseline_key_sets[name] & applicable,
                 )
                 for name in baselines
             },

--- a/tests/sharp/test_roster_percentage.py
+++ b/tests/sharp/test_roster_percentage.py
@@ -883,3 +883,161 @@ def test_query_movements_does_not_close_a_caller_supplied_connection(tmp_path):
         conn.execute("SELECT 1").fetchone()
     finally:
         conn.close()
+
+
+class TestTrendBaselineLoopInvariants:
+    """The row loop's trend block hoists two per-baseline structures out of
+    the per-asset loop (V1-61: 57.4s of a measured 128.1s production
+    ``build_board`` wall, run 33303611063). It must stay byte-identical to
+    the retired per-asset formulation, which rebuilt both from
+    ``baseline_holdings`` for every (asset x baseline) pair.
+    """
+
+    @staticmethod
+    def _retired_baseline_holders(baseline_holdings, name, asset_id):
+        """Exactly what build_board used to pass as ``baseline_holders``."""
+        return {
+            key: assets
+            for key, assets in (baseline_holdings[name] or {}).items()
+            if asset_id in assets
+        }
+
+    def test_inverted_index_iterates_the_same_roster_keys_as_the_retired_filter(self):
+        baseline_holdings = {
+            "thirtyDay": {
+                "L1#1": {"4046", "6794"},
+                "L1#2": {"4046"},
+                "L1#3": {"5849"},
+                "L1#4": set(),
+            }
+        }
+        inverted: dict[str, set[str]] = {}
+        for roster_key, held in baseline_holdings["thirtyDay"].items():
+            for asset in held:
+                inverted.setdefault(asset, set()).add(roster_key)
+
+        for asset_id in ("4046", "6794", "5849", "never-held"):
+            retired = self._retired_baseline_holders(baseline_holdings, "thirtyDay", asset_id)
+            current = inverted.get(asset_id, rp._NO_ROSTER_KEYS)
+            # _trend only ever iterates this argument, and only for keys.
+            assert set(retired) == set(current), asset_id
+
+    def test_an_asset_held_by_nobody_at_the_baseline_is_empty_not_missing(self):
+        """MISSING IS NEVER ZERO's neighbour: held-by-nobody is a real
+        measurement (rosterPctThen 0.0), not absent evidence, and the
+        retired filter produced an empty mapping for it rather than
+        omitting the baseline."""
+        shared_keys = {f"L1#{i}" for i in range(1, 11)}
+        then = rp._trend(
+            "never-held",
+            current_holders={"L1#1"},
+            baseline_holders=rp._NO_ROSTER_KEYS,
+            current_roster_keys=shared_keys,
+            baseline_roster_keys=shared_keys,
+        )
+        retired = rp._trend(
+            "never-held",
+            current_holders={"L1#1"},
+            baseline_holders={},
+            current_roster_keys=shared_keys,
+            baseline_roster_keys=shared_keys,
+        )
+        assert then == retired
+        assert then["available"] is True
+        assert then["rosterPctThen"] == 0.0
+
+    def test_trend_treats_a_key_set_and_the_retired_mapping_identically(self):
+        shared_keys = {f"L1#{i}" for i in range(1, 21)}
+        holders = {"L1#1", "L1#2", "L1#3"}
+        mapping = {"L1#2": {"4046"}, "L1#5": {"4046"}}
+        assert rp._trend(
+            "4046",
+            current_holders=holders,
+            baseline_holders=mapping,
+            current_roster_keys=shared_keys,
+            baseline_roster_keys=shared_keys,
+        ) == rp._trend(
+            "4046",
+            current_holders=holders,
+            baseline_holders=set(mapping),
+            current_roster_keys=shared_keys,
+            baseline_roster_keys=shared_keys,
+        )
+
+    def test_every_asset_on_a_multi_asset_baseline_roster_is_indexed(self, ledger, cohort_of):
+        """The per-baseline inverted index must record EVERY asset each
+        baseline roster held, not just one of them.
+
+        The retired formulation re-scanned the whole holdings map per asset,
+        so it could not lose a holding. An inverted index can, and a lost
+        baseline holding is invisible in the worst way: it silently deflates
+        ``rosterPctThen`` and inflates ``rostersAdded``, manufacturing a buy
+        signal out of an indexing bug. Every roster here holds BOTH players
+        at both endpoints, so both trends must be flat.
+        """
+        keys = [f"sleeper:u{i}" for i in range(1, 11)]
+        cohort_of(keys)
+        then = NOW - 40 * DAY
+        for observed in (then, NOW):
+            rs.record_rosters(
+                [
+                    roster(k, f"sleeper:L{i}", assets=["wr1", "rb1"], observed=observed)
+                    for i, k in enumerate(keys)
+                ],
+                path=ledger,
+            )
+
+        payload = board(ledger)
+        for name in ("Star Receiver", "Good Back"):
+            trend = row_for(payload, name)["trend"]["thirtyDay"]
+            assert trend["available"] is True, name
+            assert trend["rosterPctThen"] == 1.0, (
+                f"{name} was held by all 10 baseline rosters; a lower 'then' "
+                "means its baseline holdings were dropped from the index"
+            )
+            assert trend["rosterPctNow"] == 1.0, name
+            assert trend["rosterPctChange"] == 0.0, name
+            assert trend["rostersAdded"] == 0, name
+            assert trend["rostersDropped"] == 0, name
+
+    def test_baseline_roster_keys_stay_intersected_with_applicable(self, ledger, cohort_of):
+        """The per-asset intersection with ``applicable`` is deliberately NOT
+        hoisted, and this exercises the real ``build_board`` path rather than
+        ``_trend`` in isolation.
+
+        _trend's ``union`` is ``current_roster_keys | baseline_roster_keys``,
+        so handing it the whole baseline population widens the union and
+        deflates populationOverlap -- the guard that stops a cohort which
+        grew between endpoints reading as ownership gain.
+
+        An IDP player is the case that separates them: his ``applicable`` set
+        is narrowed to IDP-fielding leagues, while ``baseline_holdings``
+        spans every roster in the cohort. Hoisting the intersection out of
+        the loop therefore measures his 3-roster IDP population against all
+        15 rosters (overlap 0.20 < 0.80) and WITHHOLDS a trend that is
+        genuinely available.
+        """
+        idp_keys = [f"sleeper:idp{i}" for i in range(1, 4)]
+        offense_keys = [f"sleeper:off{i}" for i in range(1, 13)]
+        cohort_of(idp_keys + offense_keys)
+        then = NOW - 40 * DAY
+
+        def _rosters(observed):
+            return [
+                roster(k, f"sleeper:LI{i}", assets=["lb1"], fmt=IDP_LEAGUE, observed=observed)
+                for i, k in enumerate(idp_keys)
+            ] + [
+                roster(k, f"sleeper:LO{i}", assets=["wr1"], fmt=OFFENSE_ONLY, observed=observed)
+                for i, k in enumerate(offense_keys)
+            ]
+
+        rs.record_rosters(_rosters(then), path=ledger)
+        rs.record_rosters(_rosters(NOW), path=ledger)
+
+        trend = row_for(board(ledger), "Star Linebacker")["trend"]["thirtyDay"]
+        assert trend["available"] is True, (
+            "the IDP population never moved, so this trend is real; seeing it "
+            "withheld means baseline_roster_keys was widened past `applicable`"
+        )
+        assert trend["comparableRosters"] == 3
+        assert trend["populationOverlap"] == 1.0


### PR DESCRIPTION
## First: #1183 worked, and worked big

Measured on production (dynasty_main, same profiler, same box), after
#1183 deployed and the deploy train settled on `eef6669` (a descendant
of #1183's merge `3f9c5dd`; the four intervening commits are data-refresh
only, **zero** source diff):

| | before (#1182 tree, run 33299478678) | after (#1183, run **33303611063**) | |
|---|---|---|---|
| `build_board` wallMs | 290,184.7 | **128,065.8** | **−55.9%** |
| `cohort_members` | 204,883.9 | **44,271.8** | **−78.4%** |
| ↳ `cohort_score_managers` | *(not instrumented)* | 32,025.4 | |
| ↳ `cohort_build_manager_records` | *(not instrumented)* | 11,880.7 | |
| `load_rosters` | 20,284.3 | 14,648.1 | |
| `holdings_as_of_multi` | 7,449.2 | 7,965.2 | |

## But V1-61 is still NOT verified, and this PR does not claim to close it

The authenticated production consumer was exercised (run **33304333940**,
deployed SHA `eef6669`, `api` suite) and `/api/sharp/roster-percentage`
**still exceeds its 60s client timeout**:

```
V61A       V1-61   unmeasurable
V61A:crash   -     error   TimeoutError: The read operation timed out
```

Recorded truthfully as `unmeasurable` + `error`, never a pass — timeout ≠
zero, timeout ≠ green. **V1-61 stays `IMPLEMENTED_UNVERIFIED`.** This is
one more measured step, not closure.

## Root cause this PR fixes — taken literally from the new profile

The largest remaining cost is **not a named stage**. Instrumented stages
sum to 70.7s of the 128.1s wall; the other **57.4s (44.8%)** is inside
`build_board`'s per-asset row loop, which the profiler does not wrap.
`wallMs` brackets exactly `build_board()`, so this is real work, not
harness overhead.

It is the `trend` block. For every (asset × baseline) pair it rebuilt two
O(rosters) structures from `baseline_holdings`:

* a filtered copy of the whole baseline holdings map, kept only to iterate
  its keys;
* a fresh `set()` of that baseline's roster keys.

At the measured shape — 2,379 qualifying assets × 4 baselines × 9,544
eligible rosters — that is ~180M operations per board build.

## The fix

Both are loop-invariant per baseline and are now computed once:

* **`baseline_asset_rosters`** — an inverted `asset → roster-keys` index.
  `_trend` only ever *iterates* `baseline_holders`, and only for roster
  keys (`{k for k in baseline_holders if k in shared}`), so a bare key set
  and the old `{roster_key: assets}` mapping are interchangeable —
  iterating a mapping yields exactly its keys. Annotation widened to
  `Collection[str]`, with the reasoning in its docstring.
* **`baseline_key_sets`** — that baseline's roster keys.

**Deliberately NOT hoisted:** `baseline_roster_keys` keeps its per-asset
intersection with `applicable`. `_trend`'s `union` is
`current_roster_keys | baseline_roster_keys`, so passing the unintersected
set widens the union and deflates `populationOverlap` — the guard that
stops a cohort which grew between endpoints reading as ownership gain. An
IDP player is where the two diverge: his `applicable` is narrowed to
IDP-fielding leagues while `baseline_holdings` spans every roster.

## No value changes

Not the percentage, denominator, trend, exclusion counts, or cohort.
Measured **1.60×** on the affected section at production shape with
**byte-identical `_trend` output** across all 2,379 assets (sandbox
25.6s → 16.0s; the box runs ~2.2× slower, so ≈57.4s → ≈36s).

## Tests — all mutation-verified

Two of them only after a first attempt **failed to catch its own mutation**
and was replaced with a board-level test that exercises the real
`build_board` path:

* **every asset on a multi-asset baseline roster is indexed** — catches a
  lossy inverted index, which would silently deflate `rosterPctThen` and
  manufacture a buy signal. Mutation caught: `0.0` vs `1.0`.
* **`baseline_roster_keys` stay intersected with `applicable`** — IDP
  player through the real board; the hoisted-intersection mutation
  withholds a genuinely available trend (overlap 0.20 < 0.80). Caught.
* inverted index iterates the same roster keys as the retired filter.
* held-by-nobody at a baseline stays an empty *measurement*, not missing
  evidence.

`tests/sharp/` **335 passed**. `ruff check` clean. `check_planning_integrity.py` OK.
`ruff format` leaves one pre-existing hunk at test line ~808 that is
already on `main` under CI's ruff version — deliberately not touched.

## What is measurably next (not guessed)

After this lands, expected wall ≈106s, still above 60s. The remaining
ranked levers from the same profile:

1. `cohort_score_managers` **32.0s** — post-#1183 residual: two
   `check_eligibility` passes per record plus per-manager object
   construction over the ~45,286-manager evidence population.
2. `load_rosters` **14.6s**
3. `holdings_as_of_multi` **8.0s**

Also worth noting for whoever picks this up: `cohort_members` is memoized
per process on a ledger fingerprint, but a concurrent `Bootstrap Sharp
Records` crawl was rewriting that ledger during these runs, so the warm
path may not be reached as often as the memo implies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg)_