### PR TITLE
test(e2e): follow semantic league tabs

### DIFF
--- a/tests/e2e/specs/public-league.spec.js
+++ b/tests/e2e/specs/public-league.spec.js
@@ -146,7 +146,7 @@ test.describe("public /league page", () => {
     });
 
     // On mobile (≤768px) the tab row is hidden and sections are selected
-    // via a <select> dropdown; on desktop, each tab is a <button>.
+    // via a <select> dropdown; on desktop, each ds/Tabs control is a\n    // <button role="tab">.
     //
     // This used to probe which control was live:
     //
@@ -204,7 +204,7 @@ test.describe("public /league page", () => {
         continue;
       }
       const btn = page
-        .getByRole("button", { name: label, exact: true })
+        .getByRole("tab", { name: label, exact: true })
         .first();
       if ((await btn.count()) === 0) {
         missingTabs.push(label);
@@ -249,9 +249,9 @@ test.describe("public /league page", () => {
       ).toHaveValue("awards");
     } else {
       await expect(
-        page.locator(".sub-nav-btn.active"),
-        "the active tab button must be Awards",
-      ).toHaveText("Awards");
+        page.getByRole("tab", { name: "Awards", exact: true }),
+        "the Awards tab must be selected",
+      ).toHaveAttribute("aria-selected", "true");
     }
   });
 


### PR DESCRIPTION
Fixes the production `/league` E2E regression exposed by scheduled run `34228564351`.

Root cause: the Chase Upside `/league` shell migrated from legacy `SubNav` controls (`.sub-nav-btn`, implicit button role) to `ds/Tabs`, which correctly renders `<button role="tab" aria-selected=...>`. The production page was reachable and 42 assertions passed; only the two stale tab selectors failed.

Changes:
- walk desktop league navigation by accessible `tab` role instead of `button` role;
- assert the deep-linked Awards tab via `role=tab` + `aria-selected=true` instead of `.sub-nav-btn.active`;
- keep the existing public/private endpoint isolation and all content assertions unchanged.

This is test-contract reconciliation only: no scoring, public/private boundary, API, Week 1 capture, simulation, deployment, or product methodology changes.