### PR TITLE
Fix /waivers main table never sending teamOwnerId to the FAAB engine

### DIFF
--- a/docs/faab-live-opportunity-model.md
+++ b/docs/faab-live-opportunity-model.md
@@ -208,6 +208,66 @@ log, not a retroactive backtest. The September 1 board comparison above is a
 **structural explanation case**, not statistical backtest evidence, and is
 reported as such.
 
+## 5a. Activation / calibration plan (added 2026-09-01 follow-up)
+
+The owner's requirement was a *live* daily waiver engine — role/injury/
+opportunity evidence actually moving production FAAB numbers. As shipped,
+this layer is shadow-only: it is computed (when `waiver_live_opportunity` is
+enabled) and logged for comparison, but never read by the live recommendation.
+That is not yet the finished feature; it is the champion/challenger scaffold
+the finished feature has to be validated through. Per CLAUDE.md's own
+invariant ("evaluation is not activation, nothing self-promotes"), promotion
+is a staged, criteria-gated, human-reviewed process, not a flag flip on
+completion of the code:
+
+- **Stage 0 (current state).** `waiver_live_opportunity` defaults off in
+  production. Nothing changes for a live user.
+- **Stage 1 — turn on shadow logging in production.** Flip the flag on (via
+  the per-process env-var override this codebase already uses for
+  script-only/shadow features, matching the `bdvm_engine` precedent) and
+  restart. This requires deploy access this development session does not
+  have (see the follow-up report's production-verification section) — it is
+  a named action item for whoever operates the deploy, not something claimed
+  done here.
+- **Stage 2 — accumulation window.** No review is meaningful on a thin
+  sample. Minimum bar before Stage 3 runs: **N ≥ 200** logged rows in
+  `data/faab/shadow_comparisons_<leagueKey>.json`, spanning **at least one**
+  real injury or depth-chart-promotion event class (not only
+  `hasEvidence: false` rows) and **at least 2 weeks** of in-season play, so
+  the sample isn't dominated by the no-evidence case this layer degrades to.
+- **Stage 3 — analysis.** Extend `scripts/faab_backtest.py`'s existing
+  CHALLENGER column to join the shadow log against realized outcomes once
+  they exist: `faab_history.py`'s recorded bids (did teams actually pay more
+  for opportunity-flagged players?) and, where obtainable, the player's
+  realized weekly production after the claim (did a promoted backup's role
+  actually hold?). Report: how often `opportunity_value` moved the
+  recommended bid, the size of the move, and whether the direction agreed
+  with what happened — not a single pass/fail number, since a role bet can
+  be well-calibrated and still wrong on any individual case.
+- **Stage 4 — human review.** Same posture as Hill-curve promotion
+  (`scripts/model_registry.py promote` + `apply`): a person reads the Stage 3
+  report and explicitly decides promote / partially promote (e.g., cap
+  `retention()` below 1.0, or gate promotion to specific event types with
+  strong Stage 3 evidence) / hold. No automatic promotion path exists or
+  should be built.
+- **Stage 5 — promotion mechanism, if approved.** Change is localized to the
+  `add_value` assignment at each call site (`server.py`'s
+  `/api/waiver/faab-recommend` handler, and `find_waiver_targets`'s
+  market-aware branch after the 2026-09-01 follow-up fix) — read
+  `opportunity_value(...)["value"]` instead of raw `rankDerivedValue` when a
+  promoted-live state is set, keeping the champion/challenger boundary at
+  exactly one line per call site, matching the BDVM/Hill-curve precedent
+  already in this codebase. This is deliberately not a new flag *state*
+  invented for the occasion — reuse whatever mechanism `scripts/model_registry.py`
+  already established for exactly this "challenger evaluated, human
+  approved, promote" sequence rather than inventing a second one.
+
+None of Stages 1-5 are executed by the 2026-09-01 follow-up work — that work
+fixed the `/waivers` frontend bug (see the FAAB redesign report addendum,
+`docs/faab-redesign-2026-09-01-report.md`) and left the shadow layer's status
+otherwise unchanged. This section exists so "when does this become live" has
+a concrete, falsifiable answer instead of an open-ended "later."
+
 ## 6. See also
 
 - `docs/faab-model.md` — the engine reference (unchanged, still binding).

--- a/docs/faab-redesign-2026-09-01-report.md
+++ b/docs/faab-redesign-2026-09-01-report.md
@@ -195,3 +195,183 @@ Directive Part XIII's 20-item checklist, mapped:
 5. Fold best-ball lineup-crackability into the short-term-surplus scoring, reusing the existing exact lineup solver.
 6. Build the portfolio/multi-claim optimizer (directive Part XII) on top of the now-independent per-player `recommend()` calls.
 7. Wire the trending-drops velocity/acceleration data (persisted, computable) into the market layer once a real outcome study justifies a specific transform — deliberately left diagnostic-only in this pass.
