### PR TITLE
feat(v1-onbox): add v20 check — C1-SRC-02 fails-closed, against the deployed tree

### DIFF
--- a/.github/workflows/v1-onbox-checklists.yml
+++ b/.github/workflows/v1-onbox-checklists.yml
@@ -3,7 +3,8 @@ name: V1 On-Box Checklists (read-only by default)
 # Executable form of V1 production checklists that exist as prose and whose
 # inputs are prod-only:
 #   V1-89  (DraftSharks §6),  V1-15/16/17 (C1-U8 §8),  V1-59 (journal chain),
-#   V1-83  (F-20 delivery-keyed cooldown),  V1-11 item 1,  V1-124 (job matrix).
+#   V1-83  (F-20 delivery-keyed cooldown),  V1-11 item 1,  V1-124 (job matrix),
+#   V1-20  (C1-SRC-02 fails-closed half, against the deployed tree).
 #
 # Same SSH mechanism, permissions, concurrency and buffering posture as
 # lane4-onbox-verification.yml (see its header for why -u and tee-without-
@@ -20,7 +21,7 @@ on:
   workflow_dispatch:
     inputs:
       checks:
-        description: "Comma list of check groups (v89,c1u8,v59,v83,v11,v124) or 'all'"
+        description: "Comma list of check groups (v89,c1u8,v59,v83,v11,v124,v20) or 'all'"
         required: false
         default: "all"
         type: string

--- a/scripts/verify_v1_onbox.py
+++ b/scripts/verify_v1_onbox.py
@@ -1,4 +1,4 @@
-"""On-box V1 production checklists — V1-89, V1-15/16/17, V1-59, V1-83, V1-11, V1-124.
+"""On-box V1 production checklists — V1-89, V1-15/16/17, V1-59, V1-83, V1-11, V1-124, V1-20.
 
 Runs ON the production box (dispatched by
 ``.github/workflows/v1-onbox-checklists.yml`` over the existing SSH lane),
@@ -14,6 +14,10 @@ executable form of checklists that already exist as prose:
              ops-alert state
 * ``v11``  — C1-U5 §6 item 1: the deployed SHA contains the unit
 * ``v124`` — the background-jobs / data matrix (timers, services, artifacts)
+* ``v20``  — C1-SRC-02's fails-closed half, against the DEPLOYED
+             ``src.api.data_contract`` module (the proven-per-feed half is
+             already L3; the real registry is all-DYNASTY so a live
+             negative case cannot exist, hence the injectable-rogue check)
 
 Rules, inherited from ``verify_lane4_production.py`` and enforced here:
 
@@ -754,6 +758,87 @@ def check_v11() -> None:
         )
 
 
