### PR TITLE
FAAB Stage 1: enable shadow comparison logging on current main

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ snapshots). This line said "Private repo" while `SECURITY.md` and
   Sleeper-login allowlist; public routes hit `/api/public/league/*`.
 - **Feature flags** (`src/api/feature_flags.py`): every new
   capability from the 2026-04 upgrade ships flag-gated. Defaults are
-  **per-flag**: 9 of the 20 in `_DEFAULTS` ship enabled (`ledger_rank_change`, `bdvm_engine`,
+  **per-flag**: 10 of the 20 in `_DEFAULTS` ship enabled (`ledger_rank_change`, `bdvm_engine`,
   `te_basis_conversion`, `monte_carlo_trade`, `idp_scoring_fit`,
   `reception_scoring_fit`, `nfl_data_ingest`, `realized_points_api`,
-  `perfect_draft`),
+  `perfect_draft`, `waiver_live_opportunity`),
   several deliberately. For those the env var is a rollback lever, not an
   opt-in. Read `_DEFAULTS` before assuming a capability is dormant.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,13 +26,14 @@ Browser ─► Nginx ─► Next.js (port 3000) ─► FastAPI (port 8000) ─�
    `src/api/feature_flags.py`. Env override via `RISKIT_FEATURE_<NAME>=1`
    (or `=0` to disable).
 
-   **Defaults are per-flag.** As of 2026-08-25, 9 of the 20 entries in
+   **Defaults are per-flag.** As of 2026-09-09, 10 of the 20 entries in
    `_DEFAULTS` ship enabled — `ledger_rank_change` (registered closing
    F-24: the ledger-derived `rankChange` derivation, previously an
    invisible direct env read), `bdvm_engine`, `te_basis_conversion`
    (which reprices every tight end on the live board),
    `monte_carlo_trade`, `idp_scoring_fit`, `reception_scoring_fit`,
-   `nfl_data_ingest`, `realized_points_api`, `perfect_draft` — several
+   `nfl_data_ingest`, `realized_points_api`, `perfect_draft`,
+   `waiver_live_opportunity` (shadow-only; response remains canonical-only) — several
    with comments
    recording that the enabled default is deliberate. For those, the env
    var is a rollback lever rather than an opt-in.

--- a/docs/faab-live-opportunity-model.md
+++ b/docs/faab-live-opportunity-model.md
@@ -220,15 +220,13 @@ invariant ("evaluation is not activation, nothing self-promotes"), promotion
 is a staged, criteria-gated, human-reviewed process, not a flag flip on
 completion of the code:
 
