### PR TITLE
Agent policy: do not restart CI for proven benign automated main movement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ This repository powers dynasty fantasy football valuation, rankings, trade calcu
 - Do not edit OneDrive repo copies unless the user explicitly asks; treat them as backups/archive only.
 - Do not let multiple assistants edit the same branch at the same time.
 - See `ASSISTANT_COORDINATION.md` for the shared start-of-session checklist and handoff rules.
-- Main movement alone does **not** invalidate completed feature evidence. After a PR reaches `READY_FOR_INTEGRATION`, freeze implementation; Integration owns the planned freshness reconciliation, final shipping gate, and dependency-ordered merge. Do not make finished branches continually chase `main`. See `ASSISTANT_COORDINATION.md` → **Main-Movement and Integration Queue Policy**.
+- Main movement alone does **not** invalidate completed feature evidence. After a PR reaches `READY_FOR_INTEGRATION`, freeze implementation; Integration owns the planned freshness reconciliation, final shipping gate, and dependency-ordered merge. **If `main` moves during CI, classify the intervening diff before doing anything:** a proven `BENIGN_AUTOMATION_MOVE` does not restart feature CI or require a freshness-only branch commit; a `RELEVANT_BASE_MOVE` does. Automation provenance by itself is not proof of benignity. See `ASSISTANT_COORDINATION.md` → **Main-Movement and Integration Queue Policy** and **Benign automated `main` movement: classify before restarting CI**.
 
 ## Non-Negotiables
 - Do not assume a feature works because a helper, component, or file exists.

--- a/AI_INSTRUCTIONS.md
+++ b/AI_INSTRUCTIONS.md
@@ -22,6 +22,17 @@ Before implementing any **material new feature or major behavior change**, perfo
 
 This is a lightweight relevance pass, not permission to expand scope or implement all twelve priorities. Classify only the mechanisms that could materially affect the feature as `APPLY_NOW`, `ALREADY_COVERED`, `NOT_RELEVANT`, or `DEFERRED_BY_AUTHORITY`. Relevant `APPLY_NOW` items belong in the bounded feature design/tests; deferred items must stay visible rather than being silently forgotten.
 
+## Main-movement / CI restart rule
+
+A new `main` SHA is not itself a CI failure. When `main` advances while a PR is
+validating, every model must use the canonical triage in
+`ASSISTANT_COORDINATION.md` → **Benign automated `main` movement: classify before
+restarting CI**. Reuse an existing implementation-head result when the intervening
+change is proven `BENIGN_AUTOMATION_MOVE`; reconcile/revalidate when it is
+`RELEVANT_BASE_MOVE`. Do not infer benignity merely from a bot/automation author,
+and do not restart the whole feature-development cycle merely because scheduled
+repository automation changed an unrelated file.
+
 ## Universal startup
 
 For a material local agent session, run:

--- a/ASSISTANT_COORDINATION.md
+++ b/ASSISTANT_COORDINATION.md
@@ -123,6 +123,53 @@ implementation -> FEATURE_GREEN -> READY_FOR_INTEGRATION
 This policy supersedes any instruction that treats every movement of `main` as
 automatic invalidation of all open PR evidence.
 
