### PR TITLE
Start Stage 1 of FAAB Live Opportunity activation: shadow logging on by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ snapshots). This line said "Private repo" while `SECURITY.md` and
   Sleeper-login allowlist; public routes hit `/api/public/league/*`.
 - **Feature flags** (`src/api/feature_flags.py`): every new
   capability from the 2026-04 upgrade ships flag-gated. Defaults are
-  **per-flag**: 9 of the 20 in `_DEFAULTS` ship enabled (`ledger_rank_change`, `bdvm_engine`,
+  **per-flag**: 10 of the 20 in `_DEFAULTS` ship enabled (`ledger_rank_change`, `bdvm_engine`,
   `te_basis_conversion`, `monte_carlo_trade`, `idp_scoring_fit`,
   `reception_scoring_fit`, `nfl_data_ingest`, `realized_points_api`,
-  `perfect_draft`),
+  `perfect_draft`, `waiver_live_opportunity`),
   several deliberately. For those the env var is a rollback lever, not an
   opt-in. Read `_DEFAULTS` before assuming a capability is dormant.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,13 +26,16 @@ Browser ─► Nginx ─► Next.js (port 3000) ─► FastAPI (port 8000) ─�
    `src/api/feature_flags.py`. Env override via `RISKIT_FEATURE_<NAME>=1`
    (or `=0` to disable).
 
-   **Defaults are per-flag.** As of 2026-08-25, 9 of the 20 entries in
+   **Defaults are per-flag.** As of 2026-09-02, 10 of the 20 entries in
    `_DEFAULTS` ship enabled — `ledger_rank_change` (registered closing
    F-24: the ledger-derived `rankChange` derivation, previously an
    invisible direct env read), `bdvm_engine`, `te_basis_conversion`
    (which reprices every tight end on the live board),
    `monte_carlo_trade`, `idp_scoring_fit`, `reception_scoring_fit`,
-   `nfl_data_ingest`, `realized_points_api`, `perfect_draft` — several
+   `nfl_data_ingest`, `realized_points_api`, `perfect_draft`,
+   `waiver_live_opportunity` (shadow-only — computes a second value
+   alongside the canonical one and logs it; never changes what any
+   caller is served) — several
    with comments
    recording that the enabled default is deliberate. For those, the env
    var is a rollback lever rather than an opt-in.

--- a/docs/faab-live-opportunity-model.md
+++ b/docs/faab-live-opportunity-model.md
@@ -222,13 +222,15 @@ completion of the code:
 
 - **Stage 0 (current state).** `waiver_live_opportunity` defaults off in
   production. Nothing changes for a live user.
-- **Stage 1 — turn on shadow logging in production.** Flip the flag on (via
-  the per-process env-var override this codebase already uses for
-  script-only/shadow features, matching the `bdvm_engine` precedent) and
-  restart. This requires deploy access this development session does not
-  have (see the follow-up report's production-verification section) — it is
-  a named action item for whoever operates the deploy, not something claimed
-  done here.
+- **Stage 1 — turn on shadow logging in production.** STARTED 2026-09-02:
+  `waiver_live_opportunity`'s default in `_DEFAULTS` is now `True` (see
+  `src/api/feature_flags.py`), motivated by the real overnight evidence in
+  the follow-up report's §16 — so a fresh production deploy picks this up
+  without a separate env-var change. Completing Stage 1 still requires this
+  code to actually reach production (pull `main` + restart both systemd
+  services), which this development session cannot do — see the follow-up
+  report's production-verification section. Until that deploy happens, the
+  flag change sits in the repo but does not yet affect the live server.
 - **Stage 2 — accumulation window.** No review is meaningful on a thin
   sample. Minimum bar before Stage 3 runs: **N ≥ 200** logged rows in
   `data/faab/shadow_comparisons_<leagueKey>.json`, spanning **at least one**

