### PR TITLE
fix(game-day): the probe answered about the wrong unit

### DIFF
--- a/.github/workflows/game-day-capture.yml
+++ b/.github/workflows/game-day-capture.yml
@@ -174,7 +174,7 @@ jobs:
           if [ -n "$TIMER" ]; then
             echo "###   $TIMER"
             systemctl is-enabled --quiet "$(systemctl list-units --type=timer --all --no-legend \
-              | awk '/game-day-capture/ && !s {print $1; s=1}')" 2>/dev/null \
+              | awk '/game-day-capture/ && !s { for (i=1;i<=NF;i++) if ($i ~ /\.timer$/) { print $i; s=1; break } }')" 2>/dev/null \
               && echo "###   enabled: yes" || echo "###   enabled: NO"
           else
             echo "###   NOT INSTALLED — no game-day-capture timer on this host."
@@ -210,10 +210,18 @@ jobs:
           # The pre-existing timer lookup below survives the same idiom
           # only because `--type=timer` is short enough to fit the pipe
           # buffer; `--type=service --all` is not. Consume the stream.
+          # And NOT `print $1`: `systemctl list-units` puts a status BULLET
+          # in the first column for any unit that is not in a clean state,
+          # so $1 is "●" and the unit name shifts to $2. Measured: run
+          # 34170621573 printed `unit: ●`, then answered every question
+          # about a unit that does not exist — "(none)", "NO", "inactive".
+          # A probe that silently reads the wrong subject is worse than no
+          # probe, because its answers look like findings. Select the field
+          # by SUFFIX, which is position-independent and bullet-proof.
           SVC="$(systemctl list-units --type=service --all --no-legend 2>/dev/null \
-            | awk '/game-day-capture/ && !s {print $1; s=1}' || true)"
+            | awk '/game-day-capture/ && !s { for (i=1;i<=NF;i++) if ($i ~ /\.service$/) { print $i; s=1; break } }' || true)"
           SVC="${SVC:-$(systemctl list-unit-files --no-legend 2>/dev/null \
-            | awk '/game-day-capture\.service/ && !s {print $1; s=1}' || true)}"
+            | awk '/game-day-capture\.service/ && !s { for (i=1;i<=NF;i++) if ($i ~ /\.service$/) { print $i; s=1; break } }' || true)}"
           if [ -n "$SVC" ]; then
             SES="$(systemctl show "$SVC" -p SuccessExitStatus --value 2>/dev/null || true)"
             echo "###   unit: $SVC"
@@ -231,6 +239,10 @@ jobs:
               *)               echo "###   1 and 3 still fail loudly: yes" ;;
             esac
             echo "###   current state: $(systemctl is-failed "$SVC" 2>/dev/null || true)"
+            # A `failed` state here can be STALE — left by a firing that
+            # predates the SuccessExitStatus fix reaching the box — so it is
+            # only meaningful alongside the timestamp of the last run above.
+            echo "###   last result: $(systemctl show "$SVC" -p Result --value 2>/dev/null || true)"
           else
             echo "###   no game-day-capture service unit found on this host."
           fi


### PR DESCRIPTION
## The probe produced a verdict about nothing

Run [34170621573](https://github.com/jasonleetucker-code/riskittogetthebrisket/actions/runs/34170621573) finally printed the block, and it read:

```
###   unit: ●
###   SuccessExitStatus: (none)
###   exit 2 counts as SUCCESS: NO — the unit will sit failed between windows
###   current state: inactive
```

`systemctl list-units` puts a **status bullet in column 1** for any unit not in a clean state, so `$1` is `●` and the unit name shifts to `$2`. Every line after that was `systemctl show ●` — a unit that does not exist. `(none)`, `NO` and `inactive` are all answers about nothing.

**So the `NO` was unproven, not false.** Taken at face value it would have been reported as a live production defect on the eve of the Week 1 capture window, and someone would have gone looking for a broken deploy that may well be fine. A probe that silently reads the wrong subject is worse than no probe, because its output *looks* like a finding — the same fabricated-certainty class this unit exists to prevent, this time arriving from inside the verification itself.

## Fix

Select the field by **suffix** (`$i ~ /\.service$/`) rather than by column position. Applied to the timer lookup too: that one happens to work today only because a healthy timer prints no bullet, which is a property of the current state, not of the parse.

Also prints `Result`, and records in-line that a `failed` state can be **stale** — left by a firing that predates `SuccessExitStatus` reaching the box (the 20:00 run preceded the 21:07 deploy). The state is only meaningful read against the last-run timestamp, so both are now in the same output.

Worth noting as a real signal rather than noise: the service line *had* a bullet while the timer line did not. That is consistent with the service sitting failed from that pre-fix 20:00 firing — which would be expected and harmless. It is a thing to measure, not to assume in either direction.

## Verification

Extracted all three awk programs verbatim from the workflow and ran them against bulleted and unbulleted fixtures:

| fixture | old idiom | new idiom |
|---|---|---|
| `● dynasty-game-day-capture.service …` | `●` | `dynasty-game-day-capture.service` |
| `  dynasty-game-day-capture.service …` | correct | `dynasty-game-day-capture.service` |
| `● dynasty-game-day-capture.timer …` | `●` | `dynasty-game-day-capture.timer` |
| `  dynasty-game-day-capture.timer …` | correct | `dynasty-game-day-capture.timer` |

`ruff format --check` (1392 files) and `ruff check` clean; YAML valid; 20 deploy + release-gate tests pass; decision-coercion gate clean.

## Status of the underlying question

Still **unanswered** — this is the fourth attempt. The window does not open until **Tue 2026-09-08 18:20 UTC**, so there is a full day of margin, and the timer now fires every four hours, meaning the next reading also carries a real post-firing `is-failed` observation.

Contract untouched at 24/30; no row moves.

Agent-OS-Receipt: `7a029d37f101240a408c6cf285d87a3876fe49d6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmUK5EBJvJkzX8xb3s1Bve

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmUK5EBJvJkzX8xb3s1Bve)_