### PR TITLE
W1-23: reconcile Sleeper median semantics on current main

### DIFF
--- a/docs/game-day/MEDIAN_SEMANTICS_VERIFICATION.md
+++ b/docs/game-day/MEDIAN_SEMANTICS_VERIFICATION.md
@@ -1,109 +1,98 @@
-# Sleeper median-game semantics — verification attempt, 2026-09-04
+# Sleeper median-game semantics — verification record
 
-**Status:** UNRESOLVED. Recorded so the attempt is not repeated blind, and
-so no later reader mistakes the simulator's default for a verified fact.
+**Status:** RESOLVED for the owner's 12-team league and other even-sized
+Sleeper leagues by authoritative host documentation, 2026-09-06.
 
 `docs/GAME_DAY_PROBABILITY_SPEC.md` §3 requires the league-median
-threshold to be host-faithful and says explicitly: *"Verify Sleeper/host
-behavior for ties at the median and odd/even league sizes rather than
-guessing."* Contract row `W1-23` depends on it. This is that attempt.
+threshold and exact-tie behavior to be host-faithful rather than guessed.
+Contract row `W1-23` depends on that evidence.
 
-## What IS established
+## Authoritative host evidence
 
-`league_average_match = 1` on the owner's league for **2026, 2025 and
-2024** (walked via `previous_league_id`). The 2025 league ran
-`best_ball=1`, 10 teams, `playoff_week_start=14`.
+Sleeper's own support article is the authority used here:
 
-The median game is unambiguously **real and live**:
+- **Sleeper HQ, "Extra Game Each Week Against League Median"**
+- published **2024-03-26**
+- verified/retrieved **2026-09-06**
+- https://support.sleeper.com/en/articles/3971690-extra-game-each-week-against-league-median
 
-- head-to-head results alone reproduce Sleeper's reported 2025 records
-  for **0 of 10** teams;
-- every team's reported record totals exactly **26** decisions over a
-  13-week regular season — two per week, not one.
+The article settles the two facts that were previously blocked:
 
-So each week awards an H2H result **and** a threshold result. That much
-is settled and the simulator relies on it.
+1. the extra regular-season result is against the **league median**;
+2. for an even-sized league, the median is the average of the two middle
+   weekly team scores;
+3. a team whose score is exactly equal to that median receives a **tie**,
+   not a win or a loss.
 
-## What could NOT be established
+The owner's league has 12 teams, so this directly settles W1-23's
+current-league threshold and tie semantics.
 
-Whether the threshold is the league **median** or the league **average**
-— the Sleeper setting is literally named `league_average_match` — and
-what an exact tie does.
+### Honest boundary: odd-sized leagues
 
-Six variants were tested against 2025, adding each team's threshold-leg
-record to its computed H2H record and comparing with Sleeper's own
-reported `settings.wins/losses`:
+The article describes the median using the middle **two** teams and gives
+10-team and 12-team examples. It does not explicitly state Sleeper's
+behavior for an odd number of fantasy teams.
 
-| variant | teams reproduced |
-|---|---|
-| mean of all 10 | 3 / 10 |
-| median of all 10 | 2 / 10 |
-| mean excluding self | 3 / 10 |
-| median excluding self | 2 / 10 |
-| median as the lower middle value | 1 / 10 |
-| median as the upper middle value | 0 / 10 |
+The simulator therefore does **not** extend the evidence beyond what the
+host documented: `threshold_semantics_verified` is true only for the
+canonical `"median"` rule on an even-sized simulated league. An odd-sized
+league remains unverified until authoritative host evidence establishes
+that case.
 
-A season-total check does not discriminate either: across the 13 weeks,
-**both** mean and median award exactly 65 wins, which is also the number
-implied by the reported records.
+## Earlier retrospective attempt — preserved, not used as authority
 
-## Why it could not be established — the load-bearing finding
+Before the host documentation was located, the repository tried to infer
+the rule retrospectively from the owner's 2025 Sleeper league.
 
-**Sleeper's stored historical matchup points no longer reproduce
-Sleeper's own season totals.** Summing the `points` field over the 2025
-regular season and comparing with each roster's `settings.fpts`:
+What that attempt established remains useful:
 
