### PR TITLE
W1-16/W1-12: make the Game Day verification instruments actually able to run

### DIFF
--- a/frontend/__tests__/components/game-day-panel.test.jsx
+++ b/frontend/__tests__/components/game-day-panel.test.jsx
@@ -24,6 +24,13 @@ vi.mock("@/components/useUserState", () => ({
   useUserState: () => mockUserState,
 }));
 
+// The URL's `?team=` override. A Map has the same `.get` shape the panel
+// uses, so no adapter is needed.
+const mockSearchParams = { value: new Map() };
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams.value,
+}));
+
 const PRICED = {
   leagueKey: "dynasty_main",
   season: 2026,
@@ -341,5 +348,51 @@ describe("GameDayPanel — the state machine (W1-26)", () => {
     render(<GameDayPanel />);
     await waitFor(() => expect(screen.getByText("Live")).toBeTruthy());
     expect(screen.queryByText(/%/)).toBeNull();
+  });
+});
+
+
+describe("GameDayPanel — explicit ?team= wins over the switcher", () => {
+  afterEach(() => {
+    mockSearchParams.value = new Map();
+    mockUserState.state = { selectedTeam: null };
+  });
+
+  it("uses the URL team when one is present", async () => {
+    mockSearchParams.value = new Map([["team", "own-URL"]]);
+    mockUserState.state = { selectedTeam: { ownerId: "own-SWITCHER" } };
+    mockJson(PRICED);
+    render(<GameDayPanel />);
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    const [url] = globalThis.fetch.mock.calls[0];
+    // Explicit over implicit — the same precedence the backend resolver
+    // uses (query param, then session, then registry default).
+    expect(url).toContain("team=own-URL");
+    expect(url).not.toContain("own-SWITCHER");
+  });
+
+  it("falls back to the switcher when the URL names no team", async () => {
+    mockSearchParams.value = new Map();
+    mockUserState.state = { selectedTeam: { ownerId: "own-SWITCHER" } };
+    mockJson(PRICED);
+    render(<GameDayPanel />);
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(globalThis.fetch.mock.calls[0][0]).toContain("team=own-SWITCHER");
+  });
+
+  it("sends no team parameter when neither names one", async () => {
+    mockJson(PRICED);
+    render(<GameDayPanel />);
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(globalThis.fetch.mock.calls[0][0]).toBe("/api/matchup/intel");
+  });
+
+  it("ignores a blank ?team= rather than requesting a team named \"\"", async () => {
+    mockSearchParams.value = new Map([["team", "   "]]);
+    mockUserState.state = { selectedTeam: { ownerId: "own-SWITCHER" } };
+    mockJson(PRICED);
+    render(<GameDayPanel />);
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(globalThis.fetch.mock.calls[0][0]).toContain("team=own-SWITCHER");
   });
 });

--- a/frontend/app/game-day/page.jsx
+++ b/frontend/app/game-day/page.jsx
@@ -22,7 +22,8 @@
  * which is why it is not there.
  */
 
-import { PageHeader } from "@/components/ui";
+import { Suspense } from "react";
+import { LoadingState, PageHeader } from "@/components/ui";
 import GameDayPanel from "@/components/GameDayPanel";
 
 export default function GameDayPage() {
@@ -32,7 +33,12 @@ export default function GameDayPage() {
         title="Game Day"
         subtitle="Your matchup, projected: win probability from the canonical league-week simulation, the expected best-ball lineup for both sides, and what the numbers were built on."
       />
-      <GameDayPanel />
+      {/* `useSearchParams` inside the panel requires a Suspense boundary
+          during static prerender — same convention as
+          app/players/compare/page.jsx. */}
+      <Suspense fallback={<LoadingState message="Loading this week's matchup..." />}>
+        <GameDayPanel />
+      </Suspense>
     </section>
   );
 }

--- a/frontend/components/GameDayPanel.jsx
+++ b/frontend/components/GameDayPanel.jsx
@@ -28,6 +28,7 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { LoadingState } from "@/components/ui";
 import { EmptyState, FailureState } from "@/components/ds";
 import { useUserState } from "@/components/useUserState";
