### PR TITLE
season-launch: wire game_day_archive's first real caller (C5-GD-02)

### DIFF
--- a/deploy/install-systemd-service.sh
+++ b/deploy/install-systemd-service.sh
@@ -1151,6 +1151,11 @@ main() {
   install_simple_timer "depth-charts-refresh" "ESPN depth-chart diff -> BDVM promotion/demotion events"
   install_simple_timer "injury-feed-refresh" "ESPN injury-status diff -> BDVM injury/return events"
   install_simple_timer "trending-history-refresh" "Sleeper trending adds+drops history snapshot"
+  # C5-GD-02's first real caller — captures perishable pregame roster/
+  # lineup state before each week's games lock. No credentials, no
+  # special seeding; see the .service.template's own comment for why
+  # this evidence cannot be recovered after the fact.
+  install_simple_timer "game-day-snapshots" "Game Day pregame prediction snapshot capture"
 
   # ── daemon-reload and enable ────────────────────────────────────────────
   # ce_needs_install was missing from this list. Every other timer's

--- a/deploy/systemd/dynasty-game-day-snapshots.service.template
+++ b/deploy/systemd/dynasty-game-day-snapshots.service.template
@@ -1,0 +1,78 @@
+[Unit]
+Description=Dynasty Trade Calculator Game Day pregame snapshot capture (__SERVICE_NAME__)
+After=network-online.target
+Wants=network-online.target
+
+# C5-GD-02 — first real caller of src/ros/game_day_archive.py, which
+# was built (per docs/GAME_DAY_PROBABILITY_SPEC.md §5's archival
+# requirement) but had ZERO callers anywhere in the repo, meaning the
+# perishable pregame prediction state it exists to preserve was never
+# actually being captured. That state cannot be recovered after the
+# fact — once a week is scored, the pre-event roster/lineup-eligibility
+# state that produced any prediction is gone unless captured before the
+# outcome was known. This timer closes that gap.
+#
+# WHAT IT CAPTURES, HONESTLY: roster composition, the lineup-eligible
+# pool (by pure positional eligibility against the league's resolved
+# starter slots), the league's PROVEN-CURRENT scoring identity, and a
+# real wall-clock timestamp. It does NOT capture a per-week point
+# projection — none exists anywhere in this codebase today (confirmed
+# by a repo-wide check when this unit was written, 2026-09-03; see
+# scripts/capture_game_day_snapshots.py's own module docstring). Every
+# captured PlayerPointEstimate carries pointEstimate: null rather than
+# a fabricated number.
+#
+# CADENCE: weekly, early Thursday UTC — matching src.trade.faab_engine
+# .current_nfl_week()'s own Thursday-to-Wednesday week boundary (which
+# ticks over at UTC midnight) and well before that week's first game
+# (the earliest possible kickoff is Thursday Night Football, evening US
+# time / very late UTC or Friday UTC). This is an OPERATIONAL CHOICE,
+# not a spec requirement — docs/GAME_DAY_PROBABILITY_SPEC.md §5 requires
+# archiving pregame snapshots but does not name an exact cutoff. Revise
+# the OnCalendar line in the paired .timer if a tighter or looser window
+# is later decided.
+#
+# SAFE TO RE-RUN: record_snapshot() refuses an exact-duplicate
+# (league, season, week, team, capture_kind) tuple rather than
+# overwriting it, so a re-run within the same week is a no-op, not an
+# error. Persistent=true in the timer backfills a missed run after a
+# reboot within the same week for the same reason.
+#
+# WHY A PROD-SIDE TIMER AND NOT CI: this reads the live board export
+# from data/ (gitignored, VPS-only) and needs the deployed league
+# registry + scoring snapshots to resolve a PROVEN-CURRENT scoring
+# identity — same reasoning as every other data-producing timer in this
+# directory (BDVM refresh, FAAB history, player-context).
+#
+# OFFSEASON BEHAVIOR: current_nfl_season()/current_nfl_week() answer
+# "not in season" for roughly 34 weeks a year, and the script exits 1 in
+# that case (matching the rest of this directory's convention that a
+# nonzero exit communicates "nothing happened" rather than "the box is
+# broken") — systemd will show these as failed runs in the offseason;
+# that is expected and not actionable.
+#
+# Exit codes (scripts/capture_game_day_snapshots.py):
+#   0 - at least one snapshot recorded
+#   1 - soft: not in season, no active leagues, or no roster data
+#   2 - hard: no contract export found, or the league registry could
+#       not be read
+# On any exit code, whatever was already captured for prior weeks stays
+# on disk untouched — this unit only ever appends.
+
+[Service]
+Type=oneshot
+User=__APP_USER__
+Group=__APP_USER__
+WorkingDirectory=__APP_DIR__
+EnvironmentFile=-__APP_DIR__/.env
+ExecStart=__VENV_DIR__/bin/python __APP_DIR__/scripts/capture_game_day_snapshots.py
+StandardOutput=journal
+StandardError=journal
+# A handful of Sleeper HTTP calls per league plus one contract parse —
+# not resource-heavy, but never on a request path.
+Nice=10
+IOSchedulingClass=idle
+TimeoutStartSec=300
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/dynasty-game-day-snapshots.timer.template
+++ b/deploy/systemd/dynasty-game-day-snapshots.timer.template
@@ -1,0 +1,37 @@
+[Unit]
+Description=Weekly Game Day pregame snapshot capture for __SERVICE_NAME__
+# No Requires= here: [Timer] Unit= already binds the service, and a
+# [Unit] Requires= would start it on every boot regardless of OnCalendar
+# and let a service failure stop the timer itself.  Persistent=true below
+# is the intended catch-up.
+
+[Timer]
+# Weekly, Thursday 10:00 UTC — an OPERATIONAL CHOICE (the spec names no
+# exact cutoff; see the paired .service for the full reasoning). Chosen
+# to sit safely inside the window between the two boundaries that
+# matter:
+#
+#   - AFTER current_nfl_week()'s own week-turnover instant (UTC
+#     midnight on Thursday), so the capture is stamped under the
+#     correct upcoming week rather than the one that just ended;
+#   - BEFORE that week's first possible kickoff (Thursday Night
+#     Football, evening US time / late UTC or Friday UTC), so the
+#     snapshot is genuinely pregame and not contaminated by outcomes
+#     that already happened.
+#
+# Persistent=true backfills a missed run (box down over the window) —
+# safe because record_snapshot() refuses an exact-duplicate capture
+# rather than overwriting, so a late catch-up run still lands under the
+# right week and does not corrupt an earlier capture.
+#
+# This fires every Thursday year-round, including the ~34 offseason
+# weeks; the script exits 1 (soft, "not in season") on those and is not
+# actionable — see the .service file.
+OnCalendar=Thu *-*-* 10:00:00 UTC
+RandomizedDelaySec=600
+Persistent=true
+AccuracySec=5min
+Unit=__SERVICE_NAME__-game-day-snapshots.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/season-launch/2026_SEASON_LAUNCH_STATUS.md
+++ b/docs/season-launch/2026_SEASON_LAUNCH_STATUS.md
@@ -46,7 +46,7 @@ per-team matchup page. That's a product-boundary question worth confirming
 with the owner before building, since building the wrong one wastes real
 effort against a hard kickoff deadline.
 
-## 2. Game Day dashboard — NOT STARTED (live surface); evidence-capture substrate built but NOT RUNNING
+## 2. Game Day dashboard — NOT STARTED (live surface); evidence-capture substrate now WIRED (2026-09-03)
 
 - `docs/GAME_DAY_PROBABILITY_SPEC.md` (13 sections) is a complete, approved
   design: win-matchup %, beat-league-median %, one canonical scoring
@@ -76,17 +76,68 @@ effort against a hard kickoff deadline.
   is wired in is unrecoverable evidence loss, by the module's own stated
   rationale.
 
-**Highest-value next action, in order**: (1) wire `game_day_archive`'s
-capture call into a scheduled job that runs before each week's games lock
-(even a bare-minimum cron hitting it once a week beats zero capture — this
-is a `RET`-flagged row, "collection should start as early as the phase
-allows," per `docs/C_SERIES_SCOPE_MANIFEST.md`); (2) only then build the
-actual live dashboard (state machine: scheduled → live → final, per the
-directive's own required order), since the dashboard is a large,
-methodology-sensitive build (the spec explicitly says the simulator's
-distribution family / sample count / correlation handling are product-
-semantics-changing decisions, not to be invented unilaterally) while the
-archive wiring is small, mechanical, and time-critical.
+**Closed this session (2026-09-03)**: `scripts/capture_game_day_snapshots.py`
+is `game_day_archive`'s first real caller, plus
+`deploy/systemd/dynasty-game-day-snapshots.{service,timer}.template` (picked
+up automatically on the next production deploy — `deploy/deploy.sh` globs
+every `*.timer.template` in that directory and installs any that are
+missing, no other deploy-script change needed). Validated end-to-end against
+real production data in this sandbox (real Sleeper rosters for
+`dynasty_main`, real scoring-fingerprint evidence, a real write, a real
+idempotent re-run refusing the duplicate) before being committed — not just
+unit-tested against fakes, though 8 unit tests (`tests/scripts/
+test_capture_game_day_snapshots.py`) pin the behavior too, including the one
+real bug that validation run caught:
+
+- **A real defect, found and fixed before shipping**: the contract's
+  `sleeper.positions` map is keyed by player NAME, not playerId —
+  `sleeper.idToPlayer` (playerId → name) is the missing intermediate step.
+  The first draft assumed a direct playerId → position map and silently
+  captured every single player as `position: "UNKNOWN"` against a real
+  real dynasty_main data (12 real teams, 45-58 players each). Caught
+  by inspecting the actual written output rather than trusting a clean exit
+  code — the script ran without erroring either way. Fixed and pinned by
+  `test_position_map_chains_through_idtoplayer`.
+- **What it honestly captures**: roster composition, a lineup-eligible flag
+  (pure positional eligibility against the league's resolved starter slots —
+  documented in the script's own module docstring as the simpler of two
+  possible readings, since nothing else in the codebase defines this term
+  for an unpriced, scripted capture), the league's PROVEN-CURRENT scoring
+  fingerprint (fails closed — refuses the whole league rather than stamp an
+  unverified identity — when that evidence is stale or missing), and a real
+  wall-clock timestamp.
+- **What it does NOT capture, and cannot yet**: every `pointEstimate` is
+  `null`. A repo-wide check (this same design pass) found no per-week
+  point-projection source anywhere in this codebase — BDVM produces a
+  season-long/ROS rate and a dynasty asset value, neither of which is a
+  specific upcoming week's expected score. This is not a shortcut; it is the
+  only honest value `PlayerPointEstimate` supports today, and the module was
+  explicitly designed to require exactly this state rather than coerce a
+  guess. When a real per-week source lands, it plugs in as this script's
+  `estimate_source` without changing the capture cadence or roster
+  resolution.
+- **Cadence is a documented, revisable operational choice**, not a spec
+  requirement: `docs/GAME_DAY_PROBABILITY_SPEC.md` §5 requires archiving
+  pregame snapshots but names no exact cutoff. Chosen: weekly, Thursday
+  10:00 UTC — after `current_nfl_week()`'s own UTC-midnight Thursday
+  week-turnover, before that week's first possible kickoff (Thursday Night
+  Football). See the `.timer.template`'s own comment for the full
+  reasoning; revise there if a tighter window is later decided.
+- **Not yet installed on production** — that happens automatically on the
+  next `deploy.sh` run once this lands on `main`; there is no separate
+  manual step, but it has not been observed running on the real box yet.
+
+**Highest-value next action, now**: (1) confirm the timer actually installs
+and fires on the next production deploy (`journalctl -u
+dynasty-game-day-snapshots.service` after the first Thursday post-deploy,
+matching `SERVICE_NAME="${SERVICE_NAME:-dynasty}"` in `deploy/deploy.sh`);
+(2) build the actual live dashboard (state machine: scheduled → live →
+final, per the directive's own required order), since the dashboard is a
+large, methodology-sensitive build (the spec explicitly says the
+simulator's distribution family / sample count / correlation handling are
+product-semantics-changing decisions, not to be invented unilaterally)
+while the archive wiring above was small, mechanical, and time-critical —
+now done.
 
 ## 3. Postgame writeups — READY (public factual layer), same private-layer gap as pregame
 

--- a/docs/season-launch/2026_SEASON_LAUNCH_STATUS.md
+++ b/docs/season-launch/2026_SEASON_LAUNCH_STATUS.md
@@ -78,10 +78,18 @@ effort against a hard kickoff deadline.
 
 **Closed this session (2026-09-03)**: `scripts/capture_game_day_snapshots.py`
 is `game_day_archive`'s first real caller, plus
-`deploy/systemd/dynasty-game-day-snapshots.{service,timer}.template` (picked
-up automatically on the next production deploy — `deploy/deploy.sh` globs
-every `*.timer.template` in that directory and installs any that are
-missing, no other deploy-script change needed). Validated end-to-end against
+`deploy/systemd/dynasty-game-day-snapshots.{service,timer}.template` wired
+into `deploy/install-systemd-service.sh` via the shared `install_simple_timer`
+helper. **Correction to an initial claim this section made**: shipping the
+two template files alone is NOT enough — `deploy/deploy.sh`'s glob loop only
+DETECTS a missing timer and re-runs the installer; it is
+`install-systemd-service.sh` that actually renders and enables a unit, from a
+hand-written per-timer call, and a template with no such call is reported
+missing on every deploy forever without ever being installed
+(`tests/deploy/test_all_timers_are_wired.py` exists specifically to catch
+this class of mistake — and did, on this PR's first CI run). Fixed by adding
+`install_simple_timer "game-day-snapshots" "Game Day pregame prediction
+snapshot capture"` alongside the other no-special-case timers. Validated end-to-end against
 real production data in this sandbox (real Sleeper rosters for
 `dynasty_main`, real scoring-fingerprint evidence, a real write, a real
 idempotent re-run refusing the duplicate) before being committed — not just

--- a/scripts/capture_game_day_snapshots.py
+++ b/scripts/capture_game_day_snapshots.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Capture pregame Game Day prediction snapshots (C5-GD-02).
+
+Calls ``src.ros.game_day_archive.record_snapshot`` once per (league,
+team) so the perishable pre-kickoff state -- roster composition, the
+lineup-eligible pool, the league's scoring/slot identity, and a real
+wall-clock timestamp -- is not silently lost. That module is a pure
+append-only store; this script is its first real caller, closing the
+"zero callers anywhere" gap named in
+``docs/season-launch/2026_SEASON_LAUNCH_STATUS.md``.
+
+WHAT THIS DOES NOT DO, STATED EXPLICITLY
+-----------------------------------------
+Every captured ``PlayerPointEstimate`` carries ``point_estimate=None,
+estimate_source=None``. This is not a placeholder to be filled in
+later by this script -- it is the only honest choice available today:
+a repo-wide check (this unit's own design pass, 2026-09-03) found no
+per-week point-projection source anywhere in this codebase. BDVM
+(``src/bdvm/``) produces a season-long/ROS per-game RATE (``fpg``,
+itself frequently a backward-looking proxy) and a dynasty ASSET VALUE
+(``rankDerivedValue``) -- neither is a specific upcoming week's
+expected score, and treating either as one would be exactly the
+fabrication ``game_day_archive.py``'s own docstring says is not its
+job. ``PlayerPointEstimate`` is explicitly designed to support and
+require this "no source" state (see its ``__post_init__``). When a
+real per-week projection source lands, it plugs in as this script's
+``estimate_source`` -- the capture cadence and roster resolution below
+do not change.
+
+``is_lineup_eligible`` uses the SIMPLER of two readings the design
+pass identified: "is this player's position legal in at least one of
+the league's resolved starter slots" (pure positional eligibility),
+not "does this player win a slot in an optimal lineup" (which would
+need a priced pool -- see ``src/ros/lineup.py::assign_lineup`` -- and
+BDVM's dynasty value is not the same currency as a weekly lineup
+decision). Documented here because nothing else in the codebase
+defines this term for a scripted, unpriced capture.
+
+CADENCE -- AN OPERATIONAL CHOICE, NOT A SPEC REQUIREMENT
+-----------------------------------------------------------
+``docs/GAME_DAY_PROBABILITY_SPEC.md`` Sec5 requires archiving pregame
+snapshots but is silent on exactly how far before kickoff. This
+script is meant to run once per NFL week, early on the Thursday the
+week turns over (matching ``current_nfl_week()``'s own Thursday
+boundary) and before that week's first game -- see
+``deploy/systemd/dynasty-game-day-snapshots.timer.template`` for the
+chosen time and its stated rationale. Re-running within the same week
+is safe: ``record_snapshot`` refuses an exact-duplicate
+(league, season, week, team, capture_kind) tuple rather than
+overwriting it, so this script logs and skips those rather than
+failing.
+
+Exit codes (repo convention -- see scripts/refresh_playerctx.py):
+    0 - at least one snapshot recorded (or --dry-run resolved cleanly)
+    1 - soft failure (not in season, no leagues, no roster data)
+    2 - hard/structural error (no contract export, registry unreadable)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from src.api import league_registry  # noqa: E402
+from src.bdvm.actuals import current_nfl_season  # noqa: E402
+from src.ros import game_day_archive  # noqa: E402
+from src.ros.lineup import resolve_starter_slots, slot_eligible_positions  # noqa: E402
+from src.trade.faab_engine import current_nfl_week  # noqa: E402
+
+
+def log(msg: str) -> None:
+    print(f"[game-day-capture] {msg}", flush=True)
+
+
+def _fetch_json(url: str) -> Any:
+    req = urllib.request.Request(url, headers={"User-Agent": "riskittogetthebrisket/1.0"})
+    with urllib.request.urlopen(req, timeout=20) as resp:  # noqa: S310
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _load_contract() -> dict | None:
+    """The live contract, same discovery order as scripts/snapshot_board.py.
+
+    Only ``sleeper.idToPlayer`` and ``sleeper.positions`` are read from it
+    (both NFL-wide, per CLAUDE.md) -- per-league roster composition below
+    comes straight from Sleeper, since the shared contract's own
+    ``sleeper`` block is stamped for one league only (the scoring-
+    profile/leagueKey split) and this script must capture every active
+    league, not just whichever one happened to be loaded when the export
+    was built. Position lookup is a two-step chain, confirmed against a
+    real export rather than assumed from the field name alone:
+    ``sleeper.idToPlayer`` maps playerId -> canonical name, and
+    ``sleeper.positions`` maps that name -> position; there is no
+    playerId -> position map directly.
+    """
+    from src.api.data_contract import build_api_data_contract  # noqa: PLC0415
+
+    for directory in (REPO / "exports" / "latest", REPO / "data"):
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.glob("dynasty_data*.json"), reverse=True):
+            try:
+                raw = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError) as exc:
+                log(f"skip {path.name}: {exc}")
+                continue
+            if not isinstance(raw, dict):
+                continue
+            log(f"building contract from {path.relative_to(REPO)}")
+            return build_api_data_contract(raw)
+    return None
+
+
+def _position_map_from_contract(contract: dict[str, Any]) -> dict[str, str]:
+    """``playerId -> position`` chained through the contract's own two
+    NFL-wide maps -- there is no direct playerId -> position map.
+    ``sleeper.idToPlayer`` gives ``playerId -> canonical name``;
+    ``sleeper.positions`` gives ``name -> position``. A name present in
+    one but not the other is dropped rather than guessed.
+    """
+    sleeper_block = contract.get("sleeper") or {}
+    id_to_player = sleeper_block.get("idToPlayer") or {}
+    positions_by_name = sleeper_block.get("positions") or {}
+    return {
+        pid: positions_by_name[name]
+        for pid, name in id_to_player.items()
+        if name in positions_by_name
+    }
+
+
+def _capture_league(
+    cfg: league_registry.LeagueConfig,
+    *,
+    position_map: dict[str, Any],
+    season: int,
+    week: int,
+    capture_kind: str,
+    dry_run: bool,
+) -> tuple[int, int]:
+    """Capture every team's snapshot for one league. Returns (written, skipped)."""
+    fingerprint = league_registry.scoring_fingerprint_for_league(cfg)
+    if not fingerprint:
+        # Fail closed, per this repo's own invariant: scoring_config_id is
+        # a required field on the snapshot, and a PROVEN-CURRENT identity
+        # is exactly what scoring_fingerprint_for_league refuses to
+        # fabricate when its evidence is stale or missing. An unverified
+        # id would be a silent wrongness baked into permanent evidence.
+        log(
+            f"  {cfg.key}: scoring evidence not fresh/available -- refusing this league (fails closed)"
+        )
+        return 0, 0
+
+    try:
+        live_league = _fetch_json(f"https://api.sleeper.app/v1/league/{cfg.sleeper_league_id}")
+        rosters = _fetch_json(f"https://api.sleeper.app/v1/league/{cfg.sleeper_league_id}/rosters")
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError) as exc:
+        log(f"  {cfg.key}: could not fetch Sleeper league/roster data ({exc}) -- skipping")
+        return 0, 0
+
+    if not isinstance(rosters, list) or not rosters:
+        log(f"  {cfg.key}: no rosters returned from Sleeper -- skipping")
+        return 0, 0
+
+    slots, slot_source = resolve_starter_slots(
+        roster_positions=(live_league or {}).get("roster_positions"),
+        roster_settings=cfg.roster_settings,
+    )
+    if not slots:
+        log(f"  {cfg.key}: no starter slots resolved (neither live host nor registry) -- refusing")
+        return 0, 0
+
+    eligible_position_union: set[str] = set()
+    for slot in slots:
+        eligible_position_union |= slot_eligible_positions(slot)
+
+    written = 0
+    skipped = 0
+    for roster in rosters:
+        owner_id = roster.get("owner_id")
+        roster_id = roster.get("roster_id")
+        team_id = str(owner_id or f"roster_{roster_id}")
+        player_ids = [str(p) for p in (roster.get("players") or [])]
+        if not player_ids:
+            log(
+                f"  {cfg.key}/{team_id}: empty roster -- skipping (a snapshot with nobody on it is not evidence)"
+            )
+            skipped += 1
+            continue
+
+        estimates = []
+        for pid in player_ids:
+            position = str(position_map.get(pid) or "").upper()
+            is_eligible = bool(position) and position in eligible_position_union
+            estimates.append(
+                game_day_archive.PlayerPointEstimate(
+                    player_id=pid,
+                    position=position or "UNKNOWN",
+                    is_lineup_eligible=is_eligible,
+                    point_estimate=None,
+                    estimate_source=None,
+                )
+            )
+
+        if dry_run:
+            log(
+                f"  {cfg.key}/{team_id}: would capture {len(estimates)} players (dry-run, not written)"
+            )
+            written += 1
+            continue
+
+        try:
+            game_day_archive.record_snapshot(
+                league_key=cfg.key,
+                season=season,
+                week=week,
+                team_id=team_id,
+                capture_kind=capture_kind,
+                scoring_config_id=fingerprint,
+                starter_slots=tuple(slots),
+                roster=tuple(estimates),
+                run_id=f"capture_game_day_snapshots:{slot_source}",
+            )
+            log(f"  {cfg.key}/{team_id}: captured {len(estimates)} players")
+            written += 1
+        except game_day_archive.GameDayArchiveError as exc:
+            # Already captured this (league, season, week, team, kind) --
+            # append-only refusal, not a failure. Re-running this script
+            # within the same week must be a safe no-op.
+            log(f"  {cfg.key}/{team_id}: {exc}")
+            skipped += 1
+
+    return written, skipped
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--league", help="only this league key (default: every active league)")
+    parser.add_argument(
+        "--capture-kind",
+        default="pregame",
+        choices=sorted(game_day_archive.CAPTURE_KINDS),
+        help="which capture_kind to record (default: pregame)",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="resolve and report, write nothing")
+    args = parser.parse_args(argv)
+
+    season = current_nfl_season()
+    if season is None:
+        log("not in the NFL season window (current_nfl_season() is None) -- nothing to capture")
+        return 1
+
+    week, in_season = current_nfl_week()
+    if not in_season or week is None:
+        log("not in the NFL regular-season week window (current_nfl_week()) -- nothing to capture")
+        return 1
+
+    contract = _load_contract()
+    if contract is None:
+        log("error: no dynasty_data export found under exports/latest/ or data/")
+        return 2
+    position_map = _position_map_from_contract(contract)
+    if not position_map:
+        log(
+            "warning: could not build a playerId -> position map from "
+            "sleeper.idToPlayer + sleeper.positions -- every player will "
+            "be captured as position UNKNOWN"
+        )
+
+    try:
+        leagues = league_registry.active_leagues()
+    except Exception as exc:  # noqa: BLE001 -- a recording job reports, it never crashes the box
+        log(f"error: could not read league registry: {exc}")
+        return 2
+
+    if args.league:
+        leagues = [cfg for cfg in leagues if cfg.key == args.league]
+
+    if not leagues:
+        log("error: no matching active leagues")
+        return 2
+
+    total_written = 0
+    total_skipped = 0
+    for cfg in leagues:
+        log(f"-> {cfg.key} season={season} week={week} kind={args.capture_kind}")
+        try:
+            written, skipped = _capture_league(
+                cfg,
+                position_map=position_map,
+                season=season,
+                week=week,
+                capture_kind=args.capture_kind,
+                dry_run=args.dry_run,
+            )
+        except Exception as exc:  # noqa: BLE001 -- a recording job reports, it never crashes the box
+            log(f"  {cfg.key}: unexpected error ({exc}) -- skipping this league")
+            continue
+        total_written += written
+        total_skipped += skipped
+
+    log(f"done: {total_written} snapshot(s) recorded, {total_skipped} skipped")
+    return 0 if total_written > 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_capture_game_day_snapshots.py
+++ b/tests/scripts/test_capture_game_day_snapshots.py
@@ -1,0 +1,234 @@
+"""C5-GD-02's first real caller.
+
+Pinned against a real production shape discovered while validating this
+script by hand (2026-09-03): ``sleeper.positions`` is keyed by player
+NAME, not playerId -- ``sleeper.idToPlayer`` (playerId -> name) is the
+missing link. The first version of this script assumed a direct
+playerId -> position map and silently captured every player as position
+UNKNOWN against real production data; ``test_position_map_chains_through_idtoplayer``
+exists specifically so that regression can't come back quietly.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scripts.capture_game_day_snapshots import (  # noqa: E402
+    _capture_league,
+    _position_map_from_contract,
+)
+from src.api.league_registry import LeagueConfig  # noqa: E402
+from src.ros import game_day_archive  # noqa: E402
+
+
+def _league_cfg(**overrides) -> LeagueConfig:
+    base = dict(
+        key="dynasty_test",
+        display_name="Test League",
+        sleeper_league_id="123",
+        scoring_profile="superflex_tep15_ppr1",
+        roster_settings={"starters": {"QB": 1, "RB": 2, "WR": 2, "FLEX": 1}, "teamCount": 2},
+        idp_enabled=False,
+    )
+    base.update(overrides)
+    return LeagueConfig(**base)
+
+
+def test_position_map_chains_through_idtoplayer():
+    """The real bug this test exists to pin: sleeper.positions is
+    name-keyed, so a direct playerId lookup against it silently misses
+    every player. idToPlayer is the required intermediate step."""
+    contract = {
+        "sleeper": {
+            "idToPlayer": {"111": "Jane Runner", "222": "Joe Thrower"},
+            "positions": {"Jane Runner": "RB", "Joe Thrower": "QB"},
+        }
+    }
+    assert _position_map_from_contract(contract) == {"111": "RB", "222": "QB"}
+
+
+def test_position_map_drops_names_with_no_position_entry():
+    contract = {
+        "sleeper": {
+            "idToPlayer": {"111": "Jane Runner", "999": "Nobody Known"},
+            "positions": {"Jane Runner": "RB"},
+        }
+    }
+    assert _position_map_from_contract(contract) == {"111": "RB"}
+
+
+def test_position_map_empty_sleeper_block_returns_empty():
+    assert _position_map_from_contract({}) == {}
+    assert _position_map_from_contract({"sleeper": {}}) == {}
+
+
+def test_capture_league_writes_one_snapshot_per_roster(tmp_path, monkeypatch):
+    """End-to-end against fakes: real record_snapshot writes, real
+    starter-slot resolution, real position-eligibility derivation --
+    only the Sleeper HTTP calls and the scoring fingerprint are faked."""
+    monkeypatch.setattr(game_day_archive, "ARCHIVE_ROOT", tmp_path)
+
+    responses = {
+        "https://api.sleeper.app/v1/league/123": {
+            "roster_positions": ["QB", "RB", "WR", "FLEX", "BN", "BN"],
+        },
+        "https://api.sleeper.app/v1/league/123/rosters": [
+            {"owner_id": "u1", "roster_id": 1, "players": ["111", "222", "333"]},
+            {"owner_id": "u2", "roster_id": 2, "players": []},
+        ],
+    }
+
+    def fake_fetch_json(url):
+        return responses[url]
+
+    import scripts.capture_game_day_snapshots as mod
+
+    monkeypatch.setattr(mod, "_fetch_json", fake_fetch_json)
+    monkeypatch.setattr(
+        "src.api.league_registry.scoring_fingerprint_for_league",
+        lambda cfg: "sf1:fake",
+    )
+
+    cfg = _league_cfg()
+    position_map = {"111": "RB", "222": "QB", "333": "K"}
+
+    written, skipped = _capture_league(
+        cfg,
+        position_map=position_map,
+        season=2026,
+        week=1,
+        capture_kind="pregame",
+        dry_run=False,
+    )
+
+    # roster u2 is empty -> skipped, not written or errored
+    assert written == 1
+    assert skipped == 1
+
+    snap = game_day_archive.load_snapshot("dynasty_test", 2026, 1, "u1", "pregame")
+    assert snap is not None
+    assert snap.scoring_config_id == "sf1:fake"
+    by_id = {p.player_id: p for p in snap.roster}
+    assert by_id["111"].position == "RB"
+    assert by_id["111"].is_lineup_eligible is True  # RB legal in RB or FLEX
+    assert by_id["333"].position == "K"
+    assert by_id["333"].is_lineup_eligible is False  # K not in this league's resolved slots
+    # Every captured estimate is honestly unknown -- no per-week
+    # projection source exists anywhere in this codebase (see the
+    # script's own module docstring).
+    assert all(p.point_estimate is None and p.estimate_source is None for p in snap.roster)
+
+
+def test_capture_league_refuses_when_scoring_fingerprint_unavailable(tmp_path, monkeypatch):
+    """Fails closed: an unproven scoring identity must never be
+    fabricated into permanent evidence."""
+    monkeypatch.setattr(game_day_archive, "ARCHIVE_ROOT", tmp_path)
+    monkeypatch.setattr(
+        "src.api.league_registry.scoring_fingerprint_for_league",
+        lambda cfg: None,
+    )
+
+    written, skipped = _capture_league(
+        _league_cfg(),
+        position_map={},
+        season=2026,
+        week=1,
+        capture_kind="pregame",
+        dry_run=False,
+    )
+    assert (written, skipped) == (0, 0)
+    assert game_day_archive.load_snapshots_for_week("dynasty_test", 2026, 1) == []
+
+
+def test_capture_league_second_call_is_a_safe_noop(tmp_path, monkeypatch):
+    """Re-running against a week already captured must not error --
+    record_snapshot's append-only refusal is caught and counted as
+    skipped, not raised."""
+    monkeypatch.setattr(game_day_archive, "ARCHIVE_ROOT", tmp_path)
+
+    responses = {
+        "https://api.sleeper.app/v1/league/123": {"roster_positions": ["QB", "BN"]},
+        "https://api.sleeper.app/v1/league/123/rosters": [
+            {"owner_id": "u1", "roster_id": 1, "players": ["222"]},
+        ],
+    }
+
+    import scripts.capture_game_day_snapshots as mod
+
+    monkeypatch.setattr(mod, "_fetch_json", lambda url: responses[url])
+    monkeypatch.setattr(
+        "src.api.league_registry.scoring_fingerprint_for_league",
+        lambda cfg: "sf1:fake",
+    )
+
+    cfg = _league_cfg()
+    kwargs = dict(
+        position_map={"222": "QB"},
+        season=2026,
+        week=1,
+        capture_kind="pregame",
+        dry_run=False,
+    )
+    first = _capture_league(cfg, **kwargs)
+    second = _capture_league(cfg, **kwargs)
+    assert first == (1, 0)
+    assert second == (0, 1)
+
+
+def test_capture_league_dry_run_writes_nothing(tmp_path, monkeypatch):
+    monkeypatch.setattr(game_day_archive, "ARCHIVE_ROOT", tmp_path)
+
+    responses = {
+        "https://api.sleeper.app/v1/league/123": {"roster_positions": ["QB", "BN"]},
+        "https://api.sleeper.app/v1/league/123/rosters": [
+            {"owner_id": "u1", "roster_id": 1, "players": ["222"]},
+        ],
+    }
+
+    import scripts.capture_game_day_snapshots as mod
+
+    monkeypatch.setattr(mod, "_fetch_json", lambda url: responses[url])
+    monkeypatch.setattr(
+        "src.api.league_registry.scoring_fingerprint_for_league",
+        lambda cfg: "sf1:fake",
+    )
+
+    written, skipped = _capture_league(
+        _league_cfg(),
+        position_map={"222": "QB"},
+        season=2026,
+        week=1,
+        capture_kind="pregame",
+        dry_run=True,
+    )
+    assert written == 1
+    assert game_day_archive.load_snapshots_for_week("dynasty_test", 2026, 1) == []
+
+
+def test_capture_league_skips_on_sleeper_fetch_failure(tmp_path, monkeypatch):
+    monkeypatch.setattr(game_day_archive, "ARCHIVE_ROOT", tmp_path)
+    monkeypatch.setattr(
+        "src.api.league_registry.scoring_fingerprint_for_league",
+        lambda cfg: "sf1:fake",
+    )
+
+    import scripts.capture_game_day_snapshots as mod
+
+    def raise_url_error(url):
+        raise OSError("network unreachable")
+
+    monkeypatch.setattr(mod, "_fetch_json", raise_url_error)
+
+    written, skipped = _capture_league(
+        _league_cfg(),
+        position_map={},
+        season=2026,
+        week=1,
+        capture_kind="pregame",
+        dry_run=False,
+    )
+    assert (written, skipped) == (0, 0)


### PR DESCRIPTION
## Summary

Post-V1 season-launch work, explicitly out of the V1 denominator (V1 closed at 132/132 in PR #1238). Not V1 scope, no product code/auth/methodology/canonical-identity/value/lineup changes.

`src/ros/game_day_archive.py` was built 2026-08-20 specifically because its evidence is **perishable** — once a week is scored, the pre-game roster/lineup state that would let a future simulator validate against it is gone forever — but had **zero callers anywhere** in the repo, so it was capturing nothing while the season starts within days.

This PR is that first caller: `scripts/capture_game_day_snapshots.py` + `deploy/systemd/dynasty-game-day-snapshots.{service,timer}.template`, wired into `deploy/install-systemd-service.sh`'s `install_simple_timer` call so the timer actually installs on the next production deploy (a first draft of this shipped the templates without that wiring — caught by `tests/deploy/test_all_timers_are_wired.py` in a since-superseded branch, fixed here in the same commit sequence).

## Validated end-to-end against real production data, not just unit tests

Real Sleeper rosters for `dynasty_main` (12 teams, 45-58 players each), a real scoring-fingerprint lookup, a real write, and a real idempotent re-run correctly refusing the duplicate. That validation caught one real bug before it shipped: `sleeper.positions` is keyed by player NAME, not playerId — `sleeper.idToPlayer` (playerId → name) is the missing intermediate step. The first draft assumed a direct playerId → position map and silently captured every player as position `UNKNOWN`. Fixed and pinned by `test_position_map_chains_through_idtoplayer`.

## What this honestly captures — and what it doesn't

Every captured `pointEstimate` is `null`. A repo-wide check (this unit's own design pass) found **no per-week point-projection source anywhere in this codebase** — BDVM only has a season-long/ROS rate and a dynasty asset value, neither of which is a specific week's expected score. `PlayerPointEstimate` is explicitly designed to require this honest "no source" state rather than accept a fabricated one. Roster composition, lineup eligibility (positional, documented as the simpler of two possible readings), scoring identity (fails closed on stale/missing evidence), and a real timestamp are still real, useful, spec-compliant evidence on their own — and when a real per-week source lands later, it plugs in as this script's `estimate_source` without changing the capture cadence or roster resolution.

Cadence (weekly, Thursday 10:00 UTC) is a documented, revisable operational choice — the spec requires archiving pregame snapshots but names no exact cutoff; see the `.timer.template`'s own comment for the full reasoning.

## Verification

- `python3 -m py_compile scripts/capture_game_day_snapshots.py`
- `bash -n deploy/install-systemd-service.sh`
- `python3 -m ruff format --check` / `ruff check` — clean
- `pytest tests/scripts/test_capture_game_day_snapshots.py tests/deploy/test_all_timers_are_wired.py -v` — **17/17 passed**
- `python3 scripts/check_planning_integrity.py` / `check_decision_coercions.py` — clean
- `python3 scripts/capture_game_day_snapshots.py --dry-run` against the real environment — correctly reports "not in season" (exit 1) ahead of Week 1 kickoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPwRjfLMMgHj4xLCQKgoDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPwRjfLMMgHj4xLCQKgoDW)_