### PR TITLE
fix(retention): restore+verify game_day, the artifact its own header calls irreplaceable

### DIFF
--- a/deploy/diagnostics/retention_backup_restore_proof.sh
+++ b/deploy/diagnostics/retention_backup_restore_proof.sh
@@ -480,6 +480,16 @@ prove_dir "${DATA_DIR}/faab"              "faab"              "C1-RET-01 faab/"
 prove_dir "${DATA_DIR}/identity"          "identity"          "C1-RET-07 identity/"
 prove_dir "${DATA_DIR}/playerctx/history" "playerctx_history" "C1-RET-08 playerctx history/"
 
+# C5-GD-02: the Game Day pregame archive. riskit-state-backup.sh's own
+# header calls this "THE most irreplaceable artifact in this list" and
+# writes it (backup_dir "${DATA_DIR}/game_day", :427) — but until now
+# nothing here restored or verified it, so a backup that WROTE
+# game_day.tar.gz and a proof run that never opened it could both go
+# green while W1-03's literal bar ("restored and verified", not merely
+# written) stayed unmet. Same function, same privacy posture (counts
+# and tar integrity only, no payload) as every artifact above it.
+prove_dir "${DATA_DIR}/game_day"          "game_day"          "C5-GD-02 game_day/"
+
 log "─────────────────────────────────────────────────────────────────"
 if (( FAILURES > 0 )); then
     warn "${FAILURES} artifact(s) failed backup/restore proof"

--- a/tests/deploy/test_backup_root_resolution.py
+++ b/tests/deploy/test_backup_root_resolution.py
@@ -1077,6 +1077,31 @@ def test_a_successful_proof_reports_what_it_actually_verified(tmp_path):
     ), out
 
 
+def test_game_day_is_restored_and_verified_when_present(tmp_path):
+    """C5-GD-02 wiring, not prove_dir's own correctness (that is covered by
+    the faab/identity/playerctx cases already in this suite).
+
+    Before this, the writer (riskit-state-backup.sh) wrote
+    game_day.tar.gz into every generation while this proof never opened
+    it, so a green run asserted nothing about the artifact its own
+    header calls "THE most irreplaceable" one. A capture that landed in
+    the backup and a proof that never restored it could both go green
+    at once, which is exactly the gap the runbook warns a badge alone
+    cannot catch.
+    """
+    app, data = _app(tmp_path)
+    league_dir = data / "game_day" / "predictions" / "2026" / "dynasty_main" / "week_1"
+    league_dir.mkdir(parents=True)
+    for team_id in (1, 2, 3):
+        (league_dir / f"{team_id}_pregame.json").write_text("{}", encoding="utf-8")
+
+    result = _run_proof(app, data, tmp_path / "primary", tmp_path / "fallback")
+    out = result.stdout + result.stderr
+
+    assert result.returncode == 0, out
+    assert "C5-GD-02 game_day/: restored 3 file(s) (archive listed 3, source holds 3)" in out, out
+
+
 def test_an_unresolvable_source_is_not_a_stream_that_never_started(tmp_path):
     """ROOT-SAFE. The same ENOENT/EACCES conflation, on the artifact side.
 


### PR DESCRIPTION
## Found while executing the Wednesday W1-04/W1-03 authentic capture

The real write capture ran clean — 22 pregame snapshot files written across both leagues, evidence recorded on `WEEK_1_LAUNCH_CONTRACT.md`'s W1-04 row separately. The retention backup step then correctly wrote `data/game_day` into the generation (`dir ok: ... -> .../dirs/game_day.tar.gz`, not a `skip dir (absent)` skip).

But `deploy/diagnostics/retention_backup_restore_proof.sh`'s explicit checklist covers exactly `C1-RET-01` through `C1-RET-08`. `game_day` carries a different identifier (`C5-GD-02`, per `riskit-state-backup.sh`'s own header, which calls it *"THE most irreplaceable artifact in this list"*) and was never wired into the restore+verify loop at all.

So the backup step **wrote** `game_day.tar.gz`, and the proof step **never opened it**. Both could go green together, which is exactly the failure mode the W1-03 runbook explicitly warns a passing badge alone cannot catch — just from the other direction: the runbook worries about a silent `skip dir (absent)`; this is a silent *skip verify*.

## Fix

One additional call to the **existing** `prove_dir` function — the same one already proving `faab/`, `identity/`, `playerctx/history` — so no new logic, and the same privacy posture (tar integrity + file counts only, never payload contents, matching how `league_events.sqlite` is already handled schema/counts-only for the same reason).

```diff
+prove_dir "${DATA_DIR}/game_day"          "game_day"          "C5-GD-02 game_day/"
```

## Verification

- New test (`test_game_day_is_restored_and_verified_when_present`) wires a synthetic `game_day` tree through the *real* script via `subprocess`, asserting the restored-file-count line.
- **Mutation-proven**: reverting the `prove_dir` call sends the new test RED with the exact expected failure (falls back to reporting 1 artifact instead of the wired coverage); restored GREEN.
- Full `test_backup_root_resolution.py`: **50 passed** (up from 49), 4 skipped (environment-gated, unchanged).
- `ruff format --check`, `ruff check`, `bash -n`, decision-coercion, planning-integrity, product-plan-governance all clean.

`docs/retention/RETENTION_REGISTER.md` is deliberately untouched — it's explicitly scoped to the `C1-RET-01`…`C1-RET-08` C1A tranche manifest, and `game_day` is a different tranche (`C5-GD-02`).

Deploy-adjacent, test-only-plus-one-shell-line — no production API/data-contract surface touched.

Agent-OS-Receipt: `1d065ab778c1671c0c43dff8f088149fb3843944`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmUK5EBJvJkzX8xb3s1Bve

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmUK5EBJvJkzX8xb3s1Bve)_