### PR TITLE
perf(sharp): stop re-deriving set quantities build_board already knows (V1-61)

### DIFF
--- a/src/sharp/roster_percentage.py
+++ b/src/sharp/roster_percentage.py
@@ -503,6 +503,8 @@ def _trend(
     baseline_holders: Collection[str],
     current_roster_keys: set[str],
     baseline_roster_keys: set[str],
+    shared: set[str] | None = None,
+    union_size: int | None = None,
 ) -> dict[str, Any]:
     """Change in roster percentage between two instants.
 
@@ -518,10 +520,33 @@ def _trend(
     a mapping yields exactly its keys.  ``build_board`` passes a set from
     a per-baseline inverted index; the older per-asset filtered mapping
     produced the identical iteration at O(rosters) cost per asset.
+
+    ``shared`` and ``union_size`` are OPTIONAL precomputed forms of the two
+    quantities derived immediately below.  Left as ``None`` they are derived
+    here exactly as before, so ad-hoc and historical callers are unaffected;
+    the hot path passes them.  They exist because ``build_board`` already
+    knows both without doing the work:
+
+        it passes ``current_roster_keys=applicable`` and
+        ``baseline_roster_keys=<that baseline's keys> & applicable``
+
+    so ``baseline_roster_keys ⊆ current_roster_keys`` BY CONSTRUCTION, and
+    therefore ``shared == baseline_roster_keys`` and
+    ``union == current_roster_keys``.  Deriving them anyway costs two set
+    operations over roster-key-sized sets per (asset × baseline) — eight per
+    asset, ~9,536 elements each, on a board of 2,379 assets (V1-61).
+
+    The containment is the precondition, and it is the caller's to honour: a
+    caller that passes a ``baseline_roster_keys`` NOT contained in
+    ``current_roster_keys`` must NOT pass these, or the overlap it gets back
+    will be measured against the wrong population.  Pinned by
+    ``TestTrendBaselineLoopInvariants``.
     """
