### PR TITLE
Replace 10% affinity threshold with coverage-maximizing 5-team assignment

### DIFF
--- a/config/team_assignment.json
+++ b/config/team_assignment.json
@@ -1,5 +1,5 @@
 {
-  "_doc": "Team Assignment configuration -- NFL Team Affinity model. See src/api/team_assignment.py. Edit favorites/aliases/weights here without redeploy; the file reloads on each section build. Roster-based affinity is driven by the canonical Meaningful Roster Core and canonical player values, not by weights declared here -- the only tunables left are the one owner-approved starting-QB multiplier and the affinity-share qualification threshold.",
+  "_doc": "Team Assignment configuration -- NFL Team Affinity model. See src/api/team_assignment.py. Edit favorites/aliases/weights here without redeploy; the file reloads on each section build. Roster-based affinity is driven by the canonical Meaningful Roster Core and canonical player values, not by weights declared here -- the only tunable left is the one owner-approved starting-QB multiplier. Non-favorite team selection is a fixed, owner-locked favorite + up to 4 coverage-maximizing teams (see _NON_FAVORITE_TEAMS_PER_OWNER in src/api/team_assignment.py) -- there is no percentage threshold and no config knob for the count; it is intentionally not configurable.",
 
   "favorites": {
     "joel":     {"abbr": "KC",  "display": "Kansas City Chiefs"},
@@ -40,12 +40,7 @@
     "nflStartingQbMultiplier": 2.0
   },
 
-  "thresholds": {
-    "_doc": "Minimum SHARE (0-1) of a manager's total weighted Meaningful Core value an NFL team's affinity score must reach to qualify as a roster-based assignment. A share rather than an absolute point total on purpose: it does not go stale every time the canonical value scale is refit. Favorites bypass this threshold entirely. Replaces the old flat assignmentMinPoints (points on an ad hoc 0-15+ scale); nothing reads that key any more.",
-    "rosterAssignmentMinShare": 0.10
-  },
-
   "limits": {
-    "_doc": "Currently empty. All NFL teams meeting the affinity-share threshold are automatically assigned."
+    "_doc": "Currently empty and deliberately not a place to configure the non-favorite team count. That count (favorite + up to 4) is a hardcoded, owner-locked constant (_NON_FAVORITE_TEAMS_PER_OWNER in src/api/team_assignment.py), not a runtime knob -- the percentage-threshold model this file used to configure (rosterAssignmentMinShare) was retired 2026-09-01 in favor of a coverage-maximizing selection across the whole league; see the module docstring."
   }
 }

--- a/frontend/app/league/sections/team-assignment.jsx
+++ b/frontend/app/league/sections/team-assignment.jsx
@@ -2,12 +2,16 @@
 
 // TeamAssignmentSection — "Team Assignment" tab on /league.
 //
-// NFL TEAM AFFINITY (2026-09-01 rewrite). Renders one card per fantasy
-// team showing:
+// NFL TEAM AFFINITY (2026-09-01 rewrite; coverage-maximizing selection
+// added same day). Renders one card per fantasy team showing:
 //   * Manager display name + avatar
-//   * 1–3 NFL teams (favorite + roster-based qualifiers)
-//   * Each NFL team chip with logo, full name, and tag
-//     ("Favorite" / "Roster-Based" with Affinity Score + Affinity Share)
+//   * Favorite + up to 4 NFL teams (fixed count, no percentage
+//     threshold) -- chosen to correlate with the manager's own roster
+//     as closely as possible while maximizing how many of the 32 real
+//     NFL teams are represented leaguewide; see
+//     ``_assign_coverage_maximizing_teams`` in the backend module.
+//   * Each NFL team chip with logo, full name, and tag ("Favorite" /
+//     "Roster-Based" / "League Coverage" with Affinity Score + Share)
 //   * Optional "Show breakdown" toggle that expands a per-player
 //     canonical-value breakdown per NFL team (canonical value, the
 //     starting-QB multiplier when it applied, and the weighted result)
@@ -131,8 +135,22 @@ function fmtShare(v) {
   return `${(Number(v) * 100).toFixed(1)}%`;
 }
 
