### PR TITLE
test(v1-45): record the capacity arithmetic, not just its verdict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,11 @@ tests/e2e/test-results/
 # own artifact dirs so a prod run never clobbers the default suite's.
 tests/e2e/playwright-report-prod-auth/
 tests/e2e/test-results-prod-auth/
+# The json reporter's output (#1194): the run's EVIDENCE, uploaded as a CI
+# artifact and read there. It is a per-run product, never a tracked file —
+# committing one would put a stale set of `states-observed` annotations in
+# the tree beside the live spec.
+tests/e2e/prod-auth-results.json
 tests/e2e/tests/
 test-results/
 

--- a/tests/e2e/specs/prod-auth/v1-45-trade-surface.spec.js
+++ b/tests/e2e/specs/prod-auth/v1-45-trade-surface.spec.js
@@ -245,6 +245,45 @@ test.describe("V1-45: /trade renders finalRosterSimulation from the page's own s
       `finalRosterSimulation keys: ${Object.keys(frs).join(",")} · ` +
         `rosterCapacity.requiresDrops=${rc ? rc.requiresDrops : "absent"}`,
     );
+    // The capacity ARITHMETIC, recorded unconditionally.
+    //
+    // `requiresDrops` alone cannot be reconciled against the roster this
+    // spec deliberately picked. Run 33397534205 annotated an at-cap
+    // receiving team (Ed, 58 of a 58 limit) taking a net +1 trade — the
+    // forced-release path this spec's own side-B comment says it is
+    // building — and the response still stamped `requiresDrops=false`.
+    // Whether that is correct is unknowable from the artifact, because the
+    // counts the backend actually used were never recorded: they are
+    // asserted only inside the `requiresDrops === true` branch, which did
+    // not fire.
+    //
+    // The two candidate explanations differ by exactly these fields. If
+    // `sizeBefore` is 58 the verdict contradicts its own inputs; if it is
+    // smaller, the backend is counting a different roster than
+    // `contract.sleeper.teams[].players` and the verdict is right. Missing
+    // is never zero, and an unreadable verdict must not read as a passing
+    // one, so the numbers are published either way.
+    annotate(
+      testInfo,
+      "capacity-arithmetic",
+      rc
+        ? `rosterLimit=${rc.rosterLimit} sizeBefore=${rc.sizeBefore} ` +
+          `sizeAfter=${rc.sizeAfter} openSpotsBefore=${rc.openSpotsBefore} ` +
+          `overLimitAfter=${rc.overLimitAfter} certainty=${rc.certainty} ` +
+          `requiresDrops=${rc.requiresDrops} ` +
+          `forcedDrops=${(rc.forcedDrops || []).length}`
+        : "rosterCapacity absent from the response",
+    );
+    // Contract-side counts for the same team, so the two sources of "how
+    // big is this roster" can be compared directly rather than inferred.
+    annotate(
+      testInfo,
+      "capacity-arithmetic",
+      `contract-side: ${myTeam.name} players=${(myTeam.players || []).length} ` +
+        `contractRosterLimit=${rosterLimit} ` +
+        `out=${1} in=${receiveNames.length} ` +
+        `expectedSizeAfter=${(myTeam.players || []).length - 1 + receiveNames.length}`,
+    );
 
     const panel = page
       .locator(".ds-panel")


### PR DESCRIPTION
Run [`33397534205`](https://github.com/jasonleetucker-code/riskittogetthebrisket/actions/runs/33397534205) produced V1-45's first **readable** production evidence — #1194's json reporter carried the annotations into the artifact (8,320 bytes, up from 1,081), and the spec recorded:

```json
{ "type": "states-observed", "description": "finalRosterSimulation: populated" }
```

It also recorded something that does not reconcile, and the artifact cannot settle it. **So I am not promoting V1-45 on this run.**

## What the run said

```
league          dynasty_main rosterLimit=58
receiving-team  Ed (58 players, atCap=true)
trade           give [Colby Parkinson] · receive [Barrett Carter, Kyler Murray] from Jason
response-shape  rosterCapacity.requiresDrops=false
```

The spec asserts the request body — `teamName`, `playersOut`, `playersIn` — and those assertions passed, so the simulate really was for Ed with one out and two in. This spec's own side-B comment states what it is building: *"Net +1 player to an at-cap roster → the forced-release path."*

**58 − 1 + 2 = 59 against a 58 limit, and the verdict was `false`.**

## Why this is V1-45's concern, not a neighbouring row's

`trade_simulator.py` builds `finalRosterSimulation` through `simulate_final_legal_roster` **only when `requires_drops` is not `None`** — so the `populated` block this run observed was computed with **no cleanup applied**. If a release is genuinely required, the rendered "final roster" is a 59-man legal roster. That would make the render untruthful, which is exactly V1-45's bar.

## Why the spec could not catch it — and why that's the right design

The spec asserts the **render matches the response**, and says so: *"the assertions below follow what the backend actually stamps rather than assuming the forced-release branch."* A wrong verdict renders consistently and passes. That is correct for a render spec; it just means the verdict's **inputs** have to be legible somewhere.

They weren't. `rosterCapacity` publishes `rosterLimit`, `sizeBefore`, `sizeAfter`, `openSpotsBefore`, `overLimitAfter` and `certainty`, but the spec annotated only `requiresDrops` and asserted the counts inside the `requiresDrops === true` branch — which did not fire.

## What this changes

Records the arithmetic unconditionally, from both sides:

- the response's own `rosterLimit` / `sizeBefore` / `sizeAfter` / `openSpotsBefore` / `overLimitAfter` / `certainty` / `requiresDrops` / `forcedDrops.length`
- the **contract-side** counts for the same team, so "how big is this roster" can be *compared* across its two sources rather than inferred

The two candidate explanations differ by exactly these fields:

| if | then |
|---|---|
| `sizeBefore == 58` | the verdict contradicts its own inputs — a real defect to fix |
| `sizeBefore < 58` | the backend counts a different roster than `contract.sleeper.teams[].players`, the verdict is right, and the contradiction was mine |

**Annotations only** — no assertion added, no threshold, no product code, no change to what the spec passes or fails on. Evidence legibility, same class as #1194's json reporter: an unreadable verdict must not read as a passing one.

`node --check` clean. Still collected by the prod-auth config only (2 projects) and still ignored by the default config (0 matches), so the default suite's size is unchanged.

## Tally

Promotes no V1 row. **V1-45 stays `IMPLEMENTED_UNVERIFIED`, 120/136.** Its populated-state observation is real, but it was taken on a response whose capacity verdict is unexplained — and promoting on evidence that cannot be fully read is the failure mode this lane exists to prevent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg)_