--- a/docs/faab-redesign-2026-09-01-report.md
+++ b/docs/faab-redesign-2026-09-01-report.md
@@ -373,5 +373,105 @@ No config or migration changes are required — this is a pure code fix.
 ### 15.6 Live Waiver Opportunity activation plan
 
 See `docs/faab-live-opportunity-model.md` §5a (added alongside this
-addendum) for the staged, criteria-gated activation/calibration plan. Status
-unchanged by this follow-up: the layer remains shadow-only, default off.
+addendum) for the staged, criteria-gated activation/calibration plan. As of
+2026-09-02 (§16 below), Stage 1 has started — `waiver_live_opportunity`
+now defaults to `True` in `_DEFAULTS`, so the shadow computation runs and
+logs by default rather than requiring a second deploy just to turn logging
+on. The layer is still shadow-only: nothing it computes reaches a live bid
+without a separate, later, human-reviewed promotion step (Stage 5).
+
+## 16. Real overnight validation (2026-09-01/02 waiver results)
+
+**What happened.** The owner reported the fixed `/waivers` page (§15) still
+looked wrong in a different way: with team "Jason" selected, the model
+recommended $0 for almost every candidate except Cyrus Allen ($8, capped
+"Max I'd pay" $23). The owner's real Sleeper waiver claims, placed the
+previous evening from independent manual research, spread $1-$7 across
+eleven players — a materially different shape. Rather than treat this as a
+hypothesis, the actual overnight waiver run was used as ground truth: Sleeper
+exposes a public, unauthenticated transactions API, separate from this
+project's own production site (which remains unreachable from this session),
+and it was queried directly for `league 1312006700437352448`'s real
+`round 1` waiver results the morning after processing.
+
+**The comparison**, model vs. reality, for every named candidate plus the
+players that actually got contested:
+
+| player | dynasty value | vs. replacement (1695) | model bid | model max | real winner | real price | next-best real bid |
+|---|---|---|---|---|---|---|---|
+| Cyrus Allen | 2282 | +587 | $0 | $25 | Ty | **$45** | $21 |
+| Marlin Klein | 1927 | +232 | $0 | $0 | Roy | **$19** | — |
+| Sam Roush | 1795 | +100 | $0 | $0 | Roy | **$7** | — |
+| Seth McGowan | 1607 | below | $0 | $0 | Roy | **$6** | $9 (Joey lost) |
+| George Holani | 1464 | below | $0 | $0 | Brent | **$6** | $3 (Jason, lost) |
+| Barion Brown | 1438 | below | $0 | $0 | Joey | **$12** | $3 |
+| Malik Benson | 1411 | below | $0 | $0 | Brent | **$6** | $4 |
+| Jonas Sanker / Derrick Moore / Jacob Saylors / Kamren Kinchens / Justice Hill / Dohnte Meyers | 711-1998 | mixed | $0-$1 | $0-$3 | **Jason** (us) | $1-$3 | uncontested or ~tied |
+
+Every claim in the last row — the ones the model and the owner's own manual
+bids agreed were worth $1-3 — was WON at exactly that price, uncontested or
+against light competition. That is real confirmation the model's floor
+behavior is correct: at this price tier, nobody else wanted these players
+either. The disconnect is entirely on the contested rows above it.
+
+**Root-caused into two distinct, independent mechanisms — not one bug:**
+
+1. **Bid shading below a genuinely positive ceiling (Cyrus Allen).** The
+   engine's own objective ceiling put Cyrus Allen's worth at $81 — *higher*
+   than the $45 he actually cost. The optimizer's recommended bid ($0) and
+   even its max-rational bid ($25) shade well below that ceiling by design
+   (`optimal_bid`'s docstring: "bidding the ceiling captures zero surplus by
+   construction"). That shading is intentional and matches the documented,
+   pre-existing tradeoff from the original NEW-vs-OLD FAAB backtest — the
+   new model has a *lower* win rate than the old one on purpose, because the
+   old one bought its win rate by bidding roughly 5x market on everything.
+   Losing Cyrus Allen to a $45 bid by a wide margin (our max: $25) is that
+   tradeoff operating exactly as measured before this was ever deployed —
+   not a new defect.
+
+2. **A real, unpriced short-term-value gap (Klein, Roush, McGowan, Holani,
+   Brown, Benson).** Four of these six sit *below* the league's own
+   replacement-value anchor (1695) in canonical dynasty terms — the
+   objective ceiling is architecturally $0 for a below-replacement asset,
+   which is correct FOR THE QUESTION THE ENGINE ANSWERS ("is this worth
+   keeping"). Real managers paid $6-19 for them anyway, which is not
+   explainable by shading (there is no ceiling to shade below). This is the
+   gap the Live Waiver Opportunity layer exists to close: real managers were
+   very plausibly pricing in this-week role clarity (this is the week after
+   final roster cuts — exactly when backup/depth-chart information updates
+   fastest) that a dynasty-only value has no way to see.
+
+**A canonical-board-defect hypothesis was checked and ruled out**, not
+assumed away. Marlin Klein's `canonicalSiteValues` were inspected directly:
+the true value-scale votes (`ktc` 1319, `ktcSfTep` 1913, `idpTradeCalc`
+1689) are broadly self-consistent with his blended 1927 — the large numbers
+elsewhere in that same dict (944100, 970200, …) are rank-signal synthetic
+encodings from rank-only sources, not value-scale figures, and reading them
+as dollars would have been the wrong comparison. Every one of the six
+above-market rows is independently flagged `confidenceBucket: "low"` by the
+existing B11 confidence gate — the system already knows these rows are
+less-certain than most, which is a different, weaker claim than "wrong,"
+but is consistent with "not enough evidence to move a valuation that a
+depth-chart signal legitimately would."
+
+**Decision, made with the owner in conversation, not unilaterally:** leave
+the objective-ceiling curve and anchors untouched — nothing in this data
+says they are miscalibrated, and last night is exactly the kind of evidence
+the shading tradeoff predicted. Start Stage 1 of the activation plan
+instead: `waiver_live_opportunity`'s default flipped to `True` (still
+shadow-only — see `src/api/feature_flags.py`, `tests/api/
+test_feature_flags.py::test_every_flag_defaults_off_except_safe_additive`'s
+`safe_on` entry for the additive-safety argument), so future nights like
+this one accumulate in `data/faab/shadow_comparisons_<leagueKey>.json`
+automatically rather than being reconstructed by hand from the Sleeper API
+after the fact. This is a genuine Stage 3-shaped evidence point arriving
+before Stage 1 had even started — reusing it is more honest than waiting
+for the next occurrence to start measuring.
+
+**Caveat that travels with this section:** this is one night, twelve
+players, one league. It demonstrates the SHAPE and rough SIZE of the gap
+(a handful of dollars to ~$20 on below/near-replacement players; the
+shading gap on a clearly-above-replacement player can be much larger) —
+it is not a calibrated blast radius and must not be read as one. The
+accumulating shadow log, not this single night, is what a promotion
+decision should eventually be based on.

--- a/src/api/feature_flags.py
+++ b/src/api/feature_flags.py
@@ -9,12 +9,14 @@ enabled.**  This docstring, ``README.md`` and ``docs/ARCHITECTURE.md``
 all used to assert a blanket disabled-by-default rule, and
 ARCHITECTURE built a stronger claim on top of it about production
 behaviour being frozen until a flag was flipped.  Both were false:
-9 of the 20 entries in ``_DEFAULTS`` below are ``True`` —
+10 of the 20 entries in ``_DEFAULTS`` below are ``True`` —
 ``bdvm_engine``, ``te_basis_conversion`` (which reprices every tight
 end on the live board), ``monte_carlo_trade``, ``idp_scoring_fit``,
 ``reception_scoring_fit``, ``nfl_data_ingest``, ``realized_points_api``,
-``perfect_draft`` and ``ledger_rank_change`` — several with comments
-recording that the enabled default is deliberate.
+``perfect_draft``, ``ledger_rank_change`` and ``waiver_live_opportunity``
+(shadow-only — computes a second value alongside the canonical one and
+logs it; never changes what any caller is served) — several with
+comments recording that the enabled default is deliberate.
 
 **No live gate sits outside this registry any more.**  The last one —
 ``RISKIT_FEATURE_LEDGER_RANK_CHANGE``, read directly in
@@ -406,7 +408,21 @@ _DEFAULTS: Final[dict[str, bool]] = {
     # above: evaluation is not activation.  Promotion to the live bid is
     # a separate, later, human-reviewed step once the shadow log gives
     # outcome evidence — never automatic.
-    "waiver_live_opportunity": False,
+    #
+    # Stage 1 of the activation plan (docs/faab-live-opportunity-model.md
+    # §5a), started 2026-09-02: default flipped True so shadow comparisons
+    # begin accumulating in production rather than waiting on a second,
+    # separate deploy just to turn logging on.  Motivated by real evidence,
+    # not a guess — the 2026-09-01/02 overnight waiver results measured a
+    # genuine gap on several below-replacement players real managers paid
+    # $6-$19 for (docs/faab-redesign-2026-09-01-report.md §16), and ruling
+    # out a canonical-board defect on the same data left "the layer that
+    # isn't logging yet" as the best-supported explanation.  Still governed
+    # by ``_GATE_STATUS`` below, already ``LIVE`` for this key since the
+    # computation has been mechanically reachable since it shipped — this
+    # only changes whether it actually RUNS by default.  This does NOT
+    # change what any live user sees; see the docstring above.
+    "waiver_live_opportunity": True,
 }
 
 _ENV_PREFIX: Final[str] = "RISKIT_FEATURE_"

--- a/tests/api/test_faab_recommend_endpoint.py
+++ b/tests/api/test_faab_recommend_endpoint.py
@@ -778,7 +778,7 @@ def _with_stated_format(monkeypatch, *, scoring=None, evidence="fresh"):
     monkeypatch.setattr(
         server._league_registry,
         "scoring_settings_for_league",
-        lambda cfg: (dict(card) if card else None),
+        lambda cfg: dict(card) if card else None,
     )
     monkeypatch.setattr(
         server._league_registry,
@@ -948,10 +948,18 @@ def test_a_proven_te_premium_is_read_from_the_card_not_the_label(faab_env, monke
 # the live response — evaluation is not activation.
 
 
-def test_shadow_flag_off_by_default_and_response_unaffected(faab_env, monkeypatch):
+def test_shadow_flag_default_computes_but_response_still_ok(faab_env, monkeypatch):
+    """Stage 1 of the activation plan (docs/faab-live-opportunity-model.md
+    §5a, 2026-09-02) flipped this flag's default to True so shadow
+    comparisons accumulate without a second deploy — so, unlike before,
+    the shadow computation now runs by default.  The invariant this test
+    still owns is that a default-state call succeeds; whether the SHADOW
+    computation actually ran without touching the response is the
+    stronger guarantee `test_shadow_computation_never_changes_the_live_
+    response` below pins directly, at both flag states."""
     from src.api import feature_flags
 
-    assert feature_flags.is_enabled("waiver_live_opportunity") is False
+    assert feature_flags.is_enabled("waiver_live_opportunity") is True
     with TestClient(server.app) as c:
         res = _post(c, monkeypatch, {"addPlayerName": "Hot Pickup"})
     assert res.status_code == 200

--- a/tests/api/test_feature_flags.py
+++ b/tests/api/test_feature_flags.py
@@ -72,6 +72,21 @@ def test_every_flag_defaults_off_except_safe_additive():
         # model as a live code path.
         # Rollback: RISKIT_FEATURE_PERFECT_DRAFT=0 + restart.
         "perfect_draft",
+        # Live Waiver Opportunity shadow computation (Stage 1 of the
+        # activation plan, docs/faab-live-opportunity-model.md §5a,
+        # started 2026-09-02). Additive in the strict sense this set
+        # requires: it computes a SECOND value
+        # (src.trade.faab_opportunity.opportunity_value) alongside the
+        # canonical-only one inside server.py's /api/waiver/faab-recommend
+        # handler and logs both to
+        # data/faab/shadow_comparisons_<leagueKey>.json — the response
+        # object returned to every caller is built from the canonical-only
+        # value regardless of this flag
+        # (test_shadow_computation_never_changes_the_live_response pins
+        # this). Turning it on cannot move a number that was already on
+        # screen; it only starts a log file accumulating.
+        # Rollback: RISKIT_FEATURE_WAIVER_LIVE_OPPORTUNITY=0.
+        "waiver_live_opportunity",
     }
     # Flags that default ON and KNOWINGLY change output.  Deliberately a
     # separate set from ``safe_on``: every member of that one is there


### PR DESCRIPTION
## Summary

Follow-up to the `/waivers` `teamOwnerId` fix (#1213). The owner noticed the fixed page recommended $0 for almost every candidate except Cyrus Allen, while their own manually-placed Sleeper bids spread $1-$7 across many players. Rather than guess, I pulled the actual overnight waiver results directly from Sleeper's public transactions API (unauthenticated, separate from this project's own production site) once they processed, and compared them to what the market-aware engine says.

**Two distinct, independent findings, not one bug:**

1. **Intentional below-ceiling shading (Cyrus Allen).** The engine's own objective ceiling put him at $81 — higher than the $45 he actually cost — but the optimizer's recommended/max-rational bids ($0/$25) shade well below that on purpose (`optimal_bid`: "bidding the ceiling captures zero surplus by construction"). This matches the documented, pre-existing tradeoff from the original NEW-vs-OLD backtest (new model has a lower win rate on purpose, to stop overpaying) — not a new defect.
2. **A real, unpriced gap on below-replacement players (Marlin Klein, Sam Roush, Seth McGowan, George Holani, Barion Brown, Malik Benson).** These sit at/below the league's replacement anchor in canonical dynasty terms, so the objective ceiling is architecturally $0 — yet real managers paid $6-19 for them, most plausibly pricing in post-cutdown role clarity that a dynasty-only value has no way to see. A canonical-board-defect hypothesis was checked and ruled out (Klein's true value-scale source votes are self-consistent with his blended value; the model already flags these rows `confidence: low`).

This is exactly the gap the (already-built, still shadow-only) Live Waiver Opportunity layer exists to close, and it arrived as real Stage-3-shaped evidence before Stage 1 of the activation plan had even started.

**What this PR does — Stage 1 only, nothing promoted to live bids:**

- `src/api/feature_flags.py` — `waiver_live_opportunity` now defaults `True`. Still shadow-only: it's gated inside `server.py`'s `/api/waiver/faab-recommend` handler, computes a second value alongside the canonical one, and logs both to `data/faab/shadow_comparisons_<leagueKey>.json` — the live response is unaffected regardless of this flag (`test_shadow_computation_never_changes_the_live_response` pins this at both flag states). Added to the `safe_on` allowlist in the flag-safety test with the additive-safety rationale, matching the `bdvm_engine`/`perfect_draft` precedent.
- `docs/faab-redesign-2026-09-01-report.md` §16 — the full real-vs-model comparison table and root-cause writeup for both mechanisms above, plus the canonical-board-defect check.
- `docs/faab-live-opportunity-model.md` §5a — Stage 1 marked started (the flag default is flipped in the repo; actually reaching production still needs a deploy this session has no access to).
- `README.md` / `docs/ARCHITECTURE.md` / `feature_flags.py`'s own docstring — updated for the doc/registry flag-count parity gate (10 of 20 now default on).
- `tests/api/test_faab_recommend_endpoint.py` — renamed the test that asserted "off by default" (no longer true) to match the new default; the real shadow-never-changes-response invariant is pinned separately and unaffected.

**Explicitly not done here:** no change to the objective-ceiling curve, anchors, or bid-shading logic — nothing in the overnight data said those are miscalibrated. No promotion of the opportunity layer to live bids (that's Stage 5, gated on accumulated shadow-log evidence and human review per the staged plan).

## Test plan

- [x] `python -m pytest tests/api/test_feature_flags.py -q` — 8 passed (new `waiver_live_opportunity` entry in `safe_on`)
- [x] `python -m pytest tests/api/test_feature_flag_docs_match_registry.py -q` — 6 passed (doc/registry parity restored)
- [x] `python -m pytest tests/api/ -k "faab_recommend_endpoint or feature_flag" -q` — 103 passed
- [x] `python -m pytest tests/trade/ tests/api/ -k "faab or waiver or feature_flag" -q` — 592 passed, 1 skipped
- [x] `ruff format --check` / `ruff check` / `scripts/check_decision_coercions.py` — clean
- [ ] Production verification — blocked on deploy access this session doesn't have; the flag default change only takes effect once `main` is pulled and both systemd services restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1djzFg9ASgF2ek5FgsGDH

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1djzFg9ASgF2ek5FgsGDH)_