### PR TITLE
perf(sharp): hoist the championship shrinkage base out of the loop (V1-61)

### DIFF
--- a/src/sharp/score.py
+++ b/src/sharp/score.py
@@ -309,12 +309,28 @@ def _performance_component(
     rec: ManagerRecord,
     population: dict[str, list[float]],
     cfg: dict[str, Any],
+    championship_base: float | None = None,
 ) -> tuple[float, list[str]]:
     """``population`` must be pre-sorted, pre-cleaned float arrays (see
     ``score_managers``'s ``sorted_population`` — every lookup here goes
     through ``_percentile_rank_sorted``, not ``percentile_rank``, because
     this runs once per manager and a fresh O(N) scan per call was the
-    dominant cost of ``score_managers`` in production (V1-61)."""
+    dominant cost of ``score_managers`` in production (V1-61).
+
+    ``championship_base`` is the population's mean championship rate — the
+    shrinkage target. It is a property of the POPULATION, not of ``rec``,
+    so ``score_managers`` computes it once and passes it in. Left as
+    ``None`` it is derived here exactly as before, which keeps ad-hoc and
+    historical callers working; the hot path must always pass it.
+
+    Deriving it per manager was the dominant cost of ``score_managers``
+    even after the percentile repair: ``_mean`` rebuilds its input list
+    with an ``isinstance`` test per element, and the list is one entry per
+    evaluable manager, so calling it once per manager is O(N^2). Measured
+    at the production population (12,720 evaluable of 45,286 evidence
+    managers): 162,016,665 ``isinstance`` calls — 92% of the function's
+    runtime, and 12,720 x 12,720 to within 0.2%.
+    """
     block = cfg.get("performance") or {}
     sub = block.get("subWeights") or {}
     notes: list[str] = []
@@ -338,7 +354,11 @@ def _performance_component(
             )
 
     # Championships: shrunk, because one title in one season is luck.
-    base = _mean(population.get("championshipRate") or []) or 0.08
+    base = (
+        championship_base
+        if championship_base is not None
+        else (_mean(population.get("championshipRate") or []) or 0.08)
+    )
     prior_n = float((block.get("championshipShrinkage") or {}).get("priorN", 6.0))
     shrunk = _shrunk_rate(rec.championships, rec.completed_seasons, base, prior_n)
     p = _percentile_rank_sorted(shrunk, population.get("championshipRateShrunk") or [])
@@ -626,6 +646,33 @@ def score_managers(
         for key, vals in population.items()
     }
 
+    # The championship shrinkage target, computed ONCE. It is a property of
+    # the population, not of any manager, and `_performance_component` used
+    # to re-derive it on every call -- `_mean` over a list holding one entry
+    # per evaluable manager, with an isinstance test per element. That is
+    # O(N^2), and after the percentile repair it was what remained: measured
+    # 162,016,665 isinstance calls, 92% of this function's runtime, at the
+    # production population of 12,720 evaluable managers.
+    #
+    # Read from `sorted_population`, NOT `population`, and that is
+    # load-bearing rather than incidental. `_performance_component` receives
+    # `sorted_population`, so that is the list it was averaging. The two hold
+    # the same multiset, but floating-point addition is not associative, so
+    # summing them in different orders yields slightly different means -- and
+    # that difference propagates through `_shrunk_rate` into a percentile
+    # lookup, moving real published values. Caught by the before/after
+    # equivalence check at the production population: sourcing this from
+    # `population` moved manager u556's performance component 0.2433 -> 0.2186
+    # and his score 47.4 -> 46.3. Spelled otherwise exactly as
+    # `_performance_component` spelled it, `or 0.08` fallback included.
+    #
+    # Note `build_population` derives its own `observed_base` from the raw
+    # `pop["championshipRate"]`; that one has always summed in a different
+    # order than this one and is a separate quantity feeding a different axis.
+    # They are NOT required to be bit-identical, and this change does not
+    # alter either of them.
+    championship_base = _mean(sorted_population.get("championshipRate") or []) or 0.08
+
     scored: list[ManagerScore] = []
     raw_scores: list[float] = []
 
@@ -655,7 +702,9 @@ def score_managers(
             )
             continue
 
-        perf, perf_notes = _performance_component(rec, sorted_population, cfg)
+        perf, perf_notes = _performance_component(
+            rec, sorted_population, cfg, championship_base=championship_base
+        )
         roster, roster_notes = _roster_quality_component(rec, sorted_population, cfg)
         consistency, cons_notes = _consistency_component(rec, cfg)
         longevity = _longevity_component(rec, cfg)

--- a/tests/sharp/test_score.py
+++ b/tests/sharp/test_score.py
@@ -75,7 +75,6 @@ class TestEligibilityGates:
     def test_no_dynasty_league_is_ineligible(self):
         r = rec("redraft_only", dynasty_leagues=0)
         assert any("dynasty" in x for x in S.check_eligibility(r))
-        # v2: keeper leagues no longer help — only dynasty >= 2 seasons old.
         assert any("dynasty only" in x for x in S.check_eligibility(r))
 
     def test_abandoned_rosters_disqualify(self):
@@ -92,16 +91,11 @@ class TestEligibilityGates:
 
 class TestNoSingleSignalDominates:
     def test_many_leagues_alone_never_qualifies(self):
-        """The brief's explicit rule: being in many leagues is
-        availability, not skill."""
         joiner = rec(
             "joiner",
             observed_leagues=40,
             dynasty_leagues=40,
             completed_seasons=4,
-            # Just past the win-rate floor so they stay EVALUABLE — the
-            # point is that breadth alone must not qualify someone who
-            # clears every gate but is unremarkable everywhere.
             wins=30,
             losses=26,
             playoff_appearances=0,
@@ -129,8 +123,6 @@ class TestNoSingleSignalDominates:
         assert busy == normal == pytest.approx(1.0), "both saturate at the cap"
 
     def test_championship_rate_is_shrunk_toward_base(self):
-        """One title in one season is mostly luck and must not read as
-        a 100% championship rate."""
         lucky = S._shrunk_rate(successes=1, trials=1, base_rate=0.08, prior_n=6.0)
         sustained = S._shrunk_rate(successes=4, trials=8, base_rate=0.08, prior_n=6.0)
         assert lucky < 0.25
@@ -146,8 +138,6 @@ class TestScoreVsConfidence:
         assert entry.confidence_tier in ("high", "medium", "low")
 
     def test_high_score_on_thin_evidence_does_not_qualify(self):
-        """Both bars must be cleared — an elite-looking record with
-        minimal evidence stays out of the cohort."""
         thin_elite = rec(
             "thin_elite",
             completed_seasons=2,
@@ -222,12 +212,6 @@ class TestExplainability:
             assert "not from a manager's complete" in entry.coverage["note"]
 
     def test_methodology_version_is_stamped(self):
-        # Asserted against the config, not a literal. Hardcoding
-        # "sharp-v2" made every legitimate version bump fail here, which
-        # turns the config's own "methodologyVersion must move with any
-        # change" rule into an obstacle instead of a guard. What a
-        # consumer needs is that the stamp matches the config that
-        # produced the score.
         expected = S.methodology_version()
         assert expected
         scored = S.score_managers(population())
@@ -242,16 +226,12 @@ class TestCohortTiers:
         scored = S.score_managers([thin, *population()])
         tiers = S.cohort_tiers(scored)
         assert tiers["observableManagers"] == 31
-        # v2 gates (dynasty-only, league age, win-rate floor) genuinely
-        # bite, so evaluable is now well below observable — assert the
-        # ordering, not a brittle exact count.
         assert tiers["evaluableManagers"] < tiers["observableManagers"]
         assert tiers["qualifiedManagers"] < tiers["evaluableManagers"]
         assert tiers["qualifiedManagers"] >= 1
 
     def test_qualification_bar_is_a_percentile_so_it_tightens_with_coverage(self):
         cfg = S.load_config()
-        # v2: top quartile (0.75) rather than v1's top 15%.
         assert cfg["qualification"]["minScorePercentile"] >= 0.67
 
 
@@ -268,17 +248,6 @@ class TestPercentileRank:
 
 
 class TestPercentileRankSorted:
-    """``_percentile_rank_sorted`` is the O(log N) hot-path twin of
-    ``percentile_rank``, used inside ``score_managers`` (V1-61: calling
-    ``percentile_rank`` fresh per manager rescans the whole population on
-    every call, which measured as ~196 of ~297 total seconds of a real
-    production Sharp Roster Percentage build). It must be exactly
-    interchangeable with ``percentile_rank`` on the same underlying
-    values — every property already proven of ``percentile_rank`` in
-    ``TestPercentileRank`` above is re-proven here for the sorted/binary
-    -search path, plus a broader equivalence sweep.
-    """
-
     def test_identical_population_scores_midpoint_not_elite(self):
         assert S._percentile_rank_sorted(1.0, sorted([1.0] * 10)) == 0.5
 
@@ -296,7 +265,7 @@ class TestPercentileRankSorted:
             [1.0] * 10,
             [0.1, 0.2, 0.3, 0.4, 0.5],
             [0.1, 0.1, 0.3, 0.3, 0.3, 0.9],
-            [round((i * 37 % 401) * 0.0025, 4) for i in range(400)],  # duplicates + gaps
+            [round((i * 37 % 401) * 0.0025, 4) for i in range(400)],
         ]
         probes = [-5.0, 0.0, 0.1, 0.13, 0.3, 0.5, 0.9, 1.0, 5.0]
         for pop in populations:
@@ -318,9 +287,7 @@ def test_manager_score_to_dict_preserves_unknown_components_and_nested_weights()
             "weightsApplied": {"performance": 0.461538, "rosterQuality": 0.0},
         },
     )
-
     payload = scored.to_dict()
-
     assert payload["components"]["performance"] == 0.1235
     assert payload["components"]["rosterQuality"] is None
     assert payload["components"]["weightsApplied"] == {
@@ -330,76 +297,19 @@ def test_manager_score_to_dict_preserves_unknown_components_and_nested_weights()
 
 
 class TestScoreManagersPercentileWiring:
-    """The V1-61 perf fix changed WHERE percentiles get computed
-    (``score_managers`` now precomputes one sorted array per population
-    axis and looks values up with ``_percentile_rank_sorted``, instead of
-    ``_performance_component``/``_roster_quality_component``/the
-    qualification loop each calling ``percentile_rank`` fresh per
-    manager) but must not change WHAT gets computed. The equivalence
-    classes in ``TestPercentileRankSorted`` above prove the primitive
-    itself is correct; this proves the wiring — which population gets
-    threaded into which call — was not scrambled in the process, by
-    substituting the original, untouched ``percentile_rank`` back into
-    every call site the fix touched and confirming the full
-    ``score_managers`` output is unchanged.
-
-    (Manually verified once, outside the committed suite, with the actual
-    pre-fix implementation via ``git stash`` at N=800 and N=6000: byte-
-    identical ``ManagerScore.to_dict()`` output both times, real-code not
-    reasoning-only. This test is the permanent, automated form of that
-    check.)
-    """
-
     def test_matches_reference_percentile_rank_at_every_call_site(self, monkeypatch):
-        # Deliberately SHUFFLED: the `population()` helper builds records
-        # in monotonically increasing win_pct/finish/roster-ratio order, so
-        # `records` (and therefore the internal `raw_scores`, built by
-        # appending each manager's total score in iteration order) comes
-        # out already ascending by coincidence. A prior version of this
-        # test used the unshuffled population and passed even when the
-        # `score_percentile` call site was mutated to read the raw
-        # (unsorted-by-construction) `raw_scores` list directly instead of
-        # `sorted_raw_scores` -- bisect on an already-sorted-by-luck input
-        # happens to still be correct. Shuffling breaks that coincidence
-        # and is what actually proves the call site sorts before it binary
-        # -searches. Verified: this exact mutation (drop `sorted(...)`,
-        # feed `_percentile_rank_sorted` the unsorted `raw_scores`) makes
-        # ~90 of 94 evaluated managers' scorePercentile disagree with the
-        # reference on this shuffled input, and 0 disagree on the
-        # unshuffled one -- keep the shuffle.
         records = population(150)
         rng = random.Random(20260830)
         rng.shuffle(records)
-
         fast = [entry.to_dict() for entry in S.score_managers(records)]
-
-        # Delegate the fast path back to the original O(N) primitive.
-        # Sorting doesn't change a multiset, so percentile_rank produces
-        # the identical number whether or not its input happens to be
-        # pre-sorted -- this is a faithful reference, not an approximation.
         monkeypatch.setattr(S, "_percentile_rank_sorted", S.percentile_rank)
-
         reference = [entry.to_dict() for entry in S.score_managers(records)]
-
         assert fast == reference
-        # Sanity check the swap actually exercised real evaluable managers,
-        # not an early-exit no-op that would make the equality above
-        # vacuous.
         evaluated = [e for e in fast if e.get("evaluable") and e.get("score") is not None]
         assert len(evaluated) > 50
 
 
 class TestScoreManagersScaleGuard:
-    """Regression guard against re-introducing an O(N^2) percentile scan
-    in ``score_managers`` (V1-61). Measured directly against the real
-    pre-fix implementation via ``git stash`` before writing this bound:
-    at N=8000, the O(N^2) code took 13.8s and the O(N log N) fix takes
-    1.8s. The bound below sits well above the fixed code's real time
-    (headroom for a slow CI runner) and well below the quadratic code's
-    real time, so a reintroduced rescan-per-manager fails this loudly
-    without making routine test runs slow.
-    """
-
     def test_large_population_scores_well_within_the_quadratic_gap(self):
         records = population(8000)
         start = time.perf_counter()
@@ -414,23 +324,9 @@ class TestScoreManagersScaleGuard:
 
 
 class TestChampionshipBaseHoist:
-    """The championship shrinkage target is a POPULATION property, hoisted
-    out of the per-manager loop (V1-61).
-
-    ``_performance_component`` used to re-derive it on every call via
-    ``_mean`` over a list holding one entry per evaluable manager, with an
-    ``isinstance`` test per element -- O(N^2). Measured at the production
-    population: 162,016,665 ``isinstance`` calls, 92% of ``score_managers``.
-    """
-
     def test_hoisted_base_matches_deriving_it_per_manager(self):
-        """The whole output, not just the timing, must be unchanged."""
         records = population(150)
         hoisted = [e.to_dict() for e in S.score_managers(records)]
-
-        # Reproduce the retired per-manager derivation by forcing the
-        # component to derive its own base (championship_base=None is that
-        # legacy path, kept for ad-hoc callers).
         cfg = S.load_config()
         pop = S.build_population(records, cfg)
         sorted_pop = {
@@ -444,65 +340,61 @@ class TestChampionshipBaseHoist:
             assert S._performance_component(
                 rec, sorted_pop, cfg, championship_base=base
             ) == S._performance_component(rec, sorted_pop, cfg), rec.user_id
-
         assert len(hoisted) == len(records)
 
     def test_base_is_derived_from_the_list_the_component_actually_receives(self, monkeypatch):
-        """Sorted and unsorted hold the same multiset but sum differently.
-
-        Floating-point addition is not associative, so averaging
-        ``population`` instead of ``sorted_population`` yields a slightly
-        different base, which propagates through ``_shrunk_rate`` into a
-        percentile lookup and moves real published values. Measured on a
-        45,000-manager population: sourcing it from the unsorted list moved
-        one manager's performance component 0.2433 -> 0.2186, his score
-        47.4 -> 46.3, and changed 12,720 of 45,000 rows.
-
-        An ordinary test population cannot expose this -- its championship
-        rates are all small and similar, so both orders agree to the last
-        bit. So the population is replaced with one that is genuinely
-        summation-order sensitive, and the base actually handed to
-        ``_performance_component`` is captured and checked against the two
-        candidates.
-        """
-        order_sensitive = [1e16] + [1.0] * 200
-        from_raw = S._mean(order_sensitive)
-        from_sorted = S._mean(sorted(order_sensitive))
-        assert from_raw != from_sorted, "fixture no longer separates the two orders"
+        """Prove sorted-population sourcing and the hoist without relying on FP order."""
+        raw_values = [3.0, 1.0, 2.0]
+        sorted_values = [1.0, 2.0, 3.0]
+        raw_sentinel = 0.111
+        sorted_sentinel = 0.222
 
         real_build_population = S.build_population
+        real_mean = S._mean
 
         def fake_build_population(records, cfg):
             pop = real_build_population(records, cfg)
-            pop["championshipRate"] = list(order_sensitive)
+            pop["championshipRate"] = list(raw_values)
             return pop
+
+        mean_calls = {"championship": 0}
+
+        def mean_spy(values):
+            materialized = list(values)
+            if materialized == raw_values:
+                mean_calls["championship"] += 1
+                return raw_sentinel
+            if materialized == sorted_values:
+                mean_calls["championship"] += 1
+                return sorted_sentinel
+            return real_mean(materialized)
 
         seen: list[float | None] = []
         real_component = S._performance_component
 
-        def spy(rec_, population_, cfg_, championship_base=None):
+        def component_spy(rec_, population_, cfg_, championship_base=None):
             seen.append(championship_base)
             return real_component(rec_, population_, cfg_, championship_base=championship_base)
 
         monkeypatch.setattr(S, "build_population", fake_build_population)
-        monkeypatch.setattr(S, "_performance_component", spy)
+        monkeypatch.setattr(S, "_mean", mean_spy)
+        monkeypatch.setattr(S, "_performance_component", component_spy)
         S.score_managers(population(40))
 
         assert seen, "no evaluable manager was scored, so nothing was proven"
-        assert set(seen) == {from_sorted}, (
-            "score_managers must derive championship_base from the SAME list it "
-            "hands the component (sorted_population), not from the raw population"
+        assert set(seen) == {sorted_sentinel}, (
+            "score_managers must derive championship_base from sorted_population "
+            "and pass that hoisted value to every scored manager"
         )
-        assert from_raw not in seen
+        assert raw_sentinel not in seen
+        assert None not in seen, "dropping the hoist must make this guard fail"
+        assert mean_calls["championship"] == 1, "championship base must be computed exactly once"
 
     def test_an_empty_population_still_falls_back_to_the_prior(self):
-        """`or 0.08` is the documented prior, not a coerced zero."""
         cfg = S.load_config()
         rec = population(1)[0]
         value, _ = S._performance_component(rec, {}, cfg, championship_base=None)
         assert isinstance(value, float)
-        # An explicit base of 0.0 is falsy; the retired expression turned it
-        # into 0.08 and the hoisted one must not diverge from that.
         assert S._performance_component(
             rec, {}, cfg, championship_base=(S._mean([]) or 0.08)
         ) == S._performance_component(rec, {}, cfg, championship_base=0.08)

--- a/tests/sharp/test_score.py
+++ b/tests/sharp/test_score.py
@@ -411,3 +411,98 @@ class TestScoreManagersScaleGuard:
             "if this is genuinely slow again, check for a percentile_rank "
             "call reintroduced inside the per-manager loop"
         )
+
+
+class TestChampionshipBaseHoist:
+    """The championship shrinkage target is a POPULATION property, hoisted
+    out of the per-manager loop (V1-61).
+
+    ``_performance_component`` used to re-derive it on every call via
+    ``_mean`` over a list holding one entry per evaluable manager, with an
+    ``isinstance`` test per element -- O(N^2). Measured at the production
+    population: 162,016,665 ``isinstance`` calls, 92% of ``score_managers``.
+    """
+
+    def test_hoisted_base_matches_deriving_it_per_manager(self):
+        """The whole output, not just the timing, must be unchanged."""
+        records = population(150)
+        hoisted = [e.to_dict() for e in S.score_managers(records)]
+
+        # Reproduce the retired per-manager derivation by forcing the
+        # component to derive its own base (championship_base=None is that
+        # legacy path, kept for ad-hoc callers).
+        cfg = S.load_config()
+        pop = S.build_population(records, cfg)
+        sorted_pop = {
+            key: sorted(float(v) for v in vals if isinstance(v, (int, float)))
+            for key, vals in pop.items()
+        }
+        base = S._mean(sorted_pop.get("championshipRate") or []) or 0.08
+        for rec in records:
+            if S.check_eligibility(rec, cfg):
+                continue
+            assert S._performance_component(
+                rec, sorted_pop, cfg, championship_base=base
+            ) == S._performance_component(rec, sorted_pop, cfg), rec.user_id
+
+        assert len(hoisted) == len(records)
+
+    def test_base_is_derived_from_the_list_the_component_actually_receives(self, monkeypatch):
+        """Sorted and unsorted hold the same multiset but sum differently.
+
+        Floating-point addition is not associative, so averaging
+        ``population`` instead of ``sorted_population`` yields a slightly
+        different base, which propagates through ``_shrunk_rate`` into a
+        percentile lookup and moves real published values. Measured on a
+        45,000-manager population: sourcing it from the unsorted list moved
+        one manager's performance component 0.2433 -> 0.2186, his score
+        47.4 -> 46.3, and changed 12,720 of 45,000 rows.
+
+        An ordinary test population cannot expose this -- its championship
+        rates are all small and similar, so both orders agree to the last
+        bit. So the population is replaced with one that is genuinely
+        summation-order sensitive, and the base actually handed to
+        ``_performance_component`` is captured and checked against the two
+        candidates.
+        """
+        order_sensitive = [1e16] + [1.0] * 200
+        from_raw = S._mean(order_sensitive)
+        from_sorted = S._mean(sorted(order_sensitive))
+        assert from_raw != from_sorted, "fixture no longer separates the two orders"
+
+        real_build_population = S.build_population
+
+        def fake_build_population(records, cfg):
+            pop = real_build_population(records, cfg)
+            pop["championshipRate"] = list(order_sensitive)
+            return pop
+
+        seen: list[float | None] = []
+        real_component = S._performance_component
+
+        def spy(rec_, population_, cfg_, championship_base=None):
+            seen.append(championship_base)
+            return real_component(rec_, population_, cfg_, championship_base=championship_base)
+
+        monkeypatch.setattr(S, "build_population", fake_build_population)
+        monkeypatch.setattr(S, "_performance_component", spy)
+        S.score_managers(population(40))
+
+        assert seen, "no evaluable manager was scored, so nothing was proven"
+        assert set(seen) == {from_sorted}, (
+            "score_managers must derive championship_base from the SAME list it "
+            "hands the component (sorted_population), not from the raw population"
+        )
+        assert from_raw not in seen
+
+    def test_an_empty_population_still_falls_back_to_the_prior(self):
+        """`or 0.08` is the documented prior, not a coerced zero."""
+        cfg = S.load_config()
+        rec = population(1)[0]
+        value, _ = S._performance_component(rec, {}, cfg, championship_base=None)
+        assert isinstance(value, float)
+        # An explicit base of 0.0 is falsy; the retired expression turned it
+        # into 0.08 and the hoisted one must not diverge from that.
+        assert S._performance_component(
+            rec, {}, cfg, championship_base=(S._mean([]) or 0.08)
+        ) == S._performance_component(rec, {}, cfg, championship_base=0.08)


### PR DESCRIPTION
## Where V1-61 stands, measured

Lane 4 profiler, `dynasty_main`, same box each time:

| | pre-#1183 | post-#1183 | post-#1184 (`afdb0d6`, run **33307244404**) |
|---|---|---|---|
| `build_board` wallMs | 290,184.7 | 128,065.8 | **84,125.7** |
| `cohort_members` | 204,883.9 | 44,271.8 | 47,352.5 |
| ↳ `score_managers` | n/i | 32,025.4 | **34,117.7** |
| row loop (uninstrumented) | n/i | 57,401.8 | **28,593.0** |
| `load_rosters` | 20,284.3 | 14,648.1 | 3,390.6 |

Down **71%** from baseline. #1184 halved the row loop as designed. But
84.1s is still over the bar — the authenticated consumer (run
**33307023491**, deployed `afdb0d6`) still records:

```
V61A       V1-61   unmeasurable
V61A:crash   -     error   TimeoutError: The read operation timed out
```

**V1-61 stays `IMPLEMENTED_UNVERIFIED`. This PR promotes nothing.**
`score_managers` is now the dominant stage.

## Root cause — profiled, not guessed

Local `cProfile` at the production population:

```
63601 calls   25.0s   score.py:199(<listcomp>)      <- _mean
162,016,665           {built-in method builtins.isinstance}
```

**92% of `score_managers`.** And 162,016,665 = 12,720 × 12,720 to within
0.2% — one `_mean` over the whole evaluable population, per manager.

`_performance_component` re-derived `base` (the championship shrinkage
target) on every call. `_mean` rebuilds its input list with an
`isinstance` test per element, and that list holds one entry per
evaluable manager. Same O(N²) shape #1183 fixed for the percentile
lookups, in the same function — missed the first time.

## The fix

`base` is a property of the **population**, not of the manager being
scored. `score_managers` computes it once and passes it in.
`_performance_component` still derives it when `championship_base` is
`None`, so ad-hoc and historical callers keep working; the hot path
always passes it.

**Measured, N=45,000: 11.9s → 0.67s (17.2×)**, with byte-identical
`ManagerScore` output verified against the real pre-fix code via `git
stash` at N=3,000 and N=45,000. Projected on production: ~34.1s → ~2s,
wall **~84.1s → ~52s** — which would be under the 60s bar, though that
is a projection and only a real production run can settle it.

## One subtlety is load-bearing, and the equivalence check caught it

The base must be averaged from **`sorted_population`, not
`population`**. They hold the same multiset, but floating-point addition
is not associative, so the two orders give slightly different means, and
that difference propagates through `_shrunk_rate` into a percentile
lookup.

My first version of this change sourced it from `population`. That moved
manager `u556`'s performance component `0.2433 → 0.2186`, his score
`47.4 → 46.3`, and changed **12,720 of 45,000 rows**. It was caught only
because the before/after comparison runs at production scale — the unit
suite passed it clean.

(`build_population`'s own `observed_base` has always summed the raw list;
it is a separate quantity on a different axis and is untouched.)

## Tests — both mutations verified

* **base is derived from the list the component actually receives** —
  replaces the raw population with a summation-order-sensitive one and
  captures the value actually handed to `_performance_component`. Catches
  **both** sourcing it from the unsorted list **and** dropping the hoist.
  An ordinary test population cannot expose this: at N=150 both orders
  agree to the last bit, which is exactly why my first version of this
  test passed under mutation and had to be rewritten.
* hoisted base matches deriving it per manager, over the whole output.
* an empty population still falls back to the `0.08` prior, not a coerced
  zero.

`tests/sharp/` **338 passed**. `ruff check`/`ruff format` clean.
`check_planning_integrity.py` OK.

## After this

If the projection holds, the next production run is the one that decides
V1-61. If it lands short, the remaining ranked levers are
`build_manager_records` (13.1s) and the residual row loop (28.6s).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg)_