### PR TITLE
fix(e2e): scope V1-131's /more negative-control locator

### DIFF
--- a/tests/e2e/specs/prod-auth/v1-131-nav-gating.spec.js
+++ b/tests/e2e/specs/prod-auth/v1-131-nav-gating.spec.js
@@ -194,8 +194,22 @@ test.describe("V1-131: nav gating on the deployed shell", () => {
 
     // ── /more site map ───────────────────────────────────────────────
     await page.goto(prodUrl("/more"), { waitUntil: "domcontentloaded" });
+    // Scoped to the site-map panels (frontend/app/more/page.jsx,
+    // .shell-sitemap-panel): observed on production run 33528409461
+    // (2026-09-01), an unscoped `a.shell-menu-item[href="/edge"]` resolved
+    // to TWO elements — one visible, one carrying `hidden`. The visible
+    // one is confirmed correct (the run's own accessibility snapshot shows
+    // exactly one "Source Disagreement" link under Market, reachable and
+    // correctly labelled), so the hidden second node is not a user-facing
+    // regression; scoping to the page's own site-map container makes the
+    // negative control unambiguous regardless of the second node's exact
+    // origin, which static review of NavMenu.jsx/TopBar.jsx did not
+    // conclusively identify (NavMenu's dropdown items are conditionally
+    // rendered on `open`, and the header's own persistent Market link
+    // carries a different class, `shell-nav-link`, so neither is a
+    // confirmed source — left for a follow-up if it recurs elsewhere).
     await expect(
-      page.locator('a.shell-menu-item[href="/edge"]'),
+      page.locator('.shell-sitemap-panel a.shell-menu-item[href="/edge"]'),
       "/more site map should list Source Disagreement (negative control)",
     ).toBeVisible({ timeout: 30_000 });
     const moreCeLinks = page.locator('a[href="/consensus-edge"]');


### PR DESCRIPTION
## Summary

- Found while investigating V1-109's authenticated production verification run (`33528409461`) — its overall job read `failure`, and the single failing test turned out to be an unrelated V1-131 assertion, not V1-109's own.
- `v1-131-nav-gating.spec.js`'s "/more site map should list Source Disagreement (negative control)" check used an unscoped `page.locator('a.shell-menu-item[href="/edge"]')`, which resolved to two elements — one visible, one `hidden`.
- Confirmed via the failed run's own accessibility snapshot that the real user-facing behavior is correct: exactly one visible "Source Disagreement" link renders under Market on `/more`, correctly labelled and reachable. This is a locator-scoping bug, not a product regression.
- No product code change. Scopes the locator to `.shell-sitemap-panel` (the site-map page's own container), matching how the rest of this same spec already scopes its assertions (e.g. `marketMenu.getByRole(...)`) rather than searching the whole page.

## Honest gap

Static review of `NavMenu.jsx`/`TopBar.jsx` did not conclusively identify the second (hidden) node's exact origin — NavMenu's dropdown items are conditionally rendered on `open`, and the header's own persistent Market link carries a different class (`shell-nav-link`), so neither is a confirmed source. Reproducing this against production directly needs an authenticated session this environment can't mint standalone. Recorded as a named gap in the fix's comment rather than guessed at — worth a follow-up if it recurs elsewhere or on another route.

## Test plan

- [x] `node -c` syntax check
- [x] `npx playwright test --config=tests/e2e/prod-auth.config.js --list` — collects all 34 specs (10 for this file, 5 tests × 2 projects) with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg)_