-```
-rid  sum wk1-13    sleeper fpts     delta
-  1     4325.90        4828.64   -502.74
-  4     4711.89        5280.65   -568.76
-  9     5581.01        6088.63   -507.62
-```
+- `league_average_match = 1` on the owner's 2026, 2025 and 2024 leagues;
+- 2025 standings contained two decisions per regular-season week, proving
+  that the extra weekly standings result was active.
 
-Every team is short by 500-630 points, and **no week range closes it** —
-1-13, 1-14, 1-15, 1-16 and 1-17 all miss (closest, 1-14, still averages
-188 points per team off).
+What it could **not** establish was median-vs-mean or exact-tie behavior.
+Six candidate reconstructions reproduced at most 3 of 10 teams' recorded
+2025 results.
 
-The mechanism is specific to this format: in a **best-ball** league
-Sleeper recomputes the optimal lineup from current player stats, so any
-stat correction changes both the chosen lineup and the total. Those
-revisions accumulate across a season. The consequence is that
-back-computing *what the host decided at the time* from *what the host
-reports now* is not a sound method here, whatever threshold statistic is
-assumed.
+The load-bearing reason was historical drift: Sleeper's currently stored
+best-ball matchup points no longer reproduce Sleeper's own season totals.
+Across sampled teams, reconstructed regular-season points were hundreds of
+points short of the stored season totals. In a best-ball format, later stat
+corrections can also change the optimal lineup, so reconstructing what the
+host decided at the time from today's historical point rows is not a sound
+authority for this rule.
 
-This is the same perishability argument that motivated the Game Day
-prediction archive (`src/ros/game_day_archive.py`), arriving from the
-other direction: historical host data is not a faithful record of what
-was true when a decision was made.
+That failed reconstruction is retained here because it explains why the
+repository must prefer direct host documentation over reverse-engineering
+mutable historical data.
 
-## What the simulator does in the meantime
+## Canonical implementation disposition
 
-`src/ros/game_day_sim.py` defaults to `THRESHOLD_SEMANTICS = "median"`
-— the statistic the product spec names — and:
+`src/ros/game_day_sim.py` now follows the verified evidence:
 
-- carries `threshold_semantics` on every result, so the assumption is
-  visible rather than implicit;
-- hard-codes `threshold_semantics_verified = False`, which no caller can
-  set true;
-- accepts `threshold_semantics="mean"` as a parameter, so switching is a
-  one-argument change;
-- keeps `median_enabled=None` (`STANDINGS_RULE_UNVERIFIED`) distinct
-  from `False` (`NOT_APPLICABLE`), per spec §9.
+- `THRESHOLD_SEMANTICS = "median"`;
+- Python's `statistics.median` gives the documented average of the middle
+  two scores for an even-sized league;
+- `Beat League Median %` counts only scores strictly above the threshold;
+- an exact-median score is a **tie** and is not silently folded into a
+  median-loss joint bucket;
+- the provenance flag is true only for the verified canonical median
+  semantics on an even-sized league;
+- an explicit non-canonical `"mean"` override remains visibly unverified;
+- the semantic repair is versioned as `game-day-sim-v2`;
+- `MODEL_VERSION` participates in the disk-cache fingerprint, so a deployment
+  cannot reuse a pre-v2 cached simulation merely because roster/projection
+  inputs are unchanged.
 
-An exact tie is counted as **neither** a win nor a loss and is not
-folded into either — no tie-breaking rule has been invented.
+The four optional joint buckets in the product spec describe win/loss
+combinations only (2-0, the two 1-1 paths, 0-2). A draw containing a
+median tie is therefore excluded from those win/loss buckets rather than
+misrepresented as a loss.
 
-## How to resolve it
+## W1-23 disposition
 
-A human with the Sleeper app can settle both questions in under a
-minute, which no amount of API archaeology replaces. Open any completed
-2025 week; each team shows two results. Read off:
-
-1. whether the extra result is scored against the league **median** or
-   the league **average**;
-2. what an exact tie with that threshold is recorded as.
-
-Then set `THRESHOLD_SEMANTICS`, add the tie rule if one exists, and flip
-`threshold_semantics_verified` — with the observation recorded here as
-its evidence.
+The **methodology/evidence blocker is resolved** by the authoritative
+Sleeper source above. W1-23 should be promoted to `VERIFIED` only when
+the bounded code/tests carrying that rule have passed the repository's
+required integration evidence and the contract tally is updated
+mechanically. This document alone is not a green-CI or merged-code claim.

