### PR TITLE
ci(v1-45): make the browser lane's evidence legible and its verdict binding

### DIFF
--- a/.github/workflows/v1-authenticated-verification.yml
+++ b/.github/workflows/v1-authenticated-verification.yml
@@ -289,18 +289,31 @@ jobs:
           REMOTE
           echo "Audit: pass ${PASS_ID} minted and revoked within this run."
 
-      - name: Fail the job on API/lane4 verdicts
-        if: ${{ inputs.suite != 'browser' }}
+      - name: Fail the job on API/lane4/browser verdicts
         shell: bash
         env:
           API_EXIT: ${{ steps.api.outputs.api_exit }}
           LANE4_EXIT: ${{ steps.lane4.outputs.lane4_exit }}
+          BROWSER_EXIT: ${{ steps.browser.outputs.browser_exit }}
         run: |
           set -Eeuo pipefail
-          echo "api=$API_EXIT lane4=$LANE4_EXIT (0 pass · 2 fail · 3 proved nothing)"
+          echo "api=$API_EXIT lane4=$LANE4_EXIT browser=$BROWSER_EXIT (0 pass · 2 fail · 3 proved nothing)"
           # Exit 3 is recorded but does not fail the job: an evidence-free
           # check must be visible, and a red job hides which one happened.
-          for code in "$API_EXIT" "$LANE4_EXIT"; do
+          #
+          # The browser code is consumed HERE rather than by a second step,
+          # so there is one verdict owner. It used to be captured into
+          # `browser_exit` and read by nothing, while this step carried
+          # `if: inputs.suite != 'browser'` — so on a browser run the job's
+          # conclusion was structurally independent of whether the Playwright
+          # specs passed, and a failing browser suite reported success. That
+          # is the same class as a gate that cannot find its input and
+          # therefore reads exactly like a gate that passed.
+          #
+          # A skipped suite leaves its output empty, which the case below
+          # ignores: absent is not a verdict, and must not read as either a
+          # pass or a failure.
+          for code in "$API_EXIT" "$LANE4_EXIT" "$BROWSER_EXIT"; do
             case "$code" in
               1|2) echo "::error title=V1 authenticated::a suite reported exit $code"; exit "$code" ;;
             esac
@@ -315,6 +328,7 @@ jobs:
             v1-auth-report.json
             lane4-remote.txt
             prod-auth-browser.txt
+            tests/e2e/prod-auth-results.json
             tests/e2e/test-results-prod-auth/
           if-no-files-found: warn
           retention-days: 30

--- a/config/ci/release_gate_classification.json
+++ b/config/ci/release_gate_classification.json
@@ -722,7 +722,7 @@
     "v1-authenticated-verification.yml::v1-authenticated::Configure production SSH": {
       "category": "blocking"
     },
