### PR TITLE
Fix two production defects the Game Day verification run found

### DIFF
--- a/frontend/app/league/LeagueClient.jsx
+++ b/frontend/app/league/LeagueClient.jsx
@@ -38,6 +38,7 @@
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import { useRouter, useSearchParams } from "next/navigation";
+import ResilientSection from "@/components/ResilientSection";
 import { SubNav, PageHeader, LoadingState, EmptyState } from "@/components/ui";
 import { PUBLIC_SECTION_KEYS, fetchPublicSection } from "@/lib/public-league-data";
 import { buildManagerLookup } from "./shared.jsx";
@@ -71,6 +72,19 @@ import OverviewSection from "./sections/overview.jsx";
 // Pattern (dynamic + `_`-prefixed siblings) matches
 // ./sections/draft-capital.jsx, which already splits its own two heavy
 // panels this way.
+//
+// KNOWN GAP, not fixed here (found 2026-09-06 investigating a W1-12
+// production failure): none of the 20 `lazySection`-mounted tabs below
+// are wrapped in an error boundary. A failed dynamic `import()` (e.g. a
+// ChunkLoadError from a non-atomic deploy overwriting `.next/` while
+// `next start` is serving — the exact class `next.config.mjs` already
+// documents) or any render throw inside a lazy section falls through to
+// the route-wide `app/error.jsx`, blanking the ENTIRE page rather than
+// just that tab. `PreviewsSection` below is wrapped in `ResilientSection`
+// because a real failure was observed reaching it via the Home tab's
+// "Full H2H preview" link; the other 19 share the identical structural
+// gap and are not fixed here — wrapping all of them is a separate,
+// larger change than the one defect this fixes.
 const sectionLoading = () => <LoadingState message="Loading section..." />;
 const lazySection = (loader) =>
   dynamic(loader, { ssr: false, loading: sectionLoading });
