### PR TITLE
Fix two more test-harness races found by run 35 (nested lazy-load, panel's own fetch)

### DIFF
--- a/tests/e2e/specs/prod-auth/w1-12-public-pregame.spec.js
+++ b/tests/e2e/specs/prod-auth/w1-12-public-pregame.spec.js
@@ -142,6 +142,18 @@ test.describe("W1-12: public Week 1 pregame surfaces (production)", () => {
     // rather than inverted.
     await page.goto(prodUrl(PREVIEWS), { waitUntil: "domcontentloaded" });
     await expect(page.getByText(/Week \d+ matchups · \d{4}/)).toBeVisible({ timeout: 60_000 });
+    // ArticlesSection is a SECOND, nested lazy import inside the already
+    // lazy-loaded PreviewsSection (matchup-previews.jsx dynamic-imports
+    // ./articles.jsx separately, with its own "Loading articles..."
+    // placeholder). The outer heading resolving only proves the structured
+    // matchup cards painted — the nested chunk can still be loading.
+    // Measured in production (run 35, 2026-09-06): reading body text right
+    // after the outer heading caught the page still showing "Loading
+    // articles..." on both viewports, matching none of the three states
+    // below. Wait for it to clear first.
+    await page.waitForFunction(() => !document.body.innerText.includes("Loading articles"), null, {
+      timeout: 60_000,
+    });
 
     const body = await page.locator("body").innerText();
 

--- a/tests/e2e/specs/prod-auth/w1-16-game-day.spec.js
+++ b/tests/e2e/specs/prod-auth/w1-16-game-day.spec.js
@@ -118,6 +118,20 @@ test.describe("W1-16: the owner's Game Day experience (production)", () => {
 
     await page.goto(prodUrl(`/game-day${q}`), { waitUntil: "domcontentloaded" });
     await expect(page.getByRole("heading", { name: "Game Day" })).toBeVisible({ timeout: 60_000 });
+    // The "Game Day" heading is static SSR content and resolves near-instantly
+    // — GameDayPanel's OWN client-side fetch to /api/matchup/intel is a
+    // separate round trip that has not necessarily finished yet, even though
+    // the direct getJson call above already warmed the cache. Measured in
+    // production (run 35, 2026-09-06): reading body text right after the
+    // heading raced this and caught the panel still showing its loading
+    // state on both viewports (3.0s/5.4s total — fast, but not zero). Wait
+    // for the loading state to clear, same pattern this suite already uses
+    // for other client-fetched panels (v1-123-public-league-matrix.spec.js).
+    await page.waitForFunction(
+      () => !document.body.innerText.includes("Loading this week's matchup"),
+      null,
+      { timeout: 90_000 },
+    );
     const text = await page.locator("body").innerText();
 
     // The matchup identity is a fact and must always render.


### PR DESCRIPTION
Re-dispatched `v1-authenticated-verification.yml` (run 35, `34058396217`) against the deployed #1256 + #1257 fixes. Both previously-fixed races are confirmed gone: every w1-16 endpoint call answered in 3-7s (the cache fix works end to end) and the w1-12 CTA hydration-race fix held on both viewports. Two DIFFERENT, previously-undiscovered races surfaced instead — evidenced the same way as before (downloaded artifact + `error-context.md` DOM snapshots), not guessed.

## w1-12: "an older article slate is labelled as older..." (both viewports)

`matchup-previews.jsx` (`PreviewsSection`, itself already a `next/dynamic` lazy import) separately `next/dynamic`-imports a SECOND component, `ArticlesSection` (`./articles.jsx`), with its own `"Loading articles..."` placeholder. The test's outer wait (the `Week \d+ matchups · \d{4}` heading) only proves the OUTER lazy chunk's structured matchup cards painted — it says nothing about the nested chunk. The failure's `error-context.md` confirms this exactly: every matchup card fully rendered, with `Loading articles…` still present at the bottom, matching none of the test's three expected slate-voice strings and producing "the slate must name exactly one state: expected 1, got 0".

**Fix**: wait for `"Loading articles"` to clear (`page.waitForFunction`) before reading body text — the same wait-for-loading-to-clear pattern this suite already uses in `v1-123-public-league-matrix.spec.js`.

## w1-16: "the page's numbers are the endpoint's numbers" (both viewports)

The test's direct `getJson` call to `/api/matchup/intel` already proved the cache fix works (3.0s/5.4s total test duration — night and day from the previous 45s+ timeouts). But `GameDayPanel`'s own CLIENT-SIDE fetch to the same endpoint is a separate round trip, and the test read `body.innerText()` immediately after the static "Game Day" heading resolved (near-instant SSR content) rather than waiting for that second fetch. `error-context.md` confirms the page was still showing `"Loading this week's matchup..."` at the moment of the failed assertion — the identical race class as the badge-count fix from the previous round, just on a different read.

**Fix**: same wait-for-loading-to-clear pattern, 90s budget matching this endpoint's established convention elsewhere in this spec.

## What this does NOT change

No production code, and no change to either of the two now-confirmed-fixed defects (Game Day sim caching, CTA hydration race) — both held up cleanly across every other assertion in run 35. This is purely catching two more instances of "a client-fetched panel needs its own wait before its content is read."

## Testing

- `tests/e2e/test_e2e_harness_guards.py` — 15/15
- prod-auth collection unchanged: 104 tests / 23 files
- `node --check` clean on both changed files

## Contract movement

None yet. Every other assertion in run 35 passed cleanly on both viewports for w1-12 and w1-16 (including the tests that map to W1-14/W1-15/W1-25's own acceptance text), but W1-12 and W1-16 each had one failing assertion within their own row's literal scope, so nothing is promoted until one more clean re-dispatch of `v1-authenticated-verification.yml` against this fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPwRjfLMMgHj4xLCQKgoDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPwRjfLMMgHj4xLCQKgoDW)_