### PR TITLE
Correct Defect 2's diagnosis and fix W1-16's own timing races

### DIFF
--- a/tests/e2e/specs/prod-auth/helpers.js
+++ b/tests/e2e/specs/prod-auth/helpers.js
@@ -60,8 +60,8 @@ function readCookieValue() {
  * the browser context's cookie jar).  Returns { status, body } — body is
  * null when the response is not JSON.
  */
-async function getJson(page, path) {
-  const res = await page.request.get(prodUrl(path), { timeout: 45_000 });
+async function getJson(page, path, { timeoutMs = 45_000 } = {}) {
+  const res = await page.request.get(prodUrl(path), { timeout: timeoutMs });
   let body = null;
   try {
     body = await res.json();

--- a/tests/e2e/specs/prod-auth/w1-12-public-pregame.spec.js
+++ b/tests/e2e/specs/prod-auth/w1-12-public-pregame.spec.js
@@ -75,16 +75,24 @@ test.describe("W1-12: public Week 1 pregame surfaces (production)", () => {
   test("the Home card's Full H2H preview link reaches the previews tab", async ({
     publicPage: page,
   }, testInfo) => {
-    // Captured from before navigation starts, so a failure during EITHER
-    // the initial load or the client-side tab switch is caught. This test
-    // previously failed on production with a bare 60s timeout and no
-    // error text to root-cause from; a leading hypothesis (investigated
-    // 2026-09-06, see LeagueClient.jsx's `lazySection` comment) is a
-    // failed chunk load or a render throw inside the lazy-loaded previews
-    // section, which a page-wide error boundary would swallow visually
-    // but which still reaches the console. Recording it here means the
-    // NEXT failure, if there is one, carries real evidence instead of
-    // another bare timeout to guess at.
+    // Captured from before navigation starts. A first attempt at this row
+    // (2026-09-06) hypothesized a crashed lazy-chunk load and wrapped the
+    // previews section in an error boundary — the WRONG fix. Real
+    // evidence from that attempt's own failure (console/pageerror capture:
+    // zero of either, both viewports; the failure's DOM snapshot: the page
+    // was still rendering the Home tab's OWN content, "Full H2H preview →"
+    // still present and un-clicked-looking) proves there was no crash for
+    // a boundary to catch — the click simply had no effect.
+    //
+    // This is a HYDRATION RACE, the same class this repo already diagnosed
+    // and fixed once in v1-131-nav-gating.spec.js's mobile drawer test:
+    // `domcontentloaded` + a visible CTA only proves the SSR markup
+    // painted (OverviewSection is statically imported, so its markup is
+    // in the initial HTML) — the onClick is wired by React hydration,
+    // which can still be in flight. A native click landing in that gap
+    // dispatches a real DOM event with nobody listening for it yet, and
+    // once hydration completes there is no replay. Kept here rather than
+    // removed: a real future crash would still show up in these arrays.
     const consoleErrors = [];
     const pageErrors = [];
     page.on("console", (msg) => {
@@ -97,9 +105,23 @@ test.describe("W1-12: public Week 1 pregame surfaces (production)", () => {
     await page.goto(prodUrl("/league"), { waitUntil: "domcontentloaded" });
     const cta = page.getByText(/Full H2H preview/i).first();
     await expect(cta).toBeVisible({ timeout: 60_000 });
+    // Give hydration a bounded chance to finish before clicking — same
+    // networkidle-with-fallback pattern v1-131-nav-gating.spec.js already
+    // uses for this exact race. `.catch()` because a page that legitimately
+    // never goes fully idle (polling, analytics) must not hang the test.
+    await page.waitForLoadState("networkidle", { timeout: 15_000 }).catch(() => {});
     await cta.click();
+    const previewsHeading = page.getByText(/Week \d+ matchups · \d{4}/);
     try {
-      await expect(page.getByText(/Week \d+ matchups · \d{4}/)).toBeVisible({ timeout: 60_000 });
+      try {
+        await expect(previewsHeading).toBeVisible({ timeout: 5_000 });
+      } catch {
+        // One retry covers a click that still landed pre-hydration despite
+        // the networkidle wait (e.g. a slow runner) — a genuine navigation
+        // defect fails this too, since neither attempt reaches the tab.
+        await cta.click();
+        await expect(previewsHeading).toBeVisible({ timeout: 60_000 });
+      }
     } finally {
       // Recorded on pass too — a clean run with captured errors would
       // itself be worth knowing about (an error the page recovered from).

--- a/tests/e2e/specs/prod-auth/w1-16-game-day.spec.js
+++ b/tests/e2e/specs/prod-auth/w1-16-game-day.spec.js
@@ -62,8 +62,17 @@ test.describe("W1-16: the owner's Game Day experience (production)", () => {
     // Exactly one state badge, and it must be one of the real ones — a
     // surface that renders no state at all is the implicit default this
     // row exists to remove.
+    //
+    // The badge is NOT part of the initial page shell — GameDayPanel fetches
+    // /api/matchup/intel client-side after mount, and (see the next test's
+    // comment) a cold call against a real league can genuinely take tens of
+    // seconds. `.count()` does not wait; checking it immediately after the
+    // static heading appears raced the fetch and failed at 0+0 even when the
+    // page was working correctly (measured in production, 2026-09-06). Wait
+    // for the badge itself, on the same 90s budget as the direct API calls.
     const scheduled = page.getByText(/Scheduled · pregame/);
     const live = page.getByText(/^Live$/);
+    await expect(scheduled.or(live)).toBeVisible({ timeout: 90_000 });
     const scheduledCount = await scheduled.count();
     const liveCount = await live.count();
     expect(scheduledCount + liveCount).toBeGreaterThan(0);
@@ -76,7 +85,16 @@ test.describe("W1-16: the owner's Game Day experience (production)", () => {
     // assertion would pass against a stale client bundle.
     const team = await resolveTeam(page);
     const q = `?team=${encodeURIComponent(team)}`;
-    const { status, body } = await getJson(page, `/api/matchup/intel${q}`);
+    // 90s, matching this suite's existing convention for slow-loading
+    // scenarios (v1-109/v1-111/v1-123-*): a cold call here runs the full
+    // league-week Monte Carlo (measured production floor here, before
+    // caching: 45-51s; the eligibility hoist + cache fix reduces this on
+    // a WARM hit to ~1ms, but the very first caller for a league-week
+    // still pays a real, if reduced, cost). 45s was proven too tight by
+    // this exact call timing out at exactly that mark in production.
+    const { status, body } = await getJson(page, `/api/matchup/intel${q}`, {
+      timeoutMs: 90_000,
+    });
     annotate(testInfo, "w1-16-endpoint-status", String(status));
 
     if (status === 409) {
@@ -126,7 +144,10 @@ test.describe("W1-16: the owner's Game Day experience (production)", () => {
     // intelligence.
     const team = await resolveTeam(page);
     const q = `?team=${encodeURIComponent(team)}`;
-    const { status, body } = await getJson(page, `/api/matchup/intel${q}`);
+    // 90s — see the previous test's comment for why 45s is too tight here.
+    const { status, body } = await getJson(page, `/api/matchup/intel${q}`, {
+      timeoutMs: 90_000,
+    });
     if (status === 409) {
       test.skip(true, "week in progress — the pregame lineage panel is not the question today");
       return;


### PR DESCRIPTION
Re-dispatched `v1-authenticated-verification.yml` (run 34, `34044879179`) against the deployed #1256 fixes. Real evidence, not guesses, from downloading the run's actual artifact.

## Defect 2's diagnosis was wrong

The Full H2H preview CTA test failed **identically** after the `ResilientSection` fix — same locator, same 60s timeout, same ~1.1m duration, both viewports. I downloaded the run's `v1-authenticated-report` artifact and read what my own instrumentation actually captured:

- **console/pageerror capture: zero of either, both viewports.** No crash — so there was nothing for an error boundary to catch. The chunk-load hypothesis doesn't hold.
- **the failure's `error-context.md` (a DOM snapshot at timeout)**: the page was still rendering the **Home tab's own content** — "Full H2H preview →" still present, un-clicked-looking. None of the previews content ever appeared.

This is a **hydration race** — the exact class this repo already diagnosed and fixed once before, in this same suite: `v1-131-nav-gating.spec.js`'s mobile drawer test carries the identical finding (`domcontentloaded` + visible-in-DOM only proves the SSR markup painted; the `onClick` is wired by React hydration, which can still be in flight; a native click in that gap dispatches an event nobody is listening for yet, and there is no replay once hydration completes). `OverviewSection` is statically imported (unlike lazy-loaded `PreviewsSection`), so its CTA is in the initial SSR HTML and `toBeVisible()` resolves near-instantly — well before a production bundle necessarily finishes hydrating.

**Fix**: the same established pattern already proven in this file — `page.waitForLoadState("networkidle", {timeout: 15_000}).catch(() => {})` before clicking, plus one click retry with a longer timeout. `ResilientSection` stays (harmless, independently worth having) but its comment no longer claims it fixed this row — it fixed nothing here, because nothing crashed.

## Defect 1's fix works, but the cold path still exceeds the test's 45s budget on real hardware

Run 34: desktop's first real call to `/api/matchup/intel` still hit the exact 45.0s client timeout. But by the time mobile's tests ran (~5 min later, same job), the **same endpoint answered in 3.6s and 5.4s** — the cache is demonstrably working once populated. My own local measurement (synthetic rosters, this sandbox's hardware) showed a ~19s cold path, which is why I judged a manual warm step unnecessary before this run. Real production evidently runs slower and/or with larger real rosters than my approximation — the 45s client timeout was proven too tight by measurement.

**Fix**: `getJson` gains an optional `timeoutMs` override (default unchanged at 45s for every other caller — all 15 other call sites are untouched, verified). The two `/api/matchup/intel` calls now request `90_000ms`, matching this exact suite's own established convention for slow-loading scenarios (`v1-109`/`v1-111`/`v1-123-league-comparison`/`v1-123-perfect-draft`/`v1-123-rankings-journeys` already all use `90_000` for comparable cases).

Also fixed a second, independent race in the same spec: "the page renders for the owner's own team and names its state" checked `scheduled.count()`/`live.count()` **immediately** after the static "Game Day" heading appeared — but the state badge is populated by `GameDayPanel`'s own client-side fetch to the same slow endpoint, and `.count()` doesn't wait the way `expect().toBeVisible()` does. This could fail at 0+0 even on a fully working page, purely from checking too early. Fixed to wait (`expect(scheduled.or(live)).toBeVisible({timeout: 90_000})`) before counting.

## What this does NOT change

**No production code.** Every change is to the test harness, each tied to specific evidence from run 34's artifact rather than a repeat guess. `helpers.js`'s change is additive and backward compatible.

## Testing

- `tests/e2e/test_e2e_harness_guards.py` — 15/15
- prod-auth collection unchanged: 104 tests / 23 files
- `node --check` clean on all three changed files

## Contract movement

**None yet.** W1-12/16 (and by extension 14/15/25/26, sharing the same underlying surface/endpoint) stay at their current status pending one more re-dispatch of `v1-authenticated-verification.yml` against this fix. Since this PR touches only test files under `tests/e2e/specs/prod-auth/`, no production deploy is needed before dispatching — the verification workflow runs these files from the CI runner against the already-deployed production site.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPwRjfLMMgHj4xLCQKgoDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPwRjfLMMgHj4xLCQKgoDW)_