### PR TITLE
ops: un-stick scheduled-refresh (Flock rookie floor) + kill a false-alarm health check

### DIFF
--- a/.claude/health-check.sh
+++ b/.claude/health-check.sh
@@ -118,7 +118,26 @@ def _git(*args):
     return out.stdout if out.returncode == 0 else None
 
 
-def main_contract_age_h():
+def local_main_ref_age_h():
+    """Age of the local `origin/main` REF itself, or None if unreadable.
+
+    `_git` reads refs already on disk and never fetches, so `origin/main`
+    here is whatever this checkout last saw — not what GitHub holds. A ref
+    that is itself old is not evidence about the pipeline in EITHER
+    direction, which is the half this block originally missed.
+    """
+    out = _git("log", "-1", "--format=%cI", "origin/main")
+    if not out or not out.strip():
+        return None
+    try:
+        committed = dt.datetime.fromisoformat(out.strip())
+    except ValueError:
+        return None
+    now_ = dt.datetime.now(committed.tzinfo) if committed.tzinfo else dt.datetime.now()
+    return (now_ - committed).total_seconds() / 3600.0
+
+
+def main_contract_age_h(limit):
     """Age of the contract on `origin/main`, or None if it cannot be read.
 
     This — not "how many commits behind am I" — is the predicate that
@@ -128,10 +147,24 @@ def main_contract_age_h():
     wrong cause. That is the exact defect this whole block exists to fix,
     so it must not be reintroduced in miniature.
 
+    But the ref is only evidence if the ref is CURRENT. On 2026-09-05 this
+    checkout's `origin/main` was ~38h stale and never fetched, so this
+    function read a 38h-old contract off it and the caller printed
+    "origin/main's contract is 38h old too — not a branch artifact" — a
+    confident pipeline-outage claim while production and real `main` were
+    both ~1h fresh. It cost a full incident response.
+    (docs/ops/INCIDENT_2026-09-05_FLOCK_ROOKIE_FLOOR.md)
+
+    So a ref older than the freshness budget answers None. The file's own
+    rule — "an unproven excuse must never silence a real alarm" — has a
+    converse, and this is it: an unproven ref must not raise a false one.
+
     None on any failure, and the caller treats None as "cannot tell" and
-    keeps the original warning. An unproven excuse must never silence a
-    real alarm.
+    keeps the original warning.
     """
+    ref_age = local_main_ref_age_h()
+    if ref_age is None or ref_age > limit:
+        return None
     listing = _git("ls-tree", "--name-only", "origin/main", "exports/latest/")
     if listing is None:
         return None
@@ -190,7 +223,7 @@ if age_h > limit:
     # Only a KNOWN-FRESH main redirects. None (cannot tell) falls through to
     # the warning — the guard must keep firing whenever the excuse is
     # unproven.
