### PR TITLE
fix(pregame): label prior-season form, and stop reporting no form as zero

### DIFF
--- a/src/public_league/matchup_narrative.py
+++ b/src/public_league/matchup_narrative.py
@@ -889,6 +889,30 @@ and start/sit calls are fair game in the narrative.
 """
 
 
+# Week 1 (and any week whose recent-form window lies entirely in a
+# previous season) hands the model a ``record``/``avgPoints`` pair that
+# describes LAST season. Every game in that window is prior-season by
+# construction — including the championship, which is the most
+# quotable and the most misleading. Without this the model has the
+# per-game ``season`` fields available but no instruction to use them,
+# and the natural phrasing ("averaging 118 a week") silently asserts
+# current-season form that does not exist yet.
+_PRIOR_SEASON_FORM_BLURB = """\
+IMPORTANT — RECENT FORM IS FROM A PREVIOUS SEASON. For {sides}, every \
+game in the ``recentForm`` window predates this season. There is no \
+current-season form yet.
+
+* DO label it explicitly: "last season", "closed 2025 with", "their \
+  final three of a year ago". The per-game ``season`` field tells you \
+  which year each result belongs to.
+* DO NOT write ``record`` or ``avgPoints`` as though they describe this \
+  season, and do not write "coming off" or "riding a streak" without \
+  saying which season it was.
+* DO NOT invent current-season stats to fill the gap. A season that has \
+  not started has no results, and that is itself the story.
+"""
+
+
 _PRIOR_OPENERS_BLURB = """\
 Here are the opening lines (and headline) of every recent article you've \
 written for this league. DO NOT reuse phrasing, structure, or metaphor from \
@@ -963,8 +987,24 @@ def assemble_prompt(
         ),
     }[brief.mode]
 
+    # Goes in the USER message, not the cached system block: whether the
+    # form window is prior-season depends on the week being written, so
+    # caching it across articles would apply Week 1's instruction to
+    # Week 5.
+    prior_form_sides = [
+        label
+        for label, side in (("the home team", brief.home), ("the away team", brief.away))
+        if (side.get("recentForm") or {}).get("isPriorSeasonOnly")
+    ]
+    prior_form_directive = ""
+    if prior_form_sides:
+        prior_form_directive = (
+            _PRIOR_SEASON_FORM_BLURB.format(sides=" and ".join(prior_form_sides)) + "\n"
+        )
+
     user_text = (
         f"{mode_directive}\n\n"
+        f"{prior_form_directive}"
         f"=== MATCHUP BRIEF ===\n{brief_json}\n\n"
         f"=== PRIOR ARTICLES (anti-repetition source) ===\n{prior_text}\n"
     )

--- a/src/public_league/matchup_preview.py
+++ b/src/public_league/matchup_preview.py
@@ -3,7 +3,13 @@
 For each matchup on the upcoming (or most recent) week, surface:
     * All-time head-to-head record between the two owners.
     * Last 5 meetings with dates / scores / winner.
-    * Recent form — last 3 games per team (average points, W-L).
+    * Recent form — last 3 games per team (average points, W-L), with
+      the seasons that window actually spans.  In WEEK 1 every game in
+      it belongs to the PREVIOUS season, so the aggregates carry
+      ``seasons`` / ``isPriorSeasonOnly`` / ``spansSeasons`` and a
+      consumer must label them rather than presenting them as
+      current-season form.  ``avgPoints`` is ``None`` — never ``0.0`` —
+      when there are no prior games at all.
 
 Current-week detection:
     1. Walk the current season's weeks in order.
