### PR TITLE
URGENT: recover canonical rankings from collapsed runtime cache

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -59,11 +59,15 @@ jobs:
     # 20 → 30 (2026-08-25): the suite legitimately grew past the old
     # ceiling — ten green runs that day measured 12.5-19.5 minutes, and
     # TWO runs were killed at exactly ~20m ("cancelled", which reads
-    # like a supersede and cost an hour of diagnosis each time). 30
-    # keeps a real hang detectable while leaving headroom for a suite
-    # that adds tests every merge. This bounds WALL CLOCK only — no
-    # test, gate or tolerance is affected.
-    timeout-minutes: 30
+    # like a supersede and cost an hour of diagnosis each time).
+    #
+    # 30 → 60 (2026-09-09): PR #1321 was killed at the 30-minute wall-clock
+    # ceiling while the blocking pure-logic suite was still progressing
+    # normally (~41%), causing every later blocking gate to be skipped.
+    # This changes only runner headroom; no test, gate, or tolerance is
+    # weakened. Sixty minutes preserves a finite hang bound while allowing
+    # the current full suite to complete.
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/scripts/verify_live_source_coverage.py
+++ b/scripts/verify_live_source_coverage.py
@@ -113,9 +113,7 @@ def _coverage_result(status: dict):
 
 def _recovering_scrape(status: dict) -> bool:
     """True only for an active scrape that still has a chance to republish."""
-    return bool(status.get("running")) and not bool(
-        status.get("stalled") or status.get("hung")
-    )
+    return bool(status.get("running")) and not bool(status.get("stalled") or status.get("hung"))
 
 
 def _print_coverage_failure(violations) -> None:

--- a/scripts/verify_live_source_coverage.py
+++ b/scripts/verify_live_source_coverage.py
@@ -57,6 +57,17 @@ _ATTEMPTS = 6
 _SLEEP_SECONDS = 5
 _TIMEOUT_SECONDS = 20
 
