### PR TITLE
V1-125: complete explicit retires reconciliation coverage

### DIFF
--- a/docs/v1/V1_125_RETIREMENT_RECONCILIATION.md
+++ b/docs/v1/V1_125_RETIREMENT_RECONCILIATION.md
@@ -1,6 +1,6 @@
 # V1-125 duplicate-owner retirement reconciliation
 
-Exact-head census base: `78e6d4f7fea0c8a426faf4b7d6a972732421a07f` (2026-09-03).
+Exact-head census base: `e98dc9a5e0e892445674c9546752a818c6b4fc46` (2026-09-03).
 
 This record exists only to reconcile historical `retires` declarations in
 `docs/C_SERIES_EXECUTION_MAP.md` against later row-specific closure evidence before any deletion.
@@ -26,6 +26,8 @@ change by inference.
 | execution-map unit | historical declaration | later governing evidence | classification | action |
 |---|---|---|---|---|
 | `C1-U2` / `C1-ID-01` | retire 3 independent player matchers | execution-map row itself records CLOSED 2026-08-16, cutover at both production sites, legacy ladders deleted, no flag/fallback; V1-01 is `VERIFIED` | `ALREADY_RETIRED_OR_INERT` | none |
+| `C1-U3` / `C1-ID-02` | `retires/adapts` the measured 39 independent pick-identity definition sites | execution-map closure records the canonical `src/identity/picks.py` owner, consumer adaptation with byte parity, and deferred consumers explicitly separated rather than silently treated as duplicate owners; V1-02 is `VERIFIED` at L2 | `ALREADY_RETIRED_OR_INERT` | none; deferred consumer migration is not a second pick-identity owner |
+| `C1-U4` / `C1-HIST-01…03` | retire fragmented as-of semantics across 5 measured decision paths while retaining raw stores as evidence feeds | execution-map closure records `src/history/` as the immutable as-of owner and explicitly says raw stores remain recording/evidence feeds; V1-03, V1-04 and V1-05 are `VERIFIED`, including production as-of proof and the never-future/missing-history semantics | `ALREADY_RETIRED_OR_INERT` | none; do not delete raw evidence stores merely because their former decision semantics were retired |
 | `C2-U1` / `C2-LINE-01` | retire 3 production greedy fills plus duplicate eligibility/demand definitions | execution-map closure text records all three competing greedy fills retired; V1-27 is `VERIFIED` against the canonical exact solver | `ALREADY_RETIRED_OR_INERT` | none |
 | `C3-U2` / `C3-VA-01`,`C3-VA-02` | consolidate Value Adjustment copies | execution-map row records COMPLETE: monkeypatch + second Python port retired; forced public/private wrapper delegates to shared stdlib core; `tests/valuation_math/test_single_owner.py` is the structural guard | `ALREADY_RETIRED_OR_INERT` | none |
 | `C3-U1` / `C3-PKG-01` | historical map names `suggestions.py` as the live package-generator holdout | later V1-36 contract row is `VERIFIED`; current trade code documents construction mechanics as owned by `src/packages/construction.py` | `ALREADY_RETIRED_OR_INERT` | no deletion from stale map prose; zero-owner guard still must include this family |
