### PR TITLE
fix(game-day): the capture timer would have MISSED Week 1 — derive the window from the schedule

### DIFF
--- a/deploy/systemd/dynasty-game-day-capture.timer.template
+++ b/deploy/systemd/dynasty-game-day-capture.timer.template
@@ -1,41 +1,38 @@
 [Unit]
 Description=Weekly pre-kickoff Game Day prediction capture for __SERVICE_NAME__
-# No Requires= here: [Timer] Unit= already binds the service, and a
-# [Unit] Requires= would start it on every boot regardless of OnCalendar.
-
-[Timer]
-# THURSDAY, BEFORE THE WEEK'S FIRST KICKOFF, AND THAT BOUND IS THE WHOLE
-# DESIGN. The capture is only honest while no game counting toward the
-# week has been played; the script refuses (exit 3) once Sleeper reports
-# any score, because a snapshot reconstructed afterwards and labelled
-# "pregame" is worse than a missing one — nothing downstream could tell.
+# No Requires= here: [Timer]
+# FIRES OFTEN; THE SCRIPT DECIDES WHICH FIRING IS THE RIGHT ONE.
 #
-# 13:00 UTC is chosen against the EARLIEST first-kickoff the season has,
-# not against the usual one:
-#   * ordinary week — Thursday Night Football, 20:15 ET = 00:15 UTC Fri,
-#     so 13:00 UTC Thursday clears it by ~11 hours;
-#   * THANKSGIVING — a Thursday with a 12:30 ET (17:30 UTC) kickoff,
-#     which is the binding constraint. A late-afternoon slot would be
-#     refused outright that week, losing it permanently.
-# It is also after Wednesday waiver processing, so the roster captured is
-# the one that actually starts the week.
+# This timer previously ran Thursday 13:00 + 15:30 UTC, on the reasoning
+# that a week's first kickoff is Thursday Night Football and Thanksgiving
+# (17:30 UTC) is the earliest case. That reasoning was WRONG, and Week 1
+# of the very season it was written for proves it: 2026 opens on a
+# WEDNESDAY — NE @ SEA, 2026-09-09 20:20 ET = 2026-09-10 00:20 UTC — so
+# the Thursday run would have fired roughly thirteen hours AFTER kickoff,
+# been correctly refused by the score-based gate, and lost Week 1's
+# pregame observation permanently.
 #
-# The 15:30 UTC second fire is a FREE RETRY, not a second observation: the
-# archive is append-only and refuses a duplicate (league, season, week,
-# team, capture_kind), which the script reports as an already-captured
-# skip and not an error. So a run that succeeded at 13:00 makes 15:30 a
-# no-op, while a 13:00 blocked by a Sleeper outage still gets a second
-# chance inside the Thanksgiving-safe window.
-OnCalendar=Thu *-*-* 13:00:00 UTC
-OnCalendar=Thu *-*-* 15:30:00 UTC
+# A weekday is a GUESS about the schedule. The schedule is a FACT, and
+# `scripts/capture_game_day_predictions.py` now reads it: it resolves the
+# week's first kickoff from the nflverse slate and captures only inside
+# the window that opens 30h before it (exit 2 "too early" outside it,
+# exit 3 "refused" after it). So the timer's only job is to fire often
+# enough that one of its runs lands in that window, whatever weekday the
+# opener falls on — Wednesday, Thursday, or Thanksgiving lunchtime.
+#
+# Every 4 hours does that with margin: a 30h window contains at least
+# seven firings, so the capture survives several consecutive failures.
+# Runs outside the window are cheap — the script exits before fetching
+# any roster.
+OnCalendar=*-*-* 00,04,08,12,16,20:00:00 UTC
 # Deliberately NO RandomizedDelaySec: every other timer in this directory
-# spreads load, but this one is racing a kickoff. Jitter here buys nothing
-# and can only move the run closer to the deadline.
+# spreads load, but this one is racing a kickoff. Jitter buys nothing here
+# and can only move a run closer to the deadline.
 #