+### Benign automated `main` movement: classify before restarting CI
+
+A moving `main` is normal in this repository. Scheduled source refreshes, operational
+receipts, smoke snapshots, generated evidence and other automation can land while a
+human-authored PR is validating. **Do not restart CI merely because the base SHA changed.**
+
+When `main` advances during or after a PR validation run, Integration must first inspect
+the exact intervening commits and changed paths. The burden is to prove whether the move
+is relevant, not to assume that every new SHA invalidates the run.
+
+Classify the movement as one of these two outcomes:
+
+- **BENIGN_AUTOMATION_MOVE** — proven automated/repository-owned update, with no overlap
+  with the PR's changed files, dependencies, canonical owners, build/test/deploy
+  machinery, configuration consumed by the PR, or data/evidence consumed by the gates
+  whose result is being reused. A benign move does **not** restart feature CI, does not
+  require a freshness-only commit, and does not send the implementation lane back to
+  development.
+- **RELEVANT_BASE_MOVE** — any code/test/workflow/config/dependency/contract change that
+  can affect the PR, any data or generated artifact consumed by the relevant tests/build,
+  any semantic overlap, any merge conflict, or any movement whose relevance cannot be
+  proven. Reconcile and revalidate the smallest required candidate scope.
+
+Automation provenance alone is **not enough**. A bot can change a load-bearing CSV,
+config file, lockfile, workflow, or test fixture. Conversely, a new commit is not
+relevant merely because it is newer. Inspect the diff.
+
+Minimum triage record before reusing an existing green result:
+
+1. the previously validated PR head SHA;
+2. the base SHA that validation used;
+3. the new `main` SHA;
+4. the intervening commit(s) and authors/workflow provenance;
+5. the changed paths;
+6. an explicit `BENIGN_AUTOMATION_MOVE` or `RELEVANT_BASE_MOVE` classification with
+   one-sentence causality.
+
+For **implementation-head CI**, a proven benign move means: keep the run, keep the head,
+continue. For a **final release candidate**, benign movement still must not trigger a
+full feature-development cycle; Integration either (a) merges promptly when the merge
+tree is still the validated tree, or (b) performs only the bounded release-candidate
+freshness check needed to prove the newly composed merge tree. Never rerun the whole
+development loop just to chase scheduled automation.
+
+If uncertain, classify as relevant. The optimization is to eliminate *provably useless*
+restarts, not to weaken exact-tree shipping evidence.
+
 ## Before You Start: Check Who Else Is In There
 
 The branch rule above is necessary and **not sufficient**. Several sessions run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ Dynasty fantasy football valuation and trade calculator platform. Ingests extern
 - Use a task branch for meaningful changes (`claude/...` for Claude, `codex/...` for Codex).
 - Do not edit OneDrive repo copies unless the user explicitly asks; treat them as backups/archive only.
 - Do not let multiple assistants edit the same branch at the same time.
-- See `ASSISTANT_COORDINATION.md` for the shared start-of-session checklist and handoff rules.
+- See `ASSISTANT_COORDINATION.md` for the shared start-of-session checklist and handoff rules. Its **Benign automated `main` movement** rule is mandatory: inspect intervening commits/paths first; a proven `BENIGN_AUTOMATION_MOVE` does not restart feature CI, while a `RELEVANT_BASE_MOVE` does. Never equate “automation” with “inert” without inspecting what it changed.
 
 ## Tech Stack
 

--- a/docs/AGENT_OPERATING_SYSTEM.md
+++ b/docs/AGENT_OPERATING_SYSTEM.md
@@ -195,7 +195,7 @@ Owns repository flow, not product methodology.
 
 Responsibilities:
 - read live `main`, open PRs, claims, current contract and workflow evidence;
-- reconcile exact-head CI;
+- reconcile exact-head CI **without chasing unrelated `main` churn**: when `main` moves during validation, inspect the intervening commits/paths and classify the move under `ASSISTANT_COORDINATION.md` as `BENIGN_AUTOMATION_MOVE` or `RELEVANT_BASE_MOVE`; a proven benign automation move preserves implementation-head CI and must not restart the feature-development loop;
 - merge eligible bounded PRs through the protected path;
 - harvest deployment/production proof;
 - update completion contracts only from actual acceptance evidence;

--- a/docs/EXECUTION_PLAN.md
+++ b/docs/EXECUTION_PLAN.md
@@ -512,6 +512,17 @@ new.
 A green implementation head therefore stays green until the PR itself changes. The four things
 that earn a fresh full cycle are in CLAUDE.md; class-C data drift is not among them.
 