+
+---
+
+## 15. Follow-up (2026-09-01): the frontend never sent `teamOwnerId`
+
+**This section documents a bug found in the deployed page after the above
+work merged, its root cause, the fix, and re-verification.** It does not
+supersede §1-14 above — the backend engine described there is correct and
+was never the problem; its market-aware path simply had no caller reaching
+it from the `/waivers` main table.
+
+### 15.1 Root cause
+
+The owner reported the deployed `/waivers` page, with team "Collin"
+selected, showing Cyrus Allen at "FAAB BID $56 · lowball $28 · aggressive
+$80" — exactly `_compute_faab_bid`'s retired fixed-fraction formula
+($56 = 70%×$80, $28 = 35%×$80), not the market-aware engine this redesign
+built.
+
+Traced to `frontend/components/useWaiverAnalysis.js` (the hook behind the
+MAIN waivers table, distinct from the single-player bid-desk modal
+`FaabRecommendation.jsx`, which already sent this field correctly). Its
+`POST /api/waiver/suggestions` body never included `teamOwnerId`, even
+though the hook already calls `useTeam()` and has `selectedTeam.ownerId`
+available in the same closure. Every request from this page's main table
+therefore resolved `team_owner_id=None` on the backend, which — by design,
+documented in `waiver.py`'s own docstring from the original pass — falls
+back to the ceiling-only estimate and stamps
+`bidMethodology: "ceiling_only_estimate"`. Nothing on the frontend read that
+field, so the fallback rendered identically to a real recommendation.
+
+This was purely a missing frontend wire-up. The backend fix from the
+original pass (§9 above) was correct and already merged; it had no caller
+that could reach it from this specific page.
+
+### 15.2 The fix
+
+- `frontend/components/useWaiverAnalysis.js` — sends
+  `teamOwnerId: selectedTeam?.ownerId`; also added `selectedTeam?.ownerId` to
+  the fetch effect's dependency array (switching between two already-selected
+  teams previously would not have re-fetched, since `bidsEnabled` stays true
+  in that case).
+- `frontend/lib/waiver-faab.js` — `buildWaiverBidIndex` now carries
+  `bidMethodology` onto the index; `waiverBidStateForRow` gained a new state,
+  `team_context_missing`, returned whenever the payload's methodology is not
+  `market_aware`. This wins over `priced` even though a `bid` object
+  genuinely exists in ceiling-only mode — it is not a recommendation and
+  must not render as one.
+- `frontend/components/waivers/WaiverBidFigure.jsx` — renders "Recommendation
+  unavailable: team context missing" for that state (satisfies the
+  requirement that the fallback must never be labeled "FAAB BID"), and
+  redesigns the priced row from "reasonable / lowball / aggressive" to
+  **"Bid $X · Expected clearing $Y-$Z · Max I'd pay $M"**, with "Max Worth"
+  (the objective ceiling) and confidence moved to the tooltip.
+- `src/trade/waiver.py::WaiverCandidate` — gained `clearing`, `clearingLow`,
+  `clearingHigh`, `maxRational`, `objectiveDollars`, `confidence` fields,
+  populated in the market-aware branch from `faab_engine.recommend()`'s
+  existing return (`rec["bids"]`, `rec["objective"]["dollars"]`,
+  `rec["confidence"]`) — these were already computed by the engine per
+  candidate and previously discarded; `null` in ceiling-only mode.
+- `src/trade/faab_engine.py::_market_clearing_price` — extended to return
+  p25/p50/p75 of the same rival-bid CDF in one scan (was p50 only), so
+  "Expected clearing $Y-$Z" is a real quantile of modelled evidence, not a
+  fabricated range.
+- New `scripts/faab_trace.py` — diagnostic CLI reproducing the exact
+  production call path (`find_waiver_targets` + a supplementary
+  `faab_engine.recommend()` call for fields the list endpoint doesn't
+  return) for one player/team, or the whole September 1 board at once.
+
+### 15.3 Why the UI said $56 — traced end to end
+
+Reproduced locally against `exports/latest/dynasty_data_2026-09-01.json`
+(the real 2026-09-01 board, including a real "Collin" team with 11
+opponents) via `scripts/faab_trace.py`:
+
+```
+$ python scripts/faab_trace.py --contract exports/latest/dynasty_data_2026-09-01.json \
+    --team-name Collin --player "Cyrus Allen"
+```
+
+| field | before fix (production, reported) | after fix (local repro) |
+|---|---|---|
+| bidMethodology | `ceiling_only_estimate` (silent) | `market_aware` |
+| canonical value | 2282 | 2282 |
+| objective ceiling ("Max Worth") | not surfaced (shim doesn't compute one honestly — it derives a ceiling but applies no rival model) | **$81** |
+| max I'd pay (maxRational) | n/a | **$36** |
+| expected clearing (band) | n/a | **$0-$0** (see caveat below) |
+| recommended bid | **$56** | **$0** |
+| lowball / aggressive shown | $28 / $80 | *(retired — not shown as bid advice)* |
+| rival count | n/a (no rival model ran) | 11 |
+| confidence | n/a | medium |
+
+The $56 was 70% of an $80 ceiling-derived figure with **zero rival
+modeling** — every uncontested, thinly-sourced rookie WR near this value
+would have priced similarly under the old fallback, regardless of actual
+market demand. Once the market-aware engine actually ran (owner id resolved,
+11 real opponents loaded from the same export), the recommended bid
+collapsed to $0.
+
+**Caveat on the exact $0, stated honestly rather than forced to match
+anything:** in this local reproduction, `rivalsWithKnownBalance` is 0 — the
+static export used here is the raw scraper block, which does not carry
+`faabRemaining` per team (that comes from a separate live Sleeper
+teams-overlay fetch the production server makes at request time,
+`_sleeper_overlay.fetch_sleeper_teams_overlay`, which this sandbox has no
+credentials to reach). Per the engine's own invariant ("a rival with no
+visible balance is excluded outright — an unverifiable rival must never
+raise your bid"), all 11 opponents were excluded from the win-probability
+math here, which pushes P(win) toward 1.0 at every bid level and collapses
+the recommended bid toward $0 for every player, not just Cyrus Allen. In
+production, with real balances loaded, the number would likely land
+somewhere in the engine's own previously-documented range for this exact
+player ($0-$19, per §9's original finding) rather than exactly $0 — but the
+qualitative result (large collapse from the ceiling-only $56-60, driven by
+real rival modeling) is confirmed, and is the property this fix is
+responsible for restoring, not a specific dollar figure.
+
+### 15.4 September 1 diagnostic board — re-run, gap explained with evidence
+
+Re-ran the fixed system (`scripts/faab_trace.py --board`) against the same
+local export/team. Full raw output is captured with the PR; summary:
+
+| player | owner's reviewed board | local repro (fixed system) | found on board? |
+|---|---|---|---|
+| Aaron Donald | ~$17 | *(not found)* | No — **already documented in §13 above** as zero canonical coverage; unrelated to this fix, present before and after |
+| George Holani | ~$6 | $0 | Yes |
+| Jacob Saylors | ~$5 | *(not in suggestions list)* | canonical value found (74), but `sourceCount: 1` — excluded by the pre-existing two-source minimum (`TestTwoSourceMinimum`), unrelated to this fix |
+| Kamren Kinchens | ~$4 | $0 | Yes |
+| Seth McGowan | ~$3 | $0 | Yes |
+| Barion Brown | ~$3 | $0 | Yes |
+| Derrick Moore | ~$1 | $0 | Yes |
+| Jonas Sanker | ~$1 | $0 | Yes |
+| Justice Hill | ~$1 | $0 | Yes |
+| Carson Wentz | ~$1 | *(not found)* | No — same pre-existing canonical-coverage gap as Aaron Donald |
+| Malik Benson | ~$1 | $0 | Yes |
+| Dohnte Meyers | ~$1 | *(not in suggestions list)* | canonical value found (711, `sourceCount: 2`, passes the two-source gate) but ranks below the top `DEFAULT_PER_POSITION_LIMIT=6` WR candidates by value, so it's capped out of `find_waiver_targets`'s per-position output — a pre-existing, unrelated behavior |
+| Jer'Zhan Newton | ~$0 | $0 | Yes |
+
+**Every priced player collapsed to $0 in this local reproduction**, where the
+owner's board shows a range from ~$0 to ~$17. This is the SAME structural
+cause as §15.3's Cyrus Allen caveat: this sandbox's rival field has zero
+known FAAB balances (no live Sleeper credentials here), so every claim reads
+as effectively uncontested and prices at the floor. This is **not evidence
+the fixed model is wrong** — it is evidence that a meaningful re-verification
+of the exact dollar amounts requires production's live balance data, which
+this session cannot reach (see §15.5). What this repro DOES confirm,
+independent of the balance-data gap: `bidMethodology` correctly resolves to
+`market_aware` for a real team against a real board, the engine runs without
+error across the whole named board, and the qualitative direction (ceiling-
+only's fixed-fraction numbers replaced by a real, lower, contention-aware
+number) is exactly what the fix was for.
+
+### 15.5 Production verification — what could and could not be done
+
+**This session has no VPS/SSH/deploy credentials** (unchanged from §12/§13).
+What was done instead:
+- Fixed the code (frontend + backend) and verified it against `pytest`
+  (backend, 524 FAAB/waiver tests passing) and the frontend test suite
+  (2404 tests passing, including new tests for the fixed request body, the
+  new `team_context_missing` state, and the redesigned row).
+- Ran the actual production code path (`find_waiver_targets` +
+  `faab_engine.recommend`) against a real archived board
+  (`exports/latest/dynasty_data_2026-09-01.json`) and a real team ("Collin",
+  the exact team from the owner's screenshot) via `scripts/faab_trace.py`,
+  confirming `bidMethodology` flips to `market_aware` and the fixed-fraction
+  numbers disappear.
+- Could NOT: push this fix to the live server, restart
+  `dynasty.service`/`dynasty-frontend.service`, fetch live Sleeper FAAB
+  balances for a fully realistic dollar-figure reproduction, or take a
+  screenshot of the actual deployed page.
+
+**To close the loop:** merge this PR, then pull `main` and restart both
+systemd services on the production VPS (per CLAUDE.md's deployment section).
+No config or migration changes are required — this is a pure code fix.
+
+### 15.6 Live Waiver Opportunity activation plan
+
+See `docs/faab-live-opportunity-model.md` §5a (added alongside this
+addendum) for the staged, criteria-gated activation/calibration plan. Status
+unchanged by this follow-up: the layer remains shadow-only, default off.

--- a/frontend/__tests__/components/waiver-faab-bids.test.jsx
+++ b/frontend/__tests__/components/waiver-faab-bids.test.jsx
@@ -131,6 +131,45 @@ describe("useWaiverAnalysis FAAB bid fetch", () => {
     expect(body.faabRemaining).toBe(63);
   });
 
+  it("sends the selected team's ownerId — this is the fix for the ceiling-only fallback bug", async () => {
+    // Regression: before this fix, /waivers' main table never sent
+    // teamOwnerId at all, so the backend could never run the
+    // market-aware engine for it — every row silently fell back to
+    // the fixed-fraction ceiling_only_estimate shim, which is exactly
+    // what produced the observed $56/$28/$80 Cyrus Allen bug.
+    setContexts({
+      team: { name: "Collin", ownerId: "831633191830933504", players: [], faabRemaining: 63 },
+    });
+    const fetchMock = vi.fn(async () => jsonResponse(OK_PAYLOAD));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<Probe />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.teamOwnerId).toBe("831633191830933504");
+  });
+
+  it("re-fetches when the selected team's ownerId changes, even if a team was already selected", async () => {
+    setContexts({ team: { name: "Collin", ownerId: "owner-a", players: [], faabRemaining: 63 } });
+    const fetchMock = vi.fn(async () => jsonResponse(OK_PAYLOAD));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { rerender } = render(<Probe />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    mockUseTeam.mockReturnValue({
+      selectedTeam: { name: "Someone Else", ownerId: "owner-b", players: [], faabRemaining: 40 },
+      leagueMismatch: false,
+      availableTeams: [],
+    });
+    rerender(<Probe />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    const secondBody = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(secondBody.teamOwnerId).toBe("owner-b");
+  });
+
   // Every failure below is the SAME observable outcome: no index, no
   // error. That sameness is the point — the column just isn't there.
   it.each([

--- a/frontend/__tests__/components/waivers-mobile-faab.test.jsx
+++ b/frontend/__tests__/components/waivers-mobile-faab.test.jsx
@@ -24,7 +24,17 @@ import { waiverBidStateForRow, buildWaiverBidIndex } from "@/lib/waiver-faab";
 
 const PRICED = {
   state: "priced",
-  bid: { reasonable: 15, aggressive: 22, lowball: 8 },
+  bid: {
+    reasonable: 15,
+    aggressive: 22,
+    lowball: 8,
+    clearing: 12,
+    clearingLow: 9,
+    clearingHigh: 18,
+    maxRational: 40,
+    objectiveDollars: 55,
+    confidence: "medium",
+  },
   label: "$15",
   reason: "",
 };
@@ -58,11 +68,30 @@ describe("WaiverBidFigure — priced", () => {
     expect(el.textContent).not.toContain("—");
   });
 
-  it("carries the lowball and aggressive ends as supporting detail", () => {
+  it("carries the expected-clearing band and max-rational bid as supporting detail — not the retired lowball/aggressive ladder", () => {
     render(<WaiverBidFigure entry={PRICED} />);
     const detail = screen.getByTestId("waiver-bid-detail").textContent;
-    expect(detail).toContain("8");
-    expect(detail).toContain("22");
+    expect(detail).toMatch(/clearing/i);
+    expect(detail).toContain("9");
+    expect(detail).toContain("18");
+    expect(detail).toMatch(/max i'?d pay/i);
+    expect(detail).toContain("40");
+    // The retired ladder must not survive under a new label.
+    expect(detail).not.toMatch(/lowball/i);
+    expect(detail).not.toMatch(/aggressive/i);
+  });
+
+  it("falls back to the bare headline (no detail line) when the market-aware fields are absent", () => {
+    // Older cached payload shape, or a transitional deploy where the
+    // backend hasn't shipped the new per-candidate fields yet — must
+    // never render half-built punctuation.
+    render(
+      <WaiverBidFigure
+        entry={{ ...PRICED, bid: { reasonable: 15, aggressive: 22, lowball: 8 } }}
+      />,
+    );
+    expect(screen.getByTestId("waiver-bid-figure")).toHaveTextContent("$15");
+    expect(screen.queryByTestId("waiver-bid-detail")).toBeNull();
   });
 });
 

--- a/frontend/__tests__/waiver-faab.test.js
+++ b/frontend/__tests__/waiver-faab.test.js
@@ -17,7 +17,7 @@
 // number that comes out is byte-identical to what the payload carried.
 
 import { describe, it, expect } from "vitest";
-import { buildWaiverBidIndex, waiverBidForRow } from "@/lib/waiver-faab";
+import { buildWaiverBidIndex, waiverBidForRow, waiverBidStateForRow } from "@/lib/waiver-faab";
 
 const EGBUKA = {
   name: "Emeka Egbuka",
@@ -172,5 +172,95 @@ describe("waiverBidForRow", () => {
     expect(waiverBidForRow(buildWaiverBidIndex(payload()), null)).toBeNull();
     expect(waiverBidForRow(buildWaiverBidIndex(payload()), { name: "" })).toBeNull();
     expect(waiverBidForRow(buildWaiverBidIndex(payload()), {})).toBeNull();
+  });
+});
+
+// ── bidMethodology / team_context_missing ───────────────────────────
+//
+// The bug this pins the fix for: the backend can silently fall back to
+// ceiling_only_estimate (a fixed 70%/35%-of-ceiling shim with NO rival
+// model) when it cannot resolve the requesting team, and until this
+// fix nothing on the frontend ever looked at bidMethodology at all —
+// so a fallback response rendered identically to a real recommendation.
+
+describe("buildWaiverBidIndex methodology + market-aware fields", () => {
+  it("carries bidMethodology through onto the index", () => {
+    const marketAware = buildWaiverBidIndex(payload({ bidMethodology: "market_aware" }));
+    expect(marketAware.methodology).toBe("market_aware");
+    const ceilingOnly = buildWaiverBidIndex(payload({ bidMethodology: "ceiling_only_estimate" }));
+    expect(ceilingOnly.methodology).toBe("ceiling_only_estimate");
+  });
+
+  it("defaults methodology to null when the payload omits it (back-compat)", () => {
+    const index = buildWaiverBidIndex(payload());
+    expect(index.methodology).toBeNull();
+  });
+
+  it("carries the new market-aware fields (clearing band, maxRational, objectiveDollars, confidence)", () => {
+    const rich = {
+      ...EGBUKA,
+      clearing: 6,
+      clearingLow: 4,
+      clearingHigh: 9,
+      maxRational: 20,
+      objectiveDollars: 55,
+      confidence: "medium",
+    };
+    const index = buildWaiverBidIndex({ by_position: { WR: [rich] }, bidMethodology: "market_aware" });
+    const bid = waiverBidForRow(index, { name: "Emeka Egbuka", pos: "WR" });
+    expect(bid.clearing).toBe(6);
+    expect(bid.clearingLow).toBe(4);
+    expect(bid.clearingHigh).toBe(9);
+    expect(bid.maxRational).toBe(20);
+    expect(bid.objectiveDollars).toBe(55);
+    expect(bid.confidence).toBe("medium");
+  });
+
+  it("nulls the market-aware fields rather than coercing to 0 when absent", () => {
+    const index = buildWaiverBidIndex(payload({ bidMethodology: "ceiling_only_estimate" }));
+    const bid = waiverBidForRow(index, { name: "Emeka Egbuka", pos: "WR" });
+    expect(bid.clearing).toBeNull();
+    expect(bid.clearingLow).toBeNull();
+    expect(bid.clearingHigh).toBeNull();
+    expect(bid.maxRational).toBeNull();
+    expect(bid.objectiveDollars).toBeNull();
+    expect(bid.confidence).toBeNull();
+  });
+});
+
+describe("waiverBidStateForRow team_context_missing", () => {
+  it("returns team_context_missing for every row when bidMethodology is ceiling_only_estimate", () => {
+    const index = buildWaiverBidIndex(payload({ bidMethodology: "ceiling_only_estimate" }));
+    const state = waiverBidStateForRow(index, { name: "Emeka Egbuka", pos: "WR" });
+    expect(state.state).toBe("team_context_missing");
+    expect(state.bid).toBeNull();
+    expect(state.label).toMatch(/Recommendation unavailable/i);
+  });
+
+  it("wins over priced even though a bid object exists on the ceiling-only payload", () => {
+    // The whole point of this fix: a ceiling_only_estimate response
+    // still carries a `bid` object per candidate (the fixed-fraction
+    // shim), but it must never render as though it were priced.
+    const index = buildWaiverBidIndex(payload({ bidMethodology: "ceiling_only_estimate" }));
+    expect(index.byName.get("emeka egbuka")).toBeTruthy(); // a bid genuinely exists
+    const state = waiverBidStateForRow(index, { name: "Emeka Egbuka", pos: "WR" });
+    expect(state.state).not.toBe("priced");
+  });
+
+  it("returns priced for a normal market_aware payload", () => {
+    const index = buildWaiverBidIndex(payload({ bidMethodology: "market_aware" }));
+    const state = waiverBidStateForRow(index, { name: "Emeka Egbuka", pos: "WR" });
+    expect(state.state).toBe("priced");
+    expect(state.bid.reasonable).toBe(8);
+  });
+
+  it("still returns priced when bidMethodology is absent (back-compat with older fixtures)", () => {
+    const index = buildWaiverBidIndex(payload());
+    const state = waiverBidStateForRow(index, { name: "Emeka Egbuka", pos: "WR" });
+    expect(state.state).toBe("priced");
+  });
+
+  it("unavailable still wins when there is no index at all, regardless of methodology", () => {
+    expect(waiverBidStateForRow(null, { name: "Emeka Egbuka", pos: "WR" }).state).toBe("unavailable");
   });
 });

--- a/frontend/components/useWaiverAnalysis.js
+++ b/frontend/components/useWaiverAnalysis.js
@@ -127,6 +127,14 @@ export function useWaiverAnalysis({
               // (unknown balance) is safe — it must never be sent as
               // the budget.
               faabRemaining: faabRemaining ?? undefined,
+              // Required for the backend to run the market-aware
+              // engine (rival contention, season option value,
+              // positional need) instead of its ceiling-only fallback
+              // — same field the manual bid desk
+              // (FaabRecommendation.jsx) already sends. Omitting this
+              // was the whole bug: bidsEnabled already requires
+              // selectedTeam, so ownerId is always available here.
+              teamOwnerId: selectedTeam?.ownerId || undefined,
             }),
           ),
         });
@@ -148,7 +156,11 @@ export function useWaiverAnalysis({
       cancelled = true;
       ctl.abort();
     };
-  }, [bidsEnabled, leagueKey, faabRemaining]);
+    // selectedTeam?.ownerId is a dependency in its own right, not just
+    // via bidsEnabled: switching between two already-selected teams
+    // keeps bidsEnabled === true, so without this the bids for the
+    // PREVIOUS team would silently stay on screen under the new one.
+  }, [bidsEnabled, leagueKey, faabRemaining, selectedTeam?.ownerId]);
 
   const faabIndex = useMemo(() => buildWaiverBidIndex(bidPayload), [bidPayload]);
 

--- a/frontend/components/waivers/WaiverBidFigure.jsx
+++ b/frontend/components/waivers/WaiverBidFigure.jsx
@@ -18,23 +18,35 @@
  * `computeFaabHint` (see the closing note in `lib/waiver-logic.js`) is
  * precisely what this must never become.
  *
- * ── Three quantities, kept apart ──────────────────────────────────
+ * ── Four quantities, kept apart ───────────────────────────────────
  * `docs/faab-model.md` separates what a player is WORTH (the objective
- * ceiling, a share of the league's ORIGINAL budget) from what THIS
- * team should BID, and the bid desk's posture shapes only the latter.
- * The triplet this component prints is the engine's bid ladder off the
- * objective ceiling (`src/trade/waiver.py::bid_range`: aggressive =
- * ceiling × budget, reasonable = 0.70 of it, lowball = 0.35). It is
- * NOT the posture-parameterised recommendation — that comes from
- * `/api/waiver/faab-recommend` in the bid desk, and the suggestions
- * endpoint neither accepts nor applies `riskPosture`. So the copy here
- * says "FAAB bid" and points at the desk; it must not be relabelled as
- * "your recommended bid" without the backend actually computing one
- * per row.
+ * ceiling, "Max Worth") from what THIS team should BID, and further
+ * separates the bid from what the MARKET is expected to clear at and
+ * from the most this budget could rationally pay. All four now come
+ * from the same market-aware engine call `find_waiver_targets` already
+ * makes per candidate (`src/trade/faab_engine.py::recommend`) — this
+ * component used to print a fixed 70%/35%-of-ceiling ladder
+ * (`lowball`/`aggressive`) that had NO rival model in it at all, which
+ * is exactly the bug this redesign replaces. It is NOT the
+ * posture-parameterised recommendation from the bid desk
+ * (`/api/waiver/faab-recommend`) — the suggestions endpoint neither
+ * accepts nor applies `riskPosture` — but it IS the same rival-
+ * contention engine, unlike the retired ladder.
+ *
+ * `entry.bid.reasonable` is the headline "Bid". `clearing`/
+ * `clearingLow`/`clearingHigh` are a real quantile band of the modelled
+ * rival-bid distribution (`faab_engine.py::_market_clearing_price`),
+ * not a fabricated range. `maxRational` is the ceiling on what this
+ * budget could rationally pay (never above the balance). All three are
+ * `null` in `ceiling_only_estimate` mode — see `waiverBidStateForRow`'s
+ * `team_context_missing` state, which withholds this component
+ * entirely in that case rather than rendering nulls as dashes.
  *
  * ── An absence states its reason ──────────────────────────────────
  * A bare `—` stood for four different facts. `entry.state` names which
- * one, and the label is rendered instead of the glyph.
+ * one (a fifth, `team_context_missing`, says explicitly that a number
+ * exists on the payload but is being withheld because it is not a
+ * recommendation), and the label is rendered instead of the glyph.
  */
 
 import styles from "@/app/waivers/waivers.module.css";
@@ -71,24 +83,39 @@ export default function WaiverBidFigure({ entry, inline = false }) {
     );
   }
 