-# Persistent=true catches up a fire missed to a reboot. It cannot resurrect
-# a missed WINDOW — a catch-up run after kickoff is refused by the same
-# gate, which is correct: the observation is gone, and the timer must not
-# manufacture a replacement.
+# Persistent=true catches up a fire missed to a reboot. It cannot
+# resurrect a missed WINDOW — a catch-up run after kickoff is refused by
+# the same gate, which is correct: the observation is gone, and the timer
+# must not manufacture a replacement.
 Persistent=true
 AccuracySec=1min
 Unit=__SERVICE_NAME__-game-day-capture.service

--- a/scripts/capture_game_day_predictions.py
+++ b/scripts/capture_game_day_predictions.py
@@ -37,9 +37,12 @@ from src.api import league_registry  # noqa: E402
 from src.public_league import sleeper_client  # noqa: E402
 from src.ros.game_day_archive import GameDayArchiveError, record_snapshot  # noqa: E402
 from src.ros.game_day_capture import (  # noqa: E402
+    CAPTURE_WINDOW_HOURS,
     GameDayCaptureRefusal,
     build_capture,
     estimate_index_from_ensemble,
+    first_kickoff_utc,
+    pregame_window_state,
 )
 from src.ros.game_day_sim import get_cached_league_week_simulation  # noqa: E402
 from src.ros.game_day_week import resolve_pregame_week  # noqa: E402