+// assignmentReason (from src/api/team_assignment.py) -> [label, color].
+// "coverage_repair" gets its own color/label so a team assigned to
+// maximize leaguewide NFL-team coverage never reads identically to one
+// that was simply this manager's own highest-affinity pick.
+const REASON_TAG = {
+  favorite: ["Favorite", "var(--cyan)"],
+  top_affinity: ["Roster-Based", "var(--green)"],
+  coverage_repair: ["League Coverage", "var(--amber)"],
+};
+
 function NflTeamChip({ team }) {
   const share = fmtShare(team.affinityShare);
+  const [label, color] = REASON_TAG[team.assignmentReason] || [
+    team.isFavorite ? "Favorite" : "Roster-Based",
+    team.isFavorite ? "var(--cyan)" : "var(--green)",
+  ];
   return (
     <div
       className="card"
@@ -142,9 +160,7 @@ function NflTeamChip({ team }) {
         gap: 10,
         padding: "8px 12px",
         marginBottom: 6,
-        borderLeft: team.isFavorite
-          ? "3px solid var(--cyan)"
-          : "3px solid var(--green)",
+        borderLeft: `3px solid ${color}`,
       }}
     >
       <NflTeamLogo team={team.abbr} size={28} />
@@ -155,13 +171,13 @@ function NflTeamChip({ team }) {
         <div style={{ fontSize: "0.7rem", color: "var(--subtext)" }}>
           <span
             style={{
-              color: team.isFavorite ? "var(--cyan)" : "var(--green)",
+              color,
               fontWeight: 700,
               textTransform: "uppercase",
               letterSpacing: "0.04em",
             }}
           >
-            {team.isFavorite ? "Favorite" : "Roster-Based"}
+            {label}
           </span>
           <span style={{ marginLeft: 8, fontFamily: "var(--mono)" }}>
             Affinity: {fmtValue(team.affinityScore)}
@@ -326,8 +342,9 @@ function ManagerCard({ assignment, managers, expanded, onToggle }) {
           className="muted"
           style={{ fontSize: "0.78rem", padding: "4px 0" }}
         >
-          No NFL team assignments yet — favorite not configured and no
-          roster team cleared the affinity-share threshold.
+          No NFL team assignments yet — favorite not configured and this
+          manager's Meaningful Core touched no NFL team with real
+          canonical value.
         </div>
       ) : (
         teams.map((t) => (
@@ -433,9 +450,9 @@ export default function TeamAssignmentSection({ managers }) {
     );
   }
 
-  const minShare = data.config?.thresholds?.rosterAssignmentMinShare ?? 0.10;
   const qbMultiplier = data.config?.weights?.nflStartingQbMultiplier ?? 2.0;
   const degraded = Array.isArray(data.degradedReasons) ? data.degradedReasons : [];
+  const coverage = data.coverageSummary;
 
   return (
     <div>
@@ -447,18 +464,28 @@ export default function TeamAssignmentSection({ managers }) {
           lineHeight: 1.5,
         }}
       >
-        Each manager is mapped to 1–3 NFL teams by NFL Team Affinity: the
-        first team is the manager's declared favorite from{" "}
-        <code style={{ fontSize: "0.7rem" }}>config/team_assignment.json</code>.
-        Additional teams are ranked by the value of this team's canonical
-        Meaningful Core players rostered from that NFL franchise (the
-        same player population and canonical values Team Strength
-        uses), with a {qbMultiplier}x weight for a player who is that
-        NFL team's current starting quarterback. A team qualifies once
-        its share of this manager's total weighted roster value reaches{" "}
-        <strong>{(minShare * 100).toFixed(0)}%</strong>; max 3 NFL
-        teams per manager. Click &quot;Show breakdown&quot; on any
-        manager to see per-player value contributions.
+        Each manager is mapped to a favorite (if configured, from{" "}
+        <code style={{ fontSize: "0.7rem" }}>config/team_assignment.json</code>
+        ) plus up to 4 more NFL teams by NFL Team Affinity, ranked by the
+        value of this team's canonical Meaningful Core players rostered
+        from that NFL franchise (the same player population and
+        canonical values Team Strength uses), with a {qbMultiplier}x
+        weight for a player who is that NFL team's current starting
+        quarterback. There is no percentage threshold — the 4 non-favorite
+        teams are chosen to track each manager's own affinity as closely
+        as possible while maximizing how many of the league's real NFL
+        teams end up represented by someone (tagged{" "}
+        <strong>League Coverage</strong> when a team is included for that
+        reason rather than being this manager's own top pick). Click
+        &quot;Show breakdown&quot; on any manager to see per-player value
+        contributions.
+        {coverage ? (
+          <>
+            {" "}
+            {coverage.coveredTeams} of {coverage.totalNflTeams} NFL teams are
+            represented across the league this week.
+          </>
+        ) : null}
       </div>
 
       {degraded.map((reason) =>

--- a/src/api/team_assignment.py
+++ b/src/api/team_assignment.py
@@ -1,5 +1,6 @@
-"""Map each fantasy team in the league to 1+ NFL teams by NFL Team
-Affinity — value-weighted roster affinity, not depth-chart points.
+"""Map each fantasy team in the league to a FIXED 5 NFL teams by NFL
+Team Affinity — value-weighted roster affinity, not depth-chart points,
+and not a percentage threshold.
 
 Two assignment sources, layered in this priority:
 
@@ -18,8 +19,8 @@ Two assignment sources, layered in this priority:
      team, with exactly one extra weight: a player who IS his NFL
      team's current starting quarterback counts double.
 
-Formula
--------
+Per-manager scoring formula (unchanged by this rewrite)
+---------------------------------------------------------
 
 For every member of a fantasy team's Meaningful Core::
 
@@ -40,19 +41,65 @@ For every member of a fantasy team's Meaningful Core::
                                     any team's numerator
     affinityShare = affinityScore / totalWeightedCoreValue
 
-A non-favorite NFL team qualifies when ``affinityShare >=
-rosterAssignmentMinShare`` (default 0.10).  No other position
-multipliers exist -- Meaningful Core membership already excludes
-players who do not materially contribute, and canonical value already
-distinguishes an elite player from a roster-filler one, so a second
-"starter" multiplier here would double-count information the core and
-the value already carry.
+No other position multipliers exist -- Meaningful Core membership
+already excludes players who do not materially contribute, and
+canonical value already distinguishes an elite player from a
+roster-filler one, so a second "starter" multiplier here would
+double-count information the core and the value already carry.
 
-Each fantasy team is assigned the favorite (if configured) plus ALL
-non-favorite NFL teams that meet the affinity threshold, sorted by
-(affinityShare desc, affinityScore desc, NFL abbreviation asc) for
-determinism. A roster built to capture multiple NFL teams' players
-will naturally affiliate with all of them.
+Selection: coverage-maximizing, not threshold-gated (2026-09-01)
+-------------------------------------------------------------------
+
+A flat percentage threshold (``affinityShare >= X%``) was tried and
+retired: it answers "is this NFL team a large share of everything this
+manager owns", which is denominator-sensitive and not the question
+that matters -- a manager can legitimately own a team's starting QB
+and several of its best assets and still fall under any fixed
+percentage simply because their overall roster is large and
+well-rounded.  MEASURED on the live league: exactly this happened
+(a manager holding a real NFL team's starting QB and multiple of its
+top assets scored under a 10% share and was silently excluded).
+
+The replacement, owner-mandated and LOCKED IN (not configurable):
+every manager gets exactly ``1 (favorite, if configured) + up to
+_NON_FAVORITE_TEAMS_PER_OWNER (4)`` NFL teams, chosen by
+``_assign_coverage_maximizing_teams`` in two steps, run ONCE across
+the whole league after every manager's ``affinityScore`` is known:
+
+  1. **Natural top-4** -- each manager's own 4 highest-``affinityScore``
+     non-favorite teams (ties broken toward whoever holds that team's
+     starting QB, then NFL abbreviation ascending).
+  2. **Coverage repair** -- a single deterministic pass that finds
+     which of the 32 real NFL teams remain unrepresented by ANYONE in
+     the league (no manager's favorite, no manager's natural top-4),
+     and swaps each such gap onto the single best-fit manager who has
+     real (nonzero) affinity for it, donating that manager's weakest
+     natural slot -- but ONLY when the donated team stays covered by
+     someone else afterward (never trade one gap for a new one), and
+     ONLY a ``"top_affinity"`` slot may ever be donated (a repaired
+     slot is never later evicted, which is what makes one pass
+     sufficient).  If the best-fit manager cannot safely donate any
+     slot, the next-best-fit manager is tried.  A tie between two
+     candidate managers for the same team is broken toward whoever
+     holds that team's starting QB -- verbatim owner instruction:
+     "ties go to who has the quarterback."
+
+  Two invariants hold no matter what: **a team is never assigned to a
+  manager with zero affinity for it**, even to pad a coverage count
+  (a team nobody in the league owns any Meaningful-Core player from
+  is reported in ``uncoverableTeams``, never faked); and **a manager
+  is never reduced below the real teams they have** just to improve
+  someone else's coverage -- the repair pass only ever SWAPS a
+  manager's own slot, never removes one to leave them short, and it
+  backs off to ``unresolvedCoverageGaps`` rather than stranding
+  anyone (expected empty on real league data; see the function's
+  docstring for the termination argument).
+
+  ``qualifiesByRoster`` on a non-favorite entry is therefore always
+  ``True`` once assigned (nothing zero-affinity is ever placed) --
+  the field survives from the retired-threshold era for the favorite
+  entry, where it still distinguishes a favorite backed by real roster
+  value from one that is not.
 
 Truthfulness / degraded states
 -------------------------------
@@ -119,6 +166,7 @@ Output shape::
               "display": str,
               "isFavorite": bool,
               "qualifiesByRoster": bool,
+              "assignmentReason": "favorite" | "top_affinity" | "coverage_repair",
               "affinityScore": float,
               "affinityShare": float | None,
               "contributors": [
@@ -141,9 +189,21 @@ Output shape::
         },
         ...
       ],
+      "uncoverableTeams": [str, ...],       # real NFL abbrs with ZERO
+                                             # affinity anywhere in the
+                                             # league -- never assigned
+      "unresolvedCoverageGaps": [str, ...], # real affinity exists but
+                                             # this pass could not place
+                                             # it without stranding a
+                                             # manager -- expected empty
+      "coverageSummary": {
+        "totalNflTeams": int,               # 32
+        "coveredTeams": int,
+        "uncoverableCount": int,
+        "unresolvedGapCount": int,
+      },
       "config": {
         "weights": {...},
-        "thresholds": {...},
         "limits": {...},
       },
       "currentSeason": str,
@@ -183,13 +243,6 @@ _DEFAULT_CONFIG: dict[str, Any] = {
     # double-count information those two owners already carry.
     "weights": {
         "nflStartingQbMultiplier": 2.0,
-    },
-    # A SHARE of a manager's total weighted core value, not an absolute
-    # point total -- so the threshold does not go stale every time the
-    # canonical value scale is refit.  Replaces the old flat
-    # ``assignmentMinPoints``.
-    "thresholds": {
-        "rosterAssignmentMinShare": 0.10,
     },
     "limits": {},
 }
@@ -296,6 +349,17 @@ _REASON_BACKUP_QB = "qb_not_starting"
 _REASON_QB_UNKNOWN = "starter_status_unknown"
 _REASON_NOT_QB = "not_qb"
 
+#: Fixed, owner-locked count of non-favorite NFL teams per manager
+#: ("I want this behavior to be locked in") -- deliberately a code
+#: constant, not a config knob.
+_NON_FAVORITE_TEAMS_PER_OWNER = 4
+
+#: Per-team assignment-reason tags, exposed for UI transparency (same
+#: spirit as ``multiplierReason``): WHY a team is on a manager's list.
+_REASON_FAVORITE = "favorite"
+_REASON_TOP_AFFINITY = "top_affinity"
+_REASON_COVERAGE_REPAIR = "coverage_repair"
+
 
 def _sleeper_id_by_canonical_name(contract: Mapping[str, Any] | None) -> dict[str, str]:
     """``{canonicalOrDisplayName: sleeperPlayerId}`` from the canonical
@@ -369,9 +433,16 @@ def _unavailable(config: dict[str, Any], reason: str) -> dict[str, Any]:
         "qbSignalAvailable": False,
         "degradedReasons": [],
         "assignments": [],
+        "uncoverableTeams": [],
+        "unresolvedCoverageGaps": [],
+        "coverageSummary": {
+            "totalNflTeams": len(_NFL_TEAM_NAMES),
+            "coveredTeams": 0,
+            "uncoverableCount": 0,
+            "unresolvedGapCount": 0,
+        },
         "config": {
             "weights": config["weights"],
-            "thresholds": config["thresholds"],
             "limits": config["limits"],
         },
         "currentSeason": None,
@@ -462,6 +533,185 @@ def _score_team_core(
     return out
 
 
+def _holds_starting_qb(core: _TeamCore, abbr: str) -> bool:
+    """Rule 5's tiebreak signal: does this manager's Meaningful Core
+    include this NFL team's CONFIRMED current starting QB.  Reads the
+    already-computed ``multiplierReason`` -- never re-derives it.
+    """
+    return any(
+        c.get("multiplierReason") == _REASON_STARTING_QB
+        for c in core.by_team_contributors.get(abbr, [])
+    )
+
+
+def _assign_coverage_maximizing_teams(
+    owner_ids: list[str],
+    scores: dict[str, dict[str, float]],
+    holds_qb: dict[str, dict[str, bool]],
+    favorite_abbrs: dict[str, str | None],
+    *,
+    all_teams: frozenset[str] = frozenset(),
+    slots_per_owner: int = _NON_FAVORITE_TEAMS_PER_OWNER,
+) -> tuple[dict[str, list[dict[str, Any]]], list[str], list[str]]:
+    """Cross-manager, coverage-maximizing NFL-team selection.  Runs
+    ONCE, after every manager's per-team ``affinityScore`` is known.
+
+    Pure function over plain dicts -- no ``_TeamCore``/snapshot
+    dependency, so it is independently testable without full
+    contract/snapshot fixtures.
+
+    Two-phase design:
+
+      1. **Natural top-4** -- each owner's ``slots_per_owner`` highest
+         ``affinityScore`` non-favorite teams (ties: QB-holder wins,
+         then abbr ascending).
+      2. **Coverage repair, single forward pass** -- every real NFL
+         team not covered by ANY favorite or ANY owner's natural top-4
+         is a "gap".  Gaps are processed most-confident-first (highest
+         best-available score across the whole league).  For each gap
+         team, candidate owners (real nonzero affinity for it) are
+         tried best-score-first (QB-holder wins ties); the first
+         candidate who can safely donate one of their OWN natural
+         slots -- i.e. the donated team stays covered by someone else
+         afterward -- takes the gap team in that slot.  A donated slot
+         is chosen weakest-first (QB-holder loses this internal sort,
+         so a QB-backed team is the last thing donated).
+
+      Only ``"top_affinity"`` slots are ever donor-eligible -- a
+      ``"coverage_repair"`` slot, once placed, is never later evicted.
+      That is what makes a SINGLE pass sufficient: each successful
+      repair strictly increases total coverage by exactly one team (a
+      valid donation requires the donated team to remain covered
+      elsewhere, so coverage never regresses), coverage is bounded by
+      ``len(all_teams)``, and the gap list is fixed and finite -- so
+      the pass always terminates and never oscillates.  It is a
+      deliberate greedy heuristic, not a formally-optimal matching
+      solver (an exhaustive augmenting-path search could occasionally
+      find a chained re-donation this cannot) -- acceptable per the
+      owner's explicit direction that this does not need to be
+      provably optimal.  A gap this pass cannot place without
+      stranding a manager below their real candidate count is reported
+      in ``unresolved_gap_teams`` rather than forced -- expected to be
+      empty on real league data (12 managers can supply up to 60
+      team-slots against a 32-team universe).
+
+    Invariants, both structural (never violated even under weird
+    input): a team is NEVER assigned to an owner with
+    ``scores[owner].get(abbr, 0) <= 0`` for it, even to pad coverage;
+    an owner is NEVER left with fewer non-favorite teams than they
+    started with in phase 1 (repair only swaps, never removes without
+    replacing).
+
+    Args:
+        owner_ids: every owner to consider, in a FIXED, caller-sorted
+            order -- output must not depend on dict iteration order.
+        scores: ``{ownerId: {abbr: affinityScore}}``, positive-only
+            (an owner/abbr pair the owner has zero affinity for should
+            simply be absent, not present at 0).
+        holds_qb: ``{ownerId: {abbr: bool}}``, keys a subset of (or
+            equal to) ``scores[ownerId]``'s keys.
+        favorite_abbrs: ``{ownerId: abbr | None}``.
+        all_teams: the full universe of real NFL team abbreviations to
+            evaluate coverage against.  Empty by default so a caller
+            who forgets it fails loudly rather than silently checking
+            coverage against nothing; ``build_section`` always passes
+            ``frozenset(_NFL_TEAM_NAMES)``.
+        slots_per_owner: non-favorite team count per owner.
+
+    Returns:
+        ``(non_favorite_by_owner, uncoverable_teams, unresolved_gap_teams)``.
+        ``non_favorite_by_owner[ownerId]`` is a list (length <=
+        ``slots_per_owner``) of ``{"abbr", "score", "holdsQb", "reason"}``
+        dicts, ``reason`` one of ``_REASON_TOP_AFFINITY`` /
+        ``_REASON_COVERAGE_REPAIR``.  ``uncoverable_teams`` -- real NFL
+        teams with ZERO affinity anywhere in the league (never
+        assigned to anyone).  ``unresolved_gap_teams`` -- real,
+        nonzero-affinity teams this pass could not place; both lists
+        are sorted and disjoint from each other and from every
+        assigned team.
+    """
+    natural: dict[str, list[dict[str, Any]]] = {}
+    for oid in owner_ids:
+        fav = favorite_abbrs.get(oid)
+        owner_scores = scores.get(oid) or {}
+        owner_qb = holds_qb.get(oid) or {}
+        candidates = [
+            {"abbr": abbr, "score": score, "holdsQb": bool(owner_qb.get(abbr))}
+            for abbr, score in owner_scores.items()
+            if abbr != fav and score > 0
+        ]
+        candidates.sort(key=lambda c: (-c["score"], not c["holdsQb"], c["abbr"]))
+        natural[oid] = [dict(c, reason=_REASON_TOP_AFFINITY) for c in candidates[:slots_per_owner]]
+
+    covered: set[str] = {abbr for abbr in favorite_abbrs.values() if abbr}
+    for oid in owner_ids:
+        covered.update(c["abbr"] for c in natural[oid])
+
+    league_wide: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for oid in owner_ids:
+        owner_scores = scores.get(oid) or {}
+        owner_qb = holds_qb.get(oid) or {}
+        for abbr, score in owner_scores.items():
+            if score > 0:
+                league_wide[abbr].append(
+                    {"ownerId": oid, "score": score, "holdsQb": bool(owner_qb.get(abbr))}
+                )
+
+    uncoverable = sorted(
+        abbr for abbr in all_teams if abbr not in covered and abbr not in league_wide
+    )
+    gaps = [abbr for abbr in all_teams if abbr not in covered and abbr in league_wide]
+
+    def _best_score(abbr: str) -> float:
+        return max(entry["score"] for entry in league_wide[abbr])
+
+    gaps.sort(key=lambda abbr: (-_best_score(abbr), abbr))
+
+    def _covered_without(oid: str, abbr: str) -> bool:
+        """Would ``abbr`` still be covered if it were removed from
+        ``oid``'s assigned list (favorite or any OTHER owner's list)?
+        """
+        if abbr in favorite_abbrs.values():
+            return True
+        return any(
+            other != oid and any(c["abbr"] == abbr for c in natural[other]) for other in owner_ids
+        )
+
+    unresolved: list[str] = []
+    for gap_abbr in gaps:
+        candidates = sorted(
+            league_wide[gap_abbr], key=lambda e: (-e["score"], not e["holdsQb"], e["ownerId"])
+        )
+        placed = False
+        for cand in candidates:
+            oid = cand["ownerId"]
+            slots = natural[oid]
+            donors = [i for i, s in enumerate(slots) if s["reason"] == _REASON_TOP_AFFINITY]
+            donors.sort(
+                key=lambda i: (slots[i]["score"], not slots[i]["holdsQb"], slots[i]["abbr"])
+            )
+            for i in donors:
+                donated_abbr = slots[i]["abbr"]
+                if _covered_without(oid, donated_abbr):
+                    slots[i] = {
+                        "abbr": gap_abbr,
+                        "score": cand["score"],
+                        "holdsQb": cand["holdsQb"],
+                        "reason": _REASON_COVERAGE_REPAIR,
+                    }
+                    placed = True
+                    break
+            if placed:
+                break
+        if not placed:
+            unresolved.append(gap_abbr)
+
+    for oid in owner_ids:
+        natural[oid].sort(key=lambda c: (-c["score"], c["abbr"]))
+
+    return natural, uncoverable, sorted(unresolved)
+
+
 def build_section(
     snapshot: PublicLeagueSnapshot,
     contract: Mapping[str, Any] | None = None,
@@ -486,7 +736,6 @@ def build_section(
         for k, v in (config.get("displayNameAliases") or {}).items()
         if isinstance(k, str) and isinstance(v, str)
     }
-    min_share = float(config.get("thresholds", {}).get("rosterAssignmentMinShare", 0.10))
     qb_weight = float(config.get("weights", {}).get("nflStartingQbMultiplier", 2.0))
 
     season = snapshot.current_season
@@ -523,9 +772,13 @@ def build_section(
     if not qb_signal_available:
         degraded_reasons.append(DEGRADED_NO_QB_SIGNAL)
 
-    # Walk every roster in the current season.  Score per (owner,
-    # NFL team) pair via the canonical Meaningful Core.
-    assignments: list[dict[str, Any]] = []
+    # Phase 1 -- score every owner's Meaningful Core (unchanged from the
+    # prior rewrite).  Collected rather than rendered inline, because
+    # team SELECTION (phase 2, below) needs every owner's scores at
+    # once -- it is a cross-manager, whole-league step, not a per-owner
+    # one.
+    owner_meta: dict[str, dict[str, Any]] = {}
+    owner_cores: dict[str, _TeamCore] = {}
     for roster in season.rosters:
         if not isinstance(roster, dict):
             continue
@@ -538,6 +791,10 @@ def build_section(
 
         favorite_key = _resolve_favorite_key(display_name, favorites, aliases)
         favorite_entry = favorites.get(favorite_key) if favorite_key else None
+        favorite_abbr = str(favorite_entry.get("abbr") or "").upper() if favorite_entry else None
+        favorite_display = (
+            str(favorite_entry.get("display") or favorite_abbr) if favorite_entry else None
+        )
 
         team_core = _TeamCore()
         team_core.reason = DEGRADED_NO_CONTRACT if not roster_scoring_available else None
@@ -555,14 +812,48 @@ def build_section(
                 qb_weight=qb_weight,
             )
 
-        # Build the NFL-teams list for this owner.
-        nfl_teams_out: list[dict[str, Any]] = []
-        favorite_abbr: str | None = None
+        owner_meta[owner_id] = {
+            "displayName": display_name or team_name or owner_id,
+            "teamName": team_name,
+            "favoriteKey": favorite_key,
+            "favoriteAbbr": favorite_abbr,
+            "favoriteDisplay": favorite_display,
+        }
+        owner_cores[owner_id] = team_core
 
-        if favorite_entry:
-            fav_abbr = str(favorite_entry.get("abbr") or "").upper()
-            fav_display = str(favorite_entry.get("display") or fav_abbr)
-            favorite_abbr = fav_abbr
+    # Phase 2 -- one cross-manager, coverage-maximizing selection pass.
+    # See ``_assign_coverage_maximizing_teams`` and the module docstring
+    # for the algorithm.
+    owner_ids_sorted = sorted(owner_meta)
+    favorite_abbrs = {oid: owner_meta[oid]["favoriteAbbr"] for oid in owner_ids_sorted}
+    scores_by_owner = {
+        oid: {a: s for a, s in owner_cores[oid].by_team_score.items() if s > 0}
+        for oid in owner_ids_sorted
+        if owner_cores[oid].scored
+    }
+    holds_qb_by_owner = {
+        oid: {a: _holds_starting_qb(owner_cores[oid], a) for a in scores_by_owner.get(oid, {})}
+        for oid in owner_ids_sorted
+        if owner_cores[oid].scored
+    }
+    non_fav_by_owner, uncoverable_teams, unresolved_gap_teams = _assign_coverage_maximizing_teams(
+        owner_ids_sorted,
+        scores_by_owner,
+        holds_qb_by_owner,
+        favorite_abbrs,
+        all_teams=frozenset(_NFL_TEAM_NAMES),
+    )
+
+    # Phase 3 -- render.  Favorite entry keeps its historical shape;
+    # non-favorite entries come straight from the selection result.
+    assignments: list[dict[str, Any]] = []
+    for owner_id in owner_ids_sorted:
+        meta = owner_meta[owner_id]
+        team_core = owner_cores[owner_id]
+        fav_abbr = meta["favoriteAbbr"]
+
+        nfl_teams_out: list[dict[str, Any]] = []
+        if fav_abbr:
             score = team_core.by_team_score.get(fav_abbr, 0.0)
             share = (
                 score / team_core.total_weighted_value
@@ -572,44 +863,43 @@ def build_section(
             nfl_teams_out.append(
                 {
                     "abbr": fav_abbr,
-                    "display": fav_display,
+                    "display": meta["favoriteDisplay"],
                     "isFavorite": True,
-                    "qualifiesByRoster": bool(share is not None and share >= min_share),
+                    "qualifiesByRoster": score > 0,
+                    "assignmentReason": _REASON_FAVORITE,
                     "affinityScore": round(score, 3),
                     "affinityShare": round(share, 4) if share is not None else None,
                     "contributors": list(team_core.by_team_contributors.get(fav_abbr, [])),
                 }
             )
 
-        roster_based = []
-        if team_core.total_weighted_value > 0:
-            for abbr, score in team_core.by_team_score.items():
-                if abbr == favorite_abbr:
-                    continue
-                share = score / team_core.total_weighted_value
-                if share < min_share:
-                    continue
-                roster_based.append(
-                    {
-                        "abbr": abbr,
-                        "display": _NFL_TEAM_NAMES.get(abbr, abbr),
-                        "isFavorite": False,
-                        "qualifiesByRoster": True,
-                        "affinityScore": round(score, 3),
-                        "affinityShare": round(share, 4),
-                        "contributors": list(team_core.by_team_contributors.get(abbr, [])),
-                    }
-                )
-        roster_based.sort(key=lambda r: (-r["affinityShare"], -r["affinityScore"], r["abbr"]))
-
-        nfl_teams_out.extend(roster_based)
+        for entry in non_fav_by_owner.get(owner_id, []):
+            abbr = entry["abbr"]
+            score = entry["score"]
+            share = (
+                score / team_core.total_weighted_value
+                if team_core.total_weighted_value > 0
+                else None
+            )
+            nfl_teams_out.append(
+                {
+                    "abbr": abbr,
+                    "display": _NFL_TEAM_NAMES.get(abbr, abbr),
+                    "isFavorite": False,
+                    "qualifiesByRoster": True,
+                    "assignmentReason": entry["reason"],
+                    "affinityScore": round(score, 3),
+                    "affinityShare": round(share, 4) if share is not None else None,
+                    "contributors": list(team_core.by_team_contributors.get(abbr, [])),
+                }
+            )
 
         assignments.append(
             {
                 "ownerId": owner_id,
-                "displayName": display_name or team_name or owner_id,
-                "teamName": team_name,
-                "favoriteKey": favorite_key,
+                "displayName": meta["displayName"],
+                "teamName": meta["teamName"],
+                "favoriteKey": meta["favoriteKey"],
                 "rosterScored": team_core.scored,
                 "rosterUnavailableReason": None if team_core.scored else team_core.reason,
                 "scoringComplete": team_core.scoring_complete,
@@ -626,6 +916,9 @@ def build_section(
     # the page is predictable across reloads.
     assignments.sort(key=lambda a: a["displayName"].lower())
 
+    total_teams = len(_NFL_TEAM_NAMES)
+    covered_count = total_teams - len(uncoverable_teams) - len(unresolved_gap_teams)
+
     return {
         "available": True,
         "unavailableReason": None,
@@ -633,9 +926,16 @@ def build_section(
         "qbSignalAvailable": qb_signal_available,
         "degradedReasons": degraded_reasons,
         "assignments": assignments,
+        "uncoverableTeams": uncoverable_teams,
+        "unresolvedCoverageGaps": unresolved_gap_teams,
+        "coverageSummary": {
+            "totalNflTeams": total_teams,
+            "coveredTeams": covered_count,
+            "uncoverableCount": len(uncoverable_teams),
+            "unresolvedGapCount": len(unresolved_gap_teams),
+        },
         "config": {
             "weights": config["weights"],
-            "thresholds": config["thresholds"],
             "limits": config["limits"],
         },
         "currentSeason": season.season,

--- a/tests/api/test_team_assignment.py
+++ b/tests/api/test_team_assignment.py
@@ -4,9 +4,12 @@ Covers config load/merge, favorite resolution (direct + alias +
 missing, mechanism unchanged from the old points-based model), the
 canonical-value formula (base value passthrough, the ONE starting-QB
 2.0x multiplier and its "unknown never becomes starter" fallback),
-affinity-share aggregation and qualification, unlimited team assignments
-for all teams meeting the threshold, and the missing-is-never-zero /
-Meaningful-Core-reuse invariants the owner mandate is built on.
+affinity-share aggregation, the FIXED favorite + up to 4
+coverage-maximizing team selection (``_assign_coverage_maximizing_teams``
+-- natural top-4 per manager, then a single deterministic cross-manager
+repair pass for any of the 32 real NFL teams nobody covers), and the
+missing-is-never-zero / Meaningful-Core-reuse invariants the owner
+mandate is built on.
 """
 
 from __future__ import annotations
@@ -128,7 +131,7 @@ def _config_path(tmp_path: Path, body: dict) -> Path:
     return p
 
 
-def _stub_config(monkeypatch, tmp_path: Path, *, min_share=0.10, qb_multiplier=2.0):
+def _stub_config(monkeypatch, tmp_path: Path, *, qb_multiplier=2.0):
     cfg_path = _config_path(
         tmp_path,
         {
@@ -140,7 +143,6 @@ def _stub_config(monkeypatch, tmp_path: Path, *, min_share=0.10, qb_multiplier=2
                 "jasonleetucker": "jason",
             },
             "weights": {"nflStartingQbMultiplier": qb_multiplier},
-            "thresholds": {"rosterAssignmentMinShare": min_share},
             "limits": {},
         },
     )
@@ -153,9 +155,9 @@ def _stub_config(monkeypatch, tmp_path: Path, *, min_share=0.10, qb_multiplier=2
 def test_load_config_uses_defaults_when_file_missing(tmp_path: Path):
     cfg = team_assignment.load_config(tmp_path / "missing.json")
     assert cfg["weights"]["nflStartingQbMultiplier"] == 2.0
-    assert cfg["thresholds"]["rosterAssignmentMinShare"] == 0.10
     assert cfg["limits"] == {}
     assert cfg["favorites"] == {}
+    assert "thresholds" not in cfg
 
 
 def test_load_config_falls_back_on_malformed_json(tmp_path: Path):
@@ -183,26 +185,27 @@ def test_load_config_strips_doc_keys(tmp_path: Path):
 
 
 def test_no_dead_weight_or_threshold_knobs_remain():
-    """The old per-position point weights and the flat point threshold
-    are retired entirely -- one weight (the QB multiplier), one
-    threshold (the affinity-share minimum)."""
+    """The old per-position point weights AND the percentage threshold
+    are retired entirely -- one weight (the QB multiplier), zero
+    thresholds.  The non-favorite team count is a hardcoded constant,
+    not a config knob at all."""
     assert set(team_assignment._DEFAULT_CONFIG["weights"]) == {"nflStartingQbMultiplier"}
-    assert set(team_assignment._DEFAULT_CONFIG["thresholds"]) == {"rosterAssignmentMinShare"}
+    assert "thresholds" not in team_assignment._DEFAULT_CONFIG
+    assert team_assignment._NON_FAVORITE_TEAMS_PER_OWNER == 4
 
 
 def test_shipped_config_declares_exactly_the_live_knobs():
     shipped = json.loads(team_assignment._CONFIG_PATH.read_text(encoding="utf-8"))
     weights = {k for k in shipped["weights"] if k != "_doc"}
-    thresholds = {k for k in shipped["thresholds"] if k != "_doc"}
     assert weights == set(team_assignment._DEFAULT_CONFIG["weights"])
-    assert thresholds == set(team_assignment._DEFAULT_CONFIG["thresholds"])
+    assert "thresholds" not in shipped
 
 
 def test_load_config_merges_partial_user_config_over_defaults(tmp_path: Path):
     p = _config_path(tmp_path, {"weights": {"nflStartingQbMultiplier": 3.0}})
     cfg = team_assignment.load_config(p)
     assert cfg["weights"]["nflStartingQbMultiplier"] == 3.0
-    assert cfg["thresholds"]["rosterAssignmentMinShare"] == 0.10
+    assert "thresholds" not in cfg
 
 
 # ── Favorite resolution (unchanged mechanism, test 19) ────────────
@@ -380,9 +383,10 @@ def test_two_teammates_aggregate_correctly(monkeypatch, tmp_path: Path):
 
 
 def test_affinity_share_denominator_is_total_weighted_core_value(monkeypatch, tmp_path: Path):
-    """Test 7: two NFL teams, verify shares sum against the TOTAL,
-    including a team that itself does not clear the threshold."""
-    _stub_config(monkeypatch, tmp_path, min_share=0.10)
+    """Test 7: two NFL teams, verify shares sum against the TOTAL. Both
+    show -- there are only two real candidate teams, well under the
+    4-team cap, so no selection logic excludes either."""
+    _stub_config(monkeypatch, tmp_path)
     mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "nofavorite")})
     rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["A", "B"]}]
     rows = [
@@ -396,14 +400,16 @@ def test_affinity_share_denominator_is_total_weighted_core_value(monkeypatch, tm
     assert a["totalWeightedCoreValue"] == 10000.0
     sea = next(t for t in a["nflTeams"] if t["abbr"] == "SEA")
     assert sea["affinityShare"] == 0.9
-    # KC is exactly 10% -- qualifies (boundary, see test 9) so both show.
     abbrs = {t["abbr"] for t in a["nflTeams"]}
     assert abbrs == {"SEA", "KC"}
 
 
-def test_non_favorite_below_threshold_does_not_qualify(monkeypatch, tmp_path: Path):
-    """Test 8."""
-    _stub_config(monkeypatch, tmp_path, min_share=0.10)
+def test_non_favorite_teams_always_shown_regardless_of_lopsided_share(monkeypatch, tmp_path: Path):
+    """No percentage threshold exists any more -- a team that would
+    have failed the old 10% cutoff (900/10000 = 9%) is still shown,
+    because selection is now purely about the 4-team cap, never a
+    share minimum."""
+    _stub_config(monkeypatch, tmp_path)
     mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "nofavorite")})
     rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["A", "B"]}]
     rows = [
@@ -414,26 +420,10 @@ def test_non_favorite_below_threshold_does_not_qualify(monkeypatch, tmp_path: Pa
     snap = _snapshot(rosters, {}, mgrs, slots=["RB", "RB", "BN"])
     section = team_assignment.build_section(snap, contract)
     abbrs = {t["abbr"] for t in section["assignments"][0]["nflTeams"]}
-    assert abbrs == {"SEA"}
+    assert abbrs == {"SEA", "KC"}
 
 
-def test_non_favorite_at_or_above_threshold_qualifies(monkeypatch, tmp_path: Path):
-    """Test 9: exactly 10.0% qualifies (>= not >)."""
-    _stub_config(monkeypatch, tmp_path, min_share=0.10)
-    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "nofavorite")})
-    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["A", "B"]}]
-    rows = [
-        _row("A", "RB", "SEA", 9000, player_id="a"),
-        _row("B", "RB", "KC", 1000, player_id="b"),
-    ]
-    contract = _contract(rows, {"oA": ["A", "B"]}, slots=["RB", "RB", "BN"])
-    snap = _snapshot(rosters, {}, mgrs, slots=["RB", "RB", "BN"])
-    section = team_assignment.build_section(snap, contract)
-    abbrs = {t["abbr"] for t in section["assignments"][0]["nflTeams"]}
-    assert "KC" in abbrs
-
-
-def test_favorite_remains_assigned_below_threshold(monkeypatch, tmp_path: Path):
+def test_favorite_remains_assigned_with_zero_affinity(monkeypatch, tmp_path: Path):
     """Test 10: favorite has zero roster contribution, still shown."""
     _stub_config(monkeypatch, tmp_path)
     mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "jason")})
