### PR TITLE
verify(game-day): read the INSTALLED exit-code policy, don't infer it

### DIFF
--- a/.github/workflows/game-day-capture.yml
+++ b/.github/workflows/game-day-capture.yml
@@ -180,6 +180,52 @@ jobs:
             echo "###   NOT INSTALLED — no game-day-capture timer on this host."
             echo "###   The scheduled pre-kickoff capture will NOT fire."
           fi
+
+          # Does the INSTALLED unit treat exit 2 as success?
+          #
+          # A green run of THIS workflow does not answer that. The workflow
+          # maps rc=2 to success itself, further down; that is a different
+          # half of the same fix from what systemd does with the same code
+          # on a timer firing. Reading one as evidence of the other is the
+          # mistake this block exists to prevent.
+          #
+          # It matters because the timer fires ~6x/day and the window is
+          # open ~30h a week, so nearly every firing exits 2. Without
+          # SuccessExitStatus=2 the unit sits `failed` almost permanently
+          # and a REAL failure becomes indistinguishable from the normal
+          # case — which is the whole point of #1272.
+          #
+          # And a template reaching the repo is not a template reaching the
+          # box: until #1267, install_simple_timer left an existing unit
+          # alone however much its template had changed, so every timer edit
+          # in this repo's history shipped into that hole. Print what is
+          # ACTUALLY installed.
+          echo "###"
+          echo "### installed unit — exit-code policy:"
+          SVC="$(systemctl list-units --type=service --all --no-legend 2>/dev/null \
+            | awk '/game-day-capture/ {print $1; exit}')"
+          SVC="${SVC:-$(systemctl list-unit-files --no-legend 2>/dev/null \
+            | awk '/game-day-capture\.service/ {print $1; exit}')}"
+          if [ -n "$SVC" ]; then
+            SES="$(systemctl show "$SVC" -p SuccessExitStatus --value 2>/dev/null || true)"
+            echo "###   unit: $SVC"
+            echo "###   SuccessExitStatus: ${SES:-(none)}"
+            case " $SES " in
+              *" 2 "*) echo "###   exit 2 counts as SUCCESS: yes" ;;
+              *)       echo "###   exit 2 counts as SUCCESS: NO — the unit will sit failed between windows" ;;
+            esac
+            # 1 and 3 must stay failures. 3 is REFUSED: the window closed and
+            # that week's observation is permanently unrecoverable. If either
+            # ever appears here, someone widened the list and silenced the two
+            # states an operator must actually be woken for.
+            case " $SES " in
+              *" 1 "*|*" 3 "*) echo "###   WARNING: 1 or 3 is being swallowed as success" ;;
+              *)               echo "###   1 and 3 still fail loudly: yes" ;;
+            esac
+            echo "###   current state: $(systemctl is-failed "$SVC" 2>/dev/null || true)"
+          else
+            echo "###   no game-day-capture service unit found on this host."
+          fi
           exit "$capture_rc"
           REMOTE
           echo "capture_exit=$rc" >> "$GITHUB_OUTPUT"

