### PR TITLE
W1-12: give the current week's pregame content a public surface

### DIFF
--- a/docs/season-launch/W1_12_PUBLIC_PREGAME_SURFACE_2026-09-05.md
+++ b/docs/season-launch/W1_12_PUBLIC_PREGAME_SURFACE_2026-09-05.md
@@ -1,0 +1,116 @@
+# W1-12 — the current week's pregame content was reachable from no public surface
+
+**Row:** `docs/season-launch/WEEK_1_LAUNCH_CONTRACT.md` W1-12 — *"Week 1 pregame
+surfaces pass mobile/navigation/link/degraded-state production verification."*
+
+**Found while auditing W1-10** (`W1_10_WEEK1_MATCHUP_AUDIT_2026-09-05.md`), which
+proved the Week 1 pregame *data* on production is present and correct. This
+document is about where that data goes, which turned out to be nowhere.
+
+---
+
+## 1. The gap
+
+On 2026-09-05 — Week 1 of the season, `state/nfl` `season 2026 week 1 regular`,
+kickoff Thursday 2026-09-10 — production served:
+
+```
+GET /api/public/league/matchupPreview
+  currentSeason 2026 · currentWeek 1 · mode "preview" · 6 matchups
+  every pairing, ownerId and rosterId matching Sleeper exactly
+```
+
+and the public site rendered **none of it**:
+
+- `/league` (Home) shows a single-matchup teaser card with one H2H narrative
+  line and a "Full H2H preview →" CTA.
+- That CTA calls `onNavigate("matchupPreview")`, which `tabs.js` aliases to the
+  `previews` tab.
+- The `previews` tab is `ArticlesSection`, which renders **AI-written articles**
+  and falls back to the most recent `(season, week)` group that has any. There
+  are **zero 2026 Week 1 articles** — `weekly-narratives.yml` skips generation
+  after its key check because `ANTHROPIC_API_KEY` is not configured (the named
+  W1-11 blocker) — so the tab landed on **2025 Week 17**.
+
+So the six Week 1 head-to-head previews were computed, served, correct, and
+unreachable. The CTA promising a "full H2H preview" led to last season's
+championship articles.
+
+**This was a deliberate design that stopped holding.** `tabs.js` records the
+reasoning for retiring the old structured "This Week" tab: *"the articles
+surface the same H2H + form data inline (the brief is built from it), so the
+structured-data tabs are redundant once articles are wired in."* That is true
+whenever an article exists for the current week. It is exactly false when none
+does, and nothing covered that case.
+
+A second, smaller problem in the same place: the heading did name the older
+slate's season and week (`"Week 17 previews · 2025"`), but the subhead read
+*"Wednesday-morning previews. Tap a card for the full article."* in the present
+tense, with nothing saying the current week has none. Labelled, but not flagged.
+
+## 2. The repair
+
+`frontend/app/league/sections/matchup-previews.jsx` (new) is the `previews` tab.
+It composes, in reading order:
+
+1. the **structured head-to-head block** for the current week, read verbatim
+   from the canonical `matchupPreview` contract section;
+2. `ArticlesSection` below it, unchanged in substance.
+
+Four constraints, all load-bearing:
+
+- **It is a fallback path for a missing article, not a second preview owner.**
+  It renders only while the contract reports `mode === "preview"` — the week is
+  genuinely unscored. Once the week scores, the recap surfaces own it and the
+  block disappears. Pinned by a test.
+- **It recomputes nothing.** Every number is read from the section; the
+  component is a materializer, the same relationship the rest of `/league` has
+  with the contract. It does not resolve the clock either — `currentSeason` /
+  `currentWeek` come from the contract, because a second answer to "what week is
+  it" is the duplicate owner this repo spends most of its rules avoiding.
+- **Missing is never zero, in the renderer too.** A first-ever meeting renders
+  "First meeting" and no margin; a manager with no prior games renders "No prior
+  games", not "0-0"; a null `avgPoints` prints nothing rather than `0.0`. The
+  `totalMeetings === 0` guard runs *before* any margin is read, so the tab is
+  correct even against a backend that has not yet taken the companion
+  `_h2h_summary` fix.
+- **Degrade, never fail.** A 503 or a network error on the optional structured
+  block leaves the article slate rendering; the failure is not cached, so a
+  transient error does not suppress the block for the rest of the session.
+
+`ArticlesSection` gains optional `currentSeason` / `currentWeek` props. When
+supplied and the newest slate is older, the heading becomes *"Most recent
+previews · 2025 Week 17"* and the subhead becomes *"No previews written yet for
+2026 Week 1 — these are the most recent on file."* **An unknown clock is
+reported as neither a match nor a mismatch** — both props must be present for
+the check to fire — so the Recaps tab and any other caller are unchanged.
+
+## 3. What this does NOT do
+
+- It does not generate any article. `ANTHROPIC_API_KEY` remains the W1-11
+  blocker and only the owner can clear it.
+- It does not touch the private/public boundary: everything rendered is
+  factual, retrospective league history already published by the public
+  contract. No values, edges, targets, forecasts or projections.
+- It does not change any contract data, and it does not move W1-10.
+
+## 4. Verification
+
+- `frontend/__tests__/components/league-previews-section.test.jsx` — 8 tests:
+  the structured block renders for an unscored week; a first-ever meeting shows
+  no margin (`avg margin 0` must appear nowhere); "No prior games" rather than
+  `0-0`; the block is withheld once the week is scored; the tab still renders
+  when the preview section is unavailable; and three on the article-slate
+  labelling including the unknown-clock case.
+- `npx vitest run` — **2416 passed / 165 files**.
+- `npm run build` — clean; `/league/page` **38.0 KB against a 50 KB budget**,
+  all 14 budgeted pages under. The section is code-split, so its cost lands only
+  when the tab is opened.
+
+## 5. Row status
+
+`W1-12` stays **NOT STARTED**. This closes the reason it could not pass — there
+is now a surface for the current week's pregame content — but the row's own
+acceptance is *production* verification of mobile, navigation, links and
+degraded states, and that requires this to be deployed and then checked on
+production. Implementation is not verification.