+# ────────────────────────────── V1-20 fails-closed ──────────────────────────────
+
+
+def check_v20() -> None:
+    """C1-SRC-02: game type proven per feed, fails closed on ``UNKNOWN``.
+
+    The proven-per-feed half is already re-verified fresh at L3 (row's own
+    §9a note, via ``/api/rankings/sources``). What has never run against
+    the DEPLOYED tree is the fails-closed half — and it structurally
+    cannot be observed as a live negative case, because the real registry
+    is all-DYNASTY (no UNKNOWN feed exists to refuse). The row records
+    this honestly as L2 rather than rounding up.
+
+    This closes the gap the row names, not by manufacturing a bad feed in
+    production (forbidden), but by running the SAME injectable-rogue
+    check ``tests/sources/test_game_type_gate_red.py`` already pins in
+    this dev/CI environment against the actual deployed ``src.api.data_contract``
+    module instead — proving the fails-closed behaviour is the code that
+    is actually running in production, not just code that exists in a
+    branch. Entirely read-only: ``_validate_source_game_types_invariant``
+    takes an injectable ``sources`` list precisely so this can run without
+    mutating ``_RANKING_SOURCES``.
+    """
+    c = _check("V20", "V1-20", "C1-SRC-02: fails-closed half, against the deployed tree")
+    try:
+        sys.path.insert(0, str(REPO_ROOT))
+        from src.api import data_contract as dc
+
+        registry = list(dc._RANKING_SOURCES)
+        base = dict(registry[0]) if registry else {}
+        cases = {
+            "unknown": {**base, "key": "v20RogueUnknown", "game_type": "UNKNOWN"},
+            "redraft": {
+                **base,
+                "key": "v20RogueRedraft",
+                "game_type": "REDRAFT",
+                "game_type_evidence": "redraft toggle — a different product",
+            },
+            "absent": {k: v for k, v in base.items() if k != "game_type"}
+            | {"key": "v20RogueSilent"},
+        }
+        refused: dict[str, bool] = {}
+        for name, rogue in cases.items():
+            try:
+                dc._validate_source_game_types_invariant([*registry, rogue])
+                refused[name] = False
+            except Exception as exc:  # noqa: BLE001 — the refusal IS the assertion
+                refused[name] = rogue["key"] in str(exc)
+        # the honest case must still pass, or this is just a blocker
+        honest = {**base, "key": "v20HonestDynasty", "game_type": "DYNASTY"}
+        honest.setdefault("game_type_evidence", "endpoint documented dynasty-only")
+        honest_ok = False
+        try:
+            dc._validate_source_game_types_invariant([*registry, honest])
+            honest_ok = True
+        except Exception:  # noqa: BLE001
+            honest_ok = False
+    except Exception as exc:  # noqa: BLE001
+        c.record("error", f"could not import deployed data_contract: {exc}")
+        return
+
+    if all(refused.values()) and honest_ok:
+        c.record(
+            "pass",
+            "the deployed tree's game-type gate refuses UNKNOWN/REDRAFT/absent "
+            "(offending key named in each refusal) and accepts a verified-DYNASTY "
+            "declaration — the fails-closed half, proven against production code",
+            refused=refused,
+            honest_case_passed=honest_ok,
+            registry_size=len(registry),
+        )
+    else:
+        c.record(
+            "fail",
+            "the deployed tree's game-type gate did not refuse a rogue source, "
+            "or refused a legitimate one",
+            refused=refused,
+            honest_case_passed=honest_ok,
+        )
+
+
 # ────────────────────────────── V1-124 matrix ──────────────────────────────
 
 _ARTIFACTS = {
@@ -835,6 +920,7 @@ CHECK_FNS = {
     "v83": lambda args: check_v83(),
     "v11": lambda args: check_v11(),
     "v124": lambda args: check_v124(),
+    "v20": lambda args: check_v20(),
 }
 
 

--- a/tests/ops/test_v1_verification_primitives.py
+++ b/tests/ops/test_v1_verification_primitives.py
@@ -356,9 +356,9 @@ def test_every_suite_verdict_is_consumed_by_the_one_verdict_step():
     for name in sorted(published):
         assert name in consumed, f"{name} is published but never reaches the verdict step"
         var = name.upper()
-        assert f"${{{var}}}" in body or f'"${var}"' in body, (
-            f"{name} reaches the verdict step's env but its body never reads ${var}"
-        )
+        assert (
+            f"${{{var}}}" in body or f'"${var}"' in body
+        ), f"{name} reaches the verdict step's env but its body never reads ${var}"
 
 
 def test_prod_auth_config_reports_annotations_as_evidence():
@@ -375,9 +375,9 @@ def test_prod_auth_config_reports_annotations_as_evidence():
     assert "prod-auth-results.json" in cfg
 
     wf = (REPO_ROOT / ".github" / "workflows" / "v1-authenticated-verification.yml").read_text()
-    assert "tests/e2e/prod-auth-results.json" in wf, (
-        "the json report is produced but never uploaded"
-    )
+    assert (
+        "tests/e2e/prod-auth-results.json" in wf
+    ), "the json report is produced but never uploaded"
 
 
 def test_onbox_workflow_gates_the_only_write_behind_a_flag():

--- a/tests/ops/test_v1_verification_primitives.py
+++ b/tests/ops/test_v1_verification_primitives.py
@@ -356,9 +356,9 @@ def test_every_suite_verdict_is_consumed_by_the_one_verdict_step():
     for name in sorted(published):
         assert name in consumed, f"{name} is published but never reaches the verdict step"
         var = name.upper()
-        assert (
-            f"${{{var}}}" in body or f'"${var}"' in body
-        ), f"{name} reaches the verdict step's env but its body never reads ${var}"
+        assert f"${{{var}}}" in body or f'"${var}"' in body, (
+            f"{name} reaches the verdict step's env but its body never reads ${var}"
+        )
 
 
 def test_prod_auth_config_reports_annotations_as_evidence():
@@ -375,9 +375,9 @@ def test_prod_auth_config_reports_annotations_as_evidence():
     assert "prod-auth-results.json" in cfg
 
     wf = (REPO_ROOT / ".github" / "workflows" / "v1-authenticated-verification.yml").read_text()
-    assert (
-        "tests/e2e/prod-auth-results.json" in wf
-    ), "the json report is produced but never uploaded"
+    assert "tests/e2e/prod-auth-results.json" in wf, (
+        "the json report is produced but never uploaded"
+    )
 
 
 def test_onbox_workflow_gates_the_only_write_behind_a_flag():
@@ -528,3 +528,45 @@ def test_v59_chain_still_fails_on_a_real_bad_result(monkeypatch):
     assert len(chain_check) == 1
     assert chain_check[0].status == "fail"
     assert "Result=failed" in chain_check[0].detail
+
+
+# ── V1-20 fails-closed, against the real (this-tree) registry ──
+
+
+def test_v20_refuses_unknown_redraft_and_absent_but_accepts_the_honest_case():
+    """The property `test_game_type_gate_red.py` already pins, run through
+    the on-box driver's own check function rather than pytest directly --
+    this is what makes it eligible to run over SSH against the deployed
+    tree via `v1-onbox-checklists.yml`'s `checks=v20`, closing V1-20's
+    named L3 gap (the fails-closed half proven against the deployed SHA,
+    not just this dev tree)."""
+    onbox.check_v20()
+    result = [c for c in onbox.CHECKS if c.check_id == "V20"]
+    assert len(result) == 1
+    assert result[0].status == "pass", result[0].detail
+    assert result[0].evidence["refused"] == {
+        "unknown": True,
+        "redraft": True,
+        "absent": True,
+    }
+    assert result[0].evidence["honest_case_passed"] is True
+
+
+def test_v20_records_fail_when_the_gate_lets_a_rogue_source_through(monkeypatch):
+    """Mutation-shaped: if the injected validator stopped refusing, this
+    check must say FAIL, not silently report pass on a broken gate."""
+    from src.api import data_contract as dc
+
+    def permissive(sources=None):
+        return None  # never raises -- simulates a broken gate
+
+    monkeypatch.setattr(dc, "_validate_source_game_types_invariant", permissive)
+    onbox.check_v20()
+    result = [c for c in onbox.CHECKS if c.check_id == "V20"]
+    assert len(result) == 1
+    assert result[0].status == "fail"
+    assert result[0].evidence["refused"] == {
+        "unknown": False,
+        "redraft": False,
+        "absent": False,
+    }


### PR DESCRIPTION
## Summary

V1-20's row is honest that it sits at L2, not the required L3, for one specific reason: production offers no live `UNKNOWN` feed to refuse (the real registry is all-`DYNASTY`), so the fails-closed half of `C1-SRC-02`'s gate has never been observed as a live negative case — and the row correctly refuses to round that up to L3.

That's a real limit on *observing* a negative case in production traffic. It is not a limit on running the deployed *code* against an injected one. `tests/sources/test_game_type_gate_red.py` already pins this property in this dev/CI tree (`_validate_source_game_types_invariant` refuses `UNKNOWN`/`REDRAFT`/absent, accepts verified-`DYNASTY`) via its injectable `sources` parameter — built for exactly this. What was missing is running that same injectable-rogue check against the code actually running in **production**, closing the gap between "the fails-closed behavior exists somewhere in this repo" and "the fails-closed behavior is live on the deployed SHA" — the L3 bar, without fabricating a bad feed anywhere in production.

## Changes

- `scripts/verify_v1_onbox.py`: new `check_v20()`, following the existing `check_v11` pattern (imports the deployed `src.api.data_contract` module over SSH, exercises the gate read-only via the module's own injectable `sources` param — no mutation of the live registry).
- Wired into `CHECK_FNS` and `.github/workflows/v1-onbox-checklists.yml`'s `checks` input description.

## Test plan

- [x] `python3 -m pytest tests/ops/ tests/deploy/ tests/sources/test_game_type_gate_red.py` — 606 passed, 4 skipped
- [x] Mutation-verified: monkeypatched a permissive (never-raises) validator and confirmed the check correctly flips to `fail` rather than a false pass on a broken gate
- [x] `ruff check` / `ruff format --check` — clean
- [x] `python3 scripts/check_planning_integrity.py` — OK
- [x] `python3 scripts/verify_v1_onbox.py --checks v20` run locally against this tree's own (real, all-`DYNASTY`) registry — `pass`, exit 0

Once merged and deployed, dispatching `v1-onbox-checklists.yml` with `checks=v20` gives V1-20 the L3 evidence its row is currently missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAWsLWYP1CqzVa1UD87FRg)_