### PR TITLE
V1-126: execute final regression on exact closeout candidate

### DIFF
--- a/docs/v1/V1_126_FINAL_REGRESSION_EVIDENCE_2026-09-03.md
+++ b/docs/v1/V1_126_FINAL_REGRESSION_EVIDENCE_2026-09-03.md
@@ -1,0 +1,36 @@
+# V1-126 Final Regression Evidence — 2026-09-03
+
+Status: **NOT VERIFIED — evidence collection in progress**
+
+Canonical row: `V1-126` / `C10-CLOSE-07` — Final regression.
+
+## Candidate
+
+- Base/current-main SHA at start of this closeout pass: `0f1e114db83bcfb8d58f8c95d2360056ad8f862b`.
+- This document does **not** promote V1-126 and does not change the V1 denominator.
+
+## Required acceptance posture
+
+Use the repository's already-settled V1-126 / §13.7 final-regression methodology. Only evidence produced for the exact final candidate may be counted. Preserve the separation between CI green, merged, deployed, and production-verified.
+
+Required evidence remains pending until independently harvested:
+
+- blocking backend gates: PENDING
+- blocking frontend gates: PENDING
+- contract/invariant gates: PENDING
+- lint/type/build gates: PENDING
+- audit/governance gates: PENDING
+- E2E/browser gates: PENDING for this exact candidate
+- integration/merge SHA: PENDING
+- deployment of the final exact tree: PENDING
+- production verification on the deployed final tree: PENDING
+
+## Prior evidence that is informative but insufficient
+
+`E2E Safety Net` run `33818952011` succeeded on SHA `9b76f58821bb74ec28fa93abd6e46741aa2fd5c7`, but the same-SHA Deploy Production workflow did not complete a deployment (`Validate Build Inputs` was cancelled and `Deploy To Production` was skipped). It therefore cannot by itself satisfy V1-126's final deployment/production-verification bar.
+
+The commits between `9b76f588…` and the base SHA above are automated scrape-state refreshes only; this note does not assume that makes the older SHA a valid final candidate. The exact candidate must still satisfy the canonical closeout bar.
+
+## Promotion rule
+
+Do not change `V1-126` to `VERIFIED` until every required blocking gate is green on one exact final candidate and the repository-required deployment/production verification evidence for the integrated tree exists and is recorded.

--- a/tests/e2e/V1_126_FINAL_REGRESSION_TRIGGER.md
+++ b/tests/e2e/V1_126_FINAL_REGRESSION_TRIGGER.md
@@ -1,0 +1,5 @@
+# V1-126 Final Regression Trigger
+
+This inert marker exists only to place the V1-126 closeout candidate inside the existing `tests/e2e/**` pull-request path filter so the repository's canonical E2E Safety Net executes on the exact candidate head.
+
+It changes no application behavior, test assertions, auth, data semantics, V1 scope, or verification methodology. Delete only after V1 closeout if desired; its presence is harmless.


### PR DESCRIPTION
Bounded V1-126 closeout vehicle. This PR initializes the final-regression evidence record on an exact candidate and deliberately does **not** promote V1-126 or change the denominator.

Starting main for this pass: `0f1e114db83bcfb8d58f8c95d2360056ad8f862b`.
PR head after evidence scaffold: `5b82e27ef907d58fb01bc1a4a8bf3f14a592140f`.

The prior E2E Safety Net run `33818952011` was green on `9b76f588...`, but its same-SHA deploy path was cancelled/skipped, so it is explicitly recorded as informative but insufficient. This PR exists to bind subsequent exact-head blocking CI, integration, deployment, and production-verification evidence to one closeout vehicle.

No product behavior, auth, methodology, canonical identity/value/lineup semantics, missing-vs-zero behavior, stale-vs-current behavior, or V1 scope changes here. V1-126 remains NOT VERIFIED until the complete canonical §13.7 bar is met.