@@ -411,7 +425,11 @@ function LeaguePage({ initialContract = null, initialTab = DEFAULT_TAB }) {
       {activeTab === "rosTeamStrength" && <RosTeamStrengthSection />}
       {activeTab === "rosChampionship" && <RosChampionshipSection />}
       {activeTab === "rosTradeDeadline" && <RosTradeDeadlineSection />}
-      {activeTab === "previews" && <PreviewsSection />}
+      {activeTab === "previews" && (
+        <ResilientSection name="Previews">
+          <PreviewsSection />
+        </ResilientSection>
+      )}
       {activeTab === "recaps" && <ArticlesSection mode="recap" />}
       {activeTab === "teamAssignment" && (
         <TeamAssignmentSection managers={managers} />

--- a/scripts/capture_game_day_predictions.py
+++ b/scripts/capture_game_day_predictions.py
@@ -41,6 +41,8 @@ from src.ros.game_day_capture import (  # noqa: E402
     build_capture,
     estimate_index_from_ensemble,
 )
+from src.ros.game_day_sim import get_cached_league_week_simulation  # noqa: E402
+from src.ros.game_day_week import resolve_pregame_week  # noqa: E402
 
 
 def _resolve_estimates(
@@ -254,6 +256,38 @@ def main() -> int:
                 # observation — that one is the better evidence.
                 skipped += 1
         print(f"    wrote {wrote} snapshot(s), {skipped} already captured")
+
+        # Warm the Game Day simulation cache so the pregame window's
+        # FIRST real request (any manager checking their matchup) reuses
+        # this instead of paying the full draws x teams x lineup-solve
+        # cost live. Best-effort: `build_capture` already proved the
+        # pregame window is open for this league (same `week_has_begun`
+        # gate `resolve_pregame_week` uses below), so a failure here is
+        # this league's projections/roster shape, not a stale window —
+        # and either way it must never turn THIS script's exit code into
+        # a false failure, since the archive write above is its real job.
+        if have > 0:
+            try:
+                resolution = resolve_pregame_week(
+                    league_key=key,
+                    league_payload=league_payload,
+                    rosters=rosters,
+                    matchups=matchups,
+                    players_meta=players_meta,
+                    starter_slots=build.starter_slots,
+                    estimates=estimates,
+                    estimate_source=label,
+                )
+                sim = get_cached_league_week_simulation(
+                    rules=resolution.rules,
+                    teams=resolution.teams,
+                    opponents=resolution.opponents,
+                    season=int(season),
+                    week=int(week),
+                )
+                print(f"    sim cache: warmed (already cached={sim.cached})")
+            except Exception as exc:  # noqa: BLE001 — see comment above
+                print(f"    sim cache: warm skipped ({type(exc).__name__}: {exc})")
 
     if refusals:
         print(f"\nREFUSED {refusals} league(s): pregame window closed.", file=sys.stderr)

--- a/src/api/matchup_intel.py
+++ b/src/api/matchup_intel.py
@@ -40,13 +40,14 @@ from typing import Any, Mapping, Sequence
 
 from src.api import roster_intelligence as _roster_intelligence
 from src.public_league import sleeper_client
-from src.ros.game_day_sim import TeamWeekOutcome, simulate_league_week
+from src.ros.game_day_sim import TeamWeekOutcome, get_cached_league_week_simulation
 from src.ros.game_day_week import GameDayWeekRefusal, resolve_pregame_week
 from src.ros.lineup import RosterPlayer, resolve_starter_slots, solve_optimal_assignment
 
-#: Draws for the league-week simulation. The simulator's own default; named
-#: here so the payload can report what it ran rather than implying a
-#: precision it did not buy.
+#: Draws for the league-week simulation. NOT `game_day_sim.DEFAULT_DRAWS`
+#: (10,000) — this endpoint runs synchronously in a web request, so it uses
+#: a smaller count named explicitly here, so the payload can report what it
+#: actually ran rather than implying a precision it did not buy.
 DEFAULT_DRAWS = 2000
 DEFAULT_SEED = 20260905
 
@@ -339,11 +340,19 @@ def build_matchup_intel(
     # The simulation runs over the WHOLE league because the median leg's
     # threshold is derived from every team's drawn score in the same
     # iteration; simulating two teams would answer a different question.
+    #
+    # Every manager in this league asking about the SAME week is asking
+    # this identical question, so this goes through the shared cache
+    # rather than `simulate_league_week` directly — measured at
+    # dynasty_main's real scale (12 teams, ~45 active players each,
+    # draws=2000), a cold call takes ~19s and a cache hit ~1ms. See
+    # `get_cached_league_week_simulation`'s own docstring for the
+    # invalidation rule and why the cache cannot live under `data/ros/`.
     simulation = None
     sim_error: str | None = None
     if resolution.estimate_coverage[0] > 0:
         try:
-            simulation = simulate_league_week(
+            simulation = get_cached_league_week_simulation(
                 rules=resolution.rules,
                 teams=resolution.teams,
                 opponents=resolution.opponents,
@@ -447,6 +456,11 @@ def build_matchup_intel(
                     "thresholdSemantics": simulation.threshold_semantics,
                     "thresholdSemanticsVerified": simulation.threshold_semantics_verified,
                     "notes": list(simulation.notes),
+                    # Honest freshness, matching this module's own stated
+                    # purpose: a number computed 90 minutes ago and one
+                    # computed 30 seconds ago should not read the same.
+                    "cached": simulation.cached,
+                    "cacheComputedAt": simulation.cache_computed_at,
                 }
                 if simulation
                 else None

--- a/src/ros/game_day_sim.py
+++ b/src/ros/game_day_sim.py
@@ -51,13 +51,18 @@ statistic is a one-constant change once a human reads it off the host.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import random
 import statistics
-from dataclasses import dataclass, field
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 
 from src.league_intel.sim_calibration import PointsModel, load_points_model
-from src.ros.lineup import RosterPlayer, solve_optimal_assignment
+from src.ros.lineup import RosterPlayer, precompute_slot_eligibility, solve_optimal_assignment
+from src.utils.config_loader import repo_root
 
 #: A player's state within the scoring period. Every one of these is a
 #: DIFFERENT statement about what is still uncertain, and collapsing any
@@ -195,6 +200,13 @@ class LeagueWeekSimulation:
     best_ball: bool
     seed: int
     notes: list[str] = field(default_factory=list)
+    #: Set only by :func:`get_cached_league_week_simulation` — this
+    #: function's own output always leaves these at the default,
+    #: because ``simulate_league_week`` is the pure, uncached
+    #: computation and does not know whether IT is being served from a
+    #: cache one layer up.
+    cached: bool = False
+    cache_computed_at: float | None = None
 
 
 def _drawable(player: PlayerWeek) -> bool:
@@ -252,6 +264,8 @@ def _team_score(
     team: TeamWeek,
     drawn: Mapping[str, float],
     rules: LeagueWeekRules,
+    *,
+    precomputed_eligibility: Mapping[str, Sequence[int]] | None = None,
 ) -> float:
     """One team's simulated weekly score under its OWN lineup rules.
 
@@ -261,6 +275,13 @@ def _team_score(
     draw can displace someone already in it. A managed league sums the
     lineup its manager actually submitted — re-optimizing there would
     award points nobody could have earned.
+
+    ``precomputed_eligibility``, when the caller has one (built once for
+    this team via :func:`src.ros.lineup.precompute_slot_eligibility`,
+    outside the per-draw loop), is passed straight through to the
+    solver so eligibility is not rederived on every one of a
+    simulation's thousands of draws for the same team. Omitting it
+    reproduces today's per-call derivation exactly.
     """
     if rules.best_ball:
         pool = [
@@ -276,7 +297,11 @@ def _team_score(
         ]
         if not pool:
             return 0.0
-        assignment = solve_optimal_assignment(pool, list(rules.starter_slots))
+        assignment = solve_optimal_assignment(
+            pool,
+            list(rules.starter_slots),
+            precomputed_eligibility=precomputed_eligibility,
+        )
         return float(sum(pl.ros_value or 0.0 for pl in assignment.values()))
     return float(sum(drawn.get(pid, 0.0) for pid in team.declared_starters))
 
@@ -327,6 +352,7 @@ def simulate_league_week(
     simulable: dict[str, tuple[PlayerWeek, ...]] = {}
     unsimulable: dict[str, tuple[str, ...]] = {}
     banked: dict[str, float] = {}
+    team_eligibility: dict[str, dict[str, tuple[int, ...]]] = {}
     for team in teams:
         ok = tuple(p for p in team.players if _drawable(p))
         simulable[team.team_id] = ok
@@ -335,6 +361,30 @@ def simulate_league_week(
         # the lineup, so a completed-but-benched score is not advertised
         # as though it is on the board.
         banked[team.team_id] = float(sum(_banked_points(p) for p in ok))
+        # Slot eligibility depends only on position/fantasy_positions,
+        # which this draws loop never changes for a given team — so it
+        # is computed ONCE here rather than once per (team, draw). At
+        # DEFAULT_DRAWS that is a 2000x-per-team reduction in redundant
+        # eligibility checks with zero change to the assignment (see
+        # precompute_slot_eligibility's own docstring for why this is
+        # exact, not an approximation). `ros_value=0.0` is a placeholder
+        # here — eligibility never reads it — and every player in `ok`
+        # is exactly the player set `_team_score` will ever build a
+        # pool from for this team, so the map is complete.
+        if rules.best_ball:
+            template_pool = [
+                RosterPlayer(
+                    player_id=p.player_id,
+                    canonical_name="",
+                    position=p.position,
+                    ros_value=0.0,
+                    fantasy_positions=p.fantasy_positions,
+                )
+                for p in ok
+            ]
+            team_eligibility[team.team_id] = precompute_slot_eligibility(
+                template_pool, list(rules.starter_slots)
+            )
 
     totals: dict[str, list[float]] = {t.team_id: [] for t in teams}
     h2h_win = {t.team_id: 0 for t in teams}
@@ -350,7 +400,15 @@ def simulate_league_week(
             drawn_by_team[team.team_id] = {
                 p.player_id: _draw_player(p, model, rng) for p in simulable[team.team_id]
             }
-        scores = {t.team_id: _team_score(t, drawn_by_team[t.team_id], rules) for t in teams}
+        scores = {
+            t.team_id: _team_score(
+                t,
+                drawn_by_team[t.team_id],
+                rules,
+                precomputed_eligibility=team_eligibility.get(t.team_id),
+            )
+            for t in teams
+        }
         for tid, sc in scores.items():
             totals[tid].append(sc)
 
@@ -472,6 +530,226 @@ def simulate_league_week(
         seed=seed,
         notes=sim_notes,
     )
+
+
+# ── Shared cache, so N managers checking one league-week pay the cost once ──
+#
+# `simulate_league_week` computes every team's outcome for a league-week in
+# ONE call (the median threshold is derived from that draw's own league-wide
+# scores, so it cannot be answered per-team). That means every manager in a
+# league checking their own Game Day page in the same window is asking the
+# IDENTICAL question — and without sharing, each of them independently pays
+# the full draws x teams x lineup-solve cost. `get_cached_league_week_simulation`
+# is that sharing. It is not a second engine: on a cache miss it calls
+# `simulate_league_week` above, unchanged, and never alters what comes back.
+
+#: Sibling to `game_day_archive.ARCHIVE_ROOT` — deliberately NOT under
+#: `data/ros/`. `scheduled-refresh.yml` force-adds `data/ros/` to git every
+#: 2 hours (`git add -f`, which overrides .gitignore) and only explicitly
+#: un-stages `data/ros/team_strength/*.json` afterward — confirmed live,
+#: `data/ros/sims/*.json` (an existing, different cache) IS tracked and
+#: committed to the public repo on that same cadence despite .gitignore
+#: saying it should not be. A per-manager win-probability/lineup cache
+#: placed under `data/ros/` would ship this league's private decision
+#: intelligence into the public repo on the next scheduled refresh.
+_SIM_CACHE_ROOT = repo_root() / "data" / "game_day" / "sims"
+
+#: Belt-and-suspenders staleness bound, matching the 2h cadence this repo
+#: already treats elsewhere (`sleeper_client`, `playoff_sim`'s own cache)
+#: as "how old before an input might have moved". The FINGERPRINT below is
+#: the real invalidation rule — a match means the cached payload IS the
+#: computation being requested, not merely "recent enough" — so this TTL
+#: only guards a fingerprint gap or bug, never decides freshness on its own.
+_GAME_DAY_SIM_CACHE_TTL_SEC = 2 * 3600
+
+
+def _sim_cache_path(league_key: str, season: int, week: int) -> Path:
+    return _SIM_CACHE_ROOT / str(league_key) / str(int(season)) / f"week_{int(week)}.json"
+
+
+def _sim_input_fingerprint(
+    *,
+    rules: LeagueWeekRules,
+    teams: Sequence[TeamWeek],
+    opponents: Mapping[str, str | None],
+    draws: int,
+    seed: int,
+    threshold_semantics: str,
+    model: PointsModel,
+) -> str:
+    """Sha256 over every input that can change ``simulate_league_week``'s
+    answer — rules, every team's players (state/position/banked/remaining/
+    fantasy positions), opponents, draws, seed, threshold semantics, and
+    the points model actually in effect. A match PROVES the cached result
+    is the same computation the caller was about to run; it is not a
+    heuristic staleness guess. Built from an explicit, sorted structure
+    rather than ``repr()``, which carries no cross-version stability
+    guarantee.
+    """
+    team_rows = []
+    for t in sorted(teams, key=lambda t: t.team_id):
+        players = sorted(
+            (
+                (
+                    p.player_id,
+                    p.position,
+                    p.state,
+                    p.points_scored,
+                    p.projected_remaining,
+                    tuple(p.fantasy_positions),
+                )
+                for p in t.players
+            ),
+            key=lambda row: row[0],
+        )
+        team_rows.append([t.team_id, players, sorted(t.declared_starters)])
+
+    payload = {
+        "rules": [
+            rules.league_key,
+            list(rules.starter_slots),
+            rules.best_ball,
+            rules.median_enabled,
+            rules.team_count,
+        ],
+        "teams": team_rows,
+        "opponents": sorted(opponents.items()),
+        "draws": draws,
+        "seed": seed,
+        "thresholdSemantics": threshold_semantics,
+        "pointsModel": [
+            model.source,
+            model.generated_at,
+            model.ros_value_per_point,
+            model.default_cv,
+            sorted(model.cv_by_position.items()),
+        ],
+    }
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+def _outcome_from_dict(row: Mapping[str, Any]) -> TeamWeekOutcome:
+    kwargs = dict(row)
+    kwargs["unsimulable_player_ids"] = tuple(kwargs.get("unsimulable_player_ids") or ())
+    kwargs["notes"] = list(kwargs.get("notes") or [])
+    return TeamWeekOutcome(**kwargs)
+
+
+def _read_sim_cache(path: Path, fingerprint: str) -> LeagueWeekSimulation | None:
+    """The cached simulation, only when its fingerprint matches and it is
+    within the TTL fallback — ``None`` on any miss, mismatch, staleness,
+    or unreadable file, never a partial or best-effort result."""
+    if not path.exists():
+        return None
+    try:
+        age_sec = time.time() - path.stat().st_mtime
+    except OSError:
+        return None
+    if age_sec > _GAME_DAY_SIM_CACHE_TTL_SEC:
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if raw.get("fingerprint") != fingerprint:
+        return None
+    body = raw.get("simulation")
+    if not isinstance(body, Mapping):
+        return None
+    try:
+        teams = tuple(_outcome_from_dict(row) for row in body["teams"])
+        sim = LeagueWeekSimulation(
+            league_key=body["league_key"],
+            season=body["season"],
+            week=body["week"],
+            draws=body["draws"],
+            teams=teams,
+            model_version=body["model_version"],
+            points_model_source=body["points_model_source"],
+            threshold_semantics=body["threshold_semantics"],
+            threshold_semantics_verified=body["threshold_semantics_verified"],
+            median_enabled=body["median_enabled"],
+            best_ball=body["best_ball"],
+            seed=body["seed"],
+            notes=list(body.get("notes") or []),
+        )
+    except (KeyError, TypeError):
+        # A cache written by a shape this reader no longer understands
+        # (e.g. a future field this version predates) is a miss, not a
+        # crash — the caller falls through to a live recompute.
+        return None
+    sim.cached = True
+    sim.cache_computed_at = raw.get("computedAt")
+    return sim
+
+
+def _write_sim_cache(path: Path, fingerprint: str, sim: LeagueWeekSimulation) -> None:
+    body = asdict(sim)
+    body.pop("cached", None)
+    body.pop("cache_computed_at", None)
+    computed_at = time.time()
+    payload = {"fingerprint": fingerprint, "computedAt": computed_at, "simulation": body}
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def get_cached_league_week_simulation(
+    *,
+    rules: LeagueWeekRules,
+    teams: Sequence[TeamWeek],
+    opponents: Mapping[str, str | None],
+    season: int,
+    week: int,
+    draws: int = DEFAULT_DRAWS,
+    seed: int = DEFAULT_SEED,
+    points_model: PointsModel | None = None,
+    threshold_semantics: str = THRESHOLD_SEMANTICS,
+) -> LeagueWeekSimulation:
+    """``simulate_league_week``, shared across every caller asking about
+    the SAME league-week rather than each paying its full cost.
+
+    On a cache miss this calls :func:`simulate_league_week` unchanged and
+    writes its result before returning it, so the FIRST caller for a
+    league-week pays the real cost once and every other manager checking
+    the same league-week reuses it. A scheduled precompute (this same
+    function, called proactively before the pregame window) is just
+    another caller — there is no separate mechanism to keep in sync.
+
+    See :func:`_sim_input_fingerprint` and the module-level cache-root
+    comment for the invalidation rule and why this cache cannot live
+    under ``data/ros/``.
+    """
+    model = points_model or load_points_model()
+    fingerprint = _sim_input_fingerprint(
+        rules=rules,
+        teams=teams,
+        opponents=opponents,
+        draws=draws,
+        seed=seed,
+        threshold_semantics=threshold_semantics,
+        model=model,
+    )
+    path = _sim_cache_path(rules.league_key, season, week)
+    cached = _read_sim_cache(path, fingerprint)
+    if cached is not None:
+        return cached
+
+    result = simulate_league_week(
+        rules=rules,
+        teams=teams,
+        opponents=opponents,
+        season=season,
+        week=week,
+        draws=draws,
+        seed=seed,
+        points_model=model,
+        threshold_semantics=threshold_semantics,
+    )
+    _write_sim_cache(path, fingerprint, result)
+    return result
 
 
 def rules_from_league(

--- a/src/ros/lineup.py
+++ b/src/ros/lineup.py
@@ -796,11 +796,44 @@ def _eligibility_predicate(
     return _predicate
 
 
+def precompute_slot_eligibility(
+    pool: list[RosterPlayer],
+    slots: list[str],
+    *,
+    slot_eligibility: Mapping[str, Collection[str]] | None = None,
+) -> dict[str, tuple[int, ...]]:
+    """Eligible slot indices per player, computed once.
+
+    Slot eligibility depends only on a player's ``position`` and
+    ``fantasy_positions`` — never on their objective value — so for a
+    FIXED pool composition and slot list it is identical every time
+    :func:`solve_optimal_assignment` is called on that pool, however
+    many times a caller re-solves it against different drawn values
+    (a Monte Carlo simulation over the same roster does exactly this,
+    thousands of times per team). Computing it once here and handing
+    the result to every one of those calls via
+    ``precomputed_eligibility`` removes O(pool × slots) redundant
+    eligibility checks per call — this is not an approximation, it is
+    the identical per-pair computation moved outside a loop whose
+    inputs it does not depend on.
+
+    Keyed by ``player_id`` rather than sort position: sort order is
+    VALUE-dependent and therefore changes between calls even when pool
+    composition does not, so an index-keyed cache would silently
+    misalign the moment two calls draw different values.
+    """
+    is_eligible = _eligibility_predicate(slot_eligibility)
+    return {
+        p.player_id: tuple(i for i, slot in enumerate(slots) if is_eligible(slot, p)) for p in pool
+    }
+
+
 def solve_optimal_assignment(
     pool: list[RosterPlayer],
     slots: list[str],
     *,
     slot_eligibility: Mapping[str, Collection[str]] | None = None,
+    precomputed_eligibility: Mapping[str, Sequence[int]] | None = None,
 ) -> dict[int, RosterPlayer]:
     """Exact maximum-weight player→slot assignment.
 
@@ -825,15 +858,33 @@ def solve_optimal_assignment(
     candidates — an unpriceable player must not win a slot a priced one
     could fill.  Use :func:`assign_lineup` to see which they were; this
     function returns only the assignment.
+
+    ``precomputed_eligibility``, when given, is used INSTEAD OF
+    deriving eligibility for this call — it must come from
+    :func:`precompute_slot_eligibility` over the SAME ``pool`` (by
+    player identity) / ``slots`` / ``slot_eligibility`` this call would
+    otherwise compute it from.  A caller re-solving one pool's
+    composition many times against different player VALUES (a
+    league-week simulation drawing one team thousands of times) should
+    compute this ONCE and pass it to every solve.  Omitting it (every
+    existing caller) reproduces today's per-call computation
+    byte-for-byte — a player absent from the map is treated as
+    ineligible everywhere, matching what a fresh derivation would give
+    a player found nowhere in ``slots``.
     """
     is_eligible = _eligibility_predicate(slot_eligibility)
     ordered = sorted(
         (p for p in pool if _objective(p) is not None),
         key=lambda p: (-_value_with_health_penalty(p), p.player_id),
     )
-    eligible_slots: list[list[int]] = [
-        [i for i, slot in enumerate(slots) if is_eligible(slot, p)] for p in ordered
-    ]
+    if precomputed_eligibility is not None:
+        eligible_slots: list[list[int]] = [
+            list(precomputed_eligibility.get(p.player_id, ())) for p in ordered
+        ]
+    else:
+        eligible_slots = [
+            [i for i, slot in enumerate(slots) if is_eligible(slot, p)] for p in ordered
+        ]
     # slot index -> index into `ordered`
     slot_owner: dict[int, int] = {}
 

--- a/tests/api/test_matchup_intel.py
+++ b/tests/api/test_matchup_intel.py
@@ -9,10 +9,36 @@ is a number, not intelligence.
 
 from __future__ import annotations
 
+import shutil
+import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
 
 from src.api import matchup_intel
+from src.ros import game_day_sim as _game_day_sim
+
+#: `build_matchup_intel` now goes through `get_cached_league_week_simulation`
+#: (Defect 1 fix), which writes to `_game_day_sim._SIM_CACHE_ROOT` on a
+#: cache miss. Redirected to a throwaway directory for the whole module so
+#: these tests stay hermetic — the real cache root lives under this repo's
+#: `data/` and must never pick up test fixtures.
+_TMP_SIM_CACHE_DIR: str | None = None
+_ORIGINAL_SIM_CACHE_ROOT: Path | None = None
+
+
+def setUpModule() -> None:
+    global _TMP_SIM_CACHE_DIR, _ORIGINAL_SIM_CACHE_ROOT
+    _TMP_SIM_CACHE_DIR = tempfile.mkdtemp(prefix="game_day_sim_cache_test_")
+    _ORIGINAL_SIM_CACHE_ROOT = _game_day_sim._SIM_CACHE_ROOT
+    _game_day_sim._SIM_CACHE_ROOT = Path(_TMP_SIM_CACHE_DIR)
+
+
+def tearDownModule() -> None:
+    _game_day_sim._SIM_CACHE_ROOT = _ORIGINAL_SIM_CACHE_ROOT
+    if _TMP_SIM_CACHE_DIR:
+        shutil.rmtree(_TMP_SIM_CACHE_DIR, ignore_errors=True)
+
 
 SLOTS = ["QB", "RB", "RB", "WR", "WR", "FLEX"]
 

--- a/tests/e2e/specs/prod-auth/w1-12-public-pregame.spec.js
+++ b/tests/e2e/specs/prod-auth/w1-12-public-pregame.spec.js
@@ -75,13 +75,37 @@ test.describe("W1-12: public Week 1 pregame surfaces (production)", () => {
   test("the Home card's Full H2H preview link reaches the previews tab", async ({
     publicPage: page,
   }, testInfo) => {
+    // Captured from before navigation starts, so a failure during EITHER
+    // the initial load or the client-side tab switch is caught. This test
+    // previously failed on production with a bare 60s timeout and no
+    // error text to root-cause from; a leading hypothesis (investigated
+    // 2026-09-06, see LeagueClient.jsx's `lazySection` comment) is a
+    // failed chunk load or a render throw inside the lazy-loaded previews
+    // section, which a page-wide error boundary would swallow visually
+    // but which still reaches the console. Recording it here means the
+    // NEXT failure, if there is one, carries real evidence instead of
+    // another bare timeout to guess at.
+    const consoleErrors = [];
+    const pageErrors = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") consoleErrors.push(msg.text());
+    });
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+
     // The navigation half of the row. This CTA used to land on a slate of
     // articles from a previous season.
     await page.goto(prodUrl("/league"), { waitUntil: "domcontentloaded" });
     const cta = page.getByText(/Full H2H preview/i).first();
     await expect(cta).toBeVisible({ timeout: 60_000 });
     await cta.click();
-    await expect(page.getByText(/Week \d+ matchups · \d{4}/)).toBeVisible({ timeout: 60_000 });
+    try {
+      await expect(page.getByText(/Week \d+ matchups · \d{4}/)).toBeVisible({ timeout: 60_000 });
+    } finally {
+      // Recorded on pass too — a clean run with captured errors would
+      // itself be worth knowing about (an error the page recovered from).
+      annotate(testInfo, "w1-12-console-errors", JSON.stringify(consoleErrors));
+      annotate(testInfo, "w1-12-page-errors", JSON.stringify(pageErrors));
+    }
     annotate(testInfo, "w1-12-cta", "Full H2H preview → structured previews");
   });
 

--- a/tests/game_day/test_game_day_sim.py
+++ b/tests/game_day/test_game_day_sim.py
@@ -12,6 +12,8 @@ seeded, so these run in the hard gate.
 
 from __future__ import annotations
 
+import random
+
 import pytest
 
 from src.league_intel.sim_calibration import PointsModel
@@ -511,3 +513,67 @@ def test_a_fallback_points_model_is_declared():
 def test_zero_draws_is_refused():
     with pytest.raises(GameDaySimError, match="draws"):
         _league(draws=0)
+
+
+# ── realistic scale ───────────────────────────────────────────────────
+#
+# Every test above uses toy scale (n=4 teams, a handful of players per
+# roster, draws in the low hundreds). `dynasty_main` is 12 teams with
+# ~45 active players each, simulated at `matchup_intel.py`'s
+# `DEFAULT_DRAWS = 2000` — a combination no test here had ever exercised
+# before it shipped to production and cost 45-51s per request (2000
+# draws x 12 teams x an exact per-draw lineup solve, with zero caching
+# anywhere on the path). This is a correctness check at that real
+# scale; the PERFORMANCE regression guard for the fix
+# (`precompute_slot_eligibility`) lives beside the solver it speeds up,
+# in `tests/lineup/test_canonical_lineup.py`, as a relative comparison
+# rather than an absolute wall-clock budget — a fixed-seconds assertion
+# here would be a CI-runner-speed test, not a correctness one.
+
+
+def test_realistic_scale_produces_a_result_for_every_team():
+    from src.ros.lineup import flatten_starter_slots
+
+    slots = tuple(
+        flatten_starter_slots(
+            {
+                "QB": 1, "RB": 2, "WR": 3, "TE": 2, "FLEX": 2, "SFLEX": 1,
+                "K": 1, "DL": 3, "LB": 3, "DB": 3,
+            }
+        )
+    )  # fmt: skip
+    rules = _rules(starter_slots=slots, team_count=12)
+
+    def roster(prefix, seed):
+        rng = random.Random(seed)
+        spec = (
+            ("QB", 3), ("RB", 8), ("WR", 10), ("TE", 4),
+            ("K", 2), ("DL", 6), ("LB", 6), ("DB", 6),
+        )  # fmt: skip
+        return tuple(
+            _p(f"{prefix}_{pos}{i}", pos, "not_started", remaining=10.0 + rng.random() * 5)
+            for pos, n in spec
+            for i in range(n)
+        )
+
+    teams = [TeamWeek(team_id=f"t{i}", players=roster(f"t{i}", i)) for i in range(1, 13)]
+    opponents = {}
+    for i in range(1, 13, 2):
+        opponents[f"t{i}"] = f"t{i + 1}"
+        opponents[f"t{i + 1}"] = f"t{i}"
+
+    sim = simulate_league_week(
+        rules=rules,
+        teams=teams,
+        opponents=opponents,
+        season=2026,
+        week=1,
+        draws=100,
+        seed=1,
+        points_model=_MODEL,
+    )
+    assert len(sim.teams) == 12
+    for outcome in sim.teams:
+        assert outcome.win_matchup_pct is not None
+        assert 0.0 <= outcome.win_matchup_pct <= 100.0
+        assert not outcome.unsimulable_player_ids

--- a/tests/game_day/test_game_day_sim_cache.py
+++ b/tests/game_day/test_game_day_sim_cache.py
@@ -1,0 +1,157 @@
+"""``get_cached_league_week_simulation`` (Defect 1 fix, 2026-09-06).
+
+``simulate_league_week`` computes every team's outcome for a league-week in
+one call, so every manager checking their own Game Day page for the same
+league-week is asking the identical question. Without sharing, N managers
+in the same window trigger N independent full recomputes of the exact same
+simulation — this is what makes it worth caching rather than just faster.
+
+What actually matters here is not "is there a file on disk" but two
+properties: a cache HIT must not re-run the simulation, and a genuine input
+change must never be served a stale answer. Both are asserted by spying on
+``simulate_league_week`` itself rather than by timing, which is the only way
+to prove the cache is doing what it claims rather than merely being fast by
+coincidence.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from src.league_intel.sim_calibration import PointsModel
+from src.ros import game_day_sim as gds
+from src.ros.game_day_sim import (
+    LeagueWeekRules,
+    PlayerWeek,
+    TeamWeek,
+    get_cached_league_week_simulation,
+)
+
+_MODEL = PointsModel(ros_value_per_point=1.0, cv_by_position={}, default_cv=0.20)
+
+_SLOTS = ("QB", "RB", "RB", "WR", "WR", "TE", "FLEX")
+
+
+def _roster(prefix, remaining=10.0):
+    spec = [
+        ("qb1", "QB"),
+        ("rb1", "RB"),
+        ("rb2", "RB"),
+        ("wr1", "WR"),
+        ("wr2", "WR"),
+        ("te1", "TE"),
+    ]
+    return tuple(
+        PlayerWeek(
+            player_id=f"{prefix}_{pid}",
+            position=pos,
+            state="not_started",
+            projected_remaining=remaining,
+        )
+        for pid, pos in spec
+    )
+
+
+def _league(remaining=10.0):
+    rules = LeagueWeekRules(
+        league_key="cache_test_league",
+        starter_slots=_SLOTS,
+        best_ball=True,
+        median_enabled=True,
+        team_count=4,
+    )
+    teams = [TeamWeek(team_id=f"t{i}", players=_roster(f"t{i}", remaining)) for i in range(1, 5)]
+    opponents = {"t1": "t2", "t2": "t1", "t3": "t4", "t4": "t3"}
+    return rules, teams, opponents
+
+
+@pytest.fixture
+def cache_dir():
+    """A throwaway cache root, patched in for the duration of one test —
+    this suite must never touch the repo's real `data/game_day/sims/`."""
+    tmp = tempfile.mkdtemp(prefix="game_day_sim_cache_test_")
+    with mock.patch.object(gds, "_SIM_CACHE_ROOT", Path(tmp)):
+        yield Path(tmp)
+    shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _call(rules, teams, opponents, **kw):
+    return get_cached_league_week_simulation(
+        rules=rules,
+        teams=teams,
+        opponents=opponents,
+        season=2026,
+        week=1,
+        draws=50,
+        seed=1,
+        points_model=_MODEL,
+        **kw,
+    )
+
+
+def test_a_cold_call_computes_and_is_marked_uncached(cache_dir):
+    rules, teams, opponents = _league()
+    with mock.patch.object(gds, "simulate_league_week", wraps=gds.simulate_league_week) as spy:
+        result = _call(rules, teams, opponents)
+    assert spy.call_count == 1
+    assert result.cached is False
+    assert result.cache_computed_at is None
+
+
+def test_a_second_identical_call_is_served_from_cache_without_recomputing(cache_dir):
+    rules, teams, opponents = _league()
+    with mock.patch.object(gds, "simulate_league_week", wraps=gds.simulate_league_week) as spy:
+        first = _call(rules, teams, opponents)
+        second = _call(rules, teams, opponents)
+    assert spy.call_count == 1, "the second call re-ran the simulation instead of reusing the cache"
+    assert second.cached is True
+    assert second.cache_computed_at is not None
+    assert first.teams == second.teams, "a cache hit must return the SAME outcome, not a fresh draw"
+
+
+def test_a_changed_player_input_forces_a_real_recompute(cache_dir):
+    """The fingerprint, not a blind TTL, is what must catch this: a
+    roster move or a projection refresh must never be served the old
+    answer just because it arrived inside the TTL window."""
+    rules, teams, opponents = _league(remaining=10.0)
+    _, changed_teams, _ = _league(remaining=999.0)
+
+    with mock.patch.object(gds, "simulate_league_week", wraps=gds.simulate_league_week) as spy:
+        _call(rules, teams, opponents)
+        _call(rules, changed_teams, opponents)
+    assert spy.call_count == 2, "a genuine input change was served a stale cached answer"
+
+
+def test_a_different_week_does_not_collide_with_another_weeks_cache(cache_dir):
+    rules, teams, opponents = _league()
+    with mock.patch.object(gds, "simulate_league_week", wraps=gds.simulate_league_week) as spy:
+        get_cached_league_week_simulation(
+            rules=rules, teams=teams, opponents=opponents, season=2026, week=1,
+            draws=50, seed=1, points_model=_MODEL,
+        )  # fmt: skip
+        get_cached_league_week_simulation(
+            rules=rules, teams=teams, opponents=opponents, season=2026, week=2,
+            draws=50, seed=1, points_model=_MODEL,
+        )  # fmt: skip
+    assert spy.call_count == 2
+
+
+def test_the_cache_never_writes_under_data_ros():
+    """`scheduled-refresh.yml` force-adds `data/ros/` to git every 2 hours
+    (`git add -f`, overriding .gitignore) and only explicitly un-stages
+    `data/ros/team_strength/*.json` afterward — confirmed live,
+    `data/ros/sims/*.json` (a different, existing cache) IS tracked and
+    committed to the public repo on that cadence. A Game Day simulation
+    cache holds real per-manager win probabilities and lineups, so this
+    module's REAL (unpatched) cache root must never resolve under
+    `data/ros/` — deliberately not using the `cache_dir` fixture, which
+    patches this constant to a throwaway path for every other test here.
+    """
+    real_root = str(gds._SIM_CACHE_ROOT).replace("\\", "/")
+    assert "data/ros" not in real_root
+    assert "data/game_day" in real_root

--- a/tests/lineup/test_canonical_lineup.py
+++ b/tests/lineup/test_canonical_lineup.py
@@ -21,6 +21,7 @@ from src.ros.lineup import (
     RosterPlayer,
     assign_lineup,
     player_eligible_for_slot,
+    precompute_slot_eligibility,
     solve_optimal_assignment,
 )
 
@@ -314,3 +315,90 @@ class TestConfiguredEligibility:
                         if all(elig(slots[chosen_slots[i]], combo[i]) for i in range(k)):
                             best = max(best, sum(p.ros_value or 0.0 for p in combo))
             assert total == pytest.approx(best, abs=1e-6)
+
+
+class TestPrecomputedEligibilityHoist:
+    """``precompute_slot_eligibility`` / ``precomputed_eligibility`` (Defect
+    1 fix, 2026-09-06): a Monte Carlo simulation re-solves the SAME pool
+    composition against different drawn VALUES thousands of times per
+    team, and eligibility depends only on position/fantasy_positions —
+    never on value — so it can be computed once and reused. Two things
+    must hold for that to be safe: the result must be IDENTICAL to
+    deriving eligibility fresh on every call, and it must actually be
+    faster (a hoist that isn't need not exist).
+    """
+
+    def test_precomputed_eligibility_matches_derived_on_every_call(self):
+        """Same pool identity, many different value draws (the exact
+        access pattern `game_day_sim._team_score` uses): the precomputed
+        path and the derive-every-time path must agree on every draw."""
+        rng = random.Random(2026)
+        pool_template = random_roster(rng, 45)
+        elig = precompute_slot_eligibility(pool_template, LIVE_SLOTS)
+
+        for _ in range(50):
+            drawn = [
+                RosterPlayer(
+                    player_id=p.player_id,
+                    canonical_name=p.canonical_name,
+                    position=p.position,
+                    ros_value=round(rng.uniform(0, 100), 2),
+                    fantasy_positions=p.fantasy_positions,
+                )
+                for p in pool_template
+            ]
+            derived = solve_optimal_assignment(drawn, LIVE_SLOTS)
+            precomputed = solve_optimal_assignment(drawn, LIVE_SLOTS, precomputed_eligibility=elig)
+            assert {i: p.player_id for i, p in derived.items()} == {
+                i: p.player_id for i, p in precomputed.items()
+            }
+
+    def test_precomputed_eligibility_is_not_slower_than_deriving_it(self):
+        """The actual production defect: `_eligibility_predicate` was
+        rederived from scratch on every one of 24,000 per-request solver
+        calls at realistic scale (2000 draws x 12 teams), measured at
+        45-51s in production. This does not assert an absolute wall-clock
+        budget — that is a CI-runner-speed test, not a correctness one —
+        it asserts the RELATIONSHIP the fix depends on, timed within one
+        run so environment speed cancels out: reusing a precomputed
+        eligibility map must not be slower than rederiving it every call.
+        A future change that quietly stops the hoist from doing anything
+        (e.g. an accidental copy that rebuilds the map internally anyway)
+        would show up here as the ratio collapsing to ~1, not as a
+        several-seconds-slower CI run someone has to notice separately.
+        """
+        import time
+
+        rng = random.Random(99)
+        pool_template = random_roster(rng, 45)
+        elig = precompute_slot_eligibility(pool_template, LIVE_SLOTS)
+
+        draws = [
+            [
+                RosterPlayer(
+                    player_id=p.player_id,
+                    canonical_name=p.canonical_name,
+                    position=p.position,
+                    ros_value=round(random.Random(i).uniform(0, 100), 2),
+                    fantasy_positions=p.fantasy_positions,
+                )
+                for p in pool_template
+            ]
+            for i in range(300)
+        ]
+
+        t0 = time.perf_counter()
+        for pool in draws:
+            solve_optimal_assignment(pool, LIVE_SLOTS)
+        without_precompute = time.perf_counter() - t0
+
+        t0 = time.perf_counter()
+        for pool in draws:
+            solve_optimal_assignment(pool, LIVE_SLOTS, precomputed_eligibility=elig)
+        with_precompute = time.perf_counter() - t0
+
+        assert with_precompute < without_precompute, (
+            f"precomputed eligibility ({with_precompute:.3f}s over 300 calls) was not "
+            f"faster than deriving it every call ({without_precompute:.3f}s) — the hoist "
+            "this test exists to guard has stopped doing anything."
+        )

--- a/tests/lineup/test_single_owner.py
+++ b/tests/lineup/test_single_owner.py
@@ -250,6 +250,7 @@ class TestNoSecondAssignmentEngine:
         # slots", which is a refusal, not a heuristic lineup.
         assignment_path = {
             "solve_optimal_assignment",
+            "precompute_slot_eligibility",
             "assign_lineup",
             "_augment",
             "_canonicalize_slots",


### PR DESCRIPTION
The Game Day verification suite's first-ever run against real production data (run 33, `34013925474`, 2026-09-06) surfaced two independent, genuine production defects — not test-instrument bugs. Both had never been exercised against real production data or real Sleeper rosters before; local tests only ever used toy-scale fixtures. This PR fixes both, with the evidence for each traced end-to-end before writing any code.

## Defect 1 — `GET /api/matchup/intel` is not request-safe against a real league

**Symptom:** every test that exercised it timed out at 45-51s (the client's own 45s timeout), on both viewports, for a real team in `dynasty_main`.

**Root cause**, confirmed by reading `src/api/matchup_intel.py`, `src/ros/game_day_sim.py`, and `src/ros/lineup.py`: `build_matchup_intel()` runs `simulate_league_week(draws=2000)` over `dynasty_main`'s 12 teams. Because `dynasty_main` is `best_ball=1`, every one of 2000 draws solves an **exact** bipartite-matching lineup assignment (`solve_optimal_assignment`) for every team — **2000 × 12 = 24,000 solver calls per request**, against real ~45-player active rosters, with zero caching anywhere on the path.

**Measured, not guessed:**
- isolated `solve_optimal_assignment`: 1.911ms/call → 0.711ms/call after hoisting eligibility out of the per-draw loop (~2.7×)
- full realistic-scale simulation (12 teams, ~45 players/team, draws=2000): ~19s after the hoist alone — extrapolating the isolated per-call numbers to 24,000 calls lands almost exactly on the 45-51s production failures (24,000 × 1.911ms ≈ 46s), confirming both the diagnosis and that the hoist alone is necessary but not sufficient
- with the cache added: ~1ms on a warm hit

**Fix, two additive pieces:**
1. `precompute_slot_eligibility()` — eligibility depends only on position/fantasy_positions, never the drawn value that changes every iteration, so for a fixed team it's identical across all 2000 draws. Hoisted via a new optional `precomputed_eligibility` param on `solve_optimal_assignment`; omitted (every existing caller) reproduces today's behavior byte-for-byte. No `Try`, no second eligibility table — respects the AST guard in `test_single_owner.py` ("no fallback greedy" is a tested invariant here). Correctness proven by an equivalence test comparing precomputed vs. derived-every-time over many random draws; the actual speedup is proven by a **relative** comparison timed within one test run, not an absolute wall-clock budget (which would just be a CI-runner-speed test).
2. `get_cached_league_week_simulation()` — every manager in a league asking about the same week is asking the identical question, so this shares the computation. Cache key is a content fingerprint (sha256 over everything that can change the answer), so a match *proves* the cached result is the computation being requested; a 2h TTL is belt-and-suspenders only. `simulate_league_week` itself stays pure/uncached — same shape as `playoff_sim.py`'s `simulate_playoff_odds`/`build_section`.

**A safety finding that changed where the cache lives:** verified live that `scheduled-refresh.yml`'s `git add -f -- data/ros/` (every 2h, overrides `.gitignore`) currently ships `data/ros/sims/*.json` to the public repo despite `.gitignore` saying it should be ignored — only `team_strength/*.json` is explicitly un-staged afterward. A per-manager win-probability/lineup cache placed under `data/ros/` would have leaked private decision intelligence into the public repo on the next refresh. The new cache lives at `data/game_day/sims/`, sibling to `game_day_archive.ARCHIVE_ROOT`, which is never in that force-add list.

Also added a best-effort precompute hook to `scripts/capture_game_day_predictions.py` (the Thursday pregame timer) so the cache is warm before any manager looks, and fixed a stale comment claiming `DEFAULT_DRAWS = 2000` was "the simulator's own default" (the real default is 10,000 — 2000 is this endpoint's own deliberate choice).

**Found and fixed along the way:** `tests/api/test_matchup_intel.py` was writing real cache files into this repo's `data/game_day/` during test runs — now hermetic via a module-level cache-root patch.

## Defect 2 — `/league`'s "Full H2H preview" CTA never reaches the previews tab

**Symptom:** the CTA was found and clicked, but the previews heading never appeared within 60s, on both viewports — while navigating *directly* to `/league?tab=previews` passed fine.

**Traced the click → state → render chain and it is correct**: `onNavigate("matchupPreview")` → `setActiveTab` → `normalizeTabKey` aliases to `"previews"` → `router.replace` (shallow) → `activeTab === "previews" && <PreviewsSection />`. The defect isn't there.

**Root cause**: `PreviewsSection` is `next/dynamic(loader, { ssr: false })` — a client-only, code-split chunk. **None of the 20 `lazySection`-mounted tabs on `/league` are wrapped in an error boundary.** A failed chunk `import()` or any render throw inside a lazy section falls through to the route-wide `app/error.jsx` and blanks the *entire page* — which reads exactly like "the heading never appears" from outside a browser. This repo already documents the failure class (`next.config.mjs`: ChunkLoadError from a non-atomic deploy overwriting `.next/` while `next start` is serving), and a client-side nav triggering a *new* chunk fetch is far more exposed to it than a fresh `page.goto` (the passing control test).

**Fix**: wrap `PreviewsSection`'s mount in `ResilientSection` — an existing error boundary already used twice elsewhere (`waivers/ManualAddDrop.jsx`, `trade/TradeMeter.jsx`) but never applied here. Minimal, evidence-scoped: only the section actually observed failing. The other 19 mounts share the identical structural gap, named explicitly in a code comment next to `lazySection`'s definition rather than silently left for the next person to rediscover — not fixed here, since wrapping all 20 is a separate, larger change.

Also instrumented the spec itself to capture `console`/`pageerror` events around the click, annotated into the report either way — static analysis alone couldn't confirm whether this reproduces reliably or was a one-off deploy race, so the next run carries real evidence instead of another bare timeout.

## Testing

- `tests/lineup/`, `tests/game_day/`, `tests/api/test_matchup_intel*.py`, `tests/ros/test_game_day_*.py` — 253 passed
- `tests/roster_intel/`, `tests/trade/`, `tests/draft/`, `tests/league_intel/test_lineup_exactness.py` (every other consumer of the touched functions) — 1625 passed, 22 pre-existing skips, unaffected since both signature changes are purely additive/optional
- `tests/e2e/test_e2e_harness_guards.py` — 15/15
- prod-auth collection unchanged: 104 tests / 23 files
- `npx vitest run` — 2446/2446 across 167 files
- `npm run build` — clean, all 14 budgeted pages under budget
- `ruff check` / `ruff format --check` clean; decision-coercion gate and `check_planning_integrity.py` clean

## Contract movement

**None yet.** W1-12/14/15/16/25/26 stay at their current status in `docs/season-launch/WEEK_1_LAUNCH_CONTRACT.md` — this fixes the production defects the verification run found. Rows move only after a clean re-run of `v1-authenticated-verification.yml` against the deployed fix, with the cache manually warmed first so that re-run doesn't hit a cold path.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPwRjfLMMgHj4xLCQKgoDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPwRjfLMMgHj4xLCQKgoDW)_