### PR TITLE
Add Best Available IDPs waiver card (IDPTC + The IDP Show, 50/50)

### DIFF
--- a/frontend/__tests__/components/best-available-idp.test.jsx
+++ b/frontend/__tests__/components/best-available-idp.test.jsx
@@ -1,0 +1,173 @@
+/**
+ * BestAvailableIdps — the "Best available IDPs" waivers card.
+ *
+ * Display-only component: every score arrives pre-computed from
+ * ``POST /api/waiver/best-available-idp`` (src/trade/waiver_idp_best_available.py).
+ * ``useBestAvailableIdp`` is mocked directly here (it's a thin fetch
+ * wrapper, already mirrored on the well-tested ``useWaiverAnalysis``
+ * bid-fetch pattern) so these tests focus on rendering: degraded
+ * states, tier labeling, truthful counts, and the mobile-safe table
+ * structure DataTable already guarantees.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const mockUseBestAvailableIdp = vi.fn();
+vi.mock("@/components/useBestAvailableIdp", () => ({
+  useBestAvailableIdp: (...args) => mockUseBestAvailableIdp(...args),
+}));
+
+import BestAvailableIdps from "@/components/waivers/BestAvailableIdps";
+
+function candidate(overrides = {}) {
+  return {
+    name: "Test Player",
+    team: "XX",
+    position: "LB",
+    tier: "A",
+    combinedScore: 75.0,
+    sourcesUsed: 2,
+    idpTradeCalc: { rank: 5, rawValue: 8000, score: 80.0 },
+    idpShowCombined: { rank: 6, rawRank: 6, score: 70.0 },
+    ...overrides,
+  };
+}
+
+describe("BestAvailableIdps — visibility", () => {
+  it("renders nothing when the league doesn't have IDP enabled", () => {
+    mockUseBestAvailableIdp.mockReturnValue({ payload: null, loading: false });
+    const { container } = render(
+      <BestAvailableIdps leagueKey="main" idpEnabled={false} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("BestAvailableIdps — Tier B labeling", () => {
+  it("marks a one-source candidate '1 of 2 sources'", () => {
+    mockUseBestAvailableIdp.mockReturnValue({
+      payload: {
+        ownershipResolved: true,
+        candidates: [candidate({ tier: "B", sourcesUsed: 1, idpShowCombined: { rank: null, rawRank: null, score: null } })],
+        availableCount: 1,
+        sources: { idpTradeCalc: { populationSize: 10 }, idpShowCombined: { populationSize: 10 } },
+        degraded: { ownershipUnresolved: false, missingSources: [] },
+        sourceFreshness: {},
+      },
+      loading: false,
+    });
+    render(<BestAvailableIdps leagueKey="main" idpEnabled />);
+    expect(screen.getByText("1 of 2 sources")).toBeInTheDocument();
+  });
+
+  it("does not label a two-source candidate", () => {
+    mockUseBestAvailableIdp.mockReturnValue({
+      payload: {
+        ownershipResolved: true,
+        candidates: [candidate({ tier: "A" })],
+        availableCount: 1,
+        sources: { idpTradeCalc: { populationSize: 10 }, idpShowCombined: { populationSize: 10 } },
+        degraded: { ownershipUnresolved: false, missingSources: [] },
+        sourceFreshness: {},
+      },
+      loading: false,
+    });
+    render(<BestAvailableIdps leagueKey="main" idpEnabled />);
+    expect(screen.queryByText("1 of 2 sources")).not.toBeInTheDocument();
+  });
+});
+
+describe("BestAvailableIdps — degraded states", () => {
+  it("shows 'Availability unavailable' when ownership can't be resolved", () => {
+    mockUseBestAvailableIdp.mockReturnValue({
+      payload: {
+        ownershipResolved: false,
+        candidates: [],
+        availableCount: 0,
+        sources: { idpTradeCalc: { populationSize: 0 }, idpShowCombined: { populationSize: 0 } },
+        degraded: { ownershipUnresolved: true, missingSources: [] },
+        sourceFreshness: {},
+      },
+      loading: false,
+    });
+    const { container } = render(<BestAvailableIdps leagueKey="main" idpEnabled />);
+    expect(container.textContent).toContain("Availability unavailable");
+    // No fabricated table when ownership is unresolved.
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("names the missing source rather than silently presenting a one-source combined score", () => {
+    mockUseBestAvailableIdp.mockReturnValue({
+      payload: {
+        ownershipResolved: true,
+        candidates: [candidate({ tier: "B" })],
+        availableCount: 1,
+        sources: { idpTradeCalc: { populationSize: 10 }, idpShowCombined: { populationSize: 0 } },
+        degraded: { ownershipUnresolved: false, missingSources: ["idpShowCombined"] },
+        sourceFreshness: {},
+      },
+      loading: false,
+    });
+    const { container } = render(<BestAvailableIdps leagueKey="main" idpEnabled />);
+    expect(screen.getByText("A source is missing")).toBeInTheDocument();
+    expect(container.textContent).toContain("The IDP Show data is currently unavailable");
+  });
+
+  it("states the true count when fewer than 20 candidates qualify, without padding rows", () => {
+    mockUseBestAvailableIdp.mockReturnValue({
+      payload: {
+        ownershipResolved: true,
+        candidates: [candidate({ name: "Only One" })],
+        availableCount: 1,
+        sources: { idpTradeCalc: { populationSize: 1 }, idpShowCombined: { populationSize: 1 } },
+        degraded: { ownershipUnresolved: false, missingSources: [] },
+        sourceFreshness: {},
+      },
+      loading: false,
+    });
+    render(<BestAvailableIdps leagueKey="main" idpEnabled />);
+    expect(screen.getByText(/Showing all 1 available IDP free agent/)).toBeInTheDocument();
+    expect(screen.getAllByText("Only One")).toHaveLength(1);
+  });
+
+  it("renders a loading state before the payload arrives", () => {
+    mockUseBestAvailableIdp.mockReturnValue({ payload: null, loading: true });
+    const { container } = render(<BestAvailableIdps leagueKey="main" idpEnabled />);
+    // A skeleton, not an empty state and not a crash.
+    expect(container.querySelector("[aria-hidden='true']")).toBeTruthy();
+    expect(screen.queryByText("Availability unavailable")).not.toBeInTheDocument();
+  });
+
+  it("shows an unavailable state when the fetch failed outright (no payload, not loading)", () => {
+    mockUseBestAvailableIdp.mockReturnValue({ payload: null, loading: false });
+    const { container } = render(<BestAvailableIdps leagueKey="main" idpEnabled />);
+    expect(container.textContent).toContain("Service unavailable");
+    expect(container.textContent).toContain(
+      "Couldn't reach the IDP Trade Calculator / The IDP Show comparison right now.",
+    );
+  });
+});
+
+describe("BestAvailableIdps — mobile-safe table structure", () => {
+  it("wraps the table in DataTable's built-in horizontal-scroll container, never a bare table", () => {
+    mockUseBestAvailableIdp.mockReturnValue({
+      payload: {
+        ownershipResolved: true,
+        candidates: [candidate()],
+        availableCount: 1,
+        sources: { idpTradeCalc: { populationSize: 10 }, idpShowCombined: { populationSize: 10 } },
+        degraded: { ownershipUnresolved: false, missingSources: [] },
+        sourceFreshness: {},
+      },
+      loading: false,
+    });
+    const { container } = render(<BestAvailableIdps leagueKey="main" idpEnabled />);
+    // DataTable's ``.ds-table-wrap`` is the horizontal-scroll boundary —
+    // its presence is what keeps a wide row set from forcing the PAGE
+    // to scroll horizontally at narrow widths (jsdom does not compute
+    // real layout, so this is a structural guard; true pixel-level
+    // overflow at ~390px is confirmed manually per the plan's
+    // verification checklist).
+    expect(container.querySelector(".ds-table-wrap")).toBeTruthy();
+  });
+});

--- a/frontend/app/api/waiver/best-available-idp/route.js
+++ b/frontend/app/api/waiver/best-available-idp/route.js
@@ -1,0 +1,53 @@
+// Dev bridge for POST /api/waiver/best-available-idp.
+//
+// Mirrors frontend/app/api/waiver/suggestions/route.js exactly — in
+// production nginx routes /api/* straight to FastAPI and this file is
+// never reached; it exists so `npm run dev` works without a reverse
+// proxy in front.
+//
+// LEAGUE-SCOPED. ``leagueKey`` rides in the body (the POST convention in
+// this codebase) and is forwarded verbatim along with the session cookie.
+//
+// Mirrored backend endpoint: server.py::post_waiver_best_available_idp()
+// Payload builder: src/trade/waiver_idp_best_available.py::best_available_idp()
+import { NextResponse } from "next/server";
+
+const BEST_AVAILABLE_IDP_URL = (() => {
+  const base = (process.env.BACKEND_API_URL || "http://127.0.0.1:8000").replace(
+    /\/api\/data\/?$/,
+    "",
+  );
+  return `${base}/api/waiver/best-available-idp`;
+})();
+
+export async function POST(request) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const cookie = request.headers.get("cookie") || "";
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), 10_000);
+  try {
+    const res = await fetch(BEST_AVAILABLE_IDP_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: cookie },
+      body: JSON.stringify(body),
+      signal: ctl.signal,
+      cache: "no-store",
+    });
+    const data = await res.json().catch(() => ({}));
+    return NextResponse.json(data, { status: res.status });
+  } catch (err) {
+    // The caller treats any non-2xx as "unavailable" and shows a
+    // degraded state, so a shaped 503 is enough — never an unhandled throw.
+    return NextResponse.json(
+      { error: "Best-available-IDP service unavailable", detail: err?.message },
+      { status: 503 },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/frontend/app/waivers/page.jsx
+++ b/frontend/app/waivers/page.jsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ds";
 import TeamSwitcher from "@/components/TeamSwitcher";
 import ManualAddDrop from "@/components/waivers/ManualAddDrop";
+import BestAvailableIdps from "@/components/waivers/BestAvailableIdps";
 import {
   DEFAULT_RISK_POSTURE,
   RISK_POSTURES,
@@ -663,6 +664,13 @@ export default function WaiversPage() {
           leagueKey={selectedLeague?.key}
           teamLoading={teamLoading}
           riskPosture={riskPosture}
+        />
+      ) : null}
+
+      {!signedOut && !leagueMismatch ? (
+        <BestAvailableIdps
+          leagueKey={selectedLeague?.key}
+          idpEnabled={Boolean(selectedLeague?.idpEnabled)}
         />
       ) : null}
 

--- a/frontend/app/waivers/waivers.module.css
+++ b/frontend/app/waivers/waivers.module.css
@@ -98,6 +98,23 @@
   opacity: 0.65;
 }
 
+/* ── Best available IDPs card ── */
+.tierBadge {
+  margin-left: var(--space-2);
+}
+.controlsInline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+@media (width < 480px) {
+  .controlsInline {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
 /* ── Manual add/drop calculator ── */
 .calc {
   display: flex;

--- a/frontend/components/useBestAvailableIdp.js
+++ b/frontend/components/useBestAvailableIdp.js
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * useBestAvailableIdp — fetches the "Best Available IDPs" waiver card
+ * payload for the given league.
+ *
+ * Silent-vanish posture, same as the FAAB bid fetch in
+ * ``useWaiverAnalysis.js``: any non-OK response, malformed body, abort or
+ * network failure leaves ``payload`` null and the card renders nothing —
+ * this is an optional decision lens, not a page-blocking dependency.
+ *
+ * ``payload.candidates`` is the FULL sorted list (not pre-sliced to 20) —
+ * the component is responsible for filtering by position and THEN
+ * slicing to the requested count, since each candidate's score already
+ * reflects its rank across the whole cross-position IDP population.
+ */
+export function useBestAvailableIdp({ leagueKey, enabled = true } = {}) {
+  const [payload, setPayload] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      setPayload(null);
+      setLoading(false);
+      return undefined;
+    }
+    let cancelled = false;
+    const ctl = new AbortController();
+    setLoading(true);
+    (async () => {
+      try {
+        const res = await fetch("/api/waiver/best-available-idp", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          signal: ctl.signal,
+          body: JSON.stringify({ leagueKey: leagueKey || undefined }),
+        });
+        if (cancelled) return;
+        if (!res.ok) {
+          setPayload(null);
+          return;
+        }
+        const json = await res.json();
+        if (cancelled) return;
+        setPayload(json && typeof json === "object" ? json : null);
+      } catch {
+        // Includes AbortError on unmount/league switch.
+        if (!cancelled) setPayload(null);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      ctl.abort();
+    };
+  }, [enabled, leagueKey]);
+
+  return { payload, loading };
+}

--- a/frontend/components/waivers/BestAvailableIdps.jsx
+++ b/frontend/components/waivers/BestAvailableIdps.jsx
@@ -1,0 +1,261 @@
+"use client";
+
+/**
+ * BestAvailableIdps — the "Best available IDPs" waivers card.
+ *
+ * A narrow, two-source-only decision lens, deliberately separate from
+ * the rest of the Waivers page's canonical-board-driven panels: it
+ * combines EXACTLY IDP Trade Calculator + The IDP Show, 50/50, for
+ * unrostered IDP players in the selected league.
+ *
+ * Display-only. All scoring happens server-side
+ * (``src/trade/waiver_idp_best_available.py``) — this component reshapes
+ * and filters the already-computed, already-sorted payload, the same
+ * materializer posture as ``buildRows`` / ``lib/bdvm.js``.
+ *
+ * ``payload.candidates`` is the FULL cross-position-scored list, not a
+ * pre-sliced top 20 — filtering by position here and THEN slicing is
+ * what finds a legitimate top-position player who sits outside the
+ * naive top-20-overall cut (see the backend test
+ * ``test_position_filter_must_apply_to_full_list_not_pre_sliced_top_20``).
+ */
+import { useMemo, useState } from "react";
+import {
+  Badge,
+  Banner,
+  DataTable,
+  EmptyState,
+  FailureState,
+  Field,
+  InfoTip,
+  Panel,
+  Select,
+  SkeletonTable,
+} from "@/components/ds";
+import { useBestAvailableIdp } from "@/components/useBestAvailableIdp";
+import styles from "@/app/waivers/waivers.module.css";
+
+const TOP_N = 20;
+
+const POSITION_FILTER_OPTIONS = [
+  { value: "ALL", label: "All IDP" },
+  { value: "DL", label: "DL" },
+  { value: "LB", label: "LB" },
+  { value: "DB", label: "DB" },
+];
+
+function formatFreshness(entry) {
+  if (!entry || typeof entry !== "object") return "unknown";
+  const hours = Number(entry.ageHours);
+  const stale = entry.staleness;
+  const age = Number.isFinite(hours) ? `${hours < 1 ? "<1" : Math.round(hours)}h ago` : "unknown age";
+  if (stale === "stale") return `${age} (stale)`;
+  if (stale === "missing") return "no data";
+  return age;
+}
+
+function SourceFormulaInfo({ sourceFreshness }) {
+  return (
+    <InfoTip label="the combined IDP score">
+      <p>
+        <strong>Combined IDP Score</strong> = 50% IDP Trade Calculator normalized
+        ranking + 50% The IDP Show normalized ranking. Each source is ranked
+        against every IDP player it covers, then converted to a 0-100 scale —
+        neither source&apos;s raw scale can dominate the other.
+      </p>
+      <p>
+        IDP Trade Calculator updated: {formatFreshness(sourceFreshness?.idpTradeCalc)}
+        <br />
+        The IDP Show updated: {formatFreshness(sourceFreshness?.idpShowCombined)}
+      </p>
+    </InfoTip>
+  );
+}
+
+const MISSING_SOURCE_LABEL = {
+  idpTradeCalc: "IDP Trade Calculator",
+  idpShowCombined: "The IDP Show",
+};
+
+export default function BestAvailableIdps({ leagueKey, idpEnabled }) {
+  const [position, setPosition] = useState("ALL");
+  const { payload, loading } = useBestAvailableIdp({
+    leagueKey,
+    enabled: Boolean(idpEnabled),
+  });
+
+  const visibleCandidates = useMemo(() => {
+    const all = Array.isArray(payload?.candidates) ? payload.candidates : [];
+    const filtered = position === "ALL" ? all : all.filter((c) => c.position === position);
+    return filtered.slice(0, TOP_N);
+  }, [payload, position]);
+
+  if (!idpEnabled) return null;
+
+  const columns = [
+    {
+      key: "rank",
+      header: "#",
+      numeric: true,
+      accessor: (_row, i) => i + 1,
+      render: (_row, i) => i + 1,
+    },
+    {
+      key: "name",
+      header: "Player",
+      render: (row) => (
+        <div className={styles.playerCell}>
+          <span className={styles.playerName}>{row.name}</span>
+          <span className={styles.playerMeta}>
+            {row.position}
+            {row.team ? ` · ${row.team}` : ""}
+            {row.tier === "B" ? (
+              <Badge tone="neutral" className={styles.tierBadge}>
+                1 of 2 sources
+              </Badge>
+            ) : null}
+          </span>
+        </div>
+      ),
+    },
+    {
+      key: "combinedScore",
+      header: "Combined",
+      numeric: true,
+      accessor: (row) => row.combinedScore,
+      render: (row) => row.combinedScore.toFixed(1),
+    },
+    {
+      key: "idptc",
+      header: "IDPTC",
+      numeric: true,
+      hideBelow: "sm",
+      headerInfo: "IDP Trade Calculator rank (raw value in parentheses)",
+      accessor: (row) => row.idpTradeCalc?.rank ?? null,
+      render: (row) =>
+        row.idpTradeCalc?.rank != null ? (
+          <span title={`Raw value: ${row.idpTradeCalc.rawValue}`}>
+            #{row.idpTradeCalc.rank}
+          </span>
+        ) : (
+          <span className={styles.faabAbsent}>—</span>
+        ),
+    },
+    {
+      key: "idpshow",
+      header: "IDP Show",
+      numeric: true,
+      hideBelow: "sm",
+      headerInfo: "The IDP Show rank",
+      accessor: (row) => row.idpShowCombined?.rank ?? null,
+      render: (row) =>
+        row.idpShowCombined?.rank != null ? (
+          `#${row.idpShowCombined.rank}`
+        ) : (
+          <span className={styles.faabAbsent}>—</span>
+        ),
+    },
+    {
+      key: "ownership",
+      header: "Ownership",
+      hideBelow: "md",
+      render: () => <Badge tone="positive">Available</Badge>,
+    },
+  ];
+
+  function renderBody() {
+    if (payload?.ownershipResolved === false) {
+      return (
+        <FailureState
+          variant="block"
+          failure={{
+            kind: "degraded",
+            message:
+              "Availability unavailable — your league's roster data hasn't loaded yet, so free-agent status can't be determined truthfully.",
+          }}
+        />
+      );
+    }
+    if (!payload && !loading) {
+      return (
+        <FailureState
+          variant="block"
+          failure={{
+            kind: "unavailable",
+            message: "Couldn't reach the IDP Trade Calculator / The IDP Show comparison right now.",
+          }}
+        />
+      );
+    }
+    if (loading && !payload) {
+      return <SkeletonTable rows={8} columns={6} />;
+    }
+
+    const missing = payload?.degraded?.missingSources || [];
+    const totalAvailable = Array.isArray(payload?.candidates) ? payload.candidates.length : 0;
+    const filteredTotal =
+      position === "ALL"
+        ? totalAvailable
+        : (payload?.candidates || []).filter((c) => c.position === position).length;
+
+    return (
+      <>
+        {missing.length > 0 ? (
+          <Banner tone="warning" title="A source is missing">
+            {missing.map((key) => MISSING_SOURCE_LABEL[key] || key).join(" and ")} data is
+            currently unavailable. Scores below reflect only the source(s) present — never a
+            silent single-source "combined" number.
+          </Banner>
+        ) : null}
+        {filteredTotal < TOP_N ? (
+          <p className={styles.controlsGainLabel}>
+            Showing all {filteredTotal} available IDP free agent{filteredTotal === 1 ? "" : "s"}
+            {position !== "ALL" ? ` at ${position}` : ""}.
+          </p>
+        ) : null}
+        <DataTable
+          caption="Best available IDP free agents by combined IDP Trade Calculator and The IDP Show score"
+          columns={columns}
+          rows={visibleCandidates}
+          rowKey={(row) => row.name}
+          presorted
+          density="compact"
+          emptyState={
+            <EmptyState
+              title="No available IDP free agents"
+              description="Nobody at this position qualifies right now."
+            />
+          }
+        />
+      </>
+    );
+  }
+
+  return (
+    <Panel
+      flush
+      title="Best available IDPs"
+      subtitle="IDP Trade Calculator + The IDP Show"
+      actions={
+        <div className={styles.controlsInline}>
+          <SourceFormulaInfo sourceFreshness={payload?.sourceFreshness} />
+          <Field label="Position" id="idp-best-available-pos">
+            <Select
+              id="idp-best-available-pos"
+              value={position}
+              onChange={(e) => setPosition(e.target.value)}
+            >
+              {POSITION_FILTER_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </Select>
+          </Field>
+        </div>
+      }
+    >
+      {renderBody()}
+    </Panel>
+  );
+}

--- a/frontend/scripts/check-bundle-sizes.mjs
+++ b/frontend/scripts/check-bundle-sizes.mjs
@@ -149,7 +149,15 @@ const BUDGETS_KB = {
   // 42 restores the ~15% headroom this table asks for. The alternative
   // was a client-side bid formula, which the no-frontend-valuation
   // rule forbids (see the closing note in lib/waiver-logic.js).
-  "/waivers/page": 42,
+  //
+  // Bumped 42→52: the "Best available IDPs" card
+  // (components/waivers/BestAvailableIdps.jsx +
+  // components/useBestAvailableIdp.js) renders the two-source IDP
+  // composite from POST /api/waiver/best-available-idp. All scoring is
+  // server-side (src/trade/waiver_idp_best_available.py); this is
+  // display/formatting weight only. Measured 44.7 KB, up from 37.6 —
+  // 52 restores the ~15% headroom this table asks for.
+  "/waivers/page": 52,
   "/settings/page": 60,  // bumped 50→55 for guest-pass admin panel (token reveal, list table, revoke); 55→60 for the Sharp Tracker intel section in the shared PlayerPopup chunk (useLeague + intel fetch, PR #534)
   "/login/page": 15,
   "/more/page": 10,

--- a/server.py
+++ b/server.py
@@ -5839,6 +5839,70 @@ async def post_waiver_suggestions(request: Request):
     return JSONResponse(content=result)
 
 
+@app.post("/api/waiver/best-available-idp")
+async def post_waiver_best_available_idp(request: Request):
+    """Top available IDP free agents: IDP Trade Calculator + The IDP Show, 50/50.
+
+    A narrow, two-source-only waiver decision lens — deliberately separate
+    from ``/api/waiver/suggestions``, which blends every ranking source via
+    ``rankDerivedValue``. This endpoint never reads ``rankDerivedValue``,
+    ``canonicalConsensusRank``, or ``sourceCount``; see
+    ``src/trade/waiver_idp_best_available.py`` for the full methodology.
+
+    Request body (JSON): ``leagueKey`` optional.
+
+    Returns ``{ownershipResolved, candidates, availableCount, sources,
+    degraded, sourceFreshness, leagueKey}``. ``candidates`` is the FULL
+    sorted list (not pre-sliced to 20) so a client-side position filter can
+    correctly find top players outside the top-20-overall slice.
+    """
+    if not latest_contract_data or not latest_contract_data.get("playersArray"):
+        return JSONResponse(
+            status_code=503,
+            content={"error": "Live contract not loaded yet."},
+        )
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    if not isinstance(body, dict):
+        body = {}
+
+    try:
+        league_cfg = _resolve_league_for_request(
+            request,
+            body=body,
+            require_loaded_contract=True,
+        )
+    except LeagueResolutionError as err:
+        return err.json_response()
+
+    from src.trade import waiver_idp_best_available as _idp_best  # noqa: PLC0415
+
+    sleeper = (latest_contract_data or {}).get("sleeper") or {}
+    sleeper_teams = sleeper.get("teams") or []
+
+    try:
+        result = await run_in_threadpool(
+            _idp_best.best_available_idp,
+            latest_contract_data,
+            sleeper_teams,
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.error(f"Best-available-IDP failed: {exc}")
+        return JSONResponse(status_code=500, content={"error": f"failed: {exc}"})
+
+    source_timestamps = (
+        (latest_contract_data or {}).get("dataFreshness", {}).get("sourceTimestamps", {}) or {}
+    )
+    result["sourceFreshness"] = {
+        "idpTradeCalc": source_timestamps.get("idpTradeCalc"),
+        "idpShowCombined": source_timestamps.get("idpShowCombined"),
+    }
+    result["leagueKey"] = league_cfg.key
+    return JSONResponse(content=result)
+
+
 @app.post("/api/waiver/faab-recommend")
 async def post_waiver_faab_recommend(request: Request):
     """Recommend a FAAB bid for a single add/drop pair.

--- a/server.py
+++ b/server.py
@@ -5892,9 +5892,9 @@ async def post_waiver_best_available_idp(request: Request):
         log.error(f"Best-available-IDP failed: {exc}")
         return JSONResponse(status_code=500, content={"error": f"failed: {exc}"})
 
-    source_timestamps = (
-        (latest_contract_data or {}).get("dataFreshness", {}).get("sourceTimestamps", {}) or {}
-    )
+    source_timestamps = (latest_contract_data or {}).get("dataFreshness", {}).get(
+        "sourceTimestamps", {}
+    ) or {}
     result["sourceFreshness"] = {
         "idpTradeCalc": source_timestamps.get("idpTradeCalc"),
         "idpShowCombined": source_timestamps.get("idpShowCombined"),

--- a/src/trade/waiver.py
+++ b/src/trade/waiver.py
@@ -214,6 +214,25 @@ def _normalize_name(name: str) -> str:
     return str(name or "").strip().lower()
 
 
+def rostered_name_set(sleeper_teams: list[dict[str, Any]] | None) -> set[str]:
+    """Every rostered player name across every team, normalized.
+
+    Extracted from ``find_waiver_targets`` (pure extraction, no behavior
+    change) so a second caller — the IDP best-available card
+    (``src/trade/waiver_idp_best_available.py``) — can determine
+    free-agent status without duplicating this loop.  ``team["players"]``
+    is Sleeper's full roster list (starters + bench + taxi + IR/reserve),
+    so no separate taxi/IR carve-out is needed here.
+    """
+    rostered: set[str] = set()
+    for team in sleeper_teams or []:
+        if not isinstance(team, dict):
+            continue
+        for n in team.get("players") or []:
+            rostered.add(_normalize_name(n))
+    return rostered
+
+
 def find_waiver_targets(
     contract: dict[str, Any],
     sleeper_teams: list[dict[str, Any]] | None,
@@ -238,12 +257,7 @@ def find_waiver_targets(
     if not isinstance(arr, list):
         return {"by_position": {}, "by_family": {}, "total": 0, "rookies_excluded": False}
 
-    rostered: set[str] = set()
-    for team in sleeper_teams or []:
-        if not isinstance(team, dict):
-            continue
-        for n in team.get("players") or []:
-            rostered.add(_normalize_name(n))
+    rostered = rostered_name_set(sleeper_teams)
 
     rookies_eligible = _rookies_eligible_today()
     positions = set(_BASE_POSITIONS)

--- a/src/trade/waiver_idp_best_available.py
+++ b/src/trade/waiver_idp_best_available.py
@@ -202,16 +202,12 @@ def best_available_idp(
     # Dense rank: idpTradeCalc descending by value, idpShowCombined
     # ascending by its raw (combined-board) rank.
     idptc_score_by_row: dict[int, tuple[int, float, float]] = {}
-    for dense_rank, reading in enumerate(
-        sorted(idptc_readings, key=lambda r: -r.raw), start=1
-    ):
+    for dense_rank, reading in enumerate(sorted(idptc_readings, key=lambda r: -r.raw), start=1):
         score = _population_score(dense_rank, idptc_population)
         idptc_score_by_row[reading.row_index] = (dense_rank, reading.raw, score)
 
     idpshow_score_by_row: dict[int, tuple[int, float, float]] = {}
-    for dense_rank, reading in enumerate(
-        sorted(idpshow_readings, key=lambda r: r.raw), start=1
-    ):
+    for dense_rank, reading in enumerate(sorted(idpshow_readings, key=lambda r: r.raw), start=1):
         score = _population_score(dense_rank, idpshow_population)
         idpshow_score_by_row[reading.row_index] = (dense_rank, reading.raw, score)
 

--- a/src/trade/waiver_idp_best_available.py
+++ b/src/trade/waiver_idp_best_available.py
@@ -1,0 +1,289 @@
+"""Best Available IDPs — a two-source waiver decision lens.
+
+Answers one narrow question for the Waivers page: among IDP players NOT
+rostered by any team in the selected league, who ranks highest on an
+equal-weight combination of exactly two named sources — **IDP Trade
+Calculator** (``idpTradeCalc``) and **The IDP Show** (``idpShowCombined``)?
+
+This is a PRESENTATION/DECISION LENS, not a canonical valuation concept.
+It never reads or writes ``rankDerivedValue``, ``canonicalConsensusRank``,
+``sourceCount``, or any other ranking source. It reuses the canonical
+identity (one contract row per real player), canonical position
+normalization (``DL``/``LB``/``DB`` families, already collapsed upstream),
+and the canonical rostered-player set (``src.trade.waiver.rostered_name_set``)
+rather than inventing any of the three.
+
+Methodology
+-----------
+Each source's raw signal is converted to a DENSE rank within its own
+IDP-only population (rostered AND unrostered players both counted — the
+percentile question is "how good is this player per this source", which is
+independent of availability):
+
+* ``idpTradeCalc`` is value-based (``canonicalSiteValues.idpTradeCalc``,
+  0-9999 scale, also covers offense/picks) — sorted descending by value.
+* ``idpShowCombined`` is rank-based (``sourceOriginalRanks.idpShowCombined``)
+  but that raw ordinal spans the vendor's COMBINED offense+IDP chart, not
+  an IDP-only ordinal — sorted ascending by that raw rank to produce a
+  clean 1..N IDP-only rank.
+
+Each dense rank converts to a 0-100 score via a small formula LOCAL to this
+module rather than ``src.canonical.player_valuation.rank_to_percentile`` —
+that function is tuned for the whole multi-source board blend (fixed
+``reference_n=500``, tail-clamp policy around rank 904) and its own
+docstring says callers should almost never override ``reference_n``.
+Coupling a narrow two-source waiver lens to those constants would import
+board-blend behavior that has nothing to do with this question.
+
+Tiering never fills a missing source with zero, an average, or a guess:
+
+* Tier A — both sources cover the player: ``combined = mean(score_a, score_b)``.
+* Tier B — exactly one source covers the player: ``combined = that score``.
+* Neither source covers the player: not a candidate at all.
+
+Selection is TIER-FIRST, then score, so a strong single-source outlier can
+never displace a genuine two-source consensus player — the owner's explicit
+requirement that "if at least 20 legitimately available players have both
+sources, the Top 20 should consist entirely of two-source players."
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from src.trade.waiver import _normalize_name, rostered_name_set
+
+_IDP_POSITIONS = frozenset({"DL", "LB", "DB"})
+
+_IDPTC_KEY = "idpTradeCalc"
+_IDPSHOW_KEY = "idpShowCombined"
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    if f != f:  # NaN
+        return None
+    return f
+
+
+def _population_score(rank: int, population_size: int) -> float:
+    """Dense rank -> 0-100, higher is better. Rank 1 -> 100.0."""
+    if population_size <= 1:
+        return 100.0
+    return round(100.0 * (population_size - rank) / (population_size - 1), 2)
+
+
+@dataclass
+class _SourceReading:
+    row_index: int
+    raw: float
+
+
+@dataclass
+class IdpCandidate:
+    name: str
+    team: str | None
+    position: str
+    tier: str  # "A" | "B"
+    combined_score: float
+    sources_used: int
+    idptc_rank: int | None
+    idptc_raw_value: float | None
+    idptc_score: float | None
+    idpshow_rank: int | None
+    idpshow_raw_rank: float | None
+    idpshow_score: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "team": self.team,
+            "position": self.position,
+            "tier": self.tier,
+            "combinedScore": self.combined_score,
+            "sourcesUsed": self.sources_used,
+            "idpTradeCalc": {
+                "rank": self.idptc_rank,
+                "rawValue": self.idptc_raw_value,
+                "score": self.idptc_score,
+            },
+            "idpShowCombined": {
+                "rank": self.idpshow_rank,
+                "rawRank": self.idpshow_raw_rank,
+                "score": self.idpshow_score,
+            },
+        }
+
+    def _sort_key(self) -> tuple[int, float, float, float, str]:
+        worst_source_score = (
+            min(self.idptc_score, self.idpshow_score)
+            if self.tier == "A" and self.idptc_score is not None and self.idpshow_score is not None
+            else self.combined_score
+        )
+        idptc_tiebreak = self.idptc_score if self.idptc_score is not None else -1.0
+        return (
+            0 if self.tier == "A" else 1,
+            -self.combined_score,
+            -worst_source_score,
+            -idptc_tiebreak,
+            self.name.lower(),
+        )
+
+
+def best_available_idp(
+    contract: dict[str, Any],
+    sleeper_teams: list[dict[str, Any]] | None,
+) -> dict[str, Any]:
+    """Rank available IDP free agents by IDPTradeCalc + The IDP Show, 50/50.
+
+    Returns the FULL sorted candidate list (never pre-sliced to 20) so
+    callers can safely re-filter by position and THEN slice — each
+    candidate's score is computed against its source's whole IDP
+    population, independent of any later position filter.
+    """
+    arr = contract.get("playersArray") if isinstance(contract, dict) else None
+    if not isinstance(arr, list):
+        arr = []
+
+    ownership_resolved = isinstance(sleeper_teams, list) and len(sleeper_teams) > 0
+    if not ownership_resolved:
+        return {
+            "ownershipResolved": False,
+            "candidates": [],
+            "availableCount": 0,
+            "sources": {
+                _IDPTC_KEY: {"populationSize": 0},
+                _IDPSHOW_KEY: {"populationSize": 0},
+            },
+            "degraded": {
+                "ownershipUnresolved": True,
+                "missingSources": [],
+            },
+        }
+
+    rostered = rostered_name_set(sleeper_teams)
+
+    # Collect the full IDP-only population per source (rostered AND
+    # unrostered rows both counted) so percentile position reflects "how
+    # good is this player per this source", independent of availability.
+    idptc_readings: list[_SourceReading] = []
+    idpshow_readings: list[_SourceReading] = []
+
+    for idx, row in enumerate(arr):
+        if not isinstance(row, dict):
+            continue
+        if row.get("assetClass") == "pick":
+            continue
+        pos = str(row.get("position") or "").strip().upper()
+        if pos not in _IDP_POSITIONS:
+            continue
+
+        site_values = row.get("canonicalSiteValues")
+        if isinstance(site_values, dict):
+            raw_value = _coerce_float(site_values.get(_IDPTC_KEY))
+            if raw_value is not None:
+                idptc_readings.append(_SourceReading(row_index=idx, raw=raw_value))
+
+        orig_ranks = row.get("sourceOriginalRanks")
+        if isinstance(orig_ranks, dict):
+            raw_rank = _coerce_float(orig_ranks.get(_IDPSHOW_KEY))
+            if raw_rank is not None:
+                idpshow_readings.append(_SourceReading(row_index=idx, raw=raw_rank))
+
+    idptc_population = len(idptc_readings)
+    idpshow_population = len(idpshow_readings)
+
+    # Dense rank: idpTradeCalc descending by value, idpShowCombined
+    # ascending by its raw (combined-board) rank.
+    idptc_score_by_row: dict[int, tuple[int, float, float]] = {}
+    for dense_rank, reading in enumerate(
+        sorted(idptc_readings, key=lambda r: -r.raw), start=1
+    ):
+        score = _population_score(dense_rank, idptc_population)
+        idptc_score_by_row[reading.row_index] = (dense_rank, reading.raw, score)
+
+    idpshow_score_by_row: dict[int, tuple[int, float, float]] = {}
+    for dense_rank, reading in enumerate(
+        sorted(idpshow_readings, key=lambda r: r.raw), start=1
+    ):
+        score = _population_score(dense_rank, idpshow_population)
+        idpshow_score_by_row[reading.row_index] = (dense_rank, reading.raw, score)
+
+    candidates: list[IdpCandidate] = []
+    for idx, row in enumerate(arr):
+        if not isinstance(row, dict):
+            continue
+        idptc_entry = idptc_score_by_row.get(idx)
+        idpshow_entry = idpshow_score_by_row.get(idx)
+        if idptc_entry is None and idpshow_entry is None:
+            continue
+
+        name = str(row.get("displayName") or row.get("canonicalName") or "").strip()
+        if not name:
+            continue
+        if _normalize_name(name) in rostered:
+            continue
+
+        pos = str(row.get("position") or "").strip().upper()
+        team = row.get("team")
+
+        idptc_rank = idptc_raw = idptc_score = None
+        if idptc_entry is not None:
+            idptc_rank, idptc_raw, idptc_score = idptc_entry
+
+        idpshow_rank = idpshow_raw = idpshow_score = None
+        if idpshow_entry is not None:
+            idpshow_rank, idpshow_raw, idpshow_score = idpshow_entry
+
+        sources_used = int(idptc_entry is not None) + int(idpshow_entry is not None)
+        if sources_used == 2:
+            tier = "A"
+            combined = round((idptc_score + idpshow_score) / 2.0, 1)
+        else:
+            tier = "B"
+            combined = round(idptc_score if idptc_score is not None else idpshow_score, 1)
+
+        candidates.append(
+            IdpCandidate(
+                name=name,
+                team=str(team) if team else None,
+                position=pos,
+                tier=tier,
+                combined_score=combined,
+                sources_used=sources_used,
+                idptc_rank=idptc_rank,
+                idptc_raw_value=idptc_raw,
+                idptc_score=idptc_score,
+                idpshow_rank=idpshow_rank,
+                idpshow_raw_rank=idpshow_raw,
+                idpshow_score=idpshow_score,
+            )
+        )
+
+    candidates.sort(key=lambda c: c._sort_key())
+
+    missing_sources = []
+    if idptc_population == 0:
+        missing_sources.append(_IDPTC_KEY)
+    if idpshow_population == 0:
+        missing_sources.append(_IDPSHOW_KEY)
+
+    return {
+        "ownershipResolved": True,
+        "candidates": [c.to_dict() for c in candidates],
+        "availableCount": len(candidates),
+        "sources": {
+            _IDPTC_KEY: {"populationSize": idptc_population},
+            _IDPSHOW_KEY: {"populationSize": idpshow_population},
+        },
+        "degraded": {
+            "ownershipUnresolved": False,
+            "missingSources": missing_sources,
+        },
+    }

--- a/tests/api/test_waiver_best_available_idp_endpoint.py
+++ b/tests/api/test_waiver_best_available_idp_endpoint.py
@@ -1,0 +1,165 @@
+"""Endpoint tests for ``POST /api/waiver/best-available-idp``.
+
+Pins: 503 when no contract is loaded, 503 ``data_not_ready`` on a league
+mismatch (via the shared ``_resolve_league_for_request`` gate every other
+waiver endpoint uses), the 200 response shape, and — the structural
+guarantee this whole feature rests on — that a row with a strong
+``rankDerivedValue`` but no ``idpTradeCalc``/``idpShowCombined`` coverage
+never appears, proving the endpoint never falls back to the canonical
+board.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+import server
+from src.api import league_registry
+
+
+@pytest.fixture
+def idp_env(tmp_path, monkeypatch):
+    path = tmp_path / "registry.json"
+    path.write_text(
+        json.dumps(
+            {
+                "defaultLeagueKey": "main",
+                "leagues": [
+                    {
+                        "key": "main",
+                        "displayName": "Main",
+                        "sleeperLeagueId": "L-MAIN",
+                        "active": True,
+                        "rosterSettings": {"teamCount": 12},
+                    },
+                    {
+                        "key": "side",
+                        "displayName": "Side",
+                        "sleeperLeagueId": "L-SIDE",
+                        "active": True,
+                        "rosterSettings": {"teamCount": 10},
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LEAGUE_REGISTRY_PATH", str(path))
+    league_registry.reload_registry()
+
+    from src.api import user_kv
+
+    monkeypatch.setattr(user_kv, "USER_KV_PATH", tmp_path / "user_kv.sqlite")
+    user_kv._SETUP_DONE.clear()
+    monkeypatch.setattr(server, "_is_authenticated", lambda request: True)
+
+    yield
+
+    league_registry.reload_registry()
+
+
+def _idp_row(name, position, *, idptc=None, idpshow_rank=None, team="XX"):
+    row = {
+        "displayName": name,
+        "canonicalName": name,
+        "position": position,
+        "team": team,
+        "assetClass": "idp",
+        "canonicalSiteValues": {},
+        "sourceOriginalRanks": {},
+    }
+    if idptc is not None:
+        row["canonicalSiteValues"]["idpTradeCalc"] = idptc
+    if idpshow_rank is not None:
+        row["sourceOriginalRanks"]["idpShowCombined"] = idpshow_rank
+    return row
+
+
+def _install_contract(monkeypatch, league_key, rows, *, rostered=None):
+    sleeper = {"teams": [{"ownerId": "oA", "name": "Team A", "players": rostered or []}]}
+    stub = {
+        "meta": {"leagueKey": league_key},
+        "players": {"stub": {"name": "Stub"}},
+        "playersArray": rows,
+        "sleeper": sleeper,
+        "dataFreshness": {
+            "sourceTimestamps": {
+                "idpTradeCalc": {"ageHours": 1.0, "staleness": "fresh"},
+                "idpShowCombined": {"ageHours": 2.0, "staleness": "fresh"},
+            }
+        },
+    }
+    monkeypatch.setattr(server, "latest_contract_data", stub)
+    return stub
+
+
+def test_503_when_no_contract_loaded(idp_env, monkeypatch):
+    monkeypatch.setattr(server, "latest_contract_data", {})
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        res = c.post("/api/waiver/best-available-idp", json={})
+    assert res.status_code == 503
+
+
+def test_503_data_not_ready_on_league_mismatch(idp_env, monkeypatch):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch, "main", [_idp_row("A", "LB", idptc=100)])
+        res = c.post("/api/waiver/best-available-idp", json={"leagueKey": "side"})
+    assert res.status_code == 503
+    body = res.json()
+    assert body["error"] == "data_not_ready"
+    assert "side" in body["message"]
+
+
+def test_200_response_shape(idp_env, monkeypatch):
+    rows = [
+        _idp_row("Alpha", "LB", idptc=9000, idpshow_rank=1),
+        _idp_row("Bravo", "DB", idptc=8000, idpshow_rank=2),
+    ]
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch, "main", rows)
+        res = c.post("/api/waiver/best-available-idp", json={"leagueKey": "main"})
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["leagueKey"] == "main"
+    assert body["ownershipResolved"] is True
+    assert body["availableCount"] == 2
+    assert len(body["candidates"]) == 2
+    assert body["sourceFreshness"]["idpTradeCalc"]["staleness"] == "fresh"
+    assert body["sourceFreshness"]["idpShowCombined"]["staleness"] == "fresh"
+    assert set(body["sources"].keys()) == {"idpTradeCalc", "idpShowCombined"}
+
+
+def test_rostered_player_never_appears(idp_env, monkeypatch):
+    rows = [_idp_row("Rostered", "LB", idptc=9999, idpshow_rank=1)]
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch, "main", rows, rostered=["Rostered"])
+        res = c.post("/api/waiver/best-available-idp", json={"leagueKey": "main"})
+    assert res.status_code == 200, res.text
+    names = {c["name"] for c in res.json()["candidates"]}
+    assert "Rostered" not in names
+
+
+def test_never_falls_back_to_canonical_board_value(idp_env, monkeypatch):
+    """A row with a strong ``rankDerivedValue`` but no IDPTC/IDP-Show
+    coverage must never appear -- proves the endpoint sources exactly
+    the two named sources and nothing else."""
+    row = _idp_row("CanonicalOnly", "LB")
+    row["rankDerivedValue"] = 9999
+    row["canonicalConsensusRank"] = 1
+    row["sourceCount"] = 5
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch, "main", [row])
+        res = c.post("/api/waiver/best-available-idp", json={"leagueKey": "main"})
+    assert res.status_code == 200, res.text
+    assert res.json()["candidates"] == []
+
+
+def test_no_league_key_falls_back_to_default(idp_env, monkeypatch):
+    with TestClient(server.app, raise_server_exceptions=True) as c:
+        _install_contract(monkeypatch, "main", [_idp_row("A", "LB", idptc=100)])
+        res = c.post("/api/waiver/best-available-idp", json={})
+    assert res.status_code == 200, res.text
+    assert res.json()["leagueKey"] == "main"

--- a/tests/trade/test_waiver_idp_best_available.py
+++ b/tests/trade/test_waiver_idp_best_available.py
@@ -1,0 +1,351 @@
+"""Tests for ``src/trade/waiver_idp_best_available.py``.
+
+The "Best Available IDPs" waivers card combines exactly two named sources
+(IDP Trade Calculator + The IDP Show) with equal weight, over free-agent
+IDP players only. Every scenario the owner's spec calls out (A-K) has a
+dedicated test below; no network, no live board.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.trade.waiver_idp_best_available import best_available_idp
+
+
+def _row(
+    name: str,
+    position: str,
+    *,
+    team: str = "XX",
+    asset_class: str = "idp",
+    idptc: float | None = None,
+    idpshow_rank: float | None = None,
+) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "displayName": name,
+        "canonicalName": name,
+        "position": position,
+        "team": team,
+        "assetClass": asset_class,
+        "canonicalSiteValues": {},
+        "sourceOriginalRanks": {},
+        # Canonical fields this feature must NEVER read for scoring —
+        # present here to prove they're ignored (see test_ignores_canonical_fields).
+        "rankDerivedValue": 9999,
+        "canonicalConsensusRank": 1,
+        "sourceCount": 5,
+    }
+    if idptc is not None:
+        row["canonicalSiteValues"]["idpTradeCalc"] = idptc
+    if idpshow_rank is not None:
+        row["sourceOriginalRanks"]["idpShowCombined"] = idpshow_rank
+    return row
+
+
+def _contract(*rows: dict[str, Any]) -> dict[str, Any]:
+    return {"playersArray": list(rows)}
+
+
+def _by_name(result: dict[str, Any], name: str) -> dict[str, Any]:
+    for c in result["candidates"]:
+        if c["name"] == name:
+            return c
+    raise AssertionError(f"{name} not found in candidates")
+
+
+# ── A: two-source composite correctness ─────────────────────────────────
+
+
+def test_two_source_composite_is_hand_computed_average():
+    contract = _contract(
+        _row("Alpha", "LB", idptc=9000, idpshow_rank=1),
+        _row("Bravo", "DB", idptc=5000, idpshow_rank=2),
+        _row("Charlie", "DL", idptc=1000, idpshow_rank=3),
+    )
+    result = best_available_idp(contract, sleeper_teams=[{"players": []}])
+    alpha = _by_name(result, "Alpha")
+    assert alpha["tier"] == "A"
+    # Population size 3: idptc rank 1 -> score 100.0; idpshow rank 1 -> score 100.0
+    assert alpha["idpTradeCalc"]["score"] == 100.0
+    assert alpha["idpShowCombined"]["score"] == 100.0
+    assert alpha["combinedScore"] == 100.0
+
+    bravo = _by_name(result, "Bravo")
+    # idptc rank 2/3 -> 50.0; idpshow rank 2/3 -> 50.0
+    assert bravo["idpTradeCalc"]["score"] == 50.0
+    assert bravo["idpShowCombined"]["score"] == 50.0
+    assert bravo["combinedScore"] == 50.0
+    assert bravo["combinedScore"] == round(
+        (bravo["idpTradeCalc"]["score"] + bravo["idpShowCombined"]["score"]) / 2.0, 1
+    )
+
+
+# ── B: raw scale cannot distort weighting ───────────────────────────────
+
+
+def test_huge_raw_value_gap_does_not_distort_composite():
+    # Alpha has a massive idpTradeCalc value lead but a mediocre IDP Show
+    # rank. If (48 + 12) / 2-style raw averaging leaked in, or if percentile
+    # weighting favored magnitude over rank position, Alpha would wrongly
+    # dominate. It must be scored purely on RANK POSITION within each
+    # source's population, not raw magnitude.
+    contract = _contract(
+        _row("Alpha", "LB", idptc=9999, idpshow_rank=10),  # huge value, weak rank
+        _row("Bravo", "LB", idptc=9000, idpshow_rank=1),  # close value, best rank
+        *[_row(f"Filler{i}", "LB", idptc=100 - i, idpshow_rank=2 + i) for i in range(8)],
+    )
+    result = best_available_idp(contract, sleeper_teams=[{"players": []}])
+    alpha = _by_name(result, "Alpha")
+    bravo = _by_name(result, "Bravo")
+    # Bravo (idptc rank 2, idpshow rank 1) must outrank Alpha (idptc rank 1,
+    # idpshow rank 10) on the combined score, because idpshow rank 10 of 10
+    # scores 0.0 -- averaging with a perfect idptc rank still can't let raw
+    # value magnitude buy back a bottom-of-population rank on the other side.
+    assert bravo["combinedScore"] > alpha["combinedScore"]
+
+
+# ── C: rostered player (another team) excluded ──────────────────────────
+
+
+def test_rostered_on_another_team_excluded():
+    contract = _contract(
+        _row("Elite", "LB", idptc=9999, idpshow_rank=1),
+        _row("Filler", "DB", idptc=100, idpshow_rank=2),
+    )
+    result = best_available_idp(
+        contract, sleeper_teams=[{"players": ["Elite"]}, {"players": []}]
+    )
+    names = {c["name"] for c in result["candidates"]}
+    assert "Elite" not in names
+    assert "Filler" in names
+
+
+# ── D: player on the user's own roster excluded ─────────────────────────
+
+
+def test_rostered_on_own_team_excluded():
+    contract = _contract(
+        _row("MyGuy", "DL", idptc=9999, idpshow_rank=1),
+        _row("Filler", "DB", idptc=100, idpshow_rank=2),
+    )
+    # "own" team is just one entry among sleeper_teams -- rostered_name_set
+    # spans ALL teams, so this proves it isn't "every team except mine".
+    result = best_available_idp(contract, sleeper_teams=[{"players": ["MyGuy"]}])
+    names = {c["name"] for c in result["candidates"]}
+    assert "MyGuy" not in names
+
+
+# ── E: unknown ownership is NOT available ───────────────────────────────
+
+
+def test_empty_sleeper_teams_means_ownership_unresolved():
+    contract = _contract(_row("Anybody", "LB", idptc=9999, idpshow_rank=1))
+    result = best_available_idp(contract, sleeper_teams=[])
+    assert result["ownershipResolved"] is False
+    assert result["candidates"] == []
+    assert result["degraded"]["ownershipUnresolved"] is True
+
+
+def test_none_sleeper_teams_means_ownership_unresolved():
+    contract = _contract(_row("Anybody", "LB", idptc=9999, idpshow_rank=1))
+    result = best_available_idp(contract, sleeper_teams=None)
+    assert result["ownershipResolved"] is False
+    assert result["candidates"] == []
+
+
+# ── F: missing source is not converted to zero ──────────────────────────
+
+
+def test_single_source_player_never_zero_filled():
+    contract = _contract(
+        _row("OnlyIdptc", "LB", idptc=9999),
+        _row("OnlyIdpShow", "DB", idpshow_rank=1),
+    )
+    result = best_available_idp(contract, sleeper_teams=[{"players": []}])
+
+    only_idptc = _by_name(result, "OnlyIdptc")
+    assert only_idptc["tier"] == "B"
+    assert only_idptc["sourcesUsed"] == 1
+    assert only_idptc["idpShowCombined"]["score"] is None
+    assert only_idptc["combinedScore"] == only_idptc["idpTradeCalc"]["score"]
+
+    only_idpshow = _by_name(result, "OnlyIdpShow")
+    assert only_idpshow["tier"] == "B"
+    assert only_idpshow["idpTradeCalc"]["score"] is None
+    assert only_idpshow["combinedScore"] == only_idpshow["idpShowCombined"]["score"]
+
+
+# ── G: duplicate identity collapses to one candidate ────────────────────
+
+
+def test_one_row_with_both_source_keys_is_one_candidate():
+    # Identity resolution already happened upstream; this is a structural
+    # regression guard that a single row carrying both source fields never
+    # produces two candidate entries.
+    contract = _contract(_row("BothSources", "LB", idptc=9000, idpshow_rank=1))
+    result = best_available_idp(contract, sleeper_teams=[{"players": []}])
+    matches = [c for c in result["candidates"] if c["name"] == "BothSources"]
+    assert len(matches) == 1
+    assert matches[0]["tier"] == "A"
+
+
+# ── H: deterministic sort / tiebreakers ──────────────────────────────────
+
+
+def test_tiebreak_order_is_deterministic():
+    # Two Tier-A players tie on combined score; the better worst-source
+    # score wins, then better idptc score, then name.
+    contract = _contract(
+        # Population of 4 for both sources.
+        _row("Zebra", "LB", idptc=9999, idpshow_rank=4),  # idptc rank1->100, idpshow rank4->0 => combined 50
+        _row("Apple", "LB", idptc=1, idpshow_rank=1),  # idptc rank4->0, idpshow rank1->100 => combined 50
+        _row("Filler1", "LB", idptc=9000, idpshow_rank=2),
+        _row("Filler2", "LB", idptc=8000, idpshow_rank=3),
+    )
+    result = best_available_idp(contract, sleeper_teams=[{"players": []}])
+    zebra = _by_name(result, "Zebra")
+    apple = _by_name(result, "Apple")
+    assert zebra["combinedScore"] == apple["combinedScore"] == 50.0
+    # Both have worst-source score 0.0 (tied) -> falls to idptc score:
+    # Zebra idptc score 100.0 > Apple idptc score 0.0 -> Zebra ranks first.
+    zebra_idx = next(i for i, c in enumerate(result["candidates"]) if c["name"] == "Zebra")
+    apple_idx = next(i for i, c in enumerate(result["candidates"]) if c["name"] == "Apple")
+    assert zebra_idx < apple_idx
+
+
+def test_sort_is_stable_across_repeated_calls():
+    contract = _contract(
+        _row("A", "LB", idptc=100, idpshow_rank=1),
+        _row("B", "DB", idptc=100, idpshow_rank=1),
+        _row("C", "DL", idptc=50, idpshow_rank=2),
+    )
+    teams = [{"players": []}]
+    first = best_available_idp(contract, sleeper_teams=teams)
+    second = best_available_idp(contract, sleeper_teams=teams)
+    assert [c["name"] for c in first["candidates"]] == [c["name"] for c in second["candidates"]]
+
+
+# ── I: Tier A fills the top 20 before Tier B (tier-priority rule) ───────
+
+
+def test_tier_a_candidates_precede_tier_b_when_enough_exist():
+    rows = []
+    # 25 Tier-A candidates with modest scores.
+    for i in range(25):
+        rows.append(_row(f"TwoSource{i}", "LB", idptc=100 - i, idpshow_rank=i + 1))
+    # One Tier-B candidate with a "perfect" single-source score that would
+    # beat every Tier-A combined score under flat score-only sorting.
+    rows.append(_row("OneSourceStar", "DB", idptc=999999))
+    contract = _contract(*rows)
+    result = best_available_idp(contract, sleeper_teams=[{"players": []}])
+    top_20 = result["candidates"][:20]
+    assert all(c["tier"] == "A" for c in top_20)
+    names = {c["name"] for c in top_20}
+    assert "OneSourceStar" not in names
+
+
+def test_tier_b_fills_remaining_slots_when_fewer_than_20_tier_a():
+    rows = []
+    for i in range(5):
+        rows.append(_row(f"TwoSource{i}", "LB", idptc=100 - i, idpshow_rank=i + 1))
+    for i in range(5):
+        rows.append(_row(f"OneSourceOnly{i}", "DB", idptc=50 - i))
+    contract = _contract(*rows)
+    result = best_available_idp(contract, sleeper_teams=[{"players": []}])
+    assert result["availableCount"] == 10
+    top_5 = result["candidates"][:5]
+    assert all(c["tier"] == "A" for c in top_5)
+    rest = result["candidates"][5:]
+    assert all(c["tier"] == "B" for c in rest)
+
+
+# ── J: fewer than 20 displays truthfully ─────────────────────────────────
+
+
+def test_fewer_than_20_reports_true_count_with_no_padding():
+    contract = _contract(
+        _row("Only1", "LB", idptc=9000, idpshow_rank=1),
+        _row("Only2", "DB", idptc=100, idpshow_rank=2),
+    )
+    result = best_available_idp(contract, sleeper_teams=[{"players": []}])
+    assert result["availableCount"] == 2
+    assert len(result["candidates"]) == 2
+
+
+# ── K: degraded state — missing source is surfaced, never faked ────────
+
+
+def test_missing_source_reports_zero_population_and_no_fabricated_scores():
+    contract = _contract(
+        _row("IdptcOnly1", "LB", idptc=9000),
+        _row("IdptcOnly2", "DB", idptc=100),
+    )
+    result = best_available_idp(contract, sleeper_teams=[{"players": []}])
+    assert result["sources"]["idpShowCombined"]["populationSize"] == 0
+    assert "idpShowCombined" in result["degraded"]["missingSources"]
+    assert "idpTradeCalc" not in result["degraded"]["missingSources"]
+    for c in result["candidates"]:
+        assert c["idpShowCombined"]["score"] is None
+        assert c["tier"] == "B"
+
+
+# ── Non-IDP / pick rows never enter the candidate pool ──────────────────
+
+
+def test_offense_and_pick_rows_excluded():
+    contract = _contract(
+        _row("QBGuy", "QB", idptc=9999, idpshow_rank=1),
+        _row("SomePick", "PICK", asset_class="pick", idptc=9999, idpshow_rank=1),
+        _row("RealIdp", "LB", idptc=100, idpshow_rank=2),
+    )
+    result = best_available_idp(contract, sleeper_teams=[{"players": []}])
+    names = {c["name"] for c in result["candidates"]}
+    assert names == {"RealIdp"}
+
+
+def test_ignores_canonical_fields_entirely():
+    # Every row in this suite carries a strong rankDerivedValue /
+    # canonicalConsensusRank / sourceCount (see _row's defaults) to prove
+    # they are structurally never read. A row with NEITHER named source but
+    # a strong canonical value must never appear.
+    contract = _contract(_row("CanonicalOnly", "LB"))  # no idptc, no idpshow
+    result = best_available_idp(contract, sleeper_teams=[{"players": []}])
+    assert result["candidates"] == []
+
+
+# ── Filter-then-slice safety (frontend DL/LB/DB filter correctness) ─────
+
+
+def test_position_filter_must_apply_to_full_list_not_pre_sliced_top_20():
+    """Guards the frontend's filter-then-slice contract.
+
+    Each candidate's score reflects its rank across the WHOLE cross-position
+    IDP population (per the "entire relevant IDP ranking population"
+    requirement), so a legitimate top-position player can sit outside the
+    top 20 overall. The backend must return the full candidate list so a
+    client-side position filter can find them; if the backend only returned
+    a pre-sliced top 20, filtering to one position afterward could wrongly
+    lose players who rank, say, 21st-30th overall but are top-10 at their
+    position.
+    """
+    rows = []
+    # 25 DB players occupying every top overall slot.
+    for i in range(25):
+        rows.append(_row(f"DB{i}", "DB", idptc=1000 - i, idpshow_rank=i + 1))
+    # 5 LB players who rank below all 25 DBs overall, but are the only LBs.
+    for i in range(5):
+        rows.append(_row(f"LB{i}", "LB", idptc=100 - i, idpshow_rank=100 + i))
+    contract = _contract(*rows)
+    result = best_available_idp(contract, sleeper_teams=[{"players": []}])
+
+    # None of the LBs made the naive "top 20 overall" cut.
+    naive_top_20_names = {c["name"] for c in result["candidates"][:20]}
+    assert not any(name.startswith("LB") for name in naive_top_20_names)
+
+    # But filtering the FULL list to LB and taking the top N finds them all.
+    lb_filtered = [c for c in result["candidates"] if c["position"] == "LB"][:5]
+    assert {c["name"] for c in lb_filtered} == {f"LB{i}" for i in range(5)}
+    # And they are still the true top 5 LBs by combined score, descending.
+    scores = [c["combinedScore"] for c in lb_filtered]
+    assert scores == sorted(scores, reverse=True)

--- a/tests/trade/test_waiver_idp_best_available.py
+++ b/tests/trade/test_waiver_idp_best_available.py
@@ -113,9 +113,7 @@ def test_rostered_on_another_team_excluded():
         _row("Elite", "LB", idptc=9999, idpshow_rank=1),
         _row("Filler", "DB", idptc=100, idpshow_rank=2),
     )
-    result = best_available_idp(
-        contract, sleeper_teams=[{"players": ["Elite"]}, {"players": []}]
-    )
+    result = best_available_idp(contract, sleeper_teams=[{"players": ["Elite"]}, {"players": []}])
     names = {c["name"] for c in result["candidates"]}
     assert "Elite" not in names
     assert "Filler" in names
@@ -198,8 +196,12 @@ def test_tiebreak_order_is_deterministic():
     # score wins, then better idptc score, then name.
     contract = _contract(
         # Population of 4 for both sources.
-        _row("Zebra", "LB", idptc=9999, idpshow_rank=4),  # idptc rank1->100, idpshow rank4->0 => combined 50
-        _row("Apple", "LB", idptc=1, idpshow_rank=1),  # idptc rank4->0, idpshow rank1->100 => combined 50
+        _row(
+            "Zebra", "LB", idptc=9999, idpshow_rank=4
+        ),  # idptc rank1->100, idpshow rank4->0 => combined 50
+        _row(
+            "Apple", "LB", idptc=1, idpshow_rank=1
+        ),  # idptc rank4->0, idpshow rank1->100 => combined 50
         _row("Filler1", "LB", idptc=9000, idpshow_rank=2),
         _row("Filler2", "LB", idptc=8000, idpshow_rank=3),
     )


### PR DESCRIPTION
## Summary

Adds a "Best available IDPs" card to the Waivers page: a narrow, two-source-only decision lens combining **IDP Trade Calculator** and **The IDP Show** rankings, equal weight, for unrostered IDP free agents in the selected league. This is a presentation lens only — it never touches `rankDerivedValue` or any other canonical valuation field, and reuses every existing canonical owner rather than building parallel systems.

- **Availability**: unrostered players only, resolved via the same rostered-name-set logic `find_waiver_targets` already uses (now extracted into `rostered_name_set()` for reuse — pure refactor, no behavior change). Unknown/unresolved ownership never reads as "available."
- **Methodology**: each source is converted to a dense rank within its own IDP-only population (DL/LB/DB, rostered + unrostered), then to a 0-100 score. Tier A (both sources) = averaged; Tier B (one source) = that score alone — never zero-filled. Selection is tier-first so genuine two-source consensus players fill the top 20 before any single-source outlier can (a hard requirement in the spec that a flat score sort alone doesn't guarantee).
- **Endpoint**: `POST /api/waiver/best-available-idp`, gated through the existing `_resolve_league_for_request` league resolver (503 `data_not_ready` on a league/contract mismatch, same as sibling waiver endpoints).
- **Frontend**: `BestAvailableIdps` card on `/waivers`, with a source-transparency info-tip (formula + per-source freshness), truthful degraded states (missing source, unresolved ownership, fewer-than-20), and an optional All/DL/LB/DB filter that re-filters the *full* ranked list rather than a pre-sliced top 20 — otherwise a legitimate top-position player outside the naive top-20-overall cut would be lost.

## Files changed

- `src/trade/waiver_idp_best_available.py` (new) — composite scoring engine
- `src/trade/waiver.py` — extracted `rostered_name_set()` helper
- `server.py` — new `POST /api/waiver/best-available-idp` endpoint
- `frontend/app/api/waiver/best-available-idp/route.js` (new) — dev bridge route
- `frontend/components/useBestAvailableIdp.js` (new) — fetch hook
- `frontend/components/waivers/BestAvailableIdps.jsx` (new) — card component
- `frontend/app/waivers/page.jsx`, `waivers.module.css` — wiring + styles
- `frontend/scripts/check-bundle-sizes.mjs` — `/waivers` budget bumped 42→52 KB (measured 44.7 KB, +15% headroom, documented inline)

## Test plan

- [x] `pytest tests/trade/test_waiver_idp_best_available.py tests/trade/test_waiver.py` — 17 new module tests (composite correctness, scale-distortion resistance, rostered/own-roster exclusion, unknown-ownership, missing-source-not-zero, tier-priority, deterministic sort, filter-safety) + refactor-safety regression, all pass
- [x] `pytest tests/api/test_waiver_best_available_idp_endpoint.py tests/api/test_idpshow_combined_source.py` — 6 endpoint tests (503s, response shape, rostered exclusion, no canonical-board fallback) + the "exactly one voting `idpShow*` key" guard, all pass
- [x] `pytest tests/trade/ tests/api/test_idpshow_combined_source.py` — 857 tests, no regressions
- [x] `npx vitest run` (frontend) — 2392 tests / 163 files, no regressions, including the repo's a11y "failure must not render as empty" guard (fixed by using `FailureState` for the two genuine degraded/unavailable states)
- [x] `next build --webpack` — compiles cleanly; `/api/waiver/best-available-idp` and `/waivers` both build
- [x] `node scripts/check-bundle-sizes.mjs` — all pages under budget
- [ ] Manual verification on a live IDP-enabled league (requires a running stack + fresh scrape) — not performed in this session

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdYoufUJQ9o41B3P6PHsx5)_