### PR TITLE
Week 1: production proof triggers on current main

### DIFF
--- a/.github/workflows/retention-backup-proof.yml
+++ b/.github/workflows/retention-backup-proof.yml
@@ -25,6 +25,14 @@ name: Retention backup + restore proof
 # manager name or roster reaches this log.
 
 on:
+  # TEMP Week-1 proof bridge: run this existing restore/verify instrument
+  # after a successful main deployment so C5-GD-02 can be proven on the
+  # deployed #1302 script. Remove after W1-03 evidence is recorded.
+  workflow_run:
+    workflows:
+      - Deploy Production
+    types:
+      - completed
   workflow_dispatch:
     inputs:
       run_backup:
@@ -49,6 +57,10 @@ concurrency:
 jobs:
   prove:
     name: Backup, restore, verify
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' ||
+          (github.event.workflow_run.conclusion == 'success' &&
+           github.event.workflow_run.head_branch == 'main') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: production
@@ -78,7 +90,7 @@ jobs:
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           APP_DIR: ${{ vars.PROD_APP_DIR || '/home/dynasty/trade-calculator' }}
           PYTHON_BIN: ${{ vars.PROD_PYTHON_BIN || '/home/dynasty/.venvs/trade-calculator/bin/python' }}
-          RUN_BACKUP: ${{ inputs.run_backup == false && '0' || '1' }}
+          RUN_BACKUP: ${{ github.event_name == 'workflow_dispatch' && inputs.run_backup == false && '0' || '1' }}
         shell: bash
         run: |
           set -Eeuo pipefail

--- a/.github/workflows/v1-authenticated-verification.yml
+++ b/.github/workflows/v1-authenticated-verification.yml
@@ -31,6 +31,14 @@ name: V1 Authenticated Production Verification (ephemeral guest session)
 # not exist here and is not being created.
 
 on:
+  # TEMP Week-1 proof bridge: run the existing verification instrument
+  # after a successful main deployment. Remove this workflow_run trigger
+  # once W1-30 evidence is recorded; workflow_dispatch remains canonical.
+  workflow_run:
+    workflows:
+      - Deploy Production
+    types:
+      - completed
   workflow_dispatch:
     inputs:
       league:
@@ -60,6 +68,10 @@ concurrency:
 jobs:
   v1-authenticated:
     name: V1 authenticated verification
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' ||
+          (github.event.workflow_run.conclusion == 'success' &&
+           github.event.workflow_run.head_branch == 'main') }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     environment: production
@@ -101,7 +113,7 @@ jobs:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           APP_DIR: ${{ vars.PROD_APP_DIR || '/home/dynasty/trade-calculator' }}
-          PASS_HOURS: ${{ inputs.pass_hours }}
+          PASS_HOURS: ${{ inputs.pass_hours || '2' }}
           RUN_ID: ${{ github.run_id }}
         shell: bash
         run: |
@@ -152,7 +164,7 @@ jobs:
         id: login
         shell: bash
         env:
-          PASS_HOURS: ${{ inputs.pass_hours }}
+          PASS_HOURS: ${{ inputs.pass_hours || '2' }}
         run: |
           set -Eeuo pipefail
           BODY=$(python3 - "$ORIGIN" "$RUNNER_TEMP/guest_pass_token" <<'PYEOF'
@@ -200,8 +212,8 @@ jobs:
         id: api
         shell: bash
         env:
-          LEAGUE: ${{ inputs.league }}
-          PASS_HOURS: ${{ inputs.pass_hours }}
+          LEAGUE: ${{ inputs.league || 'dynasty_main' }}
+          PASS_HOURS: ${{ inputs.pass_hours || '2' }}
           EXPIRES_EPOCH: ${{ steps.login.outputs.expires_epoch }}
         run: |
           set -Eeuo pipefail
@@ -221,7 +233,7 @@ jobs:
         id: lane4
         shell: bash
         env:
-          LEAGUE: ${{ inputs.league }}
+          LEAGUE: ${{ inputs.league || 'dynasty_main' }}
         run: |
           set -Eeuo pipefail
           export RISKIT_SESSION_COOKIE="jason_session=$(cat "$RUNNER_TEMP/session_cookie")"


### PR DESCRIPTION
Fresh current-main re-derivation of #1307 after the deploy-timeout repair changed the upstream `Deploy Production` workflow while #1307 was validating. The #1307 implementation itself was green (PR Validation run 34336261828); this replacement ports the identical two workflow changes onto current main so the final merge candidate includes the now-30-minute deploy workflow. No verification/test logic changed. Supersedes #1307 when green and merged.