### PR TITLE
V1-123: fix production-browser false-red selectors

### DIFF
--- a/tests/e2e/specs/prod-auth/v1-123-command-center.spec.js
+++ b/tests/e2e/specs/prod-auth/v1-123-command-center.spec.js
@@ -23,9 +23,13 @@ test.describe("V1-123 Phase 2: Command Center (production)", () => {
     await expect(commandBar).toBeVisible({ timeout: 60_000 });
     await expect(page.locator('[aria-label="Team aggregates"]')).toBeVisible({ timeout: 30_000 });
 
-    const switcherToggle = page.locator("button.team-switcher-toggle").first();
+    // Desktop and mobile variants coexist in the responsive shell. `.first()`
+    // can select the hidden desktop button on a mobile viewport, so operate on
+    // the variant that is actually visible to the production user.
+    const switcherToggle = page.locator("button.team-switcher-toggle:visible").first();
+    await expect(switcherToggle).toBeVisible({ timeout: 15_000 });
     await switcherToggle.click();
-    const menu = page.locator(".team-switcher-menu");
+    const menu = page.locator(".team-switcher-menu:visible").first();
     await expect(menu).toBeVisible({ timeout: 15_000 });
     const options = await menu.locator('[role="option"]').allInnerTexts();
     const trimmedOptions = options.map((o) => o.trim()).filter(Boolean);

--- a/tests/e2e/specs/prod-auth/v1-123-draft-capital.spec.js
+++ b/tests/e2e/specs/prod-auth/v1-123-draft-capital.spec.js
@@ -23,17 +23,19 @@ test.describe("V1-123 Phase 2: /draft-capital (production)", () => {
       "/draft-capital must redirect to /league?tab=draft-capital",
     ).toContain("tab=draft-capital");
 
-    const header = page.getByText("Draft Capital", { exact: false }).first();
+    // "Draft Capital" also exists as a hidden selected <option> in the
+    // League tab picker, so it cannot be the populated-state signal.
+    // "Pick Values" is rendered by the actual draft-capital section only.
+    const populatedSignal = page.getByText("Pick Values", { exact: true }).first();
     const unavailable = page.getByText(/Draft capital unavailable/i);
-    const settled = header.or(unavailable);
+    const settled = populatedSignal.or(unavailable);
     await expect(settled.first()).toBeVisible({ timeout: 60_000 });
 
-    const populated = await header.isVisible().catch(() => false);
+    const populated = await populatedSignal.isVisible().catch(() => false);
     if (populated) {
       await expect(page.getByText(/draft ·.*teams ·.*rounds ·.*total budget/i)).toBeVisible({
         timeout: 30_000,
       });
-      await expect(page.getByText("Pick Values", { exact: false })).toBeVisible({ timeout: 30_000 });
       annotate(testInfo, "states-observed", "draft-capital: populated");
     } else {
       annotate(testInfo, "states-observed", "draft-capital: unavailable (explicit)");

--- a/tests/e2e/specs/prod-auth/v1-123-insider-trading.spec.js
+++ b/tests/e2e/specs/prod-auth/v1-123-insider-trading.spec.js
@@ -41,11 +41,14 @@ test.describe("V1-123 Phase 2: Insider Trading (production)", () => {
         `insider-trading: populated (${rowCount} rows)${isStale ? ", stale banner shown" : ""}`,
       );
 
-      // Row expansion: clicking the top asset row must reveal its evidence tab.
+      // Row expansion must enter the member-exposure state. The page subtitle
+      // also contains "league-mates", so a broad /League-mate/ locator is not
+      // evidence that the clicked row expanded.
       await rows.first().click();
-      await expect(page.getByText(/League-mate/i).or(page.getByText(/Loading member exposure/i))).toBeVisible({
-        timeout: 30_000,
-      });
+      const exposure = page
+        .getByText(/Loading member exposure/i)
+        .or(page.getByText(/No league-mate holds or traded this asset/i));
+      await expect(exposure.first()).toBeVisible({ timeout: 30_000 });
     } else {
       const empty = (await noSnapshot.isVisible().catch(() => false))
         ? "no-snapshot-yet"

--- a/tests/e2e/specs/prod-auth/v1-123-package-builder.spec.js
+++ b/tests/e2e/specs/prod-auth/v1-123-package-builder.spec.js
@@ -24,12 +24,15 @@ test.describe("V1-123 Phase 2: Package Builder /angle (production)", () => {
       })
       .toBeGreaterThan(0);
 
-    const rosterRow = page.locator("label.rosterRow").first();
-    await expect(rosterRow, "your roster list should render at least one player").toBeVisible({
+    // Roster rows use a CSS module (`styles.rosterRow`), so the browser does
+    // not expose a literal `rosterRow` class. Target the actual checkbox
+    // control rendered by RosterPicker instead of depending on a build hash.
+    const rosterCheckbox = page.locator('input[type="checkbox"]').first();
+    await expect(rosterCheckbox, "your roster list should render at least one player").toBeVisible({
       timeout: 30_000,
     });
-    await rosterRow.click();
-    await expect(rosterRow).toHaveClass(/rosterRowSelected/);
+    await rosterCheckbox.check();
+    await expect(rosterCheckbox).toBeChecked();
 
     const submit = page.getByRole("button", { name: /Find return options/i });
     await expect(submit).toBeEnabled({ timeout: 15_000 });

--- a/tests/e2e/specs/prod-auth/v1-123-source-disagreement.spec.js
+++ b/tests/e2e/specs/prod-auth/v1-123-source-disagreement.spec.js
@@ -23,7 +23,10 @@ test.describe("V1-123 Phase 2: Source Disagreement /edge (production)", () => {
 
     const gapsPanel = page.getByRole("tabpanel", { name: "Market gaps" });
     await expect(gapsPanel).toBeVisible({ timeout: 30_000 });
-    const sellSignals = gapsPanel.getByText("Sell signals", { exact: false });
+    // The panel has both "Sell signals" and "IDP sell signals" headings.
+    // Anchor the generic panel by its heading prefix instead of a substring
+    // locator that is intentionally ambiguous in Playwright strict mode.
+    const sellSignals = gapsPanel.getByRole("heading", { name: /^Sell signals\b/i });
     await expect(sellSignals).toBeVisible({ timeout: 15_000 });
 
     const agreementTab = page.getByRole("tab", { name: "Agreement" });


### PR DESCRIPTION
ACTIVE V1 traffic-control repair for the exact production failures observed in authenticated run 33777101766.

This PR changes only V1-123 production-browser selectors; it does not promote V1-123, alter the V1 denominator, weaken auth, manufacture data, or reinterpret missing/stale states.

Observed false-reds addressed:
- Draft Capital: `Draft Capital` matched the hidden selected tab `<option>`; use the section-only `Pick Values` populated signal.
- Insider Trading: broad `/League-mate/` matched the static page subtitle as well as the expansion state; require member-exposure UI.
- Source Disagreement: substring `Sell signals` matched both offensive and IDP headings; require the heading that starts with `Sell signals`.
- Package Builder: test targeted literal `label.rosterRow`, but the product uses CSS modules; operate on the actual roster checkbox and assert checked state.
- Command Center mobile: desktop and mobile team-switcher variants coexist; operate on the visible responsive variant.

Production rerun remains mandatory before any V1-123 L4 promotion. Prior run had 49 passed / 9 failed and its failures are not being relabeled as passes retroactively.