### PR TITLE
feat(game-day): wire the prediction archive to a scheduled caller

### DIFF
--- a/.github/workflows/game-day-capture.yml
+++ b/.github/workflows/game-day-capture.yml
@@ -1,0 +1,174 @@
+name: Game Day Capture (on-box)
+
+# MANUAL TRIGGER + VERIFICATION for the Game Day pre-game prediction
+# archive. The SCHEDULED owner of this capture is the prod-side systemd
+# timer (deploy/systemd/dynasty-game-day-capture.timer.template), NOT this
+# workflow — see that unit for why the capture has to run on the box:
+# data/ is gitignored repo-wide, so an archive written on a CI runner is
+# discarded with the runner, and the projection snapshots the capture joins
+# against (data/bdvm/projections/) exist only on the box.
+#
+# So this workflow does not capture on the runner. It runs the SAME script
+# on the box over SSH, which gives two things the timer alone does not:
+#
+#   1. a "capture now" button, for the week the timer is first installed
+#      (its first fire is the only one with no prior run to prove it works,
+#      and a Week 1 pregame window missed for an install problem is
+#      unrecoverable evidence, not a retryable job); and
+#   2. a --dry-run VERIFY mode that reports coverage and whether the window
+#      is still open, without writing anything.
+#
+# DEFAULT IS DRY RUN. Writing is opt-in via the `write` input, because the
+# archive is append-only: the FIRST capture for a (league, season, week,
+# team, pregame) tuple is the one that stands, and a premature run consumes
+# that slot with an earlier, staler roster.
+#
+# Same SSH mechanism, permissions and concurrency posture as
+# lane4-onbox-verification.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      write:
+        description: "Actually write snapshots (unchecked = dry run, reports only)"
+        required: false
+        default: false
+        type: boolean
+      capture_kind:
+        description: "Which capture this is"
+        required: false
+        default: "pregame"
+        type: choice
+        options:
+          - pregame
+          - in_game
+          - postgame
+      league:
+        description: "Registry league key (blank = every ACTIVE league)"
+        required: false
+        default: ""
+        type: string
+      week:
+        description: "Override the week Sleeper reports (blank = ask Sleeper)"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+jobs:
+  capture:
+    name: Game Day capture on production
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+    steps:
+      - name: Configure production SSH
+        env:
+          DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          install -d -m 700 "$HOME/.ssh"
+          printf '%s\n' "$DEPLOY_SSH_PRIVATE_KEY" | sed 's/\r$//' > "$HOME/.ssh/id_ed25519"
+          printf '%s\n' "$DEPLOY_KNOWN_HOSTS" | sed 's/\r$//' > "$HOME/.ssh/known_hosts"
+          chmod 600 "$HOME/.ssh/id_ed25519"
+          chmod 644 "$HOME/.ssh/known_hosts"
+          ssh-keygen -y -f "$HOME/.ssh/id_ed25519" >/dev/null
+          echo "PORT=${DEPLOY_PORT:-22}" >> "$GITHUB_ENV"
+
+      - name: Run capture on the box
+        id: capture
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          APP_DIR: ${{ vars.PROD_APP_DIR || '/home/dynasty/trade-calculator' }}
+          CAPTURE_KIND: ${{ inputs.capture_kind || 'pregame' }}
+          LEAGUE_KEY: ${{ inputs.league }}
+          WEEK: ${{ inputs.week }}
+          WRITE: ${{ inputs.write && '1' || '' }}
+          RUN_ID: gha-${{ github.run_id }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          set -o pipefail
+          rc=0
+          ssh -i "$HOME/.ssh/id_ed25519" \
+            -o BatchMode=yes -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+            -o ConnectTimeout=15 -o ServerAliveInterval=15 \
+            -p "$PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "APP_DIR=$(printf %q "$APP_DIR") CAPTURE_KIND=$(printf %q "$CAPTURE_KIND") LEAGUE_KEY=$(printf %q "$LEAGUE_KEY") WEEK=$(printf %q "$WEEK") WRITE=$(printf %q "$WRITE") RUN_ID=$(printf %q "$RUN_ID") bash -s" <<'REMOTE' 2>&1 | tee game-day-capture.txt || rc=$?
+          set -Eeuo pipefail
+          cd "$APP_DIR"
+          echo "### deployed_sha: $(git rev-parse HEAD)"
+          echo "### utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "### capture_kind: $CAPTURE_KIND"
+          echo "### mode: ${WRITE:+WRITE}${WRITE:-DRY-RUN}"
+          echo "###"
+          PY="$APP_DIR/.venv/bin/python"
+          [ -x "$PY" ] || PY="$APP_DIR/venv/bin/python"
+          [ -x "$PY" ] || PY=python3
+
+          ARGS="--capture-kind $CAPTURE_KIND --run-id $RUN_ID"
+          [ -n "$LEAGUE_KEY" ] && ARGS="$ARGS --league $LEAGUE_KEY"
+          [ -n "$WEEK" ] && ARGS="$ARGS --week $WEEK"
+          [ -z "$WRITE" ] && ARGS="$ARGS --dry-run"
+
+          # -u for the same reason lane4-onbox-verification.yml needs it:
+          # no TTY at any hop, so block-buffered stdout can leave a killed
+          # run indistinguishable from a silent one.
+          set +e
+          "$PY" -u scripts/capture_game_day_predictions.py $ARGS
+          capture_rc=$?
+          set -e
+          echo "### capture-exit: $capture_rc"
+
+          # Show what is actually on disk afterwards. A workflow that
+          # reports "wrote 12 snapshots" and cannot show 12 files is
+          # reporting its own intent, not the state of production.
+          echo "###"
+          echo "### archive contents:"
+          find data/game_day/predictions -name '*.json' 2>/dev/null \
+            | sed 's|^|###   |' | sort | head -60 || true
+          echo "### archive file count: $(find data/game_day/predictions -name '*.json' 2>/dev/null | wc -l)"
+          exit "$capture_rc"
+          REMOTE
+          echo "capture_exit=$rc" >> "$GITHUB_OUTPUT"
+          echo "rc=$rc"
+          exit "$rc"
+
+      - name: Upload capture log
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: game-day-capture-log
+          path: game-day-capture.txt
+          if-no-files-found: warn
+
+      - name: Summarise
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          {
+            echo "## Game Day capture (${{ inputs.capture_kind || 'pregame' }})"
+            echo ""
+            echo "Mode: ${{ inputs.write && 'WRITE' || 'DRY RUN' }}"
+            echo "Script exit: ${{ steps.capture.outputs.capture_exit }}"
+            echo ""
+            echo "Exit codes: 0 captured/already captured · 1 error ·"
+            echo "2 nothing to do (preseason or no week) · **3 REFUSED — the"
+            echo "pregame window has closed and that week's observation is"
+            echo "permanently unrecoverable**."
+            echo ""
+            echo '```'
+            cat game-day-capture.txt 2>/dev/null || echo "(no log)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/config/ci/release_gate_classification.json
+++ b/config/ci/release_gate_classification.json
@@ -320,6 +320,18 @@
     "fd-diagnostics.yml::inventory::Configure production SSH": {
       "category": "blocking"
     },
+    "game-day-capture.yml::capture::Configure production SSH": {
+      "category": "blocking"
+    },
+    "game-day-capture.yml::capture::Run capture on the box": {
+      "category": "blocking"
+    },
+    "game-day-capture.yml::capture::Upload capture log": {
+      "category": "blocking"
+    },
+    "game-day-capture.yml::capture::Summarise": {
+      "category": "blocking"
+    },
     "health-check.yml::health::Check /api/health": {
       "category": "blocking"
     },

--- a/deploy/install-systemd-service.sh
+++ b/deploy/install-systemd-service.sh
@@ -1151,6 +1151,7 @@ main() {
   install_simple_timer "depth-charts-refresh" "ESPN depth-chart diff -> BDVM promotion/demotion events"
   install_simple_timer "injury-feed-refresh" "ESPN injury-status diff -> BDVM injury/return events"
   install_simple_timer "trending-history-refresh" "Sleeper trending adds+drops history snapshot"
+  install_simple_timer "game-day-capture" "pre-kickoff Game Day prediction archive capture"
 
   # ── daemon-reload and enable ────────────────────────────────────────────
   # ce_needs_install was missing from this list. Every other timer's

--- a/deploy/systemd/dynasty-game-day-capture.service.template
+++ b/deploy/systemd/dynasty-game-day-capture.service.template
@@ -1,0 +1,54 @@
+[Unit]
+Description=Game Day pre-game prediction archive capture (__SERVICE_NAME__)
+After=network-online.target
+Wants=network-online.target
+
+# Writes data/game_day/predictions/<season>/<league>/week_<n>/<team>_<kind>.json
+# via scripts/capture_game_day_predictions.py, which is the missing caller
+# for src/ros/game_day_archive.py (C5-GD-02).
+#
+# WHY THIS EXISTS AT ALL: the archive module shipped 2026-08-20 with the
+# explicit rationale that a pre-game prediction snapshot is PERISHABLE —
+# "once a week is scored, the pre-event state that produced any prediction
+# is gone unless it was captured before the outcome was known" — and then
+# had NO caller anywhere in the repo. A grep across .github/workflows/ and
+# scripts/ returned zero matches. It was capturing nothing.
+#
+# WHY A PROD-SIDE TIMER AND NOT CI: same reasoning as dynasty-faab-history
+# and dynasty-bdvm-refresh. data/ is gitignored repo-wide, so an archive
+# written on a CI runner never reaches the VPS and is discarded with the
+# runner. Worse here than elsewhere: the projection snapshots this capture
+# joins against (data/bdvm/projections/) exist ONLY on the box, written by
+# dynasty-bdvm-refresh, so a CI run would also record a uniformly
+# estimate-less snapshot. The evidence and its inputs are both local.
+#
+# Deploys do not endanger what this writes: deploy.sh updates tracked
+# files with `git checkout --force` and never removes gitignored data/.
+#
+# Exit codes (scripts/capture_game_day_predictions.py):
+#   0 - every league captured, or already was (the append-only skip)
+#   1 - hard error for at least one league
+#   2 - nothing to do (out of season, preseason, or no week resolved)
+#   3 - REFUSED: the pregame window has closed for a league
+#
+# Exit 3 is the one to page on. It means the timer fired after kickoff and
+# that week's pregame observation is permanently unrecoverable — the script
+# will not reconstruct one and label it pregame. Investigate the schedule,
+# do not re-run with a later capture_kind expecting the same evidence.
+
+[Service]
+Type=oneshot
+User=__APP_USER__
+Group=__APP_USER__
+WorkingDirectory=__APP_DIR__
+EnvironmentFile=-__APP_DIR__/.env
+ExecStart=__VENV_DIR__/bin/python __APP_DIR__/scripts/capture_game_day_predictions.py --capture-kind pregame --run-id systemd-timer
+StandardOutput=journal
+StandardError=journal
+# A handful of Sleeper reads per league plus one projection-snapshot load.
+# Never on a request path, but it IS time-critical, so it does not get the
+# idle IO class the sharp crawlers use.
+TimeoutStartSec=900
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/dynasty-game-day-capture.timer.template
+++ b/deploy/systemd/dynasty-game-day-capture.timer.template
@@ -1,0 +1,44 @@
+[Unit]
+Description=Weekly pre-kickoff Game Day prediction capture for __SERVICE_NAME__
+# No Requires= here: [Timer] Unit= already binds the service, and a
+# [Unit] Requires= would start it on every boot regardless of OnCalendar.
+
+[Timer]
+# THURSDAY, BEFORE THE WEEK'S FIRST KICKOFF, AND THAT BOUND IS THE WHOLE
+# DESIGN. The capture is only honest while no game counting toward the
+# week has been played; the script refuses (exit 3) once Sleeper reports
+# any score, because a snapshot reconstructed afterwards and labelled
+# "pregame" is worse than a missing one — nothing downstream could tell.
+#
+# 13:00 UTC is chosen against the EARLIEST first-kickoff the season has,
+# not against the usual one:
+#   * ordinary week — Thursday Night Football, 20:15 ET = 00:15 UTC Fri,
+#     so 13:00 UTC Thursday clears it by ~11 hours;
+#   * THANKSGIVING — a Thursday with a 12:30 ET (17:30 UTC) kickoff,
+#     which is the binding constraint. A late-afternoon slot would be
+#     refused outright that week, losing it permanently.
+# It is also after Wednesday waiver processing, so the roster captured is
+# the one that actually starts the week.
+#
+# The 15:30 UTC second fire is a FREE RETRY, not a second observation: the
+# archive is append-only and refuses a duplicate (league, season, week,
+# team, capture_kind), which the script reports as an already-captured
+# skip and not an error. So a run that succeeded at 13:00 makes 15:30 a
+# no-op, while a 13:00 blocked by a Sleeper outage still gets a second
+# chance inside the Thanksgiving-safe window.
+OnCalendar=Thu *-*-* 13:00:00 UTC
+OnCalendar=Thu *-*-* 15:30:00 UTC
+# Deliberately NO RandomizedDelaySec: every other timer in this directory
+# spreads load, but this one is racing a kickoff. Jitter here buys nothing
+# and can only move the run closer to the deadline.
+#
+# Persistent=true catches up a fire missed to a reboot. It cannot resurrect
+# a missed WINDOW — a catch-up run after kickoff is refused by the same
+# gate, which is correct: the observation is gone, and the timer must not
+# manufacture a replacement.
+Persistent=true
+AccuracySec=1min
+Unit=__SERVICE_NAME__-game-day-capture.service
+
+[Install]
+WantedBy=timers.target

--- a/docs/season-launch/2026_SEASON_LAUNCH_STATUS.md
+++ b/docs/season-launch/2026_SEASON_LAUNCH_STATUS.md
@@ -1,11 +1,94 @@
 # 2026 season-launch readiness — pregame / Game Day / postgame
 
-**Audit date:** 2026-09-03 (pre-Week-1). Owner priority order: pregame writeups →
-Game Day dashboard → postgame writeups, all before kickoff. This document
-records what already exists so no future session re-derives it, and names the
-single highest-value next action per surface. It is a status/audit record,
-not an authorization — none of this is V1-required (Game Day is explicitly
-POST-V1 per `docs/VERSION_1_COMPLETION_CONTRACT.md` §4.1).
+**Audit date:** 2026-09-03 (pre-Week-1). **Updated 2026-09-04** — the owner's
+season-launch directive answered this document's two open scope questions and
+authorized the tranche; §0 records live state, the sections below keep the
+original audit. Owner priority order: perishable evidence capture → pregame
+writeups → Game Day dashboard → postgame. This document records what already
+exists so no future session re-derives it, and names the single highest-value
+next action per surface. Game Day remains POST-V1 per
+`docs/VERSION_1_COMPLETION_CONTRACT.md` §4.1; nothing here reopens V1.
+
+## 0. Live status — 2026-09-04
+
+**The clock.** Sleeper's own `/state/nfl` reports `season=2026 week=1
+season_type=regular` as of 2026-09-04. Week 1's first kickoff is Thursday
+2026-09-10 (~00:15 UTC Fri). **The pregame capture window is OPEN and closes
+at that kickoff**, permanently.
+
+**Owner scope questions — ANSWERED by the directive**, so neither is blocking
+any more. Both public and private are wanted: "polished public Week 1 pregame
+coverage suitable for league members" AND "richer private owner-facing matchup
+intelligence", from the same canonical data with correct public/private
+filtering. §1 and §3 below are updated only by this note; their factual audit
+stands.
+
+| component | state | note |
+|---|---|---|
+| Game Day archive capture | IMPLEMENTED — awaiting merge/deploy | §2a |
+| Week 1 pregame (public) | READY, unverified for Week 1 specifically | §1 |
+| Week 1 pregame (private) | NOT STARTED | scope now authorized |
+| Game Day dashboard | NOT STARTED | §2; methodology decision outstanding |
+
+**Methodology finding that constrains Game Day, recorded here so it is not
+re-derived.** `config/projections/source_capability_census.json` has exactly
+two `implementationStatus: LIVE` `PROJECTION_MODEL` sources —
+`clayProjections` and `idpShowProjections` — and **both are
+`PRESEASON_FULL_SEASON` horizon. There are ZERO live WEEKLY-horizon projection
+sources.** `src/ros/projection_ensemble.py` says so in its own docstring and is
+why `C5-PROJ-D` (ROS/full-season) was built before `C5-PROJ-C` (weekly). So a
+Week 1 per-player point estimate today is a full-season projection's per-game
+figure, and any Game Day simulator's per-week variance term has no live weekly
+source to fit against. That is an owner methodology decision, not something to
+invent, and it is the one genuine owner decision this tranche surfaces.
+
+### 2a. Game Day archive capture — IMPLEMENTED (2026-09-04)
+
+The gap §2 recorded ("a pure library module with **no caller**") is closed:
+
+- `src/ros/game_day_capture.py` — the resolution half: the pregame window
+  gate, slot eligibility, IR/taxi subtraction, estimate joining. Pure
+  functions of already-fetched payloads, so it is testable with no network.
+- `scripts/capture_game_day_predictions.py` — the CLI. Exit codes
+  0 captured/already-captured · 1 error · 2 nothing to do · **3 REFUSED**.
+- `deploy/systemd/dynasty-game-day-capture.{service,timer}.template` — the
+  schedule: **Thursday 13:00 UTC, retry 15:30 UTC**. Chosen against the
+  season's EARLIEST first kickoff (Thanksgiving, 17:30 UTC), not the usual
+  Thursday-night one, and after Wednesday waiver processing.
+- `.github/workflows/game-day-capture.yml` — manual "capture now" + a
+  dry-run verify mode, running the same script on the box over SSH.
+- `tests/ros/test_game_day_capture.py` — 23 tests.
+
+Three decisions worth not re-litigating:
+
+1. **It runs on the box, not in CI.** Same reason `dynasty-faab-history`
+   gives: `data/` is gitignored repo-wide, so an archive written on a runner
+   is discarded with the runner. Sharper here — the projection snapshots the
+   capture joins against (`data/bdvm/projections/`) exist only on the box, so
+   a CI run would also record a uniformly estimate-less snapshot.
+2. **A `pregame` capture is REFUSED once the week has begun**
+   (`week_has_begun` — any nonzero team or player score from Sleeper). The
+   archive itself cannot enforce this: `record_snapshot` takes `capture_kind`
+   from its caller and its truthful `captured_at` proves *when* a capture ran,
+   not that the week was unplayed when it did. A missed window stays missing.
+3. **A preseason `season_type` is refused** (exit 2). The archive keys on
+   `(league, season, week, team, capture_kind)` with no season-type axis, so a
+   preseason run would consume the real Week 1 pregame slot with a preseason
+   roster and then refuse the genuine capture as a duplicate.
+
+Dry-run against live Sleeper, 2026-09-04, both leagues resolving end to end:
+
+```
+dynasty_main: teams=12 players=674 slots=21 (sleeper_roster_positions) scoring=sf1:9e51824690d091f9
+dynasty_new:  teams=10 players=290 slots=10 (sleeper_roster_positions) scoring=sf1:82a5f8ef2bfdb098
+```
+
+Estimates were `0/674` and `0/290` **in this sandbox only** — `data/bdvm/`
+is gitignored and exists on the box, where `dynasty-bdvm-refresh` writes it.
+Whether prod resolves real estimates is exactly what the workflow's dry-run
+mode is for, and it is **unverified until run there**.
+
+**Status: IMPLEMENTED. Not yet MERGED, DEPLOYED or PRODUCTION VERIFIED.**
 
 ## 1. Pregame writeups — READY (public factual layer), NOT STARTED (private decision-intelligence layer)
 

--- a/scripts/capture_game_day_predictions.py
+++ b/scripts/capture_game_day_predictions.py
@@ -43,7 +43,9 @@ from src.ros.game_day_capture import (  # noqa: E402
 )
 
 
-def _resolve_estimates(season: int, scoring_settings: dict) -> tuple[dict, str | None, tuple, tuple]:
+def _resolve_estimates(
+    season: int, scoring_settings: dict
+) -> tuple[dict, str | None, tuple, tuple]:
     """``(name → fpg, source label, loaded, unavailable)``.
 
     The only LIVE `PROJECTION_MODEL` sources in the census today are
@@ -60,9 +62,7 @@ def _resolve_estimates(season: int, scoring_settings: dict) -> tuple[dict, str |
     try:
         from src.ros.projection_ensemble import build_ros_full_season_ensemble
 
-        result = build_ros_full_season_ensemble(
-            season=season, scoring_settings=scoring_settings
-        )
+        result = build_ros_full_season_ensemble(season=season, scoring_settings=scoring_settings)
     except Exception as exc:  # noqa: BLE001 — a missing snapshot must not lose the roster capture
         print(f"    projections: unavailable ({type(exc).__name__}: {exc})")
         return {}, None, (), ()
@@ -85,21 +85,29 @@ def _resolve_estimates(season: int, scoring_settings: dict) -> tuple[dict, str |
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--league", action="append", default=[], metavar="KEY",
-                        help="registry league key; repeatable. Default: every ACTIVE league.")
-    parser.add_argument("--capture-kind", default="pregame",
-                        choices=["pregame", "in_game", "postgame"])
-    parser.add_argument("--season", type=int, default=None,
-                        help="override the season Sleeper reports.")
-    parser.add_argument("--week", type=int, default=None,
-                        help="override the week Sleeper reports.")
+    parser.add_argument(
+        "--league",
+        action="append",
+        default=[],
+        metavar="KEY",
+        help="registry league key; repeatable. Default: every ACTIVE league.",
+    )
+    parser.add_argument(
+        "--capture-kind", default="pregame", choices=["pregame", "in_game", "postgame"]
+    )
+    parser.add_argument(
+        "--season", type=int, default=None, help="override the season Sleeper reports."
+    )
+    parser.add_argument("--week", type=int, default=None, help="override the week Sleeper reports.")
     parser.add_argument("--run-id", default="", help="ties one batch of captures together.")
-    parser.add_argument("--allow-season-type", action="append", default=None,
-                        metavar="TYPE",
-                        help="Sleeper season_type values this run accepts. "
-                             "Default: regular, post.")
-    parser.add_argument("--dry-run", action="store_true",
-                        help="resolve and report, write nothing.")
+    parser.add_argument(
+        "--allow-season-type",
+        action="append",
+        default=None,
+        metavar="TYPE",
+        help="Sleeper season_type values this run accepts. " "Default: regular, post.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="resolve and report, write nothing.")
     args = parser.parse_args()
 
     if args.league:
@@ -119,11 +127,16 @@ def main() -> int:
     if season is None or week is None:
         state = sleeper_client.fetch_nfl_state()
         if not state:
-            print("ERROR: Sleeper /state/nfl unavailable and no --season/--week given. "
-                  "Refusing to guess the week.", file=sys.stderr)
+            print(
+                "ERROR: Sleeper /state/nfl unavailable and no --season/--week given. "
+                "Refusing to guess the week.",
+                file=sys.stderr,
+            )
             return 2
-        print(f"Sleeper state: season={state.get('season')} week={state.get('week')} "
-              f"season_type={state.get('season_type')}")
+        print(
+            f"Sleeper state: season={state.get('season')} week={state.get('week')} "
+            f"season_type={state.get('season_type')}"
+        )
         # A PRESEASON week 1 is not the regular season's week 1, and the
         # archive keys on (league, season, week, capture_kind) alone —
         # so capturing during the preseason would consume the real Week 1
@@ -133,8 +146,10 @@ def main() -> int:
         allowed = args.allow_season_type or ["regular", "post"]
         season_type = str(state.get("season_type") or "").strip().lower()
         if season_type not in allowed:
-            print(f"Nothing to do: season_type={season_type!r} is not in {allowed}. "
-                  "A preseason capture would consume the real week's slot.")
+            print(
+                f"Nothing to do: season_type={season_type!r} is not in {allowed}. "
+                "A preseason capture would consume the real week's slot."
+            )
             return 2
         if season is None:
             season = int(state.get("season") or 0) or None
@@ -145,15 +160,20 @@ def main() -> int:
         print("Nothing to do: no season/week resolved.")
         return 2
 
-    print(f"Capturing {args.capture_kind} for season {season}, week {week} "
-          f"across {len(configs)} league(s).{' [DRY RUN]' if args.dry_run else ''}")
+    print(
+        f"Capturing {args.capture_kind} for season {season}, week {week} "
+        f"across {len(configs)} league(s).{' [DRY RUN]' if args.dry_run else ''}"
+    )
 
     failures = 0
     refusals = 0
     players_meta = sleeper_client.fetch_nfl_players()
     if not players_meta:
-        print("ERROR: Sleeper players dump unavailable — positions and eligibility "
-              "would be unresolvable.", file=sys.stderr)
+        print(
+            "ERROR: Sleeper players dump unavailable — positions and eligibility "
+            "would be unresolvable.",
+            file=sys.stderr,
+        )
         return 1
 
     for cfg in configs:
@@ -161,7 +181,7 @@ def main() -> int:
         print(f"\n  {key}:")
         league_id = league_registry.get_sleeper_league_id(key)
         if not league_id:
-            print(f"    ERROR: no Sleeper league id", file=sys.stderr)
+            print("    ERROR: no Sleeper league id", file=sys.stderr)
             failures += 1
             continue
 
@@ -169,8 +189,7 @@ def main() -> int:
         rosters = sleeper_client.fetch_rosters(league_id)
         matchups = sleeper_client.fetch_matchups(league_id, week)
         if not league_payload or not rosters:
-            print(f"    ERROR: Sleeper returned no league payload or no rosters",
-                  file=sys.stderr)
+            print("    ERROR: Sleeper returned no league payload or no rosters", file=sys.stderr)
             failures += 1
             continue
 
@@ -204,9 +223,11 @@ def main() -> int:
             continue
 
         have, total = build.estimate_coverage
-        print(f"    teams={len(build.teams)} players={total} "
-              f"estimates={have}/{total} slots={len(build.starter_slots)} "
-              f"({build.starter_slot_source}) scoring={build.scoring_config_id}")
+        print(
+            f"    teams={len(build.teams)} players={total} "
+            f"estimates={have}/{total} slots={len(build.starter_slots)} "
+            f"({build.starter_slot_source}) scoring={build.scoring_config_id}"
+        )
         for note in build.notes:
             print(f"    note: {note}")
         if args.dry_run:

--- a/scripts/capture_game_day_predictions.py
+++ b/scripts/capture_game_day_predictions.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Capture each league's pre-game prediction state into the Game Day archive.
+
+`src/ros/game_day_archive.py` (C5-GD-02) was built specifically because
+this observation is PERISHABLE — "once a week is scored, the pre-event
+state that produced any prediction is gone unless it was captured before
+the outcome was known" — and then shipped with no caller for two weeks.
+This script is the caller. `src/ros/game_day_capture.py` holds the
+resolution logic; this file owns only fetching, iteration and reporting.
+
+Run it BEFORE a week's first kickoff. It refuses to write a `pregame`
+capture once Sleeper is reporting scores for that week (exit 3): a
+snapshot reconstructed after the fact and labelled `pregame` is worse
+than a missing one, because nothing downstream could tell.
+
+Idempotent: the archive is append-only and refuses a duplicate
+(league, season, week, team, capture_kind), which this script reports as
+an already-captured skip rather than an error — so a retried cron, or a
+second run in the same window, is safe.
+
+Exit codes
+    0  every requested league is captured (newly, or already was)
+    1  at least one league failed
+    2  nothing to do — no leagues configured, or no week resolved
+    3  refused — the pregame window has closed for a requested league
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.api import league_registry  # noqa: E402
+from src.public_league import sleeper_client  # noqa: E402
+from src.ros.game_day_archive import GameDayArchiveError, record_snapshot  # noqa: E402
+from src.ros.game_day_capture import (  # noqa: E402
+    GameDayCaptureRefusal,
+    build_capture,
+    estimate_index_from_ensemble,
+)
+
+
+def _resolve_estimates(season: int, scoring_settings: dict) -> tuple[dict, str | None, tuple, tuple]:
+    """``(name → fpg, source label, loaded, unavailable)``.
+
+    The only LIVE `PROJECTION_MODEL` sources in the census today are
+    `clayProjections` and `idpShowProjections`, both
+    `PRESEASON_FULL_SEASON` horizon — there are ZERO live WEEKLY-horizon
+    sources (`config/projections/source_capability_census.json`). So the
+    per-game figure from a full-season projection is the best available
+    Week 1 point estimate, and the label says exactly that rather than
+    implying a weekly projection exists.
+
+    Any failure yields no estimates and no label, which the capture
+    records as `point_estimate=None` throughout — never 0.0.
+    """
+    try:
+        from src.ros.projection_ensemble import build_ros_full_season_ensemble
+
+        result = build_ros_full_season_ensemble(
+            season=season, scoring_settings=scoring_settings
+        )
+    except Exception as exc:  # noqa: BLE001 — a missing snapshot must not lose the roster capture
+        print(f"    projections: unavailable ({type(exc).__name__}: {exc})")
+        return {}, None, (), ()
+
+    if not result.ensemble:
+        print(
+            f"    projections: no observations "
+            f"(loaded={list(result.sources_loaded)} unavailable={list(result.sources_unavailable)})"
+        )
+        return {}, None, tuple(result.sources_loaded), tuple(result.sources_unavailable)
+
+    label = f"ros_ensemble:{result.horizon}:equal_family_mean"
+    return (
+        estimate_index_from_ensemble(result.ensemble),
+        label,
+        tuple(result.sources_loaded),
+        tuple(result.sources_unavailable),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--league", action="append", default=[], metavar="KEY",
+                        help="registry league key; repeatable. Default: every ACTIVE league.")
+    parser.add_argument("--capture-kind", default="pregame",
+                        choices=["pregame", "in_game", "postgame"])
+    parser.add_argument("--season", type=int, default=None,
+                        help="override the season Sleeper reports.")
+    parser.add_argument("--week", type=int, default=None,
+                        help="override the week Sleeper reports.")
+    parser.add_argument("--run-id", default="", help="ties one batch of captures together.")
+    parser.add_argument("--allow-season-type", action="append", default=None,
+                        metavar="TYPE",
+                        help="Sleeper season_type values this run accepts. "
+                             "Default: regular, post.")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="resolve and report, write nothing.")
+    args = parser.parse_args()
+
+    if args.league:
+        configs = [league_registry.get_league_by_key(k) for k in args.league]
+        for key, cfg in zip(args.league, configs):
+            if cfg is None:
+                print(f"ERROR: unknown league key {key!r}", file=sys.stderr)
+        configs = [c for c in configs if c is not None]
+    else:
+        configs = list(league_registry.active_leagues())
+
+    if not configs:
+        print("Nothing to do: no leagues resolved.")
+        return 2
+
+    season, week = args.season, args.week
+    if season is None or week is None:
+        state = sleeper_client.fetch_nfl_state()
+        if not state:
+            print("ERROR: Sleeper /state/nfl unavailable and no --season/--week given. "
+                  "Refusing to guess the week.", file=sys.stderr)
+            return 2
+        print(f"Sleeper state: season={state.get('season')} week={state.get('week')} "
+              f"season_type={state.get('season_type')}")
+        # A PRESEASON week 1 is not the regular season's week 1, and the
+        # archive keys on (league, season, week, capture_kind) alone —
+        # so capturing during the preseason would consume the real Week 1
+        # pregame slot with a preseason roster and then REFUSE the genuine
+        # capture as a duplicate. The gate is on the host's own
+        # season_type rather than a date, and it fails closed.
+        allowed = args.allow_season_type or ["regular", "post"]
+        season_type = str(state.get("season_type") or "").strip().lower()
+        if season_type not in allowed:
+            print(f"Nothing to do: season_type={season_type!r} is not in {allowed}. "
+                  "A preseason capture would consume the real week's slot.")
+            return 2
+        if season is None:
+            season = int(state.get("season") or 0) or None
+        if week is None:
+            raw_week = state.get("week")
+            week = int(raw_week) if raw_week not in (None, "") else None
+    if not season or not week:
+        print("Nothing to do: no season/week resolved.")
+        return 2
+
+    print(f"Capturing {args.capture_kind} for season {season}, week {week} "
+          f"across {len(configs)} league(s).{' [DRY RUN]' if args.dry_run else ''}")
+
+    failures = 0
+    refusals = 0
+    players_meta = sleeper_client.fetch_nfl_players()
+    if not players_meta:
+        print("ERROR: Sleeper players dump unavailable — positions and eligibility "
+              "would be unresolvable.", file=sys.stderr)
+        return 1
+
+    for cfg in configs:
+        key = cfg.key
+        print(f"\n  {key}:")
+        league_id = league_registry.get_sleeper_league_id(key)
+        if not league_id:
+            print(f"    ERROR: no Sleeper league id", file=sys.stderr)
+            failures += 1
+            continue
+
+        league_payload = sleeper_client.fetch_league(league_id)
+        rosters = sleeper_client.fetch_rosters(league_id)
+        matchups = sleeper_client.fetch_matchups(league_id, week)
+        if not league_payload or not rosters:
+            print(f"    ERROR: Sleeper returned no league payload or no rosters",
+                  file=sys.stderr)
+            failures += 1
+            continue
+
+        estimates, label, loaded, unavailable = _resolve_estimates(
+            int(season), dict(league_payload.get("scoring_settings") or {})
+        )
+
+        try:
+            build = build_capture(
+                league_key=key,
+                season=int(season),
+                week=int(week),
+                capture_kind=args.capture_kind,
+                league_payload=league_payload,
+                rosters=rosters,
+                matchups=matchups,
+                players_meta=players_meta,
+                roster_settings=cfg.roster_settings,
+                estimates=estimates,
+                estimate_source_label=label,
+                sources_loaded=loaded,
+                sources_unavailable=unavailable,
+            )
+        except GameDayCaptureRefusal as exc:
+            print(f"    REFUSED: {exc}", file=sys.stderr)
+            refusals += 1
+            continue
+        except ValueError as exc:
+            print(f"    ERROR: {exc}", file=sys.stderr)
+            failures += 1
+            continue
+
+        have, total = build.estimate_coverage
+        print(f"    teams={len(build.teams)} players={total} "
+              f"estimates={have}/{total} slots={len(build.starter_slots)} "
+              f"({build.starter_slot_source}) scoring={build.scoring_config_id}")
+        for note in build.notes:
+            print(f"    note: {note}")
+        if args.dry_run:
+            continue
+
+        wrote = skipped = 0
+        for team in build.teams:
+            try:
+                record_snapshot(
+                    league_key=build.league_key,
+                    season=build.season,
+                    week=build.week,
+                    team_id=team.team_id,
+                    capture_kind=build.capture_kind,
+                    scoring_config_id=build.scoring_config_id,
+                    starter_slots=build.starter_slots,
+                    roster=team.roster,
+                    run_id=args.run_id,
+                )
+                wrote += 1
+            except GameDayArchiveError:
+                # Append-only: this exact tuple is already captured. A
+                # retried cron must not overwrite the earlier, EARLIER
+                # observation — that one is the better evidence.
+                skipped += 1
+        print(f"    wrote {wrote} snapshot(s), {skipped} already captured")
+
+    if refusals:
+        print(f"\nREFUSED {refusals} league(s): pregame window closed.", file=sys.stderr)
+        return 3
+    if failures:
+        print(f"\nFAILED for {failures} league(s).", file=sys.stderr)
+        return 1
+    print("\nDone.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/public_league/sleeper_client.py
+++ b/src/public_league/sleeper_client.py
@@ -174,6 +174,20 @@ def _request_json(url: str, timeout: float = _DEFAULT_TIMEOUT) -> Any:
     return payload
 
 
+def fetch_nfl_state() -> dict[str, Any] | None:
+    """Sleeper's own ``/state/nfl``: the host's answer to "what season and
+    week is it right now".
+
+    Preferred over any calendar derivation for anything that must agree
+    with the league it is describing — Sleeper numbers its own weeks, and
+    a snapshot filed under a week the host disagrees with is filed under
+    the wrong week.  ``None`` on any failure, so a caller can refuse
+    rather than fall back to a guess.
+    """
+    data = _request_json(f"{SLEEPER_BASE}/state/nfl")
+    return data if isinstance(data, dict) else None
+
+
 def fetch_league(league_id: str) -> dict[str, Any] | None:
     data = _request_json(f"{SLEEPER_BASE}/league/{league_id}")
     return data if isinstance(data, dict) else None

--- a/src/ros/game_day_capture.py
+++ b/src/ros/game_day_capture.py
@@ -1,0 +1,360 @@
+"""C5-GD-02b — the scheduled caller for the Game Day prediction archive.
+
+`src/ros/game_day_archive.py` is a pure, append-only store that
+deliberately does not resolve anything: "a caller resolves point
+estimates ... and passes them in already-built."  It shipped 2026-08-20
+with **no caller at all** — a `grep` for it across `.github/workflows/`
+and `scripts/` returned zero matches — so the perishable observation it
+exists to protect was being lost every week regardless.  This module is
+that missing caller's resolution half; `scripts/capture_game_day_predictions.py`
+is its CLI and `.github/workflows/game-day-capture.yml` its schedule.
+
+**Split this way on purpose.**  Everything here is a pure function of
+already-fetched Sleeper payloads plus an already-built estimate index,
+so the whole resolution path — the pregame gate, slot eligibility,
+estimate joining, the missing-estimate semantics — is testable with no
+network and no live league.  The script owns fetching and the archive
+owns writing; neither is re-implemented here.
+
+**The pregame gate is the load-bearing part.**  The directive governing
+this unit is explicit that a snapshot reconstructed after games have
+begun must never be labelled `pregame`, and the archive itself cannot
+enforce that: `record_snapshot` takes `capture_kind` from its caller and
+stamps a truthful `captured_at`, which proves *when* a capture ran but
+not that the week was still unplayed when it did.  :func:`week_has_begun`
+answers that from the host's own evidence — any nonzero team or player
+score in the week's matchups — and :func:`build_capture` REFUSES a
+`pregame` capture once it is true.  A missed pregame window is missing
+evidence, permanently, and that is the correct outcome: the alternative
+is a snapshot that lies about what was knowable when it was taken.
+
+**Missing is never zero, twice over.**  A player no projection source
+covers is recorded with `point_estimate=None` (the archive's own
+contract forbids a fabricated 0.0), and a league whose projection
+snapshot is absent entirely produces a capture whose rosters are fully
+real and whose estimates are uniformly absent — still worth capturing,
+because roster composition on the morning of Week 1 is itself perishable
+and is not recoverable later.  `CaptureBuild.estimate_coverage` reports
+which of those two states a capture is in rather than leaving a reader
+to infer it from the row count.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+from src.ros.game_day_archive import PlayerPointEstimate
+from src.ros.lineup import (
+    RosterPlayer,
+    lineup_position,
+    player_eligible_for_slot,
+    resolve_starter_slots,
+)
+from src.utils.name_clean import normalize_player_name
+
+#: Roster buckets whose occupants cannot fill a starting slot this week,
+#: read from the roster payload itself rather than assumed.  Sleeper
+#: lists IR and taxi players inside ``players`` alongside everyone else,
+#: so without subtracting them a stashed rookie reads as an available
+#: starter.  Note this is roster-payload evidence, NOT the bracketed
+#: taxi-occupancy guess `src/trade/roster_capacity.py` has to make: there
+#: the membership is genuinely invisible, here the host hands it over.
+_NON_ACTIVE_ROSTER_BUCKETS: tuple[str, ...] = ("reserve", "taxi")
+
+
+class GameDayCaptureRefusal(RuntimeError):
+    """A capture that must not be written as asked.
+
+    Distinct from an error: nothing failed, the capture is simply not
+    honest to take.  The only current cause is a `pregame` capture
+    requested after the week has begun.
+    """
+
+
+@dataclass(frozen=True)
+class TeamCapture:
+    """One team's fully-resolved snapshot arguments, ready for
+    :func:`src.ros.game_day_archive.record_snapshot`."""
+
+    team_id: str
+    roster: tuple[PlayerPointEstimate, ...]
+
+    @property
+    def estimated_count(self) -> int:
+        return sum(1 for p in self.roster if p.point_estimate is not None)
+
+
+@dataclass
+class CaptureBuild:
+    """Everything one league-week capture needs, plus the provenance a
+    later calibration consumer will need to judge it."""
+
+    league_key: str
+    season: int
+    week: int
+    capture_kind: str
+    scoring_config_id: str
+    starter_slots: tuple[str, ...]
+    starter_slot_source: str | None
+    teams: tuple[TeamCapture, ...]
+    estimate_source_label: str | None
+    sources_loaded: tuple[str, ...] = ()
+    sources_unavailable: tuple[str, ...] = ()
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def estimate_coverage(self) -> tuple[int, int]:
+        """``(players with an estimate, players total)`` across every team.
+
+        Reported rather than derived by the reader so "no source covered
+        this league" (0 of N) and "a source covered part of it" (k of N)
+        are distinguishable at a glance — they are different evidence
+        states, not degrees of the same one.
+        """
+        total = sum(len(t.roster) for t in self.teams)
+        have = sum(t.estimated_count for t in self.teams)
+        return have, total
+
+
+def week_has_begun(matchups: Sequence[Mapping[str, Any]] | None) -> bool:
+    """Has any football counting toward this league-week been played?
+
+    Decided on the host's own scoring evidence — a nonzero team total or
+    any nonzero per-player score — never on a clock or a calendar
+    derivation.  Before kickoff Sleeper reports every team at 0.0 with an
+    empty (or all-zero) ``players_points`` map; the first score to land
+    flips this and it never flips back.
+
+    A genuinely all-zero week after kickoff is not a practical concern
+    across a full slate of teams, and the failure direction is the safe
+    one anyway: this returning ``False`` late would let a slightly-late
+    capture be labelled pregame, so the caller ALSO has the schedule-
+    independent option of simply not running after kickoff.  Returning
+    ``True`` early is impossible — a score cannot precede the game.
+
+    An absent or empty matchup list returns ``False``: a week Sleeper has
+    not published matchups for has certainly not been played.
+    """
+    for row in matchups or ():
+        if not isinstance(row, Mapping):
+            continue
+        try:
+            if float(row.get("points") or 0.0) > 0.0:
+                return True
+        except (TypeError, ValueError):
+            pass
+        points_map = row.get("players_points")
+        if isinstance(points_map, Mapping):
+            for value in points_map.values():
+                try:
+                    if float(value or 0.0) > 0.0:
+                        return True
+                except (TypeError, ValueError):
+                    continue
+    return False
+
+
+def estimate_index_from_ensemble(ensemble: Sequence[Any]) -> dict[str, float]:
+    """Normalized-name → per-game point estimate.
+
+    The ensemble keys players by ``player_key``, which is already a
+    normalized canonical name (`src/bdvm/projections.py`), so this is a
+    re-key rather than a re-normalization — the join key is the one the
+    projection lane already decided on.
+    """
+    out: dict[str, float] = {}
+    for obs in ensemble or ():
+        key = getattr(obs, "player_key", None)
+        value = getattr(obs, "combined_league_scored_fpg", None)
+        if not key or value is None:
+            continue
+        out[str(key)] = float(value)
+    return out
+
+
+def _player_positions(meta: Mapping[str, Any] | None) -> tuple[str, list[str]]:
+    """``(primary position, fantasy positions)`` from a Sleeper player row."""
+    if not isinstance(meta, Mapping):
+        return "", []
+    primary = str(meta.get("position") or "").strip().upper()
+    raw = meta.get("fantasy_positions")
+    fantasy = [str(p).strip().upper() for p in raw if p] if isinstance(raw, list) else []
+    if primary and primary not in fantasy:
+        fantasy = [primary, *fantasy]
+    return primary, fantasy
+
+
+def _display_name(meta: Mapping[str, Any] | None, player_id: str) -> str:
+    if not isinstance(meta, Mapping):
+        return ""
+    full = meta.get("full_name")
+    if full:
+        return str(full)
+    first = str(meta.get("first_name") or "").strip()
+    last = str(meta.get("last_name") or "").strip()
+    joined = f"{first} {last}".strip()
+    return joined or str(meta.get("last_name") or "")
+
+
+def build_team_roster(
+    *,
+    roster: Mapping[str, Any],
+    players_meta: Mapping[str, Any],
+    starter_slots: Sequence[str],
+    estimates: Mapping[str, float],
+    estimate_source_label: str | None,
+) -> tuple[PlayerPointEstimate, ...]:
+    """Resolve one Sleeper roster into archive rows.
+
+    Every rostered player is captured, including ones no slot can hold
+    and ones no source prices — `is_lineup_eligible` and
+    `point_estimate` carry those facts as data.  Dropping either class
+    would silently narrow what a future replay can see, in the direction
+    that hides coverage gaps.
+    """
+    player_ids = [str(p) for p in (roster.get("players") or []) if p]
+    inactive: set[str] = set()
+    for bucket in _NON_ACTIVE_ROSTER_BUCKETS:
+        for pid in roster.get(bucket) or ():
+            if pid:
+                inactive.add(str(pid))
+
+    rows: list[PlayerPointEstimate] = []
+    seen: set[str] = set()
+    for pid in player_ids:
+        if pid in seen:
+            # The archive refuses a duplicate player_id outright; a
+            # Sleeper roster listing one twice is a host artifact, not
+            # two roster spots, so collapse it here rather than failing
+            # the whole league's capture.
+            continue
+        seen.add(pid)
+        meta = players_meta.get(pid) if isinstance(players_meta, Mapping) else None
+        primary, fantasy = _player_positions(meta)
+        candidate = RosterPlayer(
+            player_id=pid,
+            canonical_name=_display_name(meta, pid),
+            position=primary,
+            ros_value=None,
+            fantasy_positions=tuple(fantasy),
+        )
+        eligible = pid not in inactive and any(
+            player_eligible_for_slot(slot, candidate) for slot in starter_slots
+        )
+
+        estimate: float | None = None
+        if estimate_source_label:
+            name_key = normalize_player_name(candidate.canonical_name)
+            if name_key:
+                found = estimates.get(name_key)
+                if found is not None:
+                    estimate = float(found)
+
+        rows.append(
+            PlayerPointEstimate(
+                player_id=pid,
+                # The lineup vocabulary, so a stored position means the
+                # same thing as the slots stored beside it.  An unknown
+                # position stays empty rather than becoming a guess.
+                position=lineup_position(primary) if primary else "",
+                is_lineup_eligible=eligible,
+                point_estimate=estimate,
+                estimate_source=estimate_source_label if estimate is not None else None,
+            )
+        )
+    return tuple(rows)
+
+
+def build_capture(
+    *,
+    league_key: str,
+    season: int,
+    week: int,
+    capture_kind: str,
+    league_payload: Mapping[str, Any],
+    rosters: Sequence[Mapping[str, Any]],
+    matchups: Sequence[Mapping[str, Any]] | None,
+    players_meta: Mapping[str, Any],
+    roster_settings: Mapping[str, Any] | None = None,
+    estimates: Mapping[str, float] | None = None,
+    estimate_source_label: str | None = None,
+    sources_loaded: Sequence[str] = (),
+    sources_unavailable: Sequence[str] = (),
+) -> CaptureBuild:
+    """Resolve one league-week into a :class:`CaptureBuild`.
+
+    Raises :class:`GameDayCaptureRefusal` for a `pregame` capture of a
+    week that has already begun, and ``ValueError`` for the two states
+    that make a capture meaningless rather than merely degraded: no
+    starter slots resolved (so lineup eligibility would be a fiction)
+    and no scoring card (so the snapshot could not say what rules it was
+    taken under).  Both fail closed rather than substituting a default —
+    a snapshot filed under the wrong league's scoring is worse than no
+    snapshot, because a future consumer cannot tell.
+    """
+    from src.league_comparison.sleeper_scoring import scoring_fingerprint  # noqa: PLC0415
+
+    if capture_kind == "pregame" and week_has_begun(matchups):
+        raise GameDayCaptureRefusal(
+            f"{league_key}/{season}/w{week}: the week has already begun (Sleeper is "
+            "reporting scores), so a 'pregame' capture would be a reconstruction "
+            "labelled as a prediction. This window is closed permanently; capture "
+            "'in_game' or 'postgame' instead. Missing pregame evidence stays missing."
+        )
+
+    scoring = league_payload.get("scoring_settings")
+    fingerprint = scoring_fingerprint(scoring)
+    if not fingerprint:
+        raise ValueError(
+            f"{league_key}: no usable scoring card from the host — a snapshot that "
+            "cannot name the rules it was taken under is not evidence."
+        )
+
+    slots, slot_source = resolve_starter_slots(
+        roster_positions=league_payload.get("roster_positions"),
+        roster_settings=dict(roster_settings) if roster_settings else None,
+    )
+    if not slots:
+        raise ValueError(
+            f"{league_key}: no starter slots resolved from the host or the registry — "
+            "lineup eligibility would be invented, so nothing is captured."
+        )
+
+    estimates = estimates or {}
+    teams: list[TeamCapture] = []
+    notes: list[str] = []
+    for roster in rosters or ():
+        team_id = roster.get("roster_id")
+        if team_id is None:
+            notes.append("skipped a roster with no roster_id")
+            continue
+        rows = build_team_roster(
+            roster=roster,
+            players_meta=players_meta,
+            starter_slots=slots,
+            estimates=estimates,
+            estimate_source_label=estimate_source_label,
+        )
+        if not rows:
+            # The archive refuses an empty roster ("not evidence, a
+            # caller bug"). An genuinely empty Sleeper roster is a real
+            # state though, so report it instead of raising.
+            notes.append(f"roster {team_id} has no players; not captured")
+            continue
+        teams.append(TeamCapture(team_id=str(team_id), roster=rows))
+
+    return CaptureBuild(
+        league_key=league_key,
+        season=season,
+        week=week,
+        capture_kind=capture_kind,
+        scoring_config_id=fingerprint,
+        starter_slots=tuple(slots),
+        starter_slot_source=slot_source,
+        teams=tuple(teams),
+        estimate_source_label=estimate_source_label,
+        sources_loaded=tuple(sources_loaded),
+        sources_unavailable=tuple(sources_unavailable),
+        notes=notes,
+    )

--- a/src/ros/game_day_capture.py
+++ b/src/ros/game_day_capture.py
@@ -117,6 +117,23 @@ class CaptureBuild:
         return have, total
 
 
+def _is_positive_score(raw: Any) -> bool:
+    """Is this a real, positive score?
+
+    An ABSENT value is not a zero. Both answer "no football has been
+    played" here, so the practical result is the same — but they are
+    written as the different statements they are, rather than coerced
+    together with an ``or 0.0`` that a reader (and the repo's
+    decision-path coercion gate) would have to take on trust.
+    """
+    if raw is None:
+        return False
+    try:
+        return float(raw) > 0.0
+    except (TypeError, ValueError):
+        return False
+
+
 def week_has_begun(matchups: Sequence[Mapping[str, Any]] | None) -> bool:
     """Has any football counting toward this league-week been played?
 
@@ -139,19 +156,12 @@ def week_has_begun(matchups: Sequence[Mapping[str, Any]] | None) -> bool:
     for row in matchups or ():
         if not isinstance(row, Mapping):
             continue
-        try:
-            if float(row.get("points") or 0.0) > 0.0:
-                return True
-        except (TypeError, ValueError):
-            pass
+        if _is_positive_score(row.get("points")):
+            return True
         points_map = row.get("players_points")
         if isinstance(points_map, Mapping):
-            for value in points_map.values():
-                try:
-                    if float(value or 0.0) > 0.0:
-                        return True
-                except (TypeError, ValueError):
-                    continue
+            if any(_is_positive_score(v) for v in points_map.values()):
+                return True
     return False
 
 

--- a/tests/ros/test_game_day_capture.py
+++ b/tests/ros/test_game_day_capture.py
@@ -26,9 +26,23 @@ from src.ros.game_day_capture import (
 # actually runs (measured 2026-09-04: 21 lineup slots from Sleeper's
 # roster_positions), trimmed to the slots these tests exercise.
 _ROSTER_POSITIONS = [
-    "QB", "RB", "RB", "WR", "WR", "TE",
-    "FLEX", "SUPER_FLEX", "DL", "LB", "DB", "IDP_FLEX",
-    "BN", "BN", "BN", "IR", "TAXI",
+    "QB",
+    "RB",
+    "RB",
+    "WR",
+    "WR",
+    "TE",
+    "FLEX",
+    "SUPER_FLEX",
+    "DL",
+    "LB",
+    "DB",
+    "IDP_FLEX",
+    "BN",
+    "BN",
+    "BN",
+    "IR",
+    "TAXI",
 ]
 
 _PLAYERS_META = {
@@ -236,9 +250,14 @@ def test_a_zero_estimate_is_kept_as_a_real_claim():
 def test_no_scoring_card_refuses_the_capture():
     with pytest.raises(ValueError, match="scoring card"):
         build_capture(
-            league_key="dynasty_main", season=2026, week=1, capture_kind="pregame",
+            league_key="dynasty_main",
+            season=2026,
+            week=1,
+            capture_kind="pregame",
             league_payload={"roster_positions": _ROSTER_POSITIONS, "scoring_settings": {}},
-            rosters=[_ROSTER], matchups=[], players_meta=_PLAYERS_META,
+            rosters=[_ROSTER],
+            matchups=[],
+            players_meta=_PLAYERS_META,
         )
 
 
@@ -246,9 +265,17 @@ def test_no_starter_slots_refuses_the_capture():
     """Without slots, `is_lineup_eligible` would be invented."""
     with pytest.raises(ValueError, match="starter slots"):
         build_capture(
-            league_key="dynasty_main", season=2026, week=1, capture_kind="pregame",
-            league_payload={"roster_positions": [], "scoring_settings": _LEAGUE["scoring_settings"]},
-            rosters=[_ROSTER], matchups=[], players_meta=_PLAYERS_META,
+            league_key="dynasty_main",
+            season=2026,
+            week=1,
+            capture_kind="pregame",
+            league_payload={
+                "roster_positions": [],
+                "scoring_settings": _LEAGUE["scoring_settings"],
+            },
+            rosters=[_ROSTER],
+            matchups=[],
+            players_meta=_PLAYERS_META,
             roster_settings={},
         )
 
@@ -258,8 +285,13 @@ def test_scoring_config_id_is_the_factual_fingerprint():
     from src.league_comparison.sleeper_scoring import scoring_fingerprint
 
     build = build_capture(
-        league_key="dynasty_main", season=2026, week=1, capture_kind="pregame",
-        league_payload=_LEAGUE, rosters=[_ROSTER], matchups=[],
+        league_key="dynasty_main",
+        season=2026,
+        week=1,
+        capture_kind="pregame",
+        league_payload=_LEAGUE,
+        rosters=[_ROSTER],
+        matchups=[],
         players_meta=_PLAYERS_META,
     )
     assert build.scoring_config_id == scoring_fingerprint(_LEAGUE["scoring_settings"])
@@ -267,10 +299,14 @@ def test_scoring_config_id_is_the_factual_fingerprint():
 
 def test_an_empty_roster_is_reported_not_raised():
     build = build_capture(
-        league_key="dynasty_main", season=2026, week=1, capture_kind="pregame",
+        league_key="dynasty_main",
+        season=2026,
+        week=1,
+        capture_kind="pregame",
         league_payload=_LEAGUE,
         rosters=[_ROSTER, {"roster_id": 9, "players": []}],
-        matchups=[], players_meta=_PLAYERS_META,
+        matchups=[],
+        players_meta=_PLAYERS_META,
     )
     assert len(build.teams) == 1
     assert any("no players" in n for n in build.notes)
@@ -281,8 +317,10 @@ def test_a_duplicate_player_id_is_collapsed_not_fatal():
     roster listing one twice is a host artifact, not two roster spots."""
     rows = build_team_roster(
         roster={"roster_id": 1, "players": ["qb1", "qb1", "rb1"]},
-        players_meta=_PLAYERS_META, starter_slots=_slots(),
-        estimates={}, estimate_source_label=None,
+        players_meta=_PLAYERS_META,
+        starter_slots=_slots(),
+        estimates={},
+        estimate_source_label=None,
     )
     assert [r.player_id for r in rows] == ["qb1", "rb1"]
 
@@ -292,8 +330,10 @@ def test_unknown_players_are_captured_with_an_empty_position():
     stays empty rather than becoming a guess."""
     rows = build_team_roster(
         roster={"roster_id": 1, "players": ["ghost"]},
-        players_meta=_PLAYERS_META, starter_slots=_slots(),
-        estimates={}, estimate_source_label=None,
+        players_meta=_PLAYERS_META,
+        starter_slots=_slots(),
+        estimates={},
+        estimate_source_label=None,
     )
     assert len(rows) == 1
     assert rows[0].position == ""
@@ -322,16 +362,26 @@ def test_capture_writes_once_and_refuses_the_rerun(tmp_path):
     from src.ros.game_day_archive import GameDayArchiveError
 
     build = build_capture(
-        league_key="dynasty_main", season=2026, week=1, capture_kind="pregame",
-        league_payload=_LEAGUE, rosters=[_ROSTER], matchups=[],
+        league_key="dynasty_main",
+        season=2026,
+        week=1,
+        capture_kind="pregame",
+        league_payload=_LEAGUE,
+        rosters=[_ROSTER],
+        matchups=[],
         players_meta=_PLAYERS_META,
     )
     team = build.teams[0]
     kwargs = dict(
-        league_key=build.league_key, season=build.season, week=build.week,
-        team_id=team.team_id, capture_kind=build.capture_kind,
+        league_key=build.league_key,
+        season=build.season,
+        week=build.week,
+        team_id=team.team_id,
+        capture_kind=build.capture_kind,
         scoring_config_id=build.scoring_config_id,
-        starter_slots=build.starter_slots, roster=team.roster, base_dir=tmp_path,
+        starter_slots=build.starter_slots,
+        roster=team.roster,
+        base_dir=tmp_path,
     )
     record_snapshot(**kwargs)
     with pytest.raises(GameDayArchiveError):

--- a/tests/ros/test_game_day_capture.py
+++ b/tests/ros/test_game_day_capture.py
@@ -1,0 +1,343 @@
+"""C5-GD-02b — the scheduled caller for the Game Day prediction archive.
+
+Covers the resolution half (`src/ros/game_day_capture.py`): the pregame
+window gate, best-ball slot eligibility across Superflex / FLEX / TE /
+IDP, the IR+taxi subtraction, and the missing-estimate semantics the
+archive's own contract requires.
+
+Deliberately network-free — every Sleeper payload here is a literal, so
+these run in the hard gate rather than under `livedata`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.ros.game_day_archive import load_snapshots_for_week, record_snapshot
+from src.ros.game_day_capture import (
+    GameDayCaptureRefusal,
+    build_capture,
+    build_team_roster,
+    estimate_index_from_ensemble,
+    week_has_begun,
+)
+
+# A real-shaped Superflex + TE + IDP league: the shape dynasty_main
+# actually runs (measured 2026-09-04: 21 lineup slots from Sleeper's
+# roster_positions), trimmed to the slots these tests exercise.
+_ROSTER_POSITIONS = [
+    "QB", "RB", "RB", "WR", "WR", "TE",
+    "FLEX", "SUPER_FLEX", "DL", "LB", "DB", "IDP_FLEX",
+    "BN", "BN", "BN", "IR", "TAXI",
+]
+
+_PLAYERS_META = {
+    "qb1": {"full_name": "Real Quarterback", "position": "QB", "fantasy_positions": ["QB"]},
+    "rb1": {"full_name": "Real Runningback", "position": "RB", "fantasy_positions": ["RB"]},
+    "wr1": {"full_name": "Real Receiver", "position": "WR", "fantasy_positions": ["WR"]},
+    "te1": {"full_name": "Real Tightend", "position": "TE", "fantasy_positions": ["TE"]},
+    "lb1": {"full_name": "Real Linebacker", "position": "LB", "fantasy_positions": ["LB"]},
+    "dl1": {"full_name": "Real Lineman", "position": "DL", "fantasy_positions": ["DL", "LB"]},
+    "k1": {"full_name": "Real Kicker", "position": "K", "fantasy_positions": ["K"]},
+    "ir1": {"full_name": "Hurt Guy", "position": "WR", "fantasy_positions": ["WR"]},
+    "taxi1": {"full_name": "Stashed Rookie", "position": "RB", "fantasy_positions": ["RB"]},
+}
+
+_LEAGUE = {
+    "roster_positions": _ROSTER_POSITIONS,
+    # A non-empty card so `scoring_fingerprint` returns a real identity.
+    "scoring_settings": {"rec": 1.0, "pass_td": 4.0, "pass_yd": 0.04, "rush_td": 6.0},
+}
+
+_ROSTER = {
+    "roster_id": 7,
+    "players": ["qb1", "rb1", "wr1", "te1", "lb1", "dl1", "k1", "ir1", "taxi1"],
+    "reserve": ["ir1"],
+    "taxi": ["taxi1"],
+}
+
+
+def _slots():
+    from src.ros.lineup import starter_slots_from_roster_positions
+
+    return starter_slots_from_roster_positions(_ROSTER_POSITIONS)
+
+
+# ── the pregame window gate ────────────────────────────────────────
+
+
+def test_week_has_not_begun_before_kickoff():
+    """Sleeper reports every team at 0.0 with empty player scores."""
+    matchups = [
+        {"roster_id": 1, "points": 0.0, "players_points": {}},
+        {"roster_id": 2, "points": 0, "players_points": {"qb1": 0.0}},
+    ]
+    assert week_has_begun(matchups) is False
+
+
+def test_week_has_begun_on_a_team_total():
+    assert week_has_begun([{"roster_id": 1, "points": 12.4, "players_points": {}}]) is True
+
+
+def test_week_has_begun_on_a_single_player_score():
+    """The Thursday-night game alone closes the window, even while every
+    team total is still rounding to zero."""
+    matchups = [{"roster_id": 1, "points": 0.0, "players_points": {"qb1": 0.0, "rb1": 3.2}}]
+    assert week_has_begun(matchups) is True
+
+
+def test_absent_matchups_have_not_begun():
+    assert week_has_begun(None) is False
+    assert week_has_begun([]) is False
+
+
+def test_malformed_scores_do_not_crash_the_gate():
+    matchups = [{"points": "not-a-number", "players_points": {"x": None, "y": "nope"}}]
+    assert week_has_begun(matchups) is False
+
+
+def test_build_refuses_a_pregame_capture_after_kickoff():
+    """The directive's hard rule: never reconstruct a 'pregame' snapshot
+    once games have started and label it pregame."""
+    with pytest.raises(GameDayCaptureRefusal) as exc:
+        build_capture(
+            league_key="dynasty_main",
+            season=2026,
+            week=1,
+            capture_kind="pregame",
+            league_payload=_LEAGUE,
+            rosters=[_ROSTER],
+            matchups=[{"roster_id": 1, "points": 44.0}],
+            players_meta=_PLAYERS_META,
+        )
+    assert "already begun" in str(exc.value)
+
+
+def test_in_game_capture_is_allowed_after_kickoff():
+    """The gate is specific to the `pregame` claim — a later capture of a
+    started week is exactly what `in_game` is for."""
+    build = build_capture(
+        league_key="dynasty_main",
+        season=2026,
+        week=1,
+        capture_kind="in_game",
+        league_payload=_LEAGUE,
+        rosters=[_ROSTER],
+        matchups=[{"roster_id": 1, "points": 44.0}],
+        players_meta=_PLAYERS_META,
+    )
+    assert build.capture_kind == "in_game"
+    assert len(build.teams) == 1
+
+
+# ── best-ball lineup eligibility ───────────────────────────────────
+
+
+def _eligibility(**kwargs):
+    rows = build_team_roster(
+        roster=_ROSTER,
+        players_meta=_PLAYERS_META,
+        starter_slots=_slots(),
+        estimates=kwargs.get("estimates", {}),
+        estimate_source_label=kwargs.get("label"),
+    )
+    return {r.player_id: r for r in rows}
+
+
+def test_superflex_flex_te_and_idp_are_all_eligible():
+    rows = _eligibility()
+    for pid in ("qb1", "rb1", "wr1", "te1", "lb1", "dl1"):
+        assert rows[pid].is_lineup_eligible is True, f"{pid} should fill a slot"
+
+
+def test_a_position_the_league_starts_nowhere_is_not_eligible():
+    """This league runs no K slot, so a kicker is rostered-but-unstartable
+    — a real state, captured as data rather than dropped."""
+    rows = _eligibility()
+    assert rows["k1"].is_lineup_eligible is False
+    assert "k1" in rows  # still captured
+
+
+def test_ir_and_taxi_players_are_captured_but_not_eligible():
+    """Sleeper lists IR and taxi players inside `players`; without
+    subtracting them a stashed rookie reads as an available starter."""
+    rows = _eligibility()
+    assert rows["ir1"].is_lineup_eligible is False
+    assert rows["taxi1"].is_lineup_eligible is False
+    assert rows["ir1"].position == "WR"  # captured, with its real position
+
+
+def test_a_hybrid_defender_is_eligible_through_its_second_position():
+    """`dl1` ships as DL with fantasy_positions ["DL","LB"] — Sleeper
+    evaluates eligibility over all of them."""
+    rows = _eligibility()
+    assert rows["dl1"].is_lineup_eligible is True
+
+
+# ── missing is never zero ──────────────────────────────────────────
+
+
+def test_uncovered_players_record_none_not_zero():
+    rows = _eligibility(estimates={"real quarterback": 21.0}, label="ros_ensemble:X")
+    assert rows["qb1"].point_estimate == 21.0
+    assert rows["qb1"].estimate_source == "ros_ensemble:X"
+    # Everyone else is genuinely uncovered.
+    assert rows["rb1"].point_estimate is None
+    assert rows["rb1"].estimate_source is None
+
+
+def test_no_projection_snapshot_still_captures_every_roster():
+    """A league with no projection source is still worth capturing:
+    roster composition on the morning of Week 1 is itself perishable."""
+    build = build_capture(
+        league_key="dynasty_main",
+        season=2026,
+        week=1,
+        capture_kind="pregame",
+        league_payload=_LEAGUE,
+        rosters=[_ROSTER],
+        matchups=[],
+        players_meta=_PLAYERS_META,
+        estimates={},
+        estimate_source_label=None,
+    )
+    have, total = build.estimate_coverage
+    assert (have, total) == (0, 9)
+    assert all(p.point_estimate is None for p in build.teams[0].roster)
+
+
+def test_estimate_coverage_reports_partial_coverage():
+    build = build_capture(
+        league_key="dynasty_main",
+        season=2026,
+        week=1,
+        capture_kind="pregame",
+        league_payload=_LEAGUE,
+        rosters=[_ROSTER],
+        matchups=[],
+        players_meta=_PLAYERS_META,
+        estimates={"real quarterback": 21.0, "real receiver": 13.5},
+        estimate_source_label="ros_ensemble:X",
+    )
+    assert build.estimate_coverage == (2, 9)
+
+
+def test_a_zero_estimate_is_kept_as_a_real_claim():
+    """0.0 means 'expected to score nothing', which is not the same
+    statement as 'we have no estimate'."""
+    rows = _eligibility(estimates={"real kicker": 0.0}, label="ros_ensemble:X")
+    assert rows["k1"].point_estimate == 0.0
+    assert rows["k1"].estimate_source == "ros_ensemble:X"
+
+
+# ── fail-closed structural refusals ────────────────────────────────
+
+
+def test_no_scoring_card_refuses_the_capture():
+    with pytest.raises(ValueError, match="scoring card"):
+        build_capture(
+            league_key="dynasty_main", season=2026, week=1, capture_kind="pregame",
+            league_payload={"roster_positions": _ROSTER_POSITIONS, "scoring_settings": {}},
+            rosters=[_ROSTER], matchups=[], players_meta=_PLAYERS_META,
+        )
+
+
+def test_no_starter_slots_refuses_the_capture():
+    """Without slots, `is_lineup_eligible` would be invented."""
+    with pytest.raises(ValueError, match="starter slots"):
+        build_capture(
+            league_key="dynasty_main", season=2026, week=1, capture_kind="pregame",
+            league_payload={"roster_positions": [], "scoring_settings": _LEAGUE["scoring_settings"]},
+            rosters=[_ROSTER], matchups=[], players_meta=_PLAYERS_META,
+            roster_settings={},
+        )
+
+
+def test_scoring_config_id_is_the_factual_fingerprint():
+    """Not the `scoringProfile` label — W18-F001's whole point."""
+    from src.league_comparison.sleeper_scoring import scoring_fingerprint
+
+    build = build_capture(
+        league_key="dynasty_main", season=2026, week=1, capture_kind="pregame",
+        league_payload=_LEAGUE, rosters=[_ROSTER], matchups=[],
+        players_meta=_PLAYERS_META,
+    )
+    assert build.scoring_config_id == scoring_fingerprint(_LEAGUE["scoring_settings"])
+
+
+def test_an_empty_roster_is_reported_not_raised():
+    build = build_capture(
+        league_key="dynasty_main", season=2026, week=1, capture_kind="pregame",
+        league_payload=_LEAGUE,
+        rosters=[_ROSTER, {"roster_id": 9, "players": []}],
+        matchups=[], players_meta=_PLAYERS_META,
+    )
+    assert len(build.teams) == 1
+    assert any("no players" in n for n in build.notes)
+
+
+def test_a_duplicate_player_id_is_collapsed_not_fatal():
+    """The archive refuses a duplicate player_id outright; a Sleeper
+    roster listing one twice is a host artifact, not two roster spots."""
+    rows = build_team_roster(
+        roster={"roster_id": 1, "players": ["qb1", "qb1", "rb1"]},
+        players_meta=_PLAYERS_META, starter_slots=_slots(),
+        estimates={}, estimate_source_label=None,
+    )
+    assert [r.player_id for r in rows] == ["qb1", "rb1"]
+
+
+def test_unknown_players_are_captured_with_an_empty_position():
+    """An unmapped Sleeper id still occupies a roster spot. Its position
+    stays empty rather than becoming a guess."""
+    rows = build_team_roster(
+        roster={"roster_id": 1, "players": ["ghost"]},
+        players_meta=_PLAYERS_META, starter_slots=_slots(),
+        estimates={}, estimate_source_label=None,
+    )
+    assert len(rows) == 1
+    assert rows[0].position == ""
+    assert rows[0].is_lineup_eligible is False
+
+
+# ── the estimate index ─────────────────────────────────────────────
+
+
+def test_estimate_index_skips_rows_with_no_value():
+    class _Obs:
+        def __init__(self, k, v):
+            self.player_key = k
+            self.combined_league_scored_fpg = v
+
+    idx = estimate_index_from_ensemble([_Obs("a", 12.0), _Obs("b", None), _Obs("", 3.0)])
+    assert idx == {"a": 12.0}
+
+
+# ── append-only, end to end through the real store ─────────────────
+
+
+def test_capture_writes_once_and_refuses_the_rerun(tmp_path):
+    """A retried cron must not overwrite the earlier observation — the
+    earlier one is the better evidence."""
+    from src.ros.game_day_archive import GameDayArchiveError
+
+    build = build_capture(
+        league_key="dynasty_main", season=2026, week=1, capture_kind="pregame",
+        league_payload=_LEAGUE, rosters=[_ROSTER], matchups=[],
+        players_meta=_PLAYERS_META,
+    )
+    team = build.teams[0]
+    kwargs = dict(
+        league_key=build.league_key, season=build.season, week=build.week,
+        team_id=team.team_id, capture_kind=build.capture_kind,
+        scoring_config_id=build.scoring_config_id,
+        starter_slots=build.starter_slots, roster=team.roster, base_dir=tmp_path,
+    )
+    record_snapshot(**kwargs)
+    with pytest.raises(GameDayArchiveError):
+        record_snapshot(**kwargs)
+
+    stored = load_snapshots_for_week("dynasty_main", 2026, 1, base_dir=tmp_path)
+    assert len(stored) == 1
+    assert stored[0].starter_slots == build.starter_slots
+    assert len(stored[0].roster) == 9


### PR DESCRIPTION
## Why this is urgent

`src/ros/game_day_archive.py` (C5-GD-02, delivered 2026-08-20) was built specifically because the observation it holds is **perishable** — its own docstring: *"once a week is scored, the pre-event state that produced any prediction is gone unless it was captured before the outcome was known."*

It shipped with **no caller anywhere in the repo**. `grep -rn game_day_archive .github/workflows/ scripts/` returns zero matches; the only reference outside the module is its own test. It has been capturing nothing since it landed.

Sleeper's `/state/nfl` reports `season=2026 week=1 season_type=regular` as of today, and all six Week 1 matchups are at `0.0`. **The Week 1 pregame window is open and closes at Thursday's kickoff, permanently.** This PR is the missing caller.

## What changed

| file | role |
|---|---|
| `src/ros/game_day_capture.py` | the resolution half — pregame gate, slot eligibility, IR/taxi subtraction, estimate joining |
| `scripts/capture_game_day_predictions.py` | the CLI (exit 0/1/2/**3**) |
| `deploy/systemd/dynasty-game-day-capture.{service,timer}.template` | the schedule |
| `.github/workflows/game-day-capture.yml` | manual "capture now" + dry-run verify, on the box over SSH |
| `sleeper_client.fetch_nfl_state` | the host's own season/week |
| `tests/ros/test_game_day_capture.py` | 23 tests |

Split so the whole resolution path is a pure function of already-fetched payloads — testable with no network and no live league. The script owns fetching, the archive owns writing; neither is re-implemented.

## Four decisions that are load-bearing

**1. It runs on the box, not in CI.** Same reason `dynasty-faab-history` states: `data/` is gitignored repo-wide, so an archive written on a runner is discarded with the runner. Sharper here — the projection snapshots the capture joins against (`data/bdvm/projections/`) exist *only* on the box, so a CI run would also record a uniformly estimate-less snapshot. `deploy.sh` updates tracked files with `git checkout --force` and never removes gitignored `data/`, so captures survive deploys.

**2. A `pregame` capture is REFUSED once the week has begun.** Decided on Sleeper's own scoring evidence (any nonzero team or player score), never a clock. The archive cannot enforce this itself: `record_snapshot` takes `capture_kind` from its caller, and its truthful `captured_at` proves *when* a capture ran, not that the week was still unplayed when it did. A missed window stays missing rather than being reconstructed and labelled pregame.

**3. A preseason `season_type` is refused** (exit 2). The archive keys on `(league, season, week, team, capture_kind)` with no season-type axis, so a preseason run would consume the real Week 1 pregame slot with a preseason roster and then refuse the genuine capture as a duplicate.

**4. The timer is timed against the season's *earliest* first kickoff.** Thursday 13:00 UTC, retry 15:30 UTC — sized for Thanksgiving's 17:30 UTC kickoff rather than the usual Thursday-night 00:15 UTC, and after Wednesday waiver processing. No `RandomizedDelaySec`: every other timer in that directory spreads load, but this one is racing a kickoff. The retry is free because the archive is append-only and the script reports a duplicate as an already-captured skip, not an error.

## Missing is never zero, twice over

- A player no source covers records `point_estimate=None` — the archive's own contract forbids a fabricated `0.0`, and a real `0.0` ("expected to score nothing") is kept as the distinct claim it is.
- A league with **no** projection snapshot still captures fully real rosters with uniformly absent estimates. Worth capturing: roster composition on the morning of Week 1 is itself perishable. `estimate_coverage` reports which state a capture is in rather than leaving a reader to infer it.

Two fail-closed refusals: no scoring card (a snapshot that cannot name its rules is not evidence) and no starter slots (lineup eligibility would be invented). `scoring_config_id` is the **factual** `scoring_fingerprint`, not the `scoringProfile` label — W18-F001.

## Verification

Dry-run against live Sleeper, both leagues resolving end to end:

```
dynasty_main: teams=12 players=674 slots=21 (sleeper_roster_positions) scoring=sf1:9e51824690d091f9
dynasty_new:  teams=10 players=290 slots=10 (sleeper_roster_positions) scoring=sf1:82a5f8ef2bfdb098
```

Estimates read `0/674` and `0/290` **in the sandbox only** — `data/bdvm/` is gitignored and lives on the box. Whether prod resolves real estimates is exactly what the workflow's dry-run mode is for, and it is **unverified until run there**.

Tests: **10,595 passed, 54 skipped, 0 failures** on the full `-m "not livedata"` gate.

## Status, stated precisely

**IMPLEMENTED.** Not yet MERGED, DEPLOYED or PRODUCTION VERIFIED. After merge the deploy installs the timer automatically (`install_simple_timer "game-day-capture"`, registered so `tests/deploy/test_all_timers_are_wired.py` covers it), then the workflow's dry-run mode should be dispatched to confirm the box captures before Thursday.

## Separately found, owner action required, not fixed here

`exports/narratives/` contains **two files total**, both `2025/week-17`. Zero 2026 articles exist. Every `weekly-narratives.yml` run reports **success in ~10 seconds** with every step after the key check `skipped` — `ANTHROPIC_API_KEY` is not configured, and the workflow deliberately surfaces that as a green skip. `matchupPreview` is not rendered by `/league` at all ("the AI-article tabs replaced those views"), so **the public Week 1 pregame experience depends entirely on articles that will not be generated** on Wednesday's cron unless that secret is added. Flagged for the owner; out of scope for this bounded PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmUK5EBJvJkzX8xb3s1Bve

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmUK5EBJvJkzX8xb3s1Bve)_