@@ -165,11 +171,35 @@ def _recent_form_for_owner(
     wins = sum(1 for e in recent if e["result"] == "W")
     losses = sum(1 for e in recent if e["result"] == "L")
     ties = sum(1 for e in recent if e["result"] == "T")
-    avg = round(sum(e["points"] for e in recent) / len(recent), 2) if recent else 0.0
+    # MISSING IS NEVER ZERO. A manager with no prior scored games has no
+    # measurable form; ``0.0`` would read as "averaged zero points",
+    # which is a claim no observation supports. Callers must render the
+    # absence rather than the number.
+    avg = round(sum(e["points"] for e in recent) / len(recent), 2) if recent else None
+
+    # WHICH SEASONS THIS WINDOW ACTUALLY SPANS. The per-game rows have
+    # always carried their own ``season``, but the aggregates did not —
+    # so ``record``/``avgPoints`` read as current-season form wherever
+    # they were shown or summarised. In WEEK 1 that is guaranteed wrong:
+    # every game in the window belongs to the PREVIOUS season, including
+    # the championship, and nothing in the payload said so.
+    seasons = sorted({e["season"] for e in recent}, key=_season_sort)
+    prior_only = bool(recent) and all(
+        _season_sort(e["season"]) < _season_sort(before_season) for e in recent
+    )
     return {
         "games": recent,
         "record": f"{wins}-{losses}" + (f"-{ties}" if ties else ""),
         "avgPoints": avg,
+        #: Distinct seasons contributing to this window, oldest first.
+        "seasons": seasons,
+        #: True when EVERY game predates the season being previewed —
+        #: the Week 1 case. Consumers must label the aggregates as prior
+        #: -season rather than presenting them as current-season form.
+        "isPriorSeasonOnly": prior_only,
+        #: True when the window straddles a season boundary, so the
+        #: aggregates mix two seasons and neither label alone is honest.
+        "spansSeasons": len(seasons) > 1,
     }
 
 

--- a/tests/public_league/test_matchup_narrative.py
+++ b/tests/public_league/test_matchup_narrative.py
@@ -20,6 +20,8 @@ Coverage map:
 
 from __future__ import annotations
 
+import copy
+
 import asyncio
 import json
 import os
@@ -619,3 +621,62 @@ class GenerateArticleTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class PriorSeasonFormDirectiveTests(unittest.TestCase):
+    """Week 1 hands the model a ``record``/``avgPoints`` pair describing
+    LAST season. The per-game ``season`` fields were always in the brief,
+    but nothing instructed the model to use them — so the natural
+    phrasing ("averaging 118 a week") silently asserts current-season
+    form that does not exist yet."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.snapshot = build_test_snapshot()
+        cls.brief = mn.build_brief(cls.snapshot, season="2025", week=16, matchup_id=1, mode="recap")
+
+    def _brief_with_prior_form(self, home: bool = True, away: bool = False):
+        brief = copy.deepcopy(self.brief)
+        brief.home.setdefault("recentForm", {})["isPriorSeasonOnly"] = home
+        brief.away.setdefault("recentForm", {})["isPriorSeasonOnly"] = away
+        return brief
+
+    def test_directive_absent_when_form_is_current_season(self) -> None:
+        _, messages = mn.assemble_prompt(
+            self._brief_with_prior_form(home=False, away=False), prior_articles=[]
+        )
+        self.assertNotIn("RECENT FORM IS FROM A PREVIOUS SEASON", messages[0]["content"])
+
+    def test_directive_present_and_names_the_affected_side(self) -> None:
+        _, messages = mn.assemble_prompt(
+            self._brief_with_prior_form(home=True, away=False), prior_articles=[]
+        )
+        content = messages[0]["content"]
+        self.assertIn("RECENT FORM IS FROM A PREVIOUS SEASON", content)
+        self.assertIn("the home team", content)
+        self.assertNotIn("the away team", content)
+
+    def test_directive_names_both_sides_in_week_one(self) -> None:
+        """The real Week 1 shape: neither side has current-season form."""
+        _, messages = mn.assemble_prompt(
+            self._brief_with_prior_form(home=True, away=True), prior_articles=[]
+        )
+        content = messages[0]["content"]
+        self.assertIn("the home team and the away team", content)
+
+    def test_directive_rides_the_user_message_not_the_cached_system_block(self) -> None:
+        """Whether the window is prior-season depends on the week being
+        written, so caching it would apply Week 1's instruction to Week 5."""
+        system, messages = mn.assemble_prompt(
+            self._brief_with_prior_form(home=True, away=True), prior_articles=[]
+        )
+        self.assertNotIn("RECENT FORM IS FROM A PREVIOUS SEASON", system[0]["text"])
+        self.assertIn("RECENT FORM IS FROM A PREVIOUS SEASON", messages[0]["content"])
+
+    def test_brief_still_carries_the_per_game_seasons(self) -> None:
+        """The directive tells the model to read a field; that field must
+        actually be there."""
+        for side in (self.brief.home, self.brief.away):
+            games = (side.get("recentForm") or {}).get("games") or []
+            for g in games:
+                self.assertIn("season", g)

--- a/tests/public_league/test_matchup_preview.py
+++ b/tests/public_league/test_matchup_preview.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 
 import unittest
 
-from src.public_league.matchup_preview import build_section, _pair_key
+from src.public_league.matchup_preview import (
+    build_section,
+    _pair_key,
+    _recent_form_for_owner,
+)
 from tests.public_league.fixtures import build_test_snapshot
 
 
@@ -92,3 +96,56 @@ class PreviewModeTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class RecentFormSeasonLabellingTests(unittest.TestCase):
+    """Week 1's recent-form window lies entirely in the PREVIOUS season.
+
+    The per-game rows always carried their own ``season``; the
+    aggregates did not, so ``record`` / ``avgPoints`` read as
+    current-season form wherever they were shown or summarised. In Week
+    1 that is guaranteed wrong — including the championship, which is
+    the most quotable game in the window and the most misleading.
+    """
+
+    def setUp(self) -> None:
+        self.snapshot = build_test_snapshot()
+        # Any owner the fixture actually attributes matchups to.
+        self.owner = sorted(self.snapshot.managers.by_owner_id)[0]
+
+    def test_a_window_entirely_in_a_prior_season_is_flagged(self) -> None:
+        # Week 1 of a season AFTER the fixture's data: every prior game
+        # belongs to an earlier season.
+        form = _recent_form_for_owner(self.snapshot, self.owner, "2026", 1, n=3)
+        self.assertTrue(form["games"], "fixture should supply prior games")
+        self.assertTrue(form["isPriorSeasonOnly"])
+        self.assertNotIn("2026", form["seasons"])
+
+    def test_a_mid_season_window_is_not_flagged_as_prior(self) -> None:
+        form = _recent_form_for_owner(self.snapshot, self.owner, "2025", 16, n=3)
+        self.assertTrue(form["games"])
+        self.assertFalse(form["isPriorSeasonOnly"])
+        self.assertIn("2025", form["seasons"])
+
+    def test_seasons_are_reported_oldest_first(self) -> None:
+        form = _recent_form_for_owner(self.snapshot, self.owner, "2026", 1, n=3)
+        self.assertEqual(form["seasons"], sorted(form["seasons"]))
+
+    def test_spans_seasons_matches_the_season_count(self) -> None:
+        form = _recent_form_for_owner(self.snapshot, self.owner, "2026", 1, n=3)
+        self.assertEqual(form["spansSeasons"], len(form["seasons"]) > 1)
+
+    def test_no_prior_games_reports_none_not_zero(self) -> None:
+        """MISSING IS NEVER ZERO. A manager with no scored history has
+        no measurable form; 0.0 would read as 'averaged zero points'."""
+        form = _recent_form_for_owner(self.snapshot, "owner-who-does-not-exist", "2026", 1)
+        self.assertEqual(form["games"], [])
+        self.assertIsNone(form["avgPoints"])
+        self.assertEqual(form["seasons"], [])
+        # An empty window is not "prior season only" — it is no evidence.
+        self.assertFalse(form["isPriorSeasonOnly"])
+        self.assertFalse(form["spansSeasons"])
+
+    def test_a_real_window_still_reports_a_numeric_average(self) -> None:
+        form = _recent_form_for_owner(self.snapshot, self.owner, "2025", 16, n=3)
+        self.assertIsInstance(form["avgPoints"], float)


### PR DESCRIPTION
## Why

Two Week 1 defects in `matchup_preview._recent_form_for_owner`. That helper is not only the public preview section's — `matchup_narrative.build_brief` calls it directly (`# H2H series + recent form lifted from matchup_preview's helpers`), so it feeds the **AI article brief** too. Whatever it gets wrong, the Week 1 articles inherit.

### 1. The aggregates carried no season

Each game row has always had its own `season`. `record` and `avgPoints` did not — so they read as *current-season* form wherever they were shown or summarised.

In **Week 1 that is guaranteed wrong**: every game in a 3-game window belongs to the previous season, including the championship — the most quotable game in the window and the most misleading. The directive is explicit that previous-season information must not be presented as current-season form without labelling.

The form dict now carries:

| field | meaning |
|---|---|
| `seasons` | distinct seasons in the window, oldest first |
| `isPriorSeasonOnly` | every game predates the season being previewed — the Week 1 case |
| `spansSeasons` | the window straddles a boundary, so neither label alone is honest |

### 2. `avgPoints` fell back to `0.0` with no games

**Missing is never zero.** A manager with no scored history has no measurable form, and `0.0` reads as "averaged zero points" — a claim no observation supports. It is `None` now.

An empty window is also explicitly **not** `isPriorSeasonOnly`: that is *no evidence*, not prior-season evidence. Both are pinned by test.

## The article generator gets a matching instruction

Adding fields to a brief the model already receives is only half a fix — the per-game `season` was always there and nothing told the model to use it, so the natural phrasing ("averaging 118 a week") silently asserts form that does not exist yet.

`_PRIOR_SEASON_FORM_BLURB` fires when either side's window is prior-season-only. It tells the model to label it explicitly, not to write `record`/`avgPoints` as current-season, and **not to invent current-season stats to fill the gap** — a season that has not started has no results, and that is itself the story.

It rides the **user** message, not the cached system block, because whether the window is prior-season depends on the week being written; caching it would apply Week 1's instruction to Week 5. Pinned by test.

## Scope

Repairs the **canonical owner**. No second form helper, no second article pipeline — the narrative path already reuses these helpers deliberately, which is exactly why fixing them here reaches both surfaces.

Note `matchupPreview` is not currently rendered by `/league` ("the AI-article tabs replaced those views"), so today the user-visible effect of this change lands through the article brief. The section data is still shipped in the public contract and is now honest.

## Verification

- 11 new tests — 6 in `test_matchup_preview.py`, 5 in `test_matchup_narrative.py`.
- Full hard gate: **10,606 passed, 54 skipped, 0 failures** (`-m "not livedata"`).
- `ruff format --check`, `ruff check`, the decision-path coercion gate, and the audit-status / planning-integrity / product-plan-governance gates all clean, run locally against the repo's pinned ruff.

## Still blocked on the owner, unchanged

`ANTHROPIC_API_KEY` is not configured, so `weekly-narratives.yml` skips every step after its key check and reports success in ~10 seconds. `exports/narratives/` holds two files, both `2025/week-17`. **This PR makes the Week 1 articles more truthful; it does not make them exist.** The preview cron fires Wed Sept 9, kickoff Thu Sept 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmUK5EBJvJkzX8xb3s1Bve

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmUK5EBJvJkzX8xb3s1Bve)_