### PR TITLE
Fix player/pick names truncating to a few characters in Rankings rails

### DIFF
--- a/frontend/app/rankings/board.module.css
+++ b/frontend/app/rankings/board.module.css
@@ -288,8 +288,9 @@
 }
 .railItem {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: var(--space-2);
+  gap: var(--space-1) var(--space-2);
   font-size: var(--font-size-xs);
   min-width: 0;
 }
@@ -301,10 +302,14 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  /* flex item: must be allowed to shrink or the row overflows the
-     rail column (and on mobile widens the layout viewport). */
+  /* flex-basis 100% forces this onto its OWN row (flex-wrap above),
+     so the name gets the full rail-column width instead of splitting
+     it with the badge/detail that used to sit on the same line — that
+     is what was cutting names down to 6-8 characters in a 2- or
+     4-column rail on mobile. Still truncates as a safety net for a
+     genuinely long name, but now only after using all available width. */
+  flex: 1 1 100%;
   min-width: 0;
-  flex-shrink: 1;
 }
 .railName:hover {
   color: var(--accent);
@@ -315,13 +320,15 @@
   font-variant-numeric: tabular-nums;
   font-size: var(--font-size-2xs);
   color: var(--text-tertiary);
-  /* long detail strings ("Experts higher by 12") truncate rather than
-     widen the rail column past the viewport */
+  /* Shares its own row with the position badge (below the name, see
+     .railName's flex-basis: 100%), so it no longer needs to leave room
+     for the name on the same line — still capped so one long anomaly
+     string can't push the badge off the row. */
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 60%;
+  max-width: 80%;
 }
 .railEmpty {
   margin: 0;


### PR DESCRIPTION
## Summary

Reported: on mobile, `/rankings`' **Top Movers** and **Edge Summary** rails cut player/pick names down to 6-8 characters ("Joe Row…", "Odell Bec…", "Dont'e Th…") before the ellipsis, even though the rest of the name is the whole point of the widget.

## Root cause

`.railItem` (`frontend/app/rankings/board.module.css`) put the name, the position badge, and a detail string (a rank-delta arrow in Top Movers, or a descriptive phrase like `"Sell — retail 12% higher"` in Edge Summary) all on **one flex line**, with the detail allowed up to `max-width: 60%` of the row. In a narrow rail column — 2-across for Movers, 4-across collapsing to 2 on mobile for Edge Summary — that left the name, the thing a reader actually needs to identify the player, with whatever width was left over after the badge and detail took theirs.

## Fix

CSS-only. `.railItem` is now `flex-wrap: wrap`, and `.railName` gets `flex-basis: 100%`, which forces it onto its own full-width line; the badge and detail share a second, narrower line below it. No JSX or data change — same components, same backend-stamped content, just reflowed.

## Verification

Built a static repro at a 393px mobile viewport (matching the reported screenshot) reproducing the exact before/after CSS:

| Before | After |
|---|---|
| `#414 Joe Row…` | `#414 Joe Rowden` |
| `#680 Odell Bec…` | `#680 Odell Beckham` |
| `#587 Dont'e Th…` | `#587 Dont'e Thornton` |

Full names now render in the same space; only a genuinely long detail string still truncates (never the name).

- Full frontend Vitest suite: **167 files / 2,448 tests green** (no regressions — this is a CSS-only change, no component logic touched).
- `next build`: clean.
- Bundle budget check: all 14 budgeted routes green, `/rankings` unaffected (66.7 KB / 75 KB).

## Scope note

While investigating I found the same `text-overflow: ellipsis` truncation pattern used in several other files (`trade.module.css`, `trades.module.css`, `waivers.module.css`, `angle.module.css`, `conduct.module.css`). I checked the Terminal page's analogous "Movers" widget (`terminal.module.css`'s `.moverName`) since it's conceptually the same feature on a different page — it's already correctly built (the name's wrapper gets `flex: 1` with nothing else competing on its line), so no fix needed there. I didn't do a full sweep of the rest; this PR is scoped to the specific reported instance. Happy to audit the others in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2XVXQDDGr6UWEH4DvMua2

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2XVXQDDGr6UWEH4DvMua2)_