### PR TITLE
feat(game-day): the canonical league-aware weekly scoring simulation (W1-18..W1-24)

### DIFF
--- a/docs/game-day/MEDIAN_SEMANTICS_VERIFICATION.md
+++ b/docs/game-day/MEDIAN_SEMANTICS_VERIFICATION.md
@@ -1,0 +1,109 @@
+# Sleeper median-game semantics — verification attempt, 2026-09-04
+
+**Status:** UNRESOLVED. Recorded so the attempt is not repeated blind, and
+so no later reader mistakes the simulator's default for a verified fact.
+
+`docs/GAME_DAY_PROBABILITY_SPEC.md` §3 requires the league-median
+threshold to be host-faithful and says explicitly: *"Verify Sleeper/host
+behavior for ties at the median and odd/even league sizes rather than
+guessing."* Contract row `W1-23` depends on it. This is that attempt.
+
+## What IS established
+
+`league_average_match = 1` on the owner's league for **2026, 2025 and
+2024** (walked via `previous_league_id`). The 2025 league ran
+`best_ball=1`, 10 teams, `playoff_week_start=14`.
+
+The median game is unambiguously **real and live**:
+
+- head-to-head results alone reproduce Sleeper's reported 2025 records
+  for **0 of 10** teams;
+- every team's reported record totals exactly **26** decisions over a
+  13-week regular season — two per week, not one.
+
+So each week awards an H2H result **and** a threshold result. That much
+is settled and the simulator relies on it.
+
+## What could NOT be established
+
+Whether the threshold is the league **median** or the league **average**
+— the Sleeper setting is literally named `league_average_match` — and
+what an exact tie does.
+
+Six variants were tested against 2025, adding each team's threshold-leg
+record to its computed H2H record and comparing with Sleeper's own
+reported `settings.wins/losses`:
+
+| variant | teams reproduced |
+|---|---|
+| mean of all 10 | 3 / 10 |
+| median of all 10 | 2 / 10 |
+| mean excluding self | 3 / 10 |
+| median excluding self | 2 / 10 |
+| median as the lower middle value | 1 / 10 |
+| median as the upper middle value | 0 / 10 |
+
+A season-total check does not discriminate either: across the 13 weeks,
+**both** mean and median award exactly 65 wins, which is also the number
+implied by the reported records.
+
+## Why it could not be established — the load-bearing finding
+
+**Sleeper's stored historical matchup points no longer reproduce
+Sleeper's own season totals.** Summing the `points` field over the 2025
+regular season and comparing with each roster's `settings.fpts`:
+
+```
+rid  sum wk1-13    sleeper fpts     delta
+  1     4325.90        4828.64   -502.74
+  4     4711.89        5280.65   -568.76
+  9     5581.01        6088.63   -507.62
+```
+
+Every team is short by 500-630 points, and **no week range closes it** —
+1-13, 1-14, 1-15, 1-16 and 1-17 all miss (closest, 1-14, still averages
+188 points per team off).
+
+The mechanism is specific to this format: in a **best-ball** league
+Sleeper recomputes the optimal lineup from current player stats, so any
+stat correction changes both the chosen lineup and the total. Those
+revisions accumulate across a season. The consequence is that
+back-computing *what the host decided at the time* from *what the host
+reports now* is not a sound method here, whatever threshold statistic is
+assumed.
+
+This is the same perishability argument that motivated the Game Day
+prediction archive (`src/ros/game_day_archive.py`), arriving from the
+other direction: historical host data is not a faithful record of what
+was true when a decision was made.
+
+## What the simulator does in the meantime
+
+`src/ros/game_day_sim.py` defaults to `THRESHOLD_SEMANTICS = "median"`
+— the statistic the product spec names — and:
+
+- carries `threshold_semantics` on every result, so the assumption is
+  visible rather than implicit;
+- hard-codes `threshold_semantics_verified = False`, which no caller can
+  set true;
+- accepts `threshold_semantics="mean"` as a parameter, so switching is a
+  one-argument change;
+- keeps `median_enabled=None` (`STANDINGS_RULE_UNVERIFIED`) distinct
+  from `False` (`NOT_APPLICABLE`), per spec §9.
+
+An exact tie is counted as **neither** a win nor a loss and is not
+folded into either — no tie-breaking rule has been invented.
+
+## How to resolve it
+
+A human with the Sleeper app can settle both questions in under a
+minute, which no amount of API archaeology replaces. Open any completed
+2025 week; each team shows two results. Read off:
+
+1. whether the extra result is scored against the league **median** or
+   the league **average**;
+2. what an exact tie with that threshold is recorded as.
+
+Then set `THRESHOLD_SEMANTICS`, add the tie rule if one exists, and flip
+`threshold_semantics_verified` — with the observation recorded here as
+its evidence.

--- a/src/league_intel/sim_calibration.py
+++ b/src/league_intel/sim_calibration.py
@@ -153,13 +153,32 @@ class PointsModel:
     def cv_for(self, position: str) -> float:
         return self.cv_by_position.get((position or "").upper(), self.default_cv)
 
-    def draw(self, ros_value: float, position: str, rng: Any) -> float:
-        """Sample one weekly point total.  Hot path — keep it cheap."""
-        mean = self.mean_points(ros_value)
+    def draw_from_mean(self, mean: float, position: str, rng: Any) -> float:
+        """Sample one weekly point total from a mean ALREADY IN POINTS.
+
+        The variance half of this model — the per-position CV measured
+        under this league's own scoring — is independent of how the mean
+        was obtained.  ``draw`` gets its mean by converting a ``rosValue``
+        through the fitted scale; a caller holding a real point
+        projection (Game Day, and eventually LI-6's stat-line path)
+        supplies it directly and skips that conversion.
+
+        This is the seam the module docstring already anticipated
+        ("``PointsModel`` gains a stat-line path and the scale term
+        becomes a fallback for unprojected players.  The interface is
+        shaped for that now so the swap does not churn the sim").  It is
+        deliberately the SAME variance model rather than a second one:
+        two engines disagreeing about how volatile a QB week is would be
+        exactly the duplicate-owner problem this repo keeps closing.
+        """
         if mean <= 0.0:
             return 0.0
         sd = max(0.5, mean * self.cv_for(position))
         return max(0.0, rng.gauss(mean, sd))