-    main_age = main_contract_age_h()
+    main_age = main_contract_age_h(limit)
     if main_age is not None and main_age <= limit:
         print(
             f"  NOTE: origin/main's contract is {main_age:.0f}h old — the pipeline is "
@@ -200,6 +233,14 @@ if age_h > limit:
         print(f"  WARNING: no successful scrape in {age_h:.0f}h. Check scheduled-refresh workflow.")
         if main_age is not None:
             print(f"  (origin/main's contract is {main_age:.0f}h old too — not a branch artifact.)")
+        else:
+            # Say WHY it is unattributed instead of implying the pipeline.
+            # This hook never fetches, so a stale local ref is the common case.
+            print(
+                "  (Cause NOT attributed: this checkout's origin/main ref is itself "
+                "stale or unreadable, so it proves nothing either way. Run "
+                "`git fetch origin main` and re-check before treating this as an outage.)"
+            )
 
 players = data.get("players") or {}
 stats = data.get("siteStats") or {}

--- a/docs/ops/INCIDENT_2026-09-05_FLOCK_ROOKIE_FLOOR.md
+++ b/docs/ops/INCIDENT_2026-09-05_FLOCK_ROOKIE_FLOOR.md
@@ -1,0 +1,188 @@
+# Incident 2026-09-05 — `scheduled-refresh` red for 10 days; and a false P0
+
+**Reported as:** a P0/P1 data-freshness outage — a session health check said
+"no successful scrape in 38h" and that `origin/main` was equally stale.
+
+**Actual outcome:** two separate findings, neither of them a data outage.
+
+1. **There was no production freshness incident.** The 38h figure was a
+   monitoring artifact. §2.
+2. **There was a real, standing defect**, 10 days old and invisible behind a
+   permanently-red workflow: `flockFantasySfRookies` had not refreshed since
+   2026-08-26 because a row-count guard was calibrated against an assumption
+   that stops holding in-season. §3.
+
+Both are repaired here. Nothing about freshness thresholds, staleness policy,
+or the `stale != current` / `missing != zero` semantics was weakened, and no
+timestamp was hand-minted.
+
+---
+
+## 1. Timeline and evidence
+
+| when | fact | source |
+|---|---|---|
+| 2026-08-26 16:07:55Z | last successful `flockFantasySfRookies` fetch (83 rows) | `data/scrape_state/flockFantasySfRookies_last_success` |
+| 2026-08-31 16:26Z | Flock last updated the PROSPECTS_SF board | vendor `lastUpdated` field |
+| 2026-09-05 10:58:20Z | `main`'s contract `scrapeTimestamp`, 1078 players | `origin/main:exports/latest/dynasty_data_2026-09-05.json` |
+| 2026-09-05 11:25:06Z | production `last_success_at`; `last_failure_at: null`, `current_step: complete` | `GET https://chaseupside.com/api/status` |
+| 2026-09-05 ~12:15Z | session health check reports "no successful scrape in 38h" | `.claude/health-check.sh` |
+
+Runs 1341–1345 of `scheduled-refresh.yml` all ended `conclusion: failure`, and
+in every one of them **only step 14 ("Staleness watchdog") failed.** Steps 1–13
+and 15 succeeded: run scraper, persist freshness stamps, validate scrape sanity,
+prune archives, commit updated data, trigger deploy, assert DLF freshness,
+contract coverage watchdog. Acquisition → commit → deploy was green throughout.
+
+In the taxonomy the directive asked for, this is a **health-state bookkeeping
+failure** — not acquisition, scheduling, Actions, on-box, commit/push, or
+deployment.
+
+---
+
+## 2. The false alarm — `.claude/health-check.sh`
+
+`main_contract_age_h()` attributes a stale checked-out contract by reading what
+`origin/main` holds. Its `_git` helper deliberately never fetches (a
+SessionStart hook must not wait on the network), so `origin/main` is whatever
+**this checkout last saw**.
+
+This session's ref was ~38h old and unfetched, and the working tree sat on a
+branch cut at that time. So the probe read a 38h-old contract off a 38h-old ref
+and printed:
+
+```
+WARNING: no successful scrape in 38h. Check scheduled-refresh workflow.
+(origin/main's contract is 38h old too — not a branch artifact.)
+```
+
+The second line is the damaging one. It converts "I cannot tell" into a
+confident pipeline-outage claim. After `git fetch`, the real ages were 1.6h
+(main) and 1.2h (production).
+
+**Repair.** A ref older than the freshness budget is evidence in *neither*
+direction, so `main_contract_age_h(limit)` now consults `local_main_ref_age_h()`
+first and answers `None` ("cannot tell") when the ref itself is stale or
+unreadable. The caller prints an explicit *"Cause NOT attributed … run
+`git fetch origin main`"* line rather than silence, so an unexplained warning
+never reads like a confirmed outage again.
+
+The file's own stated rule is *"an unproven excuse must never silence a real
+alarm."* This is its converse: an unproven ref must not raise a false one.
+
+Pinned by `tests/deploy/test_health_check_stale_ref_guard.py` (behavioural — it
+execs the script's own heredoc with a stubbed `_git`; the pre-fix function
+returns a confident `38.0` on the exact incident shape, the post-fix one returns
+`None`, and a *fresh* ref can still both explain a branch artifact and confirm a
+genuine outage).
+
+---
+
+## 3. The real defect — the Flock rookie row-count floor
+
+Step 14's output on run `33961925495`:
+
+```
+fail: 1 stale source(s), 0 unmeasurable, 21 fresh.  Stale: flockFantasySfRookies
+```
+
+Cause, from the same log:
+
+```
+[fetch_flock_fantasy_rookies] row count below floor: 48 < 60
+Non-fatal — continuing with stale CSV
+```
+
+The fetcher was working correctly. It refused to overwrite good data with a
+payload it had been told to distrust, so the CSV kept its 2026-08-26 mtime, so
+the watchdog flagged the source, so the workflow went red — **every run, for
+about ten days.**
+
+### The payload is real, not truncated
+
+Measured live on 2026-09-05 against `format=PROSPECTS_SF`:
+
+- 48 entries, `averageRank` running **1..48 with no gaps**;
+- coherent position mix (WR 20 / RB 12 / TE 9 / QB 7), no IDP, no picks, no
+  nulls, every row `isRookie: true` / `isDraftPick: false`;
+- vendor's own `lastUpdated` is 2026-08-31 — the board *changed*, it did not
+  stop being served;
+- the sibling `format=superflex` board is healthy at 500 rows;
+- **all 48** prospects also appear on that main board;
+- of the 35 rows that left since 2026-08-26, **21 are now on the main board**
+  and the other 14 are deep-tail prospects the vendor dropped
+  (Chase Roberts, Colbie Young, Roman Hemby, …);
+- the main board carries 73 rows flagged `isRookie`.
+
+That is the 2026 rookie class **graduating** from the prospects board onto the
+main dynasty board as the season starts. It is normal vendor behaviour.
+
+### Why the guard mis-fired
+
+`_FF_ROOKIE_ROW_COUNT_FLOOR` was 60, and its comment justified that as *"the
+PROSPECTS_SF endpoint currently carries ~98 entries (one full rookie class)"*.
+That is true only in the pre-draft window. The floor was encoding **"how big
+should a rookie class be"**, which is not a question a truncation guard can
+answer, and which changes by phase.
+
+### Repair
+
+The floor is re-derived as what it actually is — a **truncation guard** — and
+set to **24**: two rounds of a 12-team superflex rookie draft, i.e. the region
+this source's within-class rank has to cover for the rookie-ladder translation
+to mean anything, with 2x headroom under today's observed 48. A genuinely
+broken or truncated response still trips exit 2 (verified: the existing
+2-row test still exits 2). The evidence above is recorded in the constant's own
+comment so the next reader does not re-derive it.
+
+Verified by running the fetcher for real: exit 0, 48 rows written, CSV mtime
+advanced, content genuinely new. `run_fetcher` in `scheduled-refresh.yml` stamps
+`*_last_success` on fetcher exit 0, so the watchdog clears on the next scheduled
+run **from a real fetch** — no stamp was written by hand here, and the
+sandbox-fetched CSV was deliberately **not** committed so that production's
+first fresh copy comes from the pipeline.
+
+### What was deliberately NOT done
+
+- **`flockFantasy` was not added to `soft` in `config/source_staleness.json`.**
+  That file's own governance says soft is *"A DELAY, NOT AN EXEMPTION"*; it is
+  for operator-chore sources like `idpShow`'s hand-minted cookie, and it
+  escalates to hard-fail anyway. Quieting an alarm without fixing acquisition is
+  the failure mode this repo exists to avoid.
+- **No threshold was lowered and no timestamp was minted.**
+
+---
+
+## 4. Known follow-up (not fixed here)
+
+This board is expected to keep shrinking as the 2026 class fully graduates,
+possibly to zero, before repopulating with the 2027 class. **"The vendor no
+longer publishes a rookie board this phase" is a different question from "the
+fetch broke,"** and a fixed row-count floor cannot tell them apart — the new
+floor is not pretending to. When the board empties, the fetcher will exit 1
+("no rows extracted") and the source will go stale again with the same
+symptom and a different cause.
+
+The honest shape for that is a source whose *expected coverage is
+phase-dependent* — either a declared seasonal window for `flockFantasySfRookies`
+in `config/source_staleness.json`, or a relative drop guard measured against the
+source's own recent history rather than an absolute count. Both are new
+methodology and neither is invented here.
+
+---
+
+## 5. Impact
+
+`flockFantasySfRookies` is a registered canonical rank-signal source
+(`needs_rookie_translation=True`, ladder-translating onto the `ktcSfTep`
+backbone), so for ten days the rookie region of the board voted with
+2026-08-26 ranks. Real, but bounded: one voter among many, under a count-aware
+blend where a missing row is missing coverage rather than a zero.
+
+**The larger damage was the signal loss.** A workflow that is red on every run
+cannot report a new failure. Any genuine acquisition outage between 2026-08-26
+and today would have been indistinguishable from this one.
+
+No Week 1 launch row is affected: rookie boards drive dynasty valuation, not
+current-season matchups. `docs/season-launch/WEEK_1_LAUNCH_CONTRACT.md` is
+unchanged by this incident — no acceptance evidence for any existing row moved.

--- a/scripts/fetch_flock_fantasy_rookies.py
+++ b/scripts/fetch_flock_fantasy_rookies.py
@@ -5,12 +5,19 @@ Flock Fantasy publishes a public JSON API at::
 
     https://api.flockfantasy.com/rankings?format=PROSPECTS_SF
 
-which returns ``{ format, year, data: [...] }`` with ~98 entries — the
-current incoming rookie class only (``isRookie == true`` and
-``isDraftPick == false`` for every row, scoped to the upcoming
-``draftYear``).  Each entry carries ``playerName``, ``position``,
-``averageRank`` (float, lower is better), and ``isRookie``.  After
-filtering to offensive positions (QB/RB/WR/TE) ~95+ prospects remain.
+which returns ``{ format, year, lastUpdated, data: [...] }`` — the
+current rookie class only (``isRookie == true`` and ``isDraftPick ==
+false`` for every row, scoped to that ``draftYear``).  Each entry
+carries ``playerName``, ``position``, ``averageRank`` (float, lower is
+better), and ``isRookie``.  We keep the offensive positions
+(QB/RB/WR/TE).
+
+**The board's size is phase-dependent, not fixed.**  It is largest in
+the pre-draft window (~98 entries) and CONTRACTS through the season as
+the vendor graduates rookies onto its main ``format=superflex`` board
+and prunes the deep tail.  A shrinking board here is normal vendor
+behaviour, not a degraded fetch — see
+:data:`_FF_ROOKIE_ROW_COUNT_FLOOR`.
 
 Core model
 ----------
@@ -73,13 +80,36 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_DST = REPO_ROOT / "CSVs" / "site_raw" / "flockFantasySfRookies.csv"
 DATA_DIR_DST = REPO_ROOT / "data" / "exports" / "latest" / "site_raw" / "flockFantasySfRookies.csv"
 
-# Minimum row count.  The PROSPECTS_SF endpoint currently carries ~98
-# entries (one full rookie class).  Floor set at ~60 so a class shrink
-# or a scrape regression trips exit 2 rather than silently publishing a
-# degraded CSV.  Class sizes vary year-over-year — a small class is
-# normal in summers before the next college season fully enters the
-# board, so the floor is intentionally permissive.
-_FF_ROOKIE_ROW_COUNT_FLOOR: int = 60
+# Minimum row count — a TRUNCATION guard, not a class-size expectation.
+#
+# Re-derived 2026-09-05 (incident: docs/ops/INCIDENT_2026-09-05_FLOCK_ROOKIE_FLOOR.md).
+# The previous floor of 60 was calibrated against "~98 entries = one full
+# rookie class", which is only true in the pre-draft window.  In-season the
+# vendor graduates rookies onto its main ``format=superflex`` board and
+# prunes the deep tail, so the prospects board contracts:
+#
+#   2026-08-26   83 rows   (last write that cleared the old floor)
+#   2026-09-05   48 rows   (vendor ``lastUpdated`` 2026-08-31)
+#
+# Verified on 2026-09-05 that the 48 are a COMPLETE small board and not a
+# truncated large one: ``averageRank`` runs 1..48 with no gaps, the position
+# mix is coherent (WR 20 / RB 12 / TE 9 / QB 7), all 48 also appear on the
+# healthy 500-row main board, and of the 35 departures 21 had moved to that
+# main board while the other 14 were deep-tail prospects the vendor dropped.
+#
+# So the floor cannot encode "how big should a rookie class be" — it can only
+# encode "below this, a payload is far likelier truncated than real".  24 is
+# two rounds of a 12-team superflex rookie draft: the region this source's
+# within-class rank actually has to cover for the rookie-ladder translation
+# to mean anything, and 2x headroom under today's observation.  A genuinely
+# broken or truncated response still trips exit 2.
+#
+# Known follow-up recorded in that incident note: this board is expected to
+# keep shrinking as the class fully graduates, and "the vendor no longer
+# publishes a rookie board this phase" is a DIFFERENT question from "the
+# fetch broke".  A fixed floor cannot tell those apart and this one is not
+# pretending to.
+_FF_ROOKIE_ROW_COUNT_FLOOR: int = 24
 
 # Offensive positions we accept from Flock Fantasy rookies.  The
 # PROSPECTS_SF endpoint already excludes IDP and draft picks, but we

--- a/tests/deploy/test_health_check_stale_ref_guard.py
+++ b/tests/deploy/test_health_check_stale_ref_guard.py
@@ -57,9 +57,7 @@ def _load_probe_namespace() -> dict:
 
 
 def _iso(hours_ago: float) -> str:
-    return (
-        dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=hours_ago)
-    ).isoformat()
+    return (dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=hours_ago)).isoformat()
 
 
 @pytest.fixture()

