### PR TITLE
V1-125: add exact-head zero-live-second-owner gate

### DIFF
--- a/scripts/v1_125_zero_second_owner.py
+++ b/scripts/v1_125_zero_second_owner.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""V1-125 — exact-head zero-live-second-owner composite gate.
+
+This is an orchestration check, not a new ownership methodology.  Every family
+below is already reconciled in ``docs/v1/V1_125_RETIREMENT_RECONCILIATION.md``
+and delegates to that family's existing deterministic guard.  A missing guard,
+an unresolved reconciliation classification, an unmeasured command, or a guard
+failure is a failure; missing is never treated as zero.
+
+Exit codes: 0 clean, 1 violation, 2 unmeasured.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+RECONCILIATION = REPO / "docs" / "v1" / "V1_125_RETIREMENT_RECONCILIATION.md"
+TAG = "[v1-125-zero-owner]"
+
+EXIT_OK, EXIT_VIOLATION, EXIT_UNMEASURED = 0, 1, 2
+
+
+@dataclass(frozen=True)
+class Family:
+    unit: str
+    capability: str
+    command: tuple[str, ...]
+
+
+# These are the nine V1-applicable historical retirement declarations already
+# reconciled on main. C6-U1 is intentionally absent: the completion contract
+# classifies that signal-intelligence continuation as POST-V1.
+FAMILIES: tuple[Family, ...] = (
+    Family(
+        "C1-U2",
+        "player identity",
+        (
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/identity/test_dual_read_zero_divergence.py",
+            "tests/identity/test_name_primitives_parity.py",
+            "-q",
+        ),
+    ),
+    Family(
+        "C1-U3",
+        "pick identity",
+        (sys.executable, "-m", "pytest", "tests/identity/test_pick_identity_red.py", "-q"),
+    ),
+    Family(
+        "C1-U4",
+        "as-of/history ownership",
+        (sys.executable, "-m", "pytest", "tests/history/", "-q"),
+    ),
+    Family(
+        "C2-U1",
+        "lineup ownership",
+        (sys.executable, "-m", "pytest", "tests/lineup/test_single_owner.py", "-q"),
+    ),
+    Family(
+        "C2-U2",
+        "replacement ownership",
+        (sys.executable, "scripts/replacement_census.py"),
+    ),
+    Family(
+        "C2-U4",
+        "Team Strength ownership",
+        (
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/roster_intel/test_strength_weakness_single_owner.py",
+            "-q",
+        ),
+    ),
+    Family(
+        "C2-U5",
+        "Team Weakness ownership",
+        (
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/roster_intel/test_strength_weakness_single_owner.py",
+            "-q",
+        ),
+    ),
+    Family(
+        "C3-U1",
+        "package construction ownership",
+        (sys.executable, "-m", "pytest", "tests/packages/test_construction.py", "-q"),
+    ),
+    Family(
+        "C3-U2",
+        "Value Adjustment ownership",
+        (sys.executable, "-m", "pytest", "tests/valuation_math/test_single_owner.py", "-q"),
+    ),
+)
+
+FORBIDDEN_CLASSIFICATIONS = {
+    "LIVE_SECOND_OWNER_SETTLED_REPLACEMENT",
+    "OWNER_DECISION_REQUIRED",
+    "NEEDS_CURRENT_REACHABILITY_CHECK",
+}
+EXPECTED_CLASSIFICATION = "ALREADY_RETIRED_OR_INERT"
+
+
+def _reconciliation_rows() -> dict[str, str]:
+    if not RECONCILIATION.exists():
+        raise FileNotFoundError(RECONCILIATION)
+    text = RECONCILIATION.read_text(encoding="utf-8")
+    rows: dict[str, str] = {}
+    for unit in (f.unit for f in FAMILIES):
+        # Restrict to the markdown table row so explanatory prose cannot make a
+        # missing classification look present.
+        match = re.search(rf"^\| `?{re.escape(unit)}`?.*$", text, flags=re.MULTILINE)
+        if match is None:
+            continue
+        row = match.group(0)
+        classifications = re.findall(r"`([A-Z][A-Z_]+)`", row)
+        rows[unit] = classifications[-1] if classifications else ""
+    return rows
+
+
+def evaluate(*, run_commands: bool = True) -> tuple[int, list[str]]:
+    messages: list[str] = []
+    try:
+        rows = _reconciliation_rows()
+    except (OSError, UnicodeError) as exc:
+        return EXIT_UNMEASURED, [f"reconciliation unreadable: {exc}"]
+
+    expected = {f.unit for f in FAMILIES}
+    missing = sorted(expected - set(rows))
+    if missing:
+        return EXIT_UNMEASURED, [f"missing V1-applicable reconciliation rows: {missing}"]
+
+    unresolved = {u: c for u, c in rows.items() if c in FORBIDDEN_CLASSIFICATIONS}
+    malformed = {u: c for u, c in rows.items() if c != EXPECTED_CLASSIFICATION}
+    if unresolved:
+        return EXIT_VIOLATION, [f"unresolved ownership classification(s): {unresolved}"]
+    if malformed:
+        return EXIT_UNMEASURED, [f"unexpected/unmeasured classification(s): {malformed}"]
+
+    # This exact exclusion is part of the frozen V1 boundary, not a convenience.
+    text = RECONCILIATION.read_text(encoding="utf-8")
+    if "C6-U1" not in text or "POST-V1" not in text:
+        return EXIT_UNMEASURED, ["POST-V1 C6-U1 exclusion is not explicitly recorded"]
+
+    if not run_commands:
+        return EXIT_OK, [f"coverage: {len(FAMILIES)}/{len(FAMILIES)} V1-applicable families mapped"]
+
+    failed: list[str] = []
+    for family in FAMILIES:
+        proc = subprocess.run(
+            family.command,
+            cwd=REPO,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            tail = (proc.stdout + "\n" + proc.stderr).strip()[-3000:]
+            failed.append(f"{family.unit} {family.capability}: rc={proc.returncode}\n{tail}")
+        else:
+            messages.append(f"PASS {family.unit} — {family.capability}")
+
+    if failed:
+        return EXIT_VIOLATION, failed
+
+    messages.append(
+        f"MEASURED: 0 live second owners across {len(FAMILIES)} V1-applicable retirement families"
+    )
+    return EXIT_OK, messages
+
+
+def main() -> int:
+    code, messages = evaluate(run_commands=True)
+    for message in messages:
+        print(f"{TAG} {message}")
+    if code == EXIT_OK:
+        print(f"{TAG} clean")
+    elif code == EXIT_UNMEASURED:
+        print(f"{TAG} UNMEASURED — never coerced to pass")
+    else:
+        print(f"{TAG} VIOLATION")
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/audit/test_v1_125_zero_second_owner.py
+++ b/tests/audit/test_v1_125_zero_second_owner.py
@@ -1,0 +1,34 @@
+"""V1-125 composite zero-live-second-owner acceptance gate."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "v1_125_zero_second_owner.py"
+
+
+def _gate_module():
+    spec = importlib.util.spec_from_file_location("v1_125_zero_second_owner", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_v1_125_reconciliation_has_exact_v1_family_coverage():
+    gate = _gate_module()
+    code, messages = gate.evaluate(run_commands=False)
+    assert code == gate.EXIT_OK, messages
+    assert len(gate.FAMILIES) == 9
+
+
+def test_v1_125_zero_live_second_owner_gate():
+    gate = _gate_module()
+    code, messages = gate.evaluate(run_commands=True)
+    assert code == gate.EXIT_OK, "\n\n".join(messages)
+    assert any(
+        message == "MEASURED: 0 live second owners across 9 V1-applicable retirement families"
+        for message in messages
+    )

--- a/tests/audit/test_v1_125_zero_second_owner.py
+++ b/tests/audit/test_v1_125_zero_second_owner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
@@ -10,9 +11,14 @@ SCRIPT = REPO / "scripts" / "v1_125_zero_second_owner.py"
 
 
 def _gate_module():
-    spec = importlib.util.spec_from_file_location("v1_125_zero_second_owner", SCRIPT)
+    module_name = "v1_125_zero_second_owner"
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPT)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
+    # dataclasses resolves annotations through sys.modules while the class is
+    # being decorated. Register this synthetic file import exactly as normal
+    # import machinery would before executing the module.
+    sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module
 


### PR DESCRIPTION
## V1-125 traffic-control scope

Adds the outstanding automated acceptance gate for V1-125 without changing ownership methodology, implementation behavior, auth, or the V1 denominator.

The gate is deliberately composite: it maps the nine V1-applicable historical `retires` families already reconciled in `docs/v1/V1_125_RETIREMENT_RECONCILIATION.md` to their existing deterministic owner/retirement guards. It fails closed if a family is missing, carries an unresolved/decision-required classification, cannot be measured, or its settled guard fails. C6-U1 remains explicitly POST-V1 and is not folded into the 136-row denominator.

On success the executable measurement is exactly: `0 live second owners across 9 V1-applicable retirement families`.

This PR does **not** promote V1-125. Promotion remains contingent on this exact head passing CI/merge-tree validation and the measured gate being recorded under the contract's L2 rule.

Closes no methodology question; Issue #1214 remains the traffic-control record until the gate is actually green and harvested.