@@ -447,18 +437,19 @@ def test_favorite_remains_assigned_below_threshold(monkeypatch, tmp_path: Path):
     assert a["nflTeams"][0]["isFavorite"] is True
     assert a["nflTeams"][0]["affinityScore"] == 0.0
     assert a["nflTeams"][0]["qualifiesByRoster"] is False
+    assert a["nflTeams"][0]["assignmentReason"] == "favorite"
 
 
-def test_all_qualifying_teams_are_assigned_with_deterministic_sort(monkeypatch, tmp_path: Path):
-    """Test 11 + 12: favorite + ALL qualifying non-favorites, sorted by
-    affinityShare (desc), affinityScore (desc), abbr (asc)."""
-    _stub_config(monkeypatch, tmp_path, min_share=0.05)
+def test_natural_top4_selected_with_deterministic_sort_no_repair_needed(
+    monkeypatch, tmp_path: Path
+):
+    """Favorite + up to 4 non-favorites, sorted by (affinityScore desc,
+    abbr asc).  Exactly 4 real non-favorite candidates exist here, so
+    they all fit the cap with no coverage-repair swap needed."""
+    _stub_config(monkeypatch, tmp_path)
     mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "jason")})
     names = [f"P{i}" for i in range(5)]
     rosters = [{"roster_id": 1, "owner_id": "oA", "players": names}]
