### PR TITLE
W1-10: audit Week 1 pregame data, and stop rendering an empty H2H series as a dead heat

### DIFF
--- a/docs/season-launch/W1_10_WEEK1_MATCHUP_AUDIT_2026-09-05.md
+++ b/docs/season-launch/W1_10_WEEK1_MATCHUP_AUDIT_2026-09-05.md
@@ -1,0 +1,120 @@
+# W1-10 — Week 1 matchup-data audit, 2026-09-05
+
+**Row:** `docs/season-launch/WEEK_1_LAUNCH_CONTRACT.md` W1-10 — *"All six Week 1
+league matchups are present with correct managers/teams/schedule and current,
+non-fabricated data inputs."*
+
+**Method:** production `GET /api/public/league/matchupPreview` compared field by
+field against Sleeper as ground truth (league `1312006700437352448`, plus the
+2025 `1180092661344120832` and 2024 `1090320428817592320` links of the same
+chain). Read-only; no fixtures, no repo snapshots.
+
+**Verdict at audit time:** everything the row asks for is present and correct
+**except one missing-is-never-zero defect**, found and repaired here. W1-10
+cannot move to `VERIFIED` until that repair is deployed and re-checked on
+production — the code fix is not the acceptance evidence.
+
+---
+
+## 1. Presence, schedule and identity — all correct
+
+`data.currentSeason 2026`, `currentWeek 1`, `mode "preview"`, `isPlayoff false`,
+six matchups, 12 distinct `ownerId`s, `generatedAt 2026-09-05T12:54:32+00:00`.
+
+Every pairing matches Sleeper's `/matchups/1` exactly:
+
+| matchupId | roster pair (prod) | roster pair (Sleeper) | ownerIds |
+|---|---|---|---|
+| 1 | 5, 7 | 5, 7 | match |
+| 2 | 3, 12 | 3, 12 | match |
+| 3 | 8, 11 | 8, 11 | match |
+| 4 | 1, 4 | 1, 4 | match |
+| 5 | 2, 10 | 2, 10 | match |
+| 6 | 6, 9 | 6, 9 | match |
+
+Sleeper reports 12 week-1 rows, six `matchup_id`s of two rosters each, no null
+`matchup_id`, and **no nonzero points** — the week is genuinely unplayed and the
+league is `status: in_season`, `state/nfl` `season 2026 week 1 regular`.
+
+**Team names are a documented fallback ladder, not fabrication.** Five of the
+twelve managers have no `metadata.team_name` set on Sleeper (it is `None` or
+`""`). `identity.py` resolves `metadata.team_name → user.display_name →
+"Team {rosterId}"`, so production shows e.g. `CollinFoz` and `ughb`. Every value
+served is Sleeper-derived; nothing is invented.
+
+**Unplayed points are `null`, not `0`** on all twelve sides.
+
+## 2. The H2H block is correct, including a non-obvious aggregation
+
+Spot-checked matchup 4 (Jason vs Collin) against every meeting in the chain.
+
+A naive per-week scan of Sleeper finds **five** rows: 2024 wk8, 2024 wk16,
+2024 wk17, 2025 wk3, 2025 wk12. Production reports **four** meetings with
+`playoffMeetings: 1`. Production is right and the naive count is wrong: the 2024
+playoff was a **two-week aggregate**, and production sums it into one meeting —
+
+```
+317.95 + 274.07 = 592.02   (Jason)
+295.14 + 320.71 = 615.85   (Collin)
+```
+
+which is exactly what the `last5` entry for `2024 wk 16, isPlayoff: true`
+carries. Recounted correctly the series is 2-2, `avgMargin`
+`(19.21 + 23.83 + 56.02 + 108.0) / 4 = 51.77`, `biggestMargin 108.0` — all three
+match production, as does the narrative string.
+
+## 3. Defect found — an empty H2H series was rendered as a dead heat
+
+Two of the six matchups (2 and 3) are **first-ever meetings**: Blaine and
+jstuedle joined for 2026 and their alias lists carry 2026 only. Production
+served:
+
+```json
+{"totalMeetings": 0, "avgMargin": 0.0, "biggestMargin": 0.0,
+ "narrative": "First ever meeting between Blaine and Ty."}
+```
+
+An average and a maximum over an empty series are **undefined, not zero**, and
+the reading `avgMargin: 0.0` invites is the opposite of the truth: *these two
+always play to a dead heat.* The sibling `_form_summary` already gets this right
+— it publishes `avgPoints: null` for a manager with no games — so this was an
+inconsistency inside one module, not a missing convention.
+
+**It is not cosmetic.** `matchup_narrative._build_brief` copies the block into
+the brief and `json.dumps`es it verbatim into the article-generation prompt, so
+the generator was being handed a fabricated dead-heat series for exactly the two
+matchups with no history. That is a W1-11 quality failure manufactured upstream.
+
+### Repair
+
+- `matchup_preview._h2h_summary` returns `None` for `avgMargin`,
+  `biggestMargin` and `biggestMarginWinner` when there are no meetings.
+- `matchup_narrative._build_brief` drops its `.get(key, 0.0)` defaults, which
+  would otherwise re-coerce the `None` straight back to `0.0`.
+
+**Counts deliberately stay `0`:** `sideAWins`, `sideBWins`, `ties`,
+`playoffMeetings` are tallies of things that happened zero times, and
+`sideAPointsTotal` / `sideBPointsTotal` are sums over an empty set. Those are
+facts. Only the average and the extremum are undefined, and only they changed.
+
+A **tie** stays distinct from an empty series and is pinned by its own test: a
+tie *has* a margin (zero) and no winner; an empty series has neither.
+
+Pinned by `tests/public_league/test_matchup_preview.py`
+(`EmptySeriesIsMissingNotZeroTests`, 4 tests) and
+`tests/public_league/test_matchup_narrative.py`
+(`BriefDoesNotReintroduceZeroMarginTests`, 2 tests — one behavioural, one
+structural, because the coercion is one word long and reads like ordinary
+defensive code in a diff).
+
+`config/coercion_baseline.json` is **not** touched: neither idiom
+(`... if total else 0.0`, `.get(key, 0.0)`) was in the baseline, so nothing is
+burned down and the file's known merge hazard is avoided.
+
+## 4. Row status
+
+`W1-10` stays **NOT STARTED → IN PROGRESS**, not `VERIFIED`. The data audit
+passes on every clause except the one defect, and the repair is code, not
+production evidence. It moves to `VERIFIED` when this is merged, deployed, and
+`GET /api/public/league/matchupPreview` serves `avgMargin: null` for matchups 2
+and 3 on production.

