### PR TITLE
W1-14/W1-25: correct the surface record after the /game-day rename

### DIFF
--- a/docs/season-launch/W1_14_W1_25_GAME_DAY_SURFACE.md
+++ b/docs/season-launch/W1_14_W1_25_GAME_DAY_SURFACE.md
@@ -175,9 +175,14 @@ percentages plus the tie sum to 100.0.
 
 ## 7. The surface
 
-`/matchup` ("This Week", first item in the **My Team** nav group), rendering
-`frontend/components/MatchupIntelPanel.jsx` over the bridge route at
+`/game-day` ("Game Day", first item in the **My Team** nav group), rendering
+`frontend/components/GameDayPanel.jsx` over the bridge route at
 `frontend/app/api/matchup/intel/route.js`.
+
+The bridge path deliberately does NOT move with the page: it mirrors the
+BACKEND route (`GET /api/matchup/intel`), which did not move either. Renaming
+it would make the frontend bridge and the endpoint it proxies disagree, for no
+gain.
 
 **Private by route, for the same reason `/phases` is.** Everything under
 `/league` is served by the isolated public pipeline and must never read private
@@ -215,7 +220,7 @@ than a single happy-path render.
 
 ## 8. Verification
 
-- `frontend/__tests__/components/matchup-intel-panel.test.jsx` — 12 tests: both
+- `frontend/__tests__/components/game-day-panel.test.jsx` — 26 tests: both
   win probabilities; the lineup rendered by **slot name, not index**; the
   count of players left out of the lineup rather than counted as zero; the
   unverified median threshold surfaced; source and coverage named; the
@@ -230,5 +235,12 @@ than a single happy-path render.
 production.** The endpoint and the surface both exist and are tested, which is
 what those two rows describe — but W1-16 asks for production verification of
 the owner's experience, and this document is not that. The rows move when
-`/matchup` is live and answering for the owner's own team, which requires the
+`/game-day` is live and answering for the owner's own team, which requires the
 projection snapshots that exist only on the box.
+
+The production instrument is
+`tests/e2e/specs/prod-auth/w1-16-game-day.spec.js`, run by
+`.github/workflows/v1-authenticated-verification.yml` against the deployed
+origin. It resolves a real team from `sleeper.teams` on the authenticated
+contract and asks about it via `?team=`, because the workflow's session is a
+GUEST pass that names no team of its own.


### PR DESCRIPTION
The `/matchup` → `/game-day` rename (#1249) updated the code and the sections *describing* the rename, but left §7 and §9 naming the old route, the old nav label and the old component.

That record is canonical, so it had come to contradict the thing it documents:

> **§7** — "`/matchup` ("This Week", first item in the **My Team** nav group), rendering `frontend/components/MatchupIntelPanel.jsx`"

Live: **`/game-day`**, labelled **"Game Day"** (`nav-model.js:148`), rendering **`GameDayPanel.jsx`**. The W1-25 production spec asserts the nav reads "Game Day" — so the canonical record and the instrument disagreed about the row they both describe, and whichever one a reader reached first would have looked authoritative.

## Corrections, each verified against the tree

- **§7** — route, nav label, component name. Also records why the *bridge* path `frontend/app/api/matchup/intel/route.js` deliberately did **not** move: it mirrors the backend route `GET /api/matchup/intel`, which did not move either, so renaming it would make the bridge and the endpoint it proxies disagree for no gain. Left unexplained it reads as a spot the rename simply missed.
- **§8** — `matchup-intel-panel.test.jsx` is now `game-day-panel.test.jsx`, and it is **26 tests, not 12** (measured: `npx vitest run` on that file — 26 passed). The count had not kept up as the file grew.
- **§9** — the route again, plus the production instrument that will actually move W1-14/W1-15/W1-16 is now named (`tests/e2e/specs/prod-auth/w1-16-game-day.spec.js` via `v1-authenticated-verification.yml`), including why it resolves a real team through `?team=`: the workflow's session is a guest pass that names no team of its own.

## Checked repo-wide

No `MatchupIntelPanel` reference survives anywhere in `docs/`, `frontend/` or `tests/`. The only remaining `/matchup` mentions in this file are the two that describe the rename historically, which are correct as written and deliberately left alone.

## Contract movement

**None.** W1-14, W1-15, W1-25 and W1-26 stay `NOT STARTED` — correcting a record is not evidence. Numerator unchanged at **16/30**. `check_planning_integrity.py` clean. Doc-only, class-A inert.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPwRjfLMMgHj4xLCQKgoDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPwRjfLMMgHj4xLCQKgoDW)_