--- a/frontend/__tests__/components/league-previews-section.test.jsx
+++ b/frontend/__tests__/components/league-previews-section.test.jsx
@@ -1,0 +1,227 @@
+/**
+ * PreviewsSection — the public "Previews" tab.
+ *
+ * The behaviour under test is a truthfulness one, not a layout one. On
+ * 2026-09-05, Week 1 of the season, `/api/public/league/matchupPreview`
+ * served all six upcoming matchups with real H2H and form data while the
+ * Previews tab rendered the 2025 Week 17 articles — narrative generation is
+ * blocked on a missing `ANTHROPIC_API_KEY`, and nothing on the page
+ * distinguished "this week's previews" from "the last previews we have".
+ *
+ * Two rules are pinned here:
+ *   1. an unscored current week gets its structured head-to-head block, so
+ *      the pregame content that IS computed is reachable;
+ *   2. missing stays missing — a first-ever meeting shows no margin, and a
+ *      manager with no prior games shows no record.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ArticlesSection from "@/app/league/sections/articles.jsx";
+
+// The section under test caches at module scope, so each test needs a
+// fresh module instance.
+async function loadSection() {
+  vi.resetModules();
+  const mod = await import("@/app/league/sections/matchup-previews.jsx");
+  return mod.default;
+}
+
+const LEAGUE = {
+  managers: [
+    { ownerId: "owner-A", displayName: "Jason", currentTeamName: "Medical Murrayjuana", avatar: "" },
+    { ownerId: "owner-B", displayName: "Collin", currentTeamName: "CollinFoz", avatar: "" },
+    { ownerId: "owner-C", displayName: "Blaine", currentTeamName: "ughb", avatar: "" },
+    { ownerId: "owner-D", displayName: "Ty", currentTeamName: "TyBWell", avatar: "" },
+  ],
+};
+
+const PLAYED_SERIES = {
+  matchupId: 4,
+  home: { ownerId: "owner-A", displayName: "Jason", teamName: "Medical Murrayjuana", rosterId: 1, points: null },
+  away: { ownerId: "owner-B", displayName: "Collin", teamName: "CollinFoz", rosterId: 4, points: null },
+  h2h: {
+    totalMeetings: 4,
+    homeWins: 2,
+    awayWins: 2,
+    ties: 0,
+    avgMargin: 51.77,
+    biggestMargin: 108.0,
+    playoffMeetings: 1,
+    narrative: "series tied 2-2; most recent: Collin by 108.0 in 2025 wk 12.",
+  },
+  form: {
+    home: {
+      games: [{ season: "2025", week: 12, points: 233.58, opponentPoints: 341.58, result: "L" }],
+      record: "0-1",
+      avgPoints: 233.58,
+      isPriorSeasonOnly: true,
+    },
+    away: {
+      games: [{ season: "2025", week: 12, points: 341.58, opponentPoints: 233.58, result: "W" }],
+      record: "1-0",
+      avgPoints: 341.58,
+      isPriorSeasonOnly: true,
+    },
+  },
+};
+
+// The shape the contract serves for two managers who have never played:
+// undefined aggregates are null, counts are zero.
+const FIRST_MEETING = {
+  matchupId: 2,
+  home: { ownerId: "owner-C", displayName: "Blaine", teamName: "ughb", rosterId: 12, points: null },
+  away: { ownerId: "owner-D", displayName: "Ty", teamName: "TyBWell", rosterId: 3, points: null },
+  h2h: {
+    totalMeetings: 0,
+    homeWins: 0,
+    awayWins: 0,
+    ties: 0,
+    avgMargin: null,
+    biggestMargin: null,
+    playoffMeetings: 0,
+    narrative: "First ever meeting between Blaine and Ty.",
+  },
+  form: {
+    home: { games: [], record: "0-0", avgPoints: null, isPriorSeasonOnly: false },
+    away: {
+      games: [{ season: "2025", week: 12, points: 392.82, opponentPoints: 326.47, result: "W" }],
+      record: "1-0",
+      avgPoints: 392.82,
+      isPriorSeasonOnly: true,
+    },
+  },
+};
+
+function previewPayload({ mode = "preview", matchups = [PLAYED_SERIES, FIRST_MEETING] } = {}) {
+  return {
+    league: LEAGUE,
+    data: { currentSeason: "2026", currentWeek: 1, mode, isPlayoff: false, matchups },
+  };
+}
+
+function mockFetch(routes) {
+  return vi.fn((url) => {
+    for (const [fragment, body] of Object.entries(routes)) {
+      if (String(url).includes(fragment)) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+      }
+    }
+    return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({}) });
+  });
+}
+
+describe("PreviewsSection", () => {
+  beforeEach(() => {
+    globalThis.fetch = mockFetch({
+      "matchupPreview": previewPayload(),
+      "/api/league/articles": { articles: [] },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the structured head-to-head block for an unscored current week", async () => {
+    const PreviewsSection = await loadSection();
+    render(<PreviewsSection />);
+    await waitFor(() => {
+      expect(screen.getByText(/Week 1 matchups · 2026/)).toBeTruthy();
+    });
+    expect(screen.getByText("Jason vs Collin")).toBeTruthy();
+    expect(screen.getByText("Blaine vs Ty")).toBeTruthy();
+    expect(screen.getByText(/4 meetings · 2-2 · 1 playoff · avg margin/)).toBeTruthy();
+  });
+
+  it("shows a first-ever meeting with NO margin, never a zero one", async () => {
+    const PreviewsSection = await loadSection();
+    render(<PreviewsSection />);
+    await waitFor(() => {
+      expect(screen.getByText("First meeting")).toBeTruthy();
+    });
+    // The whole point: "avg margin 0.0" for a series that has never been
+    // played says these two always tie. It must appear nowhere.
+    expect(screen.queryByText(/avg margin 0/)).toBeNull();
+    expect(screen.queryByText(/0 meetings/)).toBeNull();
+  });
+
+  it("shows a manager with no prior games as such, not as 0-0", async () => {
+    const PreviewsSection = await loadSection();
+    render(<PreviewsSection />);
+    await waitFor(() => {
+      expect(screen.getAllByText(/No prior games/).length).toBeGreaterThan(0);
+    });
+  });
+
+  it("withholds the structured block once the week is scored", async () => {
+    globalThis.fetch = mockFetch({
+      "matchupPreview": previewPayload({ mode: "recap" }),
+      "/api/league/articles": { articles: [] },
+    });
+    const PreviewsSection = await loadSection();
+    render(<PreviewsSection />);
+    // The recap surfaces own a scored week; rendering both would be the
+    // second owner this section exists to avoid.
+    await waitFor(() => {
+      expect(screen.queryByText(/Week 1 matchups · 2026/)).toBeNull();
+    });
+    expect(screen.queryByText("Jason vs Collin")).toBeNull();
+  });
+
+  it("still renders the article slate when the preview section is unavailable", async () => {
+    globalThis.fetch = mockFetch({ "/api/league/articles": { articles: [] } });
+    const PreviewsSection = await loadSection();
+    render(<PreviewsSection />);
+    // Degrade, never fail: a 503 on the optional structured block must not
+    // take down the tab.
+    await waitFor(() => {
+      expect(screen.getByText(/No previews yet/)).toBeTruthy();
+    });
+  });
+});
+
+describe("ArticlesSection slate labelling", () => {
+  const OLD_ARTICLE = {
+    season: "2025",
+    week: 17,
+    mode: "preview",
+    matchupId: 1,
+    title: "Down 18.43, with one week to find it",
+    home: { displayName: "Ed", teamName: "JasonTuckerFanClub" },
+    away: { displayName: "Brent", teamName: "Step Burrow Im Stuck" },
+  };
+
+  beforeEach(() => {
+    globalThis.fetch = mockFetch({ "/api/league/articles": { articles: [OLD_ARTICLE] } });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("says so when the newest slate is not the current week", async () => {
+    render(<ArticlesSection mode="preview" currentSeason="2026" currentWeek={1} />);
+    await waitFor(() => {
+      expect(screen.getByText(/Most recent previews · 2025 Week 17/)).toBeTruthy();
+    });
+    expect(screen.getByText(/No previews written yet for 2026 Week 1/)).toBeTruthy();
+  });
+
+  it("keeps the present-tense subhead when the slate IS the current week", async () => {
+    render(<ArticlesSection mode="preview" currentSeason="2025" currentWeek={17} />);
+    await waitFor(() => {
+      expect(screen.getByText(/Week 17 previews · 2025/)).toBeTruthy();
+    });
+    expect(screen.getByText(/Wednesday-morning previews/)).toBeTruthy();
+  });
+
+  it("does not claim currency when the clock is unknown", async () => {
+    // An unknown clock must not be reported as a match OR as a mismatch.
+    render(<ArticlesSection mode="preview" />);
+    await waitFor(() => {
+      expect(screen.getByText(/Week 17 previews · 2025/)).toBeTruthy();
+    });
+    expect(screen.queryByText(/No previews written yet/)).toBeNull();
+  });
+});

--- a/frontend/app/league/LeagueClient.jsx
+++ b/frontend/app/league/LeagueClient.jsx
@@ -94,6 +94,10 @@ const RosPowerSection = lazySection(() => import("./sections/ros-power.jsx"));
 const RosChampionshipSection = lazySection(() => import("./sections/ros-championship.jsx"));
 const RosTradeDeadlineSection = lazySection(() => import("./sections/ros-trade-deadline.jsx"));
 const ArticlesSection = lazySection(() => import("./sections/articles.jsx"));
+// The Previews tab composes the structured current-week head-to-head
+// block with the article slate; the Recaps tab stays the bare article
+// list, because a scored week is owned by the recap surfaces.
+const PreviewsSection = lazySection(() => import("./sections/matchup-previews.jsx"));
 const TeamAssignmentSection = lazySection(() => import("./sections/team-assignment.jsx"));
 
 // SUB_TABS / VALID_TABS / DEFAULT_TAB / normalizeTabKey / SECTION_FOR_TAB
@@ -407,7 +411,7 @@ function LeaguePage({ initialContract = null, initialTab = DEFAULT_TAB }) {
       {activeTab === "rosTeamStrength" && <RosTeamStrengthSection />}
       {activeTab === "rosChampionship" && <RosChampionshipSection />}
       {activeTab === "rosTradeDeadline" && <RosTradeDeadlineSection />}
-      {activeTab === "previews" && <ArticlesSection mode="preview" />}
+      {activeTab === "previews" && <PreviewsSection />}
       {activeTab === "recaps" && <ArticlesSection mode="recap" />}
       {activeTab === "teamAssignment" && (
         <TeamAssignmentSection managers={managers} />

--- a/frontend/app/league/sections/articles.jsx
+++ b/frontend/app/league/sections/articles.jsx
@@ -13,7 +13,17 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { Card, EmptyCard } from "../shared.jsx";
 
-export default function ArticlesSection({ mode }) {
+// ``currentSeason`` / ``currentWeek`` are optional and come from the
+// canonical ``matchupPreview`` contract section (see
+// ./matchup-previews.jsx) — this component does NOT resolve the clock
+// itself, because a second answer to "what week is it" is exactly the
+// kind of duplicate owner /league avoids. When they are supplied and
+// the newest slate on disk is for an older week, say so: the heading
+// already named the season and week, but the subhead read
+// "Wednesday-morning previews" in the present tense with nothing
+// distinguishing "this week\'s articles" from "the last articles we
+// have". Stale is not current.
+export default function ArticlesSection({ mode, currentSeason = null, currentWeek = null }) {
   const [state, setState] = useState({ loading: true, error: "", articles: [] });
 
   useEffect(() => {
@@ -81,12 +91,23 @@ export default function ArticlesSection({ mode }) {
     return (a.matchupId || 0) - (b.matchupId || 0);
   });
 
-  const heading =
-    mode === "preview"
+  // Known only when the caller supplied the clock; an unknown clock
+  // must not be reported as a match, so the check requires both.
+  const clockKnown = currentSeason !== null && currentWeek !== null;
+  const isCurrentWeek =
+    clockKnown && String(latest.season) === String(currentSeason) && latest.week === Number(currentWeek);
+  const isOlderSlate = clockKnown && !isCurrentWeek;
+
+  const heading = isOlderSlate
+    ? mode === "preview"
+      ? `Most recent previews · ${latest.season} Week ${latest.week}`
+      : `Most recent recaps · ${latest.season} Week ${latest.week}`
+    : mode === "preview"
       ? `Week ${latest.week} previews · ${latest.season}`
       : `Week ${latest.week} recaps · ${latest.season}`;
-  const subhead =
-    mode === "preview"
+  const subhead = isOlderSlate
+    ? `No ${mode === "preview" ? "previews" : "recaps"} written yet for ${currentSeason} Week ${currentWeek} — these are the most recent on file.`
+    : mode === "preview"
       ? "Wednesday-morning previews. Tap a card for the full article."
       : "Tuesday-morning recaps. Tap a card for the full article.";
 

--- a/frontend/app/league/sections/matchup-previews.jsx
+++ b/frontend/app/league/sections/matchup-previews.jsx
@@ -1,0 +1,213 @@
+"use client";
+
+// PreviewsSection — the public "Previews" tab.
+//
+// Composes two DIFFERENT things about the same week, in the order a
+// reader wants them:
+//
+//   1. the STRUCTURED head-to-head preview for the CURRENT week, from
+//      the canonical `matchupPreview` contract section;
+//   2. the AI-written preview articles (`ArticlesSection`), which are
+//      generated on a cron and may not exist yet for this week.
+//
+// Why (1) exists at all. The structured "This Week" tab was retired
+// when the article tabs landed, on the reasoning — recorded in
+// `../tabs.js` — that "the articles surface the same H2H + form data
+// inline (the brief is built from it), so the structured-data tabs are
+// redundant once articles are wired in." That is true whenever an
+// article exists for the current week. It is NOT true otherwise, and
+// the gap is not hypothetical: on 2026-09-05, Week 1 of the season,
+// `/api/public/league/matchupPreview` served all six upcoming matchups
+// with real H2H and form data while the Previews tab showed the 2025
+// Week 17 articles, because narrative generation is blocked on a
+// missing `ANTHROPIC_API_KEY`. The current week's pregame content was
+// computed, served, correct — and reachable from no public surface.
+//
+// So this block is a FALLBACK PATH FOR A MISSING ARTICLE, not a second
+// preview owner. It renders only while the contract reports
+// `mode === "preview"` (the week is genuinely unscored); once the week
+// scores, the recap surfaces own it and this disappears. It recomputes
+// nothing — every number below is read verbatim from the section, the
+// same materializer relationship the rest of /league has with the
+// contract.
+//
+// Missing is never zero, throughout: a first-ever meeting renders as
+// "First meeting" with NO margin (the contract answers `null`, and a
+// margin over an empty series is undefined, not 0.0), and a manager
+// with no prior games renders "No prior games" rather than "0-0".
+
+import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+import { LoadingState } from "@/components/ui";
+import { Card } from "../shared-server.jsx";
+import { Avatar } from "../shared.jsx";
+import { buildManagerLookup, fmtPoints } from "../shared-helpers.js";
+
+const ArticlesSection = dynamic(() => import("./articles.jsx"), {
+  ssr: false,
+  loading: () => <LoadingState message="Loading articles..." />,
+});
+
+// Module-level cache so tab-switching doesn't re-fetch. Same shape and
+// TTL as ros-power.jsx's cache.
+const CACHE_TTL_MS = 30 * 60 * 1000;
+const _cache = { data: null, error: null, inflight: null, fetchedAt: 0 };
+
+async function _fetchPreview() {
+  const fresh = _cache.data && Date.now() - _cache.fetchedAt < CACHE_TTL_MS;
+  if (fresh) return { data: _cache.data, error: null };
+  if (_cache.inflight) return _cache.inflight;
+
+  const promise = fetch("/api/public/league/matchupPreview")
+    .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`${r.status}`))))
+    .then((body) => {
+      _cache.data = body;
+      _cache.error = null;
+      _cache.fetchedAt = Date.now();
+      _cache.inflight = null;
+      return { data: body, error: null };
+    })
+    .catch((err) => {
+      _cache.inflight = null;
+      // Deliberately NOT cached: a transient 503 must not suppress the
+      // block for the rest of the session.
+      return { data: null, error: String(err) };
+    });
+  _cache.inflight = promise;
+  return promise;
+}
+
+function seriesLine(h2h) {
+  if (!h2h) return null;
+  const total = h2h.totalMeetings || 0;
+  if (total === 0) return "First meeting";
+  const parts = [`${h2h.homeWins}-${h2h.awayWins}${h2h.ties ? `-${h2h.ties}` : ""}`];
+  if (h2h.playoffMeetings) {
+    parts.push(`${h2h.playoffMeetings} playoff`);
+  }
+  // `avgMargin` is null for a series with no meetings; guarded above,
+  // but a null here must still never print as "0.0".
+  if (h2h.avgMargin !== null && h2h.avgMargin !== undefined) {
+    parts.push(`avg margin ${fmtPoints(h2h.avgMargin)}`);
+  }
+  return `${total} ${total === 1 ? "meeting" : "meetings"} · ${parts.join(" · ")}`;
+}
+
+function FormLine({ label, form }) {
+  const games = (form && form.games) || [];
+  if (!games.length) {
+    return (
+      <div style={{ fontSize: "0.7rem", color: "var(--subtext)" }}>
+        {label}: <span style={{ fontStyle: "italic" }}>No prior games</span>
+      </div>
+    );
+  }
+  // `avgPoints` is null when the window is empty; that case is handled
+  // above, so a value here is real.
+  const avg = form.avgPoints === null || form.avgPoints === undefined ? null : fmtPoints(form.avgPoints);
+  const scope = form.isPriorSeasonOnly ? " (prior season)" : "";
+  return (
+    <div style={{ fontSize: "0.7rem", color: "var(--subtext)" }}>
+      {label}: {form.record}
+      {avg ? ` · ${avg} avg` : ""}
+      {scope}
+      {" "}
+      <span aria-hidden="true">
+        {games.map((g) => (g.result === "W" ? "W" : g.result === "L" ? "L" : "T")).join("")}
+      </span>
+    </div>
+  );
+}
+
+function MatchupCard({ matchup, managers }) {
+  const home = matchup.home || {};
+  const away = matchup.away || {};
+  const h2h = matchup.h2h || {};
+  const form = matchup.form || {};
+  return (
+    <div
+      style={{
+        border: "1px solid var(--border-bright)",
+        borderRadius: 8,
+        padding: 12,
+        background: "rgba(255,255,255,0.02)",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <Avatar managers={managers} ownerId={home.ownerId} size={26} />
+        <span style={{ color: "var(--subtext)", fontWeight: 700 }}>vs</span>
+        <Avatar managers={managers} ownerId={away.ownerId} size={26} />
+      </div>
+      <div style={{ fontSize: "0.95rem", fontWeight: 800, marginTop: 6, lineHeight: 1.25 }}>
+        {home.displayName} vs {away.displayName}
+      </div>
+      <div style={{ fontSize: "0.72rem", color: "var(--subtext)", marginTop: 2 }}>
+        {home.teamName} · {away.teamName}
+      </div>
+      <div style={{ fontSize: "0.72rem", color: "var(--cyan)", marginTop: 8 }}>{seriesLine(h2h)}</div>
+      {h2h.narrative && (
+        <div style={{ fontSize: "0.74rem", marginTop: 4, lineHeight: 1.35 }}>{h2h.narrative}</div>
+      )}
+      <div style={{ marginTop: 8, display: "grid", gap: 2 }}>
+        <FormLine label={home.displayName} form={form.home} />
+        <FormLine label={away.displayName} form={form.away} />
+      </div>
+    </div>
+  );
+}
+
+export default function PreviewsSection() {
+  const [state, setState] = useState({ loading: true, payload: null, error: "" });
+
+  useEffect(() => {
+    let active = true;
+    _fetchPreview().then(({ data, error }) => {
+      if (!active) return;
+      setState({ loading: false, payload: data, error: error || "" });
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const data = state.payload && state.payload.data;
+  // ``Avatar`` takes the lookup Map, not the contract's manager ARRAY.
+  const managers = buildManagerLookup(state.payload && state.payload.league);
+  const matchups = (data && data.matchups) || [];
+  // Only an UNSCORED week gets the structured block. A scored week is
+  // owned by the recap surfaces, and rendering both would be the second
+  // owner this section exists to avoid.
+  const showStructured = !state.loading && data && data.mode === "preview" && matchups.length > 0;
+
+  return (
+    <section>
+      {state.loading && <LoadingState message="Loading this week's matchups..." />}
+      {showStructured && (
+        <Card
+          title={`Week ${data.currentWeek} matchups · ${data.currentSeason}`}
+          subtitle="Head-to-head history and recent form for every upcoming matchup."
+        >
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+              gap: 12,
+              marginTop: 10,
+            }}
+          >
+            {matchups.map((m) => (
+              <MatchupCard key={m.matchupId} matchup={m} managers={managers} />
+            ))}
+          </div>
+        </Card>
+      )}
+      <div style={{ marginTop: showStructured ? "var(--space-md)" : 0 }}>
+        <ArticlesSection
+          mode="preview"
+          currentSeason={data ? data.currentSeason : null}
+          currentWeek={data ? data.currentWeek : null}
+        />
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Found while auditing W1-10 (#1247), which proved the Week 1 pregame **data** on production is present and correct. This PR is about where that data goes, which turned out to be nowhere.

Full record: `docs/season-launch/W1_12_PUBLIC_PREGAME_SURFACE_2026-09-05.md`.

## The gap

On 2026-09-05 — Week 1 of the season, kickoff Thursday 2026-09-10 — production served:

```
GET /api/public/league/matchupPreview
  currentSeason 2026 · currentWeek 1 · mode "preview" · 6 matchups
  every pairing, ownerId and rosterId matching Sleeper exactly
```

and the public site rendered **none of it**:

- `/league` Home shows a single-matchup teaser with a **"Full H2H preview →"** CTA
- that CTA calls `onNavigate("matchupPreview")`, which `tabs.js` aliases to the `previews` tab
- `previews` is `ArticlesSection`, which falls back to the newest `(season, week)` group that *has* articles. There are **zero 2026 Week 1 articles** — `weekly-narratives.yml` skips generation on the missing `ANTHROPIC_API_KEY` (the named W1-11 blocker) — so the tab landed on **2025 Week 17**.

Six correct head-to-head previews, computed and served, reachable from nothing. The CTA promising a "full H2H preview" led to last season's championship articles.

**This was a deliberate design that stopped holding.** `tabs.js` records the reasoning for retiring the old structured "This Week" tab: *"the articles surface the same H2H + form data inline (the brief is built from it), so the structured-data tabs are redundant once articles are wired in."* True whenever an article exists for the current week; exactly false when none does, and nothing covered that case.

## The fix

`frontend/app/league/sections/matchup-previews.jsx` (new) is now the `previews` tab: the structured current-week H2H block, then the article slate below it.

Four constraints, all load-bearing:

- **A fallback for a missing article, not a second preview owner.** It renders only while the contract reports `mode === "preview"` — the week is genuinely unscored. Once the week scores the recap surfaces own it and the block disappears. Test-pinned.
- **It recomputes nothing, and it does not resolve the clock either.** `currentSeason` / `currentWeek` come from the contract, because a second answer to "what week is it" is the duplicate owner this repo's rules exist to prevent.
- **Missing is never zero in the renderer too.** A first-ever meeting shows "First meeting" and **no** margin; a manager with no prior games shows "No prior games", not `0-0`; a null `avgPoints` prints nothing. The `totalMeetings === 0` guard runs *before* any margin is read, so the tab is correct **even against a backend that has not taken the companion `_h2h_summary` fix in #1247** — the two PRs are independent.
- **Degrade, never fail.** A 503 on the optional block leaves the article slate rendering, and the failure is deliberately not cached, so a transient error cannot suppress the block for the rest of the session.

`ArticlesSection` gains optional `currentSeason` / `currentWeek`. When supplied and the newest slate is older, the heading becomes *"Most recent previews · 2025 Week 17"* and the subhead *"No previews written yet for 2026 Week 1 — these are the most recent on file."* The old subhead was present-tense with nothing distinguishing "this week's" from "the last we have". **An unknown clock is reported as neither a match nor a mismatch** — both props must be present for the check to fire — so Recaps and every other caller are unchanged.

## What this does not do

- Generates no article. `ANTHROPIC_API_KEY` remains the W1-11 blocker; only the owner can clear it.
- Crosses no public/private boundary: everything rendered is factual, retrospective league history already published by the public contract — no values, edges, targets, or forecasts.
- Changes no contract data and does not move W1-10.

## Testing

- `frontend/__tests__/components/league-previews-section.test.jsx` — **8 tests**: structured block renders for an unscored week; a first-ever meeting shows no margin (`avg margin 0` must appear nowhere); "No prior games" rather than `0-0`; the block is withheld once the week is scored; the tab still renders when the preview section is unavailable; plus three on slate labelling including the unknown-clock case.
- `npx vitest run` — **2416 passed / 165 files**
- `npm run build` — clean; `/league/page` **38.0 KB against a 50 KB budget**, all 14 budgeted pages under. The section is code-split, so its cost lands only when the tab is opened.

## Contract movement

**None. W1-12 stays `NOT STARTED`.** This closes the reason it could not pass, but the row's acceptance is *production* verification of mobile/navigation/links/degraded states — implementation is not verification. Numerator unchanged at 14/30.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPwRjfLMMgHj4xLCQKgoDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPwRjfLMMgHj4xLCQKgoDW)_