+# A backend restart deliberately launches the startup scrape three seconds
+# after the cached board is primed. The served board can therefore be
+# temporarily behind the fresh checkout CSVs while that scrape is still
+# rebuilding the canonical contract. A one-shot coverage check turned that
+# recovery window into a deploy failure and triggered rollback while the
+# process was still recovering. Retry ONLY while the server reports an
+# active, non-stalled scrape. Idle/stalled degradation still fails
+# immediately. 61 x 5s = at most five minutes of bounded recovery time.
+_COVERAGE_WAIT_ATTEMPTS = 61
+_COVERAGE_WAIT_SLEEP_SECONDS = 5
+
 
 def _fetch_status(base_url: str) -> dict | None:
     """GET ``<base>/api/status`` with retries (tolerates the brief
@@ -84,6 +95,49 @@ def _fetch_status(base_url: str) -> dict | None:
     return None
 
 
+def _coverage_result(status: dict):
+    """Evaluate one /api/status payload against checkout freshness truth.
+
+    Returns (violations, ok, skipped). violations=None means the server
+    has not published a served_source_coverage map yet.
+    """
+    cov = status.get("served_source_coverage")
+    if not isinstance(cov, dict) or not cov:
+        return None, [], []
+
+    cov_int = {str(k): int(v) for k, v in cov.items()}
+    freshness = _read_freshness()
+    thresholds = load_thresholds()
+    return evaluate_coverage_map(cov_int, freshness, thresholds)
+
+
+def _recovering_scrape(status: dict) -> bool:
+    """True only for an active scrape that still has a chance to republish."""
+    return bool(status.get("running")) and not bool(
+        status.get("stalled") or status.get("hung")
+    )
+
+
+def _print_coverage_failure(violations) -> None:
+    if violations is None:
+        print(
+            "::error title=Degraded board::/api/status reported no "
+            "served_source_coverage — the live board is not enriched "
+            "(serving the bare legacy export, not the full registered-source "
+            "blend)."
+        )
+        return
+
+    for key, count in violations:
+        print(
+            f"::error title=Source absent from LIVE board: {key}::"
+            f"{key} is fresh in the checkout but only {count} player(s) "
+            f"carry it in the SERVED board (/api/status "
+            f"served_source_coverage). The live process is serving a "
+            f"degraded board."
+        )
+
+
 def main() -> int:
     base_url = (
         sys.argv[1] if len(sys.argv) > 1 else os.environ.get("DEPLOY_VERIFY_BASE_URL", "")
@@ -95,50 +149,62 @@ def main() -> int:
         )
         return 1
 
-    status = _fetch_status(base_url)
-    if status is None:
-        return 1
+    last_status: dict = {}
+    last_violations = None
+    for coverage_attempt in range(1, _COVERAGE_WAIT_ATTEMPTS + 1):
+        status = _fetch_status(base_url)
+        if status is None:
+            return 1
+        last_status = status
 
-    cov = status.get("served_source_coverage")
-    if not isinstance(cov, dict) or not cov:
-        # Empty/absent == the served board carries no per-source
-        # coverage == degraded (or a server too old to expose it,
-        # which post-deploy is itself the regression).
+        violations, ok, skipped = _coverage_result(status)
+        last_violations = violations
+        if violations == []:
+            print(
+                f"ok: live board carries {len(ok)} registered source(s); "
+                f"0 fresh-but-absent ({len(skipped)} skipped: stale/empty)"
+            )
+            return 0
+
+        if not _recovering_scrape(status):
+            break
+
+        if coverage_attempt < _COVERAGE_WAIT_ATTEMPTS:
+            missing_label = (
+                "coverage map not published yet"
+                if violations is None
+                else f"{len(violations)} fresh source(s) not yet republished"
+            )
+            print(
+                f"recovery {coverage_attempt}/{_COVERAGE_WAIT_ATTEMPTS}: "
+                f"{missing_label}; startup/scheduled scrape is still active "
+                f"(step={status.get('current_step')!r}, "
+                f"source={status.get('current_source')!r}). "
+                f"Waiting {_COVERAGE_WAIT_SLEEP_SECONDS}s before re-check."
+            )
+            time.sleep(_COVERAGE_WAIT_SLEEP_SECONDS)
+
+    _print_coverage_failure(last_violations)
+    if last_violations is None:
         print(
-            "::error title=Degraded board::/api/status reported no "
-            "served_source_coverage — the live board is not enriched "
-            "(serving the bare legacy export, not the ~11-source "
-            "blend).  The process did not re-prime from the CSVs."
+            "\nfail: served board never published source coverage after the "
+            "bounded recovery window."
         )
-        return 1
-
-    cov_int = {str(k): int(v) for k, v in cov.items()}
-    freshness = _read_freshness()
-    thresholds = load_thresholds()
-    violations, ok, skipped = evaluate_coverage_map(cov_int, freshness, thresholds)
-
-    if not violations:
+    else:
         print(
-            f"ok: live board carries {len(ok)} registered source(s); "
-            f"0 fresh-but-absent ({len(skipped)} skipped: stale/empty)"
+            f"\nfail: {len(last_violations)} fresh source(s) missing from the "
+            f"LIVE board: {', '.join(k for k, _ in last_violations)}"
         )
-        return 0
-
-    for key, c in violations:
+    if _recovering_scrape(last_status):
         print(
-            f"::error title=Source absent from LIVE board: {key}::"
-            f"{key} is fresh in the checkout but only {c} player(s) "
-            f"carry it in the SERVED board (/api/status "
-            f"served_source_coverage).  The live process is serving a "
-            f"degraded board — it did not re-prime / enrich.  A "
-            f"`systemctl restart {os.environ.get('SERVICE_NAME', 'dynasty')}` "
-            f"on the host forces a re-prime; investigate why the deploy "
-            f"restart didn't take."
+            "The scrape remained active for the entire bounded recovery "
+            "window; refusing to call this deployment healthy."
         )
-    print(
-        f"\nfail: {len(violations)} fresh source(s) missing from the "
-        f"LIVE board: {', '.join(k for k, _ in violations)}"
-    )
+    else:
+        print(
+            "The board is degraded while no recoverable scrape is active; "
+            "failing immediately instead of hiding a persistent source loss."
+        )
     return 1
 
 

--- a/server.py
+++ b/server.py
@@ -97,7 +97,11 @@ PORT = 8000
 HOST = "0.0.0.0"  # accessible from local network; use "127.0.0.1" for local only
 SCRAPE_STALL_SECONDS = int(os.getenv("SCRAPE_STALL_SECONDS", "900"))
 SCRAPE_RUN_TIMEOUT_SECONDS = int(os.getenv("SCRAPE_RUN_TIMEOUT_SECONDS", "7200"))
-# A single market/source outage must not halve the player universe and become\n# the new last-known-good cache. Relative to the prior/committed board, retain\n# at least 75% of the player population or fail over/block promotion.\nSCRAPE_PLAYER_RETENTION_FLOOR = 0.75\n# The async scraper launches a Playwright Chromium without a try/finally,
+# A single market/source outage must not halve the player universe and become
+# the new last-known-good cache. Relative to the prior/committed board, retain
+# at least 75% of the player population or fail over/block promotion.
+SCRAPE_PLAYER_RETENTION_FLOOR = 0.75
+# The async scraper launches a Playwright Chromium without a try/finally,
 # so a run-timeout cancellation skips browser.close() and orphans the
 # Chromium process tree → RAM leak across repeated 2h timeouts → OOM.
 # A single scrape_run_lock guarantees that once the scrape coroutine has

--- a/server.py
+++ b/server.py
@@ -2800,21 +2800,33 @@ async def run_scraper(trigger: str = "manual") -> dict | None:
             if not result or not result.get("players"):
                 raise RuntimeError("Scraper returned empty result")
 
-            # Mirror fresh site_raw CSVs from the scraper's DATA_DIR output
-            # path (data/exports/latest/site_raw/) back to the repo's
-            # tracked CSVs/site_raw/ directory so that the CSV
-            # enrichment in data_contract.py (which reads relative to repo
-            # root) sees up-to-date values.  Without this, enrichment reads
-            # permanently-stale CSVs from git history.  Only copies KTC and
-            # IDPTradeCalc — DLF is a rank-signal file with a different
-            # format maintained separately.
+            # Mirror fresh scraper-owned site_raw CSVs from the DATA_DIR
+            # output path (data/exports/latest/site_raw/) back to the repo's
+            # tracked CSVs/site_raw/ directory before the canonical contract
+            # rebuild. data_contract.py reads the repo-root copies.
+            #
+            # IMPORTANT: KTC became a three-source family in September 2026.
+            # Mirroring only the legacy ktc.csv left the running scraper and
+            # the canonical voter on different generations: the scraper had
+            # fresh Crowd / Trades / Crowd+Trades files under DATA_DIR while
+            # the contract could still read an older ktcCrowdTradesSfTep.csv
+            # from the checkout. Keep the complete scraper-owned family
+            # together. DLF and other rank fetchers are maintained separately.
             try:
                 import shutil as _sh
 
                 src_raw = DATA_DIR / "exports" / "latest" / "site_raw"
                 dst_raw = BASE_DIR / "CSVs" / "site_raw"
                 if src_raw.exists() and dst_raw.exists():
-                    for fname in ("ktc.csv", "idpTradeCalc.csv"):
+                    scraper_owned_site_raw = (
+                        "ktc.csv",
+                        "ktcSfTep.csv",
+                        "ktcCrowdSfTep.csv",
+                        "ktcTradesSfTep.csv",
+                        "ktcCrowdTradesSfTep.csv",
+                        "idpTradeCalc.csv",
+                    )
+                    for fname in scraper_owned_site_raw:
                         src_file = src_raw / fname
                         dst_file = dst_raw / fname
                         if src_file.exists():

--- a/server.py
+++ b/server.py
@@ -97,7 +97,7 @@ PORT = 8000
 HOST = "0.0.0.0"  # accessible from local network; use "127.0.0.1" for local only
 SCRAPE_STALL_SECONDS = int(os.getenv("SCRAPE_STALL_SECONDS", "900"))
 SCRAPE_RUN_TIMEOUT_SECONDS = int(os.getenv("SCRAPE_RUN_TIMEOUT_SECONDS", "7200"))
-# The async scraper launches a Playwright Chromium without a try/finally,
+# A single market/source outage must not halve the player universe and become\n# the new last-known-good cache. Relative to the prior/committed board, retain\n# at least 75% of the player population or fail over/block promotion.\nSCRAPE_PLAYER_RETENTION_FLOOR = 0.75\n# The async scraper launches a Playwright Chromium without a try/finally,
 # so a run-timeout cancellation skips browser.close() and orphans the
 # Chromium process tree → RAM leak across repeated 2h timeouts → OOM.
 # A single scrape_run_lock guarantees that once the scrape coroutine has
@@ -2685,27 +2685,105 @@ def _prime_latest_payload(data: dict | None, *, is_fresh_scrape: bool = False) -
     _DRAFT_CAPITAL_CACHE.clear()
 
 
+def _load_cached_payload(path: Path | None) -> dict | None:
+    if path is None or not path.exists():
+        return None
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        return payload if isinstance(payload, dict) else None
+    except Exception as exc:  # noqa: BLE001
+        log.error(f"Failed to load cached dynasty payload {path}: {exc}")
+        return None
+
+
 def load_from_disk() -> dict | None:
-    """Load most recent dynasty_data_*.json from data/ directory."""
-    json_files = sorted(DATA_DIR.glob("dynasty_data_*.json"), reverse=True)
-    if not json_files:
-        # Also check base dir for existing files from standalone scraper runs
-        json_files = sorted(BASE_DIR.glob("dynasty_data_*.json"), reverse=True)
-    if json_files:
-        try:
-            latest_path = json_files[0]
-            with open(latest_path) as f:
-                data = json.load(f)
+    """Load the newest raw payload, with a checkout-backed collapse recovery.
+
+    Runtime data/dynasty_data_*.json is normally freshest and remains the
+    first choice. The production incident on 2026-09-09 proved that an
+    accepted-but-collapsed runtime cache can survive deploys because data/
+    is intentionally untracked: service restart then faithfully re-primes the
+    broken population again even though the checked-out exports/latest
+    payload is healthy.
+
+    Compare the runtime population with the latest committed/checked-out
+    export. A >25% player-population collapse cannot plausibly be ordinary
+    dynasty churn, so recover from the checkout copy instead. This is only a
+    boot-time raw-universe choice; the canonical value engine still enriches
+    whichever raw payload wins through the same registered source CSVs.
+    """
+    runtime_files = sorted(DATA_DIR.glob("dynasty_data_*.json"), reverse=True)
+    checkout_dir = BASE_DIR / "exports" / "latest"
+    checkout_files = sorted(checkout_dir.glob("dynasty_data_*.json"), reverse=True)
+    root_files = sorted(BASE_DIR.glob("dynasty_data_*.json"), reverse=True)
+
+    runtime_path = runtime_files[0] if runtime_files else None
+    checkout_path = checkout_files[0] if checkout_files else None
+    root_path = root_files[0] if root_files else None
+
+    runtime_data = _load_cached_payload(runtime_path)
+    checkout_data = _load_cached_payload(checkout_path)
+
+    if runtime_data is not None:
+        runtime_count = len(runtime_data.get("players") or {})
+        checkout_count = len((checkout_data or {}).get("players") or {})
+        retention = (runtime_count / checkout_count) if checkout_count > 0 else 1.0
+        if (
+            checkout_data is not None
+            and checkout_count > 0
+            and retention < SCRAPE_PLAYER_RETENTION_FLOOR
+        ):
+            log.error(
+                "Runtime dynasty cache population collapsed: "
+                f"{runtime_count}/{checkout_count} players "
+                f"({retention:.1%} retained; floor={SCRAPE_PLAYER_RETENTION_FLOOR:.0%}). "
+                f"Recovering from checked-out export {checkout_path}."
+            )
             _set_latest_data_source(
-                "disk_cache", str(latest_path), produced_at=data.get("scrapeTimestamp")
+                "checkout_recovery",
+                str(checkout_path),
+                produced_at=checkout_data.get("scrapeTimestamp"),
             )
-            log.info(
-                f"Loaded cached data from {latest_path.name} "
-                f"({len(data.get('players', {}))} players)"
-            )
-            return data
-        except Exception as e:
-            log.error(f"Failed to load {json_files[0]}: {e}")
+            return checkout_data
+
+        _set_latest_data_source(
+            "disk_cache",
+            str(runtime_path),
+            produced_at=runtime_data.get("scrapeTimestamp"),
+        )
+        log.info(
+            f"Loaded cached data from {runtime_path.name} "
+            f"({runtime_count} players)"
+        )
+        return runtime_data
+
+    if checkout_data is not None:
+        checkout_count = len(checkout_data.get("players") or {})
+        _set_latest_data_source(
+            "checkout_cache",
+            str(checkout_path),
+            produced_at=checkout_data.get("scrapeTimestamp"),
+        )
+        log.warning(
+            f"Runtime cache unavailable; loaded checked-out export "
+            f"{checkout_path.name} ({checkout_count} players)"
+        )
+        return checkout_data
+
+    root_data = _load_cached_payload(root_path)
+    if root_data is not None:
+        _set_latest_data_source(
+            "root_cache",
+            str(root_path),
+            produced_at=root_data.get("scrapeTimestamp"),
+        )
+        log.warning(
+            f"Loaded legacy root cache {root_path.name} "
+            f"({len(root_data.get('players') or {})} players)"
+        )
+        return root_data
+
     return None
 
 
@@ -2831,14 +2909,6 @@ async def run_scraper(trigger: str = "manual") -> dict | None:
                         dst_file = dst_raw / fname
                         if src_file.exists():
                             _sh.copy2(src_file, dst_file)
-                    # Also mirror the full dynasty_data JSON so other
-                    # consumers (tests, CLI tools) see the fresh file.
-                    date_str = str(result.get("date") or "")
-                    if date_str:
-                        src_json = DATA_DIR / "exports" / "latest" / f"dynasty_data_{date_str}.json"
-                        dst_json = BASE_DIR / "exports" / "latest" / f"dynasty_data_{date_str}.json"
-                        if src_json.exists():
-                            _sh.copy2(src_json, dst_json)
             except Exception as _mirror_err:
                 log.warning(f"Post-scrape CSV mirror failed: {_mirror_err}")
 
@@ -3017,11 +3087,29 @@ async def run_scraper(trigger: str = "manual") -> dict | None:
             # particular is the IDP backbone and 90% of every IDP value
             # under alpha-shrinkage.
             missing_anchors = _missing_expected_sites(result)
-            if missing_anchors or (total_sites > 0 and site_count < total_sites / 2):
+            previous_player_count = len((latest_data or {}).get("players") or {})
+            player_retention = (
+                player_count / previous_player_count if previous_player_count > 0 else 1.0
+            )
+            population_collapsed = (
+                previous_player_count > 0
+                and player_retention < SCRAPE_PLAYER_RETENTION_FLOOR
+            )
+            if (
+                missing_anchors
+                or (total_sites > 0 and site_count < total_sites / 2)
+                or population_collapsed
+            ):
                 anchor_note = (
                     f"MISSING ANCHOR SOURCE(S): {', '.join(missing_anchors)}"
                     if missing_anchors
-                    else f"only {site_count}/{total_sites} sites"
+                    else (
+                        f"PLAYER POPULATION COLLAPSE: {player_count}/{previous_player_count} "
+                        f"({player_retention:.1%} retained; "
+                        f"floor={SCRAPE_PLAYER_RETENTION_FLOOR:.0%})"
+                        if population_collapsed
+                        else f"only {site_count}/{total_sites} sites"
+                    )
                 )
                 log.warning(
                     f"PARTIAL SCRAPE NOT PROMOTED — {anchor_note}; "
@@ -3072,8 +3160,35 @@ async def run_scraper(trigger: str = "manual") -> dict | None:
                     ),
                 )
 
-            latest_data = result
+            # The full raw export becomes checkout-visible only AFTER all
+            # promotion guards pass. Before 2026-09-09 this copy happened
+            # above the guard, so a refused partial scrape could overwrite the
+            # working-tree recovery artifact even while memory kept the LKG.
             result_date = str(result.get("date") or "").strip()
+            if result_date:
+                try:
+                    import shutil as _sh
+
+                    src_json = (
+                        DATA_DIR
+                        / "exports"
+                        / "latest"
+                        / f"dynasty_data_{result_date}.json"
+                    )
+                    dst_json = (
+                        BASE_DIR
+                        / "exports"
+                        / "latest"
+                        / f"dynasty_data_{result_date}.json"
+                    )
+                    if src_json.exists():
+                        _sh.copy2(src_json, dst_json)
+                except Exception as _export_mirror_err:  # noqa: BLE001
+                    log.warning(
+                        f"Post-promotion dynasty_data mirror failed: {_export_mirror_err}"
+                    )
+
+            latest_data = result
             source_path = ""
             if result_date:
                 candidate = DATA_DIR / f"dynasty_data_{result_date}.json"

--- a/server.py
+++ b/server.py
@@ -2756,10 +2756,7 @@ def load_from_disk() -> dict | None:
             str(runtime_path),
             produced_at=runtime_data.get("scrapeTimestamp"),
         )
-        log.info(
-            f"Loaded cached data from {runtime_path.name} "
-            f"({runtime_count} players)"
-        )
+        log.info(f"Loaded cached data from {runtime_path.name} " f"({runtime_count} players)")
         return runtime_data
 
     if checkout_data is not None:
@@ -3096,8 +3093,7 @@ async def run_scraper(trigger: str = "manual") -> dict | None:
                 player_count / previous_player_count if previous_player_count > 0 else 1.0
             )
             population_collapsed = (
-                previous_player_count > 0
-                and player_retention < SCRAPE_PLAYER_RETENTION_FLOOR
+                previous_player_count > 0 and player_retention < SCRAPE_PLAYER_RETENTION_FLOOR
             )
             if (
                 missing_anchors
@@ -3173,24 +3169,12 @@ async def run_scraper(trigger: str = "manual") -> dict | None:
                 try:
                     import shutil as _sh
 
-                    src_json = (
-                        DATA_DIR
-                        / "exports"
-                        / "latest"
-                        / f"dynasty_data_{result_date}.json"
-                    )
-                    dst_json = (
-                        BASE_DIR
-                        / "exports"
-                        / "latest"
-                        / f"dynasty_data_{result_date}.json"
-                    )
+                    src_json = DATA_DIR / "exports" / "latest" / f"dynasty_data_{result_date}.json"
+                    dst_json = BASE_DIR / "exports" / "latest" / f"dynasty_data_{result_date}.json"
                     if src_json.exists():
                         _sh.copy2(src_json, dst_json)
                 except Exception as _export_mirror_err:  # noqa: BLE001
-                    log.warning(
-                        f"Post-promotion dynasty_data mirror failed: {_export_mirror_err}"
-                    )
+                    log.warning(f"Post-promotion dynasty_data mirror failed: {_export_mirror_err}")
 
             latest_data = result
             source_path = ""

--- a/tests/api/test_degraded_board_recovery.py
+++ b/tests/api/test_degraded_board_recovery.py
@@ -69,7 +69,9 @@ def test_active_reprime_waits_for_healthy_coverage(monkeypatch) -> None:
     monkeypatch.setattr(live_cov.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(live_cov, "_COVERAGE_WAIT_ATTEMPTS", 3)
     monkeypatch.setattr(live_cov, "_COVERAGE_WAIT_SLEEP_SECONDS", 0)
-    monkeypatch.setattr(live_cov.sys, "argv", ["verify_live_source_coverage.py", "http://localhost"])
+    monkeypatch.setattr(
+        live_cov.sys, "argv", ["verify_live_source_coverage.py", "http://localhost"]
+    )
 
     assert live_cov.main() == 0
     assert calls == ["degraded", "healthy"]
@@ -90,7 +92,9 @@ def test_idle_degraded_board_fails_without_wait_loop(monkeypatch) -> None:
     )
     monkeypatch.setattr(live_cov.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(live_cov, "_COVERAGE_WAIT_ATTEMPTS", 3)
-    monkeypatch.setattr(live_cov.sys, "argv", ["verify_live_source_coverage.py", "http://localhost"])
+    monkeypatch.setattr(
+        live_cov.sys, "argv", ["verify_live_source_coverage.py", "http://localhost"]
+    )
 
     assert live_cov.main() == 1
     assert calls == ["fetch"]
@@ -111,7 +115,9 @@ def test_stalled_scrape_does_not_mask_degraded_board(monkeypatch) -> None:
     )
     monkeypatch.setattr(live_cov.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(live_cov, "_COVERAGE_WAIT_ATTEMPTS", 3)
-    monkeypatch.setattr(live_cov.sys, "argv", ["verify_live_source_coverage.py", "http://localhost"])
+    monkeypatch.setattr(
+        live_cov.sys, "argv", ["verify_live_source_coverage.py", "http://localhost"]
+    )
 
     assert live_cov.main() == 1
     assert calls == ["fetch"]
@@ -127,9 +133,7 @@ def _write_raw_payload(path: Path, player_count: int, stamp: str) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
-def test_startup_recovers_from_collapsed_persistent_runtime_cache(
-    tmp_path, monkeypatch
-) -> None:
+def test_startup_recovers_from_collapsed_persistent_runtime_cache(tmp_path, monkeypatch) -> None:
     data_dir = tmp_path / "data"
     checkout = tmp_path / "exports" / "latest" / "dynasty_data_2026-09-09.json"
     runtime = data_dir / "dynasty_data_2026-09-09.json"

--- a/tests/api/test_degraded_board_recovery.py
+++ b/tests/api/test_degraded_board_recovery.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import ast
+import json
 from pathlib import Path
+
+import server as srv
 
 from scripts import verify_live_source_coverage as live_cov
 from src.sources.ktc_value_sources import KTC_SOURCE_FILE_KEYS
@@ -112,3 +115,63 @@ def test_stalled_scrape_does_not_mask_degraded_board(monkeypatch) -> None:
 
     assert live_cov.main() == 1
     assert calls == ["fetch"]
+
+
+def _write_raw_payload(path: Path, player_count: int, stamp: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "date": "2026-09-09",
+        "scrapeTimestamp": stamp,
+        "players": {f"Player {i}": {"position": "WR"} for i in range(player_count)},
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_startup_recovers_from_collapsed_persistent_runtime_cache(
+    tmp_path, monkeypatch
+) -> None:
+    data_dir = tmp_path / "data"
+    checkout = tmp_path / "exports" / "latest" / "dynasty_data_2026-09-09.json"
+    runtime = data_dir / "dynasty_data_2026-09-09.json"
+
+    # Reproduce the incident shape: ignored/persistent runtime cache collapsed
+    # to roughly half the committed player universe.
+    _write_raw_payload(runtime, 531, "2026-09-09T19:40:00+00:00")
+    _write_raw_payload(checkout, 1055, "2026-09-09T16:59:50+00:00")
+
+    monkeypatch.setattr(srv, "DATA_DIR", data_dir)
+    monkeypatch.setattr(srv, "BASE_DIR", tmp_path)
+
+    recovered = srv.load_from_disk()
+
+    assert recovered is not None
+    assert len(recovered["players"]) == 1055
+    assert srv.latest_data_source["type"] == "checkout_recovery"
+    assert srv.latest_data_source["path"] == str(checkout)
+
+
+def test_startup_keeps_runtime_cache_when_population_is_not_collapsed(
+    tmp_path, monkeypatch
+) -> None:
+    data_dir = tmp_path / "data"
+    checkout = tmp_path / "exports" / "latest" / "dynasty_data_2026-09-09.json"
+    runtime = data_dir / "dynasty_data_2026-09-09.json"
+
+    _write_raw_payload(runtime, 950, "2026-09-09T19:40:00+00:00")
+    _write_raw_payload(checkout, 1055, "2026-09-09T16:59:50+00:00")
+
+    monkeypatch.setattr(srv, "DATA_DIR", data_dir)
+    monkeypatch.setattr(srv, "BASE_DIR", tmp_path)
+
+    loaded = srv.load_from_disk()
+
+    assert loaded is not None
+    assert len(loaded["players"]) == 950
+    assert srv.latest_data_source["type"] == "disk_cache"
+
+
+def test_scrape_promotion_has_relative_population_collapse_guard() -> None:
+    text = (ROOT / "server.py").read_text(encoding="utf-8")
+    assert "population_collapsed" in text
+    assert "player_retention < SCRAPE_PLAYER_RETENTION_FLOOR" in text
+    assert "PLAYER POPULATION COLLAPSE" in text

--- a/tests/api/test_degraded_board_recovery.py
+++ b/tests/api/test_degraded_board_recovery.py
@@ -1,0 +1,114 @@
+"""Regression tests for the 2026-09-09 degraded-board production incident."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from scripts import verify_live_source_coverage as live_cov
+from src.sources.ktc_value_sources import KTC_SOURCE_FILE_KEYS
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _server_scraper_owned_mirror_files() -> set[str]:
+    tree = ast.parse((ROOT / "server.py").read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "scraper_owned_site_raw"
+            for target in node.targets
+        ):
+            continue
+        assert isinstance(node.value, (ast.Tuple, ast.List))
+        return {
+            value.value
+            for value in node.value.elts
+            if isinstance(value, ast.Constant) and isinstance(value.value, str)
+        }
+    raise AssertionError("server.py has no scraper_owned_site_raw mirror declaration")
+
+
+def test_post_scrape_mirror_includes_complete_ktc_three_source_family() -> None:
+    mirrored = _server_scraper_owned_mirror_files()
+    expected = {
+        "ktc.csv",
+        "ktcSfTep.csv",
+        "idpTradeCalc.csv",
+        *(f"{file_key}.csv" for file_key in KTC_SOURCE_FILE_KEYS.values()),
+    }
+    assert expected <= mirrored
+
+
+def test_active_reprime_waits_for_healthy_coverage(monkeypatch) -> None:
+    statuses = iter(
+        [
+            {"running": True, "stalled": False, "hung": False, "phase": "degraded"},
+            {"running": False, "stalled": False, "hung": False, "phase": "healthy"},
+        ]
+    )
+    calls = []
+
+    def fake_fetch(_base_url: str):
+        status = next(statuses)
+        calls.append(status["phase"])
+        return status
+
+    def fake_coverage(status: dict):
+        if status["phase"] == "degraded":
+            return [("dlfSf", 0)], [], []
+        return [], ["dlfSf"], []
+
+    monkeypatch.setattr(live_cov, "_fetch_status", fake_fetch)
+    monkeypatch.setattr(live_cov, "_coverage_result", fake_coverage)
+    monkeypatch.setattr(live_cov.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(live_cov, "_COVERAGE_WAIT_ATTEMPTS", 3)
+    monkeypatch.setattr(live_cov, "_COVERAGE_WAIT_SLEEP_SECONDS", 0)
+    monkeypatch.setattr(live_cov.sys, "argv", ["verify_live_source_coverage.py", "http://localhost"])
+
+    assert live_cov.main() == 0
+    assert calls == ["degraded", "healthy"]
+
+
+def test_idle_degraded_board_fails_without_wait_loop(monkeypatch) -> None:
+    calls = []
+
+    def fake_fetch(_base_url: str):
+        calls.append("fetch")
+        return {"running": False, "stalled": False, "hung": False}
+
+    monkeypatch.setattr(live_cov, "_fetch_status", fake_fetch)
+    monkeypatch.setattr(
+        live_cov,
+        "_coverage_result",
+        lambda _status: ([("dlfSf", 0)], [], []),
+    )
+    monkeypatch.setattr(live_cov.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(live_cov, "_COVERAGE_WAIT_ATTEMPTS", 3)
+    monkeypatch.setattr(live_cov.sys, "argv", ["verify_live_source_coverage.py", "http://localhost"])
+
+    assert live_cov.main() == 1
+    assert calls == ["fetch"]
+
+
+def test_stalled_scrape_does_not_mask_degraded_board(monkeypatch) -> None:
+    calls = []
+
+    def fake_fetch(_base_url: str):
+        calls.append("fetch")
+        return {"running": True, "stalled": True, "hung": True}
+
+    monkeypatch.setattr(live_cov, "_fetch_status", fake_fetch)
+    monkeypatch.setattr(
+        live_cov,
+        "_coverage_result",
+        lambda _status: ([("dlfSf", 0)], [], []),
+    )
+    monkeypatch.setattr(live_cov.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(live_cov, "_COVERAGE_WAIT_ATTEMPTS", 3)
+    monkeypatch.setattr(live_cov.sys, "argv", ["verify_live_source_coverage.py", "http://localhost"])
+
+    assert live_cov.main() == 1
+    assert calls == ["fetch"]

--- a/tests/api/test_waiver_best_available_idp_endpoint.py
+++ b/tests/api/test_waiver_best_available_idp_endpoint.py
@@ -97,8 +97,12 @@ def _install_contract(monkeypatch, league_key, rows, *, rostered=None):
 
 
 def test_503_when_no_contract_loaded(idp_env, monkeypatch):
-    monkeypatch.setattr(server, "latest_contract_data", {})
+    # TestClient startup now legitimately primes the checkout-backed recovery
+    # payload when no persistent runtime cache exists. Clear the contract
+    # after startup so this test still exercises the endpoint's true
+    # no-contract behavior instead of racing app initialization.
     with TestClient(server.app, raise_server_exceptions=True) as c:
+        monkeypatch.setattr(server, "latest_contract_data", {})
         res = c.post("/api/waiver/best-available-idp", json={})
     assert res.status_code == 503
 


### PR DESCRIPTION
Production incident repair for the 2026-09-09 rankings/trade-history collapse.

Observed production evidence:
- the 19:01 UTC deploy attempt failed because the served board carried dlfSf=0, dynastyNerdsSfTep=1, fantasyProsFitzmaurice=0, flockFantasySfRookies=0 and dlfRookieSf=2;
- deploy auto-rollback then failed the same served-source gate, leaving manual intervention required;
- the broken UI showed a 531-player universe while the checked-in latest raw export carries 1,055 players;
- Trade History prices through the same canonical rows, so the board collapse makes historical assets unpriced.

This PR repairs the recovery path rather than masking the UI:
1. boot-time runtime-cache recovery: if persistent data/dynasty_data_*.json retains <75% of the checked-out latest export's player population, use the checked-out export for re-prime;
2. scrape promotion guard: refuse a new raw scrape that collapses below 75% of the current LKG population;
3. move the full dynasty_data mirror to AFTER promotion guards, so a refused partial scrape cannot overwrite the checkout recovery artifact;
4. mirror the complete KTC three-source family (Crowd / Trades / Crowd+Trades + legacy KTC files) back to repo-root site_raw before canonical rebuild;
5. make the served-source deploy gate wait, bounded, while an active non-stalled startup scrape is legitimately rebuilding; idle/stalled degradation still fails immediately;
6. regression tests reproduce the 531-vs-1,055 startup collapse, KTC mirror completeness, active-reprime wait, and fail-fast degraded states.

Do not merge unless PR Validation is green. After merge, production deploy must pass the served-board source-coverage gate; verify the board population/top ranks and Trade History values before declaring recovery.