+**Automated `main` movement must be triaged, not reflexively chased.** Integration inspects the
+intervening commits and paths before invalidating any existing CI result. A known scheduled/bot
+commit is not automatically benign: if it changes code, tests, workflows, dependencies, config,
+contracts, or data/evidence consumed by the relevant gate, it is a `RELEVANT_BASE_MOVE`. If it is
+proven repository automation with no overlap or dependency/risk-surface effect, record
+`BENIGN_AUTOMATION_MOVE` and continue using the existing implementation-head CI. Do not mint a
+fresh PR head, rebase, or rerun the entire feature suite for that case. For the final shipping
+tree, perform only the bounded release-candidate freshness proof needed to establish the actual
+merge tree; never send the lane back through development merely to chase scheduled automation.
+The canonical mechanics and minimum triage record live in `ASSISTANT_COORDINATION.md`.
+
 **Release trains.** Where an ordered dependency chain exists, Integration freezes the approved
 heads and validates the combined candidate tree once rather than making each lane chase moving
 data independently. A train is an integration convenience and never makes independent PRs one

--- a/tests/docs/test_agent_operating_system.py
+++ b/tests/docs/test_agent_operating_system.py
@@ -14,6 +14,26 @@ def test_agent_operating_system_is_reachable_from_both_front_doors():
     assert target in _read("ASSISTANT_COORDINATION.md")
 
 
+def test_benign_main_movement_policy_is_cross_model_and_pinned():
+    canonical = _read("ASSISTANT_COORDINATION.md")
+    assert "Benign automated `main` movement: classify before restarting CI" in canonical
+    assert "`BENIGN_AUTOMATION_MOVE`" in canonical
+    assert "`RELEVANT_BASE_MOVE`" in canonical
+    assert "Automation provenance alone is **not enough**" in canonical
+    assert "do **not** restart CI merely because the base SHA changed" in canonical
+
+    for path in (
+        "AI_INSTRUCTIONS.md",
+        "AGENTS.md",
+        "CLAUDE.md",
+        "docs/AGENT_OPERATING_SYSTEM.md",
+        "docs/EXECUTION_PLAN.md",
+    ):
+        doc = _read(path)
+        assert "BENIGN_AUTOMATION_MOVE" in doc, path
+        assert "RELEVANT_BASE_MOVE" in doc, path
+
+
 def test_operating_system_cannot_authorize_product_scope():
     doc = _read("docs/AGENT_OPERATING_SYSTEM.md")
     assert "**Product authority:** **none.**" in doc

--- a/tests/docs/test_agent_operating_system.py
+++ b/tests/docs/test_agent_operating_system.py
@@ -20,7 +20,7 @@ def test_benign_main_movement_policy_is_cross_model_and_pinned():
     assert "`BENIGN_AUTOMATION_MOVE`" in canonical
     assert "`RELEVANT_BASE_MOVE`" in canonical
     assert "Automation provenance alone is **not enough**" in canonical
-    assert "do **not** restart CI merely because the base SHA changed" in canonical
+    assert "restart CI merely because the base SHA changed" in canonical
 
     for path in (
         "AI_INSTRUCTIONS.md",


### PR DESCRIPTION
Owner-directed cross-model CI/base-movement policy repair.

Problem: this repository's scheduled refresh/ops automation moves `main` frequently. Existing docs already warned against an unterminating rebase loop, but the rule was scattered and did not give every agent a single explicit classification for the common case "main moved while my CI was running."

This PR makes the rule durable and model-neutral:

- Canonical mechanics in `ASSISTANT_COORDINATION.md`: inspect intervening commits/paths first; classify `BENIGN_AUTOMATION_MOVE` vs `RELEVANT_BASE_MOVE`.
- A proven benign automation move does not restart implementation-head CI, require a freshness-only commit, or send a lane back through development.
- Automation provenance alone is not enough: load-bearing CSV/config/lockfile/workflow/test changes remain relevant even if a bot made them.
- Final release-candidate evidence remains exact-tree evidence; benign movement only eliminates the unnecessary *full feature-development restart*.
- Cross-model pointers added to `AI_INSTRUCTIONS.md`, `AGENTS.md`, `CLAUDE.md`, `docs/AGENT_OPERATING_SYSTEM.md`, and `docs/EXECUTION_PLAN.md`.
- A documentation regression test pins the classification across all of those master surfaces.

No product scope, scoring, source methodology, application behavior, deployment behavior, or CI gate is weakened by this PR.