### PR TITLE
Team Assignment: replace generic point scoring with canonical NFL Team Affinity

### DIFF
--- a/config/coercion_baseline.json
+++ b/config/coercion_baseline.json
@@ -1,6 +1,6 @@
 {
  "note": "Known missing-data coercions on decision paths, recorded so the gate can block NEW ones while the remediation batches burn these down. Each batch deletes its findings' entries. Do not add to this file to make a build pass.",
- "count": 660,
+ "count": 659,
  "violations": [
   "frontend/lib/auction-power.js::const raw = names.map((n) => Number(totalsObj[n]) || 0);",
   "frontend/lib/bdvm.js::assetCount: _num(r?.assetCount) ?? 0,",
@@ -284,7 +284,6 @@
   "src/api/sleeper_overlay.py::start = int(d.get(\"start_time\") or 0)",
   "src/api/sleeper_overlay.py::trades.sort(key=lambda t: -int(t.get(\"timestamp\", 0) or 0))",
   "src/api/source_health_alerts.py::last_alerted = float(prev.get(\"lastAlertedAt\") or 0)",
-  "src/api/team_assignment.py::return int(meta.get(\"years_exp\") or 0) == 0",
   "src/api/terminal.py::-(s.get(\"value\") or 0),",
   "src/api/terminal.py::[p for p in rosterValues if (p[\"trend7\"] or 0) <= -3],",
   "src/api/terminal.py::alert = ctx.get(\"alertCount\") or 0",

--- a/config/team_assignment.json
+++ b/config/team_assignment.json
@@ -1,5 +1,5 @@
 {
-  "_doc": "Team Assignment configuration. See src/api/team_assignment.py.  Edit favorites/aliases/weights here without redeploy; the file reloads on each section build.  See README at the bottom for the rule semantics.",
+  "_doc": "Team Assignment configuration -- NFL Team Affinity model. See src/api/team_assignment.py. Edit favorites/aliases/weights here without redeploy; the file reloads on each section build. Roster-based affinity is driven by the canonical Meaningful Roster Core and canonical player values, not by weights declared here -- the only tunables left are the one owner-approved starting-QB multiplier and the affinity-share qualification threshold.",
 
   "favorites": {
     "joel":     {"abbr": "KC",  "display": "Kansas City Chiefs"},
@@ -36,18 +36,13 @@
   },
 
   "weights": {
-    "_doc": "Every weight here is read by src/api/team_assignment.py::_score_player.  eliteProductionTop10/Top24 and idpElite were removed on 2026-08-04: the Top24 weight paid a second time for a player already scored by qbAnchor/skillStarter (same depth_chart_order == 1 condition), and the other two were never read at all.",
-    "qbAnchor": 10,
-    "skillStarter": 5,
-    "skillCommittee": 2,
-    "rookieRound1": 4,
-    "rookieRound2": 2,
-    "idpStarter": 2
+    "_doc": "The ONE owner-approved extra weight (2026-09-01 NFL Team Affinity rewrite). Read by src/api/team_assignment.py::_qb_multiplier. Every prior per-position point weight (qbAnchor/skillStarter/skillCommittee/rookieRound1/rookieRound2/idpStarter) is retired: the canonical Meaningful Roster Core already decides who counts and canonical player value already decides how much, so a second per-position weight here would double-count information those two canonical owners already carry. Applied ONLY when a player is his NFL team's current starting QB (Sleeper depth_chart_order == 1); a backup QB or an unknown starter status both take 1.0x, never a guess.",
+    "nflStartingQbMultiplier": 2.0
   },
 
   "thresholds": {
-    "_doc": "Total points (per fantasy team x NFL team) needed to qualify as a roster-based assignment.  Favorites bypass this threshold.  NOTE: dropping the double-counted elite-production tier lowered every roster score — a primary QB now scores 10 (was 13) and a primary skill player 5 (was 8) — so this number is the knob to retune if too few NFL teams qualify.  The *Rank thresholds that used to sit here were removed with it; nothing read them.",
-    "assignmentMinPoints": 15
+    "_doc": "Minimum SHARE (0-1) of a manager's total weighted Meaningful Core value an NFL team's affinity score must reach to qualify as a roster-based assignment. A share rather than an absolute point total on purpose: it does not go stale every time the canonical value scale is refit. Favorites bypass this threshold entirely. Replaces the old flat assignmentMinPoints (points on an ad hoc 0-15+ scale); nothing reads that key any more.",
+    "rosterAssignmentMinShare": 0.10
   },
 
   "limits": {

--- a/frontend/__tests__/league-tab-sections.test.js
+++ b/frontend/__tests__/league-tab-sections.test.js
@@ -41,6 +41,11 @@ const SELF_FETCHING_TABS = [
   "rosChampionship",
   "rosTradeDeadline",
   "draft-capital",
+  // Moved here 2026-09-01: the NFL Team Affinity rewrite made
+  // teamAssignment a private, session-gated section (same reason
+  // rosTeamStrength/rosTradeDeadline self-fetch instead of riding the
+  // anonymous eager aggregate).
+  "teamAssignment",
 ];
 
 describe("tab → section map", () => {

--- a/frontend/app/league/LeagueClient.jsx
+++ b/frontend/app/league/LeagueClient.jsx
@@ -410,10 +410,7 @@ function LeaguePage({ initialContract = null, initialTab = DEFAULT_TAB }) {
       {activeTab === "previews" && <ArticlesSection mode="preview" />}
       {activeTab === "recaps" && <ArticlesSection mode="recap" />}
       {activeTab === "teamAssignment" && (
-        <TeamAssignmentSection
-          data={sections.teamAssignment}
-          managers={managers}
-        />
+        <TeamAssignmentSection managers={managers} />
       )}
         </>
       )}

--- a/frontend/app/league/sections/team-assignment.jsx
+++ b/frontend/app/league/sections/team-assignment.jsx
@@ -2,43 +2,44 @@
 
 // TeamAssignmentSection — "Team Assignment" tab on /league.
 //
-// Renders one card per fantasy team showing:
+// NFL TEAM AFFINITY (2026-09-01 rewrite). Renders one card per fantasy
+// team showing:
 //   * Manager display name + avatar
 //   * 1–3 NFL teams (favorite + roster-based qualifiers)
 //   * Each NFL team chip with logo, full name, and tag
-//     ("Favorite" / "Roster-Based" with point total)
-//   * Optional "Show Scoring Breakdown" toggle that expands a
-//     per-player point list per NFL team
+//     ("Favorite" / "Roster-Based" with Affinity Score + Affinity Share)
+//   * Optional "Show breakdown" toggle that expands a per-player
+//     canonical-value breakdown per NFL team (canonical value, the
+//     starting-QB multiplier when it applied, and the weighted result)
 //
-// Reads strictly from ``sections.teamAssignment`` of the public
-// contract.  Server-computed by ``src/api/team_assignment.py``;
-// re-runs whenever the contract is re-built (per-request, cached
-// at the public-league snapshot layer for 30 min).
+// This section is now PRIVATE (B8): it publishes per-manager sums and
+// per-player breakdowns of canonical dynasty value — the same class of
+// per-manager decomposition that made ``rosTeamStrength`` require a
+// session. It self-fetches ``/api/public/league/teamAssignment`` with
+// same-origin credentials (so a signed-in session's cookie rides
+// along), same pattern as ``ros-team-strength.jsx``. An anonymous
+// visitor gets a 401 and a plain-language explanation rather than the
+// data.
+//
+// Backend: ``src/api/team_assignment.py``. It computes nothing this
+// component re-derives — every score, share, multiplier and canonical
+// value is server-stamped; this file only formats and lays them out.
 //
 // ─────────────────────────────────────────────────────────────────────
-// COMPATIBILITY REPAIR (#815) — owned by the UI lane, not the roster
-// lane that made it.
-//
-// The roster-intelligence lane changed the SERVER contract so a
-// degraded snapshot stops rendering as a real empty result, adding
-// ``available`` / ``unavailableReason`` / ``rosterScoringAvailable`` and
-// per-assignment ``rosterScored``.  This file had to change with it for
-// one reason only: it previously printed a CAUSE it had not measured
-// ("current season has no rosters yet") for every empty payload, so
-// leaving it alone would have kept the defect visible to users while
-// the API underneath was correct.
-//
-// Deliberately scoped to truthfulness: consume the new fields, stop
-// asserting an unmeasured cause.  A section-level styled banner was
-// written and then REMOVED as presentation — the per-card
-// ``rosterScored === false`` note already carries the same fact on
-// every affected card.  No layout, styling, component or copy work
-// beyond that; the Premium UI treatment of these states is the UI
-// lane's call to make.
+// COMPATIBILITY (#815, carried forward) — an empty ``assignments`` list
+// is only ever a real answer when the server says the section is
+// available (``available: true``). ``unavailableReason`` /
+// ``rosterScoringAvailable`` / ``qbSignalAvailable`` / per-assignment
+// ``rosterScored`` all distinguish "we asked and nothing qualified"
+// from "we could not ask" — this file must never assert a cause it has
+// not measured.
 // ─────────────────────────────────────────────────────────────────────
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import NflTeamLogo from "@/components/ui/NflTeamLogo";
+import { LoadingState } from "@/components/ui";
+import { FailureState } from "@/components/ds";
+import { classifyContractFailure } from "@/lib/contract-failure";
 import { Avatar, EmptyCard, nameFor } from "../shared.jsx";
 
 // Machine-readable reason (from ``src/api/team_assignment.py``) → the
@@ -51,7 +52,87 @@ const UNAVAILABLE_MESSAGES = {
     "Assignment is unavailable — the current season carries no rosters yet.",
 };
 
+const DEGRADED_MESSAGES = {
+  canonical_contract_unavailable:
+    "Roster-based affinity is unavailable — the canonical player-value board is not loaded for this league right now. Favorite teams are still shown below.",
+  qb_starter_signal_unavailable:
+    "NFL starting-quarterback status is unavailable right now, so the starting-QB multiplier is not being applied to any player.",
+};
+
+const ROSTER_UNAVAILABLE_MESSAGES = {
+  canonical_contract_unavailable:
+    "Roster-based affinity unavailable — the canonical player-value board is not loaded. Only a configured favorite can be shown.",
+  team_not_in_contract_pool:
+    "Roster-based affinity unavailable for this team specifically — its roster could not be matched to the canonical board. Other managers may still be scored normally.",
+};
+
+const MULTIPLIER_LABELS = {
+  nfl_starting_qb: "NFL starting-QB multiplier",
+  qb_not_starting: "Not his NFL team's starting QB",
+  starter_status_unknown: "Starter status unknown",
+  not_qb: null, // no second line — canonical value alone explains it
+};
+
+// Module-level cache so tab-switching doesn't re-fetch on every mount.
+// Same pattern the other private/self-fetching /league sections use
+// (see ros-team-strength.jsx), except the failure half goes through
+// ``classifyContractFailure`` + ``FailureState`` instead of a bare
+// message string — a 401 ("sign in required") and a 503 ("degraded")
+// are different situations that want different UI, not one generic
+// error sentence.  See ``lib/contract-failure.js`` / ``components/ds/
+// FailureState.jsx`` for why: a failure rendered through the EMPTY
+// primitive tells a screen reader "there is nothing here" instead of
+// "we could not find out", and offers no retry.
+const CACHE_TTL_MS = 30 * 60 * 1000;
+const _cache = { data: null, failure: null, inflight: null, fetchedAt: 0 };
+
+async function _fetchTeamAssignment({ force = false } = {}) {
+  const fresh = !force && _cache.data && Date.now() - _cache.fetchedAt < CACHE_TTL_MS;
+  if (fresh) return { data: _cache.data, failure: null };
+  if (_cache.inflight) return _cache.inflight;
+
+  const promise = fetch("/api/public/league/teamAssignment")
+    .then(async (r) => {
+      let body = null;
+      try {
+        body = await r.json();
+      } catch {
+        body = null;
+      }
+      if (!r.ok) return { failure: classifyContractFailure(r.status, body) };
+      return { payload: body };
+    })
+    .catch(() => ({ failure: classifyContractFailure(null, null) }))
+    .then((result) => {
+      _cache.inflight = null;
+      if (result.failure) {
+        _cache.data = null;
+        _cache.failure = result.failure;
+        return { data: null, failure: result.failure };
+      }
+      const body = result.payload?.data || result.payload?.section || result.payload;
+      _cache.data = body;
+      _cache.failure = null;
+      _cache.fetchedAt = Date.now();
+      return { data: body, failure: null };
+    });
+
+  _cache.inflight = promise;
+  return promise;
+}
+
+function fmtValue(v) {
+  if (v == null || !Number.isFinite(Number(v))) return "—";
+  return Math.round(Number(v)).toLocaleString();
+}
+
+function fmtShare(v) {
+  if (v == null || !Number.isFinite(Number(v))) return null;
+  return `${(Number(v) * 100).toFixed(1)}%`;
+}
+
 function NflTeamChip({ team }) {
+  const share = fmtShare(team.affinityShare);
   return (
     <div
       className="card"
@@ -72,46 +153,27 @@ function NflTeamChip({ team }) {
           {team.display}
         </div>
         <div style={{ fontSize: "0.7rem", color: "var(--subtext)" }}>
-          {team.isFavorite ? (
-            <span>
-              <span
-                style={{
-                  color: "var(--cyan)",
-                  fontWeight: 700,
-                  textTransform: "uppercase",
-                  letterSpacing: "0.04em",
-                }}
-              >
-                Favorite
-              </span>
-              {Number.isFinite(Number(team.score)) && team.score > 0 ? (
-                <span style={{ marginLeft: 8 }}>
-                  · {team.score} pts from roster
-                </span>
-              ) : null}
-            </span>
-          ) : (
-            <span>
-              <span
-                style={{
-                  color: "var(--green)",
-                  fontWeight: 700,
-                  textTransform: "uppercase",
-                  letterSpacing: "0.04em",
-                }}
-              >
-                Roster-Based
-              </span>
-              <span style={{ marginLeft: 8 }}>· {team.score} pts</span>
-            </span>
-          )}
+          <span
+            style={{
+              color: team.isFavorite ? "var(--cyan)" : "var(--green)",
+              fontWeight: 700,
+              textTransform: "uppercase",
+              letterSpacing: "0.04em",
+            }}
+          >
+            {team.isFavorite ? "Favorite" : "Roster-Based"}
+          </span>
+          <span style={{ marginLeft: 8, fontFamily: "var(--mono)" }}>
+            Affinity: {fmtValue(team.affinityScore)}
+            {share ? ` · ${share}` : ""}
+          </span>
         </div>
       </div>
     </div>
   );
 }
 
-function ScoringBreakdown({ team }) {
+function AffinityBreakdown({ team }) {
   const contributors = Array.isArray(team.contributors) ? team.contributors : [];
   if (!contributors.length) {
     return (
@@ -123,10 +185,11 @@ function ScoringBreakdown({ team }) {
       </div>
     );
   }
-  // Sort by points desc so the biggest signals show first.
+  // Sort by weighted contribution desc so the biggest signals show first.
   const sorted = [...contributors].sort(
-    (a, b) => (Number(b.points) || 0) - (Number(a.points) || 0),
+    (a, b) => (Number(b.weightedValue) || 0) - (Number(a.weightedValue) || 0),
   );
+  const share = fmtShare(team.affinityShare);
   return (
     <div
       style={{
@@ -144,33 +207,51 @@ function ScoringBreakdown({ team }) {
           marginBottom: 4,
         }}
       >
-        {team.display} — {team.score} pts
+        {team.display} — {fmtValue(team.affinityScore)}
+        {share ? ` · ${share}` : ""}
       </div>
-      {sorted.map((c, idx) => (
-        <div
-          key={idx}
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            fontSize: "0.74rem",
-            padding: "2px 0",
-          }}
-        >
-          <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis" }}>
-            {c.player}
-          </span>
-          <span style={{ fontFamily: "var(--mono)", marginLeft: 8 }}>
-            <span
+      {sorted.map((c, idx) => {
+        const multiplierLabel = MULTIPLIER_LABELS[c.multiplierReason];
+        return (
+          <div key={idx} style={{ padding: "3px 0" }}>
+            <div
               style={{
-                color: c.points > 0 ? "var(--green)" : "var(--subtext)",
+                display: "flex",
+                justifyContent: "space-between",
+                fontSize: "0.74rem",
               }}
             >
-              +{c.points}
-            </span>{" "}
-            <span className="muted">{c.reason}</span>
-          </span>
-        </div>
-      ))}
+              <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis" }}>
+                {c.canonicalName}
+                {c.role === "reserve" ? (
+                  <span className="muted" style={{ marginLeft: 6 }}>
+                    (reserve)
+                  </span>
+                ) : null}
+              </span>
+              <span style={{ fontFamily: "var(--mono)", marginLeft: 8 }}>
+                <span style={{ color: "var(--green)" }}>
+                  {fmtValue(c.weightedValue)}
+                </span>
+              </span>
+            </div>
+            {multiplierLabel ? (
+              <div
+                className="muted"
+                style={{ fontSize: "0.66rem", paddingLeft: 2 }}
+              >
+                {fmtValue(c.canonicalValue)} canonical value
+                {c.multiplier && c.multiplier !== 1 ? ` × ${c.multiplier} ` : " "}
+                {multiplierLabel}
+              </div>
+            ) : (
+              <div className="muted" style={{ fontSize: "0.66rem", paddingLeft: 2 }}>
+                {fmtValue(c.canonicalValue)} canonical value
+              </div>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -225,7 +306,7 @@ function ManagerCard({ assignment, managers, expanded, onToggle }) {
               fontSize: "0.7rem",
               padding: "3px 8px",
             }}
-            title="Toggle per-player scoring breakdown"
+            title="Toggle per-player affinity breakdown"
           >
             {expanded ? "Hide breakdown" : "Show breakdown"}
           </button>
@@ -236,9 +317,8 @@ function ManagerCard({ assignment, managers, expanded, onToggle }) {
           className="muted"
           style={{ fontSize: "0.78rem", padding: "4px 0" }}
         >
-          Roster-based assignment unavailable — Sleeper&apos;s player
-          directory could not be read, so only a configured favorite can
-          be shown. This is not a claim that no roster team qualified.
+          {ROSTER_UNAVAILABLE_MESSAGES[assignment.rosterUnavailableReason] ||
+            "Roster-based assignment unavailable for this team. This is not a claim that no roster team qualified."}
         </div>
       ) : null}
       {teams.length === 0 && assignment.rosterScored !== false ? (
@@ -247,22 +327,76 @@ function ManagerCard({ assignment, managers, expanded, onToggle }) {
           style={{ fontSize: "0.78rem", padding: "4px 0" }}
         >
           No NFL team assignments yet — favorite not configured and no
-          roster team passed the threshold.
+          roster team cleared the affinity-share threshold.
         </div>
       ) : (
         teams.map((t) => (
           <div key={t.abbr}>
             <NflTeamChip team={t} />
-            {expanded ? <ScoringBreakdown team={t} /> : null}
+            {expanded ? <AffinityBreakdown team={t} /> : null}
           </div>
         ))
       )}
+      {assignment.rosterScored === true && assignment.scoringComplete === false ? (
+        <div
+          className="muted"
+          style={{ fontSize: "0.66rem", padding: "2px 0" }}
+        >
+          Partial roster read
+          {assignment.unpricedCount ? ` — ${assignment.unpricedCount} unpriced player(s)` : ""}
+          {assignment.unresolvedNflTeamCount
+            ? `${assignment.unpricedCount ? "," : " —"} ${assignment.unresolvedNflTeamCount} player(s) with an unresolved NFL team`
+            : ""}
+          .
+        </div>
+      ) : null}
     </div>
   );
 }
 
-export default function TeamAssignmentSection({ data, managers }) {
+export default function TeamAssignmentSection({ managers }) {
+  const [data, setData] = useState(() => _cache.data);
+  const [failure, setFailure] = useState(_cache.failure);
+  const [loading, setLoading] = useState(!_cache.data && !_cache.failure);
   const [expandedOwner, setExpandedOwner] = useState(null);
+
+  const load = (opts) => {
+    setLoading(true);
+    _fetchTeamAssignment(opts).then(({ data: d, failure: f }) => {
+      setData(d);
+      setFailure(f);
+      setLoading(false);
+    });
+  };
+
+  useEffect(() => {
+    let active = true;
+    _fetchTeamAssignment().then(({ data: d, failure: f }) => {
+      if (!active) return;
+      setData(d);
+      setFailure(f);
+      setLoading(false);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (loading && !data) {
+    return <LoadingState message="Loading team assignment..." />;
+  }
+
+  if (failure && !data) {
+    return (
+      <div className="card">
+        <FailureState
+          failure={failure}
+          context="NFL Team Affinity"
+          onRetry={() => load({ force: true })}
+        />
+      </div>
+    );
+  }
 
   if (!data) {
     return (
@@ -274,13 +408,7 @@ export default function TeamAssignmentSection({ data, managers }) {
   }
 
   // #815: an empty ``assignments`` list is only a real answer when the
-  // server says the section is available.  This branch used to assert a
-  // cause it had not measured ("current season has no rosters yet") for
-  // every empty payload, including a degraded/seasonless snapshot.
-  //
-  // ``available === undefined`` is an OLD payload from a server that
-  // predates the flag, not a claim of health — treated as unknown so a
-  // rolling deploy degrades honestly rather than confidently.
+  // server says the section is available.
   if (data.available === false) {
     return (
       <EmptyCard
@@ -305,7 +433,9 @@ export default function TeamAssignmentSection({ data, managers }) {
     );
   }
 
-  const threshold = data.config?.thresholds?.assignmentMinPoints ?? 15;
+  const minShare = data.config?.thresholds?.rosterAssignmentMinShare ?? 0.10;
+  const qbMultiplier = data.config?.weights?.nflStartingQbMultiplier ?? 2.0;
+  const degraded = Array.isArray(data.degradedReasons) ? data.degradedReasons : [];
 
   return (
     <div>
@@ -317,16 +447,37 @@ export default function TeamAssignmentSection({ data, managers }) {
           lineHeight: 1.5,
         }}
       >
-        Each manager is mapped to 1–3 NFL teams.  The first team is
-        the manager's declared favorite from{" "}
+        Each manager is mapped to 1–3 NFL teams by NFL Team Affinity: the
+        first team is the manager's declared favorite from{" "}
         <code style={{ fontSize: "0.7rem" }}>config/team_assignment.json</code>.
-        Additional teams are derived from roster composition: starting
-        QBs, primary skill-position players, rookies with high draft
-        capital, and (if IDP is enabled) starting defenders.  Teams
-        scoring at least <strong>{threshold} pts</strong> qualify; max
-        3 NFL teams per manager.  Click "Show breakdown" on any
-        manager to see per-player point contributions.
+        Additional teams are ranked by the value of this team's canonical
+        Meaningful Core players rostered from that NFL franchise (the
+        same player population and canonical values Team Strength
+        uses), with a {qbMultiplier}x weight for a player who is that
+        NFL team's current starting quarterback. A team qualifies once
+        its share of this manager's total weighted roster value reaches{" "}
+        <strong>{(minShare * 100).toFixed(0)}%</strong>; max 3 NFL
+        teams per manager. Click &quot;Show breakdown&quot; on any
+        manager to see per-player value contributions.
       </div>
+
+      {degraded.map((reason) =>
+        DEGRADED_MESSAGES[reason] ? (
+          <div
+            key={reason}
+            className="muted"
+            style={{
+              fontSize: "0.74rem",
+              padding: "6px 10px",
+              marginBottom: 10,
+              border: "1px solid var(--border)",
+              borderRadius: 6,
+            }}
+          >
+            {DEGRADED_MESSAGES[reason]}
+          </div>
+        ) : null,
+      )}
 
       {assignments.map((a) => (
         <ManagerCard

--- a/frontend/app/league/tabs.js
+++ b/frontend/app/league/tabs.js
@@ -96,11 +96,16 @@ export function leagueTabHref(key, currentSearch = "", extraParams = {}) {
 // the contract: `previews`/`recaps` (ArticlesSection), `power`
 // (RosPowerSection reads the lazy `rosPower` section directly — the v1
 // engine and its eager `power` section are retired), the four `ros*`
-// tabs, and `draft-capital`.  That absence is load-bearing — it is what
-// lets the server ship a contract containing only the sections the
-// landing tab actually reads instead of all seventeen (2.01 MB, of
-// which `weeklyRecap` alone is 378 KB that this page never renders at
-// all since the articles tabs replaced it).
+// tabs, `draft-capital`, and `teamAssignment` (moved to self-fetching
+// 2026-09-01 when the NFL Team Affinity rewrite made it a private,
+// session-gated section — see `PRIVATE_INTELLIGENCE_SECTIONS` in
+// `src/public_league/public_contract.py`; it can no longer ride the
+// anonymous eager aggregate the way its old points-based scoring did).
+// That absence is load-bearing — it is what lets the server ship a
+// contract containing only the sections the landing tab actually reads
+// instead of all seventeen (2.01 MB, of which `weeklyRecap` alone is
+// 378 KB that this page never renders at all since the articles tabs
+// replaced it).
 export const SECTION_FOR_TAB = Object.freeze({
   overview: "overview",
   luck: "luck",
@@ -116,7 +121,6 @@ export const SECTION_FOR_TAB = Object.freeze({
   weekly: "weekly",
   superlatives: "superlatives",
   archives: "archives",
-  teamAssignment: "teamAssignment",
 });
 
 /**

--- a/frontend/lib/public-league-data.js
+++ b/frontend/lib/public-league-data.js
@@ -42,7 +42,6 @@ export const PUBLIC_SECTION_KEYS = Object.freeze([
   "luck",
   "streaks",
   "conduct",
-  "teamAssignment",
   "matchupPreview",
   "weeklyRecap",
 ]);

--- a/server.py
+++ b/server.py
@@ -11437,7 +11437,9 @@ async def get_public_league_section_csv(
         else:
 
             def _build_csv():
-                payload = build_section_payload(snapshot, section)
+                payload = build_section_payload(
+                    snapshot, section, team_assignment_contract=latest_contract_data
+                )
                 assert_public_payload_safe(payload)
                 kwargs = {}
                 if section == "franchise" and owner:
@@ -11548,6 +11550,7 @@ async def get_public_league_section(
                     snapshot,
                     section,
                     activity_valuation=_build_public_activity_valuation(),
+                    team_assignment_contract=latest_contract_data,
                 )
                 if section == "franchise" and owner:
                     detail_map = payload.get("data", {}).get("detail") or {}

--- a/src/api/roster_intelligence.py
+++ b/src/api/roster_intelligence.py
@@ -74,7 +74,7 @@ from src.roster_intel.age_portfolio import (
 )
 from src.roster_intel.core import build_meaningful_core
 from src.roster_intel.droppability import league_droppability, team_droppability
-from src.roster_intel.exposure import build_nfl_exposure, exposure_from_core
+from src.roster_intel.exposure import build_nfl_exposure, exposure_from_core, nfl_team_by_player
 from src.roster_intel.strength import build_team_strength, rank_team_strengths
 from src.roster_intel.weakness import build_position_ranks, build_team_weakness
 
@@ -189,34 +189,6 @@ def _ages(contract: Mapping[str, Any] | None) -> dict[str, float | None]:
     return out
 
 
-def _nfl_teams(contract: Mapping[str, Any] | None) -> dict[str, str]:
-    """``{playerName: nflTeam}`` from the canonical board.
-
-    Keyed the same way ``contract_roster_pools`` keys players, for the reason
-    ``_board_players`` documents at length: a join key that disagrees with the
-    pools fails silently and completely.
-
-    An empty ``team`` is left OUT rather than stored as ``""`` — the exposure
-    owner reads absence as UNKNOWN and reports the player, and an empty string
-    would instead create a bucket that holds a share.  Measured on the live
-    board, 0 of 660 rostered players lack one, but 25 carry ``FA``, which is a
-    real answer (unsigned) and not a missing one.
-    """
-    out: dict[str, str] = {}
-    if not isinstance(contract, Mapping):
-        return out
-    for row in contract.get("playersArray") or []:
-        if not isinstance(row, Mapping) or row.get("assetClass") == "pick":
-            continue
-        team = str(row.get("team") or "").strip()
-        if not team:
-            continue
-        for key in (row.get("canonicalName"), row.get("displayName")):
-            if key:
-                out.setdefault(str(key), team)
-    return out
-
-
 def build_league_roster_intelligence(
     contract: Mapping[str, Any] | None,
     *,
@@ -277,7 +249,7 @@ def build_league_roster_intelligence(
     )
 
     drops = league_droppability(contract) if include_droppability else {}
-    nfl_teams = _nfl_teams(contract)
+    nfl_teams = nfl_team_by_player(contract)
     roster_values = {pl.player_id: pl.ros_value for pool in pools.values() for pl in pool}
 
     teams = {

--- a/src/api/team_assignment.py
+++ b/src/api/team_assignment.py
@@ -1,56 +1,96 @@
-"""Map each fantasy team in the league to 1–3 NFL teams.
+"""Map each fantasy team in the league to 1-3 NFL teams by NFL Team
+Affinity — value-weighted roster affinity, not depth-chart points.
 
 Two assignment sources, layered in this priority:
 
   1. **Favorite team** — declared in ``config/team_assignment.json``
      under ``favorites.<lowercased manager key>``.  Always assigned
      regardless of roster composition.  ``displayNameAliases``
-     resolves Sleeper display_name variants ("JasonLeeTucker" →
-     "jason") to the favorites key.
+     resolves Sleeper display_name variants ("JasonLeeTucker" ->
+     "jason") to the favorites key.  UNCHANGED by this rewrite.
 
-  2. **Roster-based correlation** — score every (fantasy team,
-     NFL team) pair using a tiered point model that rewards
-     starting QBs, skill-position starters/committee backs, rookie
-     draft capital, and IDP starters.  NFL teams scoring ≥
-     ``assignmentMinPoints`` (default 15) qualify.
+  2. **Roster-based affinity** — the site's EXISTING canonical
+     Meaningful Roster Core (``src.roster_intel.core``) and EXISTING
+     canonical player values (``rankDerivedValue``, reached via
+     ``contract_roster_pools``).  This module never selects players and
+     never computes a value; it aggregates what Team Strength's own
+     population and values already say, grouped by each player's NFL
+     team, with exactly one extra weight: a player who IS his NFL
+     team's current starting quarterback counts double.
+
+Formula
+-------
+
+For every member of a fantasy team's Meaningful Core::
+
+    multiplier(member) = 2.0  iff member.position == "QB" AND the NFL
+                                 depth-chart signal affirmatively shows
+                                 depth_chart_order == 1 for his current
+                                 NFL team
+                        = 1.0  otherwise (backup QB, unknown/stale
+                                 signal -- unknown never becomes starter)
+    weightedValue(member) = member.canonicalValue * multiplier(member)
+
+    affinityScore(team, nflTeam) = sum(weightedValue) over members whose
+                                    NFL team == nflTeam
+    totalWeightedCoreValue(team) = sum(weightedValue) over EVERY member,
+                                    including members whose NFL team
+                                    could not be resolved -- they count
+                                    toward the denominator, never toward
+                                    any team's numerator
+    affinityShare = affinityScore / totalWeightedCoreValue
+
+A non-favorite NFL team qualifies when ``affinityShare >=
+rosterAssignmentMinShare`` (default 0.10).  No other position
+multipliers exist -- Meaningful Core membership already excludes
+players who do not materially contribute, and canonical value already
+distinguishes an elite player from a roster-filler one, so a second
+"starter" multiplier here would double-count information the core and
+the value already carry.
 
 Each fantasy team gets at most ``maxTeamsPerOwner`` (default 3) NFL
-teams.  Favorite always counts toward the cap.  When more teams
-qualify than the cap, the highest-scoring non-favorites win.
+teams: the favorite (if configured) plus up to the two highest-
+qualifying non-favorites, sorted by (affinityShare desc, affinityScore
+desc, NFL abbreviation asc) for determinism.
 
-The section's ``debug`` block carries per-player point contributions
-so the UI can render a breakdown panel ("Buffalo Bills — 22 pts:
-Josh Allen +10 (QB anchor), Stefon Diggs +5 (Starter), …").
+Truthfulness / degraded states
+-------------------------------
 
-**An empty ``assignments`` list is never the answer to a question we
-could not ask** (#815).  The section previously returned
-``{"assignments": []}`` with HTTP 200 whenever the snapshot carried no
-current season, so a degraded Sleeper fetch rendered identically to a
-league that genuinely has no rosters — and the frontend printed a
-fabricated diagnosis ("current season has no rosters yet") for a cause
-it had not measured.  Availability is now stated explicitly, in the
-same ``{"available": bool, "reason": ...}`` shape
-``data_contract.stamp_optimal_lineups`` already uses for the lineup
-stamp.
-
-Three distinct failure states, deliberately not collapsed:
+Three independent things can be missing, and none of them may read as
+a confident answer about something else:
 
 ``no_current_season`` / ``no_rosters``
-    Total: ``available`` is ``False`` and ``assignments`` is empty
-    because there was nothing to assign, not because nothing qualified.
+    BLOCKING.  ``available`` is ``False`` and ``assignments`` is empty
+    because there was nothing to assign at all.
 
-``player_directory_unavailable``
-    PARTIAL.  ``snapshot.nfl_players`` is empty — the ~5 MB Sleeper
-    dump failed or was not requested — so no player can be scored
-    against an NFL team.  Favorites are config-derived and still real,
-    so ``available`` stays ``True`` while ``rosterScoringAvailable`` is
-    ``False``.  Without this flag a favorite-only card reads as "we
-    scored the roster and nothing cleared the threshold", which is a
-    confident claim about evidence we never had.
+``rosterScoringAvailable`` (top-level)
+    ``False`` when no canonical contract was supplied, or the supplied
+    contract's rosters could not be matched against this league at
+    all.  Favorites are config-derived and still real, so the section
+    stays ``available: True`` -- a favorite-only card must not read as
+    "we scored this roster and nothing qualified" when we never had
+    the evidence to score it.
 
-Per assignment, ``playersResolved`` / ``playersTotal`` report how much
-of the roster the directory could actually answer for, so a *partial*
-directory is visible too rather than silently lowering every score.
+Per assignment, ``rosterScored`` / ``rosterUnavailableReason`` cover
+the narrower case where the league-wide contract IS usable but THIS
+manager's roster specifically could not be matched to a pool (an empty
+or colliding Sleeper ``ownerId`` at contract-build time), or that
+manager's Meaningful Core itself refused (e.g. the league's starter
+slots could not be resolved).
+
+``qbSignalAvailable`` (top-level)
+    ``False`` when Sleeper's public NFL player directory was not
+    fetched.  This affects ONLY the starting-QB multiplier (every QB
+    falls back to 1.0x rather than guessing); it does not block
+    roster-based scoring the way a missing contract does.
+
+Per assignment, ``unpricedCount`` names Meaningful-Core-eligible
+players the canonical board could not price -- MISSING IS NEVER ZERO,
+so those players contribute nothing rather than 0, and the count says
+so rather than letting the total look complete.  ``unresolvedNflTeamCount``
+does the same for players whose NFL team could not be determined
+(including genuine unsigned free agents, who resolve to a real but
+non-franchise state and must never be counted as a 33rd NFL team).
 
 Output shape::
 
@@ -58,24 +98,40 @@ Output shape::
       "available": bool,
       "unavailableReason": str | None,
       "rosterScoringAvailable": bool,
+      "qbSignalAvailable": bool,
       "degradedReasons": [str, ...],
       "assignments": [
         {
           "ownerId": str,
           "displayName": str,
-          "teamName": str,            # current Sleeper team name
-          "favoriteKey": str | None,  # which favorites entry was matched
-          "rosterScored": bool,       # False ⇒ nflTeams is favorite-only
-          "playersResolved": int,     # roster ids the directory answered
-          "playersTotal": int,
+          "teamName": str,
+          "favoriteKey": str | None,
+          "rosterScored": bool,
+          "rosterUnavailableReason": str | None,
+          "scoringComplete": bool,
+          "totalWeightedCoreValue": float | None,
+          "unpricedCount": int,
+          "unresolvedNflTeamCount": int,
           "nflTeams": [
             {
-              "abbr": str,            # 3-letter abbr, e.g. "KC"
-              "display": str,         # "Kansas City Chiefs"
+              "abbr": str,
+              "display": str,
               "isFavorite": bool,
-              "score": int,           # 0 for favorite-only when no roster contribution
+              "qualifiesByRoster": bool,
+              "affinityScore": float,
+              "affinityShare": float | None,
               "contributors": [
-                {"player": str, "points": int, "reason": str},
+                {
+                  "canonicalName": str,
+                  "sleeperPlayerId": str | None,
+                  "position": str,
+                  "nflTeam": str | None,
+                  "role": "starter" | "reserve",
+                  "canonicalValue": float,
+                  "multiplier": float,
+                  "multiplierReason": str,
+                  "weightedValue": float,
+                },
                 ...
               ],
             },
@@ -101,53 +157,48 @@ import json
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
+from .data_contract import contract_roster_pools, contract_slot_eligibility
 from ..public_league.snapshot import PublicLeagueSnapshot
+from ..roster_intel.core import MeaningfulCore, build_meaningful_core
+from ..roster_intel.exposure import NON_FRANCHISE_TOKENS, nfl_team_by_player
 
 log = logging.getLogger(__name__)
 
 _CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "team_assignment.json"
 
 # Built-in defaults.  A missing or malformed config file falls back
-# to these so the section never crashes — it just degrades to "no
-# favorites configured" + the spec's recommended weights.
+# to these so the section never crashes -- it just degrades to "no
+# favorites configured" + the spec's recommended threshold/multiplier.
 _DEFAULT_CONFIG: dict[str, Any] = {
     "favorites": {},
     "displayNameAliases": {},
-    # Every weight here is read by ``_score_player``.  The set used to
-    # be larger — ``eliteProductionTop10``/``Top24`` and ``idpElite``
-    # were declared but the first two paid for a signal the tier above
-    # had already paid for (see the T3 note in ``_score_player``) and
-    # the third was never read at all.  A declared-but-unread knob is
-    # worse than no knob: editing it looks like it does something.
+    # The ONE owner-approved extra weight.  Every RB/WR/TE/IDP multiplier
+    # that used to live here (qbAnchor/skillStarter/skillCommittee/
+    # rookieRound1/rookieRound2/idpStarter) is retired: Meaningful Core
+    # membership already decides who counts, and canonical value already
+    # distinguishes how much, so a second per-position weight here would
+    # double-count information those two owners already carry.
     "weights": {
-        "qbAnchor": 10,
-        "skillStarter": 5,
-        "skillCommittee": 2,
-        "rookieRound1": 4,
-        "rookieRound2": 2,
-        "idpStarter": 2,
+        "nflStartingQbMultiplier": 2.0,
     },
-    # Likewise the ``*Rank`` thresholds: they described a
-    # position-rank model this module never had the data for, and
-    # nothing read them.  Starter status comes from Sleeper's
-    # ``depth_chart_order``, which needs no threshold.
+    # A SHARE of a manager's total weighted core value, not an absolute
+    # point total -- so the threshold does not go stale every time the
+    # canonical value scale is refit.  Replaces the old flat
+    # ``assignmentMinPoints``.
     "thresholds": {
-        "assignmentMinPoints": 15,
+        "rosterAssignmentMinShare": 0.10,
     },
     "limits": {
         "maxTeamsPerOwner": 3,
     },
 }
 
-_SKILL_POSITIONS = frozenset({"RB", "WR", "TE"})
-_IDP_POSITIONS = frozenset({"DL", "DE", "DT", "LB", "DB", "CB", "S"})
-
 
 def load_config(path: Path | None = None) -> dict[str, Any]:
     """Read the team-assignment config from disk, falling back to
-    defaults on any error.  ``_doc`` keys are stripped silently —
+    defaults on any error.  ``_doc`` keys are stripped silently --
     they're inline documentation in the JSON file, not data.
     """
     target = path or _CONFIG_PATH
@@ -206,15 +257,7 @@ def _resolve_favorite_key(
     return None
 
 
-def _normalize_position(raw: str) -> str:
-    """Uppercase + canonical alias fold (DE/DT → DL family kept as
-    raw codes; we don't collapse here because ``_IDP_POSITIONS`` and
-    ``_SKILL_POSITIONS`` are keyed on the canonical Sleeper code).
-    """
-    return str(raw or "").strip().upper()
-
-
-def _player_meta(snapshot: PublicLeagueSnapshot, player_id: str) -> dict[str, Any]:
+def _player_meta(snapshot: PublicLeagueSnapshot, player_id: str | None) -> dict[str, Any]:
     """Look up Sleeper's player record.  Returns ``{}`` when missing
     so callers can early-return.  The lookup tolerates ``None`` and
     non-string ids defensively.
@@ -225,162 +268,98 @@ def _player_meta(snapshot: PublicLeagueSnapshot, player_id: str) -> dict[str, An
     return p if isinstance(p, dict) else {}
 
 
-def _is_rookie(meta: dict[str, Any]) -> bool:
-    """True when the Sleeper record indicates ``years_exp == 0``.
-    Falls back to False on missing fields.
+def _depth_chart_order(meta: dict[str, Any]) -> int | None:
+    """Sleeper's primary starter-status indicator.  ``None`` when
+    unknown -- the caller's heuristic falls through to "unknown", never
+    a guess.
     """
+    raw = meta.get("depth_chart_order")
     try:
-        return int(meta.get("years_exp") or 0) == 0
-    except (TypeError, ValueError):
-        return False
-
-
-def _draft_round(meta: dict[str, Any]) -> int | None:
-    """Extract NFL draft round from Sleeper's player record.  Returns
-    None when unknown.  Used for rookie capital scoring.
-    """
-    raw = meta.get("draft_round") or meta.get("draftRound")
-    try:
-        n = int(raw) if raw is not None else None
+        return int(raw) if raw is not None else None
     except (TypeError, ValueError):
         return None
-    return n if isinstance(n, int) and n > 0 else None
-
-
-def _score_player(
-    meta: dict[str, Any],
-    *,
-    config: dict[str, Any],
-    league_idp_enabled: bool,
-) -> tuple[int, list[dict[str, Any]]]:
-    """Score one player against their NFL team.  Returns
-    ``(total_points, contributors)`` where contributors is a list of
-    ``{points, reason}`` dicts so the debug UI can show the
-    breakdown.
-
-    All scoring rules layer additively, and each one pays for a
-    DISTINCT signal:
-      - QB anchor (T1): primary depth-chart QB → +qbAnchor
-      - Skill starter / committee (T2): RB/WR/TE
-      - Rookie capital (T4): NFL draft round 1 / 2
-      - IDP starter (T5): depth-chart-based, only when league has IDP
-
-    There is no T3.  It was an "elite production" tier that fired on
-    ``depth_order == 1`` for QB/RB/WR/TE — the exact condition T1 and
-    T2 already pay for — so being primary on the depth chart scored
-    twice: a starting RB was worth 8 points where the config reads 5,
-    and a starting QB 13 where it reads 10.  Its own comment called it
-    a "stand-in" for a top-10/top-24 list, and a stand-in for a signal
-    we already have is a double-count, not a proxy.  Reinstating an
-    elite tier needs a genuinely independent input (projections, or
-    ``canonicalConsensusRank``) — not another read of depth order.
-    """
-    weights = config["weights"]
-    # config["thresholds"] is deliberately not read here.  main's version
-    # of this comment described those keys as forward-looking scaffolding
-    # for a future canonicalConsensusRank drop-in; that stopped being true
-    # in the same change that removed T3 — the *Rank keys went with it
-    # because nothing read them (see the T3 note in _score_player and the
-    # config's own _doc).  The one threshold in live use,
-    # assignmentMinPoints, is read where it is applied.
-    pos = _normalize_position(meta.get("position"))
-    if not pos:
-        return 0, []
-
-    contributors: list[dict[str, Any]] = []
-    points = 0
-
-    # Depth-chart order — Sleeper's primary indicator of starter
-    # status.  ``None`` when unknown; the heuristic below falls
-    # through to "no starter credit".
-    order_raw = meta.get("depth_chart_order")
-    try:
-        depth_order = int(order_raw) if order_raw is not None else None
-    except (TypeError, ValueError):
-        depth_order = None
-
-    # T1 — QB anchor.
-    if pos == "QB" and depth_order == 1:
-        pts = int(weights["qbAnchor"])
-        points += pts
-        contributors.append({"points": pts, "reason": "QB anchor"})
-
-    # T2 — Skill position starter / committee.
-    if pos in _SKILL_POSITIONS and depth_order is not None:
-        if depth_order == 1:
-            pts = int(weights["skillStarter"])
-            points += pts
-            contributors.append({"points": pts, "reason": f"{pos} starter"})
-        elif depth_order in (2, 3):
-            pts = int(weights["skillCommittee"])
-            points += pts
-            contributors.append({"points": pts, "reason": f"{pos} committee"})
-        # depth_order >= 4 → 0 (bench / camp body)
-
-    # T4 — Rookie capital.
-    if _is_rookie(meta):
-        rd = _draft_round(meta)
-        if rd == 1:
-            pts = int(weights["rookieRound1"])
-            points += pts
-            contributors.append({"points": pts, "reason": "1st-round rookie"})
-        elif rd == 2:
-            pts = int(weights["rookieRound2"])
-            points += pts
-            contributors.append({"points": pts, "reason": "2nd-round rookie"})
-
-    # T5 — IDP starter.
-    if league_idp_enabled and pos in _IDP_POSITIONS and depth_order is not None:
-        if depth_order == 1:
-            pts = int(weights["idpStarter"])
-            points += pts
-            contributors.append({"points": pts, "reason": f"IDP {pos} starter"})
-        # An elite-IDP tier would need projection data we don't carry.
-        # Its ``idpElite`` weight was removed from the config rather
-        # than left sitting there unread.
-
-    return points, contributors
-
-
-def _league_idp_enabled(snapshot: PublicLeagueSnapshot) -> bool:
-    """Inspect the current season's roster_positions to detect IDP
-    slots.  IDP is enabled when any starting slot is in the IDP
-    family (DL/LB/DB/IDP_FLEX/etc.).  Falls back to False when
-    settings are missing.
-    """
-    season = snapshot.current_season
-    if season is None:
-        return False
-    raw = season.league.get("roster_positions") or []
-    for slot in raw:
-        s = str(slot or "").upper()
-        if s in _IDP_POSITIONS or s in ("IDP", "IDP_FLEX", "IDP_DL", "IDP_LB", "IDP_DB"):
-            return True
-    return False
-
-
-def _player_display(meta: dict[str, Any], pid: str) -> str:
-    full = meta.get("full_name")
-    if full:
-        return str(full)
-    first = str(meta.get("first_name") or "").strip()
-    last = str(meta.get("last_name") or "").strip()
-    name = f"{first} {last}".strip()
-    return name or str(pid)
 
 
 #: Machine-readable reasons the section cannot be produced at all.
 UNAVAILABLE_NO_CURRENT_SEASON = "no_current_season"
 UNAVAILABLE_NO_ROSTERS = "no_rosters"
-#: Degraded — the section is produced, but part of its evidence is absent.
-DEGRADED_NO_PLAYER_DIRECTORY = "player_directory_unavailable"
+#: Degraded -- the section is produced, but part of its evidence is absent.
+DEGRADED_NO_CONTRACT = "canonical_contract_unavailable"
+DEGRADED_NO_QB_SIGNAL = "qb_starter_signal_unavailable"
+
+#: Per-assignment reasons roster-based scoring could not be produced
+#: for THIS manager even though the league-wide contract is usable.
+ROSTER_REASON_NOT_IN_CONTRACT = "team_not_in_contract_pool"
+
+#: Multiplier reasons, exposed per contributor for the breakdown UI.
+_REASON_STARTING_QB = "nfl_starting_qb"
+_REASON_BACKUP_QB = "qb_not_starting"
+_REASON_QB_UNKNOWN = "starter_status_unknown"
+_REASON_NOT_QB = "not_qb"
+
+
+def _sleeper_id_by_canonical_name(contract: Mapping[str, Any] | None) -> dict[str, str]:
+    """``{canonicalOrDisplayName: sleeperPlayerId}`` from the canonical
+    board.
+
+    Keyed the same way ``contract_roster_pools`` / ``nfl_team_by_player``
+    key players, so this join cannot silently disagree with the pool a
+    ``CoreMember`` came from.  A name with no Sleeper id (unmatched
+    ``_sleeperId``) is simply absent -- the caller treats that as
+    "starter status unknown", never a guess.
+    """
+    out: dict[str, str] = {}
+    if not isinstance(contract, Mapping):
+        return out
+    for row in contract.get("playersArray") or []:
+        if not isinstance(row, Mapping) or row.get("assetClass") == "pick":
+            continue
+        pid = row.get("playerId")
+        if not pid:
+            continue
+        for key in (row.get("canonicalName"), row.get("displayName")):
+            if key:
+                out.setdefault(str(key), str(pid))
+    return out
+
+
+def _qb_multiplier(
+    *,
+    position: str,
+    canonical_name: str,
+    sleeper_ids: Mapping[str, str],
+    snapshot: PublicLeagueSnapshot,
+    qb_signal_available: bool,
+    weight: float,
+) -> tuple[float, str]:
+    """The ONE owner-approved extra weight.  Returns ``(multiplier, reason)``.
+
+    Never guesses: a backup QB and an UNKNOWN starter both resolve to
+    1.0x, and the reason string distinguishes them for the breakdown UI.
+    """
+    if position != "QB":
+        return 1.0, _REASON_NOT_QB
+    if not qb_signal_available:
+        return 1.0, _REASON_QB_UNKNOWN
+    sleeper_id = sleeper_ids.get(canonical_name)
+    if not sleeper_id:
+        return 1.0, _REASON_QB_UNKNOWN
+    meta = _player_meta(snapshot, sleeper_id)
+    if not meta:
+        return 1.0, _REASON_QB_UNKNOWN
+    depth = _depth_chart_order(meta)
+    if depth is None:
+        return 1.0, _REASON_QB_UNKNOWN
+    if depth == 1:
+        return float(weight), _REASON_STARTING_QB
+    return 1.0, _REASON_BACKUP_QB
 
 
 def _unavailable(config: dict[str, Any], reason: str) -> dict[str, Any]:
     """A shaped payload that says WHY it is empty.
 
     Same field set as the healthy path so the frontend's
-    destructure-and-map flow still never hits ``undefined`` — the
+    destructure-and-map flow still never hits ``undefined`` -- the
     difference is that ``available: False`` names the cause instead of
     letting an empty list imply one (#815).
     """
@@ -388,6 +367,7 @@ def _unavailable(config: dict[str, Any], reason: str) -> dict[str, Any]:
         "available": False,
         "unavailableReason": reason,
         "rosterScoringAvailable": False,
+        "qbSignalAvailable": False,
         "degradedReasons": [],
         "assignments": [],
         "config": {
@@ -400,14 +380,105 @@ def _unavailable(config: dict[str, Any], reason: str) -> dict[str, Any]:
     }
 
 
-def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
+class _TeamCore:
+    """One manager's resolved Meaningful Core + affinity aggregation,
+    or the reason it could not be produced.
+    """
+
+    __slots__ = (
+        "scored",
+        "reason",
+        "total_weighted_value",
+        "unpriced_count",
+        "unresolved_team_count",
+        "scoring_complete",
+        "by_team_score",
+        "by_team_contributors",
+    )
+
+    def __init__(self) -> None:
+        self.scored = False
+        self.reason: str | None = None
+        self.total_weighted_value = 0.0
+        self.unpriced_count = 0
+        self.unresolved_team_count = 0
+        self.scoring_complete = False
+        self.by_team_score: dict[str, float] = defaultdict(float)
+        self.by_team_contributors: dict[str, list[dict[str, Any]]] = defaultdict(list)
+
+
+def _score_team_core(
+    core: MeaningfulCore,
+    *,
+    team_map: Mapping[str, str],
+    sleeper_ids: Mapping[str, str],
+    snapshot: PublicLeagueSnapshot,
+    qb_signal_available: bool,
+    qb_weight: float,
+) -> _TeamCore:
+    out = _TeamCore()
+    if not core.available:
+        out.reason = core.unavailable_reason
+        return out
+
+    out.scored = True
+    out.unpriced_count = len(core.unpriced_ids)
+    out.scoring_complete = not (
+        core.unpriced_ids or core.unfilled_starter_slots or core.unfilled_reserve_slots
+    )
+
+    for member in core.members:
+        canonical_name = member.canonical_name or member.player_id
+        multiplier, reason = _qb_multiplier(
+            position=member.position,
+            canonical_name=canonical_name,
+            sleeper_ids=sleeper_ids,
+            snapshot=snapshot,
+            qb_signal_available=qb_signal_available,
+            weight=qb_weight,
+        )
+        weighted = float(member.value) * multiplier
+        out.total_weighted_value += weighted
+
+        nfl_team = team_map.get(canonical_name)
+        contributor = {
+            "canonicalName": canonical_name,
+            "sleeperPlayerId": sleeper_ids.get(canonical_name),
+            "position": member.position,
+            "nflTeam": nfl_team if nfl_team else None,
+            "role": member.role,
+            "canonicalValue": round(float(member.value), 3),
+            "multiplier": multiplier,
+            "multiplierReason": reason,
+            "weightedValue": round(weighted, 3),
+        }
+
+        if not nfl_team or nfl_team in NON_FRANCHISE_TOKENS:
+            out.unresolved_team_count += 1
+            continue
+
+        out.by_team_score[nfl_team] += weighted
+        out.by_team_contributors[nfl_team].append(contributor)
+
+    return out
+
+
+def build_section(
+    snapshot: PublicLeagueSnapshot,
+    contract: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
     """Assemble the team-assignment payload for the public-league
     aggregate response.  Always emits a fully-shaped payload so the
     frontend's destructure-and-map flow never hits ``undefined``.
 
-    See the module docstring for the availability semantics: an empty
-    ``assignments`` list is only ever a real answer when ``available``
-    is ``True``.
+    ``contract`` is the internal canonical ``/api/data`` contract
+    (``latest_contract_data`` in ``server.py``) -- the SAME source Team
+    Strength reads.  ``None`` (or a contract whose rosters cannot be
+    matched to this league at all) degrades to a favorites-only
+    payload; it never fails the whole section, and it never scores a
+    Meaningful-Core-eligible player at 0 -- see the module docstring.
+
+    See the module docstring for the full availability semantics.
     """
     config = load_config()
     favorites = config.get("favorites") or {}
@@ -416,9 +487,9 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         for k, v in (config.get("displayNameAliases") or {}).items()
         if isinstance(k, str) and isinstance(v, str)
     }
-    threshold = int(config.get("thresholds", {}).get("assignmentMinPoints", 15))
+    min_share = float(config.get("thresholds", {}).get("rosterAssignmentMinShare", 0.10))
     max_teams = int(config.get("limits", {}).get("maxTeamsPerOwner", 3))
-    idp_enabled = _league_idp_enabled(snapshot)
+    qb_weight = float(config.get("weights", {}).get("nflStartingQbMultiplier", 2.0))
 
     season = snapshot.current_season
     if season is None:
@@ -428,18 +499,34 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     if not season.rosters:
         return _unavailable(config, UNAVAILABLE_NO_ROSTERS)
 
-    # Roster-based scoring needs Sleeper's player directory.  It is
-    # fetched on a separate future that falls back to ``{}`` on error
-    # (``snapshot.build`` swallows the exception), and tests / cheap
-    # callers pass ``include_nfl_players=False`` — so "no directory" is
-    # a REACHABLE state that scores every player zero.  Detected up
-    # front rather than inferred from a run of zeros.
-    roster_scoring_available = bool(snapshot.nfl_players)
-    degraded_reasons: list[str] = [] if roster_scoring_available else [DEGRADED_NO_PLAYER_DIRECTORY]
+    qb_signal_available = bool(snapshot.nfl_players)
+
+    # Resolve the canonical contract into per-team Meaningful Cores.
+    # A missing/mismatched contract degrades to favorites-only rather
+    # than failing the section -- "roster affinity unavailable", never
+    # "no roster-based NFL teams" (which would look like a confident
+    # empty answer).
+    pools: dict[str, list[Any]] = {}
+    slots: list[str] = []
+    eligibility: dict[str, Any] | None = None
+    team_map: dict[str, str] = {}
+    sleeper_ids: dict[str, str] = {}
+    if isinstance(contract, Mapping) and contract:
+        pools, slots, _slot_source = contract_roster_pools(dict(contract))
+        eligibility = contract_slot_eligibility(contract) or None
+        team_map = nfl_team_by_player(contract)
+        sleeper_ids = _sleeper_id_by_canonical_name(contract)
+
+    roster_scoring_available = bool(pools) and bool(slots)
+
+    degraded_reasons: list[str] = []
+    if not roster_scoring_available:
+        degraded_reasons.append(DEGRADED_NO_CONTRACT)
+    if not qb_signal_available:
+        degraded_reasons.append(DEGRADED_NO_QB_SIGNAL)
 
     # Walk every roster in the current season.  Score per (owner,
-    # NFL team) pair.  Track contributors so the breakdown panel can
-    # render the per-player point list.
+    # NFL team) pair via the canonical Meaningful Core.
     assignments: list[dict[str, Any]] = []
     for roster in season.rosters:
         if not isinstance(roster, dict):
@@ -454,75 +541,69 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         favorite_key = _resolve_favorite_key(display_name, favorites, aliases)
         favorite_entry = favorites.get(favorite_key) if favorite_key else None
 
-        # Aggregator: nfl_team_abbr -> (score, contributors_list).
-        scored: dict[str, dict[str, Any]] = defaultdict(lambda: {"score": 0, "contributors": []})
-
-        player_ids = roster.get("players") or []
-        players_resolved = 0
-        for pid in player_ids:
-            meta = _player_meta(snapshot, pid)
-            if not meta:
-                continue
-            players_resolved += 1
-            nfl_team = str(meta.get("team") or "").upper()
-            if not nfl_team:
-                continue
-            pts, contributors = _score_player(
-                meta,
-                config=config,
-                league_idp_enabled=idp_enabled,
+        team_core = _TeamCore()
+        team_core.reason = DEGRADED_NO_CONTRACT if not roster_scoring_available else None
+        pool = pools.get(owner_id) if roster_scoring_available else None
+        if roster_scoring_available and pool is None:
+            team_core.reason = ROSTER_REASON_NOT_IN_CONTRACT
+        elif roster_scoring_available and pool is not None:
+            core = build_meaningful_core(pool, slots, slot_eligibility=eligibility)
+            team_core = _score_team_core(
+                core,
+                team_map=team_map,
+                sleeper_ids=sleeper_ids,
+                snapshot=snapshot,
+                qb_signal_available=qb_signal_available,
+                qb_weight=qb_weight,
             )
-            if pts <= 0:
-                continue
-            slot = scored[nfl_team]
-            slot["score"] += pts
-            display = _player_display(meta, pid)
-            for c in contributors:
-                slot["contributors"].append(
-                    {
-                        "player": display,
-                        "points": int(c["points"]),
-                        "reason": str(c["reason"]),
-                    }
-                )
 
         # Build the NFL-teams list for this owner.
         nfl_teams_out: list[dict[str, Any]] = []
+        favorite_abbr: str | None = None
 
-        # 1. Always emit the favorite (with whatever roster score it earned).
         if favorite_entry:
             fav_abbr = str(favorite_entry.get("abbr") or "").upper()
             fav_display = str(favorite_entry.get("display") or fav_abbr)
-            slot = scored.get(fav_abbr, {"score": 0, "contributors": []})
+            favorite_abbr = fav_abbr
+            score = team_core.by_team_score.get(fav_abbr, 0.0)
+            share = (
+                score / team_core.total_weighted_value
+                if team_core.total_weighted_value > 0
+                else None
+            )
             nfl_teams_out.append(
                 {
                     "abbr": fav_abbr,
                     "display": fav_display,
                     "isFavorite": True,
-                    "score": int(slot["score"]),
-                    "contributors": list(slot["contributors"]),
+                    "qualifiesByRoster": bool(share is not None and share >= min_share),
+                    "affinityScore": round(score, 3),
+                    "affinityShare": round(share, 4) if share is not None else None,
+                    "contributors": list(team_core.by_team_contributors.get(fav_abbr, [])),
                 }
             )
 
-        # 2. Roster-based qualifiers — anyone else above threshold,
-        #    sorted by score desc.  Skip the favorite (already added).
-        favorite_abbr = nfl_teams_out[0]["abbr"] if nfl_teams_out else None
-        roster_based = sorted(
-            (
-                {
-                    "abbr": abbr,
-                    "display": _NFL_TEAM_NAMES.get(abbr, abbr),
-                    "isFavorite": False,
-                    "score": int(slot["score"]),
-                    "contributors": list(slot["contributors"]),
-                }
-                for abbr, slot in scored.items()
-                if abbr != favorite_abbr and slot["score"] >= threshold
-            ),
-            key=lambda r: (-int(r["score"]), r["abbr"]),
-        )
+        roster_based = []
+        if team_core.total_weighted_value > 0:
+            for abbr, score in team_core.by_team_score.items():
+                if abbr == favorite_abbr:
+                    continue
+                share = score / team_core.total_weighted_value
+                if share < min_share:
+                    continue
+                roster_based.append(
+                    {
+                        "abbr": abbr,
+                        "display": _NFL_TEAM_NAMES.get(abbr, abbr),
+                        "isFavorite": False,
+                        "qualifiesByRoster": True,
+                        "affinityScore": round(score, 3),
+                        "affinityShare": round(share, 4),
+                        "contributors": list(team_core.by_team_contributors.get(abbr, [])),
+                    }
+                )
+        roster_based.sort(key=lambda r: (-r["affinityShare"], -r["affinityScore"], r["abbr"]))
 
-        # 3. Cap at max_teams total (favorite counts).
         remaining_capacity = max(0, max_teams - len(nfl_teams_out))
         nfl_teams_out.extend(roster_based[:remaining_capacity])
 
@@ -532,17 +613,19 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
                 "displayName": display_name or team_name or owner_id,
                 "teamName": team_name,
                 "favoriteKey": favorite_key,
-                # A favorite-only card must not read as "we scored this
-                # roster and nothing qualified" when we could not score
-                # it at all.
-                "rosterScored": roster_scoring_available,
-                "playersResolved": players_resolved,
-                "playersTotal": len(player_ids),
+                "rosterScored": team_core.scored,
+                "rosterUnavailableReason": None if team_core.scored else team_core.reason,
+                "scoringComplete": team_core.scoring_complete,
+                "totalWeightedCoreValue": (
+                    round(team_core.total_weighted_value, 3) if team_core.scored else None
+                ),
+                "unpricedCount": team_core.unpriced_count,
+                "unresolvedNflTeamCount": team_core.unresolved_team_count,
                 "nflTeams": nfl_teams_out,
             }
         )
 
-    # Sort by display name for stable rendering — alphabetical so
+    # Sort by display name for stable rendering -- alphabetical so
     # the page is predictable across reloads.
     assignments.sort(key=lambda a: a["displayName"].lower())
 
@@ -550,6 +633,7 @@ def build_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
         "available": True,
         "unavailableReason": None,
         "rosterScoringAvailable": roster_scoring_available,
+        "qbSignalAvailable": qb_signal_available,
         "degradedReasons": degraded_reasons,
         "assignments": assignments,
         "config": {

--- a/src/public_league/public_contract.py
+++ b/src/public_league/public_contract.py
@@ -37,7 +37,9 @@ from .snapshot import PublicLeagueSnapshot
 PUBLIC_CONTRACT_VERSION = "public-league/2026-08-23.v1"
 
 
-def _team_assignment_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
+def _team_assignment_section(
+    snapshot: PublicLeagueSnapshot, contract: dict[str, Any] | None = None
+) -> dict[str, Any]:
     """Lazy-import wrapper for src.api.team_assignment.
 
     Imports inside the function body (PLC0415-style) so the
@@ -45,10 +47,20 @@ def _team_assignment_section(snapshot: PublicLeagueSnapshot) -> dict[str, Any]:
     import time — keeps the public pipeline isolated from the
     private contract builder, even though this section happens to
     reuse the snapshot directly.
+
+    ``contract`` is the internal canonical ``/api/data`` contract
+    (``latest_contract_data`` in ``server.py``) — the NFL Team Affinity
+    model reads canonical Meaningful Core membership and canonical
+    player values from it, the same source Team Strength reads.  It is
+    threaded in explicitly by the caller (``build_section_payload``)
+    rather than imported here, mirroring how ``activity_valuation`` is
+    already threaded into ``_build_activity_section`` for the same
+    reason: a section builder that needs privileged, non-snapshot data.
+    ``None`` degrades to a favorites-only payload rather than failing.
     """
     from src.api import team_assignment  # noqa: PLC0415
 
-    return team_assignment.build_section(snapshot)
+    return team_assignment.build_section(snapshot, contract)
 
 
 # Sections exposed by the public contract.  Each entry maps the public
@@ -73,11 +85,6 @@ _SECTION_BUILDERS: dict[str, Callable[[PublicLeagueSnapshot], dict[str, Any]]] =
     "streaks": streaks.build_section,
     "matchupPreview": matchup_preview.build_section,
     "weeklyRecap": weekly_recap.build_section,
-    # Team Assignment — maps each fantasy team to 1–3 NFL teams.  Cheap
-    # to compute (one walk through current rosters + Sleeper player
-    # metadata), so it ships in the eager aggregate response and the
-    # /league?tab=teamAssignment frontend reads it from sections.
-    "teamAssignment": _team_assignment_section,
 }
 
 # Sections that are expensive enough to warrant lazy-loading — they are
@@ -166,6 +173,16 @@ _LAZY_SECTION_BUILDERS: dict[str, Callable[[PublicLeagueSnapshot], dict[str, Any
     # /waivers' FAAB recommender (Phase B6).  Lazy because the
     # /league landing page doesn't consume it.
     "faabAnalytics": _faab_analytics_section,
+    # NFL Team Affinity (2026-09-01 rewrite of the old points-based Team
+    # Assignment).  Moved out of the eager ``_SECTION_BUILDERS`` and into
+    # ``PRIVATE_INTELLIGENCE_SECTIONS`` below: the model now publishes
+    # per-manager sums and per-player breakdowns of canonical dynasty
+    # value, the same class of per-manager decomposition that made
+    # ``rosTeamStrength`` private.  ``_team_assignment_section`` takes an
+    # optional second ``contract`` argument (unlike every other entry in
+    # this dict) — ``build_section_payload`` special-cases this one key
+    # to thread it, the same pattern ``activity_valuation`` already uses.
+    "teamAssignment": _team_assignment_section,
 }
 
 # Derived overview is a first-class section key the UI can fetch just
@@ -180,7 +197,7 @@ PUBLIC_SECTION_KEYS: tuple[str, ...] = (
 # ── The public/private boundary (B8) ──────────────────────────────────
 #
 # Registering a builder above makes a section BUILDABLE.  It does not
-# make it PUBLIC.  These three are per-manager decision intelligence and
+# make it PUBLIC.  These four are per-manager decision intelligence and
 # require a session, per CLAUDE.md §5: proprietary values, edges,
 # targets, weaknesses, forecasts and manager tendencies are private.
 #
@@ -206,6 +223,22 @@ PUBLIC_SECTION_KEYS: tuple[str, ...] = (
 #                     with literal strategy text ("Sell aging veterans
 #                     aggressively for picks + youth").
 #
+# ``teamAssignment`` (added 2026-09-01) joins this set for the identical
+# reason, not a new one: the NFL Team Affinity rewrite replaced flat
+# depth-chart points with per-manager sums (and a full per-player
+# breakdown) of canonical dynasty value, drawn from the same canonical
+# Meaningful Core / ``rankDerivedValue`` pipeline that made
+# ``rosTeamStrength`` private.  A manager's Affinity Score/Share per NFL
+# team, and the contributing players' canonical values, are exactly the
+# "decomposition attached to it" this boundary is written around — not
+# any specific field name (the payload avoids the literal blocklisted
+# names regardless; see ``_PRIVATE_FIELD_BLOCKLIST`` below).  Favorite-team
+# tags alone would not need gating (they are static config, not derived
+# from canonical value), but this boundary is enforced per SECTION, not
+# per field — "one predicate so the JSON route, the CSV route and any
+# future representation cannot drift apart" — so the whole section is
+# private rather than splitting it.
+#
 # rosTradeDeadline currently answers "Insufficient evidence" because the
 # product is preseason.  That is not a safe boundary: it populates real
 # per-manager calls at week 1.  An empty payload today is a timing
@@ -224,6 +257,7 @@ PRIVATE_INTELLIGENCE_SECTIONS: frozenset[str] = frozenset(
         "rosTeamStrength",
         "faabAnalytics",
         "rosTradeDeadline",
+        "teamAssignment",
     }
 )
 
@@ -399,6 +433,7 @@ def build_section_payload(
     section: str,
     *,
     activity_valuation: activity._ResolverFactory | None = None,
+    team_assignment_contract: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a single public-section payload, wrapped in the standard header.
 
@@ -410,6 +445,13 @@ def build_section_payload(
     ``activity.build_section``'s docstring for the exact shape.  Only
     the derived grade letter/label is emitted — raw values never leave
     the backend.
+
+    ``team_assignment_contract`` (optional) is the internal canonical
+    ``/api/data`` contract — the same non-snapshot-privileged-data
+    threading ``activity_valuation`` already does, for the same reason:
+    ``teamAssignment`` needs the canonical Meaningful Core / player-value
+    pipeline, which the public snapshot alone cannot supply.  Ignored for
+    every other section.
 
     Raises ``KeyError`` if ``section`` is unknown.
     """
@@ -432,6 +474,8 @@ def build_section_payload(
         section_body = _build_activity_section(snapshot, activity_valuation)
     elif section in _SECTION_BUILDERS:
         section_body = _SECTION_BUILDERS[section](snapshot)
+    elif section == "teamAssignment":
+        section_body = _team_assignment_section(snapshot, team_assignment_contract)
     elif section in _LAZY_SECTION_BUILDERS:
         # Lazy section builders (e.g. playoffOdds) run on-demand via
         # ``/api/public/league/<section>`` but are deliberately excluded

--- a/src/roster_intel/exposure.py
+++ b/src/roster_intel/exposure.py
@@ -77,6 +77,7 @@ __all__ = [
     "build_nfl_exposure",
     "exposure_change",
     "exposure_from_core",
+    "nfl_team_by_player",
     "simulation_exposure_change",
 ]
 
@@ -192,6 +193,43 @@ def _normalize_team(raw: Any) -> str | None:
     """``"phi "`` → ``"PHI"``; anything empty → ``None`` (UNKNOWN, not a bucket)."""
     token = str(raw or "").strip().upper()
     return token or None
+
+
+def nfl_team_by_player(contract: Mapping[str, Any] | None) -> dict[str, str]:
+    """``{playerName: nflTeam}`` from the canonical board.
+
+    Keyed the same way :func:`src.api.data_contract.contract_roster_pools`
+    keys players (``canonicalName`` first, falling back to ``displayName``),
+    so a caller joining this against a ``RosterPlayer``/``CoreMember``
+    population cannot silently miss every row — a join key that disagrees
+    with the pools fails completely rather than partially, which is what
+    made the original bug (this function's predecessor keyed by
+    ``playerId``, matching nothing) invisible until a live board was run.
+
+    An empty ``team`` is left OUT rather than stored as ``""`` — callers
+    read absence as UNKNOWN. ``"FA"`` (an unsigned free agent) IS a real,
+    resolved value here, not a missing one — see :data:`NON_FRANCHISE_TOKENS`
+    for the caller-side rule that a resolved-but-non-franchise team must not
+    be bucketed as if it were one of the 32 NFL teams.
+
+    Moved here from ``src/api/roster_intelligence.py`` (2026-09) so a second
+    consumer (Team Assignment's NFL affinity model) does not need to keep a
+    private duplicate of this join — one owner for "which NFL team is this
+    canonical player on".
+    """
+    out: dict[str, str] = {}
+    if not isinstance(contract, Mapping):
+        return out
+    for row in contract.get("playersArray") or []:
+        if not isinstance(row, Mapping) or row.get("assetClass") == "pick":
+            continue
+        team = str(row.get("team") or "").strip()
+        if not team:
+            continue
+        for key in (row.get("canonicalName"), row.get("displayName")):
+            if key:
+                out.setdefault(str(key), team)
+    return out
 
 
 def build_nfl_exposure(

--- a/tests/api/test_board_key_identity.py
+++ b/tests/api/test_board_key_identity.py
@@ -2,7 +2,7 @@
 
 Integration's finding 9: ``_board_players`` keys each row by
 ``canonicalName`` only, taking the FIRST of ``canonicalName`` /
-``displayName``, while ``_ages`` and ``_nfl_teams`` key by BOTH.  The
+``displayName``, while ``_ages`` and ``nfl_team_by_player`` key by BOTH.  The
 pool, meanwhile, is keyed by whatever string ``sleeper.teams[].players``
 carries, and ``contract_roster_pools`` matches that against either name.
 
@@ -18,6 +18,7 @@ consequence; this is the same class, one field over.
 from __future__ import annotations
 
 from src.api import roster_intelligence as ri
+from src.roster_intel.exposure import nfl_team_by_player
 
 _SLOTS = ["QB", "RB", "WR", "TE", "FLEX"]
 
@@ -91,7 +92,7 @@ def test_the_three_board_joins_key_the_same_way():
     rank_keys = {k for k, _pos, _v in ri._board_players(contract, pool_keys={"A. Jones"})}
     assert "A. Jones" in rank_keys
     assert "A. Jones" in set(ri._ages(contract))
-    assert "A. Jones" in set(ri._nfl_teams(contract))
+    assert "A. Jones" in set(nfl_team_by_player(contract))
 
 
 # ══ No silent fallback that invents a plausible-but-wrong roster ═══

--- a/tests/api/test_public_league_privacy_boundary.py
+++ b/tests/api/test_public_league_privacy_boundary.py
@@ -43,7 +43,7 @@ import server
 from src.api import league_registry
 
 #: Sections whose payload is per-manager decision intelligence.
-PRIVATE_SECTIONS = ("rosTeamStrength", "faabAnalytics", "rosTradeDeadline")
+PRIVATE_SECTIONS = ("rosTeamStrength", "faabAnalytics", "rosTradeDeadline", "teamAssignment")
 
 #: Sections that are genuinely league-wide facts and must STAY public.
 #: Listed explicitly so a future "make it all private" sweep has to

--- a/tests/api/test_roster_intelligence.py
+++ b/tests/api/test_roster_intelligence.py
@@ -20,6 +20,7 @@ import pytest
 
 from src.api import roster_intelligence as ri
 from src.roster_intel.core import build_meaningful_core
+from src.roster_intel.exposure import nfl_team_by_player
 from src.roster_intel.strength import build_team_strength
 
 _SLOTS = ["QB", "RB", "RB", "WR", "WR", "WR", "TE", "FLEX", "SUPER_FLEX"]
@@ -355,7 +356,7 @@ def test_exposure_matches_the_owner_called_directly():
     c, out = _league()
     pools, slots, _ = contract_roster_pools(c)
     core = build_meaningful_core(pools["o0"], slots)
-    direct = exposure_from_core(core, teams=ri._nfl_teams(c))
+    direct = exposure_from_core(core, teams=nfl_team_by_player(c))
     assert out["teams"]["o0"]["nflExposure"]["core"] == direct.to_dict()
 
 
@@ -387,7 +388,7 @@ def test_nfl_teams_are_keyed_the_way_the_pools_are():
     c = _contract()
     for row in c["playersArray"]:
         row["team"] = "MIN"
-    keys = set(ri._nfl_teams(c))
+    keys = set(nfl_team_by_player(c))
     assert "o0_QB0" in keys
     assert not any(k.startswith("id_") for k in keys)
     out = ri.build_league_roster_intelligence(c, team_count=12)

--- a/tests/api/test_team_assignment.py
+++ b/tests/api/test_team_assignment.py
@@ -1,47 +1,36 @@
-"""Tests for ``src/api/team_assignment.py``.
+"""Tests for ``src/api/team_assignment.py`` — the NFL Team Affinity model.
 
-Covers favorite resolution (direct + alias + missing), per-tier
-scoring rules (T1 QB anchor, T2 skill, T4 rookie, T5 IDP), the
-assignment threshold, the max-3 cap, the favorite-always-wins
-invariant, and the config fallback when the JSON file is
-malformed.
-
-The per-player point totals below are the single-count ones.  There
-is no T3: an "elite production" tier fired on the same
-``depth_chart_order == 1`` condition as T1/T2 and paid a second time
-for it (math audit 2026-08-04, H5b), so a primary QB scored 13 and a
-primary skill player 8 against a config that reads 10 and 5.
+Covers config load/merge, favorite resolution (direct + alias +
+missing, mechanism unchanged from the old points-based model), the
+canonical-value formula (base value passthrough, the ONE starting-QB
+2.0x multiplier and its "unknown never becomes starter" fallback),
+affinity-share aggregation and qualification, the max-3 cap, and the
+missing-is-never-zero / Meaningful-Core-reuse invariants the owner
+mandate is built on.
 """
 
 from __future__ import annotations
 
 import json
-import re
 from pathlib import Path
-
 
 from src.api import team_assignment
 from src.public_league.identity import Manager, ManagerRegistry, TeamAlias
 from src.public_league.snapshot import PublicLeagueSnapshot, SeasonSnapshot
+from src.roster_intel.core import build_meaningful_core
+from src.ros.lineup import RosterPlayer
 
 
 # ── Helpers ────────────────────────────────────────────────────────
 
+_DEFAULT_SLOTS = ["QB", "RB", "RB", "WR", "WR", "TE", "FLEX", "BN", "BN"]
 
-def _season(rosters, *, idp=False):
-    """Minimal SeasonSnapshot.  ``rosters`` is a list of dicts as
-    Sleeper returns them.  ``idp`` controls roster_positions to
-    flip the IDP gate on/off."""
-    league_settings: dict = {
-        "roster_positions": (
-            ["QB", "RB", "RB", "WR", "WR", "TE", "FLEX", "BN", "BN"]
-            + (["DL", "LB", "DB"] if idp else [])
-        ),
-    }
+
+def _season(rosters, *, slots=None):
     return SeasonSnapshot(
         season="2026",
         league_id="L1",
-        league={"settings": {}, "roster_positions": league_settings["roster_positions"]},
+        league={"settings": {}, "roster_positions": list(slots or _DEFAULT_SLOTS)},
         users=[],
         rosters=rosters,
         matchups_by_week={},
@@ -54,15 +43,14 @@ def _season(rosters, *, idp=False):
     )
 
 
-def _snapshot(rosters, nfl_players, managers, *, idp=False):
-    snap = PublicLeagueSnapshot(
+def _snapshot(rosters, nfl_players, managers, *, slots=None):
+    return PublicLeagueSnapshot(
         root_league_id="L1",
         generated_at="2026-04-30T00:00:00Z",
-        seasons=[_season(rosters, idp=idp)],
+        seasons=[_season(rosters, slots=slots)],
         managers=managers,
         nfl_players=nfl_players,
     )
-    return snap
 
 
 def _manager(owner_id, display_name, team_name=""):
@@ -83,18 +71,55 @@ def _manager(owner_id, display_name, team_name=""):
     )
 
 
-def _player(team, position, *, depth=1, years_exp=2, draft_round=None, name=None):
-    """Synthesize a Sleeper-shaped player record."""
-    rec = {
+def _nfl_player(team, position, *, depth=1, years_exp=2, name=None):
+    """Synthesize a Sleeper-shaped player record for the QB-starter signal."""
+    return {
         "team": team,
         "position": position,
         "depth_chart_order": depth,
         "years_exp": years_exp,
         "full_name": name or f"{position}-{team}-{depth}",
     }
-    if draft_round is not None:
-        rec["draft_round"] = draft_round
-    return rec
+
+
+def _row(canonical_name, position, team, value, *, player_id=None, asset_class="offense"):
+    return {
+        "canonicalName": canonical_name,
+        "displayName": canonical_name,
+        "position": position,
+        "team": team,
+        "rankDerivedValue": value,
+        "playerId": player_id,
+        "assetClass": asset_class,
+    }
+
+
+def _contract(rows, teams, *, slots=None):
+    """``teams`` is ``{ownerId: [canonicalName, ...]}``.  ``playerIds`` is
+    derived from each row's ``playerId`` (or omitted when None, mirroring
+    a name the Sleeper roster carries with no resolvable id)."""
+    positions = {r["canonicalName"]: r["position"] for r in rows}
+    by_name = {r["canonicalName"]: r for r in rows}
+    team_dicts = []
+    for owner_id, names in teams.items():
+        team_dicts.append(
+            {
+                "ownerId": owner_id,
+                "name": f"team-{owner_id}",
+                "players": list(names),
+                "playerIds": [by_name.get(n, {}).get("playerId") for n in names],
+            }
+        )
+    return {
+        "meta": {"leagueKey": "dynasty_main"},
+        "playersArray": rows,
+        "sleeper": {
+            "teams": team_dicts,
+            "rosterPositions": list(slots or _DEFAULT_SLOTS),
+            "positions": positions,
+            "fantasyPositions": {},
+        },
+    }
 
 
 def _config_path(tmp_path: Path, body: dict) -> Path:
@@ -103,13 +128,32 @@ def _config_path(tmp_path: Path, body: dict) -> Path:
     return p
 
 
+def _stub_config(monkeypatch, tmp_path: Path, *, min_share=0.10, qb_multiplier=2.0):
+    cfg_path = _config_path(
+        tmp_path,
+        {
+            "favorites": {
+                "jason": {"abbr": "MIN", "display": "Minnesota Vikings"},
+                "brent": {"abbr": "BUF", "display": "Buffalo Bills"},
+            },
+            "displayNameAliases": {
+                "jasonleetucker": "jason",
+            },
+            "weights": {"nflStartingQbMultiplier": qb_multiplier},
+            "thresholds": {"rosterAssignmentMinShare": min_share},
+            "limits": {"maxTeamsPerOwner": 3},
+        },
+    )
+    monkeypatch.setattr(team_assignment, "_CONFIG_PATH", cfg_path)
+
+
 # ── Config loader ─────────────────────────────────────────────────
 
 
 def test_load_config_uses_defaults_when_file_missing(tmp_path: Path):
     cfg = team_assignment.load_config(tmp_path / "missing.json")
-    assert cfg["weights"]["qbAnchor"] == 10
-    assert cfg["thresholds"]["assignmentMinPoints"] == 15
+    assert cfg["weights"]["nflStartingQbMultiplier"] == 2.0
+    assert cfg["thresholds"]["rosterAssignmentMinShare"] == 0.10
     assert cfg["limits"]["maxTeamsPerOwner"] == 3
     assert cfg["favorites"] == {}
 
@@ -118,8 +162,7 @@ def test_load_config_falls_back_on_malformed_json(tmp_path: Path):
     p = tmp_path / "team_assignment.json"
     p.write_text("not-json", encoding="utf-8")
     cfg = team_assignment.load_config(p)
-    # Same defaults as the missing-file path.
-    assert cfg["weights"]["qbAnchor"] == 10
+    assert cfg["weights"]["nflStartingQbMultiplier"] == 2.0
 
 
 def test_load_config_strips_doc_keys(tmp_path: Path):
@@ -139,29 +182,15 @@ def test_load_config_strips_doc_keys(tmp_path: Path):
     assert cfg["favorites"]["joel"]["abbr"] == "KC"
 
 
-def test_every_declared_weight_is_actually_read(tmp_path: Path):
-    """A declared-but-unread knob is a lie in the config file.
-
-    Static check over the module source: the default ``weights`` block
-    and the ``weights[...]`` reads in ``_score_player`` must be the same
-    set.  ``idpElite`` was declared and never read; the two
-    ``eliteProduction*`` weights were read by a tier that
-    double-counted.  Either direction of drift is a defect, so this
-    fails on both.
-    """
-    src = Path(team_assignment.__file__).read_text(encoding="utf-8")
-    read = set(re.findall(r'weights\["([A-Za-z0-9]+)"\]', src))
-    declared = set(team_assignment._DEFAULT_CONFIG["weights"])
-    assert declared == read
+def test_no_dead_weight_or_threshold_knobs_remain():
+    """The old per-position point weights and the flat point threshold
+    are retired entirely -- one weight (the QB multiplier), one
+    threshold (the affinity-share minimum)."""
+    assert set(team_assignment._DEFAULT_CONFIG["weights"]) == {"nflStartingQbMultiplier"}
+    assert set(team_assignment._DEFAULT_CONFIG["thresholds"]) == {"rosterAssignmentMinShare"}
 
 
 def test_shipped_config_declares_exactly_the_live_knobs():
-    """The on-disk config must not re-introduce dead keys.
-
-    ``_merge_config_with_defaults`` unions the user file over the
-    defaults, so a stale key in the JSON survives into the payload's
-    ``config`` block and reads as a live setting.
-    """
     shipped = json.loads(team_assignment._CONFIG_PATH.read_text(encoding="utf-8"))
     weights = {k for k in shipped["weights"] if k != "_doc"}
     thresholds = {k for k in shipped["thresholds"] if k != "_doc"}
@@ -170,21 +199,13 @@ def test_shipped_config_declares_exactly_the_live_knobs():
 
 
 def test_load_config_merges_partial_user_config_over_defaults(tmp_path: Path):
-    p = _config_path(
-        tmp_path,
-        {
-            "weights": {"qbAnchor": 999},  # override one knob; rest stays default
-        },
-    )
+    p = _config_path(tmp_path, {"weights": {"nflStartingQbMultiplier": 3.0}})
     cfg = team_assignment.load_config(p)
-    assert cfg["weights"]["qbAnchor"] == 999
-    # Sibling weights still defaulted.
-    assert cfg["weights"]["skillStarter"] == 5
-    # Unrelated keys still defaulted.
-    assert cfg["thresholds"]["assignmentMinPoints"] == 15
+    assert cfg["weights"]["nflStartingQbMultiplier"] == 3.0
+    assert cfg["thresholds"]["rosterAssignmentMinShare"] == 0.10
 
 
-# ── Favorite resolution ───────────────────────────────────────────
+# ── Favorite resolution (unchanged mechanism, test 19) ────────────
 
 
 def test_resolve_favorite_key_direct_match():
@@ -209,266 +230,394 @@ def test_resolve_favorite_key_missing_falls_to_none():
     assert team_assignment._resolve_favorite_key(None, favs, aliases) is None
 
 
-# ── Per-player scoring ────────────────────────────────────────────
-
-
-def _config():
-    return team_assignment._merge_config_with_defaults({})
-
-
-def test_score_qb_anchor():
-    qb = _player("KC", "QB", depth=1, years_exp=5)
-    pts, contribs = team_assignment._score_player(
-        qb,
-        config=_config(),
-        league_idp_enabled=False,
-    )
-    # T1 only — being primary at QB is ONE signal, paid once.
-    assert pts == 10
-    reasons = {c["reason"] for c in contribs}
-    assert "QB anchor" in reasons
-
-
-def test_score_qb_backup_no_anchor():
-    qb = _player("KC", "QB", depth=2, years_exp=5)
-    pts, _ = team_assignment._score_player(
-        qb,
-        config=_config(),
-        league_idp_enabled=False,
-    )
-    # No T1 (depth != 1).  No rookie / IDP / skill rules apply.  → 0.
-    assert pts == 0
-
-
-def test_score_skill_starter_is_paid_once():
-    """The config's ``skillStarter`` is 5, so a starter scores 5.
-
-    Regression guard for the double-count: the retired elite-production
-    tier added another 3 on the same ``depth_order == 1`` test, so this
-    player used to be worth 8 — a number that appeared nowhere in the
-    config and made the weights unreadable.
-    """
-    rb = _player("BUF", "RB", depth=1, years_exp=3)
-    pts, contribs = team_assignment._score_player(
-        rb,
-        config=_config(),
-        league_idp_enabled=False,
-    )
-    assert pts == 5
-    reasons = {c["reason"] for c in contribs}
-    assert any("starter" in r for r in reasons)
-    # Exactly one rule fired, so exactly one contributor row.
-    assert len(contribs) == 1
-
-
-def test_score_skill_committee():
-    rb = _player("BUF", "RB", depth=2, years_exp=3)
-    pts, _ = team_assignment._score_player(
-        rb,
-        config=_config(),
-        league_idp_enabled=False,
-    )
-    # T2 committee (2).  → 2.
-    assert pts == 2
-
-
-def test_score_skill_bench_zero():
-    rb = _player("BUF", "RB", depth=4, years_exp=3)
-    pts, _ = team_assignment._score_player(
-        rb,
-        config=_config(),
-        league_idp_enabled=False,
-    )
-    assert pts == 0
-
-
-def test_score_rookie_round_one():
-    rookie = _player("CHI", "WR", depth=1, years_exp=0, draft_round=1)
-    pts, contribs = team_assignment._score_player(
-        rookie,
-        config=_config(),
-        league_idp_enabled=False,
-    )
-    # T2 starter (5) + T4 round 1 (4) = 9.  Rookie capital is a
-    # genuinely independent signal, so it still layers on top.
-    assert pts == 9
-    assert any("1st-round rookie" in c["reason"] for c in contribs)
-
-
-def test_score_rookie_round_two():
-    rookie = _player("CHI", "WR", depth=2, years_exp=0, draft_round=2)
-    pts, contribs = team_assignment._score_player(
-        rookie,
-        config=_config(),
-        league_idp_enabled=False,
-    )
-    # T2 committee (2) + T4 round 2 (2) = 4.
-    assert pts == 4
-    assert any("2nd-round rookie" in c["reason"] for c in contribs)
-
-
-def test_score_idp_starter_only_when_league_idp_enabled():
-    lb = _player("DAL", "LB", depth=1, years_exp=3)
-    # IDP off -> no points at all.
-    off_pts, _ = team_assignment._score_player(
-        lb,
-        config=_config(),
-        league_idp_enabled=False,
-    )
-    assert off_pts == 0
-    # IDP on -> T5 starter (2).
-    on_pts, _ = team_assignment._score_player(
-        lb,
-        config=_config(),
-        league_idp_enabled=True,
-    )
-    assert on_pts == 2
-
-
-def test_score_player_with_no_position_returns_zero():
-    odd = {"team": "KC", "position": ""}
-    pts, contribs = team_assignment._score_player(
-        odd,
-        config=_config(),
-        league_idp_enabled=False,
-    )
-    assert pts == 0
-    assert contribs == []
-
-
-# ── End-to-end build_section ──────────────────────────────────────
-
-
-def _stub_config(monkeypatch, tmp_path: Path):
-    """Patch the module's _CONFIG_PATH to a tmp file so each test
-    runs against an isolated config without leaking real favorites."""
-    cfg_path = _config_path(
-        tmp_path,
-        {
-            "favorites": {
-                "jason": {"abbr": "MIN", "display": "Minnesota Vikings"},
-                "brent": {"abbr": "BUF", "display": "Buffalo Bills"},
-            },
-            "displayNameAliases": {
-                "jasonleetucker": "jason",
-            },
-            "thresholds": {"assignmentMinPoints": 10},
-            "limits": {"maxTeamsPerOwner": 3},
-        },
-    )
-    monkeypatch.setattr(team_assignment, "_CONFIG_PATH", cfg_path)
-
-
-def test_build_section_assigns_favorite_with_zero_roster_score(monkeypatch, tmp_path: Path):
-    """Favorite is included even when the manager has no roster
-    contribution to that team."""
-    _stub_config(monkeypatch, tmp_path)
-    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "Jason", "Vikings Fan")})
-    rosters = [
-        {"roster_id": 1, "owner_id": "oA", "players": ["p1"]},
-    ]
-    nfl = {
-        # Jason's only player is on KC, NOT MIN.
-        "p1": _player("KC", "QB", depth=1, years_exp=5),
-    }
-    snap = _snapshot(rosters, nfl, mgrs)
-    section = team_assignment.build_section(snap)
-    assignments = section["assignments"]
-    assert len(assignments) == 1
-    a = assignments[0]
-    assert a["favoriteKey"] == "jason"
-    # First entry MUST be the favorite (Vikings) with score 0.
-    assert a["nflTeams"][0]["abbr"] == "MIN"
-    assert a["nflTeams"][0]["isFavorite"] is True
-    assert a["nflTeams"][0]["score"] == 0
-
-
-def test_build_section_includes_roster_based_when_above_threshold(monkeypatch, tmp_path: Path):
-    _stub_config(monkeypatch, tmp_path)
-    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "Jason", "Vikings")})
-    rosters = [
-        {"roster_id": 1, "owner_id": "oA", "players": ["p1", "p2", "p3"]},
-    ]
-    nfl = {
-        "p1": _player("BUF", "QB", depth=1, years_exp=5),  # +10
-        "p2": _player("BUF", "RB", depth=1, years_exp=3),  # +5
-        "p3": _player("BUF", "WR", depth=2, years_exp=3),  # +2
-    }
-    # Total Bills score: 17.  Threshold is 10.  Should appear.
-    snap = _snapshot(rosters, nfl, mgrs)
-    section = team_assignment.build_section(snap)
-    teams = section["assignments"][0]["nflTeams"]
-    abbrs = [t["abbr"] for t in teams]
-    assert "MIN" in abbrs  # favorite
-    assert "BUF" in abbrs  # roster-based qualifier
-    bills = next(t for t in teams if t["abbr"] == "BUF")
-    assert bills["isFavorite"] is False
-    assert bills["score"] == 17
-
-
-def test_build_section_filters_below_threshold(monkeypatch, tmp_path: Path):
-    _stub_config(monkeypatch, tmp_path)
-    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "Jason", "Vikings")})
-    rosters = [
-        {"roster_id": 1, "owner_id": "oA", "players": ["p1"]},
-    ]
-    nfl = {
-        # 1 RB committee on BUF = 2 points.  Below threshold of 10.
-        "p1": _player("BUF", "RB", depth=2, years_exp=3),
-    }
-    snap = _snapshot(rosters, nfl, mgrs)
-    section = team_assignment.build_section(snap)
-    teams = section["assignments"][0]["nflTeams"]
-    abbrs = [t["abbr"] for t in teams]
-    # Only Vikings (favorite); BUF below threshold.
-    assert abbrs == ["MIN"]
-
-
-def test_build_section_caps_at_max_teams(monkeypatch, tmp_path: Path):
-    """Even when 5 NFL teams qualify, return only the cap (default 3).
-    Favorite always counts toward the cap."""
-    _stub_config(monkeypatch, tmp_path)
-    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "Jason", "Vikings")})
-    rosters = [
-        {"roster_id": 1, "owner_id": "oA", "players": [f"p{i}" for i in range(1, 11)]},
-    ]
-    # Stock five different NFL teams with +10 each (QB anchor).
-    nfl = {
-        "p1": _player("BUF", "QB", depth=1, years_exp=5),
-        "p2": _player("KC", "QB", depth=1, years_exp=5),
-        "p3": _player("DET", "QB", depth=1, years_exp=5),
-        "p4": _player("PHI", "QB", depth=1, years_exp=5),
-        "p5": _player("BAL", "QB", depth=1, years_exp=5),
-        # Ensure tiebreaker is alphabetical when scores are equal.
-        "p6": _player("BUF", "RB", depth=1, years_exp=5),  # bumps BUF to 15
-        "p7": _player("BUF", "WR", depth=1, years_exp=5),  # bumps BUF to 20
-        "p8": _player("KC", "RB", depth=1, years_exp=5),  # bumps KC to 15
-        "p9": _player("DET", "RB", depth=1, years_exp=5),  # bumps DET to 15
-        "p10": _player("PHI", "RB", depth=1, years_exp=5),  # bumps PHI to 15
-    }
-    snap = _snapshot(rosters, nfl, mgrs)
-    section = team_assignment.build_section(snap)
-    teams = section["assignments"][0]["nflTeams"]
-    abbrs = [t["abbr"] for t in teams]
-    # Cap of 3: Vikings (favorite) + top 2 by score.  BUF has 20
-    # which beats KC/DET/PHI's 15.  Tiebreak among the 15-scorers
-    # is alphabetical.
-    assert len(abbrs) == 3
-    assert abbrs[0] == "MIN"  # favorite always first
-    assert abbrs[1] == "BUF"  # 29 pts
-    # 2nd place is one of KC/DET/PHI (all 15); alphabetical → DET.
-    assert abbrs[2] == "DET"
-
-
 def test_build_section_alias_resolves_jasonleetucker(monkeypatch, tmp_path: Path):
     _stub_config(monkeypatch, tmp_path)
     mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "JasonLeeTucker")})
     rosters = [{"roster_id": 1, "owner_id": "oA", "players": []}]
     snap = _snapshot(rosters, {}, mgrs)
-    section = team_assignment.build_section(snap)
+    section = team_assignment.build_section(snap, None)
     a = section["assignments"][0]
     assert a["favoriteKey"] == "jason"
     assert a["nflTeams"][0]["abbr"] == "MIN"
+
+
+# ── Owner worked example: the canonical formula, exactly ──────────
+
+
+def test_owner_worked_example_dart_nabers_18000(monkeypatch, tmp_path: Path):
+    """Jackson Dart (5,000, NFL starting QB) x2 + Malik Nabers (8,000)
+    = 18,000 MIN affinity -- the owner's own worked example, verbatim."""
+    _stub_config(monkeypatch, tmp_path)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "jason")})
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["Jackson Dart", "Malik Nabers"]}]
+    nfl = {"sqb": _nfl_player("MIN", "QB", depth=1)}
+    snap = _snapshot(rosters, nfl, mgrs, slots=["QB", "WR", "BN"])
+    rows = [
+        _row("Jackson Dart", "QB", "MIN", 5000, player_id="sqb"),
+        _row("Malik Nabers", "WR", "MIN", 8000, player_id="wr1"),
+    ]
+    contract = _contract(rows, {"oA": ["Jackson Dart", "Malik Nabers"]}, slots=["QB", "WR", "BN"])
+    section = team_assignment.build_section(snap, contract)
+    a = section["assignments"][0]
+    assert a["totalWeightedCoreValue"] == 18000.0
+    min_team = next(t for t in a["nflTeams"] if t["abbr"] == "MIN")
+    assert min_team["affinityScore"] == 18000.0
+    dart = next(c for c in min_team["contributors"] if c["canonicalName"] == "Jackson Dart")
+    assert dart["canonicalValue"] == 5000.0
+    assert dart["multiplier"] == 2.0
+    assert dart["multiplierReason"] == "nfl_starting_qb"
+    assert dart["weightedValue"] == 10000.0
+    nabers = next(c for c in min_team["contributors"] if c["canonicalName"] == "Malik Nabers")
+    assert nabers["multiplier"] == 1.0
+    assert nabers["weightedValue"] == 8000.0
+
+
+def test_canonical_value_player_contributes_actual_value(monkeypatch, tmp_path: Path):
+    """Test 2: a non-QB core member contributes exactly his canonical
+    value, no multiplier."""
+    _stub_config(monkeypatch, tmp_path)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "nofavorite")})
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["Some WR"]}]
+    rows = [_row("Some WR", "WR", "KC", 4321, player_id="w1")]
+    contract = _contract(rows, {"oA": ["Some WR"]}, slots=["WR", "BN"])
+    snap = _snapshot(rosters, {}, mgrs, slots=["WR", "BN"])
+    section = team_assignment.build_section(snap, contract)
+    kc = next(t for t in section["assignments"][0]["nflTeams"] if t["abbr"] == "KC")
+    assert kc["affinityScore"] == 4321.0
+    assert kc["contributors"][0]["canonicalValue"] == 4321.0
+    assert kc["contributors"][0]["multiplier"] == 1.0
+
+
+def test_nfl_starting_qb_receives_exactly_2x(monkeypatch, tmp_path: Path):
+    """Test 3."""
+    _stub_config(monkeypatch, tmp_path)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "nofavorite")})
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["QB One"]}]
+    nfl = {"sid": _nfl_player("KC", "QB", depth=1)}
+    rows = [_row("QB One", "QB", "KC", 3000, player_id="sid")]
+    contract = _contract(rows, {"oA": ["QB One"]}, slots=["QB", "BN"])
+    snap = _snapshot(rosters, nfl, mgrs, slots=["QB", "BN"])
+    section = team_assignment.build_section(snap, contract)
+    kc = next(t for t in section["assignments"][0]["nflTeams"] if t["abbr"] == "KC")
+    c = kc["contributors"][0]
+    assert c["multiplier"] == 2.0
+    assert c["multiplierReason"] == "nfl_starting_qb"
+    assert c["weightedValue"] == 6000.0
+
+
+def test_backup_qb_does_not_receive_2x(monkeypatch, tmp_path: Path):
+    """Test 4."""
+    _stub_config(monkeypatch, tmp_path)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "nofavorite")})
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["QB Two"]}]
+    nfl = {"bid": _nfl_player("KC", "QB", depth=2)}
+    rows = [_row("QB Two", "QB", "KC", 500, player_id="bid")]
+    contract = _contract(rows, {"oA": ["QB Two"]}, slots=["QB", "BN"])
+    snap = _snapshot(rosters, nfl, mgrs, slots=["QB", "BN"])
+    section = team_assignment.build_section(snap, contract)
+    kc = next(t for t in section["assignments"][0]["nflTeams"] if t["abbr"] == "KC")
+    c = kc["contributors"][0]
+    assert c["multiplier"] == 1.0
+    assert c["multiplierReason"] == "qb_not_starting"
+    assert c["weightedValue"] == 500.0
+
+
+def test_unknown_qb_starter_state_does_not_receive_2x(monkeypatch, tmp_path: Path):
+    """Test 5: no Sleeper player directory at all -- unknown never
+    becomes starter."""
+    _stub_config(monkeypatch, tmp_path)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "nofavorite")})
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["QB Three"]}]
+    rows = [_row("QB Three", "QB", "KC", 500, player_id="uid")]
+    contract = _contract(rows, {"oA": ["QB Three"]}, slots=["QB", "BN"])
+    snap = _snapshot(rosters, {}, mgrs, slots=["QB", "BN"])  # empty nfl_players
+    section = team_assignment.build_section(snap, contract)
+    assert section["qbSignalAvailable"] is False
+    assert team_assignment.DEGRADED_NO_QB_SIGNAL in section["degradedReasons"]
+    kc = next(t for t in section["assignments"][0]["nflTeams"] if t["abbr"] == "KC")
+    c = kc["contributors"][0]
+    assert c["multiplier"] == 1.0
+    assert c["multiplierReason"] == "starter_status_unknown"
+
+
+def test_unresolvable_sleeper_id_also_falls_back_to_unknown(monkeypatch, tmp_path: Path):
+    """A canonical name with no matched Sleeper id (playerId=None on the
+    board row) cannot be looked up in the NFL depth chart at all."""
+    _stub_config(monkeypatch, tmp_path)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "nofavorite")})
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["QB Four"]}]
+    nfl = {"someone_else": _nfl_player("KC", "QB", depth=1)}
+    rows = [_row("QB Four", "QB", "KC", 500, player_id=None)]
+    contract = _contract(rows, {"oA": ["QB Four"]}, slots=["QB", "BN"])
+    snap = _snapshot(rosters, nfl, mgrs, slots=["QB", "BN"])
+    section = team_assignment.build_section(snap, contract)
+    kc = next(t for t in section["assignments"][0]["nflTeams"] if t["abbr"] == "KC")
+    c = kc["contributors"][0]
+    assert c["multiplier"] == 1.0
+    assert c["multiplierReason"] == "starter_status_unknown"
+    assert c["sleeperPlayerId"] is None
+
+
+# ── Aggregation / qualification ────────────────────────────────────
+
+
+def test_two_teammates_aggregate_correctly(monkeypatch, tmp_path: Path):
+    """Test 6: QB = 5,000 x2 + WR = 8,000 -> team score = 18,000
+    (same shape as the owner example, phrased as its own test)."""
+    _stub_config(monkeypatch, tmp_path)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "nofavorite")})
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["Q", "W"]}]
+    nfl = {"q": _nfl_player("SEA", "QB", depth=1)}
+    rows = [
+        _row("Q", "QB", "SEA", 5000, player_id="q"),
+        _row("W", "WR", "SEA", 8000, player_id="w"),
+    ]
+    contract = _contract(rows, {"oA": ["Q", "W"]}, slots=["QB", "WR", "BN"])
+    snap = _snapshot(rosters, nfl, mgrs, slots=["QB", "WR", "BN"])
+    section = team_assignment.build_section(snap, contract)
+    sea = next(t for t in section["assignments"][0]["nflTeams"] if t["abbr"] == "SEA")
+    assert sea["affinityScore"] == 18000.0
+
+
+def test_affinity_share_denominator_is_total_weighted_core_value(monkeypatch, tmp_path: Path):
+    """Test 7: two NFL teams, verify shares sum against the TOTAL,
+    including a team that itself does not clear the threshold."""
+    _stub_config(monkeypatch, tmp_path, min_share=0.10)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "nofavorite")})
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["A", "B"]}]
+    rows = [
+        _row("A", "RB", "SEA", 9000, player_id="a"),
+        _row("B", "RB", "KC", 1000, player_id="b"),
+    ]
+    contract = _contract(rows, {"oA": ["A", "B"]}, slots=["RB", "RB", "BN"])
+    snap = _snapshot(rosters, {}, mgrs, slots=["RB", "RB", "BN"])
+    section = team_assignment.build_section(snap, contract)
+    a = section["assignments"][0]
+    assert a["totalWeightedCoreValue"] == 10000.0
+    sea = next(t for t in a["nflTeams"] if t["abbr"] == "SEA")
+    assert sea["affinityShare"] == 0.9
+    # KC is exactly 10% -- qualifies (boundary, see test 9) so both show.
+    abbrs = {t["abbr"] for t in a["nflTeams"]}
+    assert abbrs == {"SEA", "KC"}
+
+
+def test_non_favorite_below_threshold_does_not_qualify(monkeypatch, tmp_path: Path):
+    """Test 8."""
+    _stub_config(monkeypatch, tmp_path, min_share=0.10)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "nofavorite")})
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["A", "B"]}]
+    rows = [
+        _row("A", "RB", "SEA", 9100, player_id="a"),
+        _row("B", "RB", "KC", 900, player_id="b"),
+    ]
+    contract = _contract(rows, {"oA": ["A", "B"]}, slots=["RB", "RB", "BN"])
+    snap = _snapshot(rosters, {}, mgrs, slots=["RB", "RB", "BN"])
+    section = team_assignment.build_section(snap, contract)
+    abbrs = {t["abbr"] for t in section["assignments"][0]["nflTeams"]}
+    assert abbrs == {"SEA"}
+
+
+def test_non_favorite_at_or_above_threshold_qualifies(monkeypatch, tmp_path: Path):
+    """Test 9: exactly 10.0% qualifies (>= not >)."""
+    _stub_config(monkeypatch, tmp_path, min_share=0.10)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "nofavorite")})
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["A", "B"]}]
+    rows = [
+        _row("A", "RB", "SEA", 9000, player_id="a"),
+        _row("B", "RB", "KC", 1000, player_id="b"),
+    ]
+    contract = _contract(rows, {"oA": ["A", "B"]}, slots=["RB", "RB", "BN"])
+    snap = _snapshot(rosters, {}, mgrs, slots=["RB", "RB", "BN"])
+    section = team_assignment.build_section(snap, contract)
+    abbrs = {t["abbr"] for t in section["assignments"][0]["nflTeams"]}
+    assert "KC" in abbrs
+
+
+def test_favorite_remains_assigned_below_threshold(monkeypatch, tmp_path: Path):
+    """Test 10: favorite has zero roster contribution, still shown."""
+    _stub_config(monkeypatch, tmp_path)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "jason")})
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["A"]}]
+    rows = [_row("A", "RB", "KC", 9999, player_id="a")]
+    contract = _contract(rows, {"oA": ["A"]}, slots=["RB", "BN"])
+    snap = _snapshot(rosters, {}, mgrs, slots=["RB", "BN"])
+    section = team_assignment.build_section(snap, contract)
+    a = section["assignments"][0]
+    assert a["nflTeams"][0]["abbr"] == "MIN"
+    assert a["nflTeams"][0]["isFavorite"] is True
+    assert a["nflTeams"][0]["affinityScore"] == 0.0
+    assert a["nflTeams"][0]["qualifiesByRoster"] is False
+
+
+def test_max_three_assignments_enforced_with_deterministic_tiebreak(monkeypatch, tmp_path: Path):
+    """Test 11 + 12: favorite + top two qualifiers, tiebreak by abbr."""
+    _stub_config(monkeypatch, tmp_path, min_share=0.05)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "jason")})
+    names = [f"P{i}" for i in range(5)]
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": names}]
+    # BUF highest, then three teams tied at the same share -> alphabetical.
+    rows = [
+        _row("P0", "RB", "BUF", 5000, player_id="p0"),
+        _row("P1", "RB", "KC", 1000, player_id="p1"),
+        _row("P2", "RB", "DET", 1000, player_id="p2"),
+        _row("P3", "RB", "PHI", 1000, player_id="p3"),
+        _row("P4", "RB", "MIN", 100, player_id="p4"),  # favorite, tiny
+    ]
+    contract = _contract(rows, {"oA": names}, slots=["RB", "RB", "RB", "RB", "RB", "BN"])
+    snap = _snapshot(rosters, {}, mgrs, slots=["RB", "RB", "RB", "RB", "RB", "BN"])
+    section = team_assignment.build_section(snap, contract)
+    abbrs = [t["abbr"] for t in section["assignments"][0]["nflTeams"]]
+    assert len(abbrs) == 3
+    assert abbrs[0] == "MIN"  # favorite always first
+    assert abbrs[1] == "BUF"  # clearly highest share
+    assert abbrs[2] == "DET"  # tied with KC/PHI at same share, alphabetical wins
+
+
+def test_missing_canonical_value_is_not_converted_to_zero(monkeypatch, tmp_path: Path):
+    """Test 13: an unpriced rostered player is excluded from the core
+    (never seated at 0) and reported via unpricedCount."""
+    _stub_config(monkeypatch, tmp_path)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "nofavorite")})
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["Priced", "Unpriced"]}]
+    rows = [
+        _row("Priced", "RB", "KC", 4000, player_id="p"),
+        # "Unpriced" has no matching playersArray row at all -> no value.
+    ]
+    contract = _contract(rows, {"oA": ["Priced", "Unpriced"]}, slots=["RB", "RB", "BN"])
+    snap = _snapshot(rosters, {}, mgrs, slots=["RB", "RB", "BN"])
+    section = team_assignment.build_section(snap, contract)
+    a = section["assignments"][0]
+    assert a["unpricedCount"] == 1
+    assert a["totalWeightedCoreValue"] == 4000.0
+    kc = next(t for t in a["nflTeams"] if t["abbr"] == "KC")
+    assert len(kc["contributors"]) == 1
+
+
+def test_meaningful_core_unavailable_for_one_team_is_not_a_confident_empty_answer(
+    monkeypatch, tmp_path: Path
+):
+    """Test 14 (per-team narrower case): contract is usable league-wide,
+    but THIS manager's roster has no matching pool -- must say so, not
+    render a silent empty roster-based result indistinguishable from
+    'scored, nothing qualified'."""
+    _stub_config(monkeypatch, tmp_path)
+    mgrs = ManagerRegistry(
+        by_owner_id={
+            "oA": _manager("oA", "nofavorite-a"),
+            "oB": _manager("oB", "nofavorite-b"),
+        }
+    )
+    rosters = [
+        {"roster_id": 1, "owner_id": "oA", "players": ["A"]},
+        {"roster_id": 2, "owner_id": "oB", "players": ["B"]},
+    ]
+    rows = [_row("A", "RB", "KC", 4000, player_id="a")]
+    # Contract only carries oA's team -- oB is absent from sleeper.teams.
+    contract = _contract(rows, {"oA": ["A"]}, slots=["RB", "BN"])
+    snap = _snapshot(rosters, {}, mgrs, slots=["RB", "BN"])
+    section = team_assignment.build_section(snap, contract)
+    assert section["rosterScoringAvailable"] is True  # league-wide is fine
+    by_owner = {a["ownerId"]: a for a in section["assignments"]}
+    assert by_owner["oA"]["rosterScored"] is True
+    assert by_owner["oB"]["rosterScored"] is False
+    assert by_owner["oB"]["rosterUnavailableReason"] == team_assignment.ROSTER_REASON_NOT_IN_CONTRACT
+    assert by_owner["oB"]["totalWeightedCoreValue"] is None
+
+
+def test_favorite_survives_degraded_roster_intelligence(monkeypatch, tmp_path: Path):
+    """Test 15: no canonical contract at all -- favorite still shown,
+    with a truthful degraded reason, not a confident empty roster."""
+    _stub_config(monkeypatch, tmp_path)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "jason")})
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["A"]}]
+    snap = _snapshot(rosters, {}, mgrs)
+    section = team_assignment.build_section(snap, None)
+    assert section["available"] is True
+    assert section["rosterScoringAvailable"] is False
+    assert team_assignment.DEGRADED_NO_CONTRACT in section["degradedReasons"]
+    a = section["assignments"][0]
+    assert a["rosterScored"] is False
+    assert a["nflTeams"][0]["abbr"] == "MIN"
+    assert a["nflTeams"][0]["isFavorite"] is True
+
+
+def test_idp_players_use_canonical_value_with_no_penalty(monkeypatch, tmp_path: Path):
+    """Test 16: an LB counts its full canonical value like any other
+    position -- no arbitrary IDP discount, no special-case gate."""
+    _stub_config(monkeypatch, tmp_path)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "nofavorite")})
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["LB One"]}]
+    rows = [_row("LB One", "LB", "DAL", 2500, player_id="lb1", asset_class="idp")]
+    contract = _contract(rows, {"oA": ["LB One"]}, slots=["LB", "BN"])
+    snap = _snapshot(rosters, {}, mgrs, slots=["LB", "BN"])
+    section = team_assignment.build_section(snap, contract)
+    dal = next(t for t in section["assignments"][0]["nflTeams"] if t["abbr"] == "DAL")
+    c = dal["contributors"][0]
+    assert c["canonicalValue"] == 2500.0
+    assert c["weightedValue"] == 2500.0
+    assert c["multiplier"] == 1.0
+    assert c["multiplierReason"] == "not_qb"
+
+
+def test_deep_non_core_roster_players_contribute_nothing(monkeypatch, tmp_path: Path):
+    """Test 17: a roster with far more players than starter + reserve
+    demand -- the excess never enters the core, and their value never
+    reaches the total."""
+    _stub_config(monkeypatch, tmp_path)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "nofavorite")})
+    # 1 RB slot + 1 BN (no reserve demand configured beyond the core's
+    # own multiplier ceiling) -- five RBs on the roster, only a few can
+    # ever be seated.
+    names = [f"RB{i}" for i in range(6)]
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": names}]
+    rows = [_row(n, "RB", "KC", 1000 * (i + 1), player_id=n.lower()) for i, n in enumerate(names)]
+    contract = _contract(rows, {"oA": names}, slots=["RB", "BN"])
+    snap = _snapshot(rosters, {}, mgrs, slots=["RB", "BN"])
+    section = team_assignment.build_section(snap, contract)
+    a = section["assignments"][0]
+    core = build_meaningful_core(
+        [
+            RosterPlayer(
+                player_id=n, canonical_name=n, position="RB", ros_value=1000.0 * (i + 1)
+            )
+            for i, n in enumerate(names)
+        ],
+        ["RB", "BN"],
+    )
+    seated = len(core.members)
+    assert seated < len(names)
+    kc = next(t for t in a["nflTeams"] if t["abbr"] == "KC")
+    assert len(kc["contributors"]) == seated
+
+
+def test_flex_players_are_not_selected_a_second_time(monkeypatch, tmp_path: Path):
+    """Test 18: the total weighted core value must equal exactly the
+    sum over the Meaningful Core's own members -- never double-counting
+    a FLEX-assigned player against both his native slot and FLEX."""
+    _stub_config(monkeypatch, tmp_path)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "nofavorite")})
+    names = ["RB1", "RB2", "RB3", "WR1"]
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": names}]
+    rows = [
+        _row("RB1", "RB", "KC", 5000, player_id="rb1"),
+        _row("RB2", "RB", "KC", 4000, player_id="rb2"),
+        _row("RB3", "RB", "KC", 3000, player_id="rb3"),  # eligible for FLEX
+        _row("WR1", "WR", "KC", 100, player_id="wr1"),
+    ]
+    slots = ["RB", "RB", "FLEX", "BN"]
+    contract = _contract(rows, {"oA": names}, slots=slots)
+    snap = _snapshot(rosters, {}, mgrs, slots=slots)
+    section = team_assignment.build_section(snap, contract)
+    a = section["assignments"][0]
+    # 5000 + 4000 + 3000 = 12000 seated as starters (RB3 fills FLEX);
+    # WR1 (100) is the sole reserve candidate depending on demand -- in
+    # any case no player's value can appear twice.
+    kc = next(t for t in a["nflTeams"] if t["abbr"] == "KC")
+    names_seen = [c["canonicalName"] for c in kc["contributors"]]
+    assert len(names_seen) == len(set(names_seen))
+
+
+# ── Structural / global availability ───────────────────────────────
 
 
 def test_build_section_no_current_season_returns_empty():
@@ -477,83 +626,9 @@ def test_build_section_no_current_season_returns_empty():
         generated_at="2026-04-30T00:00:00Z",
         seasons=[],
     )
-    section = team_assignment.build_section(snap)
+    section = team_assignment.build_section(snap, None)
     assert section["assignments"] == []
     assert section["currentSeason"] is None
-
-
-def test_build_section_emits_contributors_breakdown(monkeypatch, tmp_path: Path):
-    _stub_config(monkeypatch, tmp_path)
-    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "Jason", "Vikings")})
-    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["p1", "p2"]}]
-    nfl = {
-        "p1": _player("BUF", "QB", depth=1, years_exp=5, name="Josh Allen"),
-        "p2": _player("BUF", "WR", depth=1, years_exp=3, name="Stefon Diggs"),
-    }
-    snap = _snapshot(rosters, nfl, mgrs)
-    section = team_assignment.build_section(snap)
-    bills = next(t for t in section["assignments"][0]["nflTeams"] if t["abbr"] == "BUF")
-    contribs = bills["contributors"]
-    # Expect one contributor row per scoring rule that fired — here one
-    # each (QB anchor, WR starter), not two apiece.
-    assert len(contribs) == 2
-    # Every contributor has player + points + reason.
-    for c in contribs:
-        assert "player" in c and "points" in c and "reason" in c
-    # Allen contributes 10, Diggs 5 → Bills total 15.
-    assert bills["score"] == 15
-    # The breakdown must add up to the score the UI renders.
-    assert sum(c["points"] for c in contribs) == bills["score"]
-
-
-def test_build_section_idp_off_excludes_idp_starter_points(monkeypatch, tmp_path: Path):
-    _stub_config(monkeypatch, tmp_path)
-    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "Jason", "Vikings")})
-    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["p1"]}]
-    nfl = {"p1": _player("DAL", "LB", depth=1, years_exp=3)}
-    snap = _snapshot(rosters, nfl, mgrs, idp=False)
-    section = team_assignment.build_section(snap)
-    teams = section["assignments"][0]["nflTeams"]
-    abbrs = [t["abbr"] for t in teams]
-    # IDP off: LB is worth zero points → DAL not above threshold.
-    assert abbrs == ["MIN"]
-
-
-def test_build_section_idp_on_includes_idp_starter_when_above_threshold(
-    monkeypatch, tmp_path: Path
-):
-    """With IDP enabled, a couple of starting LBs on the same NFL
-    team should accumulate enough points to clear the threshold."""
-    _stub_config(monkeypatch, tmp_path)
-    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "Jason", "Vikings")})
-    rosters = [{"roster_id": 1, "owner_id": "oA", "players": [f"p{i}" for i in range(1, 6)]}]
-    # 5 starting LBs on DAL = 10 points (5 × 2).  Threshold is 10.
-    nfl = {f"p{i}": _player("DAL", "LB", depth=1, years_exp=3) for i in range(1, 6)}
-    snap = _snapshot(rosters, nfl, mgrs, idp=True)
-    section = team_assignment.build_section(snap)
-    teams = section["assignments"][0]["nflTeams"]
-    abbrs = [t["abbr"] for t in teams]
-    assert "DAL" in abbrs
-
-
-def test_build_section_no_favorite_match_still_emits_roster_assignment(monkeypatch, tmp_path: Path):
-    """Manager with no favorite configured still gets roster-based
-    assignments above the threshold."""
-    _stub_config(monkeypatch, tmp_path)
-    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "Stranger")})
-    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["p1", "p2"]}]
-    nfl = {
-        "p1": _player("KC", "QB", depth=1, years_exp=5),  # +10
-        "p2": _player("KC", "RB", depth=1, years_exp=3),  # +5
-    }
-    snap = _snapshot(rosters, nfl, mgrs)
-    section = team_assignment.build_section(snap)
-    a = section["assignments"][0]
-    assert a["favoriteKey"] is None
-    teams = a["nflTeams"]
-    assert len(teams) == 1  # No favorite, just the one roster qualifier.
-    assert teams[0]["abbr"] == "KC"
-    assert teams[0]["isFavorite"] is False
 
 
 def test_build_section_orders_assignments_alphabetically_by_display_name(
@@ -573,7 +648,7 @@ def test_build_section_orders_assignments_alphabetically_by_display_name(
         {"roster_id": 3, "owner_id": "oC", "players": []},
     ]
     snap = _snapshot(rosters, {}, mgrs)
-    section = team_assignment.build_section(snap)
+    section = team_assignment.build_section(snap, None)
     names = [a["displayName"] for a in section["assignments"]]
     assert names == ["Alex", "Brent", "Zane"]
 
@@ -583,23 +658,27 @@ def test_build_section_orders_assignments_alphabetically_by_display_name(
 
 def test_section_registered_in_public_contract():
     from src.public_league.public_contract import (
-        _SECTION_BUILDERS,
+        _LAZY_SECTION_BUILDERS,
+        PRIVATE_INTELLIGENCE_SECTIONS,
         PUBLIC_SECTION_KEYS,
     )
 
-    assert "teamAssignment" in _SECTION_BUILDERS
+    assert "teamAssignment" in _LAZY_SECTION_BUILDERS
     assert "teamAssignment" in PUBLIC_SECTION_KEYS
+    assert "teamAssignment" in PRIVATE_INTELLIGENCE_SECTIONS
 
 
 def test_section_payload_safe(monkeypatch, tmp_path: Path):
-    """Section's output passes the public-payload safety check —
-    no private field names leak."""
+    """No private field names leak, regardless of the section's auth
+    gate (the safety assertion runs unconditionally)."""
     from src.public_league.public_contract import assert_public_payload_safe
 
     _stub_config(monkeypatch, tmp_path)
-    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "Jason")})
-    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["p1"]}]
-    nfl = {"p1": _player("KC", "QB", depth=1, years_exp=5)}
-    snap = _snapshot(rosters, nfl, mgrs)
-    section = team_assignment.build_section(snap)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "jason")})
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["A"]}]
+    nfl = {"a": _nfl_player("KC", "QB", depth=1)}
+    rows = [_row("A", "QB", "KC", 5000, player_id="a")]
+    contract = _contract(rows, {"oA": ["A"]}, slots=["QB", "BN"])
+    snap = _snapshot(rosters, nfl, mgrs, slots=["QB", "BN"])
+    section = team_assignment.build_section(snap, contract)
     assert_public_payload_safe(section)

--- a/tests/api/test_team_assignment.py
+++ b/tests/api/test_team_assignment.py
@@ -520,7 +520,9 @@ def test_meaningful_core_unavailable_for_one_team_is_not_a_confident_empty_answe
     by_owner = {a["ownerId"]: a for a in section["assignments"]}
     assert by_owner["oA"]["rosterScored"] is True
     assert by_owner["oB"]["rosterScored"] is False
-    assert by_owner["oB"]["rosterUnavailableReason"] == team_assignment.ROSTER_REASON_NOT_IN_CONTRACT
+    assert (
+        by_owner["oB"]["rosterUnavailableReason"] == team_assignment.ROSTER_REASON_NOT_IN_CONTRACT
+    )
     assert by_owner["oB"]["totalWeightedCoreValue"] is None
 
 
@@ -577,9 +579,7 @@ def test_deep_non_core_roster_players_contribute_nothing(monkeypatch, tmp_path: 
     a = section["assignments"][0]
     core = build_meaningful_core(
         [
-            RosterPlayer(
-                player_id=n, canonical_name=n, position="RB", ros_value=1000.0 * (i + 1)
-            )
+            RosterPlayer(player_id=n, canonical_name=n, position="RB", ros_value=1000.0 * (i + 1))
             for i, n in enumerate(names)
         ],
         ["RB", "BN"],

--- a/tests/api/test_team_assignment_availability.py
+++ b/tests/api/test_team_assignment_availability.py
@@ -229,7 +229,9 @@ def test_league_wide_contract_available_but_one_team_unmatched(monkeypatch, tmp_
     by_owner = {a["ownerId"]: a for a in section["assignments"]}
     assert by_owner["oA"]["rosterScored"] is True
     assert by_owner["oB"]["rosterScored"] is False
-    assert by_owner["oB"]["rosterUnavailableReason"] == team_assignment.ROSTER_REASON_NOT_IN_CONTRACT
+    assert (
+        by_owner["oB"]["rosterUnavailableReason"] == team_assignment.ROSTER_REASON_NOT_IN_CONTRACT
+    )
 
 
 def test_qb_signal_unavailable_does_not_block_roster_scoring(monkeypatch, tmp_path: Path):

--- a/tests/api/test_team_assignment_availability.py
+++ b/tests/api/test_team_assignment_availability.py
@@ -2,13 +2,14 @@
 
 Observed in production: public ``/league`` ``teamAssignment`` returned
 ``{"assignments": []}`` with HTTP 200 during a degraded/seasonless
-snapshot, and recovered later.  Nothing in the payload distinguished
-"we asked and the answer is none" from "we could not ask", and the
-frontend printed a cause ("current season has no rosters yet") that it
-had not measured.
+snapshot, and recovered later. Nothing in the payload distinguished
+"we asked and the answer is none" from "we could not ask".
 
-This suite pins the three states apart.  It is deliberately separate
-from ``test_team_assignment.py``, which pins the SCORING model — mixing
+The 2026-09-01 NFL Team Affinity rewrite adds two MORE ways evidence
+can be partial or absent (no canonical contract; no NFL starter
+signal) on top of the original season/roster gate, and this suite
+pins all of them apart. Deliberately separate from
+``test_team_assignment.py``, which pins the FORMULA — mixing
 availability semantics into that file would bury them.
 """
 
@@ -24,12 +25,14 @@ from src.public_league.snapshot import PublicLeagueSnapshot, SeasonSnapshot
 
 # ── Helpers (kept local; see the module docstring) ─────────────────
 
+_SLOTS = ["QB", "RB", "WR", "TE", "FLEX", "BN"]
+
 
 def _season(rosters):
     return SeasonSnapshot(
         season="2026",
         league_id="L1",
-        league={"settings": {}, "roster_positions": ["QB", "RB", "WR", "TE", "FLEX", "BN"]},
+        league={"settings": {}, "roster_positions": list(_SLOTS)},
         users=[],
         rosters=rosters,
         matchups_by_week={},
@@ -70,6 +73,42 @@ def _snapshot(rosters, nfl_players, managers):
     )
 
 
+def _row(canonical_name, position, team, value, *, player_id=None):
+    return {
+        "canonicalName": canonical_name,
+        "displayName": canonical_name,
+        "position": position,
+        "team": team,
+        "rankDerivedValue": value,
+        "playerId": player_id,
+        "assetClass": "offense",
+    }
+
+
+def _contract(rows, teams):
+    positions = {r["canonicalName"]: r["position"] for r in rows}
+    by_name = {r["canonicalName"]: r for r in rows}
+    team_dicts = [
+        {
+            "ownerId": owner_id,
+            "name": f"team-{owner_id}",
+            "players": list(names),
+            "playerIds": [by_name.get(n, {}).get("playerId") for n in names],
+        }
+        for owner_id, names in teams.items()
+    ]
+    return {
+        "meta": {"leagueKey": "dynasty_main"},
+        "playersArray": rows,
+        "sleeper": {
+            "teams": team_dicts,
+            "rosterPositions": list(_SLOTS),
+            "positions": positions,
+            "fantasyPositions": {},
+        },
+    }
+
+
 def _stub_config(monkeypatch, tmp_path: Path):
     p = tmp_path / "team_assignment.json"
     p.write_text(
@@ -77,7 +116,8 @@ def _stub_config(monkeypatch, tmp_path: Path):
             {
                 "favorites": {"jason": {"abbr": "MIN", "display": "Minnesota Vikings"}},
                 "displayNameAliases": {},
-                "thresholds": {"assignmentMinPoints": 10},
+                "weights": {"nflStartingQbMultiplier": 2.0},
+                "thresholds": {"rosterAssignmentMinShare": 0.10},
                 "limits": {"maxTeamsPerOwner": 3},
             }
         ),
@@ -92,6 +132,7 @@ _REQUIRED_KEYS = {
     "available",
     "unavailableReason",
     "rosterScoringAvailable",
+    "qbSignalAvailable",
     "degradedReasons",
     "assignments",
     "config",
@@ -111,7 +152,7 @@ def _assert_shaped(section):
     assert isinstance(section["degradedReasons"], list)
 
 
-# ── Total unavailability ───────────────────────────────────────────
+# ── Total unavailability (season/roster gate, unchanged) ───────────
 
 
 def test_no_current_season_is_unavailable_not_empty():
@@ -125,7 +166,7 @@ def test_no_current_season_is_unavailable_not_empty():
         generated_at="2026-04-30T00:00:00Z",
         seasons=[],
     )
-    section = team_assignment.build_section(snap)
+    section = team_assignment.build_section(snap, None)
     _assert_shaped(section)
     assert section["available"] is False
     assert section["unavailableReason"] == team_assignment.UNAVAILABLE_NO_CURRENT_SEASON
@@ -138,63 +179,76 @@ def test_season_present_but_no_rosters_is_its_own_reason():
     carries nothing.  Collapsing the two would make the recovered vs.
     never-started cases indistinguishable."""
     snap = _snapshot([], {}, ManagerRegistry(by_owner_id={}))
-    section = team_assignment.build_section(snap)
+    section = team_assignment.build_section(snap, None)
     _assert_shaped(section)
     assert section["available"] is False
     assert section["unavailableReason"] == team_assignment.UNAVAILABLE_NO_ROSTERS
 
 
-# ── Partial degradation ────────────────────────────────────────────
+# ── Contract-level degradation (new: canonical MeaningfulCore/value) ─
 
 
-def test_missing_player_directory_is_degraded_not_a_zero_score(monkeypatch, tmp_path: Path):
-    """``snapshot.nfl_players`` empty scores every player 0.
-
-    That is reachable in production: ``snapshot.build`` swallows the
-    ~5 MB dump's fetch error and falls back to ``{}``.  Without the
-    flag, a favorite-only card asserts "no roster team qualified" from
-    evidence that was never read.
-    """
+def test_missing_contract_is_degraded_not_a_zero_score(monkeypatch, tmp_path: Path):
+    """No canonical contract at all -- roster-based scoring is
+    unavailable, but the favorite is config-derived and real."""
     _stub_config(monkeypatch, tmp_path)
     mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "jason")})
     rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["p1", "p2", "p3"]}]
-    section = team_assignment.build_section(_snapshot(rosters, {}, mgrs))
+    section = team_assignment.build_section(_snapshot(rosters, {}, mgrs), None)
     _assert_shaped(section)
 
-    # The section IS available — the favorite is config-derived and real.
     assert section["available"] is True
     assert section["rosterScoringAvailable"] is False
-    assert team_assignment.DEGRADED_NO_PLAYER_DIRECTORY in section["degradedReasons"]
+    assert team_assignment.DEGRADED_NO_CONTRACT in section["degradedReasons"]
 
     a = section["assignments"][0]
     assert a["rosterScored"] is False
-    assert a["playersResolved"] == 0
-    assert a["playersTotal"] == 3
+    assert a["totalWeightedCoreValue"] is None
     # The favorite still surfaces; only the roster-derived half is absent.
     assert [t["abbr"] for t in a["nflTeams"]] == ["MIN"]
 
 
-def test_partial_directory_reports_how_much_it_could_resolve(monkeypatch, tmp_path: Path):
-    """A directory that answers for SOME ids is not a failure, but the
-    coverage must be visible — otherwise a half-read roster silently
-    scores half as high as it should."""
+def test_league_wide_contract_available_but_one_team_unmatched(monkeypatch, tmp_path: Path):
+    """The contract loads and scores fine for managers it can match;
+    a manager missing from the contract's own team list is reported
+    per-team, not silently folded into the global degraded state."""
+    _stub_config(monkeypatch, tmp_path)
+    mgrs = ManagerRegistry(
+        by_owner_id={"oA": _manager("oA", "jason"), "oB": _manager("oB", "nofavorite")}
+    )
+    rosters = [
+        {"roster_id": 1, "owner_id": "oA", "players": ["p1"]},
+        {"roster_id": 2, "owner_id": "oB", "players": ["p2"]},
+    ]
+    rows = [_row("p1", "RB", "KC", 4000, player_id="p1")]
+    contract = _contract(rows, {"oA": ["p1"]})  # oB absent
+    section = team_assignment.build_section(_snapshot(rosters, {}, mgrs), contract)
+    _assert_shaped(section)
+    assert section["rosterScoringAvailable"] is True
+
+    by_owner = {a["ownerId"]: a for a in section["assignments"]}
+    assert by_owner["oA"]["rosterScored"] is True
+    assert by_owner["oB"]["rosterScored"] is False
+    assert by_owner["oB"]["rosterUnavailableReason"] == team_assignment.ROSTER_REASON_NOT_IN_CONTRACT
+
+
+def test_qb_signal_unavailable_does_not_block_roster_scoring(monkeypatch, tmp_path: Path):
+    """No Sleeper NFL player directory -- the QB multiplier fails
+    closed to 1.0x, but roster-based affinity still computes from
+    canonical values."""
     _stub_config(monkeypatch, tmp_path)
     mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "jason")})
-    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["p1", "p2", "ghost"]}]
-    nfl = {
-        "p1": {"team": "KC", "position": "QB", "depth_chart_order": 1, "years_exp": 5},
-        "p2": {"team": "KC", "position": "WR", "depth_chart_order": 1, "years_exp": 3},
-    }
-    section = team_assignment.build_section(_snapshot(rosters, nfl, mgrs))
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["p1"]}]
+    rows = [_row("p1", "RB", "KC", 4000, player_id="p1")]
+    contract = _contract(rows, {"oA": ["p1"]})
+    section = team_assignment.build_section(_snapshot(rosters, {}, mgrs), contract)
     _assert_shaped(section)
-    assert section["available"] is True
+    assert section["qbSignalAvailable"] is False
+    assert team_assignment.DEGRADED_NO_QB_SIGNAL in section["degradedReasons"]
     assert section["rosterScoringAvailable"] is True
-    assert section["degradedReasons"] == []
-
     a = section["assignments"][0]
     assert a["rosterScored"] is True
-    assert a["playersResolved"] == 2
-    assert a["playersTotal"] == 3
+    assert a["totalWeightedCoreValue"] == 4000.0
 
 
 # ── The healthy path keeps its meaning ─────────────────────────────
@@ -203,21 +257,21 @@ def test_partial_directory_reports_how_much_it_could_resolve(monkeypatch, tmp_pa
 def test_healthy_empty_result_is_still_expressible(monkeypatch, tmp_path: Path):
     """A real "nothing qualified" answer must remain available:True.
 
-    Otherwise the repair overcorrects and every quiet league reads as
-    broken.
-    """
+    An empty roster (present in the contract, zero players) is scored
+    fine -- Meaningful Core is legitimately empty, not unreadable -- and
+    must render as ``nflTeams: []`` rather than a degraded state."""
     _stub_config(monkeypatch, tmp_path)
     mgrs = ManagerRegistry(by_owner_id={"oB": _manager("oB", "nofavorite")})
-    rosters = [{"roster_id": 1, "owner_id": "oB", "players": ["p1"]}]
-    # One deep-bench body: resolves fine, scores 0, clears no threshold.
-    nfl = {"p1": {"team": "KC", "position": "WR", "depth_chart_order": 7, "years_exp": 4}}
-    section = team_assignment.build_section(_snapshot(rosters, nfl, mgrs))
+    rosters = [{"roster_id": 1, "owner_id": "oB", "players": []}]
+    contract = _contract([], {"oB": []})
+    section = team_assignment.build_section(_snapshot(rosters, {}, mgrs), contract)
     _assert_shaped(section)
     assert section["available"] is True
     assert section["unavailableReason"] is None
     assert section["rosterScoringAvailable"] is True
     a = section["assignments"][0]
     assert a["rosterScored"] is True
+    assert a["totalWeightedCoreValue"] == 0.0
     assert a["nflTeams"] == []
 
 
@@ -227,6 +281,14 @@ def test_reason_constants_are_distinct_and_stable():
     reasons = {
         team_assignment.UNAVAILABLE_NO_CURRENT_SEASON,
         team_assignment.UNAVAILABLE_NO_ROSTERS,
-        team_assignment.DEGRADED_NO_PLAYER_DIRECTORY,
+        team_assignment.DEGRADED_NO_CONTRACT,
+        team_assignment.DEGRADED_NO_QB_SIGNAL,
+        team_assignment.ROSTER_REASON_NOT_IN_CONTRACT,
     }
-    assert reasons == {"no_current_season", "no_rosters", "player_directory_unavailable"}
+    assert reasons == {
+        "no_current_season",
+        "no_rosters",
+        "canonical_contract_unavailable",
+        "qb_starter_signal_unavailable",
+        "team_not_in_contract_pool",
+    }

--- a/tests/e2e/specs/public-league.spec.js
+++ b/tests/e2e/specs/public-league.spec.js
@@ -589,131 +589,24 @@ test.describe("public /league page", () => {
     expect(body).toHaveProperty("metrics.total_served");
   });
 
-  test("teamAssignment covers every manager slot and labels unknowns explicitly", async ({
-    request,
-  }) => {
-    // This test pins the AVAILABILITY contract of
-    // src/api/team_assignment.py, not an aspiration about its data.
-    //
-    // It used to require `nflTeams.length > 0` for every manager — a
-    // deliberate red written against defect #815 (favorite map + roster
-    // scoring both whiffing).  But an empty `nflTeams` is a
-    // pinned-legitimate state of the producer (see
-    // tests/api/test_team_assignment_availability.py::
-    // test_healthy_empty_result_is_still_expressible): no configured
-    // favorite plus nothing clearing the scoring threshold is a
-    // measured "nothing qualified", and inventing a team to satisfy a
-    // test is exactly the fabrication MISSING-IS-NEVER-ZERO forbids.
-    // The section is also built from live Sleeper data, so which
-    // managers qualify moves between runs — E2E runs 140/142 failed on
-    // two different transient shapes of it.  What IS guaranteed, and
-    // asserted here: every current manager gets a slot, every known
-    // (favorite-resolved) assignment is preserved, nothing is priced
-    // into the list without clearing the threshold, and when the
-    // producer cannot answer it says why instead of serving a bare
-    // empty list.  Defect #815 stays tracked at the unit level.
-    const res = await request.get("/api/public/league/teamAssignment");
-    expect(res.status()).toBe(200);
-    const json = await res.json();
-    const data = json.data || {};
-    const assignments = data.assignments || [];
-    expect(Array.isArray(assignments)).toBeTruthy();
-
-    if (data.available === false) {
-      // Degraded is a legal answer, but only an EXPLICIT one: the
-      // payload must name a known cause, and must not carry
-      // assignments it just declared unavailable.
-      expect(
-        ["no_current_season", "no_rosters"],
-        "available:false must name a machine-readable reason",
-      ).toContain(data.unavailableReason);
-      expect(assignments).toHaveLength(0);
-      expect(data.rosterScoringAvailable).toBe(false);
-      return;
-    }
-
-    // Healthy path: one slot per manager with a current roster, keyed
-    // by ownerId — derived from the same response's league header, so
-    // the expectation tracks the league instead of a magic count.
-    expect(data.available).toBe(true);
-    expect(data.unavailableReason).toBeNull();
-    const managers = json.league?.managers || [];
-    const activeOwnerIds = managers
-      .filter((m) => m.currentRosterId !== null && m.currentRosterId !== undefined)
-      .map((m) => m.ownerId)
-      .sort();
-    expect(
-      activeOwnerIds.length,
-      "the league header must carry current-season managers",
-    ).toBeGreaterThanOrEqual(8); // realistic floor for a real league
-    expect(
-      assignments.map((a) => a.ownerId).sort(),
-      "one assignment per current manager — no drops, no duplicates, no inventions",
-    ).toEqual(activeOwnerIds);
-
-    const threshold = data.config?.thresholds?.assignmentMinPoints;
-    const maxTeams = data.config?.limits?.maxTeamsPerOwner;
-    expect(typeof threshold).toBe("number");
-    expect(typeof maxTeams).toBe("number");
-
-    for (const a of assignments) {
-      const who = a.displayName || a.ownerId;
-      expect(typeof a.displayName).toBe("string");
-      expect(typeof a.rosterScored, `${who}: rosterScored must be stated`).toBe(
-        "boolean",
-      );
-      expect(Array.isArray(a.nflTeams), `${who}: nflTeams must be an array`).toBeTruthy();
-      expect(
-        a.nflTeams.length,
-        `${who}: at most ${maxTeams} NFL teams`,
-      ).toBeLessThanOrEqual(maxTeams);
-
-      // A resolved favorite is emitted unconditionally and first —
-      // dropping it means the producer lost a KNOWN assignment.
-      if (a.favoriteKey != null) {
-        expect(
-          a.nflTeams.length,
-          `${who}: favorite ${a.favoriteKey} resolved but no team emitted`,
-        ).toBeGreaterThanOrEqual(1);
-        expect(
-          a.nflTeams[0].isFavorite,
-          `${who}: the favorite must lead the list`,
-        ).toBe(true);
-      }
-
-      for (const t of a.nflTeams) {
-        expect(String(t.abbr), `${who}: NFL team abbr`).toMatch(/^[A-Z]{2,3}$/);
-        expect(typeof t.isFavorite).toBe("boolean");
-        expect(Number.isFinite(t.score), `${who}: ${t.abbr} score`).toBeTruthy();
-        // No fabrication: everything in the list is there because it is
-        // the favorite or because it EARNED the threshold.
-        if (!t.isFavorite) {
-          expect(
-            t.score,
-            `${who}: ${t.abbr} is listed without clearing the ${threshold}-point threshold`,
-          ).toBeGreaterThanOrEqual(threshold);
-        }
-      }
-    }
-
-    // When roster scoring was unavailable the section must say so, and
-    // every per-manager card must carry the same honesty.
-    if (data.rosterScoringAvailable === false) {
-      expect(data.degradedReasons).toContain("player_directory_unavailable");
-      for (const a of assignments) {
-        expect(a.rosterScored, `${a.displayName || a.ownerId}: rosterScored must be false when the directory is unavailable`).toBe(false);
-      }
-    }
-  });
-
   // ── the private-intelligence boundary, from the anonymous door ────────
   //
   // This block used to assert that `faabAnalytics` answered an anonymous
   // GET with **200** and the full recommender payload.  It does not, and
-  // must not: B8 classified it as one of three
-  // `PRIVATE_INTELLIGENCE_SECTIONS` (with `rosTeamStrength` and
-  // `rosTradeDeadline`), and `_public_section_access_error` refuses it
-  // without a session.  The 401 is the feature.
+  // must not: B8 classified it as one of four
+  // `PRIVATE_INTELLIGENCE_SECTIONS` (with `rosTeamStrength`,
+  // `rosTradeDeadline` and, since the 2026-09-01 NFL Team Affinity
+  // rewrite, `teamAssignment`), and `_public_section_access_error`
+  // refuses it without a session.  The 401 is the feature.
+  //
+  // `teamAssignment` moved into this loop for the same reason the other
+  // three are here: it now publishes per-manager sums and per-player
+  // breakdowns of canonical dynasty value, not flat depth-chart points,
+  // and the old standalone "covers every manager slot" test (asserting
+  // an anonymous 200) would be exactly the stale assertion this comment
+  // warns about — reopening the section to make it pass would delete the
+  // privacy boundary. Its shape coverage relocated to
+  // `signed-in-smoke.spec.js`, same as `faabAnalytics` before it.
   //
   // A stale assertion here is not a harmless red: the obvious way to make
   // it pass is to reopen the section, which would delete the privacy
@@ -725,6 +618,7 @@ test.describe("public /league page", () => {
     "faabAnalytics",
     "rosTeamStrength",
     "rosTradeDeadline",
+    "teamAssignment",
   ]) {
     test(`${section} refuses an anonymous caller (B8 private intelligence)`, async ({
       request,

--- a/tests/e2e/specs/signed-in-smoke.spec.js
+++ b/tests/e2e/specs/signed-in-smoke.spec.js
@@ -407,6 +407,105 @@ test.describe("signed-in: private-intelligence sections", () => {
     expect(typeof data.positionBids).toBe("object");
     expect(typeof data.tierBids).toBe("object");
   });
+
+  // Relocated from `public-league.spec.js`'s "teamAssignment covers every
+  // manager slot" test, which asserted an anonymous 200. The 2026-09-01
+  // NFL Team Affinity rewrite made `teamAssignment` a fourth
+  // `PRIVATE_INTELLIGENCE_SECTIONS` member (same reason as
+  // `faabAnalytics`: it now publishes per-manager sums and per-player
+  // breakdowns of canonical dynasty value), so the shape contract is
+  // exercised from a session, same relocation pattern.
+  test("teamAssignment returns the documented shape to a session", async ({
+    authedPage,
+  }) => {
+    const res = await authedPage.request.get(
+      "/api/public/league/teamAssignment",
+    );
+    expect(res.status(), "a session must be able to read it").toBe(200);
+    const json = await res.json();
+    const data = json.data || json.body || json;
+    const assignments = data.assignments || [];
+    expect(Array.isArray(assignments)).toBeTruthy();
+
+    if (data.available === false) {
+      // Degraded is a legal answer, but only an EXPLICIT one.
+      expect(
+        ["no_current_season", "no_rosters"],
+        "available:false must name a machine-readable reason",
+      ).toContain(data.unavailableReason);
+      expect(assignments).toHaveLength(0);
+      return;
+    }
+
+    expect(data.available).toBe(true);
+    expect(data.unavailableReason).toBeNull();
+    expect(typeof data.rosterScoringAvailable).toBe("boolean");
+    expect(typeof data.qbSignalAvailable).toBe("boolean");
+    expect(Array.isArray(data.degradedReasons)).toBeTruthy();
+
+    const managers = json.league?.managers || [];
+    const activeOwnerIds = managers
+      .filter((m) => m.currentRosterId !== null && m.currentRosterId !== undefined)
+      .map((m) => m.ownerId)
+      .sort();
+    expect(
+      assignments.map((a) => a.ownerId).sort(),
+      "one assignment per current manager — no drops, no duplicates, no inventions",
+    ).toEqual(activeOwnerIds);
+
+    const minShare = data.config?.thresholds?.rosterAssignmentMinShare;
+    const qbMultiplier = data.config?.weights?.nflStartingQbMultiplier;
+    const maxTeams = data.config?.limits?.maxTeamsPerOwner;
+    expect(typeof minShare).toBe("number");
+    expect(typeof qbMultiplier).toBe("number");
+    expect(typeof maxTeams).toBe("number");
+
+    for (const a of assignments) {
+      const who = a.displayName || a.ownerId;
+      expect(typeof a.rosterScored, `${who}: rosterScored must be stated`).toBe(
+        "boolean",
+      );
+      expect(Array.isArray(a.nflTeams), `${who}: nflTeams must be an array`).toBeTruthy();
+      expect(
+        a.nflTeams.length,
+        `${who}: at most ${maxTeams} NFL teams`,
+      ).toBeLessThanOrEqual(maxTeams);
+
+      if (a.favoriteKey != null) {
+        expect(
+          a.nflTeams.length,
+          `${who}: favorite ${a.favoriteKey} resolved but no team emitted`,
+        ).toBeGreaterThanOrEqual(1);
+        expect(
+          a.nflTeams[0].isFavorite,
+          `${who}: the favorite must lead the list`,
+        ).toBe(true);
+      }
+
+      for (const t of a.nflTeams) {
+        expect(String(t.abbr), `${who}: NFL team abbr`).toMatch(/^[A-Z]{2,3}$/);
+        expect(typeof t.isFavorite).toBe("boolean");
+        expect(Number.isFinite(t.affinityScore), `${who}: ${t.abbr} affinityScore`).toBeTruthy();
+        // No fabrication: everything in the list is there because it is
+        // the favorite or because it EARNED the share threshold.
+        if (!t.isFavorite) {
+          expect(
+            t.affinityShare,
+            `${who}: ${t.abbr} is listed without an affinityShare`,
+          ).not.toBeNull();
+          expect(
+            t.affinityShare,
+            `${who}: ${t.abbr} is listed without clearing the ${minShare} share threshold`,
+          ).toBeGreaterThanOrEqual(minShare);
+        }
+        for (const c of t.contributors || []) {
+          expect(typeof c.canonicalValue).toBe("number");
+          expect(typeof c.weightedValue).toBe("number");
+          expect([1.0, qbMultiplier]).toContain(c.multiplier);
+        }
+      }
+    }
+  });
 });
 
 test.describe("signed-in: admin endpoints are gated", () => {

--- a/tests/roster_intel/test_exposure.py
+++ b/tests/roster_intel/test_exposure.py
@@ -100,6 +100,14 @@ def test_nothing_in_the_trade_or_roster_chain_imports_exposure():
     assert importers <= {
         "src/roster_intel/__init__.py",
         "src/api/roster_intelligence.py",
+        # Team Assignment (NFL Team Affinity, 2026-09-01) reads
+        # ``nfl_team_by_player``/``NON_FRANCHISE_TOKENS`` — the same pure
+        # canonical-name -> NFL-team join ``roster_intelligence.py``
+        # already uses — for player-to-franchise attribution.  It is not
+        # part of the trade/roster GRADING chain this test guards: it
+        # computes no flag, verdict, grade, penalty or recommendation,
+        # same as ``exposure.py`` itself.
+        "src/api/team_assignment.py",
     }, importers
 
 


### PR DESCRIPTION
## Summary

Owner-directed methodology change: `League → Team Assignment` no longer scores NFL-team correlation with flat, ad hoc depth-chart points (`qbAnchor +10`, `skillStarter +5`, `rookieRound1 +4`, ...). It now aggregates the site's **existing** canonical Meaningful Roster Core (`src/roster_intel/core.py`) and **existing** canonical player values (`rankDerivedValue`, via `contract_roster_pools`) — the same population and values Team Strength already uses — with exactly one new weight: an NFL team's current **starting quarterback** (Sleeper depth-chart signal) counts **2.0x**. No other position multipliers, no new top-N selection, no re-derivation of lineup/reserve demand.

```
weightedValue(member) = canonicalValue × (2.0 if he is his NFL team's starting QB else 1.0)
affinityScore(team, nflTeam) = Σ weightedValue over that team's Meaningful Core members on nflTeam
affinityShare = affinityScore / totalWeightedCoreValue   (denominator = the WHOLE core)
qualifies (non-favorite) iff affinityShare >= rosterAssignmentMinShare (0.10)
```

Favorites (`config/team_assignment.json`) are unchanged — always assigned, alias resolution untouched. Max 3 NFL teams per manager: favorite + top 2 qualifying non-favorites by `(affinityShare desc, affinityScore desc, abbr asc)`.

## Architectural finding, resolved with the owner before implementation

The new model necessarily publishes per-manager sums and per-player breakdowns of canonical dynasty value — the same class of data that made `rosTeamStrength` a private, session-gated section (it was previously public and got moved for measurably the same reason: per-manager roster-value decomposition). CLAUDE.md's public/private boundary rule states proprietary values are private, factual content is public.

**Owner decision: `teamAssignment` moves behind the same auth gate as `rosTeamStrength` / `faabAnalytics` / `rosTradeDeadline`.** Anonymous `/league` visitors no longer see this tab; signed-in users see the full feature. The frontend now self-fetches with a session (same pattern as `ros-team-strength.jsx`) and shows a classified "Sign in required" state via `FailureState` instead of the data.

## MeaningfulCore reuse (no duplicate owner)

- `contract_roster_pools(contract)` → per-team `RosterPlayer` pools (canonical value = `rankDerivedValue`, unpriced players excluded rather than zeroed)
- `build_meaningful_core(pool, slots, slot_eligibility=...)` → THE population (same call shape `roster_intelligence.py` already uses for Team Strength)
- `nfl_team_by_player(contract)` — moved from a private helper in `roster_intelligence.py` into `src/roster_intel/exposure.py` and exported, so Team Assignment and roster-intelligence share one canonical-name → NFL-team join instead of two copies that could drift
- NFL starting-QB status: no canonical signal exists anywhere in `src/` — resolved via a `{canonicalName: sleeperPlayerId}` join over `playersArray`, then `PublicLeagueSnapshot.nfl_players[...]["depth_chart_order"]` (the same Sleeper depth-chart source the old model already read). Unknown/unresolvable never guesses — falls back to 1.0x.

## Truthfulness / degraded states

- `rosterScoringAvailable` (top-level): false when no canonical contract was supplied or it can't be matched to this league at all — favorites still shown (`canonical_contract_unavailable`)
- `qbSignalAvailable` (top-level): false when Sleeper's NFL player directory is unavailable — only the QB multiplier fails closed to 1.0x, roster scoring otherwise proceeds (`qb_starter_signal_unavailable`)
- Per assignment: `rosterScored` / `rosterUnavailableReason` (`team_not_in_contract_pool`) for the narrower case where the league-wide contract is fine but one manager's roster can't be matched
- Per assignment: `unpricedCount`, `unresolvedNflTeamCount`, `scoringComplete` — a Meaningful-Core-eligible player without a canonical value is excluded from the core (never scored 0) and counted, never silently absorbed
- `"FA"` (unsigned free agent) is a real, resolved value — excluded from every NFL-team bucket, never counted as a 33rd team

## Before/after — all 12 real teams

Ran both the old (git `44445df`) and new `build_section` against the identical live Sleeper snapshot + the newest complete canonical board (`exports/archive/dynasty_export_20260901_054316.zip`):

| Manager | OLD | NEW | Changed? |
|---|---|---|---|
| Blaine | CIN★8, PHI17 | CIN★6,755/6.6%, BUF24,425/23.8%, PHI21,327/20.8% | BUF added |
| Brent | BUF★0, CLE20, KC20 | BUF★1,932/1.2%, KC19,312/11.6%, LAR17,981/10.8% | CLE dropped, LAR added |
| Collin | GB★28 | GB★26,580/21.3%, NE21,688/17.4% | NE added |
| Ed | DAL★20, IND15, TEN15 | DAL★18,092/16.9%, TEN12,128/11.3%, IND10,899/10.2% | same 3, reordered by real value |
| Eric | HOU★15, CHI31, JAX15 | HOU★9,975/7.4%, CHI41,980/31.3%, JAX17,271/12.9% | same 3 |
| Jason | MIN★41, NYG19 | MIN★28,136/16.9%, NYG29,968/18.0%, WAS22,013/13.2% | WAS added |
| Joey | HOU★6, DEN19, DET19 | HOU★7,008/5.0%, DET24,372/17.5%, DEN19,549/14.1% | same 3, reordered |
| jstuedle | KC★8 | KC★5,540/6.4%, TB11,052/12.8% | TB added |
| Kich | HOU★2, BAL17, LAR16 | HOU★1,514/1.6%, BAL24,552/25.5%, LAR16,756/17.4% | same 3 |
| MaKayla | MIA★33, ARI16 | MIA★26,508/20.4%, LAC18,068/13.9% | ARI dropped, LAC added |
| Roy | LAC★7 | LAC★4,978/7.6%, CAR10,965/16.8% | CAR added |
| Ty | HOU★19 | HOU★23,496/22.9%, SF12,712/12.4% | SF added |

Every diff traces to the model swap: old flat points needed *multiple* depth-chart-primary players on one team to clear 15pts; new model credits one genuinely valuable player crossing 10% of core value. No favorite ever dropped. `unpricedCount`/`unresolvedNflTeamCount` were single digits per manager on a ~50-man roster in every case — never silently zeroed.

## Files changed

- `src/api/team_assignment.py` — full rewrite of the scoring path
- `src/roster_intel/exposure.py` — new `nfl_team_by_player` (moved from `roster_intelligence.py`)
- `src/api/roster_intelligence.py` — uses the shared helper
- `config/team_assignment.json` — old weights/threshold removed, `nflStartingQbMultiplier` + `rosterAssignmentMinShare` added
- `src/public_league/public_contract.py` — `teamAssignment` moved to `_LAZY_SECTION_BUILDERS` + `PRIVATE_INTELLIGENCE_SECTIONS`, contract threaded through `build_section_payload`
- `server.py` — threads `latest_contract_data` into both the JSON and CSV route call sites
- `frontend/app/league/sections/team-assignment.jsx` — self-fetching, new payload shape, classified sign-in/failure states via `FailureState`
- `frontend/app/league/{LeagueClient.jsx,tabs.js}`, `frontend/lib/public-league-data.js` — wiring to match the private/self-fetching pattern
- Tests: `tests/api/test_team_assignment.py` (full rewrite, 32 tests covering all 20 owner-listed cases plus config/favorite mechanics), `tests/api/test_team_assignment_availability.py` (rewritten degraded-state coverage), `tests/api/test_public_league_privacy_boundary.py` (`teamAssignment` added to the private-section parametrized suite), `tests/roster_intel/test_exposure.py` (import allowlist updated for the new legitimate consumer), `tests/api/test_board_key_identity.py` / `tests/api/test_roster_intelligence.py` (updated for the helper move), `tests/e2e/specs/{public-league,signed-in-smoke}.spec.js` (anon-401 coverage relocated to the authenticated shape test)

## Test plan

- [x] `python -m pytest tests/api/test_team_assignment.py tests/api/test_team_assignment_availability.py tests/api/test_public_league_privacy_boundary.py tests/api/test_board_key_identity.py tests/api/test_roster_intelligence.py tests/roster_intel/ tests/public_league/test_public_contract.py -q` → 763 passed, 35 skipped
- [x] `npx vitest run` (frontend) → 2392 passed, including the a11y failure-vs-empty guard
- [x] Manual real-data run: both old and new `build_section` against a live Sleeper snapshot + the newest complete canonical board, all 12 managers (table above)
- [x] `python -m py_compile` on every changed Python file; `node --check` on the changed Playwright specs
- [ ] Full `pytest tests/ -k "not livedata"` (broad, largely unrelated modules) — running in CI; a background local run was still in progress at push time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtPdwag9gWvXdmAoeQrxjb

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtPdwag9gWvXdmAoeQrxjb)_