### PR TITLE
fix(waivers): disambiguate the IDP-panel position filter's label

### DIFF
--- a/frontend/components/waivers/BestAvailableIdps.jsx
+++ b/frontend/components/waivers/BestAvailableIdps.jsx
@@ -239,7 +239,7 @@ export default function BestAvailableIdps({ leagueKey, idpEnabled }) {
       actions={
         <div className={styles.controlsInline}>
           <SourceFormulaInfo sourceFreshness={payload?.sourceFreshness} />
-          <Field label="Position" id="idp-best-available-pos">
+          <Field label="IDP Position" id="idp-best-available-pos">
             <Select
               id="idp-best-available-pos"
               value={position}


### PR DESCRIPTION
## Summary

- Fixes a real, currently-red E2E Safety Net failure on `main` caused by `a1546dd` ("Add Best Available IDPs waiver card"), found while investigating an unrelated CI failure on #1205.
- `a1546dd` added a second `<Field label="Position">` to `/waivers` (`BestAvailableIdps.jsx`), which renders alongside the pre-existing `<Field label="Position">` waiver filter whenever `idpEnabled` is true — true for `dynasty_main`, the default test league. Two controls sharing one accessible name makes `getByLabel(/^Position$/i)` ambiguous.
- One-line fix: rename the IDP panel's label to `"IDP Position"`. Distinct accessible name, same control `id`, no other behavior change.

## Evidence

```
Error: strict mode violation: getByLabel(/^Position$/i) resolved to 2 elements:
  1) <select class="ds-select" id="idp-best-available-pos">…</select>
  2) <select id="waiver-pos" class="ds-select">…</select>
```

Failing on both `desktop-1366` and `mobile-chromium` in `tests/e2e/specs/waivers-smoke.spec.js:53:3`. Deterministic, not a flake — the last known-green run of this test (`33400408482`, 2026-08-31T14:12) predates `a1546dd` (2026-09-01 05:47 -0400).

## Test plan

- [x] `cd frontend && npx vitest run` — 163 files, 2392 tests passed, including `__tests__/components/best-available-idp.test.jsx` unchanged
- [x] No e2e spec needed updating: `tests/e2e/helpers/journey.js`'s existing `NAME.waiverPositionFilter` (`/^Position$/i`) already resolves to exactly one element once the two labels differ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg)_