@@ -312,9 +313,24 @@ export default function GameDayPanel() {
   // which is a DIFFERENT question — "who is signed in" rather than "which
   // team did you pick" — so switching teams left the matchup unchanged.
   const { state: userState } = useUserState();
-  const selectedOwnerId = userState?.selectedTeam?.ownerId
-    ? String(userState.selectedTeam.ownerId)
-    : "";
+  // An explicit `?team=<ownerId>` WINS over the switcher.
+  //
+  // Two reasons, and the second is the one that made this necessary. It
+  // makes the page linkable per team, which the endpoint has always
+  // supported (`/api/matchup/intel?team=`) while the page did not. And it
+  // is the only way a session that has selected no team — a guest pass in
+  // the production-verification workflow, say — can see this surface for a
+  // REAL team at all; without it such a session gets "No team selected"
+  // and the page cannot be verified for anyone.
+  //
+  // Explicit-over-implicit is also the same precedence the backend
+  // resolver uses (query param, then session, then registry default), so
+  // the page and the endpoint agree about who wins.
+  const searchParams = useSearchParams();
+  const urlOwnerId = String(searchParams?.get("team") || "").trim();
+  const selectedOwnerId =
+    urlOwnerId ||
+    (userState?.selectedTeam?.ownerId ? String(userState.selectedTeam.ownerId) : "");
 
   const load = useCallback(async () => {
     setState({ status: "loading", payload: null, error: null });

--- a/tests/e2e/specs/prod-auth/w1-12-public-pregame.spec.js
+++ b/tests/e2e/specs/prod-auth/w1-12-public-pregame.spec.js
@@ -98,14 +98,32 @@ test.describe("W1-12: public Week 1 pregame surfaces (production)", () => {
     await expect(page.getByText(/Week \d+ matchups · \d{4}/)).toBeVisible({ timeout: 60_000 });
 
     const body = await page.locator("body").innerText();
+
+    // THREE states, not two, and they must be told apart by strings that
+    // cannot both be true. `/Wednesday-morning previews/` on its own is
+    // ambiguous: `articles.jsx` uses that phrase BOTH in the healthy
+    // subhead ("…previews. Tap a card for the full article.") and in the
+    // zero-articles EmptyCard ("…previews will land here once the cron
+    // runs."). Matching the bare phrase would record an EMPTY surface as a
+    // healthy current-week slate — the exact "degraded state presented as
+    // current" defect this row exists to catch, committed by the
+    // instrument instead of by the product.
+    const empty = /No previews yet/.test(body);
     const older = /Most recent previews ·/.test(body);
-    const current = /Wednesday-morning previews/.test(body);
-    // Exactly one of the two voices, never both and never neither.
-    expect(older || current).toBe(true);
+    const current = /Wednesday-morning previews\. Tap a card/.test(body);
+
+    const named = [empty, older, current].filter(Boolean);
+    expect(named.length, "the slate must name exactly one state").toBe(1);
+
     if (older) {
+      // Stale is not current: the older slate must name the week that is
+      // actually missing, and must not also speak in the present tense.
       expect(body).toMatch(/No previews written yet for \d{4} Week \d+/);
+      expect(body).not.toMatch(/Wednesday-morning previews\. Tap a card/);
     }
-    annotate(testInfo, "w1-12-slate-voice", older ? "older slate, labelled" : "current-week slate");
+
+    const voice = empty ? "empty slate, labelled" : older ? "older slate, labelled" : "current-week slate";
+    annotate(testInfo, "w1-12-slate-voice", voice);
   });
 
   test("the surface is usable at a phone viewport without horizontal scroll", async ({

--- a/tests/e2e/specs/prod-auth/w1-16-game-day.spec.js
+++ b/tests/e2e/specs/prod-auth/w1-16-game-day.spec.js
@@ -148,6 +148,30 @@ test.describe("W1-16: the owner's Game Day experience (production)", () => {
     annotate(testInfo, "w1-16-anon-api", `HTTP ${res.status()}`);
   });
 
+  test("W1-25: the shell offers Game Day in the My Team group", async ({
+    prodPage: page,
+  }, testInfo) => {
+    // W1-25's navigation-shell clause. Asserted on the DEPLOYED shell
+    // rather than by reading nav-model.js, because the row is about the
+    // integrated shell and a source read cannot tell whether the built
+    // bundle carries it.
+    desktopOnly(test, testInfo);
+    await page.goto(prodUrl("/rankings"), { waitUntil: "domcontentloaded" });
+    // Shell readiness: the same "authenticated UI is hydrated" signal
+    // v1-131-nav-gating uses.
+    await expect(page.locator(".shell-search-btn")).toBeVisible({ timeout: 60_000 });
+
+    await page.getByRole("button", { name: "My Team menu" }).click();
+    const menu = page.locator('[role="menu"][aria-label="My Team"]');
+    await expect(menu).toBeVisible();
+
+    const item = menu.getByRole("menuitem", { name: /Game Day/ });
+    await expect(item, "the My Team menu does not offer Game Day").toBeVisible();
+    const href = await item.getAttribute("href");
+    expect(href, "Game Day nav item points somewhere else").toContain("/game-day");
+    annotate(testInfo, "w1-25-nav", `My Team → Game Day → ${href}`);
+  });
+
   test("usable at a phone viewport without horizontal scroll", async ({
     prodPage: page,
   }, testInfo) => {

--- a/tests/e2e/specs/prod-auth/w1-16-game-day.spec.js
+++ b/tests/e2e/specs/prod-auth/w1-16-game-day.spec.js
@@ -23,7 +23,15 @@
  * asserted on what must and must not appear, and the run annotates which
  * state production was actually in.
  */
-const { test, expect, prodUrl, getJson, annotate, mobileOnly } = require("./helpers");
+const {
+  test,
+  expect,
+  prodUrl,
+  getJson,
+  annotate,
+  desktopOnly,
+  mobileOnly,
+} = require("./helpers");
 
 /**
  * A real ownerId from the deployed board. Same source `v1-27` uses

--- a/tests/e2e/specs/prod-auth/w1-16-game-day.spec.js
+++ b/tests/e2e/specs/prod-auth/w1-16-game-day.spec.js
@@ -7,6 +7,15 @@
  * the OWNER'S experience, and everything on the page is private decision
  * intelligence under CLAUDE.md §5.
  *
+ * TEAM RESOLUTION. The workflow's session is a GUEST pass (it logs in as
+ * `guest`), so it carries no Sleeper user id and the league's default team map
+ * does not name it — `/api/matchup/intel` would answer 400 `team_required` and
+ * the page would show "No team selected". That is CORRECT behaviour and not
+ * what this row is about, so the spec resolves a real team the way the other
+ * prod-auth specs do — from `sleeper.teams` on the deployed authenticated
+ * contract — and asks about that team explicitly. Recorded because a reader
+ * would otherwise reasonably expect the session's own team to be used.
+ *
  * The assertions are deliberately about TRUTHFULNESS, not pixels. This page
  * can legitimately be in one of three states on any given day — priced,
  * unpriced, or live — and the failure mode that matters is not "it looked
@@ -16,11 +25,29 @@
  */
 const { test, expect, prodUrl, getJson, annotate, mobileOnly } = require("./helpers");
 
+/**
+ * A real ownerId from the deployed board. Same source `v1-27` uses
+ * (`/api/data?view=app` → `sleeper.teams`), so the spec cannot drift onto a
+ * team the production contract does not actually hold.
+ */
+async function resolveTeam(page) {
+  const { status, body } = await getJson(page, "/api/data?view=app");
+  expect(status, "/api/data must serve the session").toBe(200);
+  const teams = (body && body.sleeper && body.sleeper.teams) || [];
+  const withOwner = teams.filter((t) => t && t.ownerId);
+  expect(withOwner.length, "contract carries no Sleeper team with an ownerId").toBeGreaterThan(0);
+  return String(withOwner[0].ownerId);
+}
+
 test.describe("W1-16: the owner's Game Day experience (production)", () => {
   test("the page renders for the owner's own team and names its state", async ({
     prodPage: page,
   }, testInfo) => {
-    await page.goto(prodUrl("/game-day"), { waitUntil: "domcontentloaded" });
+    const team = await resolveTeam(page);
+    annotate(testInfo, "w1-16-team", team);
+    await page.goto(prodUrl(`/game-day?team=${encodeURIComponent(team)}`), {
+      waitUntil: "domcontentloaded",
+    });
 
     await expect(page.getByRole("heading", { name: "Game Day" })).toBeVisible({ timeout: 60_000 });
 
@@ -39,12 +66,14 @@ test.describe("W1-16: the owner's Game Day experience (production)", () => {
     // Same posture as the other prod-auth specs: read the API the page
     // reads, then require the page to show THAT. A screenshot-shaped
     // assertion would pass against a stale client bundle.
-    const { status, body } = await getJson(page, "/api/matchup/intel");
+    const team = await resolveTeam(page);
+    const q = `?team=${encodeURIComponent(team)}`;
+    const { status, body } = await getJson(page, `/api/matchup/intel${q}`);
     annotate(testInfo, "w1-16-endpoint-status", String(status));
 
     if (status === 409) {
       // Live week. The page must say so and show no probability at all.
-      await page.goto(prodUrl("/game-day"), { waitUntil: "domcontentloaded" });
+      await page.goto(prodUrl(`/game-day${q}`), { waitUntil: "domcontentloaded" });
       await expect(page.getByText(/This week has already started/)).toBeVisible({
         timeout: 60_000,
       });
@@ -61,7 +90,7 @@ test.describe("W1-16: the owner's Game Day experience (production)", () => {
       `${body.lineage?.estimateCoverage?.priced}/${body.lineage?.estimateCoverage?.active} priced`,
     );
 
-    await page.goto(prodUrl("/game-day"), { waitUntil: "domcontentloaded" });
+    await page.goto(prodUrl(`/game-day${q}`), { waitUntil: "domcontentloaded" });
     await expect(page.getByRole("heading", { name: "Game Day" })).toBeVisible({ timeout: 60_000 });
     const text = await page.locator("body").innerText();
 
@@ -87,14 +116,16 @@ test.describe("W1-16: the owner's Game Day experience (production)", () => {
     // W1-15's actual ask. A win probability with no stated projection
     // source, coverage or threshold-semantics flag is a number, not
     // intelligence.
-    const { status, body } = await getJson(page, "/api/matchup/intel");
+    const team = await resolveTeam(page);
+    const q = `?team=${encodeURIComponent(team)}`;
+    const { status, body } = await getJson(page, `/api/matchup/intel${q}`);
     if (status === 409) {
       test.skip(true, "week in progress — the pregame lineage panel is not the question today");
       return;
     }
     expect(status).toBe(200);
 
-    await page.goto(prodUrl("/game-day"), { waitUntil: "domcontentloaded" });
+    await page.goto(prodUrl(`/game-day${q}`), { waitUntil: "domcontentloaded" });
     await expect(page.getByText("Where these numbers come from")).toBeVisible({ timeout: 60_000 });
     const text = await page.locator("body").innerText();
 
@@ -121,7 +152,10 @@ test.describe("W1-16: the owner's Game Day experience (production)", () => {
     prodPage: page,
   }, testInfo) => {
     mobileOnly(test, testInfo);
-    await page.goto(prodUrl("/game-day"), { waitUntil: "domcontentloaded" });
+    const team = await resolveTeam(page);
+    await page.goto(prodUrl(`/game-day?team=${encodeURIComponent(team)}`), {
+      waitUntil: "domcontentloaded",
+    });
     await expect(page.getByRole("heading", { name: "Game Day" })).toBeVisible({ timeout: 60_000 });
     const overflow = await page.evaluate(
       () => document.documentElement.scrollWidth - document.documentElement.clientWidth,

--- a/tests/e2e/test_e2e_harness_guards.py
+++ b/tests/e2e/test_e2e_harness_guards.py
@@ -606,5 +606,115 @@ class TestNoWaitCanOutliveItsTest(unittest.TestCase):
         )
 
 
+class TestProdAuthSpecsImportEveryHelperTheyUse(unittest.TestCase):
+    """A prod-auth spec that calls an un-imported helper fails in PRODUCTION.
+
+    ``desktopOnly`` shipped in ``w1-16-game-day.spec.js`` used but not
+    destructured from ``./helpers``.  Nothing caught it:
+
+    * there is no ESLint at the repo root, so ``no-undef`` never ran;
+    * ``playwright test --list`` parses the ``describe``/``test``
+      declarations and never enters a test BODY, so the collected count
+      was correct (102 tests) while one of them could not execute;
+    * the prod-auth config is driven only by
+      ``v1-authenticated-verification.yml``, which needs a deployed
+      origin and an ephemeral guest pass — so the first execution of
+      that line would have been a production-verification cycle.
+
+    The failure would also have been misread.  ``desktopOnly(test, …)``
+    is the FIRST statement in its body, so both projects raise
+    ``ReferenceError`` before any assertion — including the
+    ``prod-mobile`` run, which the helper exists to make SKIP.  A row
+    would then have read "the deployed shell does not offer Game Day"
+    when the deployed shell was never asked.
+
+    Scoped to the helper module's own exports on purpose: this is not a
+    general undefined-identifier checker (that is ESLint's job, and
+    adding ESLint for one rule is a bigger change than the defect).  It
+    answers exactly one question — does a spec use a name that
+    ``helpers.js`` exports, without importing it — which is the shape
+    every one of these specs is written in.
+    """
+
+    _PROD_AUTH_DIR = E2E_DIR / "specs" / "prod-auth"
+
+    @staticmethod
+    def _exported_names(helpers_src: str) -> set[str]:
+        """Names in helpers.js's ``module.exports = { … }`` block."""
+        start = helpers_src.index("module.exports")
+        body = helpers_src[helpers_src.index("{", start) : helpers_src.index("}", start) + 1]
+        body = re.sub(r"//[^\n]*", "", body)
+        return {m.group(1) for m in re.finditer(r"^\s*([A-Za-z_$][\w$]*)\s*,", body, re.M)}
+
+    @staticmethod
+    def _imported_names(spec_src: str) -> set[str]:
+        """Names destructured from ``require("./helpers")``.
+
+        Handles the renaming form (``publicTest: test``) that
+        ``w1-12-public-pregame.spec.js`` uses: the LOCAL name is what the
+        body can refer to, so that is what is collected.
+        """
+        match = re.search(
+            r"""const\s*\{(.*?)\}\s*=\s*require\(\s*["']\./helpers["']\s*\)""",
+            spec_src,
+            re.S,
+        )
+        if not match:
+            return set()
+        names: set[str] = set()
+        for part in match.group(1).split(","):
+            part = re.sub(r"//[^\n]*", "", part).strip()
+            if not part:
+                continue
+            local = part.split(":")[-1].strip()
+            if re.fullmatch(r"[A-Za-z_$][\w$]*", local):
+                names.add(local)
+        return names
+
+    def test_no_prod_auth_spec_uses_an_unimported_helper(self) -> None:
+        helpers = self._PROD_AUTH_DIR / "helpers.js"
+        self.assertTrue(helpers.exists(), "prod-auth helpers.js is gone")
+        exported = self._exported_names(helpers.read_text(encoding="utf-8"))
+        self.assertGreater(
+            len(exported),
+            5,
+            f"only parsed {sorted(exported)} out of helpers.js — the "
+            "module.exports shape changed and this guard stopped seeing "
+            "anything, which would make it silently vacuous.",
+        )
+
+        offenders: list[str] = []
+        scanned = 0
+        for path in sorted(self._PROD_AUTH_DIR.glob("*.spec.js")):
+            scanned += 1
+            src = path.read_text(encoding="utf-8")
+            imported = self._imported_names(src)
+            # Compare against CODE only: a helper named in a docstring or
+            # a comment is prose, not a call.
+            code = "\n".join(_code_only(line) for line in src.splitlines())
+            for name in sorted(exported - imported):
+                for m in re.finditer(rf"\b{re.escape(name)}\s*\(", code):
+                    line_no = code[: m.start()].count("\n") + 1
+                    offenders.append(
+                        f"{path.relative_to(E2E_DIR).as_posix()}:{line_no} calls "
+                        f"{name}() but does not import it from ./helpers"
+                    )
+                    break
+
+        self.assertGreater(
+            scanned, 5, f"only found {scanned} prod-auth specs — glob stopped matching"
+        )
+        self.assertEqual(
+            offenders,
+            [],
+            "These prod-auth specs call a helper they never imported. The "
+            "line raises ReferenceError the moment the test body runs, and "
+            "the only thing that runs these specs is the production "
+            "verification workflow — so the first report would be a failed "
+            "production cycle blaming the product. Add the name to the "
+            "require({ … }) destructure.\n" + "\n".join(offenders),
+        )
+
+
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
Three defects found by reading my own prod-auth specs adversarially **before** running them, rather than by burning production-verification cycles. All three would have reported as product failures.

## 1. The page could not be asked about a team

`v1-authenticated-verification.yml` logs in as `guest`. That session carries no Sleeper user id and the league's `default_team_map` does not name it — so `/api/matchup/intel` would answer **400 `team_required`** and the page would show "No team selected". Correct behaviour, and not what W1-16 is about.

The spec now resolves a real team the way the other prod-auth specs do (`v1-27`: `/api/data?view=app` → `sleeper.teams`) and asks about it explicitly, annotating which one.

**The product gap behind it:** the endpoint has *always* accepted `?team=`; the page never passed one through, so the surface was reachable only by a session that had already picked a team in the switcher, and was not linkable per team. `GameDayPanel` now reads `?team=<ownerId>` and prefers it over `useUserState().selectedTeam` — explicit over implicit, the same precedence the backend resolver already uses (query → session → registry default), so page and endpoint agree about who wins. A blank/whitespace `?team=` is ignored rather than sent, since `?team=` would be a request for a team named `""`. `useSearchParams` needs a Suspense boundary during static prerender, so the page wraps the panel (same convention as `app/players/compare/page.jsx`).

Not a test-only accommodation: it makes the surface linkable per team for real users.

## 2. A helper was called but never imported

`w1-16-game-day.spec.js` called `desktopOnly(test, testInfo)` without destructuring it from `./helpers`. Nothing in the repo could see it:

- there is no ESLint at the root, so `no-undef` never ran;
- `playwright test --list` parses declarations and never enters a test body, so collection reported a correct count while one test could not execute;
- the prod-auth config runs only from the production-verification workflow, so the first execution of that line would have been a production cycle.

It would also have been **misread**: the call is the first statement in its body, so both projects raise `ReferenceError` before any assertion — including `prod-mobile`, which the helper exists to make *skip*. W1-25 would have read "the deployed shell does not offer Game Day" when the deployed shell was never asked.

Fixed by the import. The guard is the point: a new class in `tests/e2e/test_e2e_harness_guards.py` (same fast pytest gate, same rationale as its siblings — harness bugs fail everywhere at once and so look like a broken product). It answers exactly one question: does a spec call a name `helpers.js` exports without importing it. Deliberately scoped — adding ESLint for one rule is a bigger change than the defect. It parses the renaming form (`publicTest: test`), ignores comments so prose is not a call, and fails loudly if either the `module.exports` shape or the spec glob stops matching, so it cannot go vacuous.

Verified by reintroducing the bug: the guard names `w1-16-game-day.spec.js:165 calls desktopOnly()` and fails; with the import it passes.

## 3. The empty slate was indistinguishable from the healthy one

`w1-12`'s degraded-state test matched the bare phrase `Wednesday-morning previews`, which `articles.jsx` renders in **two** states:

| state | text |
|---|---|
| healthy | "Wednesday-morning previews. Tap a card for the full article." |
| empty | "Wednesday-morning previews will land here once the cron runs." |

So a surface with zero preview articles would have satisfied the `current` branch and been annotated "current-week slate" — a degraded state recorded as current, which is the exact defect the row exists to catch, committed by the instrument and then filed as evidence.

Now three mutually exclusive states (empty | older | current), asserted to be exactly one, each keyed on a string that cannot be true in another state. The older branch also asserts the present-tense subhead is *absent*, not merely that the past-tense one is present.

Measured against what production ships: `exports/narratives` carries exactly one preview article (2025 Week 17) against a 2026 Week 1 clock, so the older branch is the one that will run; the empty branch is latent coverage for when W1-11's key lands.

## Also verified while reading, no change needed

- `/league` is public by prefix in `public-routes.js`; `/game-day` is not — so the anonymous-401 assertion tests a real boundary.
- The matchup card renders `{home} vs {away}` as its own text node, so `/\svs\s/` matches something real.
- `matchup-previews.jsx` contains no projection, probability or median language, so the privacy markers assert against a genuine absence rather than a string that was never going to appear.

## Testing

- 4 new component tests on the `?team=` precedence: URL wins over the switcher; falls back to the switcher; sends nothing when neither names a team; ignores a blank value
- `npx vitest run` — 2446 passed / 166 files
- `npm run build` — clean, `/game-day` present, all 14 budgeted pages under budget
- `tests/e2e/test_e2e_harness_guards.py` — 15/15
- prod-auth collection — 104 tests in 23 files
- `ruff check` / `ruff format` clean; decision-coercion gate clean; `check_planning_integrity.py` clean

No prettier run: the repo carries no prettier config, so `npx prettier` defaults to 80 columns against specs written at 100 and reports 20 pre-existing files as unformatted. Reformatting them is not this PR's change.

## Contract movement

**None. W1-12 and W1-16 stay `NOT STARTED`** — the instruments are now correct, the evidence is not yet gathered. Numerator unchanged at **16/30**.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPwRjfLMMgHj4xLCQKgoDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPwRjfLMMgHj4xLCQKgoDW)_