@@ -33,15 +35,26 @@ change by inference.
 | `C2-U4` / `C2-STR-01` | retire 4 notions of Team Strength | canonical owner is `src/roster_intel/strength.py`. `tests/roster_intel/test_strength_weakness_single_owner.py` scans all production Python definition sites by AST and asserts every public Team Strength owner symbol (`PositionStrength`, `TeamStrength`, `build_team_strength`, `rank_team_strengths`) is defined only at that canonical path; its positive-control probe demonstrates a second owner is detected. The test’s own historical note records the previously live frontend duplicates as retired. | `ALREADY_RETIRED_OR_INERT` | none; retain the definition-site discovery guard and do not collapse semantically distinct ROS/portfolio/marginal quantities into Team Strength |
 | `C2-U5` / `C2-WEAK-01` | retire >=5 need definitions | canonical owner is `src/roster_intel/weakness.py`. The same AST discovery guard asserts every public Team Weakness owner symbol (`PositionRanks`, `SlotRung`, `PositionNeed`, `TeamWeakness`, `build_position_ranks`, `build_team_weakness`) is defined only at that canonical path; its positive-control probe demonstrates a second weakness owner is detected, and the guard pins the historical `PositionNeed` naming collision as renamed rather than redefined. | `ALREADY_RETIRED_OR_INERT` | none; retain the definition-site discovery guard and keep distinct roster quantities distinct |
 
+## Explicit `retires` lines outside the V1 denominator
+
+`C6-U1` also carries a historical `retires` declaration (the Central Buy/Sell reconciler retires
+multiple emitters). The V1 contract explicitly classifies the full analyst/signal-intelligence
+continuation ecosystem as POST-V1. It is therefore **not** silently folded into V1-125's V1
+acceptance set and is not used to enlarge the 136-row denominator. Its eventual retirement work
+remains governed by its own post-V1 unit.
+
 ## Hard stops discovered so far
 
-None of the entries above currently requires an owner methodology decision. The reconciled C2
-families are guarded as single-owner or explicitly distinct by unit/population; deleting those
-distinct implementations merely to satisfy historical duplicate counts would violate the
-canonical-owner methodology rather than enforce it.
+None of the V1-applicable entries above currently requires an owner methodology decision. The
+reconciled C1/C2/C3 families are guarded as single-owner, explicitly adapted, or intentionally
+distinct by role/unit/population; deleting those distinct implementations or evidence stores
+merely to satisfy historical duplicate counts would violate the canonical-owner methodology
+rather than enforce it.
 
 ## Promotion gate still outstanding
 
-V1-125 remains ineligible for promotion until **every V1-applicable** `retires` declaration is
-classified using current reachability evidence, every `LIVE_SECOND_OWNER_SETTLED_REPLACEMENT` is
-retired without semantic drift, and an exact-head automated zero-live-second-owner check is green.
+The explicit V1-applicable `retires` declarations are now represented in this reconciliation
+record, but V1-125 remains ineligible for promotion until an **exact-head automated
+zero-live-second-owner check** proves those classifications against current code. Any future
+`LIVE_SECOND_OWNER_SETTLED_REPLACEMENT` discovered by that check must be retired without semantic
+drift; any `OWNER_DECISION_REQUIRED` result remains a hard stop rather than an inferred choice.


### PR DESCRIPTION
## V1-125 bounded reconciliation follow-up

Exact base: `e98dc9a5e0e892445674c9546752a818c6b4fc46`.

This PR closes the documentation-coverage gap in the V1-125 census without deleting code or promoting the row.

### What changed
- Adds the two V1-applicable explicit retirement declarations that were missing from the reconciliation record:
  - `C1-U3` pick identity (`retires/adapts` measured definition sites)
  - `C1-U4` temporal/as-of semantics (fragmented decision semantics retired while raw evidence stores remain intentionally retained)
- Records `C6-U1`'s explicit `retires` declaration as POST-V1, so it is not silently added to V1-125 or the 136-row denominator.
- Advances the census base to exact audited `main` `e98dc9a5…`.

### Truth posture
Every V1-applicable explicit `retires` declaration in the execution map is now represented in the reconciliation record. This still does **not** make V1-125 VERIFIED: the remaining acceptance gate is an exact-head automated zero-live-second-owner check proving the classifications against current code. Any newly discovered live second owner with a settled replacement may be mechanically retired; any ownership ambiguity remains a hard stop for an owner decision.

No methodology, auth, V1 scope, denominator, identity/value/lineup semantics, missing-vs-zero semantics, or stale-vs-current semantics change.