-  const { reasonable, aggressive, lowball } = entry.bid;
-  // The ladder ends ride along as a `title` on desktop and as visible
-  // small print inline, so a phone user is not asked to hover.
-  const detail =
-    `lowball ${fmtDollars(lowball)} · aggressive ${fmtDollars(aggressive)}`;
+  const { reasonable, clearing, clearingLow, clearingHigh, maxRational, objectiveDollars, confidence } =
+    entry.bid;
+
+  // Real market-aware fields, all present together or all null — see
+  // to_dict() on WaiverCandidate. Older cached payload shapes (or a
+  // transitional deploy) fall back to the bare headline bid rather
+  // than rendering half-built punctuation.
+  const hasMarketDetail =
+    Number.isFinite(clearingLow) && Number.isFinite(clearingHigh) && Number.isFinite(maxRational);
+
+  const detail = hasMarketDetail
+    ? `Expected clearing ${fmtDollars(clearingLow)}–${fmtDollars(clearingHigh)} · Max I'd pay ${fmtDollars(maxRational)}`
+    : "";
+
+  const tooltipParts = [`Bid ${fmtDollars(reasonable)}`];
+  if (Number.isFinite(clearing)) tooltipParts.push(`Clearing (median) ${fmtDollars(clearing)}`);
+  if (Number.isFinite(objectiveDollars)) tooltipParts.push(`Max Worth ${fmtDollars(objectiveDollars)}`);
+  if (confidence) tooltipParts.push(`Confidence: ${confidence}`);
 
   return (
     <span
       className={className}
       data-testid="waiver-bid-figure"
       data-state="priced"
-      title={`Reasonable ${fmtDollars(reasonable)} · ${detail}`}
+      title={tooltipParts.join(" · ")}
     >
-      {inline ? <span className={styles.faabInlineLabel}>FAAB bid</span> : null}
+      {inline ? <span className={styles.faabInlineLabel}>Bid</span> : null}
       <span className={styles.faabAmount}>{fmtDollars(reasonable)}</span>
-      <span className={styles.faabDetail} data-testid="waiver-bid-detail">
-        {detail}
-      </span>
+      {detail ? (
+        <span className={styles.faabDetail} data-testid="waiver-bid-detail">
+          {detail}
+        </span>
+      ) : null}
     </span>
   );
 }

