### PR TITLE
Week 1: harden production verifier and post-deploy proof path

### DIFF
--- a/.github/workflows/v1-authenticated-verification.yml
+++ b/.github/workflows/v1-authenticated-verification.yml
@@ -208,7 +208,10 @@ jobs:
           fi
 
       - name: API verification suite
-        if: ${{ inputs.suite != 'browser' }}
+        # The temporary post-deploy Week 1 bridge needs the prod-auth browser
+        # artifact for W1-30; API/Lane-4 rows are already independently
+        # VERIFIED. Manual dispatch semantics stay unchanged.
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.suite != 'browser' }}
         id: api
         shell: bash
         env:
@@ -229,7 +232,7 @@ jobs:
           echo "API suite exit: $rc (0 pass · 2 fail · 3 proved nothing)"
 
       - name: Lane 4 remote verification (C1-C3 + C8/C9)
-        if: ${{ inputs.suite != 'browser' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.suite != 'browser' }}
         id: lane4
         shell: bash
         env:
@@ -252,7 +255,7 @@ jobs:
           echo "Lane 4 remote exit: $rc"
 
       - name: Browser verification suite (prod-auth Playwright specs)
-        if: ${{ inputs.suite != 'api' && hashFiles('tests/e2e/prod-auth.config.js') != '' }}
+        if: ${{ (github.event_name == 'workflow_run' || inputs.suite != 'api') && hashFiles('tests/e2e/prod-auth.config.js') != '' }}
         id: browser
         shell: bash
         env:

