### PR TITLE
test(v1-45): make roster-source divergence legible

### DIFF
--- a/tests/e2e/specs/prod-auth/v1-45-roster-source.spec.js
+++ b/tests/e2e/specs/prod-auth/v1-45-roster-source.spec.js
@@ -1,0 +1,95 @@
+/**
+ * V1-45 evidence-only follow-up.
+ *
+ * The production render proof found a receiving team whose contract-side
+ * `players.length` was 58 while the canonical roster-capacity response used
+ * `sizeBefore=57`. This spec does not choose a verdict or change product
+ * behaviour. It makes the two contract-side identity populations legible so
+ * the already-set evidence rule can distinguish an empty display-name entry
+ * from an unresolved real roster asset.
+ */
+const {
+  test,
+  expect,
+  getJson,
+  annotate,
+  desktopOnly,
+} = require("./helpers");
+
+function nonblank(value) {
+  return String(value ?? "").trim().length > 0;
+}
+
+test.describe("V1-45: roster source reconciliation", () => {
+  test("contract publishes enough identity evidence to explain roster-capacity sizeBefore", async ({
+    prodPage: page,
+  }, testInfo) => {
+    desktopOnly(test, testInfo);
+
+    const { status, body: contract } = await getJson(page, "/api/data?view=app");
+    expect(status, "/api/data must serve the authenticated session").toBe(200);
+
+    const teams = contract?.sleeper?.teams || [];
+    expect(teams.length, "contract carries no Sleeper teams").toBeGreaterThan(0);
+
+    const { body: leaguesBody } = await getJson(page, "/api/leagues");
+    const leagueList = Array.isArray(leaguesBody)
+      ? leaguesBody
+      : leaguesBody?.leagues || [];
+    const contractLeagueKey = contract?.meta?.leagueKey || contract?.leagueKey || null;
+    const leagueEntry =
+      leagueList.find((l) => l?.key === contractLeagueKey) || leagueList[0] || null;
+    const rosterLimit = Number(leagueEntry?.rosterSettings?.rosterSize) || null;
+
+    // Match the production trade-surface spec's receiving-team selection,
+    // deliberately using raw `players.length`. We are explaining that exact
+    // population rather than selecting a friendlier one after seeing data.
+    const bySizeDesc = [...teams].sort(
+      (a, b) => (b.players || []).length - (a.players || []).length,
+    );
+    const team =
+      bySizeDesc.find(
+        (t) => rosterLimit != null && (t.players || []).length >= rosterLimit,
+      ) || bySizeDesc[0];
+
+    const players = Array.isArray(team?.players) ? team.players : [];
+    const playerIds = Array.isArray(team?.playerIds) ? team.playerIds : [];
+    const blankNameIndexes = players
+      .map((value, index) => ({ value, index }))
+      .filter(({ value }) => !nonblank(value))
+      .map(({ index }) => index);
+    const blankIdIndexes = playerIds
+      .map((value, index) => ({ value, index }))
+      .filter(({ value }) => !nonblank(value))
+      .map(({ index }) => index);
+    const idsPresentAtBlankNameIndexes = blankNameIndexes.filter(
+      (index) => index < playerIds.length && nonblank(playerIds[index]),
+    );
+
+    annotate(testInfo, "league", `${contractLeagueKey} rosterLimit=${rosterLimit}`);
+    annotate(testInfo, "receiving-team", `${team?.name || "unknown"}`);
+    annotate(
+      testInfo,
+      "roster-source",
+      `players raw=${players.length} nonblank=${players.filter(nonblank).length} ` +
+        `blankIndexes=[${blankNameIndexes.join(",")}]`,
+    );
+    annotate(
+      testInfo,
+      "roster-source",
+      `playerIds raw=${playerIds.length} nonblank=${playerIds.filter(nonblank).length} ` +
+        `blankIndexes=[${blankIdIndexes.join(",")}]`,
+    );
+    annotate(
+      testInfo,
+      "roster-source",
+      `idsPresentAtBlankNameIndexes=[${idsPresentAtBlankNameIndexes.join(",")}]`,
+    );
+
+    // Evidence-only assertions: arrays and selected team must be real. Do not
+    // assert which of the competing explanations is true; that would bake the
+    // answer into the instrument before production supplies it.
+    expect(team, "no receiving team resolved").toBeTruthy();
+    expect(players.length, "selected team has no raw player population").toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Why

Fresh authenticated production browser run `33405403953` on current `main` produced the decisive V1-45 Case-B shape:

- contract-side selected team: 58 players, roster limit 58
- canonical roster-capacity response: `sizeBefore=57`, `sizeAfter=58`, `requiresDrops=false`
- populated `finalRosterSimulation` rendered successfully on the real `/trade` surface

That clears the apparent capacity-arithmetic contradiction, but it does **not** yet make V1-45 promotable: the one-player population difference must be reconciled truthfully first.

## What this PR does

Adds one production-auth **evidence-only** spec that uses the exact receiving-team selection rule already used by `v1-45-trade-surface.spec.js` and records, without choosing an answer:

- raw vs nonblank `players` counts
- raw vs nonblank `playerIds` counts
- blank indexes in each population
- whether a nonblank stable player ID exists at any blank display-name index

This directly distinguishes the two important possibilities:

1. a blank display name still has a stable ID → an unresolved real roster asset may be getting omitted from capacity, which would violate the canonical owner's explicit invariant that unresolved players still occupy a spot;
2. no real ID backs the extra raw entry → the raw `players.length` evidence was counting a placeholder/artifact rather than a roster asset.

It deliberately **does not assert which explanation is true**. Baking the expected production answer into the instrument would be a false-green risk.

## Scope

- no product code
- no auth changes
- no roster-capacity changes
- no identity changes
- no methodology/threshold changes
- no V1 status change
- no denominator change

This PR promotes no row by itself. V1 remains 120/136 until the production artifact is read and the source difference is reconciled.