-    # BUF highest (5000), then KC/DET/PHI tied (1000 each), MIN favorite (100).
-    # All except MIN meet the 0.05 share threshold: (5000 + 1000*3 + 100 = 8100 total).
-    # BUF: 5000/8100 = 61.7%, KC/DET/PHI: 1000/8100 = 12.3% each (all > 5%).
     rows = [
         _row("P0", "RB", "BUF", 5000, player_id="p0"),
         _row("P1", "RB", "KC", 1000, player_id="p1"),
@@ -470,12 +461,40 @@ def test_all_qualifying_teams_are_assigned_with_deterministic_sort(monkeypatch, 
     snap = _snapshot(rosters, {}, mgrs, slots=["RB", "RB", "RB", "RB", "RB", "BN"])
     section = team_assignment.build_section(snap, contract)
     abbrs = [t["abbr"] for t in section["assignments"][0]["nflTeams"]]
-    # All 5 teams qualify: favorite + 4 roster-based
     assert len(abbrs) == 5
     assert abbrs[0] == "MIN"  # favorite always first
-    assert abbrs[1] == "BUF"  # clearly highest share
-    # KC, DET, PHI tied at same share -- alphabetical order
+    assert abbrs[1] == "BUF"  # clearly highest score
+    # KC, DET, PHI tied at the same score -- alphabetical order
     assert abbrs[2:5] == ["DET", "KC", "PHI"]
+    reasons = {t["abbr"]: t["assignmentReason"] for t in section["assignments"][0]["nflTeams"]}
+    assert reasons["MIN"] == "favorite"
+    assert all(reasons[a] == "top_affinity" for a in ("BUF", "KC", "DET", "PHI"))
+
+
+def test_fifth_candidate_naturally_excluded_not_silently_dropped(monkeypatch, tmp_path: Path):
+    """A manager with 5 real non-favorite candidate teams keeps only
+    the top 4 by score; the 5th (weakest) is excluded from this
+    single-manager league by construction -- with no other manager to
+    keep it covered, repair cannot safely place it either, so it is
+    reported in unresolvedCoverageGaps rather than silently vanishing."""
+    _stub_config(monkeypatch, tmp_path)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "nofavorite")})
+    names = [f"P{i}" for i in range(5)]
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": names}]
+    rows = [
+        _row("P0", "RB", "BUF", 5000, player_id="p0"),
+        _row("P1", "RB", "KC", 4000, player_id="p1"),
+        _row("P2", "RB", "DET", 3000, player_id="p2"),
+        _row("P3", "RB", "PHI", 2000, player_id="p3"),
+        _row("P4", "RB", "SEA", 1000, player_id="p4"),
+    ]
+    contract = _contract(rows, {"oA": names}, slots=["RB", "RB", "RB", "RB", "RB", "BN"])
+    snap = _snapshot(rosters, {}, mgrs, slots=["RB", "RB", "RB", "RB", "RB", "BN"])
+    section = team_assignment.build_section(snap, contract)
+    abbrs = {t["abbr"] for t in section["assignments"][0]["nflTeams"]}
+    assert abbrs == {"BUF", "KC", "DET", "PHI"}
+    assert "SEA" not in abbrs
+    assert "SEA" in section["unresolvedCoverageGaps"]
 
 
 def test_missing_canonical_value_is_not_converted_to_zero(monkeypatch, tmp_path: Path):
