### PR TITLE
fix(ci): unblock production deploy timeout on current main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,18 @@ jobs:
   validate:
     name: Validate Build Inputs
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Measured 2026-09-09: the last SUCCESSFUL deploy (run 34267910262,
+    # 2026-09-08T19:15-19:35) finished in 19m59s -- one second inside the
+    # old 20-minute budget. Every deploy since timed out mid-run (three in
+    # a row: runs 34326611988, 34326615945, 34329213659, all cut off
+    # around the 20:00 mark during or just after "Run unit tests"), which
+    # for 14+ hours looked identical to the documented queued-run eviction
+    # below and was misread as that. It wasn't: no run was queued behind
+    # any of them: it was this timeout, not concurrency, silently
+    # blocking every production deploy including fixes for this week's
+    # launch tranche. 30 minutes gives real margin above the observed
+    # ~20-minute unit-test step instead of racing it every run.
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
Fresh current-main re-derivation of #1304 after main advanced while Claude was finishing other merges.

The production deploy validate job has a 20-minute timeout. The last successful deploy finished in 19m59s, and three subsequent deploys were cut off at roughly 20 minutes before the production job could run. This ports the measured #1304 fix onto current main without dragging its stale branch history.

Change: raise only `jobs.validate.timeout-minutes` from 20 to 30 and retain the measured rationale in the workflow comment.

No application code, data contracts, scoring, frontend logic, or production behavior is changed except allowing the existing validation job enough time to complete.

Supersedes #1304 once this exact-head PR is green and merged.