### PR TITLE
fix(sharp): restore the championship-base tie invariant broken by #1183 (V1-61)

### DIFF
--- a/src/sharp/score.py
+++ b/src/sharp/score.py
@@ -654,24 +654,35 @@ def score_managers(
     # 162,016,665 isinstance calls, 92% of this function's runtime, at the
     # production population of 12,720 evaluable managers.
     #
-    # Read from `sorted_population`, NOT `population`, and that is
-    # load-bearing rather than incidental. `_performance_component` receives
-    # `sorted_population`, so that is the list it was averaging. The two hold
-    # the same multiset, but floating-point addition is not associative, so
-    # summing them in different orders yields slightly different means -- and
-    # that difference propagates through `_shrunk_rate` into a percentile
-    # lookup, moving real published values. Caught by the before/after
-    # equivalence check at the production population: sourcing this from
-    # `population` moved manager u556's performance component 0.2433 -> 0.2186
-    # and his score 47.4 -> 46.3. Spelled otherwise exactly as
-    # `_performance_component` spelled it, `or 0.08` fallback included.
+    # Read from `population`, NOT `sorted_population`, and that is
+    # load-bearing rather than incidental -- it must reproduce
+    # `build_population`'s own `observed_base` BIT-FOR-BIT.
     #
-    # Note `build_population` derives its own `observed_base` from the raw
-    # `pop["championshipRate"]`; that one has always summed in a different
-    # order than this one and is a separate quantity feeding a different axis.
-    # They are NOT required to be bit-identical, and this change does not
-    # alter either of them.
-    championship_base = _mean(sorted_population.get("championshipRate") or []) or 0.08
+    # `build_population` derives `observed_base = _mean(pop["championshipRate"])`
+    # over the RAW list and uses it to fill `pop["championshipRateShrunk"]`.
+    # `_performance_component` then recomputes THIS SAME MANAGER's shrunk rate
+    # from `base` and looks it up in that population. When the two bases agree
+    # exactly, a manager's recomputed value lands exactly ON its own stored
+    # entry, and `percentile_rank` counts it in the `equal` block, applying the
+    # midpoint rule. That self-consistency is the contract, not a coincidence.
+    #
+    # Averaging `sorted_population` instead holds the same multiset but sums it
+    # in a different order, and float addition is not associative: measured
+    # delta 7.2e-16, one ULP. That is enough to push the recomputed value off
+    # its own tie block -- and `championshipRateShrunk` is extremely tied (44
+    # distinct values across 3,390 entries; largest block 150), so a broken tie
+    # moves the percentile by up to 0.5 * 150 / 3390 = 0.022, not by an ULP.
+    #
+    # Measured against the pre-#1183 baseline at a shuffled 12,000-manager
+    # population: sourcing this from `sorted_population` changed the
+    # `performance` component on 3,390 of 3,390 evaluable managers, `score` on
+    # 3,230 (max delta 0.40), `score_percentile` on 3,102, and flipped
+    # `qualified` on 8 -- i.e. it moved sharp COHORT MEMBERSHIP. Reading
+    # `population` here restores byte-identical output.
+    #
+    # The `or 0.08` fallback matches `build_population`'s own `base_champ`,
+    # so the empty-population case agrees too.
+    championship_base = _mean(population.get("championshipRate") or []) or 0.08
 
     scored: list[ManagerScore] = []
     raw_scores: list[float] = []

--- a/tests/sharp/test_score.py
+++ b/tests/sharp/test_score.py
@@ -343,7 +343,32 @@ class TestChampionshipBaseHoist:
         assert len(hoisted) == len(records)
 
     def test_base_is_derived_from_the_list_the_component_actually_receives(self, monkeypatch):
-        """Prove sorted-population sourcing and the hoist without relying on FP order."""
+        """Prove RAW-population sourcing and the hoist without relying on FP order.
+
+        The base must reproduce ``build_population``'s own ``observed_base``,
+        which is ``_mean`` over the RAW ``pop["championshipRate"]``. That is a
+        bit-for-bit requirement, not a stylistic one: ``build_population`` uses
+        ``observed_base`` to fill ``championshipRateShrunk``, and
+        ``_performance_component`` then recomputes the SAME manager's shrunk
+        rate and looks it up in that population. Equal bases make the manager
+        land exactly on its own stored entry, inside ``percentile_rank``'s
+        ``equal`` block.
+
+        Averaging the sorted list holds the same multiset but sums it in a
+        different order, and float addition is not associative -- one ULP is
+        enough to push the value off its own tie block. ``championshipRateShrunk``
+        is heavily tied (44 distinct values across 3,390 entries, largest block
+        150), so that ULP moves the percentile by up to 0.022, not by an ULP.
+        Measured against the pre-#1183 baseline at 12,000 managers: the sorted
+        sourcing moved ``performance`` on every evaluable manager, ``score`` on
+        3,230 (max 0.40), and flipped ``qualified`` on 8 -- sharp COHORT
+        MEMBERSHIP.
+
+        Sentinels rather than real means, deliberately: whether two summation
+        orders actually differ is interpreter-dependent (CPython 3.12 gave
+        ``sum()`` compensated summation), so a fixture built on that passes on
+        one interpreter and silently fails on another.
+        """
         raw_values = [3.0, 1.0, 2.0]
         sorted_values = [1.0, 2.0, 3.0]
         raw_sentinel = 0.111
@@ -382,13 +407,75 @@ class TestChampionshipBaseHoist:
         S.score_managers(population(40))
 
         assert seen, "no evaluable manager was scored, so nothing was proven"
-        assert set(seen) == {sorted_sentinel}, (
-            "score_managers must derive championship_base from sorted_population "
-            "and pass that hoisted value to every scored manager"
+        assert set(seen) == {raw_sentinel}, (
+            "score_managers must derive championship_base from the RAW population "
+            "-- the same list, in the same order, that build_population averaged "
+            "into observed_base -- and pass that hoisted value to every manager"
         )
-        assert raw_sentinel not in seen
+        assert sorted_sentinel not in seen, (
+            "sourcing the base from sorted_population desynchronizes it from "
+            "observed_base by an ULP and breaks the championshipRateShrunk tie"
+        )
         assert None not in seen, "dropping the hoist must make this guard fail"
         assert mean_calls["championship"] == 1, "championship base must be computed exactly once"
+
+    def test_a_managers_shrunk_rate_lands_on_its_own_population_entry(self, monkeypatch):
+        """The invariant the ULP broke, stated behaviourally rather than by sourcing.
+
+        Every evaluable manager's shrunk championship rate, recomputed inside
+        ``_performance_component`` from the hoisted base, must be an EXACT
+        member of ``championshipRateShrunk`` -- because ``build_population``
+        already computed that very number for that very manager. If it is not,
+        the manager is being percentile-ranked against a population it is not a
+        member of, and ``percentile_rank``'s tie handling silently stops
+        applying to it.
+
+        Deliberately asserts exact membership, not closeness: the whole defect
+        is that a value one ULP away is no longer a tie.
+
+        Coverage, stated rather than implied: this catches a DROPPED hoist
+        (base ``None``) and any structural break between ``build_population``
+        and ``_performance_component``. It does NOT catch the raw-vs-sorted
+        sourcing mutation at this fixture size -- the two summation orders
+        agree bit-for-bit on a 300-manager population, verified by running the
+        mutation against it. ``test_base_is_derived_from_the_list_the_component
+        _actually_receives`` is the mutation guard for the sourcing; this test
+        states the invariant that mutation violates.
+        """
+        records = population(300)
+        cfg = S.load_config()
+        pop = S.build_population(records, cfg)
+
+        seen: list[float | None] = []
+        real_component = S._performance_component
+
+        def component_spy(rec_, population_, cfg_, championship_base=None):
+            seen.append(championship_base)
+            return real_component(rec_, population_, cfg_, championship_base=championship_base)
+
+        monkeypatch.setattr(S, "_performance_component", component_spy)
+        S.score_managers(records)
+        monkeypatch.undo()
+
+        assert seen, "no evaluable manager was scored, so nothing was proven"
+        base = seen[0]
+        assert base is not None, "the hoisted base must reach the component"
+
+        prior_n = float(
+            ((cfg.get("performance") or {}).get("championshipShrinkage") or {}).get("priorN", 6.0)
+        )
+        stored = set(pop["championshipRateShrunk"])
+        assert stored, "fixture produced no evaluable managers"
+
+        for rec in records:
+            if S.check_eligibility(rec, cfg):
+                continue
+            shrunk = S._shrunk_rate(rec.championships, rec.completed_seasons, base, prior_n)
+            assert shrunk in stored, (
+                f"{rec.user_id}: recomputed shrunk rate {shrunk!r} is not an exact "
+                "member of championshipRateShrunk, so this manager no longer ties "
+                "with itself in the percentile lookup"
+            )
 
     def test_an_empty_population_still_falls_back_to_the_prior(self):
         cfg = S.load_config()


### PR DESCRIPTION
A real scoring regression, introduced by my own #1183 and found by the V1-61 false-green hunt rather than by anything failing. **It is live in production right now.**

## What broke

`build_population` derives `observed_base = _mean(pop["championshipRate"])` over the **raw** list and uses it to fill `pop["championshipRateShrunk"]`. `_performance_component` then recomputes *this same manager's* shrunk rate from `base` and looks that value up in that same population. When the two bases agree exactly, the manager lands exactly **on its own stored entry** and `percentile_rank` counts it in the `equal` block, applying the midpoint rule. That self-consistency is the contract, not a coincidence.

#1183 threaded `sorted_population` into the component, so `base` became a mean over the same multiset summed in a different order. Float addition is not associative: measured delta **7.2e-16**, one ULP. #1185 then hoisted the value and faithfully preserved the wrong source.

## Why one ULP is not an ULP-sized problem

`championshipRateShrunk` is heavily tied — **44 distinct values across 3,390 entries**, largest block 150. One ULP pushes the recomputed value off its own tie block entirely, moving the percentile by up to `0.5 × 150 / 3390 = 0.022`.

## Measured

Against the pre-#1183 baseline (`56a9be9`) at a shuffled 12,000-manager population, both trees run through the same harness:

| field | rows changed |
|---|---|
| `components` | 3,390 of 3,390 evaluable managers (**100%**) |
| `score` | 3,230 (max Δ 0.40) |
| `score_percentile` | 3,102 (max Δ 0.008) |
| **`qualified`** | **8 flipped — sharp cohort membership moved** |

The qualification flips are the serious half: the cohort is what `/api/sharp/roster-percentage` publishes. Production served `cohortManagers=2396` / `eligibleRosters=9529` on 2026-08-30 against a prior expectation of ~2,397 / ~9,536.

## The fix

Average `population`, not `sorted_population` — the same list, in the same order, that `build_population` averaged into `observed_base`. The `or 0.08` fallback already matches `build_population`'s own `base_champ`, so the empty-population case agrees too.

The percentile **lookups** keep using `sorted_population` and `_percentile_rank_sorted`; those are exact equivalences and are untouched.

- **Byte-identical** to the pre-#1183 baseline at N=3,000 / 12,000 / 45,000, shuffled populations, whole `score_managers` output compared field by field with floats rendered via `repr` so nothing is hidden by formatting.
- **Performance fully preserved**: `score_managers` at N=45,000 is **138.99s** on the pre-#1183 baseline and **1.11s** here (125×).

## Tests

The existing sentinel test asserted `{sorted_sentinel}` — it **pinned the regression as intended behaviour**, which is why nothing caught this. Flipped to `{raw_sentinel}` with the rationale recorded. Sentinels rather than real means remain the right shape: whether two summation orders actually differ is interpreter-dependent (CPython 3.12 gave `sum()` compensated summation).

Added `test_a_managers_shrunk_rate_lands_on_its_own_population_entry`, which states the invariant behaviourally — every evaluable manager's recomputed shrunk rate must be an **exact** member of `championshipRateShrunk`.

Mutations, both run:

| mutation | result |
|---|---|
| MUT1 — restore `sorted_population` | sentinel test fails (`{0.222} != {0.111}`) |
| MUT2 — drop the hoist | both tests fail |

MUT1 is **not** caught by the behavioural test at its 300-manager fixture: the two summation orders agree bit-for-bit there. That is recorded in its docstring rather than left to be discovered — it covers a dropped hoist and structural breaks; the sentinel test is the mutation guard for the sourcing.

`tests/sharp/` 342 passed. `ruff` clean. `check_planning_integrity.py` clean.

## Does NOT promote V1-61

The endpoint now answers inside its 60s bar — `V61A` **pass**, run [33330872852](https://github.com/jasonleetucker-code/riskittogetthebrisket/actions/runs/33330872852), `cohortCoveragePct=0.7604` — but that evidence rests on a board this regression was moving. The row stays `IMPLEMENTED_UNVERIFIED` and the tally stays **119/136** until it is re-measured on a repaired board.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg)_