@@ -620,6 +639,218 @@ def test_flex_players_are_not_selected_a_second_time(monkeypatch, tmp_path: Path
     kc = next(t for t in a["nflTeams"] if t["abbr"] == "KC")
     names_seen = [c["canonicalName"] for c in kc["contributors"]]
     assert len(names_seen) == len(set(names_seen))
+
+
+# ── Coverage-maximizing selection (cross-manager) ──────────────────
+#
+# Direct, pure-function tests of ``_assign_coverage_maximizing_teams``
+# -- no snapshot/contract fixtures needed.  ``ALL_TEAMS`` below is a
+# small closed universe (never the real 32) so gap/uncoverable-team
+# behavior is exercisable without constructing every real NFL team.
+
+
+_ALL_TEAMS = frozenset({"BUF", "KC", "DET", "PHI", "SEA", "CLE", "MIA", "DAL"})
+
+
+def _assign(owner_ids, scores, holds_qb=None, favorites=None, all_teams=None, **kwargs):
+    return team_assignment._assign_coverage_maximizing_teams(
+        owner_ids,
+        scores,
+        holds_qb or {oid: {} for oid in owner_ids},
+        favorites or {oid: None for oid in owner_ids},
+        all_teams=all_teams if all_teams is not None else _ALL_TEAMS,
+        **kwargs,
+    )
+
+
+def test_natural_top4_when_league_already_covers_everything():
+    """Two managers whose natural top-4s collectively already cover
+    every team with any leaguewide affinity -- no repair fires."""
+    owner_ids = ["m1", "m2"]
+    scores = {
+        "m1": {"BUF": 5000, "KC": 4000, "DET": 3000, "PHI": 2000},
+        "m2": {"SEA": 5000, "CLE": 4000, "MIA": 3000, "DAL": 2000},
+    }
+    non_fav, uncoverable, unresolved = _assign(owner_ids, scores)
+    assert {c["abbr"] for c in non_fav["m1"]} == {"BUF", "KC", "DET", "PHI"}
+    assert {c["abbr"] for c in non_fav["m2"]} == {"SEA", "CLE", "MIA", "DAL"}
+    assert all(c["reason"] == "top_affinity" for c in non_fav["m1"] + non_fav["m2"])
+    assert uncoverable == []
+    assert unresolved == []
+
+
+def test_coverage_gap_resolved_by_clear_best_fit_swap():
+    """CLE is uncovered.  m1 is the only manager with CLE affinity;
+    m1's weakest natural team (PHI) is also naturally held by m2, so
+    donating it is safe -- m1 gains CLE via coverage_repair, m2 keeps
+    PHI untouched."""
+    owner_ids = ["m1", "m2"]
+    scores = {
+        "m1": {"BUF": 5000, "KC": 4000, "DET": 3000, "PHI": 2000, "CLE": 500},
+        "m2": {"SEA": 5000, "MIA": 4000, "DAL": 3000, "PHI": 2000},
+    }
+    non_fav, uncoverable, unresolved = _assign(owner_ids, scores)
+    m1_abbrs = {c["abbr"] for c in non_fav["m1"]}
+    assert "CLE" in m1_abbrs
+    assert "PHI" not in m1_abbrs
+    cle_entry = next(c for c in non_fav["m1"] if c["abbr"] == "CLE")
+    assert cle_entry["reason"] == "coverage_repair"
+    assert {c["abbr"] for c in non_fav["m2"]} == {"SEA", "MIA", "DAL", "PHI"}
+    assert uncoverable == []
+    assert unresolved == []
+
+
+def test_gap_falls_to_second_best_fit_when_best_fit_cannot_afford_swap():
+    """m1 has the highest CLE score, but ALL FOUR of m1's natural
+    teams (BUF/KC/DET/PHI) are solely covered by m1 -- nobody else's
+    natural list touches any of them, so no safe donation exists on
+    m1.  Repair falls through to m2 (lower CLE score, but m2's
+    weakest natural team NE is also a third manager m3's sole
+    candidate, so it is safe to donate)."""
+    owner_ids = ["m1", "m2", "m3"]
+    scores = {
+        "m1": {"BUF": 5000, "KC": 4000, "DET": 3000, "PHI": 2000, "CLE": 900},
+        "m2": {"SEA": 5000, "MIA": 4000, "DAL": 3000, "NE": 2500, "CLE": 100},
+        "m3": {"NE": 1000},
+    }
+    all_teams = _ALL_TEAMS | {"NE"}
+    non_fav, uncoverable, unresolved = _assign(owner_ids, scores, all_teams=all_teams)
+    # m1's slots are untouched -- no safe donor was found on m1.
+    assert {c["abbr"] for c in non_fav["m1"]} == {"BUF", "KC", "DET", "PHI"}
+    m2_abbrs = {c["abbr"] for c in non_fav["m2"]}
+    assert "CLE" in m2_abbrs
+    assert "NE" not in m2_abbrs
+    cle_entry = next(c for c in non_fav["m2"] if c["abbr"] == "CLE")
+    assert cle_entry["reason"] == "coverage_repair"
+    assert {c["abbr"] for c in non_fav["m3"]} == {"NE"}
+    assert uncoverable == []
+    assert unresolved == []
+
+
+def test_donor_search_tries_next_weakest_before_giving_up_on_manager():
+    """m1's single weakest team (PHI) is solely-covered (unsafe), but
+    the second-weakest (DET) is safely covered elsewhere -- the search
+    must not give up on m1 after the first unsafe candidate."""
+    owner_ids = ["m1", "m2"]
+    scores = {
+        "m1": {"BUF": 5000, "KC": 4000, "DET": 3000, "PHI": 2000, "CLE": 900},
+        "m2": {"SEA": 5000, "DET": 200},  # DET also held by m2 -> safe to donate
+    }
+    non_fav, uncoverable, unresolved = _assign(owner_ids, scores)
+    m1_abbrs = {c["abbr"] for c in non_fav["m1"]}
+    assert "CLE" in m1_abbrs
+    assert "PHI" in m1_abbrs  # weakest kept -- it was unsafe to donate
+    assert "DET" not in m1_abbrs  # second-weakest donated instead
+    assert {c["abbr"] for c in non_fav["m2"]} == {"SEA", "DET"}
+    # MIA/DAL have zero affinity anywhere in this fixture -- genuinely
+    # uncoverable, not a failure of the repair logic under test here.
+    assert set(uncoverable) == {"MIA", "DAL"}
+    assert unresolved == []
+
+
+def test_totally_uncoverable_team_reported_transparently():
+    """DAL has zero affinity anywhere in the league -- reported in
+    uncoverable_teams, never assigned to anyone."""
+    owner_ids = ["m1"]
+    scores = {"m1": {"BUF": 5000, "KC": 4000, "DET": 3000, "PHI": 2000}}
+    non_fav, uncoverable, unresolved = _assign(owner_ids, scores)
+    assert "DAL" in uncoverable
+    assert all("DAL" != c["abbr"] for c in non_fav["m1"])
+    assert "DAL" not in unresolved
+
+
+def test_qb_holder_tiebreak_decides_between_equal_scored_managers():
+    """m1 and m2 are tied exactly on CLE score; only m2 holds CLE's
+    starting QB -- the tiebreak orders m2 ahead of m1 as CLE's repair
+    candidate, so m2 is tried first and wins immediately."""
+    owner_ids = ["m1", "m2"]
+    scores = {
+        "m1": {"BUF": 5000, "KC": 4000, "DET": 3000, "PHI": 2000, "CLE": 1000},
+        "m2": {"SEA": 5000, "MIA": 4000, "DAL": 3000, "PHI": 2000, "CLE": 1000},
+    }
+    holds_qb = {
+        "m1": {"CLE": False},
+        "m2": {"CLE": True},
+    }
+    non_fav, uncoverable, unresolved = _assign(owner_ids, scores, holds_qb)
+    assert "CLE" not in {c["abbr"] for c in non_fav["m1"]}
+    assert "CLE" in {c["abbr"] for c in non_fav["m2"]}
+
+
+def test_manager_with_fewer_than_four_real_candidates_not_padded():
+    owner_ids = ["m1"]
+    scores = {"m1": {"BUF": 5000, "KC": 4000}}
+    non_fav, uncoverable, unresolved = _assign(owner_ids, scores)
+    assert {c["abbr"] for c in non_fav["m1"]} == {"BUF", "KC"}
+    assert len(non_fav["m1"]) == 2
+
+
+def test_selection_deterministic_across_repeated_calls():
+    owner_ids = ["m1", "m2", "m3"]
+    scores = {
+        "m1": {"BUF": 5000, "KC": 4000, "DET": 3000, "PHI": 2000, "CLE": 900},
+        "m2": {"SEA": 5000, "MIA": 4000, "DAL": 3000},
+        "m3": {"CLE": 100},
+    }
+    result_a = _assign(owner_ids, scores)
+    result_b = _assign(owner_ids, scores)
+    assert result_a == result_b
+
+
+def test_zero_or_absent_score_never_assigned():
+    """A team present in ``scores`` at 0 (defensive input -- callers
+    are supposed to omit it) must never be treated as real affinity."""
+    owner_ids = ["m1"]
+    scores = {"m1": {"BUF": 5000, "CLE": 0}}
+    non_fav, uncoverable, unresolved = _assign(owner_ids, scores)
+    assert "CLE" not in {c["abbr"] for c in non_fav["m1"]}
+
+
+def test_favorite_excluded_from_gap_and_natural_candidacy():
+    """A team that is someone's favorite counts as covered and is
+    never separately assigned as a repair -- it also never appears as
+    a natural candidate for the manager whose favorite it is.  m2 has
+    enough OTHER real candidates that its own marginal CLE affinity is
+    naturally excluded from its top-4 anyway, isolating what this test
+    actually checks: CLE never becomes a repair target for m2 because
+    it is already covered by m1's favorite."""
+    owner_ids = ["m1", "m2"]
+    scores = {
+        "m1": {"BUF": 5000, "KC": 4000, "DET": 3000, "PHI": 2000, "CLE": 9999},
+        "m2": {"SEA": 5000, "MIA": 4000, "DAL": 3000, "NE": 2000, "CLE": 100},
+    }
+    favorites = {"m1": "CLE", "m2": None}
+    all_teams = _ALL_TEAMS | {"NE"}
+    non_fav, uncoverable, unresolved = _assign(
+        owner_ids, scores, favorites=favorites, all_teams=all_teams
+    )
+    # CLE is m1's favorite, so it is excluded from m1's own natural
+    # candidacy even though it scores highest of all -- favorites never
+    # compete for a non-favorite slot.
+    assert "CLE" not in {c["abbr"] for c in non_fav["m1"]}
+    assert {c["abbr"] for c in non_fav["m1"]} == {"BUF", "KC", "DET", "PHI"}
+    # CLE is covered (via m1's favorite) so it is not a gap for m2 either
+    # -- m2's own top-4 naturally excludes its marginal CLE affinity.
+    assert "CLE" not in {c["abbr"] for c in non_fav["m2"]}
+    assert {c["abbr"] for c in non_fav["m2"]} == {"SEA", "MIA", "DAL", "NE"}
+    assert uncoverable == []
+    assert unresolved == []
+
+
+def test_coverage_summary_arithmetic_and_disjointness(monkeypatch, tmp_path: Path):
+    _stub_config(monkeypatch, tmp_path)
+    mgrs = ManagerRegistry(by_owner_id={"oA": _manager("oA", "jason")})
+    rosters = [{"roster_id": 1, "owner_id": "oA", "players": ["A"]}]
+    rows = [_row("A", "RB", "KC", 4000, player_id="a")]
+    contract = _contract(rows, {"oA": ["A"]}, slots=["RB", "BN"])
+    snap = _snapshot(rosters, {}, mgrs, slots=["RB", "BN"])
+    section = team_assignment.build_section(snap, contract)
+    summary = section["coverageSummary"]
+    assert (
+        summary["coveredTeams"] + summary["uncoverableCount"] + summary["unresolvedGapCount"]
+        == summary["totalNflTeams"]
+    )
+    assert not (set(section["uncoverableTeams"]) & set(section["unresolvedCoverageGaps"]))
 
 
 # ── Structural / global availability ───────────────────────────────

--- a/tests/api/test_team_assignment_availability.py
+++ b/tests/api/test_team_assignment_availability.py
@@ -117,8 +117,7 @@ def _stub_config(monkeypatch, tmp_path: Path):
                 "favorites": {"jason": {"abbr": "MIN", "display": "Minnesota Vikings"}},
                 "displayNameAliases": {},
                 "weights": {"nflStartingQbMultiplier": 2.0},
-                "thresholds": {"rosterAssignmentMinShare": 0.10},
-                "limits": {"maxTeamsPerOwner": 3},
+                "limits": {},
             }
         ),
         encoding="utf-8",