-    shared = current_roster_keys & baseline_roster_keys
-    union = current_roster_keys | baseline_roster_keys
-    overlap = (len(shared) / len(union)) if union else 0.0
+    if shared is None:
+        shared = current_roster_keys & baseline_roster_keys
+    if union_size is None:
+        union_size = len(current_roster_keys | baseline_roster_keys)
+    overlap = (len(shared) / union_size) if union_size else 0.0
     if not shared or overlap < MIN_TREND_POPULATION_OVERLAP:
         return {
             "available": False,
@@ -712,6 +737,35 @@ def build_board(
                 _inverted.setdefault(_held_asset, set()).add(_roster_key)
         baseline_asset_rosters[_name] = _inverted
 
+    # Per-FAMILY and per-(FAMILY, BASELINE) precomputes, so the row loop stops
+    # intersecting roster-key-sized sets once per asset (V1-61).  ``denominators``
+    # is keyed by the fixed ``POSITION_FAMILIES`` tuple, so this is a handful of
+    # intersections for the whole board instead of ~4 per asset x 2,379 assets.
+    #
+    #   family_rosters[f]        == denominators[f] & roster_keys
+    #   baseline_family[b][f]    == baseline_key_sets[b] & family_rosters[f]
+    #
+    # and then, per asset, with H_r = held_by & roster_keys:
+    #
+    #   applicable               == family_rosters[f] | H_r
+    #   baseline_key_sets[b] & applicable
+    #                            == baseline_family[b][f] | (baseline_key_sets[b] & H_r)
+    #
+    # by distributivity, with the second term O(|held_by|) rather than
+    # O(|rosters|).  Verified numerically over 20,000 randomised cases, zero
+    # counterexamples, alongside the two identities _trend's new parameters
+    # rest on.
+    family_rosters: dict[str, set[str]] = {
+        _family: (_keys or set()) & roster_keys for _family, _keys in denominators.items()
+    }
+    baseline_family_rosters: dict[str, dict[str, set[str]]] = {
+        _name: {
+            _family: baseline_key_sets[_name] & _fam_keys
+            for _family, _fam_keys in family_rosters.items()
+        }
+        for _name in baselines
+    }
+
     rows: list[dict[str, Any]] = []
     unpriced = 0
     for asset_id, held_by in holders.items():
@@ -728,16 +782,32 @@ def build_board(
             continue
 
         family = FAMILY_UNKNOWN if is_pick else position_family(pos)
-        denominator_keys = denominators.get(family) or set()
+        family_keys = family_rosters.get(family) or set()
         # A roster that HOLDS the player proves its league fields his
         # position, so it belongs in his denominator even when the
         # format capture was incomplete. Without this an unknown-format
         # roster could contribute a numerator it was excluded from
         # counting against, and a percentage could exceed 100%.
-        applicable = (denominator_keys | held_by) & roster_keys
+        #
+        # ``held_rosters`` is BOTH the second half of ``applicable`` and, on
+        # its own, ``counted``: ``held_by & applicable == held_by &
+        # roster_keys`` because ``held_by ⊆ denominator_keys | held_by``.
+        # Computing it once at O(|held_by|) replaces two roster-key-sized
+        # intersections.
+        #
+        # The ``& roster_keys`` is a GUARD, not an observable behaviour, and a
+        # mutation test will not catch its removal today: ``roster_keys`` and
+        # ``holders`` are both derived from the same ``filtered`` list above,
+        # so ``held_by ⊆ roster_keys`` already holds and the intersection is a
+        # no-op. It is kept because that containment is an accident of how
+        # those two are built, not a stated invariant, and dropping it would
+        # let a future change to either one inflate ``sharpRosters`` with
+        # rosters that were filtered out.
+        held_rosters = held_by & roster_keys
+        applicable = family_keys | held_rosters
         if not applicable:
             continue
-        counted = held_by & applicable
+        counted = held_rosters
         pct = len(counted) / len(applicable)
         if meta.get("value") is None:
             unpriced += 1
@@ -750,6 +820,33 @@ def build_board(
         manager_counts = Counter(roster_manager[rk] for rk in counted)
         distinct_managers = len(manager_counts)
         manager_concentration = max(manager_counts.values()) / len(counted)
+
+        # Built before the row rather than inline, because each baseline needs
+        # its own keys twice — once as ``baseline_roster_keys`` and once as the
+        # ``shared`` it is provably equal to. Expressing that inline would mean
+        # a walrus inside a keyword argument, which silently depends on
+        # left-to-right argument evaluation and breaks if the arguments are
+        # ever reordered.
+        trend_by_baseline: dict[str, dict[str, Any]] = {}
+        for _baseline in baselines:
+            # == baseline_key_sets[_baseline] & applicable, by distributivity
+            # over ``applicable = family_keys | held_rosters``.
+            _baseline_keys = (baseline_family_rosters[_baseline].get(family) or set()) | (
+                baseline_key_sets[_baseline] & held_rosters
+            )
+            trend_by_baseline[_baseline] = _trend(
+                asset_id,
+                current_holders=counted,
+                baseline_holders=baseline_asset_rosters[_baseline].get(asset_id, _NO_ROSTER_KEYS),
+                current_roster_keys=applicable,
+                baseline_roster_keys=_baseline_keys,
+                # A subset of ``applicable`` by construction, so ``shared`` is
+                # itself and ``union`` is ``applicable`` — see _trend's
+                # docstring. Passing them skips two roster-key-sized set
+                # operations per baseline.
+                shared=_baseline_keys,
+                union_size=len(applicable),
+            )
 
         market = market_pct.get(asset_id)
         row = {
@@ -782,16 +879,7 @@ def build_board(
                 if len(applicable) < MIN_PLAYER_DENOMINATOR
                 else None
             ),
-            "trend": {
-                name: _trend(
-                    asset_id,
-                    current_holders=counted,
-                    baseline_holders=baseline_asset_rosters[name].get(asset_id, _NO_ROSTER_KEYS),
-                    current_roster_keys=applicable,
-                    baseline_roster_keys=baseline_key_sets[name] & applicable,
-                )
-                for name in baselines
-            },
+            "trend": trend_by_baseline,
         }
         rows.append(row)
 

--- a/tests/sharp/test_roster_percentage.py
+++ b/tests/sharp/test_roster_percentage.py
@@ -1041,3 +1041,119 @@ class TestTrendBaselineLoopInvariants:
         )
         assert trend["comparableRosters"] == 3
         assert trend["populationOverlap"] == 1.0
+
+    def test_precomputed_shared_and_union_match_deriving_them(self):
+        """``_trend``'s optional fast-path arguments must be exactly the
+        quantities it would otherwise derive (V1-61).
+
+        ``build_board`` passes ``current_roster_keys=applicable`` and a
+        ``baseline_roster_keys`` that is ``<baseline keys> & applicable``, so
+        the baseline set is a SUBSET of the current set by construction, and
+        therefore ``shared == baseline_roster_keys`` and
+        ``union == current_roster_keys``. Deriving them anyway costs two
+        roster-key-sized set operations per (asset x baseline).
+        """
+        current = {f"L1#{i}" for i in range(1, 41)}
+        for baseline in (
+            set(),  # nothing observed at the baseline
+            {"L1#1"},  # a single overlapping roster
+            {f"L1#{i}" for i in range(1, 41)},  # the whole population
+            {f"L1#{i}" for i in range(1, 33)},  # exactly at the 0.80 bar
+            {f"L1#{i}" for i in range(1, 32)},  # just under it
+        ):
+            holders = {"L1#1", "L1#2", "L1#3"}
+            baseline_holders = {"L1#1", "L1#2"}
+            derived = rp._trend(
+                "4046",
+                current_holders=holders,
+                baseline_holders=baseline_holders,
+                current_roster_keys=current,
+                baseline_roster_keys=baseline,
+            )
+            fast = rp._trend(
+                "4046",
+                current_holders=holders,
+                baseline_holders=baseline_holders,
+                current_roster_keys=current,
+                baseline_roster_keys=baseline,
+                shared=baseline,
+                union_size=len(current),
+            )
+            assert derived == fast, baseline
+
+    def test_board_percentages_survive_the_precomputed_denominators(self, ledger, cohort_of):
+        """The row loop derives ``applicable`` and ``counted`` from
+        per-family precomputes rather than intersecting roster-key-sized
+        sets per asset. The published arithmetic must not move.
+
+        Mixed formats matter here: an IDP player's denominator is narrowed
+        to IDP-fielding leagues while an offense player's is not, so this
+        exercises both the narrowed and the full family sets.
+        """
+        idp_keys = [f"sleeper:idp{i}" for i in range(1, 5)]
+        off_keys = [f"sleeper:off{i}" for i in range(1, 7)]
+        cohort_of(idp_keys + off_keys)
+        rs.record_rosters(
+            [
+                roster(k, f"sleeper:LI{i}", assets=["lb1", "wr1"], fmt=IDP_LEAGUE)
+                for i, k in enumerate(idp_keys)
+            ]
+            + [
+                roster(k, f"sleeper:LO{i}", assets=["wr1"], fmt=OFFENSE_ONLY)
+                for i, k in enumerate(off_keys)
+            ],
+            path=ledger,
+        )
+        payload = board(ledger)
+
+        wr = row_for(payload, "Star Receiver")
+        lb = row_for(payload, "Star Linebacker")
+        # WR: held by all 10, every roster can field him.
+        assert (wr["sharpRosters"], wr["eligibleRosters"]) == (10, 10)
+        assert wr["sharpRosterPct"] == 1.0
+        # LB: held by the 4 IDP rosters, and only those 4 can field him --
+        # the offense-only rosters are correctly out of his denominator.
+        assert (lb["sharpRosters"], lb["eligibleRosters"]) == (4, 4)
+        assert lb["sharpRosterPct"] == 1.0
+
+    def test_a_holding_roster_outside_the_family_still_counts_at_the_baseline(
+        self, ledger, cohort_of
+    ):
+        """The baseline key set is built by distributing the intersection over
+        ``applicable = family_keys | held_rosters``, and BOTH terms are needed.
+
+        A roster that HOLDS an IDP player is inside his denominator even when
+        its captured format says the league fields no IDP — holding him is
+        proof it does. Those rosters are in ``held_rosters`` but NOT in
+        ``family_keys``, so dropping the ``held_rosters`` half of the baseline
+        set silently shrinks ``shared`` and can withhold a trend that is
+        genuinely available. Here 6 IDP + 4 offense-only rosters all hold the
+        linebacker at both endpoints: correct behaviour is overlap 1.0 and an
+        available trend; dropping the term gives 6/10 = 0.60 and withholds it.
+        """
+        idp_keys = [f"sleeper:idp{i}" for i in range(1, 7)]
+        off_keys = [f"sleeper:off{i}" for i in range(1, 5)]
+        cohort_of(idp_keys + off_keys)
+
+        def _rosters(observed):
+            return [
+                roster(k, f"sleeper:LI{i}", assets=["lb1"], fmt=IDP_LEAGUE, observed=observed)
+                for i, k in enumerate(idp_keys)
+            ] + [
+                roster(k, f"sleeper:LO{i}", assets=["lb1"], fmt=OFFENSE_ONLY, observed=observed)
+                for i, k in enumerate(off_keys)
+            ]
+
+        rs.record_rosters(_rosters(NOW - 40 * DAY), path=ledger)
+        rs.record_rosters(_rosters(NOW), path=ledger)
+
+        lb = row_for(board(ledger), "Star Linebacker")
+        # All 10 hold him, so all 10 are in his denominator.
+        assert (lb["sharpRosters"], lb["eligibleRosters"]) == (10, 10)
+        trend = lb["trend"]["thirtyDay"]
+        assert trend["available"] is True, (
+            "the population never moved; a withheld trend means the "
+            "held_rosters half of the baseline key set was dropped"
+        )
+        assert trend["comparableRosters"] == 10
+        assert trend["populationOverlap"] == 1.0


### PR DESCRIPTION
## Why this, and why now

After #1183/#1184/#1185 the profiled `build_board` wall is **57,396 ms
against a 60,000 ms bar — 4.3% headroom**. Meanwhile run-to-run variance
on *unchanged* row-loop code is **+32.1%** (28,593 ms post-#1184 vs
37,781 ms post-#1185; #1185 never touched the row loop). At that margin
the endpoint cannot pass reliably, and it doesn't: the authenticated
consumer still records `TimeoutError` (run `33319262265`, deployed
`51fe43f`).

V1-61 needs **headroom**, not another hidden-path theory. **Nothing here
promotes it — the row stays `IMPLEMENTED_UNVERIFIED`, tally 119/136.**

## The redundancy

The per-asset row loop did ~13 set operations over roster-key-sized sets,
per asset, against ~9,536 rosters on a 2,379-asset board — roughly **295M
element-operations** per build:

| ops | what |
|---|---|
| 1 | `applicable = (denominator_keys \| held_by) & roster_keys` |
| 4 | `baseline_key_sets[name] & applicable` (per baseline) |
| 8 | inside `_trend`: `shared = current & baseline`, `union = current \| baseline` |

**Twelve of the thirteen are redundant.** `build_board` always passes
`current_roster_keys=applicable` and
`baseline_roster_keys=<baseline> & applicable`, so the baseline set is a
**subset of the current set by construction**. Three identities follow:

```
shared  == baseline_roster_keys
union   == current_roster_keys
counted == held_by & roster_keys
```

Verified numerically — **0 counterexamples in 20,000 randomised cases
each** — not merely derived on paper.

## The change

`_trend` gains **optional** precomputed `shared` / `union_size` — the same
pattern `championship_base` uses in `score.py` (#1185). `None` derives them
exactly as before, so ad-hoc and historical callers are unaffected; the hot
path passes them. The loop precomputes per family and per (family,
baseline): `denominators` is keyed by the fixed `POSITION_FAMILIES` tuple,
so that's **~5 and ~20 intersections for the whole board** instead of
~11,900. Remaining per-asset work is `held_by & roster_keys`, O(|held_by|).

The trend dict is now built in an explicit loop before the row rather than
inline, because each baseline needs its keys twice — inline would have
required a walrus inside a keyword argument, which silently depends on
left-to-right argument evaluation and breaks if the arguments are reordered.

## Measured

Real board through `build_board()` against a synthetic ledger at production
shape (~9,400 rosters, 2,379 assets), whole payload diffed against the
pre-change code via `git stash`:

```
before 22.20s  ->  after 10.24s    2.17x    PAYLOAD BYTE-IDENTICAL
```

An isolated benchmark of the trend block alone showed 6.0×. **2.17× on the
whole board is the honest figure** and the one quoted — the isolated number
also skipped materialising `applicable`, which this PR keeps.

## Tests — mutation-verified

* precomputed `shared`/`union_size` match deriving them, across an empty
  baseline, a single overlap, the full population, and **both sides of the
  0.80 overlap bar**.
* **a holding roster outside the family still counts at the baseline** —
  6 IDP + 4 offense-only rosters all holding the linebacker. Dropping the
  `held_rosters` half of the baseline set gives 6/10 = 0.60 and withholds a
  genuinely available trend. Mutation caught.
* `union_size` must be `len(applicable)`, not `len(roster_keys)` — caught by
  the existing IDP intersection guard.
* board percentages survive the per-family precomputes, on mixed formats.

## One thing recorded rather than papered over

Removing `& roster_keys` from `held_rosters` is **not caught by any test**,
and that is *not* a gap: `roster_keys` and `holders` both derive from the
same `filtered` list, so the containment already holds and the intersection
is a no-op. I kept it as a guard against a future change to either
construction, and the code says exactly that rather than implying coverage
it doesn't have.

`tests/sharp/` **341 passed**. `ruff check` clean; `ruff format` leaves only
the pre-existing line-808 hunk already on `main` under CI's ruff version.
`check_planning_integrity.py` OK.

## After this

Projected wall drops meaningfully below the bar, but **the real number must
come from the Lane 4 profiler post-deploy** — and ideally from a run with no
`Bootstrap Sharp Records` crawl in flight, since every measurement today has
been contended.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg)_