### PR TITLE
fix(game-day): the exit-code probe killed the run it was verifying

### DIFF
--- a/.github/workflows/game-day-capture.yml
+++ b/.github/workflows/game-day-capture.yml
@@ -174,7 +174,7 @@ jobs:
           if [ -n "$TIMER" ]; then
             echo "###   $TIMER"
             systemctl is-enabled --quiet "$(systemctl list-units --type=timer --all --no-legend \
-              | awk '/game-day-capture/ {print $1; exit}')" 2>/dev/null \
+              | awk '/game-day-capture/ && !s {print $1; s=1}')" 2>/dev/null \
               && echo "###   enabled: yes" || echo "###   enabled: NO"
           else
             echo "###   NOT INSTALLED — no game-day-capture timer on this host."
@@ -202,10 +202,18 @@ jobs:
           # ACTUALLY installed.
           echo "###"
           echo "### installed unit — exit-code policy:"
+          # NOTE the awk idiom: match-and-set, never `{print; exit}`.
+          # `exit` closes the pipe while systemctl is still writing, which
+          # is SIGPIPE -> 141, and under `set -Eeuo pipefail` that aborts
+          # the whole run before a single line of this diagnostic prints.
+          # Measured: run 34167418550 died at exit 141 doing exactly that.
+          # The pre-existing timer lookup below survives the same idiom
+          # only because `--type=timer` is short enough to fit the pipe
+          # buffer; `--type=service --all` is not. Consume the stream.
           SVC="$(systemctl list-units --type=service --all --no-legend 2>/dev/null \
-            | awk '/game-day-capture/ {print $1; exit}')"
+            | awk '/game-day-capture/ && !s {print $1; s=1}' || true)"
           SVC="${SVC:-$(systemctl list-unit-files --no-legend 2>/dev/null \
-            | awk '/game-day-capture\.service/ {print $1; exit}')}"
+            | awk '/game-day-capture\.service/ && !s {print $1; s=1}' || true)}"
           if [ -n "$SVC" ]; then
             SES="$(systemctl show "$SVC" -p SuccessExitStatus --value 2>/dev/null || true)"
             echo "###   unit: $SVC"


### PR DESCRIPTION
## My bug, shipped an hour ago in #1274

Run [34167418550](https://github.com/jasonleetucker-code/riskittogetthebrisket/actions/runs/34167418550) died at **exit 141** — SIGPIPE — before printing a single line of the diagnostic #1274 added. So the verification that was supposed to answer "does the installed unit carry `SuccessExitStatus=2`?" produced a red run and *no evidence at all*.

## Root cause — reproduced, not guessed

Under `set -Eeuo pipefail`, `awk '/re/ {print $1; exit}'` closes the pipe while `systemctl` is still writing. `systemctl` takes SIGPIPE (128+13 = 141), `pipefail` propagates it, and the whole remote script aborts.

Reproduced locally against a 200k-line stand-in stream:

| idiom | result |
|---|---|
| `awk '/re/ {print $1; exit}'` | **rc=141, no output at all** |
| `awk '/re/ && !s {print $1; s=1}'` | rc=0, correct first match, reached the end |

## Why both call sites, not just mine

The pre-existing timer lookup in the same block uses the identical idiom and has never failed. That is not luck worth relying on: `--type=timer` is short enough that the write fits the pipe buffer before awk exits, while my `--type=service --all` listing is not. Same pattern, same block, same total-loss failure mode — the run reports nothing, and "nothing" is indistinguishable from a box that was never reached.

`|| true` is also added on the substitutions, so a future `systemctl` oddity degrades **this diagnostic** rather than destroying the verification around it. A check that can kill its own run is worse than no check.

Worth naming the shape: a verification step that cannot fail safely turned a green-or-red question into no answer — the same signal-destroying class as #1272 (a correct outcome reading as failure) and #1273 (a stale record reading as current), arriving a third way.

## Timing

Unchanged and still ahead of the **00:00 UTC** firing, which is the first under the unit deployed at 21:07. This workflow runs from the GitHub runner and SSHes in, so it needs no deploy and can be re-dispatched the moment this lands.

## Verification

- SIGPIPE reproduced and the fix confirmed against the same synthetic stream (both directions).
- No `print $1; exit` idiom remains in the workflow (grep: 0).
- `ruff format --check` (1392 files) and `ruff check` clean — I skipped format on the previous push and it cost a CI cycle; running the whole set now.
- YAML valid; 20 deploy + release-gate tests pass; decision-coercion gate clean.

Contract untouched at 24/30; no row moves.

Agent-OS-Receipt: `7a029d37f101240a408c6cf285d87a3876fe49d6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmUK5EBJvJkzX8xb3s1Bve

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmUK5EBJvJkzX8xb3s1Bve)_