+
+    def draw(self, ros_value: float, position: str, rng: Any) -> float:
+        """Sample one weekly point total.  Hot path — keep it cheap."""
+        return self.draw_from_mean(self.mean_points(ros_value), position, rng)
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/src/ros/game_day_sim.py
+++ b/src/ros/game_day_sim.py
@@ -1,0 +1,508 @@
+"""CE-20 — THE canonical league-aware current-week scoring simulation.
+
+Governed by `docs/GAME_DAY_PROBABILITY_SPEC.md`; contract rows
+`W1-18`…`W1-24` in `docs/season-launch/WEEK_1_LAUNCH_CONTRACT.md`.
+
+**One simulation, two outcomes.** The spec's §2/§3 requirement is that
+`Win Matchup %` and `Beat League Median %` are correlated descendants of
+the same simulated week, never two formulas. That is structural here:
+:func:`simulate_league_week` draws the whole league's scores together,
+and for each draw computes the threshold **from that draw's own
+league-wide scores** before deciding either outcome. There is no code
+path that produces one without the other from the same draws.
+
+**It is not a new engine.** The per-player weekly distribution is
+`src.league_intel.sim_calibration.PointsModel` — the per-position CV
+measured under this league's own scoring by the golden-validated scorer
+— and the best-ball lineup is `src.ros.lineup.solve_optimal_assignment`,
+the exact solver that goes 10/10 against Sleeper's own awarded lineups.
+This module owns the WEEK: which players can still move, what a draw
+means for each of them, and how a league-wide draw becomes two
+probabilities.
+
+**Best ball is a league FACT, not this league's default.** `best_ball`
+and `league_average_match` are read per league and passed in
+(:class:`LeagueWeekRules`). Measured 2026-09-04: `dynasty_main` is
+`best_ball=1, league_average_match=1` with 12 teams, and `dynasty_new`
+is `best_ball=0, league_average_match=0` with 10. Assuming either
+would serve one league the other's game.
+
+**Missing is never zero, and neither is unknown.**
+`median_enabled=None` means the standings rule was not verifiable and
+yields `STANDINGS_RULE_UNVERIFIED` — distinct from `False`, which yields
+`NOT_APPLICABLE`, and both distinct from a fabricated `0.0`. A player
+whose remaining production cannot be estimated is EXCLUDED from the
+lineup pool and reported in `unsimulable_player_ids`, never drawn as
+zero. A team with no opponent is `UNSIMULABLE`, never 50%.
+
+**Host semantics for the threshold are NOT yet verified**, and this
+module says so rather than implying otherwise. `THRESHOLD_SEMANTICS`
+carries the statistic actually used and
+`threshold_semantics_verified=False` travels on every result. The
+attempt and why it failed are recorded in
+`docs/game-day/MEDIAN_SEMANTICS_VERIFICATION.md`: reconciling 2025's
+records against Sleeper's own reported records reproduced at most 3 of
+10 teams under six variants, because Sleeper's stored historical
+matchup points no longer reproduce Sleeper's own season totals (a
+best-ball league recomputes the optimal lineup from current player
+stats, so accumulated stat corrections move the history). Swapping the
+statistic is a one-constant change once a human reads it off the host.
+"""
+
+from __future__ import annotations
+
+import random
+import statistics
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Sequence
+
+from src.league_intel.sim_calibration import PointsModel, load_points_model
+from src.ros.lineup import RosterPlayer, solve_optimal_assignment
+
+#: A player's state within the scoring period. Every one of these is a
+#: DIFFERENT statement about what is still uncertain, and collapsing any
+#: two of them is what produces double-projection (spec §6: "do not
+#: treat already-scored points as uncertain or completed players as
+#: still having a full projection remaining").
+PLAYER_STATES: frozenset[str] = frozenset(
+    {"completed", "in_progress", "not_started", "inactive", "unknown"}
+)
+
+#: The statistic the extra weekly result is decided against. NOT yet
+#: verified against the host — see the module docstring.
+THRESHOLD_SEMANTICS: str = "median"
+
+#: Default draws. Matches the playoff sim's own 10,000 rather than
+#: introducing a second number for the same kind of question.
+DEFAULT_DRAWS: int = 10_000
+
+#: Fixed so a probability does not flicker between identical requests.
+#: A re-render is not new evidence.
+DEFAULT_SEED: int = 20260910
+
+MODEL_VERSION: str = "game-day-sim-v1"
+
+
+class GameDaySimError(ValueError):
+    """Raised for a request that cannot be simulated as asked."""
+
+
+@dataclass(frozen=True)
+class PlayerWeek:
+    """One player's contribution to one team-week.
+
+    ``points_scored`` is what is ALREADY BANKED — a fact, not an
+    estimate. ``projected_remaining`` is the MEAN of what is still to
+    come, in points. ``None`` there means genuinely unknown; it is never
+    coerced to 0.0, because "expected to score nothing more" and "we
+    cannot say" are different claims and only the first is evidence.
+    """
+
+    player_id: str
+    position: str
+    state: str
+    points_scored: float | None = None
+    projected_remaining: float | None = None
+    fantasy_positions: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.state not in PLAYER_STATES:
+            raise GameDaySimError(
+                f"{self.player_id}: state {self.state!r} not in {sorted(PLAYER_STATES)}"
+            )
+
+
+@dataclass(frozen=True)
+class TeamWeek:
+    """One team's roster for one scoring period."""
+
+    team_id: str
+    players: tuple[PlayerWeek, ...]
+    #: Only consulted in a MANAGED-lineup league, where the manager's
+    #: submitted lineup is the lineup. Ignored under best ball, where the
+    #: host optimizes and no start/sit decision exists.
+    declared_starters: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class LeagueWeekRules:
+    """The requested league's own rules. Never another league's."""
+
+    league_key: str
+    starter_slots: tuple[str, ...]
+    best_ball: bool
+    #: True / False / **None**. ``None`` is "the standings rule could not
+    #: be verified", which is not the same as the median game being off.
+    median_enabled: bool | None
+    team_count: int
+
+    def __post_init__(self) -> None:
+        if not self.starter_slots:
+            raise GameDaySimError(
+                f"{self.league_key}: no starter slots — a lineup cannot be filled from "
+                "an empty slot list, and defaulting one would simulate a different league."
+            )
+
+
+@dataclass
+class TeamWeekOutcome:
+    """Simulated outcomes for one team. Percentages are 0-100 floats, or
+    ``None`` with a reason when the question does not apply."""
+
+    team_id: str
+    opponent_id: str | None
+    draws: int
+
+    win_matchup_pct: float | None
+    tie_matchup_pct: float | None
+    #: ``None`` with ``beat_median_state`` naming why.
+    beat_median_pct: float | None
+    beat_median_state: str
+
+    projected_mean: float
+    projected_p10: float
+    projected_p50: float
+    projected_p90: float
+    points_banked: float
+
+    #: Joint outcomes, spec §8. Present only when both legs are live.
+    joint_2_0_pct: float | None = None
+    joint_1_1_h2h_pct: float | None = None
+    joint_1_1_median_pct: float | None = None
+    joint_0_2_pct: float | None = None
+
+    unsimulable_player_ids: tuple[str, ...] = ()
+    notes: list[str] = field(default_factory=list)
+
+
+@dataclass
+class LeagueWeekSimulation:
+    """Every team's outcome for one league-week, plus the provenance the
+    UI needs to tell a fresh estimate from a degraded one (spec §9)."""
+
+    league_key: str
+    season: int
+    week: int
+    draws: int
+    teams: tuple[TeamWeekOutcome, ...]
+    model_version: str
+    points_model_source: str
+    threshold_semantics: str
+    threshold_semantics_verified: bool
+    median_enabled: bool | None
+    best_ball: bool
+    seed: int
+    notes: list[str] = field(default_factory=list)
+
+
+def _drawable(player: PlayerWeek) -> bool:
+    """Can this player's week be simulated at all?
+
+    A ``completed`` player needs a real banked score; a player who still
+    has football left needs a remaining estimate. Neither is invented.
+    """
+    if player.state in ("completed", "inactive"):
+        return player.points_scored is not None or player.state == "inactive"
+    if player.state in ("in_progress", "not_started"):
+        return player.projected_remaining is not None
+    return False  # "unknown"
+
+
+def _banked_points(player: PlayerWeek) -> float:
+    """Points this player has ALREADY scored this week.
+
+    An absent ``points_scored`` here is a REAL zero, not missing data,
+    and the distinction is worth writing out rather than leaving to an
+    ``or 0.0`` a reader has to take on trust. A player whose game has not
+    kicked off has scored nothing — that is an observation, not a gap.
+    The genuinely-unknown case never reaches this function: ``_drawable``
+    already refuses a ``completed`` player with no score, and an
+    ``unknown`` player is excluded from the pool entirely.
+    """
+    scored = player.points_scored
+    return 0.0 if scored is None else float(scored)
+
+
+def _draw_player(player: PlayerWeek, model: PointsModel, rng: random.Random) -> float:
+    """One player's simulated final total for this week.
+
+    The state decides what is random, and that is the whole point:
+
+    * ``completed`` — banked points, NO draw. Re-projecting a finished
+      game would put uncertainty on a fact.
+    * ``inactive`` — whatever is banked (usually nothing) and no more. A
+      player who will not play is a known zero, not a missing estimate.
+    * ``in_progress`` — banked points are kept as certain and only the
+      REMAINDER is drawn, so a player mid-game is neither double-counted
+      nor treated as finished.
+    * ``not_started`` — the full remaining distribution.
+    """
+    banked = _banked_points(player)
+    if player.state in ("completed", "inactive"):
+        return banked
+    remaining = player.projected_remaining
+    if remaining is None:  # guarded by _drawable; defensive
+        return banked
+    return banked + model.draw_from_mean(float(remaining), player.position, rng)
+
+
+def _team_score(
+    team: TeamWeek,
+    drawn: Mapping[str, float],
+    rules: LeagueWeekRules,
+) -> float:
+    """One team's simulated weekly score under its OWN lineup rules.
+
+    Best ball re-solves the exact optimal assignment against THIS draw's
+    scores, which is what makes lineup displacement real: a player
+    outside the provisional best lineup still matters, because a big
+    draw can displace someone already in it. A managed league sums the
+    lineup its manager actually submitted — re-optimizing there would
+    award points nobody could have earned.
+    """
+    if rules.best_ball:
+        pool = [
+            RosterPlayer(
+                player_id=p.player_id,
+                canonical_name="",
+                position=p.position,
+                ros_value=drawn[p.player_id],
+                fantasy_positions=p.fantasy_positions,
+            )
+            for p in team.players
+            if p.player_id in drawn
+        ]
+        if not pool:
+            return 0.0
+        assignment = solve_optimal_assignment(pool, list(rules.starter_slots))
+        return float(sum(pl.ros_value or 0.0 for pl in assignment.values()))
+    return float(sum(drawn.get(pid, 0.0) for pid in team.declared_starters))
+
+
+def _threshold(scores: Sequence[float], semantics: str = THRESHOLD_SEMANTICS) -> float:
+    if semantics == "median":
+        return float(statistics.median(scores))
+    if semantics == "mean":
+        return float(statistics.fmean(scores))
+    raise GameDaySimError(f"unknown threshold semantics {semantics!r}")
+
+
+def _pct(count: int, draws: int) -> float:
+    return round(100.0 * count / draws, 2) if draws else 0.0
+
+
+def simulate_league_week(
+    *,
+    rules: LeagueWeekRules,
+    teams: Sequence[TeamWeek],
+    opponents: Mapping[str, str | None],
+    season: int,
+    week: int,
+    draws: int = DEFAULT_DRAWS,
+    seed: int = DEFAULT_SEED,
+    points_model: PointsModel | None = None,
+    threshold_semantics: str = THRESHOLD_SEMANTICS,
+) -> LeagueWeekSimulation:
+    """Simulate the whole league-week once and derive BOTH outcomes.
+
+    ``opponents`` maps team_id → opponent team_id, or ``None`` for a team
+    with no scheduled opponent. A missing opponent makes that team's
+    matchup probability ``None`` / ``UNSIMULABLE`` (spec §9) — never 50%,
+    which would be a claim about a game that is not on the schedule.
+
+    The league-wide draw happens ONCE per iteration and both legs read
+    it, so the threshold moves with the other teams' simulated scores
+    exactly as spec §3 requires.
+    """
+    if draws <= 0:
+        raise GameDaySimError("draws must be positive")
+    if not teams:
+        raise GameDaySimError(f"{rules.league_key}: no teams to simulate")
+
+    model = points_model or load_points_model()
+    rng = random.Random(seed)
+
+    simulable: dict[str, tuple[PlayerWeek, ...]] = {}
+    unsimulable: dict[str, tuple[str, ...]] = {}
+    banked: dict[str, float] = {}
+    for team in teams:
+        ok = tuple(p for p in team.players if _drawable(p))
+        simulable[team.team_id] = ok
+        unsimulable[team.team_id] = tuple(p.player_id for p in team.players if not _drawable(p))
+        # Banked points are reported from the players that COUNT toward
+        # the lineup, so a completed-but-benched score is not advertised
+        # as though it is on the board.
+        banked[team.team_id] = float(sum(_banked_points(p) for p in ok))
+
+    totals: dict[str, list[float]] = {t.team_id: [] for t in teams}
+    h2h_win = {t.team_id: 0 for t in teams}
+    h2h_tie = {t.team_id: 0 for t in teams}
+    med_win = {t.team_id: 0 for t in teams}
+    joint = {t.team_id: {"2_0": 0, "1_1_h2h": 0, "1_1_med": 0, "0_2": 0} for t in teams}
+
+    median_live = rules.median_enabled is True
+
+    for _ in range(draws):
+        drawn_by_team: dict[str, dict[str, float]] = {}
+        for team in teams:
+            drawn_by_team[team.team_id] = {
+                p.player_id: _draw_player(p, model, rng) for p in simulable[team.team_id]
+            }
+        scores = {t.team_id: _team_score(t, drawn_by_team[t.team_id], rules) for t in teams}
+        for tid, sc in scores.items():
+            totals[tid].append(sc)
+
+        # THE SAME DRAW decides both legs. The threshold is computed from
+        # this iteration's league-wide scores, so it moves with them.
+        thr = _threshold(list(scores.values()), threshold_semantics) if median_live else None
+
+        for team in teams:
+            tid = team.team_id
+            opp = opponents.get(tid)
+            won_h2h: bool | None = None
+            if opp is not None and opp in scores:
+                if scores[tid] > scores[opp]:
+                    h2h_win[tid] += 1
+                    won_h2h = True
+                elif scores[tid] == scores[opp]:
+                    h2h_tie[tid] += 1
+                    won_h2h = None
+                else:
+                    won_h2h = False
+            if thr is None:
+                continue
+            beat_med = scores[tid] > thr
+            if beat_med:
+                med_win[tid] += 1
+            if won_h2h is None:
+                continue
+            if won_h2h and beat_med:
+                joint[tid]["2_0"] += 1
+            elif won_h2h:
+                joint[tid]["1_1_h2h"] += 1
+            elif beat_med:
+                joint[tid]["1_1_med"] += 1
+            else:
+                joint[tid]["0_2"] += 1
+
+    out: list[TeamWeekOutcome] = []
+    for team in teams:
+        tid = team.team_id
+        series = sorted(totals[tid])
+        opp = opponents.get(tid)
+        notes: list[str] = []
+
+        if opp is None:
+            win_pct: float | None = None
+            tie_pct: float | None = None
+            notes.append("UNSIMULABLE: no scheduled opponent this week")
+        else:
+            win_pct = _pct(h2h_win[tid], draws)
+            tie_pct = _pct(h2h_tie[tid], draws)
+
+        if rules.median_enabled is None:
+            med_pct: float | None = None
+            med_state = "STANDINGS_RULE_UNVERIFIED"
+        elif rules.median_enabled is False:
+            med_pct = None
+            med_state = "NOT_APPLICABLE"
+        else:
+            med_pct = _pct(med_win[tid], draws)
+            med_state = "OK"
+
+        if unsimulable[tid]:
+            notes.append(
+                f"{len(unsimulable[tid])} player(s) had no estimable remaining "
+                "production and were excluded rather than drawn as zero"
+            )
+
+        joint_live = med_state == "OK" and opp is not None
+        out.append(
+            TeamWeekOutcome(
+                team_id=tid,
+                opponent_id=opp,
+                draws=draws,
+                win_matchup_pct=win_pct,
+                tie_matchup_pct=tie_pct,
+                beat_median_pct=med_pct,
+                beat_median_state=med_state,
+                projected_mean=round(statistics.fmean(series), 2),
+                projected_p10=round(series[int(0.10 * (len(series) - 1))], 2),
+                projected_p50=round(statistics.median(series), 2),
+                projected_p90=round(series[int(0.90 * (len(series) - 1))], 2),
+                points_banked=round(banked[tid], 2),
+                joint_2_0_pct=_pct(joint[tid]["2_0"], draws) if joint_live else None,
+                joint_1_1_h2h_pct=_pct(joint[tid]["1_1_h2h"], draws) if joint_live else None,
+                joint_1_1_median_pct=_pct(joint[tid]["1_1_med"], draws) if joint_live else None,
+                joint_0_2_pct=_pct(joint[tid]["0_2"], draws) if joint_live else None,
+                unsimulable_player_ids=unsimulable[tid],
+                notes=notes,
+            )
+        )
+
+    sim_notes: list[str] = []
+    if rules.median_enabled is None:
+        sim_notes.append(
+            "median standings rule unverified for this league — reported as "
+            "STANDINGS_RULE_UNVERIFIED, not as disabled"
+        )
+    if model.source == "fallback-constants":
+        sim_notes.append(
+            "points model is the documented FALLBACK, not this league's measured "
+            "calibration — treat the spread as weaker evidence"
+        )
+
+    return LeagueWeekSimulation(
+        league_key=rules.league_key,
+        season=season,
+        week=week,
+        draws=draws,
+        teams=tuple(out),
+        model_version=MODEL_VERSION,
+        points_model_source=model.source,
+        threshold_semantics=threshold_semantics,
+        # Deliberately hard-coded False: see the module docstring. It flips
+        # when a human reads the rule off the host, not when a caller
+        # would like it to be true.
+        threshold_semantics_verified=False,
+        median_enabled=rules.median_enabled,
+        best_ball=rules.best_ball,
+        seed=seed,
+        notes=sim_notes,
+    )
+
+
+def rules_from_league(
+    *,
+    league_key: str,
+    league_payload: Mapping[str, Any],
+    starter_slots: Iterable[str],
+) -> LeagueWeekRules:
+    """Build the rules from the requested league's OWN Sleeper payload.
+
+    ``best_ball`` and ``league_average_match`` are read; neither is
+    defaulted. An absent ``league_average_match`` yields ``None``
+    (unverified), not ``False`` — the spec is explicit that an unknown
+    median setting is `STANDINGS_RULE_UNVERIFIED` rather than disabled.
+    """
+    settings = league_payload.get("settings") or {}
+    raw_median = settings.get("league_average_match")
+    median_enabled: bool | None
+    if raw_median is None:
+        median_enabled = None
+    else:
+        try:
+            median_enabled = bool(int(raw_median))
+        except (TypeError, ValueError):
+            median_enabled = None
+    try:
+        team_count = int(settings.get("num_teams") or 0)
+    except (TypeError, ValueError):
+        team_count = 0
+    return LeagueWeekRules(
+        league_key=league_key,
+        starter_slots=tuple(starter_slots),
+        best_ball=bool(int(settings.get("best_ball") or 0)),
+        median_enabled=median_enabled,
+        team_count=team_count,
+    )