--- a/docs/season-launch/WEEK_1_LAUNCH_CONTRACT.md
+++ b/docs/season-launch/WEEK_1_LAUNCH_CONTRACT.md
@@ -33,7 +33,7 @@ The denominator is frozen at 30 for this launch tranche. Do not add/remove rows 
 | W1-07 | Public pregame | Public league contract exposes the canonical pregame/narrative outputs consumed by frontend surfaces. | VERIFIED |
 | W1-08 | Public pregame | Canonical Week page renders the existing matchup preview path. | VERIFIED |
 | W1-09 | Public pregame | Canonical articles route renders the existing narrative path. | VERIFIED |
-| W1-10 | Public pregame | All six Week 1 league matchups are present with correct managers/teams/schedule and current, non-fabricated data inputs. | NOT STARTED |
+| W1-10 | Public pregame | All six Week 1 league matchups are present with correct managers/teams/schedule and current, non-fabricated data inputs. | IN PROGRESS |
 | W1-11 | Public pregame | All six Week 1 narratives/previews are generated and pass factual, freshness, repetition, and matchup-specific quality review. | NOT STARTED |
 | W1-12 | Public pregame | Week 1 pregame surfaces pass mobile/navigation/link/degraded-state production verification. | NOT STARTED |
 | W1-13 | Public pregame | Public/private leakage audit proves proprietary values, edges, targets, forecasts, or private decision intelligence are not exposed publicly. | NOT STARTED |
@@ -57,12 +57,12 @@ The denominator is frozen at 30 for this launch tranche. Do not add/remove rows 
 
 ## Mechanical tally
 
-*Recounted 2026-09-04T21:00Z after merge of #1244.*
+*Recounted 2026-09-05T13:10Z. The numerator is unchanged; only W1-10 moved, NOT STARTED -> IN PROGRESS.*
 
 - VERIFIED: 14
 - IMPLEMENTED_UNVERIFIED: 1
