### PR TITLE
V1-125: reconcile replacement/strength/weakness owner guards

### DIFF
--- a/docs/v1/V1_125_RETIREMENT_RECONCILIATION.md
+++ b/docs/v1/V1_125_RETIREMENT_RECONCILIATION.md
@@ -1,6 +1,6 @@
 # V1-125 duplicate-owner retirement reconciliation
 
-Exact-head census base: `f83e1e3f104125e4ea12e3d7b3befcebb24fe534` (2026-09-02).
+Exact-head census base: `78e6d4f7fea0c8a426faf4b7d6a972732421a07f` (2026-09-03).
 
 This record exists only to reconcile historical `retires` declarations in
 `docs/C_SERIES_EXECUTION_MAP.md` against later row-specific closure evidence before any deletion.
@@ -29,14 +29,16 @@ change by inference.
 | `C2-U1` / `C2-LINE-01` | retire 3 production greedy fills plus duplicate eligibility/demand definitions | execution-map closure text records all three competing greedy fills retired; V1-27 is `VERIFIED` against the canonical exact solver | `ALREADY_RETIRED_OR_INERT` | none |
 | `C3-U2` / `C3-VA-01`,`C3-VA-02` | consolidate Value Adjustment copies | execution-map row records COMPLETE: monkeypatch + second Python port retired; forced public/private wrapper delegates to shared stdlib core; `tests/valuation_math/test_single_owner.py` is the structural guard | `ALREADY_RETIRED_OR_INERT` | none |
 | `C3-U1` / `C3-PKG-01` | historical map names `suggestions.py` as the live package-generator holdout | later V1-36 contract row is `VERIFIED`; current trade code documents construction mechanics as owned by `src/packages/construction.py` | `ALREADY_RETIRED_OR_INERT` | no deletion from stale map prose; zero-owner guard still must include this family |
-| `C2-U2` / `C2-REPL-01` | owner shown historically as `(to consolidate)`; retire 5 implementations | later V1-29 work explicitly closed the replacement-level single-owner discovery gap and corrected the canonical-unit record, but the execution-map line itself was never reconciled | `NEEDS_CURRENT_REACHABILITY_CHECK` | enumerate current replacement definitions/importers and compare to the V1-29 guard before deleting anything |
-| `C2-U4` / `C2-STR-01` | retire 4 notions of Team Strength | map was corrected 2026-08-20 to canonical `src/roster_intel/strength.py`; historical count alone does not prove four live owners remain | `NEEDS_CURRENT_REACHABILITY_CHECK` | use current import/definition census plus the row-specific single-owner evidence; stop if a distinct ROS composite is semantically intentional |
-| `C2-U5` / `C2-WEAK-01` | retire >=5 need definitions | historical declaration does not identify enough current targets to delete safely | `NEEDS_CURRENT_REACHABILITY_CHECK` | enumerate definitions and consumers; require later row-specific owner evidence before any retirement |
+| `C2-U2` / `C2-REPL-01` | owner shown historically as `(to consolidate)`; retire 5 implementations | `scripts/replacement_census.py` is the current V1-29 discovery/ownership guard. It declares the live replacement implementations by quantity, unit, population and disposition, derives production callers by AST, preserves materially distinct quantities rather than collapsing them, marks `src/scoring/replacement_level.py::vorp_table` as RETIRED, and fails if retired symbols reappear. The canonical owners are explicit for each actually shared quantity (`src/league_intel/replacement.py` for ROS-production levels; `src/scoring/replacement_level.py::replacement_per_game` for fantasy-points replacement), while adapters delegate and distinct populations/units remain intentionally separate. | `ALREADY_RETIRED_OR_INERT` | no deletion from the historical “5 implementations” count; keep the V1-29 census/retired-symbol guard as the zero-second-owner authority for this family |
+| `C2-U4` / `C2-STR-01` | retire 4 notions of Team Strength | canonical owner is `src/roster_intel/strength.py`. `tests/roster_intel/test_strength_weakness_single_owner.py` scans all production Python definition sites by AST and asserts every public Team Strength owner symbol (`PositionStrength`, `TeamStrength`, `build_team_strength`, `rank_team_strengths`) is defined only at that canonical path; its positive-control probe demonstrates a second owner is detected. The test’s own historical note records the previously live frontend duplicates as retired. | `ALREADY_RETIRED_OR_INERT` | none; retain the definition-site discovery guard and do not collapse semantically distinct ROS/portfolio/marginal quantities into Team Strength |
+| `C2-U5` / `C2-WEAK-01` | retire >=5 need definitions | canonical owner is `src/roster_intel/weakness.py`. The same AST discovery guard asserts every public Team Weakness owner symbol (`PositionRanks`, `SlotRung`, `PositionNeed`, `TeamWeakness`, `build_position_ranks`, `build_team_weakness`) is defined only at that canonical path; its positive-control probe demonstrates a second weakness owner is detected, and the guard pins the historical `PositionNeed` naming collision as renamed rather than redefined. | `ALREADY_RETIRED_OR_INERT` | none; retain the definition-site discovery guard and keep distinct roster quantities distinct |
 
 ## Hard stops discovered so far
 
-None of the entries above currently requires an owner methodology decision. The unresolved entries
-are evidence/reachability work, not permission to delete.
+None of the entries above currently requires an owner methodology decision. The reconciled C2
+families are guarded as single-owner or explicitly distinct by unit/population; deleting those
+distinct implementations merely to satisfy historical duplicate counts would violate the
+canonical-owner methodology rather than enforce it.
 
 ## Promotion gate still outstanding
 


### PR DESCRIPTION
## V1-125 bounded reconciliation

Exact base: `78e6d4f7fea0c8a426faf4b7d6a972732421a07f`.

This PR advances only the V1-125 ownership/reachability census. It does **not** promote V1-125, delete implementations, change methodology, change V1 scope, or treat merged/CI state as verification.

### What changed
- Reconciles `C2-U2` replacement-level ownership against the existing `scripts/replacement_census.py` V1-29 guard, which explicitly distinguishes OWNER / ADAPTER / DISTINCT / RETIRED by unit and population and guards retired symbols from returning.
- Reconciles `C2-U4` Team Strength and `C2-U5` Team Weakness against `tests/roster_intel/test_strength_weakness_single_owner.py`, which scans current production definition sites by AST and positively proves a second owner would be detected.
- Updates the census base SHA to the exact audited `main` head.

### Truth posture
The historical execution-map duplicate counts are not deletion authority. Current row-specific guards prove these families are already single-owner or intentionally distinct by semantics. Collapsing those distinct quantities would be a methodology change and is explicitly not done here.

V1-125 remains unverified until every V1-applicable `retires` declaration is reconciled and an exact-head zero-live-second-owner gate is green.