--- a/src/ros/game_day_sim.py
+++ b/src/ros/game_day_sim.py
@@ -134,7 +134,9 @@ class LeagueWeekRules:
     #: True / False / **None**. ``None`` is "the standings rule could not
     #: be verified", which is not the same as the median game being off.
     median_enabled: bool | None
-    team_count: int
+    #: Descriptive only — nothing here decides on it. ``None`` when the
+    #: host did not state one, rather than a fabricated 0.
+    team_count: int | None
 
     def __post_init__(self) -> None:
         if not self.starter_slots:
@@ -486,6 +488,7 @@ def rules_from_league(
     median setting is `STANDINGS_RULE_UNVERIFIED` rather than disabled.
     """
     settings = league_payload.get("settings") or {}
+
     raw_median = settings.get("league_average_match")
     median_enabled: bool | None
     if raw_median is None:
@@ -495,14 +498,39 @@ def rules_from_league(
             median_enabled = bool(int(raw_median))
         except (TypeError, ValueError):
             median_enabled = None
+
+    # BEST BALL FAILS CLOSED. It decides whether the week is scored by
+    # re-solving the optimal lineup or by summing the manager's
+    # submitted one, which changes every number this module produces —
+    # so an absent flag must not quietly become "managed", the same way
+    # an absent median setting must not become "off". Sleeper states it
+    # for both live leagues (measured 2026-09-04: 1 and 0), so this
+    # refusal describes a broken payload, not a supported configuration.
+    raw_best_ball = settings.get("best_ball")
+    if raw_best_ball is None:
+        raise GameDaySimError(
+            f"{league_key}: the host did not state `best_ball`. Guessing it would "
+            "score the week under the wrong lineup rule for every team; a lineup "
+            "semantic is not a field to default."
+        )
     try:
-        team_count = int(settings.get("num_teams") or 0)
+        best_ball = bool(int(raw_best_ball))
+    except (TypeError, ValueError) as exc:
+        raise GameDaySimError(
+            f"{league_key}: `best_ball` is {raw_best_ball!r}, which is not a flag."
+        ) from exc
+
+    raw_teams = settings.get("num_teams")
+    team_count: int | None
+    try:
+        team_count = int(raw_teams) if raw_teams is not None else None
     except (TypeError, ValueError):
-        team_count = 0
+        team_count = None
+
     return LeagueWeekRules(
         league_key=league_key,
         starter_slots=tuple(starter_slots),
-        best_ball=bool(int(settings.get("best_ball") or 0)),
+        best_ball=best_ball,
         median_enabled=median_enabled,
         team_count=team_count,
     )

--- a/tests/game_day/test_game_day_sim.py
+++ b/tests/game_day/test_game_day_sim.py
@@ -1,0 +1,481 @@
+"""CE-20 — the canonical league-aware current-week scoring simulation.
+
+Covers the acceptance matrix in `docs/GAME_DAY_PROBABILITY_SPEC.md` §12
+and contract rows W1-18..W1-24: one simulation family for both
+outcomes, the per-draw league-wide median threshold, exact league
+scoring/slot rules, best-ball displacement, every player game state, and
+the missing/unavailable semantics that must never read as zero.
+
+Network-free and deterministic — every input is a literal and the sim is
+seeded, so these run in the hard gate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.league_intel.sim_calibration import PointsModel
+from src.ros.game_day_sim import (
+    GameDaySimError,
+    LeagueWeekRules,
+    PlayerWeek,
+    TeamWeek,
+    rules_from_league,
+    simulate_league_week,
+)
+
+# A tight points model so simulated scores are predictable enough to
+# assert on without being deterministic.
+_MODEL = PointsModel(ros_value_per_point=1.0, cv_by_position={}, default_cv=0.20)
+
+_SF_SLOTS = ("QB", "RB", "RB", "WR", "WR", "TE", "FLEX", "SUPER_FLEX")
+
+
+def _p(pid, pos, state, scored=None, remaining=None, fpos=()):
+    return PlayerWeek(
+        player_id=pid,
+        position=pos,
+        state=state,
+        points_scored=scored,
+        projected_remaining=remaining,
+        fantasy_positions=fpos,
+    )
+
+
+def _full_roster(prefix, base=10.0):
+    """A roster that can fill every slot in _SF_SLOTS."""
+    spec = [
+        ("qb1", "QB"),
+        ("qb2", "QB"),
+        ("rb1", "RB"),
+        ("rb2", "RB"),
+        ("rb3", "RB"),
+        ("wr1", "WR"),
+        ("wr2", "WR"),
+        ("wr3", "WR"),
+        ("te1", "TE"),
+        ("te2", "TE"),
+    ]
+    return tuple(_p(f"{prefix}_{pid}", pos, "not_started", remaining=base) for pid, pos in spec)
+
+
+def _rules(**kw):
+    base = dict(
+        league_key="test_league",
+        starter_slots=_SF_SLOTS,
+        best_ball=True,
+        median_enabled=True,
+        team_count=4,
+    )
+    base.update(kw)
+    return LeagueWeekRules(**base)
+
+
+def _league(n=4, base=10.0, rules=None, draws=400):
+    rules = rules or _rules()
+    teams = [
+        TeamWeek(team_id=f"t{i}", players=_full_roster(f"t{i}", base + i)) for i in range(1, n + 1)
+    ]
+    opponents = {}
+    for i in range(1, n + 1, 2):
+        opponents[f"t{i}"] = f"t{i+1}"
+        opponents[f"t{i+1}"] = f"t{i}"
+    return simulate_league_week(
+        rules=rules,
+        teams=teams,
+        opponents=opponents,
+        season=2026,
+        week=1,
+        draws=draws,
+        points_model=_MODEL,
+    )
+
+
+# ── one simulation family, both outcomes ───────────────────────────
+
+
+def test_both_outcomes_come_from_one_simulation():
+    sim = _league()
+    for t in sim.teams:
+        assert t.win_matchup_pct is not None
+        assert t.beat_median_pct is not None
+        assert t.beat_median_state == "OK"
+
+
+def test_probabilities_are_bounded():
+    sim = _league()
+    for t in sim.teams:
+        for v in (t.win_matchup_pct, t.tie_matchup_pct, t.beat_median_pct):
+            assert v is not None and 0.0 <= v <= 100.0
+
+
+def test_a_matchup_pair_win_probabilities_are_complementary():
+    """Both sides come from the same draws, so their win/tie shares must
+    account for every draw — a property two independent formulas would
+    not guarantee."""
+    sim = _league()
+    by_id = {t.team_id: t for t in sim.teams}
+    a, b = by_id["t1"], by_id["t2"]
+    total = a.win_matchup_pct + b.win_matchup_pct + a.tie_matchup_pct
+    assert total == pytest.approx(100.0, abs=0.5)
+
+
+def test_beat_median_across_the_league_sums_to_about_half():
+    """The threshold is the median OF EACH DRAW, so across a whole league
+    roughly half the team-draws clear it. This is the property that
+    fails if the threshold is a fixed historical number."""
+    sim = _league(n=4)
+    assert sum(t.beat_median_pct for t in sim.teams) == pytest.approx(200.0, abs=15.0)
+
+
+def test_joint_outcomes_sum_to_one_hundred():
+    """Spec §8: the four mutually exclusive weekly outcomes come from the
+    same draws and must sum to ~100%."""
+    sim = _league()
+    for t in sim.teams:
+        total = t.joint_2_0_pct + t.joint_1_1_h2h_pct + t.joint_1_1_median_pct + t.joint_0_2_pct
+        assert total == pytest.approx(100.0, abs=1.0), t.team_id
+
+
+def test_joint_outcomes_agree_with_the_headline_numbers():
+    sim = _league()
+    for t in sim.teams:
+        assert t.joint_2_0_pct + t.joint_1_1_h2h_pct == pytest.approx(t.win_matchup_pct, abs=1.0)
+        assert t.joint_2_0_pct + t.joint_1_1_median_pct == pytest.approx(t.beat_median_pct, abs=1.0)
+
+
+def test_a_stronger_team_wins_more_often():
+    sim = _league()
+    by_id = {t.team_id: t for t in sim.teams}
+    # t2's roster is built on a higher base than t1's.
+    assert by_id["t2"].win_matchup_pct > by_id["t1"].win_matchup_pct
+
+
+def test_the_simulation_is_deterministic_for_one_seed():
+    a, b = _league(), _league()
+    assert [t.win_matchup_pct for t in a.teams] == [t.win_matchup_pct for t in b.teams]
+
+
+# ── median ON / OFF / UNKNOWN ──────────────────────────────────────
+
+
+def test_median_disabled_is_not_applicable_not_zero():
+    sim = _league(rules=_rules(median_enabled=False))
+    for t in sim.teams:
+        assert t.beat_median_pct is None
+        assert t.beat_median_state == "NOT_APPLICABLE"
+        assert t.joint_2_0_pct is None
+
+
+def test_median_unknown_is_unverified_not_disabled():
+    """Spec §9: an unknown median setting is STANDINGS_RULE_UNVERIFIED,
+    a distinct state from the median game being off."""
+    sim = _league(rules=_rules(median_enabled=None))
+    for t in sim.teams:
+        assert t.beat_median_pct is None
+        assert t.beat_median_state == "STANDINGS_RULE_UNVERIFIED"
+    assert any("unverified" in n for n in sim.notes)
+
+
+def test_the_three_median_states_are_distinguishable():
+    states = {
+        _league(rules=_rules(median_enabled=v)).teams[0].beat_median_state
+        for v in (True, False, None)
+    }
+    assert states == {"OK", "NOT_APPLICABLE", "STANDINGS_RULE_UNVERIFIED"}
+
+
+# ── missing opponent ───────────────────────────────────────────────
+
+
+def test_a_missing_opponent_is_unsimulable_not_fifty_percent():
+    rules = _rules()
+    teams = [
+        TeamWeek(team_id="solo", players=_full_roster("solo")),
+        TeamWeek(team_id="other", players=_full_roster("other")),
+    ]
+    sim = simulate_league_week(
+        rules=rules,
+        teams=teams,
+        opponents={"solo": None, "other": None},
+        season=2026,
+        week=1,
+        draws=200,
+        points_model=_MODEL,
+    )
+    for t in sim.teams:
+        assert t.win_matchup_pct is None
+        assert any("UNSIMULABLE" in n for n in t.notes)
+        # The median leg still works — a team with no opponent still has
+        # a weekly score.
+        assert t.beat_median_pct is not None
+
+
+# ── player game states ─────────────────────────────────────────────
+
+
+def _one_team_sim(players, **kw):
+    rules = kw.pop("rules", _rules(median_enabled=False))
+    teams = [
+        TeamWeek(team_id="a", players=tuple(players), **kw),
+        TeamWeek(team_id="b", players=_full_roster("b")),
+    ]
+    return simulate_league_week(
+        rules=rules,
+        teams=teams,
+        opponents={"a": "b", "b": "a"},
+        season=2026,
+        week=1,
+        draws=300,
+        points_model=_MODEL,
+    )
+
+
+def test_a_completed_player_is_banked_and_never_redrawn():
+    """A finished game is a fact. Re-projecting it would put uncertainty
+    on something already known."""
+    players = [_p("done", "QB", "completed", scored=25.0)]
+    sim = _one_team_sim(players)
+    a = next(t for t in sim.teams if t.team_id == "a")
+    assert a.points_banked == 25.0
+    # One player, one slot, no randomness at all.
+    assert a.projected_p10 == a.projected_p90 == 25.0
+
+
+def test_an_in_progress_player_keeps_banked_points_and_draws_only_the_rest():
+    players = [_p("live", "QB", "in_progress", scored=8.0, remaining=10.0)]
+    sim = _one_team_sim(players)
+    a = next(t for t in sim.teams if t.team_id == "a")
+    assert a.points_banked == 8.0
+    # Never below what is already banked, and centred above it.
+    assert a.projected_p10 >= 8.0
+    assert a.projected_mean > 8.0
+
+
+def test_a_not_started_player_is_fully_uncertain():
+    players = [_p("soon", "QB", "not_started", remaining=15.0)]
+    sim = _one_team_sim(players)
+    a = next(t for t in sim.teams if t.team_id == "a")
+    assert a.points_banked == 0.0
+    assert a.projected_p90 > a.projected_p10
+
+
+def test_an_inactive_player_contributes_a_known_zero_not_a_projection():
+    """Truthful availability: a player who will not play is a known zero,
+    which is a different statement from a missing estimate."""
+    players = [_p("out", "QB", "inactive", remaining=20.0)]
+    sim = _one_team_sim(players)
+    a = next(t for t in sim.teams if t.team_id == "a")
+    assert a.projected_mean == 0.0
+    assert "out" not in a.unsimulable_player_ids
+
+
+def test_an_unknown_player_is_excluded_and_reported_not_drawn_as_zero():
+    players = [_p("ghost", "QB", "unknown"), _p("real", "QB", "not_started", remaining=12.0)]
+    sim = _one_team_sim(players)
+    a = next(t for t in sim.teams if t.team_id == "a")
+    assert a.unsimulable_player_ids == ("ghost",)
+    assert any("excluded rather than drawn as zero" in n for n in a.notes)
+
+
+def test_a_player_with_no_remaining_estimate_is_unsimulable():
+    players = [_p("noproj", "RB", "not_started"), _p("ok", "QB", "not_started", remaining=9.0)]
+    sim = _one_team_sim(players)
+    a = next(t for t in sim.teams if t.team_id == "a")
+    assert "noproj" in a.unsimulable_player_ids
+
+
+def test_a_bad_state_is_refused():
+    with pytest.raises(GameDaySimError, match="state"):
+        PlayerWeek(player_id="x", position="QB", state="probably")
+
+
+# ── best ball vs managed lineup ────────────────────────────────────
+
+
+def test_best_ball_lets_a_bench_score_displace_a_starter():
+    """The non-negotiable best-ball property: a player outside the
+    provisional best lineup still matters, because a big draw can
+    displace one already in it."""
+    rules = LeagueWeekRules(
+        league_key="bb",
+        starter_slots=("QB",),
+        best_ball=True,
+        median_enabled=False,
+        team_count=2,
+    )
+    players = [
+        _p("starter", "QB", "completed", scored=10.0),
+        _p("bench", "QB", "completed", scored=30.0),
+    ]
+    teams = [
+        TeamWeek(team_id="a", players=tuple(players)),
+        TeamWeek(team_id="b", players=(_p("x", "QB", "completed", scored=1.0),)),
+    ]
+    sim = simulate_league_week(
+        rules=rules,
+        teams=teams,
+        opponents={"a": "b", "b": "a"},
+        season=2026,
+        week=1,
+        draws=50,
+        points_model=_MODEL,
+    )
+    a = next(t for t in sim.teams if t.team_id == "a")
+    assert a.projected_mean == 30.0, "best ball must take the higher score"
+
+
+def test_a_managed_league_sums_the_submitted_lineup_only():
+    """Re-optimizing a managed lineup would award points nobody could
+    have earned."""
+    rules = LeagueWeekRules(
+        league_key="mg",
+        starter_slots=("QB",),
+        best_ball=False,
+        median_enabled=False,
+        team_count=2,
+    )
+    players = [
+        _p("started", "QB", "completed", scored=10.0),
+        _p("benched", "QB", "completed", scored=30.0),
+    ]
+    teams = [
+        TeamWeek(team_id="a", players=tuple(players), declared_starters=("started",)),
+        TeamWeek(
+            team_id="b", players=(_p("x", "QB", "completed", scored=1.0),), declared_starters=("x",)
+        ),
+    ]
+    sim = simulate_league_week(
+        rules=rules,
+        teams=teams,
+        opponents={"a": "b", "b": "a"},
+        season=2026,
+        week=1,
+        draws=50,
+        points_model=_MODEL,
+    )
+    a = next(t for t in sim.teams if t.team_id == "a")
+    assert a.projected_mean == 10.0, "managed lineup must not re-optimize"
+
+
+def test_superflex_flex_te_and_idp_slots_are_all_fillable():
+    rules = LeagueWeekRules(
+        league_key="idp",
+        starter_slots=("QB", "SUPER_FLEX", "FLEX", "TE", "DL", "LB", "DB", "IDP_FLEX"),
+        best_ball=True,
+        median_enabled=False,
+        team_count=2,
+    )
+    players = [
+        _p(f"p{i}", pos, "completed", scored=10.0)
+        for i, pos in enumerate(["QB", "QB", "RB", "TE", "DL", "LB", "DB", "LB"])
+    ]
+    teams = [
+        TeamWeek(team_id="a", players=tuple(players)),
+        TeamWeek(team_id="b", players=(_p("x", "QB", "completed", scored=1.0),)),
+    ]
+    sim = simulate_league_week(
+        rules=rules,
+        teams=teams,
+        opponents={"a": "b", "b": "a"},
+        season=2026,
+        week=1,
+        draws=20,
+        points_model=_MODEL,
+    )
+    a = next(t for t in sim.teams if t.team_id == "a")
+    assert a.projected_mean == 80.0, "all eight slots must fill at 10.0 each"
+
+
+def test_a_hybrid_defender_fills_either_slot():
+    rules = LeagueWeekRules(
+        league_key="idp",
+        starter_slots=("DL", "LB"),
+        best_ball=True,
+        median_enabled=False,
+        team_count=2,
+    )
+    players = [
+        _p("hybrid", "DL", "completed", scored=10.0, fpos=("DL", "LB")),
+        _p("pure", "DL", "completed", scored=10.0),
+    ]
+    teams = [
+        TeamWeek(team_id="a", players=tuple(players)),
+        TeamWeek(team_id="b", players=(_p("x", "DL", "completed", scored=1.0),)),
+    ]
+    sim = simulate_league_week(
+        rules=rules,
+        teams=teams,
+        opponents={"a": "b", "b": "a"},
+        season=2026,
+        week=1,
+        draws=20,
+        points_model=_MODEL,
+    )
+    a = next(t for t in sim.teams if t.team_id == "a")
+    assert a.projected_mean == 20.0, "the hybrid must fill LB so both slots score"
+
+
+# ── league rules are the REQUESTED league's ────────────────────────
+
+
+def test_rules_are_read_from_the_league_payload_never_defaulted():
+    r = rules_from_league(
+        league_key="k",
+        league_payload={"settings": {"best_ball": 1, "league_average_match": 1, "num_teams": 12}},
+        starter_slots=("QB",),
+    )
+    assert (r.best_ball, r.median_enabled, r.team_count) == (True, True, 12)
+
+    r2 = rules_from_league(
+        league_key="k2",
+        league_payload={"settings": {"best_ball": 0, "league_average_match": 0, "num_teams": 10}},
+        starter_slots=("QB",),
+    )
+    assert (r2.best_ball, r2.median_enabled, r2.team_count) == (False, False, 10)
+
+
+def test_an_absent_median_setting_is_unknown_not_disabled():
+    r = rules_from_league(
+        league_key="k",
+        league_payload={"settings": {"best_ball": 1}},
+        starter_slots=("QB",),
+    )
+    assert r.median_enabled is None
+
+
+def test_no_starter_slots_is_refused():
+    with pytest.raises(GameDaySimError, match="starter slots"):
+        LeagueWeekRules(
+            league_key="k", starter_slots=(), best_ball=True, median_enabled=True, team_count=2
+        )
+
+
+# ── truth metadata ─────────────────────────────────────────────────
+
+
+def test_every_result_carries_its_provenance():
+    sim = _league()
+    assert sim.model_version
+    assert sim.points_model_source
+    assert sim.threshold_semantics == "median"
+    assert sim.seed and sim.draws
+
+
+def test_threshold_semantics_are_declared_unverified():
+    """Reconciling 2025 against Sleeper's own records reproduced at most
+    3 of 10 teams, because Sleeper's stored historical points no longer
+    reproduce its own season totals. Until a human reads the rule off
+    the host, this must not claim fidelity."""
+    assert _league().threshold_semantics_verified is False
+
+
+def test_a_fallback_points_model_is_declared():
+    sim = _league()
+    assert sim.points_model_source == "fallback-constants"
+    assert any("FALLBACK" in n for n in sim.notes)
+
+
+def test_zero_draws_is_refused():
+    with pytest.raises(GameDaySimError, match="draws"):
+        _league(draws=0)

--- a/tests/game_day/test_game_day_sim.py
+++ b/tests/game_day/test_game_day_sim.py
@@ -444,6 +444,38 @@ def test_an_absent_median_setting_is_unknown_not_disabled():
     assert r.median_enabled is None
 
 
+def test_an_absent_best_ball_flag_is_refused_not_defaulted():
+    """The lineup semantic decides whether the week is scored by
+    re-solving the optimal lineup or summing the submitted one, so
+    guessing it would score every team under the wrong rule."""
+    with pytest.raises(GameDaySimError, match="best_ball"):
+        rules_from_league(
+            league_key="k",
+            league_payload={"settings": {"league_average_match": 1}},
+            starter_slots=("QB",),
+        )
+
+
+def test_a_non_flag_best_ball_value_is_refused():
+    with pytest.raises(GameDaySimError, match="not a flag"):
+        rules_from_league(
+            league_key="k",
+            league_payload={"settings": {"best_ball": "maybe"}},
+            starter_slots=("QB",),
+        )
+
+
+def test_an_absent_team_count_is_none_not_zero():
+    """Descriptive, but still not fabricated — nothing decides on it and
+    a 0-team league is not what an absent field means."""
+    r = rules_from_league(
+        league_key="k",
+        league_payload={"settings": {"best_ball": 1}},
+        starter_slots=("QB",),
+    )
+    assert r.team_count is None
+
+
 def test_no_starter_slots_is_refused():
     with pytest.raises(GameDaySimError, match="starter slots"):
         LeagueWeekRules(


### PR DESCRIPTION
CE-20's simulation core. Contract rows **W1-18 … W1-24**.

## One simulation, two outcomes — structurally, not by convention

Spec §2/§3 requires Win Matchup % and Beat League Median % to be correlated descendants of the same simulated week. That is enforced by shape here: the league's scores are drawn **together**, and each draw's threshold is computed **from that draw's own league-wide scores** before either outcome is decided. There is no code path that produces one without the other.

Pinned by test: the four joint outcomes (2-0 / 1-1 via H2H / 1-1 via median / 0-2) sum to ~100%, and each headline number equals the sum of its two joint components. Two independent formulas would not guarantee that.

## It is not a new engine

| concern | owner |
|---|---|
| per-player weekly distribution | `sim_calibration.PointsModel` — per-position CV measured under **this league's own scoring** |
| best-ball lineup | `lineup.solve_optimal_assignment` — the exact solver, 10/10 vs Sleeper's own awarded lineups |
| the *week* | this module |

`PointsModel` gains `draw_from_mean` — the seam its own docstring already anticipated (*"gains a stat-line path… the interface is shaped for that now so the swap does not churn the sim"*). `draw` now delegates to it, so `playoff_sim` is bit-identical. One variance model, two ways to supply the mean; two engines disagreeing about how volatile a QB week is is exactly the duplicate-owner problem this repo keeps closing.

## Best ball is a league fact, not a default

`best_ball` and `league_average_match` are read per league, never assumed. Measured today: **dynasty_main** is `best_ball=1, league_average_match=1`, 12 teams; **dynasty_new** is `best_ball=0, league_average_match=0`, 10 teams. Assuming either would serve one league the other's game.

Best ball re-solves the optimal assignment against *each draw*, which is what makes displacement real — a player outside the provisional best lineup still matters because a big draw can displace one already in it. A managed league sums the **submitted** lineup; re-optimizing there would award points nobody could have earned. Both pinned.

## Five player states, five different statements

- **completed** — banked, never redrawn. Re-projecting a finished game puts uncertainty on a fact.
- **in_progress** — banked points kept certain, only the **remainder** drawn. No double projection.
- **not_started** — full remaining distribution.
- **inactive** — a *known* zero, not a missing estimate.
- **unknown** — excluded from the pool and reported in `unsimulable_player_ids`, **never drawn as zero**.

`_banked_points` writes out why an absent score is a genuine zero here rather than leaving it to an `or 0.0` a reader has to take on trust — the same standard applied in #1243.

## Missing is never zero; unknown is never false

| condition | result |
|---|---|
| `median_enabled=None` | `STANDINGS_RULE_UNVERIFIED` |
| `median_enabled=False` | `NOT_APPLICABLE` |
| no scheduled opponent | `UNSIMULABLE`, not 50% |
| fallback points model | declared in `notes` |

An exact tie is counted as neither a win nor a loss — no tie-breaking rule has been invented.

## Host semantics are NOT verified, and this says so

`threshold_semantics_verified` is hard-coded `False`; no caller can set it true.

`docs/game-day/MEDIAN_SEMANTICS_VERIFICATION.md` records the attempt required by spec §3 ("verify… rather than guessing"). **What is established:** the median game is real — H2H alone reproduces 0/10 of Sleeper's 2025 records, and every record totals exactly 26 = 13 weeks × 2 results. **What is not:** whether the threshold is the median or the average (the setting is literally named `league_average_match`). Six variants reproduced at most **3 of 10** teams.

The reason is the load-bearing finding: **Sleeper's stored historical points no longer reproduce Sleeper's own season totals** — every team is 500-630 short of its `fpts`, and no week range closes it. In a best-ball league Sleeper recomputes the optimal lineup from current stats, so accumulated corrections move the history. Back-computing what the host decided from what it reports now is unsound here, whatever statistic is assumed.

It also independently restates the archive's premise from the other direction: historical host data is not a faithful record of what was true when a decision was made.

**Resolving it takes a human under a minute** — open any completed 2025 week in the Sleeper app and read off whether the extra result is vs the median or the average, and what a tie records as. Then it is a one-constant change plus flipping the flag.

## Scope

Backend only. No route, no UI, no consumer wired — W1-25…W1-28 are separate. Nothing existing changed behaviour: `PointsModel.draw` delegates to the new method and `playoff_sim` is unaffected (`tests/league_intel` + `tests/ros` green).

## Verification

- **30 new tests** in `tests/game_day/`: both-outcomes-one-sim, joint sums, median ON/OFF/UNKNOWN, missing opponent, all five player states, best-ball displacement, managed-lineup non-optimization, Superflex/FLEX/TE/IDP/hybrid eligibility, rules-from-payload, determinism, truth metadata.
- Full hard gate: **10,636 passed, 54 skipped, 0 failures**.
- `ruff format --check`, `ruff check`, coercion gate, and the three governance gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmUK5EBJvJkzX8xb3s1Bve

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmUK5EBJvJkzX8xb3s1Bve)_