--- a/tests/deploy/test_all_timers_are_wired.py
+++ b/tests/deploy/test_all_timers_are_wired.py
@@ -306,9 +306,9 @@ class TestNothingToDoIsNotAFailure:
 
         So the workflow must interrogate what is ACTUALLY installed.
         """
-        workflow = (
-            _REPO / ".github" / "workflows" / "game-day-capture.yml"
-        ).read_text(encoding="utf-8")
+        workflow = (_REPO / ".github" / "workflows" / "game-day-capture.yml").read_text(
+            encoding="utf-8"
+        )
         assert "systemctl show" in workflow and "SuccessExitStatus" in workflow, (
             "the on-box verification must read the installed unit's exit-code "
             "policy, not infer it from the workflow's own exit handling"

--- a/tests/deploy/test_all_timers_are_wired.py
+++ b/tests/deploy/test_all_timers_are_wired.py
@@ -291,3 +291,29 @@ class TestNothingToDoIsNotAFailure:
         codes = success_line.split("=", 1)[1].split()
         assert "1" not in codes, "a hard error must not be declared a success"
         assert "3" not in codes, "a closed capture window must not be declared a success"
+
+    def test_the_verification_workflow_reads_the_INSTALLED_policy(self):
+        """A green run of the capture workflow does NOT prove the unit on
+        the box treats exit 2 as success.
+
+        The workflow maps rc=2 to success in its own shell; systemd's
+        handling of the same code on a timer firing is a separate half of
+        the same fix. Reading one as evidence of the other is the mistake
+        this guard exists to prevent — and the distinction has teeth here,
+        because until #1267 a changed template never reached the box at
+        all, so the repo and production could disagree indefinitely with
+        every signal green.
+
+        So the workflow must interrogate what is ACTUALLY installed.
+        """
+        workflow = (
+            _REPO / ".github" / "workflows" / "game-day-capture.yml"
+        ).read_text(encoding="utf-8")
+        assert "systemctl show" in workflow and "SuccessExitStatus" in workflow, (
+            "the on-box verification must read the installed unit's exit-code "
+            "policy, not infer it from the workflow's own exit handling"
+        )
+        assert "is-failed" in workflow, (
+            "report the unit's current state: a unit already sitting failed "
+            "is the symptom this fix exists to remove"
+        )


### PR DESCRIPTION
## The production verification of #1272 came back green without proving what it was run to prove

Run [34164151157](https://github.com/jasonleetucker-code/riskittogetthebrisket/actions/runs/34164151157) on `deployed_sha a3c5e30e` verified plenty:

```
Pregame window: early — first kickoff is 2026-09-10T00:20:00+00:00;
  the capture window opens 30h before it, at 2026-09-08T18:20:00+00:00
### capture-exit: 2        → job SUCCESS
##[notice] Nothing to do yet; this is the expected state between windows.
### archive file count: 0
### scheduled timer: Tue 2026-09-08 02:00 CEST (2h 8min) · enabled: yes
```

But **that green does not establish that the installed unit treats exit 2 as success.** The workflow maps `rc=2` to success *in its own shell*, further down. What systemd does with the same code on a timer firing is the other half of #1272, and nothing in the log touches it. A green run was being read as evidence for a claim it never tested.

## Why that distinction has teeth here

Two reasons, both measured in this repo rather than hypothetical:

1. **The repo and the box can disagree indefinitely with every signal green.** Until #1267, `install_simple_timer` left an existing unit alone however much its template had changed — which is exactly how the Thursday capture schedule would have survived its own fix. "The template says `SuccessExitStatus=2`" and "the unit on the box says it" are different facts, and this codebase has already been bitten by treating them as one.

2. **The failure is silent and cumulative.** The timer fires ~6×/day against a window open ~30h a week, so nearly every firing exits 2. Without `SuccessExitStatus=2` on the *installed* unit, the service sits `failed` almost permanently and a real failure becomes indistinguishable from the normal case — the precise condition #1272 exists to remove.

The service's last run was 1h51m before deploy 2943 landed, so **the 00:00 UTC firing is the first one under the new unit.** Better to be able to answer this before it than after.

## What this does

Extends the existing on-box verification block to print what is *actually installed*: the unit name, its `SuccessExitStatus`, whether `2` counts as success, whether `1` (hard error) and `3` (REFUSED — window closed, observation unrecoverable) are still failures, and the unit's current `is-failed` state. A unit already sitting failed is the symptom, so it's reported rather than inferred.

No new workflow step, so no `release_gate_classification.json` entry is needed (its suite passes unchanged).

## Verification

- New guard asserts the workflow interrogates the installed policy rather than its own exit handling.
- **Mutation**: blanking the `systemctl show` probe turns it RED at the intended assertion (`test_all_timers_are_wired.py:312`); restored GREEN. Non-vacuous.
- 16 passed in `tests/deploy/test_all_timers_are_wired.py`, 19 with `test_release_gate_classification.py`.
- YAML parses; planning-integrity, product-plan-governance and decision-coercion gates clean.

Contract untouched at 24/30; no row moves.

Agent-OS-Receipt: `7a029d37f101240a408c6cf285d87a3876fe49d6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmUK5EBJvJkzX8xb3s1Bve

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmUK5EBJvJkzX8xb3s1Bve)_