@@ -103,6 +106,19 @@ def main() -> int:
     parser.add_argument("--week", type=int, default=None, help="override the week Sleeper reports.")
     parser.add_argument("--run-id", default="", help="ties one batch of captures together.")
     parser.add_argument(
+        "--ignore-window",
+        action="store_true",
+        help="capture regardless of how far off kickoff is. For an owner-authorized "
+        "manual capture; the post-kickoff refusal still applies and is not bypassable.",
+    )
+    parser.add_argument(
+        "--window-hours",
+        type=float,
+        default=CAPTURE_WINDOW_HOURS,
+        help="hours before the week's first kickoff that the pregame window opens "
+        f"(default {CAPTURE_WINDOW_HOURS:g}).",
+    )
+    parser.add_argument(
         "--allow-season-type",
         action="append",
         default=None,
@@ -161,6 +177,39 @@ def main() -> int:
     if not season or not week:
         print("Nothing to do: no season/week resolved.")
         return 2
+
+    # THE CAPTURE WINDOW IS DERIVED FROM THE SCHEDULE, NOT FROM A WEEKDAY.
+    # The retired timer assumed a Thursday-night opener; Week 1 of 2026
+    # opens on a WEDNESDAY (NE @ SEA, 2026-09-09 20:20 ET = 2026-09-10
+    # 00:20 UTC), so a Thursday-13:00-UTC run would have been ~13 hours
+    # late, been correctly refused, and lost the observation for good.
+    # The timer now fires several times a day and THIS decides which of
+    # those firings is the right one.
+    if args.capture_kind == "pregame":
+        try:
+            from src.nfl_data import ingest as _nfl_ingest
+
+            kickoff = first_kickoff_utc(
+                _nfl_ingest.fetch_schedules([int(season)]),
+                season=int(season),
+                week=int(week),
+            )
+        except Exception as exc:  # noqa: BLE001 — a schedule outage must not lose a capture
+            print(f"  schedule unavailable ({type(exc).__name__}: {exc})")
+            kickoff = None
+        state, why = pregame_window_state(first_kickoff=kickoff, window_hours=args.window_hours)
+        print(f"Pregame window: {state} — {why}")
+        if args.ignore_window:
+            print("  --ignore-window: proceeding (post-kickoff refusal still applies)")
+        elif state == "early":
+            print(
+                "Nothing to do yet: capturing now would consume the append-only "
+                "pregame slot with a roster waivers will still change."
+            )
+            return 2
+        elif state == "closed":
+            print("REFUSED: the pregame window has closed for this week.", file=sys.stderr)
+            return 3
 
     print(
         f"Capturing {args.capture_kind} for season {season}, week {week} "

--- a/src/ros/game_day_capture.py
+++ b/src/ros/game_day_capture.py
@@ -42,7 +42,9 @@ to infer it from the row count.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
 from typing import Any, Mapping, Sequence
+from zoneinfo import ZoneInfo
 
 from src.ros.game_day_archive import PlayerPointEstimate
 from src.ros.lineup import (
@@ -77,6 +79,29 @@ def non_active_player_ids(roster: Mapping[str, Any]) -> set[str]:
             if pid:
                 out.add(str(pid))
     return out
+
+
+#: nflverse publishes `gametime` in US Eastern. Converting with a fixed
+#: offset would be wrong for exactly the games that matter here — the
+#: season spans the DST boundary — so the zone does the work.
+_NFL_CLOCK = ZoneInfo("America/New_York")
+
+#: How long before the week's first kickoff a pregame capture is taken.
+#:
+#: A WINDOW, not a weekday. The original timer assumed a Thursday-night
+#: opener and fired Thursday 13:00 UTC. Week 1 of 2026 opens on a
+#: WEDNESDAY (NE @ SEA, 2026-09-09 20:20 ET = 2026-09-10 00:20 UTC), so
+#: that timer would have run roughly thirteen hours AFTER kickoff, been
+#: correctly refused by `week_has_begun`, and lost the observation
+#: permanently. A weekday is a guess about the schedule; the schedule is
+#: a fact, and this reads it.
+#:
+#: 30 hours is chosen to clear a full waiver cycle: claims process
+#: Wednesday morning, and the roster that starts the week is the one
+#: that should be captured. It is wide enough that a timer firing a few
+#: times a day cannot miss it, and narrow enough that the capture is not
+#: taken days early against a roster that will still change.
+CAPTURE_WINDOW_HOURS: float = 30.0
 
 
 class GameDayCaptureRefusal(RuntimeError):
@@ -379,4 +404,90 @@ def build_capture(
         sources_loaded=tuple(sources_loaded),
         sources_unavailable=tuple(sources_unavailable),
         notes=notes,
+    )
+
+
+def first_kickoff_utc(
+    schedule_rows: Sequence[Mapping[str, Any]] | None,
+    *,
+    season: int,
+    week: int,
+) -> datetime | None:
+    """The earliest kickoff of one league-week, in UTC.
+
+    Reads `gameday` + `gametime` from nflverse schedule rows. Returns
+    ``None`` when the week has no usable rows — an UNKNOWN kickoff, which
+    the caller must not treat as "no kickoff yet".
+
+    The times are US Eastern and the season crosses the DST boundary, so
+    they are localised through a real zone rather than a fixed offset.
+    """
+    best: datetime | None = None
+    for row in schedule_rows or ():
+        if not isinstance(row, Mapping):
+            continue
+        try:
+            if int(float(row.get("season"))) != int(season):
+                continue
+            if int(float(row.get("week"))) != int(week):
+                continue
+        except (TypeError, ValueError):
+            continue
+        day = str(row.get("gameday") or "").strip()
+        clock = str(row.get("gametime") or "").strip()
+        if not day or not clock:
+            continue
+        try:
+            naive = datetime.strptime(f"{day} {clock}", "%Y-%m-%d %H:%M")
+        except ValueError:
+            continue
+        when = naive.replace(tzinfo=_NFL_CLOCK).astimezone(timezone.utc)
+        if best is None or when < best:
+            best = when
+    return best
+
+
+def pregame_window_state(
+    *,
+    first_kickoff: datetime | None,
+    now: datetime | None = None,
+    window_hours: float = CAPTURE_WINDOW_HOURS,
+) -> tuple[str, str]:
+    """``(state, human explanation)`` for the pregame capture window.
+
+    States:
+
+    * ``open``    — inside the window; capture now.
+    * ``early``   — kickoff is further away than the window. Capturing
+      would consume the append-only pregame slot with a roster that
+      waivers will still change, and the slot cannot be reused.
+    * ``closed``  — kickoff has passed. The observation is gone; this is
+      the same conclusion `week_has_begun` reaches from scores, derived
+      here from the schedule so it can be known BEFORE any score posts.
+    * ``unknown`` — no kickoff could be resolved. Deliberately NOT
+      treated as ``open`` or ``closed``: the caller decides, and the
+      script's choice is to proceed (a capture with an unverifiable
+      window still beats no capture, and the score-based gate is still
+      in front of it).
+    """
+    if first_kickoff is None:
+        return "unknown", "no kickoff time could be resolved for this week"
+    current = now or datetime.now(timezone.utc)
+    if current >= first_kickoff:
+        return (
+            "closed",
+            f"first kickoff was {first_kickoff.isoformat()} — the pregame window "
+            "has passed and that observation cannot be recovered",
+        )
+    opens_at = first_kickoff - timedelta(hours=window_hours)
+    if current < opens_at:
+        return (
+            "early",
+            f"first kickoff is {first_kickoff.isoformat()}; the capture window "
+            f"opens {window_hours:g}h before it, at {opens_at.isoformat()}",
+        )
+    return (
+        "open",
+        f"first kickoff is {first_kickoff.isoformat()}; inside the "
+        f"{window_hours:g}h capture window",
     )

--- a/tests/ros/test_game_day_capture.py
+++ b/tests/ros/test_game_day_capture.py
@@ -391,3 +391,127 @@ def test_capture_writes_once_and_refuses_the_rerun(tmp_path):
     assert len(stored) == 1
     assert stored[0].starter_slots == build.starter_slots
     assert len(stored[0].roster) == 9
+
+
+# ── the capture window is derived from the schedule, not a weekday ──
+
+
+class TestPregameCaptureWindow:
+    """The retired timer assumed a Thursday-night opener and fired
+    Thursday 13:00 UTC. Week 1 of 2026 opens on a WEDNESDAY — NE @ SEA,
+    2026-09-09 20:20 ET = 2026-09-10 00:20 UTC — so that run would have
+    been ~13 hours late, been correctly refused, and lost the
+    observation permanently. These pin the replacement.
+    """
+
+    #: The real 2026 Week 1 opener, as nflverse publishes it.
+    ROWS = [
+        {"season": 2026, "week": 1, "gameday": "2026-09-09", "gametime": "20:20"},
+        {"season": 2026, "week": 1, "gameday": "2026-09-10", "gametime": "20:35"},
+        {"season": 2026, "week": 1, "gameday": "2026-09-13", "gametime": "13:00"},
+        {"season": 2026, "week": 2, "gameday": "2026-09-17", "gametime": "20:15"},
+    ]
+
+    def _at(self, iso):
+        from datetime import datetime, timezone
+
+        return datetime.fromisoformat(iso).replace(tzinfo=timezone.utc)
+
+    def test_first_kickoff_is_the_earliest_game_of_that_week(self):
+        from src.ros.game_day_capture import first_kickoff_utc
+
+        k = first_kickoff_utc(self.ROWS, season=2026, week=1)
+        assert k == self._at("2026-09-10T00:20:00")
+
+    def test_eastern_times_convert_through_a_real_zone(self):
+        """The season crosses the DST boundary, so a fixed offset would be
+        wrong for exactly the late-season games."""
+        from src.ros.game_day_capture import first_kickoff_utc
+
+        december = [{"season": 2026, "week": 15, "gameday": "2026-12-17", "gametime": "20:15"}]
+        # EST (-5) in December, versus EDT (-4) in September.
+        assert first_kickoff_utc(december, season=2026, week=15) == self._at("2026-12-18T01:15:00")
+
+    def test_other_weeks_do_not_leak_in(self):
+        from src.ros.game_day_capture import first_kickoff_utc
+
+        assert first_kickoff_utc(self.ROWS, season=2026, week=2) == self._at("2026-09-18T00:15:00")
+
+    def test_an_unresolvable_week_is_none_not_a_guess(self):
+        from src.ros.game_day_capture import first_kickoff_utc
+
+        assert first_kickoff_utc(self.ROWS, season=2026, week=99) is None
+        assert first_kickoff_utc([], season=2026, week=1) is None
+        assert first_kickoff_utc(None, season=2026, week=1) is None
+
+    def test_malformed_rows_are_skipped_not_fatal(self):
+        from src.ros.game_day_capture import first_kickoff_utc
+
+        rows = [
+            {"season": 2026, "week": 1, "gameday": "not-a-date", "gametime": "20:20"},
+            {"season": 2026, "week": 1, "gameday": "2026-09-09", "gametime": ""},
+            {"season": "x", "week": 1, "gameday": "2026-09-09", "gametime": "20:20"},
+            {"season": 2026, "week": 1, "gameday": "2026-09-10", "gametime": "20:35"},
+        ]
+        assert first_kickoff_utc(rows, season=2026, week=1) == self._at("2026-09-11T00:35:00")
+
+    def test_the_retired_thursday_slot_would_have_been_closed(self):
+        """The regression this whole change exists for."""
+        from src.ros.game_day_capture import first_kickoff_utc, pregame_window_state
+
+        k = first_kickoff_utc(self.ROWS, season=2026, week=1)
+        state, why = pregame_window_state(first_kickoff=k, now=self._at("2026-09-10T13:00:00"))
+        assert state == "closed"
+        assert "cannot be recovered" in why
+
+    def test_the_window_is_open_the_evening_before_a_wednesday_opener(self):
+        from src.ros.game_day_capture import first_kickoff_utc, pregame_window_state
+
+        k = first_kickoff_utc(self.ROWS, season=2026, week=1)
+        # Wednesday afternoon, after waivers, before the 00:20 UTC kickoff.
+        state, _ = pregame_window_state(first_kickoff=k, now=self._at("2026-09-09T18:00:00"))
+        assert state == "open"
+
+    def test_too_early_is_early_not_open(self):
+        """Capturing days out would consume the append-only pregame slot
+        with a roster waivers will still change."""
+        from src.ros.game_day_capture import first_kickoff_utc, pregame_window_state
+
+        k = first_kickoff_utc(self.ROWS, season=2026, week=1)
+        state, _ = pregame_window_state(first_kickoff=k, now=self._at("2026-09-07T08:00:00"))
+        assert state == "early"
+
+    def test_the_window_boundary_is_exact(self):
+        from src.ros.game_day_capture import first_kickoff_utc, pregame_window_state
+
+        k = first_kickoff_utc(self.ROWS, season=2026, week=1)
+        # Opens 30h before 2026-09-10T00:20Z → 2026-09-08T18:20Z.
+        assert (
+            pregame_window_state(first_kickoff=k, now=self._at("2026-09-08T18:19:00"))[0] == "early"
+        )
+        assert (
+            pregame_window_state(first_kickoff=k, now=self._at("2026-09-08T18:21:00"))[0] == "open"
+        )
+
+    def test_kickoff_instant_itself_is_closed(self):
+        from src.ros.game_day_capture import first_kickoff_utc, pregame_window_state
+
+        k = first_kickoff_utc(self.ROWS, season=2026, week=1)
+        assert pregame_window_state(first_kickoff=k, now=k)[0] == "closed"
+
+    def test_an_unknown_kickoff_is_its_own_state(self):
+        """Not open, not closed. The caller decides, and the script's
+        choice is to proceed — the score-based gate is still in front."""
+        from src.ros.game_day_capture import pregame_window_state
+
+        state, why = pregame_window_state(first_kickoff=None)
+        assert state == "unknown"
+        assert "could be resolved" in why
+
+    def test_a_wider_window_opens_earlier(self):
+        from src.ros.game_day_capture import first_kickoff_utc, pregame_window_state
+
+        k = first_kickoff_utc(self.ROWS, season=2026, week=1)
+        now = self._at("2026-09-07T08:00:00")
+        assert pregame_window_state(first_kickoff=k, now=now)[0] == "early"
+        assert pregame_window_state(first_kickoff=k, now=now, window_hours=72)[0] == "open"


### PR DESCRIPTION
## This is a live W1-04 defect, found with the window still open

The capture timer fires **Thursday 13:00 + 15:30 UTC**. I set that schedule on the reasoning that a week's first kickoff is Thursday Night Football, with Thanksgiving (17:30 UTC) as the earliest case to defend against.

**That reasoning is wrong, and the very season it was written for disproves it:**

```
Week 1 2026 opens on a WEDNESDAY.
NE @ SEA — 2026-09-09 20:20 ET = 2026-09-10 00:20 UTC
```

The Thursday run would have fired **~12h40m after kickoff**, been correctly refused by the score-based gate, and lost Week 1's pregame observation **permanently** — the exact evidence the unit exists to protect, in a window that cannot be reopened.

Found while reading the real nflverse slate to wire live game state. Today is Monday, so the window is still ahead of us.

## A weekday is a guess. The schedule is a fact.

| piece | what it does |
|---|---|
| `first_kickoff_utc` | the week's earliest kickoff from the nflverse slate |
| `pregame_window_state` | `open` / `early` / `closed` / `unknown` |
| the timer | fires every 4h and stops guessing |

**Timezones are done through a real zone**, not a fixed offset — the season crosses the DST boundary, so an offset would be wrong for exactly the late-season games. Pinned with a December case (EST) beside the September one (EDT).

**`early` refuses (exit 2).** Capturing days out would consume the append-only pregame slot with a roster waivers will still change, and the slot cannot be reused. That is a real failure mode, not a nicety.

**`unknown` is neither open nor closed.** If the slate can't be resolved the script proceeds — a capture with an unverifiable window still beats none, and the score-based gate is still in front of it.

**The timer's only job is now to fire often enough.** A 30h window contains at least seven 4-hourly firings, so the capture survives several consecutive failures whatever weekday the opener falls on. Runs outside the window exit before fetching a single roster.

30h is chosen to clear a full waiver cycle — claims process Wednesday morning, and the roster that starts the week is the one worth capturing.

`--ignore-window` exists for an owner-authorized manual capture. It does **not** bypass the post-kickoff refusal, which stays unbypassable.

## Not a duplicate owner

`src/ros/game_day_week.py` (landed while I was away) resolves Sleeper payloads into simulation inputs and explicitly defers live resolution to *"a schedule or game-state source it can name."* This is that source, and it is also the first half of what W1-27's LIVE state needs.

## Verification

Against the real 2026 slate:

| moment | state |
|---|---|
| Mon 2026-09-07 08:00 UTC (now) | `early` |
| Tue 2026-09-08 18:21 UTC | `open` |
| Wed 2026-09-09 18:00 UTC | `open` |
| **Thu 2026-09-10 13:00 UTC (the retired slot)** | **`closed`** |

- 12 tests added, including the exact regression and both sides of the window boundary.
- Full hard gate: **10,748 passed, 54 skipped, 0 failures**.
- `ruff format --check`, `ruff check`, decision-path coercion, and the three governance gates clean on the staged tree.
- Live dry-run now reports: `Pregame window: early — first kickoff is 2026-09-10T00:20:00+00:00; the capture window opens 30h before it, at 2026-09-08T18:20:00+00:00`.

## Recommended action

Merge and deploy **before Tuesday 18:20 UTC**, so the first in-window firing is armed. The contract's Wed Sep 9 plan (post-waiver capture) then lands inside the window instead of ~13 hours past it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmUK5EBJvJkzX8xb3s1Bve

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmUK5EBJvJkzX8xb3s1Bve)_