### PR TITLE
docs(season-launch): correct the stale Week 1 status record

### DIFF
--- a/docs/season-launch/2026_SEASON_LAUNCH_STATUS.md
+++ b/docs/season-launch/2026_SEASON_LAUNCH_STATUS.md
@@ -72,9 +72,13 @@ in-progress player's remaining production is `None` and raises
 remainder, or exclusion. Each choice changes published live probabilities; no
 evidence in the repo selects one.
 
-**One owner action is BLOCKING.** `ANTHROPIC_API_KEY` is unconfigured, so
-`weekly-narratives.yml` reports success in ~10 s with every real step skipped
-and `exports/narratives/` holds only two 2025 files.
+**No owner action is blocking as of 2026-09-07.** An earlier draft of this
+block named `ANTHROPIC_API_KEY` as a blocker; that was itself stale, which is
+the failure mode this section exists to correct. W1-11 is literally `VERIFIED`
+on the canonical contract: Manual External AI is now the generation model and
+does not depend on that secret at all, and all six real Week 1 narratives exist
+and passed validation with zero errors. Do not reintroduce the key as a launch
+blocker.
 
 **Methodology finding that constrains Game Day, recorded here so it is not
 re-derived.** `config/projections/source_capability_census.json` has exactly

--- a/docs/season-launch/2026_SEASON_LAUNCH_STATUS.md
+++ b/docs/season-launch/2026_SEASON_LAUNCH_STATUS.md
@@ -32,6 +32,50 @@ stands.
 | Week 1 pregame (private) | NOT STARTED | scope now authorized |
 | Game Day dashboard | NOT STARTED | §2; methodology decision outstanding |
 