--- a/frontend/lib/waiver-faab.js
+++ b/frontend/lib/waiver-faab.js
@@ -64,6 +64,15 @@ function _entryFor(candidate) {
     reasonable,
     aggressive: _num(bid.aggressive),
     lowball: _num(bid.lowball),
+    // Market-aware-only — null in ceiling-only mode (see
+    // WaiverCandidate.to_dict on the backend). Powers the row redesign:
+    // "Bid $X · Expected clearing $Y-$Z · Max I'd pay $M".
+    clearing: _num(candidate?.clearing),
+    clearingLow: _num(candidate?.clearingLow),
+    clearingHigh: _num(candidate?.clearingHigh),
+    maxRational: _num(candidate?.maxRational),
+    objectiveDollars: _num(candidate?.objectiveDollars),
+    confidence: typeof candidate?.confidence === "string" ? candidate.confidence : null,
     consensusValue: _num(candidate?.consensusValue),
     rank: _num(candidate?.rank),
     isRookie: Boolean(candidate?.isRookie),
@@ -130,7 +139,13 @@ export function buildWaiverBidIndex(payload) {
   }
 
   if (byName.size === 0) return null;
-  return { byName, byNamePos, ambiguous };
+  // Global to the whole response, per src/trade/waiver.py::find_waiver_targets
+  // — "market_aware" (real rival contention, this team's roster) or
+  // "ceiling_only_estimate" (no resolvable team context — a fixed
+  // fraction of the objective ceiling, never a recommendation).
+  const methodology =
+    typeof payload?.bidMethodology === "string" ? payload.bidMethodology : null;
+  return { byName, byNamePos, ambiguous, methodology };
 }
 
 /**
@@ -156,15 +171,24 @@ export function waiverBidForRow(index, row) {
  * null — the four situations below are genuinely different and the
  * board used to render all of them as one `—`.
  *
- *   `unavailable`  no index at all: no team picked, a league mismatch,
- *                  or the suggestions endpoint did not answer. Nothing
- *                  is wrong with the player.
+ *   `unavailable`         no index at all: no team picked, a league
+ *                         mismatch, or the suggestions endpoint did
+ *                         not answer. Nothing is wrong with the player.
+ *   `team_context_missing`  a team WAS selected (the fetch only runs
+ *                         then) but the backend could not resolve it
+ *                         to a roster and fell back to
+ *                         `ceiling_only_estimate` — a fixed fraction
+ *                         of the objective ceiling with no rival
+ *                         model, which must never be shown as a
+ *                         recommendation. Wins over `priced` even
+ *                         though a `bid` object genuinely exists on
+ *                         the payload in this mode.
  *   `unpriced`     the index exists and this player is not priced in
  *                  it — either the engine declined him (`bid: null`)
  *                  or he is off the backend's per-position board.
  *   `ambiguous`    two candidates share this display name at different
  *                  positions, so no bid can be attributed to this row.
- *   `priced`       the backend stamped a figure.
+ *   `priced`       the backend stamped a market-aware figure.
  *
  * `unpriced` deliberately covers both "priced nothing" and "not on the
  * board": from the reader's seat they are the same fact — the backend
@@ -180,6 +204,14 @@ const BID_STATE_COPY = {
       "FAAB bids have not loaded for this board. Pick your team above — bids are " +
       "scaled to a specific manager's budget, so there is nothing to show until one " +
       "is selected.",
+  },
+  team_context_missing: {
+    label: "Recommendation unavailable: team context missing",
+    reason:
+      "Your team could not be resolved to a current roster, so the market-aware bid " +
+      "model (rival contention, your budget, your roster need) could not run. What " +
+      "would otherwise show here is only a fixed fraction of the player's objective " +
+      "ceiling with no rival model — not a recommendation — so it is withheld.",
   },
   unpriced: {
     label: "Not priced",
@@ -205,6 +237,14 @@ const BID_STATE_COPY = {
 export function waiverBidStateForRow(index, row) {
   const withCopy = (state) => ({ state, bid: null, ...BID_STATE_COPY[state] });
   if (!index) return withCopy("unavailable");
+  // A team was selected (the fetch that built this index only runs
+  // then), but the backend fell back to the ceiling-only estimate — no
+  // rival model ran, so nothing here is a recommendation. This check
+  // comes before any name lookup because it applies to EVERY row in
+  // the payload, not to whether this particular player has a bid.
+  if (index.methodology && index.methodology !== "market_aware") {
+    return withCopy("team_context_missing");
+  }
   if (!row) return withCopy("unpriced");
   const name = normalizeName(row?.name || row?.displayName);
   if (!name) return withCopy("unpriced");

--- a/scripts/faab_trace.py
+++ b/scripts/faab_trace.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""faab_trace.py — end-to-end diagnostic trace for one waiver claim.
+
+Answers "why does the /waivers page say $X for this player, for this
+team, right now?" by running the exact same production code path
+(``src/trade/waiver.py::find_waiver_targets`` plus a direct
+``src/trade/faab_engine.py::recommend`` call for the fields the list
+endpoint doesn't carry) against a real contract payload, and printing
+every field named in the FAAB redesign follow-up report: resolved
+owner id, ``bidMethodology``, canonical value, objective ceiling, team
+ceiling, clearing price (band), recommended bid, rival count,
+historical market evidence, and the shadow Live Waiver Opportunity
+value when ``RISKIT_FEATURE_WAIVER_LIVE_OPPORTUNITY=1`` is set.
+
+Usage::
+
+    python scripts/faab_trace.py \\
+        --contract exports/latest/dynasty_data_2026-09-01.json \\
+        --team-name Collin \\
+        --player "Cyrus Allen"
+
+    python scripts/faab_trace.py --contract ... --team-name Collin --board
+
+``--board`` traces every player named in a fixed diagnostic list
+(overridable with ``--players``) instead of one name — used for the
+September 1 board sanity check.  Diagnostic only: this script never
+writes to ``data/`` and never mutates the input contract.
+
+Exit codes: 0 ok, 1 player/team not resolvable, 2 contract load failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+SEPT_1_DIAGNOSTIC_BOARD = [
+    "Aaron Donald",
+    "George Holani",
+    "Jacob Saylors",
+    "Kamren Kinchens",
+    "Seth McGowan",
+    "Barion Brown",
+    "Derrick Moore",
+    "Jonas Sanker",
+    "Justice Hill",
+    "Carson Wentz",
+    "Malik Benson",
+    "Dohnte Meyers",
+    "Jer'Zhan Newton",
+]
+
+
+def _load_contract(path: Path) -> dict[str, Any]:
+    from src.api.data_contract import build_api_data_contract
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    # A raw scraper export has no ``playersArray`` (that's derived) —
+    # a full contract shape has one already.  Build only when needed,
+    # so this script also accepts an already-built /api/data dump.
+    if isinstance(raw.get("playersArray"), list) and raw["playersArray"]:
+        return raw
+    return build_api_data_contract(raw)
+
+
+def _resolve_owner_id(
+    sleeper_teams: list[dict[str, Any]], *, name: str | None, owner_id: str | None
+) -> str | None:
+    if owner_id:
+        return owner_id
+    if not name:
+        return None
+    needle = name.strip().lower()
+    for t in sleeper_teams:
+        if isinstance(t, dict) and str(t.get("name") or "").strip().lower() == needle:
+            return str(t.get("ownerId") or "") or None
+    return None
+
+
+def _find_row(contract: dict[str, Any], player_name: str) -> dict[str, Any] | None:
+    needle = player_name.strip().lower()
+    for row in contract.get("playersArray") or []:
+        if not isinstance(row, dict):
+            continue
+        nm = str(row.get("displayName") or row.get("name") or "").strip().lower()
+        if nm == needle:
+            return row
+    return None
+
+
+def trace_one(
+    *,
+    contract: dict[str, Any],
+    sleeper_teams: list[dict[str, Any]],
+    owner_id: str,
+    player_name: str,
+    league_budget: int,
+    team_count: int,
+    starters_per_team: int,
+    roster_settings: dict[str, Any],
+    roster_size: int | None,
+    market_priors: Any,
+) -> dict[str, Any]:
+    from src.trade import faab_engine as _engine
+    from src.trade import faab_recommender as _recommender
+    from src.trade import waiver as _waiver
+
+    row = _find_row(contract, player_name)
+    result: dict[str, Any] = {"player": player_name, "found": row is not None}
+    if row is None:
+        result["error"] = "player not found on canonical board (unresolvable identity or off-board)"
+        return result
+
+    canonical_value = row.get("rankDerivedValue")
+    result["canonicalValue"] = canonical_value
+    result["position"] = row.get("position")
+
+    # Same call the /api/waiver/suggestions handler makes, so
+    # bidMethodology + the new per-candidate fields are the REAL
+    # production answer, not a hand-reimplementation of it.
+    suggestions = _waiver.find_waiver_targets(
+        contract,
+        sleeper_teams,
+        min_value=0,
+        include_kicker_def=True,
+        league_budget=league_budget,
+        team_count=team_count,
+        starters_per_team=starters_per_team,
+        team_owner_id=owner_id,
+        starters=roster_settings.get("starters") or {},
+        roster_size=roster_size,
+        market_priors=market_priors,
+    )
+    result["bidMethodology"] = suggestions.get("bidMethodology")
+    result["resolvedOwnerId"] = owner_id
+
+    candidate = None
+    for items in (suggestions.get("by_position") or {}).values():
+        for c in items:
+            if str(c.get("name") or "").strip().lower() == player_name.strip().lower():
+                candidate = c
+                break
+        if candidate:
+            break
+    result["suggestionsCandidate"] = candidate
+
+    # Rival count + team ceiling + factors: recompute the same rivals
+    # find_waiver_targets built internally (that function doesn't
+    # return them), so the trace can show what actually fed the engine.
+    own_team_row = next(
+        (t for t in sleeper_teams if str(t.get("ownerId") or "") == str(owner_id)), None
+    )
+    if own_team_row is not None and candidate is not None:
+        board_values = [
+            r.get("rankDerivedValue")
+            for r in contract.get("playersArray") or []
+            if isinstance(r, dict) and isinstance(r.get("rankDerivedValue"), (int, float))
+        ]
+        league_ctx = _engine.LeagueContext(
+            original_budget=league_budget,
+            team_count=team_count,
+            starters_per_team=starters_per_team,
+        )
+        anchors = _engine.resolve_anchors(board_values, league_ctx)
+        opponents = [t for t in sleeper_teams if str(t.get("ownerId") or "") != str(owner_id)]
+        rivals = _recommender.build_rivals(
+            opponents,
+            position=row.get("position"),
+            market_priors=market_priors,
+            roster_size=roster_size,
+            anchors=anchors,
+            starters=roster_settings.get("starters") or {},
+        )
+        result["rivalCount"] = len(rivals)
+        result["rivalsWithKnownBalance"] = sum(1 for r in rivals if r.faab_remaining is not None)
+
+        own_players = own_team_row.get("players") or []
+        open_spots = max(0, int(roster_size) - len(own_players)) if roster_size else 0
+        team_ctx = _engine.TeamContext(
+            owner_id=str(owner_id),
+            faab_remaining=own_team_row.get("faabRemaining"),
+            open_roster_spots=open_spots,
+            need_level="depth",
+            competitive_status="bubble",
+            risk_posture="balanced",
+        )
+        # NOTE: this second call uses a simplified need_level ("depth")
+        # rather than find_waiver_targets's real per-position
+        # _need_level(own_players, ...) — the objective ceiling's need
+        # multiplier means this call's objectiveDollars/teamCeiling can
+        # differ from suggestionsCandidate's REAL production numbers
+        # above. Only teamCeilingDollars/winProbability/rivalCount (not
+        # returned by find_waiver_targets) are taken from it; the
+        # dollar figures the report should quote are the ones already
+        # on suggestionsCandidate.
+        rec = _engine.recommend(
+            _engine.PlayerInput(
+                name=player_name, value=float(canonical_value or 0), position=row.get("position")
+            ),
+            league_ctx,
+            team_ctx,
+            anchors=anchors,
+            rivals=rivals,
+        )
+        result["teamCeilingDollars"] = rec["teamCeilingDollars"]
+        result["winProbability"] = rec["winProbability"]
+        result["objectiveDollars"] = candidate.get("objectiveDollars") if candidate else None
+        result["clearing"] = candidate.get("clearing") if candidate else None
+        result["clearingLow"] = candidate.get("clearingLow") if candidate else None
+        result["clearingHigh"] = candidate.get("clearingHigh") if candidate else None
+        result["recommendedBid"] = candidate.get("bid", {}).get("reasonable") if candidate else None
+        result["maxRational"] = candidate.get("maxRational") if candidate else None
+        result["confidence"] = candidate.get("confidence") if candidate else None
+
+    result["historicalMarketEvidence"] = {
+        "sampleSize": getattr(market_priors, "sample_size", None),
+        "zeroBidShare": getattr(market_priors, "zero_bid_share", None),
+    }
+
+    # Shadow Live Waiver Opportunity value — never affects the numbers
+    # above; reported separately per the champion/challenger boundary.
+    try:
+        from src.api import feature_flags as _ff
+
+        if _ff.is_enabled("waiver_live_opportunity"):
+            from src.trade import faab_opportunity as _fo
+
+            sleeper_id = None
+            idx = (contract.get("sleeper") or {}).get("idToPlayer") or {}
+            for pid, nm in idx.items():
+                if str(nm).strip().lower() == player_name.strip().lower():
+                    sleeper_id = pid
+                    break
+            opp = _fo.opportunity_value(
+                float(canonical_value or 0), sleeper_id=sleeper_id, player_name=player_name
+            )
+            result["liveOpportunityValue"] = opp
+        else:
+            result["liveOpportunityValue"] = "flag off — shadow layer not computed"
+    except Exception as exc:  # noqa: BLE001 — diagnostic script, never crash the trace
+        result["liveOpportunityValueError"] = str(exc)
+
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--contract", required=True, help="Path to a raw scrape export or built contract JSON."
+    )
+    parser.add_argument("--team-name", help="Sleeper team display name (e.g. 'Collin').")
+    parser.add_argument(
+        "--team-owner-id", help="Sleeper owner id, if known — overrides --team-name."
+    )
+    parser.add_argument("--player", help="Player display name to trace.")
+    parser.add_argument(
+        "--board",
+        action="store_true",
+        help="Trace the fixed September 1 diagnostic board instead of --player.",
+    )
+    parser.add_argument(
+        "--players",
+        nargs="*",
+        help="Explicit list of players to trace (overrides --board's default list).",
+    )
+    parser.add_argument(
+        "--league-budget",
+        type=int,
+        default=None,
+        help="Override the league's original FAAB budget.",
+    )
+    parser.add_argument("--team-count", type=int, default=None)
+    parser.add_argument("--starters-per-team", type=int, default=20)
+    parser.add_argument("--roster-size", type=int, default=None)
+    args = parser.parse_args()
+
+    contract_path = Path(args.contract)
+    if not contract_path.exists():
+        print(f"error: contract file not found: {contract_path}", file=sys.stderr)
+        return 2
+    try:
+        contract = _load_contract(contract_path)
+    except Exception as exc:  # noqa: BLE001
+        print(f"error: failed to load/build contract: {exc}", file=sys.stderr)
+        return 2
+
+    sleeper = contract.get("sleeper") or {}
+    sleeper_teams = sleeper.get("teams") or []
+    if not sleeper_teams:
+        print(
+            "error: contract has no sleeper.teams block — cannot resolve a team.", file=sys.stderr
+        )
+        return 2
+
+    owner_id = _resolve_owner_id(sleeper_teams, name=args.team_name, owner_id=args.team_owner_id)
+    if not owner_id:
+        print(
+            f"error: could not resolve team (--team-name={args.team_name!r}, "
+            f"--team-owner-id={args.team_owner_id!r}) against sleeper.teams "
+            f"(names available: {[t.get('name') for t in sleeper_teams]})",
+            file=sys.stderr,
+        )
+        return 1
+
+    league_budget = args.league_budget
+    if league_budget is None:
+        league_budget = next(
+            (
+                t["faabBudget"]
+                for t in sleeper_teams
+                if isinstance(t.get("faabBudget"), int) and t["faabBudget"] > 0
+            ),
+            100,
+        )
+    team_count = args.team_count or len(sleeper_teams)
+
+    from src.trade.faab_history import load_bid_history, summarize_bid_history
+
+    league_key = None  # trace script works off a raw file, not a resolved league key
+    try:
+        market_priors = summarize_bid_history(load_bid_history(league_key))
+    except Exception:  # noqa: BLE001
+        market_priors = summarize_bid_history([])
+
+    players = (
+        args.players
+        if args.players
+        else (SEPT_1_DIAGNOSTIC_BOARD if args.board else ([args.player] if args.player else []))
+    )
+    if not players:
+        print("error: nothing to trace — pass --player, --players, or --board.", file=sys.stderr)
+        return 1
+
+    all_ok = True
+    for name in players:
+        result = trace_one(
+            contract=contract,
+            sleeper_teams=sleeper_teams,
+            owner_id=owner_id,
+            player_name=name,
+            league_budget=league_budget,
+            team_count=team_count,
+            starters_per_team=args.starters_per_team,
+            roster_settings={},
+            roster_size=args.roster_size,
+            market_priors=market_priors,
+        )
+        if not result.get("found"):
+            all_ok = False
+        print(json.dumps(result, indent=2, default=str))
+        print("-" * 72)
+
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/trade/faab_engine.py
+++ b/src/trade/faab_engine.py
@@ -958,30 +958,43 @@ def _market_clearing_price(
     crowd_median_pct: float | None = None,
     crowd_share: float | None = None,
     trending_share: float | None = None,
-) -> int:
-    """The price at which the top rival bid is as likely to be under
-    as over — the median of the top-rival distribution.
+) -> dict[str, int]:
+    """The band of prices a rational rival field would clear this
+    player at — three quantiles of ``rival_bid_cdf`` (P(we win at this
+    bid)), scanned in one pass over the whole budget.
+
+    ``p50`` is "the price at which the top rival bid is as likely to be
+    under as over" (the historical single-number ``clearing`` figure).
+    ``p25``/``p75`` are the same CDF at the quarter and three-quarter
+    marks — a real quantile of the modelled rival-bid distribution, not
+    a fabricated band — giving the /waivers row UX an honest "expected
+    clearing $Y-$Z" range instead of one point estimate.
 
     Scanned over the whole budget, independent of our own balance or
     ceiling: this is what the player will cost, not what we can pay.
     """
     budget = max(1, int(league.original_budget))
+    found = {"p25": None, "p50": None, "p75": None}
     for b in range(0, budget + 1):
-        if (
-            rival_bid_cdf(
-                float(b),
-                rivals,
-                demand_signal=demand_signal,
-                league=league,
-                config=config,
-                crowd_median_pct=crowd_median_pct,
-                crowd_share=crowd_share,
-                trending_share=trending_share,
-            )
-            >= 0.5
-        ):
-            return b
-    return budget
+        if all(v is not None for v in found.values()):
+            break
+        p_win = rival_bid_cdf(
+            float(b),
+            rivals,
+            demand_signal=demand_signal,
+            league=league,
+            config=config,
+            crowd_median_pct=crowd_median_pct,
+            crowd_share=crowd_share,
+            trending_share=trending_share,
+        )
+        if found["p25"] is None and p_win >= 0.25:
+            found["p25"] = b
+        if found["p50"] is None and p_win >= 0.5:
+            found["p50"] = b
+        if found["p75"] is None and p_win >= 0.75:
+            found["p75"] = b
+    return {k: (v if v is not None else budget) for k, v in found.items()}
 
 
 def optimal_bid(
@@ -1039,7 +1052,9 @@ def optimal_bid(
             "conservative": 0,
             "aggressive": 0,
             "maxRational": 0,
-            "clearing": market_clearing,
+            "clearing": market_clearing["p50"],
+            "clearingLow": market_clearing["p25"],
+            "clearingHigh": market_clearing["p75"],
             "winProbability": None,
             "curve": [],
         }
@@ -1103,8 +1118,6 @@ def optimal_bid(
     )
     aggressive = min(aggressive, hard_cap)
 
-    clearing = market_clearing
-
     win_at_recommended = next(
         (p for b, p, _ in curve if b >= recommended),
         curve[-1][1] if curve else 0.0,
@@ -1115,7 +1128,9 @@ def optimal_bid(
         "conservative": int(max(0, conservative)),
         "aggressive": int(aggressive),
         "maxRational": int(hard_cap),
-        "clearing": int(clearing),
+        "clearing": int(market_clearing["p50"]),
+        "clearingLow": int(market_clearing["p25"]),
+        "clearingHigh": int(market_clearing["p75"]),
         "winProbability": round(float(win_at_recommended), 3),
         "curve": [{"bid": b, "winProb": round(p, 4)} for b, p, _ in curve[:60]],
     }
@@ -1302,6 +1317,8 @@ def recommend(
             "aggressive": bids["aggressive"],
             "maxRational": bids["maxRational"],
             "clearing": bids["clearing"],
+            "clearingLow": bids["clearingLow"],
+            "clearingHigh": bids["clearingHigh"],
         },
         "pctOfOriginalBudget": round(100.0 * bids["recommended"] / budget, 1),
         "pctOfRemaining": (

--- a/src/trade/waiver.py
+++ b/src/trade/waiver.py
@@ -82,6 +82,19 @@ class WaiverCandidate:
     bid_aggressive: int | None = None
     bid_reasonable: int | None = None
     bid_lowball: int | None = None
+    # Market-aware-only fields — the full engine already computes these
+    # per candidate (``faab_engine.recommend``'s ``bids``/``objective``/
+    # ``confidence`` keys); they stay ``None`` in ceiling-only mode,
+    # where no rival model runs at all and there is nothing honest to
+    # put here.  Consumed by the /waivers row redesign ("Bid $X ·
+    # Expected clearing $Y-$Z · Max I'd pay $M") — see
+    # ``WaiverBidFigure.jsx``.
+    clearing: int | None = None
+    clearing_low: int | None = None
+    clearing_high: int | None = None
+    max_rational: int | None = None
+    objective_dollars: int | None = None
+    confidence: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -98,6 +111,12 @@ class WaiverCandidate:
             }
             if self.bid_aggressive is not None
             else None,
+            "clearing": self.clearing,
+            "clearingLow": self.clearing_low,
+            "clearingHigh": self.clearing_high,
+            "maxRational": self.max_rational,
+            "objectiveDollars": self.objective_dollars,
+            "confidence": self.confidence,
         }
 
 
@@ -458,6 +477,21 @@ def find_waiver_targets(
                 c.bid_aggressive = min(int(bids["aggressive"]), cap)
                 c.bid_reasonable = min(int(bids["recommended"]), cap)
                 c.bid_lowball = min(int(bids["conservative"]), cap)
+                # clearing/clearingLow/clearingHigh describe the MARKET
+                # (what the player will cost) and are NOT re-capped to
+                # our own balance the way the three bids above are — a
+                # broke team still needs to know what the player will
+                # go for. maxRational is already bounded by the team's
+                # balance inside the engine (it IS "the most I could
+                # rationally pay"), so it needs no separate cap here.
+                c.clearing = int(bids["clearing"])
+                if isinstance(bids.get("clearingLow"), (int, float)):
+                    c.clearing_low = int(bids["clearingLow"])
+                if isinstance(bids.get("clearingHigh"), (int, float)):
+                    c.clearing_high = int(bids["clearingHigh"])
+                c.max_rational = int(bids["maxRational"])
+                c.objective_dollars = int(rec["objective"]["dollars"])
+                c.confidence = rec.get("confidence")
     else:
         for cs in candidates_by_position.values():
             for c in cs:

--- a/tests/trade/test_faab_engine.py
+++ b/tests/trade/test_faab_engine.py
@@ -466,6 +466,21 @@ class TestBidLadder:
         rec = self._rec(BOARD[220])
         assert rec["winProbability"] is None or 0.0 <= rec["winProbability"] <= 1.0
 
+    def test_clearing_band_is_a_real_quantile_ordering(self):
+        """clearingLow/clearing/clearingHigh are p25/p50/p75 of the
+        same rival-bid CDF _market_clearing_price scans — a real
+        quantile, not a fabricated band — so they must be monotonic
+        (rival_bid_cdf is non-decreasing in the bid amount)."""
+        rec = self._rec(BOARD[200])
+        bids = rec["bids"]
+        assert bids["clearingLow"] <= bids["clearing"] <= bids["clearingHigh"]
+
+    def test_uncontested_claim_clears_at_zero_across_the_whole_band(self):
+        rec = self._rec(BOARD[200], rivals=[])
+        assert rec["bids"]["clearing"] == 0
+        assert rec["bids"]["clearingLow"] == 0
+        assert rec["bids"]["clearingHigh"] == 0
+
     def test_percentages_use_the_right_denominators(self):
         league = _league()
         rec = FE.recommend(

--- a/tests/trade/test_faab_recommender.py
+++ b/tests/trade/test_faab_recommender.py
@@ -97,6 +97,8 @@ class TestResponseContract:
             "aggressive",
             "maxRational",
             "clearing",
+            "clearingLow",
+            "clearingHigh",
         }
 
     def test_standard_is_the_recommended_bid(self):

--- a/tests/trade/test_waiver.py
+++ b/tests/trade/test_waiver.py
@@ -441,3 +441,50 @@ class TestMarketAwareUnification:
         assert bid["aggressive"] <= 7
         assert bid["reasonable"] <= 7
         assert bid["lowball"] <= 7
+
+    def test_market_aware_candidate_exposes_clearing_max_rational_worth_confidence(
+        self, rookies_allowed
+    ):
+        """The follow-up fix: /waivers' row redesign ("Bid $X ·
+        Expected clearing $Y-$Z · Max I'd pay $M") needs these fields
+        per candidate.  The engine already computed them
+        (faab_engine.recommend's bids/objective/confidence keys) — this
+        pins that find_waiver_targets now captures them onto
+        WaiverCandidate instead of discarding them."""
+        teams = [
+            {"ownerId": "owner1", "faabRemaining": 100, "players": []},
+            {"ownerId": "owner2", "faabRemaining": 100, "players": []},
+        ]
+        out = w.find_waiver_targets(
+            _contract(_player("Solo Guy", "WR", 4000)),
+            sleeper_teams=teams,
+            team_owner_id="owner1",
+            starters={"QB": 1, "RB": 2, "WR": 3, "TE": 1},
+            roster_size=25,
+        )
+        candidate = out["by_position"]["WR"][0]
+        for key in ("clearing", "clearingLow", "clearingHigh", "maxRational", "objectiveDollars"):
+            assert isinstance(candidate[key], int), f"{key} should be an int in market_aware mode"
+        assert candidate["confidence"] in {"high", "medium", "low"}
+        assert candidate["clearingLow"] <= candidate["clearing"] <= candidate["clearingHigh"]
+
+    def test_ceiling_only_candidate_nulls_the_market_aware_fields(self, rookies_allowed):
+        """The inverse: with no resolvable team, none of these fields
+        exist (no rival model ran at all), and the fallback must report
+        that honestly rather than inventing zeros — the frontend keys
+        its 'Recommendation unavailable' state on bidMethodology, but a
+        client reading these fields directly must also see the absence."""
+        out = w.find_waiver_targets(
+            _contract(_player("Solo Guy", "WR", 4000)),
+            sleeper_teams=[{"ownerId": "owner1", "faabRemaining": 100, "players": []}],
+        )
+        candidate = out["by_position"]["WR"][0]
+        for key in (
+            "clearing",
+            "clearingLow",
+            "clearingHigh",
+            "maxRational",
+            "objectiveDollars",
+            "confidence",
+        ):
+            assert candidate[key] is None


### PR DESCRIPTION
## Summary

Follow-up to the FAAB/waiver redesign (#1209): the owner reported production `/waivers` still showing Cyrus Allen at "FAAB BID $56 · lowball $28 · aggressive $80" with team "Collin" selected — mathematically the retired ceiling-only fallback ($56 = 70%×$80, $28 = 35%×$80), not the market-aware engine built last session.

**Root cause:** `frontend/components/useWaiverAnalysis.js` (the hook behind the *main* waivers table, distinct from the single-player bid-desk modal which already sent this field correctly) never included `teamOwnerId` in its `POST /api/waiver/suggestions` body, even though `selectedTeam.ownerId` was sitting unused in the same closure. Every request therefore resolved `team_owner_id=None` on the backend, which by design falls back to the fixed 70%/35%-of-ceiling shim with no rival model — silently, since nothing on the frontend read `bidMethodology` to tell the two apart.

Verified against the real 2026-09-01 board with the real "Collin" team (`scripts/faab_trace.py`, new in this PR): after the fix, `bidMethodology` flips to `market_aware` and the bid collapses from **$56 → $0** (objective ceiling/"Max Worth" $81, Max I'd pay $36). Full trace and the re-checked September 1 diagnostic board are in the report addendum.

- `frontend/components/useWaiverAnalysis.js` — send `teamOwnerId`; refetch when the selected team's `ownerId` changes even if a team was already selected (previously `bidsEnabled` alone wouldn't catch a team switch)
- `frontend/lib/waiver-faab.js` / `WaiverBidFigure.jsx` — thread `bidMethodology` through; add a `team_context_missing` state ("Recommendation unavailable: team context missing") that wins over a rendered bid whenever the backend fell back to ceiling-only, so the fallback can never again render as a recommendation; redesign the priced row from "reasonable/lowball/aggressive" to **"Bid $X · Expected clearing $Y-$Z · Max I'd pay $M"**
- `src/trade/waiver.py` / `src/trade/faab_engine.py` — expose `clearing`/`clearingLow`/`clearingHigh` (a real p25/p50/p75 quantile of the rival-bid CDF, not a fabricated range)/`maxRational`/`objectiveDollars`/`confidence` per candidate — the engine already computed all of these and previously discarded them before the response
- New `scripts/faab_trace.py` — end-to-end diagnostic CLI (owner id, `bidMethodology`, canonical value, ceiling, clearing band, rival count, historical evidence, shadow opportunity value) for one player/team or the whole September 1 board at once
- `docs/faab-redesign-2026-09-01-report.md` §15 — root cause, before/after numbers, September 1 board re-check with honest caveats (this sandbox has no live Sleeper FAAB balances, so exact dollar figures collapse further toward $0 than production would — the qualitative fix is confirmed, not every dollar amount)
- `docs/faab-live-opportunity-model.md` §5a — staged, criteria-gated activation/calibration plan for the still-shadow-only Live Waiver Opportunity layer (unchanged status; this PR does not activate it)

**Production verification limitation, stated plainly:** this session has no VPS/SSH/deploy credentials, so the fix could not be pushed to the live server or screenshotted there. Verified instead via the actual production code path against a real archived board and the real "Collin" team. To close the loop: merge, then pull `main` and restart `dynasty.service`/`dynasty-frontend.service` on the production VPS — no config/migration changes needed.

## Test plan

- [x] `python -m pytest tests/trade/test_waiver.py tests/trade/test_faab_engine.py tests/trade/test_faab_recommender.py tests/api/test_faab_recommend_endpoint.py -q` — all pass, including 4 new tests pinning the new per-candidate fields (present in market-aware mode, `null` in ceiling-only mode) and the clearing-band ordering
- [x] `python -m pytest tests/trade/ tests/api/ -k "faab or waiver" -q` — 524 passed
- [x] Frontend: `npx vitest run` — 2404 tests passed, including new tests for `teamOwnerId` in the request body, refetch-on-team-switch, the `team_context_missing` state, and the redesigned row (with a fallback test for when the new fields are absent)
- [x] `scripts/faab_trace.py` run against the real `exports/latest/dynasty_data_2026-09-01.json` board for Cyrus Allen and the full owner-reviewed diagnostic board — output captured in the report addendum
- [x] `ruff format --check` / `ruff check` / `scripts/check_decision_coercions.py` — clean
- [ ] Production verification — blocked on deploy access this session doesn't have; see report addendum §15.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1djzFg9ASgF2ek5FgsGDH

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1djzFg9ASgF2ek5FgsGDH)_