-    "v1-authenticated-verification.yml::v1-authenticated::Fail the job on API/lane4 verdicts": {
+    "v1-authenticated-verification.yml::v1-authenticated::Fail the job on API/lane4/browser verdicts": {
       "category": "blocking"
     },
     "v1-authenticated-verification.yml::v1-authenticated::Lane 4 remote verification (C1-C3 + C8/C9)": {

--- a/tests/e2e/prod-auth.config.js
+++ b/tests/e2e/prod-auth.config.js
@@ -88,6 +88,24 @@ module.exports = defineConfig({
   reporter: [
     ["list"],
     ["html", { open: "never", outputFolder: "playwright-report-prod-auth" }],
+    // The JSON report is the EVIDENCE artifact, not a convenience.
+    //
+    // Specs record which branch of a multi-state render actually ran by
+    // pushing onto `testInfo.annotations` (helpers.js::annotate) — e.g.
+    // V1-45's `states-observed: finalRosterSimulation: populated`. Those
+    // annotations exist only in a structured report: the `list` reporter
+    // prints pass/fail lines and drops them, and the `html` folder is not
+    // uploaded. Without this, a green tick proves the spec passed but not
+    // WHICH state production produced — and V1-45's L4 bar is a statement
+    // about the observed state, so the run could not answer its own
+    // question. Inferring the branch from a pass would be exactly the
+    // "infer rather than read" error this lane exists to prevent.
+    //
+    // Absolute path via `__dirname`: Playwright resolves a reporter's
+    // relative `outputFile` against the cwd, which is the repo root here
+    // and NOT where `outputDir` above lands (that one is config-relative).
+    // Pinning it removes the discrepancy rather than depending on it.
+    ["json", { outputFile: path.join(__dirname, "prod-auth-results.json") }],
   ],
   use: {
     // Deliberately NO baseURL: every navigation and API call builds its

--- a/tests/ops/test_v1_verification_primitives.py
+++ b/tests/ops/test_v1_verification_primitives.py
@@ -12,6 +12,7 @@ import re
 from pathlib import Path
 
 import pytest
+import yaml
 
 import scripts.verify_v1_authenticated as auth
 import scripts.verify_v1_onbox as onbox
@@ -313,6 +314,70 @@ def test_workflow_declares_read_only_posture():
     # to say the workflow does not use it — so scan non-comment lines).
     code_lines = [ln for ln in wf.splitlines() if not ln.lstrip().startswith("#")]
     assert not any("E2E_TEST_MODE" in ln for ln in code_lines)
+
+
+def test_every_suite_verdict_is_consumed_by_the_one_verdict_step():
+    """A captured exit code that nothing reads is not a gate.
+
+    `browser_exit` used to be written to $GITHUB_OUTPUT and consumed by
+    nothing, while the verdict step carried `if: inputs.suite != 'browser'`.
+    On a browser run the job's conclusion was therefore structurally
+    independent of whether the Playwright specs passed: a failing browser
+    suite reported success. Same class as a gate that cannot find its input
+    and so reads exactly like a gate that passed.
+
+    Pins the property rather than the wording: every `*_exit` a step
+    publishes must reach the verdict step's environment, and that step must
+    not be conditioned away for any suite.
+    """
+    wf_path = REPO_ROOT / ".github" / "workflows" / "v1-authenticated-verification.yml"
+    wf = yaml.safe_load(wf_path.read_text())
+    steps = wf["jobs"]["v1-authenticated"]["steps"]
+
+    published = set()
+    for step in steps:
+        for name in re.findall(r"(\w+_exit)=", step.get("run") or ""):
+            published.add(name)
+    assert published, "no suite publishes an exit code — the scan is vacuous"
+
+    verdict = [s for s in steps if "verdict" in (s.get("name") or "").lower()]
+    assert len(verdict) == 1, f"expected exactly one verdict owner, found {len(verdict)}"
+    verdict = verdict[0]
+
+    # It must not be skipped for any suite: a conditioned-away verdict is
+    # what produced the defect.
+    assert verdict.get("if") is None, (
+        f"the verdict step is conditional ({verdict.get('if')!r}); a suite it "
+        "skips for has no binding verdict"
+    )
+
+    consumed = " ".join((verdict.get("env") or {}).values())
+    body = verdict.get("run") or ""
+    for name in sorted(published):
+        assert name in consumed, f"{name} is published but never reaches the verdict step"
+        var = name.upper()
+        assert (
+            f"${{{var}}}" in body or f'"${var}"' in body
+        ), f"{name} reaches the verdict step's env but its body never reads ${var}"
+
+
+def test_prod_auth_config_reports_annotations_as_evidence():
+    """`states-observed` must survive the run.
+
+    Specs record which branch of a multi-state render actually ran by
+    pushing onto `testInfo.annotations`. The `list` reporter drops them and
+    the html folder is not uploaded, so without a structured report a green
+    tick proves a spec passed but not WHICH state production produced —
+    which is precisely what V1-45's L4 bar asks.
+    """
+    cfg = (REPO_ROOT / "tests" / "e2e" / "prod-auth.config.js").read_text()
+    assert '["json"' in cfg, "no json reporter: annotations never leave the runner"
+    assert "prod-auth-results.json" in cfg
+
+    wf = (REPO_ROOT / ".github" / "workflows" / "v1-authenticated-verification.yml").read_text()
+    assert (
+        "tests/e2e/prod-auth-results.json" in wf
+    ), "the json report is produced but never uploaded"
 
 
 def test_onbox_workflow_gates_the_only_write_behind_a_flag():


### PR DESCRIPTION
Two defects in the authenticated-verification lane, found while gathering V1-45's L4 evidence. Neither touches product behaviour, auth, or the scoring-identity gate; both make the lane **stricter**.

Promotes no V1 row — the tally stays **120/136**.

## 1. The verdict was not binding on a browser run

"Fail the job on API/lane4 verdicts" carried `if: inputs.suite != 'browser'`, while the browser step wrote `browser_exit` to `$GITHUB_OUTPUT` and **nothing ever read it**. So on `suite=browser` the job's conclusion was structurally independent of whether the Playwright specs passed: **a failing browser suite reported success.**

Measured on run [`33388205681`](https://github.com/jasonleetucker-code/riskittogetthebrisket/actions/runs/33388205681): conclusion `success`, verdict step `skipped`. That run did pass on the merits — confirmed by reading the actual test output — but the gate could not have told us either way. Same class as a gate that cannot find its input and therefore reads exactly like a gate that passed (CLAUDE.md, Stabilization 2026-08-16).

Fixed by consuming `browser_exit` in the **existing** verdict step rather than adding a second one, so there stays one verdict owner. The `if:` is gone; a skipped suite leaves its output empty and the `case` ignores it, because absent is not a verdict and must read as neither pass nor failure. Exit 3 still does not fail the job, unchanged.

Verified across all five shapes:

| api / lane4 / browser | job exit |
|---|---|
| `0` / `3` / *(empty)* — api-only | 0 |
| *(empty)* / *(empty)* / `0` — browser passed | 0 |
| *(empty)* / *(empty)* / `1` — **browser failed** | **1** (previously 0) |
| *(empty)* / *(empty)* / `2` | 2 |
| `2` / `0` / `0` — suite=all, api fails | 2 |

## 2. The observed state was not recorded

Specs record which branch of a multi-state render actually ran by pushing onto `testInfo.annotations` (`helpers.js::annotate`) — V1-45's `states-observed: finalRosterSimulation: <branch>`. But `prod-auth.config.js` configured only `list` + `html` reporters; the workflow uploads the list stdout plus `tests/e2e/test-results-prod-auth/`, which is **empty on a passing run** (trace/screenshot/video are all `retain-on-failure`), and the html folder is never uploaded.

So the annotations were produced and discarded: that run's artifact is **1,081 bytes** and cannot say which branch rendered.

That matters because V1-45's L4 bar is a statement about the *observed state*, and the spec passes in **any** branch — so a green tick is not evidence for the `populated` state. Inferring the branch from a pass would be the "infer rather than read" error this lane exists to prevent.

Fixed with a `json` reporter whose output is uploaded. **Proven end-to-end rather than assumed**: a throwaway spec calling the same `annotate()` shape produced

```json
[{"type": "states-observed", "description": "finalRosterSimulation: populated"}]
```

in the JSON report. The `outputFile` is pinned via `path.join(__dirname, …)` because Playwright resolves a reporter's relative `outputFile` against the **cwd** (the repo root here) and *not* where the config-relative `outputDir` lands.

## Guards — all three mutation-verified

| mutation | result |
|---|---|
| **MUT-A** restore `if: inputs.suite != 'browser'` on the verdict step | RED |
| **MUT-B** drop `BROWSER_EXIT` from the verdict env | RED — *"browser_exit is published but never reaches the verdict step"* |
| **MUT-C** remove the json reporter | RED — *"annotations never leave the runner"* |

The verdict guard pins the **property**, not the wording: every `*_exit` a step publishes must reach the one verdict step's env and be read by its body, and that step must not be conditioned away for any suite.

## Validation

The step rename is mirrored in `config/ci/release_gate_classification.json` (still `blocking`), which keys on the step name — V1-121's manifest gate catches that.

`tests/deploy/` + `tests/ops/` — **549 passed, 4 skipped**. `ruff format --check .` / `ruff check .` clean repo-wide (1,360 files). `check_planning_integrity.py` clean.

V1-45 stays `IMPLEMENTED_UNVERIFIED` until a re-run records its `states-observed` annotation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg)_