### PR TITLE
fix(deploy): a changed timer template never reached the box

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -700,9 +700,11 @@ ensure_systemd_service() {
   # installer WITHOUT FORCE_SERVICE_INSTALL, so existing units are left
   # alone and no service is restarted — the installer only fills gaps.
   local missing_timers=""
+  local timer_templates_found=""
   local timer_template timer_unit
   shopt -s nullglob
   for timer_template in "${APP_DIR}"/deploy/systemd/*.timer.template; do
+    timer_templates_found="yes"
     timer_unit="$(basename "${timer_template}" .template)"
     # Templates are named dynasty-*; installed units use SERVICE_NAME.
     timer_unit="${SERVICE_NAME}-${timer_unit#dynasty-}"
@@ -724,13 +726,42 @@ ensure_systemd_service() {
   done
   shopt -u nullglob
 
+  # PRESENT IS NOT THE SAME AS CURRENT, and this early return used to
+  # conflate them. It asked only whether each timer EXISTED and was
+  # ENABLED, so a template whose CONTENT changed never reached the
+  # installer: the box kept the schedule it was first given while the
+  # deploy reported success. Every timer edit in this repo's history had
+  # that hole.
+  #
+  # Measured: #1263 moved the game-day capture timer off a Thursday-only
+  # schedule because Week 1 of 2026 opens on a WEDNESDAY and the old one
+  # fired ~13 hours after kickoff. Merging and deploying it would have
+  # left the wrong schedule running — a fix that ships and does not take
+  # effect is indistinguishable from no fix.
+  #
+  # Deploy does NOT re-derive currency here; that would be a second
+  # renderer beside install-systemd-service.sh, which
+  # tests/deploy/test_runtime_reconciler_wiring.py rightly forbids.
+  # Instead the installer is the single authority: it renders each
+  # template, compares it with what is installed, and rewrites only on a
+  # real difference. Running it every deploy is therefore a no-op on an
+  # up-to-date box — and it is run WITHOUT FORCE_SERVICE_INSTALL, so no
+  # service is restarted.
+  local timers_shipped="false"
+  if [[ -n "${timer_templates_found:-}" ]]; then
+    timers_shipped="true"
+  fi
+
   if [[ "${backend_present}" == "true" && "${frontend_present}" == "true" &&
-    "${force_reinstall}" != "true" && -z "${missing_timers}" ]]; then
+    "${force_reinstall}" != "true" && -z "${missing_timers}" &&
+    "${timers_shipped}" != "true" ]]; then
     return 0
   fi
 
   if [[ -n "${missing_timers}" ]]; then
     warn "Timer units missing from this host:${missing_timers}. Running installer to add them."
+  elif [[ "${timers_shipped}" == "true" ]]; then
+    log "Reconciling shipped timer templates against installed units."
   fi
 
   local installer_script

--- a/deploy/install-systemd-service.sh
+++ b/deploy/install-systemd-service.sh
@@ -168,10 +168,45 @@ install_simple_timer() {
 
   [[ -f "${service_template}" && -f "${timer_template}" ]] || return 0
 
+  # RENDER FIRST, THEN DECIDE. The old order asked "does a unit exist?"
+  # and, if it did, changed nothing without FORCE_SERVICE_INSTALL — so
+  # EDITING A TEMPLATE HAD NO EFFECT ON THE BOX. The unit stayed at
+  # whatever content it was first installed with, the deploy reported
+  # success, and nothing said otherwise.
+  #
+  # That is not hypothetical. #1263 moved this feature's timer off a
+  # Thursday-only schedule because Week 1 of 2026 opens on a Wednesday
+  # and the old schedule fired ~13 hours after kickoff. Merging and
+  # deploying it would have left the WRONG schedule running and lost the
+  # observation anyway — a fix that ships and does not take effect is
+  # indistinguishable from no fix.
+  local tmp_service tmp_timer
+  tmp_service="$(mktemp)"
+  tmp_timer="$(mktemp)"
+  sed \
+    -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
+    -e "s/__APP_USER__/$(escape_sed_replacement "${APP_USER}")/g" \
+    -e "s/__APP_DIR__/$(escape_sed_replacement "${APP_DIR}")/g" \
+    -e "s/__VENV_DIR__/$(escape_sed_replacement "${VENV_DIR}")/g" \
+    "${service_template}" > "${tmp_service}"
+  sed \
+    -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
+    "${timer_template}" > "${tmp_timer}"
+
   local needs_install=false
   if sudo -n "${SYSTEMCTL_BIN}" cat "${unit_name}.timer" >/dev/null 2>&1; then
     if [[ "${force_install_on}" == "true" ]]; then
       log "FORCE_SERVICE_INSTALL enabled; rewriting ${service_path} + timer."
+      needs_install=true
+    # Content drift. `cmp -s` against the INSTALLED FILES, read through
+    # sudo because /etc/systemd/system is not world-readable on every
+    # box. A read that fails is treated as drift: reinstalling a unit
+    # that was already correct is a no-op, while skipping one that
+    # changed is the silent failure above, so the safe direction is
+    # obvious.
+    elif ! sudo -n cmp -s "${tmp_timer}" "${timer_path}" \
+      || ! sudo -n cmp -s "${tmp_service}" "${service_path}"; then
+      log "${unit_name} differs from its template; updating."
       needs_install=true
     fi
   else
@@ -180,27 +215,15 @@ install_simple_timer() {
   fi
 
   if [[ "${needs_install}" == "true" ]]; then
-    local tmp_service tmp_timer
-    tmp_service="$(mktemp)"
-    tmp_timer="$(mktemp)"
-    sed \
-      -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
-      -e "s/__APP_USER__/$(escape_sed_replacement "${APP_USER}")/g" \
-      -e "s/__APP_DIR__/$(escape_sed_replacement "${APP_DIR}")/g" \
-      -e "s/__VENV_DIR__/$(escape_sed_replacement "${VENV_DIR}")/g" \
-      "${service_template}" > "${tmp_service}"
-    sed \
-      -e "s/__SERVICE_NAME__/$(escape_sed_replacement "${SERVICE_NAME}")/g" \
-      "${timer_template}" > "${tmp_timer}"
     sudo -n "${INSTALL_BIN}" -m 0644 "${tmp_service}" "${service_path}"
     sudo -n "${INSTALL_BIN}" -m 0644 "${tmp_timer}" "${timer_path}"
-    rm -f "${tmp_service}" "${tmp_timer}"
     # Reload here rather than joining the shared reload below: enabling a
     # unit systemd has not re-read is the ce_needs_install failure — the
     # fix deployed, reported as deployed, and not running.
     sudo -n "${SYSTEMCTL_BIN}" daemon-reload
     log "Installed ${unit_name}.service + .timer"
   fi
+  rm -f "${tmp_service}" "${tmp_timer}"
 
   # Enablement is checked SEPARATELY, and not only when we just wrote the
   # files.  deploy.sh's detector treats installed-but-disabled as missing,

--- a/docs/season-launch/W1_03_W1_04_WEDNESDAY_CAPTURE_RUNBOOK.md
+++ b/docs/season-launch/W1_03_W1_04_WEDNESDAY_CAPTURE_RUNBOOK.md
@@ -7,8 +7,9 @@ processing is confirmed complete* and *before any NFL scoring begins*.
 
 **Forbidden, restated so it travels with the procedure:** do not capture
 before waivers settle; do not backdate; do not synthesize a snapshot; do not
-weaken either acceptance criterion. The normal Thursday recurring timer is
-preserved for future weeks — nothing here changes it.
+weaken either acceptance criterion. The recurring timer now fires every four
+hours, while the capture script remains the authority that opens the real
+schedule window and enforces the one-time Wednesday post-waiver guard.
 
 This document exists so Wednesday is *execution*, not improvisation. Every
 number below was measured on 2026-09-06, not assumed; each has its source
@@ -154,8 +155,8 @@ snapshot rebuilt afterwards and labelled `pregame` is worse than a missing one
 because nothing downstream could tell the difference. The script enforces this
 itself (exit 3); do not work around it.
 
-The recurring Thursday timer still produces Week 2's capture on its normal
-cadence. A missed Week 1 costs Week 1's evidence only.
+The four-hourly recurring timer continues to probe future schedule-derived
+capture windows. A missed Week 1 costs Week 1's evidence only.
 
 
 ## 2026-09-07 timing reconciliation
@@ -167,6 +168,5 @@ instruction above still governs: the capture CLI now refuses a 2026 Week 1
 pregame write outside Wednesday or without an observed terminal Wednesday
 waiver batch after 03:00 ET and no pending claims. `--ignore-window` cannot
 bypass this exception or the kickoff refusal. Dry-run preparation writes nothing.
-Earlier statements that the Thursday timer remains installed describe the old
-implementation; verify the actual installed timer after deployment. This guard
-preserves Wednesday timing regardless of which timer is installed.
+Verify the actual installed timer after deployment. The script guard preserves
+Wednesday timing independently of the timer cadence.

--- a/tests/deploy/test_all_timers_are_wired.py
+++ b/tests/deploy/test_all_timers_are_wired.py
@@ -209,3 +209,55 @@ def test_deploy_sh_still_derives_missing_timers_from_this_directory() -> None:
     body = _DEPLOY_SH.read_text(encoding="utf-8", errors="replace")
     assert "deploy/systemd/*.timer.template" in body
     assert "is-enabled" in body, "deploy.sh must treat installed-but-disabled as missing"
+
+
+class TestAShippedTimerIsKeptCURRENT:
+    """Wired is not the same as current, and this file's own loop had the
+    second half of the hole.
+
+    ``install_simple_timer`` changed nothing when a unit already existed
+    unless ``FORCE_SERVICE_INSTALL`` was set, and ``deploy.sh`` decided
+    whether to run the installer by asking only whether each timer
+    EXISTED and was ENABLED. So editing a timer template had **no effect
+    on the box**: the unit kept the content it was first installed with,
+    and the deploy reported success. Every timer edit in this repo's
+    history shipped into that.
+
+    Measured consequence: #1263 moved the game-day capture timer off a
+    Thursday-only schedule because Week 1 of 2026 opens on a WEDNESDAY
+    (NE @ SEA, 2026-09-09 20:20 ET) and the old schedule fired roughly
+    thirteen hours after kickoff. Merging and deploying that fix would
+    have left the wrong schedule running and lost the capture anyway — a
+    fix that ships and does not take effect is indistinguishable from no
+    fix.
+    """
+
+    def test_the_installer_renders_before_it_decides(self):
+        """You cannot compare against something you have not produced."""
+        text = _INSTALLER.read_text(encoding="utf-8")
+        render_at = text.index('"${timer_template}" > "${tmp_timer}"')
+        decide_at = text.index("local needs_install=false")
+        assert render_at < decide_at, "the timer is rendered after the install decision"
+
+    def test_the_installer_compares_content_not_just_presence(self):
+        text = _INSTALLER.read_text(encoding="utf-8")
+        assert 'cmp -s "${tmp_timer}" "${timer_path}"' in text
+        assert 'cmp -s "${tmp_service}" "${service_path}"' in text
+
+    def test_deploy_reaches_the_installer_for_shipped_timers(self):
+        """deploy.sh deliberately does NOT re-derive currency — a second
+        renderer is what ``test_runtime_reconciler_wiring`` forbids. It
+        runs the installer, which is the one authority."""
+        text = _DEPLOY_SH.read_text(encoding="utf-8")
+        early_return = text[text.index('if [[ "${backend_present}" == "true"') :]
+        early_return = early_return[: early_return.index("return 0")]
+        assert "timers_shipped" in early_return, (
+            "the early return still short-circuits on presence alone, so a changed "
+            "timer template never reaches the installer"
+        )
+
+    def test_deploy_does_not_render_templates_itself(self):
+        """Restates the wiring guard at the point of temptation: the
+        obvious way to detect drift here is to render and compare, and
+        that is exactly the second renderer that must not exist."""
+        assert "__SERVICE_NAME__/" not in _DEPLOY_SH.read_text(encoding="utf-8")


### PR DESCRIPTION
## Present is not current, and deploy conflated them

`install_simple_timer` changed nothing when a unit already existed unless `FORCE_SERVICE_INSTALL` was set. `deploy.sh` decided whether to run the installer by asking only whether each timer **existed** and was **enabled**.

So **editing a `.timer.template` had no effect on the box.** The unit kept the content it was first installed with, and the deploy reported success. Every timer edit in this repo's history shipped into that hole.

## Found because it was about to eat a real one

#1263 merged minutes ago. It moves the game-day capture timer off a Thursday-only schedule because **Week 1 of 2026 opens on a Wednesday** and the old schedule fires ~13 hours after kickoff.

Deploying it would have left the **old schedule running** and lost the Week 1 pregame capture anyway. A fix that ships and does not take effect is indistinguishable from no fix — and the deploy would have said "success" both times.

This is the same incident class `test_all_timers_are_wired.py` already exists for (*"templates committed, reviewed, merged, and never once rendered onto the box"*), one step later in the lifecycle: not unwired, but frozen.

## Two halves

**`install-systemd-service.sh` renders first, then decides.** Both units are rendered up front and compared against what is installed with `cmp -s`, read through `sudo` since `/etc/systemd/system` is not world-readable everywhere. A difference is an install.

An unreadable comparison counts as drift on purpose: reinstalling a unit that was already correct is a no-op, while skipping one that changed is the silent failure above. The safe direction is not symmetric.

**`deploy.sh` no longer short-circuits on presence alone.** It deliberately does **not** re-derive currency itself — that would be a second renderer, which `tests/deploy/test_runtime_reconciler_wiring.py` forbids, and which caught my first attempt at this:

```
AssertionError: deploy.sh renders the backend template itself
```

That guard was right and the fix is better for it. The installer is the single authority; deploy just has to reach it. Running it every deploy is a no-op on an up-to-date box, and it runs **without** `FORCE_SERVICE_INSTALL`, so no service is restarted.

## Tests

Four guards, in `test_all_timers_are_wired.py` because that is where this incident class already lives:

| guard | pins |
|---|---|
| renders before deciding | you cannot compare against something you have not produced |
| compares content for both units | not just the timer — a changed `ExecStart` matters too |
| deploy reaches the installer | the early return may not fire on presence alone |
| deploy renders nothing | restates the wiring guard at the point of temptation |

## Verification

- Full hard gate: **10,752 passed, 54 skipped, 0 failures**.
- `ruff format --check`, `ruff check`, decision-path coercion, and the three governance gates clean on the staged tree.
- `bash -n` on both modified scripts.

## Why this is time-critical

Without it, #1263 is inert on production and W1-04 still fails. The Week 1 pregame window opens **Tue 2026-09-08 18:20 UTC** and closes at first kickoff **Thu 00:20 UTC**. This needs to merge and deploy before then, and the `game-day-capture.yml` dry-run should be dispatched afterwards to read the `systemctl list-timers` row and confirm the box actually shows the new 4-hourly schedule — a green deploy is not evidence the unit changed, which is the entire point of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmUK5EBJvJkzX8xb3s1Bve

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmUK5EBJvJkzX8xb3s1Bve)_