--- a/tests/deploy/test_health_check_stale_ref_guard.py
+++ b/tests/deploy/test_health_check_stale_ref_guard.py
@@ -1,0 +1,123 @@
+"""The session health check must not read a stale `origin/main` ref as evidence.
+
+INCIDENT 2026-09-05 (docs/ops/INCIDENT_2026-09-05_FLOCK_ROOKIE_FLOOR.md §2)
+──────────────────────────────────────────────────────────────────────────
+`.claude/health-check.sh` attributes a stale checked-out contract by asking
+what `origin/main` holds.  `_git` deliberately never fetches — a SessionStart
+hook must not wait on the network — so `origin/main` is whatever the checkout
+last saw.
+
+On 2026-09-05 that ref was ~38h old and unfetched.  The probe read a 38h-old
+contract off it and printed::
+
+    WARNING: no successful scrape in 38h. Check scheduled-refresh workflow.
+    (origin/main's contract is 38h old too — not a branch artifact.)
+
+Both halves were false: production's last successful scrape was 1.2h old and
+real `main` carried a 1.6h-old contract.  The second line is the damaging one
+— it upgrades "I cannot tell" into a confident pipeline-outage claim, and it
+triggered a full P0 incident response.
+
+The file's own rule is "an unproven excuse must never silence a real alarm."
+This test pins the converse: an unproven ref must not raise a false one.  A
+ref older than the freshness budget is evidence in NEITHER direction, so it
+must answer None ("cannot tell"), and the caller must say so explicitly
+rather than implying the pipeline.
+
+This is a behavioural test over the real script's own source: it extracts the
+Python heredoc from the shell file and exercises the functions with a stubbed
+`_git`.  No network, no git, no live board.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / ".claude" / "health-check.sh"
+
+
+def _load_probe_namespace() -> dict:
+    """Exec the freshness probe's function definitions in isolation.
+
+    The heredoc's trailing module-level code reads `exports/latest/` and
+    prints; we cut at it so only the definitions run.
+    """
+    text = _SCRIPT.read_text(encoding="utf-8")
+    blocks = re.findall(r"<<'PY'[^\n]*\n(.*?)\nPY\n", text, flags=re.DOTALL)
+    assert blocks, "no python heredoc found in .claude/health-check.sh"
+    src = max(blocks, key=len)
+    cut = src.index("paths = sorted(")
+    ns: dict = {}
+    exec(compile(src[:cut], str(_SCRIPT), "exec"), ns)  # noqa: S102 - the file under test
+    return ns
+
+
+def _iso(hours_ago: float) -> str:
+    return (
+        dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=hours_ago)
+    ).isoformat()
+
+
+@pytest.fixture()
+def ns():
+    return _load_probe_namespace()
+
+
+def _stub_git(ns, *, ref_age_h, contract_age_h):
+    """Replace `_git` so it answers as a checkout whose origin/main ref is
+    `ref_age_h` old and whose contract blob is `contract_age_h` old."""
+
+    def fake(*args):
+        if args[:2] == ("log", "-1"):
+            return _iso(ref_age_h) + "\n" if ref_age_h is not None else None
+        if args[0] == "ls-tree":
+            return "exports/latest/dynasty_data_20260905.json\n"
+        if args[0] == "show":
+            return '{"scrapeTimestamp": "%s"}' % _iso(contract_age_h)
+        return None
+
+    ns["_git"] = fake
+
+
+def test_stale_local_ref_answers_cannot_tell(ns):
+    # The exact 2026-09-05 shape: a 38h-old unfetched ref carrying a 38h-old
+    # contract, against a 24h budget.  It must NOT come back as a confident
+    # "the pipeline is stale too".
+    _stub_git(ns, ref_age_h=38.0, contract_age_h=38.0)
+    assert ns["main_contract_age_h"](24) is None
+
+
+def test_unreadable_local_ref_answers_cannot_tell(ns):
+    _stub_git(ns, ref_age_h=None, contract_age_h=1.0)
+    assert ns["main_contract_age_h"](24) is None
+
+
+def test_current_ref_still_attributes_a_branch_artifact(ns):
+    # The behaviour the block exists for must survive: a FRESH ref proving a
+    # fresh main is still allowed to explain away an old checkout.
+    _stub_git(ns, ref_age_h=0.5, contract_age_h=1.6)
+    age = ns["main_contract_age_h"](24)
+    assert age is not None and age < 24
+
+
+def test_current_ref_can_still_confirm_a_real_outage(ns):
+    # And a fresh ref showing a genuinely stale main must still report that
+    # age, so the "not a branch artifact" line stays reachable.
+    _stub_git(ns, ref_age_h=0.5, contract_age_h=40.0)
+    age = ns["main_contract_age_h"](24)
+    assert age is not None and age > 24
+
+
+def test_caller_explains_an_unattributed_warning():
+    """None must not print as silence.
+
+    Without this line the reader sees a bare outage warning and no reason it
+    went unexplained — which is how the false alarm read in the first place.
+    """
+    text = _SCRIPT.read_text(encoding="utf-8")
+    assert "Cause NOT attributed" in text
+    assert "git fetch origin main" in text

--- a/tests/scripts/test_fetch_flock_fantasy_rookies.py
+++ b/tests/scripts/test_fetch_flock_fantasy_rookies.py
@@ -286,7 +286,7 @@ class TestMainExitCodes(unittest.TestCase):
             self.assertFalse(dest.exists())
 
     def test_main_exits_2_on_row_count_floor_violation(self):
-        # 2 players — below the default 60-row floor.
+        # 2 players — below the default row-count floor (a truncation guard).
         data = _make_api_response(
             ("Jeremiyah Love", "RB", 1.0, False),
             ("Carnell Tate", "WR", 2.71, False),


### PR DESCRIPTION
Reported as a P0 data-freshness outage. **It was not one.** Two independent findings, both repaired here.

Full record: `docs/ops/INCIDENT_2026-09-05_FLOCK_ROOKIE_FLOOR.md`.

## What is actually true

`scheduled-refresh.yml` has ended `conclusion: failure` on every run since 2026-08-26 — runs 1341–1345 — and in **every one of them only step 14 ("Staleness watchdog") failed.** Steps 1–13 and 15 succeeded: run scraper, persist freshness stamps, validate scrape sanity, prune archives, commit updated data, trigger deploy, assert DLF freshness, contract coverage watchdog.

| when | fact |
|---|---|
| 2026-09-05 11:25:06Z | production `last_success_at`; `last_failure_at: null`, `current_step: complete` |
| 2026-09-05 10:58:20Z | `main`'s contract `scrapeTimestamp`, 1078 players |
| 2026-08-26 16:07:55Z | last successful `flockFantasySfRookies` fetch |

Acquisition → commit → deploy → production was green throughout. This is a **health-state bookkeeping failure**, not acquisition, scheduling, Actions, on-box, commit/push, or deployment.

## 1. The Flock rookie row-count floor was calibrated on a pre-draft assumption

`_FF_ROOKIE_ROW_COUNT_FLOOR` was 60, justified in its own comment as *"~98 entries (one full rookie class)"*. That holds only in the pre-draft window. In-season the vendor graduates rookies onto its main `format=superflex` board and prunes the tail, so PROSPECTS_SF contracted 83 → 48 rows.

The fetcher then did exactly the right thing — refused to publish a payload it had been told to distrust — so the CSV kept its 2026-08-26 mtime, the watchdog flagged the source, and the workflow went red on every run for ten days.

**The 48 are a complete small board, not a truncated large one.** Measured live 2026-09-05:

- `averageRank` runs **1..48 with no gaps**; coherent position mix (WR 20 / RB 12 / TE 9 / QB 7); no IDP, no picks, no nulls
- vendor's own `lastUpdated` is 2026-08-31 — the board *changed*, it did not stop being served
- the sibling `format=superflex` board is healthy at 500 rows, and **all 48** prospects appear on it
- of the 35 rows that left since 2026-08-26, **21 are now on that main board**; the other 14 are deep-tail prospects the vendor dropped

That is the 2026 class graduating. Normal vendor behaviour.

**Repair:** the floor is re-derived as what it actually is — a *truncation* guard, not a class-size expectation — and set to **24**: two rounds of a 12-team superflex rookie draft, the region this source's within-class rank must cover for the rookie-ladder translation to mean anything, with 2x headroom under today's observation. A broken or truncated response still trips exit 2 (the existing 2-row test still exits 2). The evidence is recorded in the constant's comment.

Verified by running the fetcher for real: **exit 0, 48 rows written, mtime advanced, content genuinely new.**

### What was deliberately not done

- **`flockFantasy` was NOT soft-flagged** in `config/source_staleness.json`. That file's own governance says soft is *"A DELAY, NOT AN EXEMPTION"*, it is for operator-chore sources like `idpShow`'s hand-minted cookie, and it escalates to hard-fail anyway. Quieting an alarm without fixing acquisition is the failure mode this repo exists to avoid.
- **No freshness threshold was lowered and no timestamp was hand-minted.** The sandbox-fetched CSV is deliberately **not** committed, so production's first fresh copy comes from the pipeline. `run_fetcher` stamps `*_last_success` on fetcher exit 0, so the watchdog clears on the next scheduled run from a real fetch.

## 2. `.claude/health-check.sh` read a stale unfetched ref as evidence

`_git` never fetches (a SessionStart hook must not wait on the network), so `origin/main` is whatever the checkout last saw. With a 38h-old ref the probe printed:

```
WARNING: no successful scrape in 38h. Check scheduled-refresh workflow.
(origin/main's contract is 38h old too — not a branch artifact.)
```

Both halves false — production was 1.2h fresh and real `main` 1.6h. The second line is the damaging one: it converts "I cannot tell" into a confident pipeline-outage claim, and it triggered a full P0 response.

**Repair:** `main_contract_age_h(limit)` consults a new `local_main_ref_age_h()` first and answers `None` ("cannot tell") when the ref is itself stale or unreadable; the caller now prints an explicit *"Cause NOT attributed … run `git fetch origin main`"* line instead of leaving the warning unexplained. The file's own rule is *"an unproven excuse must never silence a real alarm"* — this is its converse.

## Testing

- `tests/deploy/test_health_check_stale_ref_guard.py` (new, 5 tests) — behavioural: execs the script's own heredoc with a stubbed `_git`. Pre-fix returns a confident `38.0` on the exact incident shape; post-fix returns `None`; a *fresh* ref can still both explain a branch artifact and confirm a genuine outage.
- `tests/scripts/test_fetch_flock_fantasy_rookies.py` — 24 passed, including the floor-violation exit-2 case.
- `tests/deploy/` + `tests/adapters/test_source_config_completeness.py` — 445 passed, 4 skipped.
- `scripts/check_planning_integrity.py` — all checks pass, V1 standing tally unchanged.
- `ruff` clean on all changed Python.

## Known follow-up, named rather than hidden

This board is expected to keep shrinking as the class fully graduates, possibly to zero. **"The vendor no longer publishes a rookie board this phase" is a different question from "the fetch broke,"** and a fixed row-count floor cannot tell them apart — the new floor is not pretending to. The honest shape is a declared seasonal window or a relative drop guard measured against the source's own history. Both are new methodology and neither is invented here. Recorded in the incident note §4.

## Scope

No V1 row, no Week 1 launch row, and no acceptance evidence changes. `docs/season-launch/WEEK_1_LAUNCH_CONTRACT.md` is untouched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPwRjfLMMgHj4xLCQKgoDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPwRjfLMMgHj4xLCQKgoDW)_