--- a/docs/season-launch/W1_14_W1_25_GAME_DAY_SURFACE.md
+++ b/docs/season-launch/W1_14_W1_25_GAME_DAY_SURFACE.md
@@ -128,9 +128,11 @@ state it and the caller does not pass it, the endpoint says so.
   projections at all" and "thin coverage" cannot read the same.
 - A team with **no scheduled opponent** gets `opponent: null` and a note, never
   a 50% against a game that is not on the schedule.
-- `thresholdSemanticsVerified: false` travels on every response. W1-23 is
-  `BLOCKED` on host evidence, and a private decision surface must not present
-  the median leg as settled just because it serialized cleanly.
+- `thresholdSemanticsVerified` travels on every response. Sleeper's official
+  host documentation verifies the canonical median/tie rule for even-sized
+  leagues (including the owner's 12-team league); odd-sized or non-canonical
+  semantics remain `false`. The private surface still renders an explicit
+  warning whenever provenance is unverified.
 
 The projection lineage carries its own caveat verbatim: the only live
 `PROJECTION_MODEL` sources are `PRESEASON_FULL_SEASON` horizon, so the per-game
@@ -223,7 +225,7 @@ than a single happy-path render.
 - `frontend/__tests__/components/game-day-panel.test.jsx` — 26 tests: both
   win probabilities; the lineup rendered by **slot name, not index**; the
   count of players left out of the lineup rather than counted as zero; the
-  unverified median threshold surfaced; source and coverage named; the
+  degraded/unverified median state surfaced; source and coverage named; the
   no-projection path showing the matchup with **no fabricated 50%**; all four
   error/state branches; and `cache: "no-store"` on the request.
 - `npx vitest run` — **2429 passed / 166 files**

--- a/frontend/__tests__/components/game-day-panel.test.jsx
+++ b/frontend/__tests__/components/game-day-panel.test.jsx
@@ -93,7 +93,7 @@ const PRICED = {
     bestBall: true,
     medianEnabled: true,
     simulation: {
-      modelVersion: "game-day-sim-v1",
+      modelVersion: "game-day-sim-v2",
       pointsModelSource: "measured",
       draws: 2000,
       thresholdSemantics: "median",
@@ -155,9 +155,9 @@ describe("GameDayPanel — the answer", () => {
     );
   });
 
-  it("surfaces the unverified median threshold rather than hiding it", async () => {
-    // W1-23 is BLOCKED on host evidence; a private decision surface must
-    // not present the median leg as settled.
+  it("surfaces an unverified median threshold rather than hiding it", async () => {
+    // The owner's even-sized canonical median rule is verified, but an
+    // unsupported/odd-sized semantics state must still render honestly.
     render(<GameDayPanel />);
     await waitFor(() => expect(screen.getByText(/is NOT verified/)).toBeTruthy());
   });

--- a/frontend/components/GameDayPanel.jsx
+++ b/frontend/components/GameDayPanel.jsx
@@ -178,7 +178,7 @@ function Lineup({ side }) {
 function JointOutcomes({ outcome }) {
   // Spec §8. Optional presentation, NOT another prediction engine: these
   // four come from the same draws as the two headline numbers, which is
-  // why they sum to ~100% and why they are only rendered when the median
+  // why ties are excluded from these win/loss buckets and why they are only rendered when the median
   // leg is actually live. A median-disabled league gets nothing here
   // rather than a four-way split of a two-way week.
   const rows = [
@@ -191,7 +191,7 @@ function JointOutcomes({ outcome }) {
   return (
     <Card
       title="How the week can land"
-      subtitle="The four mutually exclusive outcomes, from the same simulated draws as the two headline numbers."
+      subtitle="Win/loss outcomes from the same simulation. Draws with a matchup or median tie are excluded, so these may total less than 100%."
     >
       <table style={{ width: "100%", fontSize: "0.82rem", borderCollapse: "collapse" }}>
         <tbody>

--- a/src/ros/game_day_sim.py
+++ b/src/ros/game_day_sim.py
@@ -35,18 +35,18 @@ whose remaining production cannot be estimated is EXCLUDED from the
 lineup pool and reported in `unsimulable_player_ids`, never drawn as
 zero. A team with no opponent is `UNSIMULABLE`, never 50%.
 
-**Host semantics for the threshold are NOT yet verified**, and this
-module says so rather than implying otherwise. `THRESHOLD_SEMANTICS`
-carries the statistic actually used and
-`threshold_semantics_verified=False` travels on every result. The
-attempt and why it failed are recorded in
-`docs/game-day/MEDIAN_SEMANTICS_VERIFICATION.md`: reconciling 2025's
-records against Sleeper's own reported records reproduced at most 3 of
-10 teams under six variants, because Sleeper's stored historical
-matchup points no longer reproduce Sleeper's own season totals (a
-best-ball league recomputes the optimal lineup from current player
-stats, so accumulated stat corrections move the history). Swapping the
-statistic is a one-constant change once a human reads it off the host.
+**Host threshold/tie semantics are verified for even-sized leagues.**
+Sleeper's official support documentation states that the extra weekly
+result is against the league median, calculated as the average of the
+middle two team scores, and that a team scoring exactly at the median
+receives a tie. The owner's league has 12 teams. Odd-sized behavior is
+not extended from evidence the host did not publish.
+The authoritative evidence and the earlier failed historical
+reconstruction attempt are recorded in
+`docs/game-day/MEDIAN_SEMANTICS_VERIFICATION.md`. The canonical
+`THRESHOLD_SEMANTICS` therefore remains `"median"`; provenance is
+verified only for that canonical setting, never for an experimental
+override.
 """
 
 from __future__ import annotations
@@ -73,9 +73,14 @@ PLAYER_STATES: frozenset[str] = frozenset(
     {"completed", "in_progress", "not_started", "inactive", "unknown"}
 )
 
-#: The statistic the extra weekly result is decided against. NOT yet
-#: verified against the host — see the module docstring.
+#: The statistic the extra weekly result is decided against. Sleeper's
+#: official support documentation verifies "median"; see the module
+#: docstring and docs/game-day/MEDIAN_SEMANTICS_VERIFICATION.md.
 THRESHOLD_SEMANTICS: str = "median"
+#: The official Sleeper article defines the threshold using the middle
+#: two teams, which verifies even-sized leagues (including the owner's
+#: 12-team league). It does not explicitly establish odd-team behavior.
+THRESHOLD_SEMANTICS_VERIFIED_FOR_EVEN_LEAGUES: bool = True
 
 #: Default draws. Matches the playoff sim's own 10,000 rather than
 #: introducing a second number for the same kind of question.
@@ -85,7 +90,7 @@ DEFAULT_DRAWS: int = 10_000
 #: A re-render is not new evidence.
 DEFAULT_SEED: int = 20260910
 
-MODEL_VERSION: str = "game-day-sim-v1"
+MODEL_VERSION: str = "game-day-sim-v2"
 
 
 class GameDaySimError(ValueError):
@@ -431,16 +436,23 @@ def simulate_league_week(
                     won_h2h = False
             if thr is None:
                 continue
-            beat_med = scores[tid] > thr
-            if beat_med:
+            if scores[tid] > thr:
+                median_result: bool | None = True
                 med_win[tid] += 1
-            if won_h2h is None:
+            elif scores[tid] == thr:
+                # Sleeper records an exact-median score as a TIE. The
+                # four joint buckets model only win/loss combinations,
+                # so a tied leg must not be silently folded into a loss.
+                median_result = None
+            else:
+                median_result = False
+            if won_h2h is None or median_result is None:
                 continue
-            if won_h2h and beat_med:
+            if won_h2h and median_result:
                 joint[tid]["2_0"] += 1
             elif won_h2h:
                 joint[tid]["1_1_h2h"] += 1
-            elif beat_med:
+            elif median_result:
                 joint[tid]["1_1_med"] += 1
             else:
                 joint[tid]["0_2"] += 1
@@ -521,10 +533,16 @@ def simulate_league_week(
         model_version=MODEL_VERSION,
         points_model_source=model.source,
         threshold_semantics=threshold_semantics,
-        # Deliberately hard-coded False: see the module docstring. It flips
-        # when a human reads the rule off the host, not when a caller
-        # would like it to be true.
-        threshold_semantics_verified=False,
+        # Sleeper's official host documentation verifies the canonical
+        # median rule. An explicit non-canonical override stays unverified
+        # rather than borrowing provenance that does not apply to it.
+        threshold_semantics_verified=(
+            THRESHOLD_SEMANTICS_VERIFIED_FOR_EVEN_LEAGUES
+            and threshold_semantics == THRESHOLD_SEMANTICS
+            and rules.team_count is not None
+            and rules.team_count == len(teams)
+            and rules.team_count % 2 == 0
+        ),
         median_enabled=rules.median_enabled,
         best_ball=rules.best_ball,
         seed=seed,
@@ -577,10 +595,11 @@ def _sim_input_fingerprint(
     threshold_semantics: str,
     model: PointsModel,
 ) -> str:
-    """Sha256 over every input that can change ``simulate_league_week``'s
-    answer — rules, every team's players (state/position/banked/remaining/
-    fantasy positions), opponents, draws, seed, threshold semantics, and
-    the points model actually in effect. A match PROVES the cached result
+    """Sha256 over every input or versioned semantic that can change
+    ``simulate_league_week``'s answer — model version, rules, every
+    team's players (state/position/banked/remaining/fantasy positions),
+    opponents, draws, seed, threshold semantics, and the points model
+    actually in effect. A match PROVES the cached result
     is the same computation the caller was about to run; it is not a
     heuristic staleness guess. Built from an explicit, sorted structure
     rather than ``repr()``, which carries no cross-version stability
@@ -605,6 +624,10 @@ def _sim_input_fingerprint(
         team_rows.append([t.team_id, players, sorted(t.declared_starters)])
 
     payload = {
+        # Cache identity must move when simulation semantics move. Otherwise
+        # a deploy can serve a pre-change result from disk even though the
+        # Python implementation and provenance changed.
+        "modelVersion": MODEL_VERSION,
         "rules": [
             rules.league_key,
             list(rules.starter_slots),

--- a/tests/api/test_matchup_intel.py
+++ b/tests/api/test_matchup_intel.py
@@ -247,13 +247,13 @@ class LineageTests(unittest.TestCase):
         self.assertEqual(lin["teamCount"], 2)
         self.assertEqual(lin["starterSlotSource"], "sleeper_roster_positions")
 
-    def test_the_unverified_threshold_semantics_travel_with_the_answer(self) -> None:
-        # The median leg's host semantics are unverified (W1-23 is BLOCKED),
-        # and a private surface must not present it as settled.
+    def test_verified_even_league_threshold_semantics_travel_with_the_answer(self) -> None:
+        # Sleeper's official host documentation verifies the canonical
+        # median/tie semantics for this even-sized league.
         with _patch_fetch(), _patch_estimates():
             out = _build()
         sim = out["lineage"]["simulation"]
-        self.assertFalse(sim["thresholdSemanticsVerified"])
+        self.assertTrue(sim["thresholdSemanticsVerified"])
         self.assertEqual(sim["thresholdSemantics"], "median")
         self.assertEqual(sim["draws"], 200)
 

--- a/tests/api/test_matchup_intel_endpoint.py
+++ b/tests/api/test_matchup_intel_endpoint.py
@@ -202,9 +202,9 @@ def test_the_payload_carries_its_projection_source_and_coverage():
     assert lin["estimateCoverage"] == {"priced": 600, "active": 674}
 
 
-def test_the_unverified_threshold_semantics_reach_the_wire():
-    # W1-23 is BLOCKED on host evidence; a private surface must not present
-    # the median leg as settled just because it serialized cleanly.
+def test_an_unverified_threshold_semantics_state_reaches_the_wire():
+    # Odd-sized/unsupported semantics must remain representable even though
+    # the owner's even-sized canonical median rule is now verified.
     with _patch(), _patch_clock(), _client() as c:
         body = c.get("/api/matchup/intel?team=own-A").json()
     assert body["lineage"]["simulation"]["thresholdSemanticsVerified"] is False

--- a/tests/e2e/specs/prod-auth/w1-16-game-day.spec.js
+++ b/tests/e2e/specs/prod-auth/w1-16-game-day.spec.js
@@ -175,8 +175,8 @@ test.describe("W1-16: the owner's Game Day experience (production)", () => {
     const cov = body.lineage?.estimateCoverage || {};
     expect(text).toContain(`${cov.priced} of ${cov.active} active players priced`);
 
-    // W1-23 is BLOCKED on host evidence; the surface must not present the
-    // median leg as settled just because it rendered.
+    // If this league's host semantics are unverified (for example an
+    // unsupported odd-sized case), the surface must still say so.
     if (body.lineage?.simulation && body.lineage.simulation.thresholdSemanticsVerified === false) {
       expect(text).toMatch(/is NOT verified/);
       annotate(testInfo, "w1-16-threshold", "unverified median semantics surfaced");

--- a/tests/game_day/test_game_day_sim.py
+++ b/tests/game_day/test_game_day_sim.py
@@ -22,6 +22,7 @@ from src.ros.game_day_sim import (
     LeagueWeekRules,
     PlayerWeek,
     TeamWeek,
+    _threshold,
     rules_from_league,
     simulate_league_week,
 )
@@ -185,6 +186,72 @@ def test_the_three_median_states_are_distinguishable():
         for v in (True, False, None)
     }
     assert states == {"OK", "NOT_APPLICABLE", "STANDINGS_RULE_UNVERIFIED"}
+
+
+def _completed_score_league(scores):
+    """A deterministic one-player-per-team league for threshold semantics."""
+    rules = LeagueWeekRules(
+        league_key="median_semantics",
+        starter_slots=("QB",),
+        best_ball=True,
+        median_enabled=True,
+        team_count=len(scores),
+    )
+    teams = tuple(
+        TeamWeek(
+            team_id=f"t{i}",
+            players=(_p(f"p{i}", "QB", "completed", scored=float(score)),),
+        )
+        for i, score in enumerate(scores, start=1)
+    )
+    opponents = {
+        "t1": "t2",
+        "t2": "t1",
+        "t3": "t4",
+        "t4": "t3",
+    }
+    return simulate_league_week(
+        rules=rules,
+        teams=teams,
+        opponents=opponents,
+        season=2026,
+        week=1,
+        draws=5,
+        points_model=_MODEL,
+    )
+
+
+def test_sleeper_threshold_is_the_middle_two_average_not_the_mean():
+    """Sleeper documents the even-league median as the average of the
+    middle two weekly scores. [0, 10, 20, 100] therefore has threshold
+    15, not the arithmetic mean 32.5."""
+    assert _threshold([0.0, 10.0, 20.0, 100.0]) == 15.0
+    sim = _completed_score_league([0, 10, 20, 100])
+    by_id = {t.team_id: t for t in sim.teams}
+    assert by_id["t2"].beat_median_pct == 0.0
+    assert by_id["t3"].beat_median_pct == 100.0
+
+
+def test_exact_median_score_is_a_tie_not_a_joint_loss():
+    """Sleeper documents an exact score at the median as a tie. The four
+    joint buckets contain only win/loss combinations, so that tied leg
+    must not be coerced into either median-loss bucket."""
+    sim = _completed_score_league([90, 100, 100, 110])
+    by_id = {t.team_id: t for t in sim.teams}
+
+    # t2 wins H2H but ties the median. Old behavior incorrectly reported
+    # this as "1-1 via H2H" (a median loss).
+    t2 = by_id["t2"]
+    assert t2.win_matchup_pct == 100.0
+    assert t2.beat_median_pct == 0.0
+    assert t2.joint_1_1_h2h_pct == 0.0
+
+    # t3 loses H2H but ties the median. Old behavior incorrectly reported
+    # this as a 0-2 week (another median loss).
+    t3 = by_id["t3"]
+    assert t3.win_matchup_pct == 0.0
+    assert t3.beat_median_pct == 0.0
+    assert t3.joint_0_2_pct == 0.0
 
 
 # ── missing opponent ───────────────────────────────────────────────
@@ -496,12 +563,44 @@ def test_every_result_carries_its_provenance():
     assert sim.seed and sim.draws
 
 
-def test_threshold_semantics_are_declared_unverified():
-    """Reconciling 2025 against Sleeper's own records reproduced at most
-    3 of 10 teams, because Sleeper's stored historical points no longer
-    reproduce its own season totals. Until a human reads the rule off
-    the host, this must not claim fidelity."""
-    assert _league().threshold_semantics_verified is False
+def test_canonical_threshold_semantics_are_verified():
+    """Sleeper's official support documentation verifies the canonical
+    median threshold and exact-tie behavior."""
+    assert _league().threshold_semantics_verified is True
+
+
+def test_noncanonical_threshold_override_cannot_borrow_verified_provenance():
+    sim = _league()
+    overridden = simulate_league_week(
+        rules=_rules(),
+        teams=tuple(
+            TeamWeek(team_id=f"t{i}", players=_full_roster(f"t{i}", 10.0 + i)) for i in range(1, 5)
+        ),
+        opponents={"t1": "t2", "t2": "t1", "t3": "t4", "t4": "t3"},
+        season=2026,
+        week=1,
+        draws=10,
+        points_model=_MODEL,
+        threshold_semantics="mean",
+    )
+    assert sim.threshold_semantics_verified is True
+    assert overridden.threshold_semantics == "mean"
+    assert overridden.threshold_semantics_verified is False
+
+
+def test_odd_team_league_does_not_overclaim_host_verification():
+    """The official Sleeper evidence describes the middle-two calculation
+    for even-sized leagues; it does not establish odd-team behavior."""
+    sim = _league(n=3, rules=_rules(team_count=3), draws=10)
+    assert sim.threshold_semantics == "median"
+    assert sim.threshold_semantics_verified is False
+
+
+def test_team_count_mismatch_does_not_claim_verified_threshold_semantics():
+    """A partial league fetch is not host-faithful merely because the
+    number of teams that happened to arrive is even."""
+    sim = _league(n=4, rules=_rules(team_count=12), draws=10)
+    assert sim.threshold_semantics_verified is False
 
 
 def test_a_fallback_points_model_is_declared():

--- a/tests/game_day/test_game_day_sim_cache.py
+++ b/tests/game_day/test_game_day_sim_cache.py
@@ -127,6 +127,17 @@ def test_a_changed_player_input_forces_a_real_recompute(cache_dir):
     assert spy.call_count == 2, "a genuine input change was served a stale cached answer"
 
 
+def test_a_model_version_change_invalidates_the_cache(cache_dir):
+    """A deployment that changes simulation semantics must not reuse a
+    disk result produced by the prior model version."""
+    rules, teams, opponents = _league()
+    with mock.patch.object(gds, "simulate_league_week", wraps=gds.simulate_league_week) as spy:
+        _call(rules, teams, opponents)
+        with mock.patch.object(gds, "MODEL_VERSION", "game-day-sim-next"):
+            _call(rules, teams, opponents)
+    assert spy.call_count == 2, "model-version change reused a stale simulation result"
+
+
 def test_a_different_week_does_not_collide_with_another_weeks_cache(cache_dir):
     rules, teams, opponents = _league()
     with mock.patch.object(gds, "simulate_league_week", wraps=gds.simulate_league_week) as spy:

--- a/tests/ros/test_game_day_week.py
+++ b/tests/ros/test_game_day_week.py
@@ -222,5 +222,6 @@ class EndToEndTests(unittest.TestCase):
         # the whole probability mass.
         total = (a.win_matchup_pct or 0) + (b.win_matchup_pct or 0) + (a.tie_matchup_pct or 0)
         self.assertAlmostEqual(total, 100.0, delta=0.05)
-        # The unverified threshold semantics travel with the result.
-        self.assertFalse(sim.threshold_semantics_verified)
+        # Sleeper's official host documentation verifies the canonical
+        # median semantics for this even-sized league.
+        self.assertTrue(sim.threshold_semantics_verified)


### PR DESCRIPTION
The canonical simulator classified exact-median ties into median-loss joint buckets and its disk cache did not include model identity.

Harvests only the intended W1-23 changes from draft #1262 onto main 110e5b50c0cc7faed4bd36cd50e05aacefe609e8. Excludes stacked Agent OS and capture-runbook changes; preserves integrated narratives and capture code. Keeps game_day_sim as the single simulation owner. Model v2 invalidates prior cache results. Host verification applies only to complete, matching, even-sized leagues; odd and experimental threshold semantics stay unverified. UI explains that tie draws are outside the four win/loss buckets.

Host evidence: https://support.sleeper.com/en/articles/3971690-extra-game-each-week-against-league-median

Validation: 94 focused backend tests passed. Ruff lint, decision coercion, planning and product governance passed. Repaired formatter spacing in harvested tests. Exact-head CI and release integration remain required; W1-23 has NOT been promoted.

Engineering applicability: APPLY_NOW host/tie and model-cache regressions; ALREADY_COVERED canonical lineup/simulation and auth boundaries; DEFERRED_BY_AUTHORITY broad typing/build artifact program.

Agent-OS-Receipt: 7a029d37f101240a408c6cf285d87a3876fe49d6