--- a/tests/e2e/specs/signed-in-smoke.spec.js
+++ b/tests/e2e/specs/signed-in-smoke.spec.js
@@ -453,12 +453,18 @@ test.describe("signed-in: private-intelligence sections", () => {
       "one assignment per current manager — no drops, no duplicates, no inventions",
     ).toEqual(activeOwnerIds);
 
-    const minShare = data.config?.thresholds?.rosterAssignmentMinShare;
     const qbMultiplier = data.config?.weights?.nflStartingQbMultiplier;
-    const maxTeams = data.config?.limits?.maxTeamsPerOwner;
-    expect(typeof minShare).toBe("number");
     expect(typeof qbMultiplier).toBe("number");
-    expect(typeof maxTeams).toBe("number");
+    // The threshold model is retired -- no config knob for it any more.
+    expect(data.config?.thresholds).toBeUndefined();
+
+    expect(Array.isArray(data.uncoverableTeams)).toBeTruthy();
+    expect(Array.isArray(data.unresolvedCoverageGaps)).toBeTruthy();
+    const summary = data.coverageSummary || {};
+    expect(typeof summary.totalNflTeams).toBe("number");
+    expect(
+      summary.coveredTeams + summary.uncoverableCount + summary.unresolvedGapCount,
+    ).toBe(summary.totalNflTeams);
 
     for (const a of assignments) {
       const who = a.displayName || a.ownerId;
@@ -466,10 +472,12 @@ test.describe("signed-in: private-intelligence sections", () => {
         "boolean",
       );
       expect(Array.isArray(a.nflTeams), `${who}: nflTeams must be an array`).toBeTruthy();
+      // Favorite (0 or 1) + up to 4 coverage-maximizing teams -- fixed,
+      // owner-locked, no threshold-driven variance any more.
       expect(
         a.nflTeams.length,
-        `${who}: at most ${maxTeams} NFL teams`,
-      ).toBeLessThanOrEqual(maxTeams);
+        `${who}: at most 5 NFL teams (favorite + 4)`,
+      ).toBeLessThanOrEqual(5);
 
       if (a.favoriteKey != null) {
         expect(
@@ -480,23 +488,22 @@ test.describe("signed-in: private-intelligence sections", () => {
           a.nflTeams[0].isFavorite,
           `${who}: the favorite must lead the list`,
         ).toBe(true);
+        expect(a.nflTeams[0].assignmentReason).toBe("favorite");
       }
 
       for (const t of a.nflTeams) {
         expect(String(t.abbr), `${who}: NFL team abbr`).toMatch(/^[A-Z]{2,3}$/);
         expect(typeof t.isFavorite).toBe("boolean");
         expect(Number.isFinite(t.affinityScore), `${who}: ${t.abbr} affinityScore`).toBeTruthy();
-        // No fabrication: everything in the list is there because it is
-        // the favorite or because it EARNED the share threshold.
+        // No fabrication: every non-favorite team on the list has real
+        // (nonzero) roster affinity -- never a threshold, never zero.
         if (!t.isFavorite) {
+          expect(["top_affinity", "coverage_repair"]).toContain(t.assignmentReason);
+          expect(t.qualifiesByRoster, `${who}: ${t.abbr} must qualify`).toBe(true);
           expect(
-            t.affinityShare,
-            `${who}: ${t.abbr} is listed without an affinityShare`,
-          ).not.toBeNull();
-          expect(
-            t.affinityShare,
-            `${who}: ${t.abbr} is listed without clearing the ${minShare} share threshold`,
-          ).toBeGreaterThanOrEqual(minShare);
+            t.affinityScore,
+            `${who}: ${t.abbr} is listed with zero affinity`,
+          ).toBeGreaterThan(0);
         }
         for (const c of t.contributors || []) {
           expect(typeof c.canonicalValue).toBe("number");


### PR DESCRIPTION
## Summary

Replaces the percentage-threshold model (`affinityShare >= 10%`) with a fixed **favorite + up to 4** NFL teams per manager, selected to maximize how many of the league's 32 real NFL teams are represented while tracking each manager's own affinity as closely as possible.

## Why

The threshold was denominator-sensitive: a manager could hold a real NFL team's starting QB and several of its best assets and still fall under any fixed percentage simply because their overall roster was large and well-rounded. This was measured live — a manager (Brent) holding the Cleveland Browns' starting QB plus multiple top Browns assets was silently excluded because Cleveland's share of his total roster value fell under 10%.

## Algorithm

Two phases, run once across the whole league after every manager's per-team `affinityScore` is known (per-manager scoring is unchanged):

1. **Natural top-4** — each manager's own 4 highest-`affinityScore` non-favorite teams (ties broken toward whoever holds that team's starting QB, then abbreviation ascending).
2. **Coverage repair** — a single deterministic pass finds every real NFL team nobody in the league covers (no favorite, no natural top-4), and swaps each gap onto the single best-fit manager who has real (nonzero) affinity for it — donating that manager's weakest natural slot, but only when the donated team stays covered by someone else afterward. Falls through to the next-best-fit manager when the best fit has nothing safe to give up. Ties between candidate managers go to whoever holds that team's starting QB (verbatim owner instruction: "ties go to who has the quarterback").

Two invariants hold structurally: a team is **never** assigned to a manager with zero affinity for it (even to pad a coverage count — reported in `uncoverableTeams` instead), and a manager is **never** reduced below what they naturally have just to improve someone else's coverage (reported in `unresolvedCoverageGaps` if a gap can't be safely placed — expected empty on real league data).

## Changes

- **`src/api/team_assignment.py`**: new `_assign_coverage_maximizing_teams` (pure, independently-testable selection function), `_holds_starting_qb` helper, `_NON_FAVORITE_TEAMS_PER_OWNER = 4` constant, `build_section` restructured into score → select → render phases. New payload fields: `uncoverableTeams`, `unresolvedCoverageGaps`, `coverageSummary`, per-team `assignmentReason`. Module docstring rewritten.
- **`config/team_assignment.json`**: `thresholds` block removed entirely — the non-favorite count is now a locked code constant, not a config knob.
- **`frontend/app/league/sections/team-assignment.jsx`**: copy rewritten for the new model; NFL team chips now show a third tag ("League Coverage") for repair-assigned teams so they don't read identically to a manager's own top pick; coverage summary surfaced in the section header.
- **Tests**: `tests/api/test_team_assignment.py` rewritten/extended — 43 tests covering natural selection, every repair-pass branch (clear best-fit swap, best-fit-can't-afford falls to second-best-fit, donor search tries next-weakest before giving up, totally uncoverable teams, QB-holder tiebreaks, sub-4-candidate managers, determinism, coverage-summary arithmetic). `tests/api/test_team_assignment_availability.py` and `tests/e2e/specs/signed-in-smoke.spec.js` updated for the new payload shape.

## Verification

- ✅ 43/43 tests in `test_team_assignment.py` pass
- ✅ 7/7 tests in `test_team_assignment_availability.py` pass
- ✅ Privacy boundary + public contract tests pass (no blocklisted field names)
- ✅ `ruff check` + `ruff format --check` clean
- ✅ Frontend JSX parses and imports cleanly (vitest smoke import)
- ✅ `league-tab-sections.test.js` unaffected/passing

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtPdwag9gWvXdmAoeQrxjb

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtPdwag9gWvXdmAoeQrxjb)_