--- a/tests/e2e/specs/prod-auth/v1-123-source-disagreement.spec.js
+++ b/tests/e2e/specs/prod-auth/v1-123-source-disagreement.spec.js
@@ -33,9 +33,12 @@ test.describe("V1-123 Phase 2: Source Disagreement /edge (production)", () => {
     await agreementTab.click();
     const agreementPanel = page.getByRole("tabpanel", { name: "Agreement" });
     await expect(agreementPanel).toBeVisible({ timeout: 15_000 });
-    await expect(agreementPanel.getByText("Consensus assets", { exact: false })).toBeVisible({
-      timeout: 15_000,
-    });
+    // The title text also appears in the panel's InfoTip accessible label,
+    // so a broad text locator resolves twice under Playwright strict mode.
+    // The section heading is the semantic target this check actually means.
+    await expect(
+      agreementPanel.getByRole("heading", { name: /^Consensus assets/ }),
+    ).toBeVisible({ timeout: 15_000 });
 
     const cautionTab = page.getByRole("tab", { name: "Data caution" });
     await cautionTab.click();

--- a/tests/e2e/specs/prod-auth/v1-123-team-strength.spec.js
+++ b/tests/e2e/specs/prod-auth/v1-123-team-strength.spec.js
@@ -40,8 +40,14 @@ test.describe("V1-123 Phase 2: Team Strength/Weakness tab (production)", () => {
       expect(rowCount, "ROS team strength table rendered with no rows").toBeGreaterThan(0);
 
       // Row click expands an inline detail row (starting lineup / bench depth).
-      await rows.first().click();
-      await expect(page.getByText(/Starting lineup/i)).toBeVisible({ timeout: 15_000 });
+      // The page-level methodology copy also says "starting lineup", so scope
+      // the assertion to the detail row inserted immediately after the team.
+      const firstRow = rows.first();
+      await firstRow.click();
+      const detailRow = firstRow.locator("xpath=following-sibling::tr[1]");
+      await expect(
+        detailRow.locator("strong").filter({ hasText: /^Starting lineup \(/ }),
+      ).toBeVisible({ timeout: 15_000 });
 
       annotate(testInfo, "states-observed", `ros-team-strength: populated (${rowCount} teams)`);
     } else {

--- a/tests/e2e/specs/prod-auth/v1-62-sharp-tracker.spec.js
+++ b/tests/e2e/specs/prod-auth/v1-62-sharp-tracker.spec.js
@@ -89,11 +89,15 @@ test.describe("V1-62: /market/sharp-tracker renders /api/sharp/market from the p
     // [note]</div>; locate the label text node then step up to its
     // wrapper (xpath=..) so the value sibling is unambiguous, rather than
     // matching every ancestor div that merely CONTAINS the label.
+    // StatTile's canonical markup uses ds-stat__label/value. The old
+    // selector still targeted the pre-design-system ".muted" label and
+    // therefore found no element even though the Assets tile was rendered.
     const assetsTile = page
-      .locator(".muted", { hasText: /^Assets$/ })
+      .locator(".ds-stat__label")
+      .filter({ hasText: /^Assets$/ })
       .locator("xpath=..");
     await expect(
-      assetsTile.locator("div").nth(1),
+      assetsTile.locator(".ds-stat__value"),
       `the rendered Assets tile must equal the response's own filtered ` +
         `asset count (${expectedAssets.length})`,
     ).toHaveText(expectedAssets.length.toLocaleString());

--- a/tests/e2e/specs/prod-auth/w1-16-game-day.spec.js
+++ b/tests/e2e/specs/prod-auth/w1-16-game-day.spec.js
@@ -144,9 +144,16 @@ test.describe("W1-16: the owner's Game Day experience (production)", () => {
     // state on both viewports (3.0s/5.4s total — fast, but not zero). Wait
     // for the loading state to clear, same pattern this suite already uses
     // for other client-fetched panels (v1-123-public-league-matrix.spec.js).
+    // Wait for positive evidence that the client-side request completed.
+    // Waiting only for the *absence* of the loading copy is racy: immediately
+    // after navigation React may not have mounted GameDayPanel yet, so the
+    // loading string is absent for one frame and that negative predicate
+    // returns true before the request even starts. Production run 39 caught
+    // exactly that state on both viewports. The endpoint's own team identity
+    // is a stronger terminal signal and is required by this assertion anyway.
     await page.waitForFunction(
-      () => !document.body.innerText.includes("Loading this week's matchup"),
-      null,
+      (teamName) => document.body.innerText.includes(teamName),
+      body.team.displayName,
       { timeout: 90_000 },
     );
     const text = await page.locator("body").innerText();


### PR DESCRIPTION
W1-30 production-proof reliability repair, driven by authenticated production run 34344782053.

That run exposed four unexpected browser-verifier failures. This PR fixes the verifier where the current production UI is already truthful; it does not weaken any product or Week 1 acceptance criterion.

1. **Game Day load race**
   - Old test waited for the loading copy to be absent, which can be true for one frame before React mounts the panel.
   - New test waits for positive terminal evidence: the endpoint's own `body.team.displayName` must appear before field-for-field assertions.

2. **Source Disagreement strict-mode ambiguity**
   - "Consensus assets" appears both as the panel title and InfoTip accessible text.
   - The test now targets the semantic panel heading.

3. **ROS Team Strength strict-mode ambiguity**
   - Page methodology copy and the expanded row both contain "starting lineup".
   - The test now scopes to the detail row inserted immediately after the clicked team and its `strong` label.

4. **Sharp Tracker design-system selector drift**
   - Production uses canonical `StatTile` markup (`.ds-stat__label` / `.ds-stat__value`); the old test still looked for the retired `.muted` stat label.
   - The test now reads the actual canonical StatTile elements and still requires the rendered count to equal the page's own API response.

**Temporary Week 1 automation efficiency**
The post-deploy `workflow_run` bridge now runs the prod-auth **browser suite only**. W1-30's final acceptance is the browser artifact, while API/Lane-4 launch rows are already independently VERIFIED. Manual `workflow_dispatch` remains completely unchanged: operators can still select `api`, `browser`, or `all`, with `all` still the default.

The verdict owner already treats skipped-suite outputs as absent, never as passes, so this does not fabricate a green result.

No production page behavior, scoring, valuation, auth semantics, or Week 1 denominator/criteria are changed.