### PR TITLE
fix(overview): withhold the power-leader headline when unrankable

### DIFF
--- a/src/public_league/overview.py
+++ b/src/public_league/overview.py
@@ -251,7 +251,25 @@ def _current_power_leader(power_section: dict[str, Any]) -> dict[str, Any] | Non
     exactly the value a real unchanged rank also produces.  A prior
     version of this function (reading the legacy engine) had this exact
     defect; not carrying it forward.
+
+    ``power_section["unrankable"]`` means every weighted component was
+    dropped -- ``currentRanking`` is still populated (facts like
+    ``record`` survive the refusal, per ``power_v2``'s own contract) but
+    the list is in enumeration order, not rank order, because there is no
+    rank.  Taking ``ranking[0]`` in that state does not fabricate a
+    number (``power`` stays ``None``), but it DOES fabricate an identity
+    claim: the card's own label is "Power rank #1", and presenting a
+    specific named owner under that label asserts a leadership fact
+    nobody can currently support.  Withhold the whole headline instead --
+    the same "missing is never zero" posture applied to the CLAIM, not
+    just the metric inside it.  Confirmed live on production
+    2026-09-03 (true preseason, ``reason:
+    "preseason_and_no_forward_looking_input"``): this function was
+    naming an arbitrary owner ("Jason", first in enumeration order) as
+    "Power rank #1" league-wide, with no score to back it.
     """
+    if power_section.get("unrankable"):
+        return None
     ranking = power_section.get("currentRanking") or []
     if not ranking:
         return None

--- a/tests/public_league/test_overview.py
+++ b/tests/public_league/test_overview.py
@@ -115,37 +115,35 @@ class OverviewTests(unittest.TestCase):
         self.assertIn("week", recap)
 
     # ── v2 Home callouts ─────────────────────────────────────────────
-    def test_current_power_leader_reads_the_canonical_engine(self) -> None:
+    def test_current_power_leader_withholds_the_whole_card_when_unrankable(self) -> None:
         """V1-52 item D: the landing card reads ``power_v2``, not the
-        legacy ``public_league/power.py`` it used to.
+        legacy ``public_league/power.py`` it used to -- and it withholds
+        the CLAIM, not just the number, when the engine cannot rank.
 
         The shared fixture (``build_test_snapshot``) is a PRESEASON state
         with no ``team_ros_strength`` snapshot -- exactly the state
         ``power_v2``'s own refuse-to-rank contract (item B) exists for:
         every historical-results component is suppressed by preseason
         mode, and the forward-looking substitute is unavailable, so there
-        is genuinely nothing to rank on. The legacy engine used to
-        fabricate a score here regardless; this asserts the CORRECT
-        behavior, not the old one -- the leader card still names an
-        owner and a factual record (both real regardless of whether a
-        score is computable), and is honest that no score exists rather
-        than showing a fabricated one.
+        is genuinely nothing to rank on.
+
+        A prior version of this test asserted the OPPOSITE of what is
+        correct: that the card should still name an owner (the first row
+        in enumeration order) under a "Power rank #1" headline with the
+        score withheld. Confirmed live on production 2026-09-03 (true
+        preseason) that this is a real, live defect -- withholding the
+        number does not rescue the label, which is itself a leadership
+        claim ("Power rank #1: <name>") nobody can support when the
+        board is unrankable. The correct behavior is the whole headline
+        withheld, matching how the frontend already treats a falsy
+        ``currentPowerLeader`` (the card section simply does not render).
         """
         leader = self.overview["currentPowerLeader"]
-        self.assertIsNotNone(leader)
-        for key in ("ownerId", "displayName", "teamName", "record"):
-            self.assertIn(key, leader)
-            self.assertIsNotNone(leader[key], f"{key} is present but None")
         self.assertIsNone(
-            leader["power"],
-            "the fixture is preseason with no team-strength snapshot -- nothing "
-            "is rankable, so a real (non-null) power score means something "
-            "fabricated a number rather than refusing",
-        )
-        self.assertIsNone(
-            leader["weekRankDelta"],
-            "no per-week ROS-strength history exists for the forward-looking "
-            "lens, so this must be unknown, never a fabricated 0",
+            leader,
+            "the fixture is preseason and genuinely unrankable -- the whole "
+            "'Power rank #1' headline claim must be withheld, not just the "
+            "numeric score inside it",
         )
 
     def test_current_power_leader_is_populated_when_the_engine_can_rank(self) -> None:


### PR DESCRIPTION
## Summary

Found while running V1-52's L2 production verification recipe (`docs/power/V1_52_L2_VERIFICATION_RECIPE.md`) against the real deployed site — today (2026-09-03) is genuinely preseason, so the board is in the real `unrankable` state the recipe's §4 asks for.

- `GET /api/public/league` returned `sections.overview.currentPowerLeader = {displayName: "Jason", power: null, ...}` under a card labelled **"POWER RANK #1"**.
- `GET /api/public/league/rosPower?lens=forward_looking` reported `unrankable.reason: "preseason_and_no_forward_looking_input"` for the exact same board — nobody can honestly be ranked right now.

`overview._current_power_leader()` took `ranking[0]` unconditionally. `power_v2` itself withholds score and rank correctly (both `None`, never fabricated), but `overview.py`'s headline still asserted a specific named owner as league leader with no rank behind the claim. Withholding the number doesn't rescue the label: "Power rank #1: `<name>`" is a leadership claim nobody can support when the board is unrankable — the same "missing is never zero" posture this codebase applies everywhere else, just not yet applied to the *claim* itself rather than the number inside it.

## Fix

`_current_power_leader` now returns `None` when `power_section["unrankable"]` is set, matching how the frontend already treats a falsy `currentPowerLeader` (the card section simply doesn't render — no new frontend code needed). The underlying `power_v2` rows are untouched: `record`/`teamName` still correctly survive the refusal there (separately tested, and correct — that's the full table, not a single "leader" claim).

An existing test (`test_current_power_leader_reads_the_canonical_engine`) had encoded the old, incorrect behavior as intended. Rewrote it (`test_current_power_leader_withholds_the_whole_card_when_unrankable`) to assert the corrected behavior.

## Test plan

- [x] Mutation-verified: reverted the source change, confirmed the updated test fails RED for the right reason (`AssertionError: {'displayName': 'AAron', 'power': None, ...} is not None`), restored, re-ran clean.
- [x] `pytest tests/public_league/ tests/ros/` — 758 passed, 1 skipped
- [x] `ruff check` / `ruff format --check` — clean
- [x] `python3 scripts/check_planning_integrity.py` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg)_