-- **Stage 0 (current state).** `waiver_live_opportunity` defaults off in
-  production. Nothing changes for a live user.
-- **Stage 1 — turn on shadow logging in production.** Flip the flag on (via
-  the per-process env-var override this codebase already uses for
-  script-only/shadow features, matching the `bdvm_engine` precedent) and
-  restart. This requires deploy access this development session does not
-  have (see the follow-up report's production-verification section) — it is
-  a named action item for whoever operates the deploy, not something claimed
-  done here.
+- **Stage 0 — scaffold complete.** The opportunity layer exists but remains
+  prohibited from changing the live recommendation.
+- **Stage 1 — shadow logging on by default.** CURRENT once this change is
+  deployed: `waiver_live_opportunity` defaults on so production accumulates
+  shadow comparisons without a separate env-var flip. The live response still
+  reads the canonical-only value; Stage 1 is observation, not promotion.
+  Rollback is `RISKIT_FEATURE_WAIVER_LIVE_OPPORTUNITY=0` + restart.
 - **Stage 2 — accumulation window.** No review is meaningful on a thin
   sample. Minimum bar before Stage 3 runs: **N ≥ 200** logged rows in
   `data/faab/shadow_comparisons_<leagueKey>.json`, spanning **at least one**
@@ -262,7 +260,7 @@ completion of the code:
   already established for exactly this "challenger evaluated, human
   approved, promote" sequence rather than inventing a second one.
 
-None of Stages 1-5 are executed by the 2026-09-01 follow-up work — that work
+Stage 1 is executed by the current default-on shadow rollout; Stages 2-5 remain evidence-gated. The 2026-09-01 follow-up work
 fixed the `/waivers` frontend bug (see the FAAB redesign report addendum,
 `docs/faab-redesign-2026-09-01-report.md`) and left the shadow layer's status
 otherwise unchanged. This section exists so "when does this become live" has

--- a/src/api/feature_flags.py
+++ b/src/api/feature_flags.py
@@ -9,11 +9,11 @@ enabled.**  This docstring, ``README.md`` and ``docs/ARCHITECTURE.md``
 all used to assert a blanket disabled-by-default rule, and
 ARCHITECTURE built a stronger claim on top of it about production
 behaviour being frozen until a flag was flipped.  Both were false:
-9 of the 20 entries in ``_DEFAULTS`` below are ``True`` —
+10 of the 20 entries in ``_DEFAULTS`` below are ``True`` —
 ``bdvm_engine``, ``te_basis_conversion`` (which reprices every tight
 end on the live board), ``monte_carlo_trade``, ``idp_scoring_fit``,
 ``reception_scoring_fit``, ``nfl_data_ingest``, ``realized_points_api``,
-``perfect_draft`` and ``ledger_rank_change`` — several with comments
+``perfect_draft``, ``ledger_rank_change`` and ``waiver_live_opportunity`` — several with comments
 recording that the enabled default is deliberate.
 
 **No live gate sits outside this registry any more.**  The last one —
@@ -406,7 +406,13 @@ _DEFAULTS: Final[dict[str, bool]] = {
     # above: evaluation is not activation.  Promotion to the live bid is
     # a separate, later, human-reviewed step once the shadow log gives
     # outcome evidence — never automatic.
-    "waiver_live_opportunity": False,
+    #
+    # Stage 1 activation (owner-directed): default ON only to accumulate
+    # shadow comparisons automatically. The response path remains pinned
+    # to the canonical-only value; this flag does not promote the
+    # challenger into a live recommendation. Roll back with
+    # RISKIT_FEATURE_WAIVER_LIVE_OPPORTUNITY=0 + restart.
+    "waiver_live_opportunity": True,
 }
 
 _ENV_PREFIX: Final[str] = "RISKIT_FEATURE_"

--- a/tests/api/test_faab_recommend_endpoint.py
+++ b/tests/api/test_faab_recommend_endpoint.py
@@ -948,10 +948,10 @@ def test_a_proven_te_premium_is_read_from_the_card_not_the_label(faab_env, monke
 # the live response — evaluation is not activation.
 
 
-def test_shadow_flag_off_by_default_and_response_unaffected(faab_env, monkeypatch):
+def test_shadow_flag_default_computes_but_response_still_ok(faab_env, monkeypatch):
     from src.api import feature_flags
 
-    assert feature_flags.is_enabled("waiver_live_opportunity") is False
+    assert feature_flags.is_enabled("waiver_live_opportunity") is True
     with TestClient(server.app) as c:
         res = _post(c, monkeypatch, {"addPlayerName": "Hot Pickup"})
     assert res.status_code == 200

--- a/tests/api/test_feature_flags.py
+++ b/tests/api/test_feature_flags.py
@@ -72,6 +72,10 @@ def test_every_flag_defaults_off_except_safe_additive():
         # model as a live code path.
         # Rollback: RISKIT_FEATURE_PERFECT_DRAFT=0 + restart.
         "perfect_draft",
+        # Stage 1 FAAB opportunity rollout: additive shadow computation only.
+        # The live response remains canonical-only; endpoint coverage pins
+        # byte-equivalence across flag states.
+        "waiver_live_opportunity",
     }
     # Flags that default ON and KNOWINGLY change output.  Deliberately a
     # separate set from ``safe_on``: every member of that one is there


### PR DESCRIPTION
Fresh current-main re-derivation of #1217. This keeps the useful behavior and drops stale historical-report churn: `waiver_live_opportunity` defaults ON only for shadow comparison accumulation; the live FAAB response remains canonical-only and existing endpoint coverage pins byte-equivalence across flag states. Includes rollback documentation and cross-doc feature-flag default parity. No promotion of opportunity value into user-facing bids.