-- IN PROGRESS: 0
-- NOT STARTED: 14
+- IN PROGRESS: 1
+- NOT STARTED: 13
 - BLOCKED: 1
 - DENOMINATOR: 30
 - COMPLETION: **14/30 = 46.7%**
@@ -78,6 +78,28 @@ The denominator is frozen at 30 for this launch tranche. Do not add/remove rows 
 - **W1-22 → VERIFIED (#1244).** `Win Matchup %` is produced by the canonical joint weekly simulation, bounded/tested, and structurally reconciles to the same draw-level joint outcomes used by the median path.
 - **W1-24 → VERIFIED (#1244).** Game Day result contracts carry generated/model/scoring metadata, coverage and unsimulable-player information, and explicit NOT_APPLICABLE / STANDINGS_RULE_UNVERIFIED / UNSIMULABLE / fallback notes instead of fabricated numeric certainty.
 - **W1-23 → BLOCKED, not VERIFIED.** #1244 correctly derives the median-side probability from the same league-wide simulation draws and correctly represents median-disabled as NOT_APPLICABLE, but host-faithful threshold/tie semantics remain unverified. `threshold_semantics_verified` is deliberately hard-coded false. The repo's historical Sleeper data cannot safely answer the question because retrospective best-ball scoring no longer reproduces the host's recorded season totals. Exact smallest decision/evidence needed: inspect one completed Sleeper week in the host UI/API evidence available at the time and establish whether `league_average_match` uses median or average and what an exact threshold tie records as. Do not guess or flip the flag without that evidence.
+
+### Row movements, 2026-09-05
+
+- **W1-10 → IN PROGRESS (not VERIFIED).** A full field-by-field audit of
+  production `GET /api/public/league/matchupPreview` against Sleeper ground
+  truth passes every clause of the row except one:
+  `docs/season-launch/W1_10_WEEK1_MATCHUP_AUDIT_2026-09-05.md`. All six Week 1
+  matchups are present in `preview` mode with pairings, `ownerId`s and roster
+  ids matching Sleeper exactly, 12 distinct owners, unplayed points as `null`
+  rather than `0`, team names resolved through the documented Sleeper fallback
+  ladder, and an H2H block that is correct including a two-week aggregated 2024
+  playoff meeting.
+  The defect: the two first-ever meetings (matchups 2 and 3 — Blaine and
+  jstuedle joined for 2026) served `avgMargin: 0.0` / `biggestMargin: 0.0` for a
+  series with zero meetings, which reads as "these two always play to a dead
+  heat" and was copied verbatim into the narrative generator's prompt JSON. An
+  average over an empty set is undefined, not zero. Repaired in
+  `matchup_preview._h2h_summary` (and the brief's re-coercing `.get(key, 0.0)`
+  defaults) with `None`; counts and sums correctly stay `0`.
+  It is IN PROGRESS rather than VERIFIED because a code repair is not
+  production evidence: the row moves when the fix is merged, deployed, and
+  production serves `avgMargin: null` for those two matchups.
 
 ### Named blockers
 

--- a/src/public_league/matchup_narrative.py
+++ b/src/public_league/matchup_narrative.py
@@ -783,8 +783,11 @@ def build_brief(
         if pair_key[0] == home_owner
         else summary.get("sideAWins", 0),
         "ties": summary.get("ties", 0),
-        "avgMargin": summary.get("avgMargin", 0.0),
-        "biggestMargin": summary.get("biggestMargin", 0.0),
+        # No ``0.0`` default: the summary answers None for a series with no
+        # meetings, and re-coercing here would put "average margin 0.0" back
+        # into the prompt JSON for a first-ever matchup.
+        "avgMargin": summary.get("avgMargin"),
+        "biggestMargin": summary.get("biggestMargin"),
         "playoffMeetings": summary.get("playoffMeetings", 0),
         "last5": last_5,
     }

--- a/src/public_league/matchup_preview.py
+++ b/src/public_league/matchup_preview.py
@@ -228,8 +228,20 @@ def _h2h_summary(meetings: list[dict[str, Any]], sideA_oid: str, sideB_oid: str)
         if m.get("isPlayoff"):
             playoff_meetings += 1
     total = len(meetings)
-    avg_margin = round(sum(abs(m) for m in margins) / total, 2) if total else 0.0
-    biggest = max(margins, key=lambda m: abs(m)) if margins else 0.0
+    # An average and a maximum over an EMPTY series are undefined, not zero.
+    # Both used to fall back to ``0.0``, which is the one reading a consumer
+    # must never take from a first-ever meeting: "average margin 0.0" says
+    # these two always play to a dead heat, and it is fed verbatim into the
+    # narrative brief's prompt JSON.  ``None`` -> ``null`` there, which is
+    # the honest statement.  This matches ``_form_summary``, which already
+    # publishes ``avgPoints: None`` for a manager with no games.
+    #
+    # The COUNTS stay 0, deliberately: wins, ties and playoff meetings are
+    # tallies of things that happened zero times, and the points totals are
+    # sums over an empty set.  Those are facts.  Only the average and the
+    # extremum are undefined, and only they change.
+    avg_margin = round(sum(abs(m) for m in margins) / total, 2) if total else None
+    biggest = max(margins, key=lambda m: abs(m)) if margins else None
     return {
         "totalMeetings": total,
         "sideAWins": wins_a,
@@ -238,8 +250,12 @@ def _h2h_summary(meetings: list[dict[str, Any]], sideA_oid: str, sideB_oid: str)
         "sideAPointsTotal": round(pts_a, 2),
         "sideBPointsTotal": round(pts_b, 2),
         "avgMargin": avg_margin,
-        "biggestMargin": round(abs(biggest), 2),
-        "biggestMarginWinner": sideA_oid if biggest > 0 else (sideB_oid if biggest < 0 else None),
+        "biggestMargin": round(abs(biggest), 2) if biggest is not None else None,
+        "biggestMarginWinner": (
+            None
+            if biggest is None
+            else (sideA_oid if biggest > 0 else (sideB_oid if biggest < 0 else None))
+        ),
         "playoffMeetings": playoff_meetings,
     }
 

--- a/tests/public_league/test_matchup_narrative.py
+++ b/tests/public_league/test_matchup_narrative.py
@@ -30,6 +30,7 @@ import unittest
 from pathlib import Path
 
 from src.public_league import matchup_narrative as mn
+from src.public_league import matchup_narrative, matchup_preview
 from tests.public_league.fixtures import build_test_snapshot
 
 
@@ -680,3 +681,34 @@ class PriorSeasonFormDirectiveTests(unittest.TestCase):
             games = (side.get("recentForm") or {}).get("games") or []
             for g in games:
                 self.assertIn("season", g)
+
+
+class BriefDoesNotReintroduceZeroMarginTests(unittest.TestCase):
+    """The brief must not re-coerce an undefined H2H aggregate back to 0.0.
+
+    `_h2h_summary` answers ``None`` for a series with no meetings.  The brief
+    read those keys with ``.get(key, 0.0)``, which put "average margin 0.0"
+    back into the prompt JSON for a first-ever matchup — the exact fabricated
+    dead-heat claim the summary fix removed.  The defaults are gone; this
+    pins that they stay gone, because the coercion is one word long and
+    reads like ordinary defensive code in a diff.
+    """
+
+    def test_no_zero_default_on_the_h2h_margin_keys(self) -> None:
+        src = Path(matchup_narrative.__file__).read_text(encoding="utf-8")
+        self.assertNotIn('summary.get("avgMargin", 0.0)', src)
+        self.assertNotIn('summary.get("biggestMargin", 0.0)', src)
+        self.assertIn('summary.get("avgMargin")', src)
+        self.assertIn('summary.get("biggestMargin")', src)
+
+    def test_empty_series_serializes_as_null_in_the_prompt_json(self) -> None:
+        summary = matchup_preview._h2h_summary([], "owner-A", "owner-B")
+        block = {
+            "totalMeetings": summary.get("totalMeetings", 0),
+            "avgMargin": summary.get("avgMargin"),
+            "biggestMargin": summary.get("biggestMargin"),
+        }
+        rendered = json.dumps(block, sort_keys=True)
+        self.assertIn('"avgMargin": null', rendered)
+        self.assertIn('"biggestMargin": null', rendered)
+        self.assertNotIn("0.0", rendered)

--- a/tests/public_league/test_matchup_preview.py
+++ b/tests/public_league/test_matchup_preview.py
@@ -12,6 +12,7 @@ import unittest
 
 from src.public_league.matchup_preview import (
     build_section,
+    _h2h_summary,
     _pair_key,
     _recent_form_for_owner,
 )
@@ -149,3 +150,85 @@ class RecentFormSeasonLabellingTests(unittest.TestCase):
     def test_a_real_window_still_reports_a_numeric_average(self) -> None:
         form = _recent_form_for_owner(self.snapshot, self.owner, "2025", 16, n=3)
         self.assertIsInstance(form["avgPoints"], float)
+
+
+class EmptySeriesIsMissingNotZeroTests(unittest.TestCase):
+    """A first-ever meeting has NO average margin — it does not have one of zero.
+
+    Two of the six 2026 Week 1 matchups on production are first-ever meetings
+    (new managers joined for 2026), and `_h2h_summary` returned
+    ``avgMargin: 0.0`` / ``biggestMargin: 0.0`` for them.  That is a missing
+    value rendered as a real one, and the reading it invites is the opposite
+    of the truth: "average margin 0.0" says these two always play to a dead
+    heat.  It is not cosmetic — the block is serialized straight into the
+    narrative brief's prompt JSON (`matchup_narrative._build_brief`), so the
+    article generator was being handed a fabricated dead-heat series.
+
+    The sibling `_form_summary` already publishes ``avgPoints: None`` for a
+    manager with no games, so this is the module's own existing convention
+    applied consistently, not a new one.
+    """
+
+    def test_no_meetings_yields_none_for_undefined_aggregates(self) -> None:
+        summary = _h2h_summary([], "owner-A", "owner-B")
+        self.assertEqual(summary["totalMeetings"], 0)
+        self.assertIsNone(summary["avgMargin"])
+        self.assertIsNone(summary["biggestMargin"])
+        self.assertIsNone(summary["biggestMarginWinner"])
+
+    def test_counts_over_an_empty_series_stay_zero(self) -> None:
+        # Deliberately NOT promoted to None: these are tallies of things that
+        # happened zero times, and sums over an empty set.  They are facts.
+        summary = _h2h_summary([], "owner-A", "owner-B")
+        for key in (
+            "sideAWins",
+            "sideBWins",
+            "ties",
+            "playoffMeetings",
+            "sideAPointsTotal",
+            "sideBPointsTotal",
+        ):
+            self.assertEqual(summary[key], 0, key)
+
+    def test_a_real_series_still_reports_numbers(self) -> None:
+        meetings = [
+            {
+                "sideAOwnerId": "owner-A",
+                "sideBOwnerId": "owner-B",
+                "sideAPoints": 110.0,
+                "sideBPoints": 100.0,
+                "isPlayoff": False,
+            },
+            {
+                "sideAOwnerId": "owner-A",
+                "sideBOwnerId": "owner-B",
+                "sideAPoints": 90.0,
+                "sideBPoints": 120.0,
+                "isPlayoff": True,
+            },
+        ]
+        summary = _h2h_summary(meetings, "owner-A", "owner-B")
+        self.assertEqual(summary["totalMeetings"], 2)
+        self.assertEqual(summary["avgMargin"], 20.0)
+        self.assertEqual(summary["biggestMargin"], 30.0)
+        self.assertEqual(summary["biggestMarginWinner"], "owner-B")
+        self.assertEqual(summary["playoffMeetings"], 1)
+
+    def test_an_exactly_tied_meeting_has_no_margin_winner(self) -> None:
+        # Distinct from the empty case and it must stay distinct: a tie HAS a
+        # margin (zero) and no winner; an empty series has neither.
+        meetings = [
+            {
+                "sideAOwnerId": "owner-A",
+                "sideBOwnerId": "owner-B",
+                "sideAPoints": 100.0,
+                "sideBPoints": 100.0,
+                "isPlayoff": False,
+            }
+        ]
+        summary = _h2h_summary(meetings, "owner-A", "owner-B")
+        self.assertEqual(summary["totalMeetings"], 1)
+        self.assertEqual(summary["ties"], 1)
+        self.assertEqual(summary["avgMargin"], 0.0)
+        self.assertEqual(summary["biggestMargin"], 0.0)
+        self.assertIsNone(summary["biggestMarginWinner"])


### PR DESCRIPTION
Field-by-field audit of production `GET /api/public/league/matchupPreview` against **Sleeper as ground truth** (league `1312006700437352448`, plus the 2025 and 2024 links of the same chain). Read-only; no fixtures, no repo snapshots.

Full record: `docs/season-launch/W1_10_WEEK1_MATCHUP_AUDIT_2026-09-05.md`.

## What passes

- All six Week 1 matchups present, `mode: "preview"`, `generatedAt` fresh
- **Every pairing, `ownerId` and `rosterId` matches Sleeper's `/matchups/1` exactly**; 12 distinct owners
- Unplayed points are `null`, **not `0`**, on all twelve sides
- Team names come from the documented Sleeper fallback ladder (`metadata.team_name` → `display_name` → `"Team {rosterId}"`), so the five managers with no custom name are shown truthfully rather than invented

The H2H block is correct including a **non-obvious** case. A naive per-week scan of Sleeper finds *five* Jason-vs-Collin rows; production reports **four** meetings with `playoffMeetings: 1` — and production is right, because the 2024 playoff was a two-week aggregate:

```
317.95 + 274.07 = 592.02   (Jason)
295.14 + 320.71 = 615.85   (Collin)
```

which is exactly the `last5` entry it serves. `avgMargin 51.77` and `biggestMargin 108.0` reconcile to the penny.

## The defect

Two of the six are **first-ever meetings** (Blaine and jstuedle joined for 2026). Production served:

```json
{"totalMeetings": 0, "avgMargin": 0.0, "biggestMargin": 0.0,
 "narrative": "First ever meeting between Blaine and Ty."}
```

An average and a maximum over an empty series are **undefined, not zero**, and the reading `avgMargin: 0.0` invites is the opposite of the truth: *these two always play to a dead heat.*

**Not cosmetic.** `matchup_narrative._build_brief` copies the block into the brief and `json.dumps`es it verbatim into the article-generation prompt — so the generator was being handed a fabricated dead-heat series for exactly the two matchups with no history. That is a W1-11 quality failure manufactured upstream.

## The fix

- `matchup_preview._h2h_summary` → `None` for `avgMargin`, `biggestMargin`, `biggestMarginWinner` when there are no meetings (serializes as `null`)
- `matchup_narrative._build_brief` drops its `.get(key, 0.0)` defaults, which would re-coerce it straight back

**Counts deliberately stay `0`.** `sideAWins` / `sideBWins` / `ties` / `playoffMeetings` are tallies of things that happened zero times, and the points totals are sums over an empty set. Those are facts. Only the average and the extremum are undefined, and only they changed.

A **tie stays distinct** from an empty series and has its own test: a tie *has* a margin (zero) and no winner; an empty series has neither.

This is the module's own convention applied consistently — the sibling `_form_summary` already publishes `avgPoints: null` for a manager with no games.

`config/coercion_baseline.json` is **untouched**: neither idiom (`... if total else 0.0`, `.get(key, 0.0)`) was baselined, so nothing is burned down and that file's known silent-merge hazard is avoided.

## Testing

- `tests/public_league/test_matchup_preview.py::EmptySeriesIsMissingNotZeroTests` — 4 tests (empty → `None`; counts stay `0`; a real series still reports numbers; a tie is not an empty series)
- `tests/public_league/test_matchup_narrative.py::BriefDoesNotReintroduceZeroMarginTests` — 2 tests, one behavioural and one structural, because the coercion is one word long and reads like ordinary defensive code in a diff
- `tests/public_league/` — **441 passed**, 50 subtests
- `ruff format --check .` and `ruff check .` clean repo-wide
- `scripts/check_planning_integrity.py` — all checks pass

## Contract movement

**W1-10: `NOT STARTED` → `IN PROGRESS`, not `VERIFIED`.** A code repair is not production evidence. **The numerator is unchanged at 14/30 (46.7%).** W1-10 moves to `VERIFIED` when this is merged, deployed, and production serves `avgMargin: null` for matchups 2 and 3.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPwRjfLMMgHj4xLCQKgoDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPwRjfLMMgHj4xLCQKgoDW)_