+## 0a. Status update — 2026-09-07 (supersedes §0's next-actions)
+
+§0 and the audit bodies below are the 2026-09-04 record and are left standing.
+This block corrects what has since become false. `WEEK_1_LAUNCH_CONTRACT.md`
+remains the canonical scoreboard and this document does not restate its tally.
+
+**§0 gets the kickoff DAY wrong, and that mislabelling is the incident.** The
+UTC timestamp is right; the weekday is not. Week 1 2026 opens on a
+**WEDNESDAY** — NE @ SEA, 2026-09-09 20:20 ET = **2026-09-10 00:20 UTC**. The
+capture timer was originally scheduled Thursday on exactly the reasoning §0
+records here, which would have fired ~12h40m AFTER kickoff, been correctly
+refused, and lost the Week 1 pregame observation permanently. The window is now
+derived from the nflverse slate rather than a weekday (#1263).
+
+**§0's "the pregame capture window is OPEN" is also false as written.** The
+window opens 30h before first kickoff — **Tue 2026-09-08 18:20 UTC** — and
+closes at kickoff. As of 2026-09-07 it has NOT opened; the script reports
+`early` and exits 2.
+
+| component | state as of 2026-09-07 | evidence |
+|---|---|---|
+| Game Day archive capture | **DEPLOYED + PRODUCTION VERIFIED** (the enabler, not a capture) | run `34154347596` on `deployed_sha c5164c46`: timer enabled, firing four-hourly, next fire 31 min out, window state correctly `early` |
+| Week 1 authentic capture | NOT YET POSSIBLE — time-gated | window opens Tue 2026-09-08 18:20 UTC |
+| Game Day simulation backend | MERGED | `src/ros/game_day_sim.py`; one simulation owner, both probabilities from the same draws |
+| Game Day LIVE / FINAL states | MERGED, awaiting live-game evidence | #1271 |
+
+**Three defects found and closed since §0, recorded so they are not
+re-derived:** the Thursday timer above (#1263); a deploy that never updated a
+CHANGED timer template, so every timer edit in repo history shipped into a hole
+and the fix above would have been inert on production (#1267); and
+`Type=oneshot` without `SuccessExitStatus`, which marked the unit `failed` on
+every correct out-of-window run and would have made a real failure
+indistinguishable from the normal case (#1272).
+
+**One owner decision is open and does NOT block anything before kickoff.** An
+in-progress player's remaining production is `None` and raises
+`OWNER_POLICY_REQUIRED` rather than silently choosing time-proration, zero
+remainder, or exclusion. Each choice changes published live probabilities; no
+evidence in the repo selects one.
+
+**One owner action is BLOCKING.** `ANTHROPIC_API_KEY` is unconfigured, so
+`weekly-narratives.yml` reports success in ~10 s with every real step skipped
+and `exports/narratives/` holds only two 2025 files.
+
 **Methodology finding that constrains Game Day, recorded here so it is not
 re-derived.** `config/projections/source_capability_census.json` has exactly
 two `implementationStatus: LIVE` `PROJECTION_MODEL` sources —
@@ -200,7 +244,7 @@ rather than a new one (avoiding a second recap-generation owner).
 | surface | classification | blocking question |
 |---|---|---|
 | Pregame writeups | READY (public) / NOT STARTED (private) | public/private scope confirmation |
-| Game Day dashboard | NOT STARTED (dashboard); substrate built but idle | none — wire the capture job now, time-critical |
+| Game Day dashboard | superseded — see §0a | capture job is wired, deployed and production-verified; do NOT re-wire it |
 | Postgame writeups | READY (public) / NOT STARTED (private "expected vs actual") | public/private scope confirmation |
 
 None of this work is V1-required; it does not touch V1-123/V1-125/V1-126 or


### PR DESCRIPTION
## Why now

`docs/season-launch/2026_SEASON_LAUNCH_STATUS.md` is dated 2026-09-04 and still carries two statements that are false as of today, two days before kickoff:

1. Its summary table says the Game Day dashboard's substrate is *"built but idle"* with the next action **"wire the capture job now, time-critical"**. That job is merged, deployed, and production-verified. The document is currently a live instruction to redo done work.
2. §0 records Week 1's opener as **Thursday**. The season opens on a **Wednesday** — NE @ SEA, 2026-09-09 20:20 ET = 2026-09-10 00:20 UTC. The UTC timestamp in §0 is right; the weekday is not, and *that exact mislabelling* is what put the capture timer on a Thursday schedule that would have fired ~12h40m after kickoff and lost the Week 1 pregame observation permanently.

A stale planning record that contradicts production is the same class of defect this tranche has been closing all day, just in prose.

## What this does

Appends a dated `## 0a` block **rather than rewriting the 2026-09-04 audit**, per this repo's append-only correction convention (the originals stand). It:

- states the real window — opens **Tue 2026-09-08 18:20 UTC**, closes at first kickoff **Thu 00:20 UTC** — and that as of 2026-09-07 it has *not* opened (the script reports `early`, exit 2);
- records component state with the IMPLEMENTED/MERGED/DEPLOYED/VERIFIED boundary preserved, and is careful that what is production-verified is the **enabler**, not a capture;
- records the three defects closed since §0 (#1263 Thursday timer, #1267 deploy never updating a changed template, #1272 `SuccessExitStatus`) so they are not re-derived;
- names the one open owner decision (in-progress remainder policy, non-blocking before kickoff);
- states explicitly that **no owner action is blocking**.

## Correction after review (7eee693)

The first push named `ANTHROPIC_API_KEY` as a blocking owner action. **That was wrong**, and it was stale in precisely the way this section exists to fix — so it is worth being blunt about rather than quietly amending.

W1-11 is literally `VERIFIED` on the canonical contract as of 2026-09-07: Manual External AI is now the generation model and does not depend on that secret at all, and all six real Week 1 narratives exist and passed validation with zero errors. Verified against `origin/main` before changing anything, not taken on assertion.

The replacement text says an earlier draft got this wrong and that the key must not be reintroduced as a blocker — a silent deletion would have left the next reader free to rediscover the same false claim.

## What it deliberately does not do

**No tally is restated and no row moves.** `WEEK_1_LAUNCH_CONTRACT.md` remains the canonical scoreboard at 24/30. W1-27/W1-28 stay NOT STARTED despite #1271 merging, because they need literal production live/final evidence; W1-04 is time-gated; W1-03 is downstream of it. A second tally that can disagree with the canonical one is exactly what the Agent OS forbids.

Docs-only, one file.

## Verification

`check_planning_integrity.py`, `check_product_plan_governance.py`, `audit_status.py` (no drift) and the decision-coercion gate all clean, re-run after the correction. Exact-head PR Validation to finish green before merge.

Agent-OS-Receipt: `7a029d37f101240a408c6cf285d87a3876fe49d6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmUK5EBJvJkzX8xb3s1Bve