### PR TITLE
HOTFIX: recover source-collapsed startup contract

### DIFF
--- a/server.py
+++ b/server.py
@@ -2788,6 +2788,71 @@ def load_from_disk() -> dict | None:
     return None
 
 
+def _recover_startup_contract_from_checkout(initial_data: dict | None) -> dict | None:
+    """Recover from a full-size runtime cache that builds a degraded contract.
+
+    The 2026-09-09 production incident showed that raw player-count retention
+    is necessary but insufficient: a persistent runtime payload can retain the
+    full player universe while identity/source joins collapse, leaving fresh
+    registered sources absent from the served canonical board.
+
+    Startup first primes the normal runtime cache. If that contract validates
+    unhealthy, try the checked-out latest export through the exact same
+    canonical build path. Keep the checkout generation only when it validates
+    healthy; otherwise restore the original runtime generation. This makes the
+    fallback evidence-based and cannot silently replace one bad board with
+    another.
+    """
+    if not initial_data:
+        return initial_data
+    if latest_data_source.get("type") != "disk_cache":
+        return initial_data
+    if bool((contract_health or {}).get("ok")):
+        return initial_data
+
+    checkout_files = sorted(
+        (BASE_DIR / "exports" / "latest").glob("dynasty_data_*.json"),
+        reverse=True,
+    )
+    checkout_path = checkout_files[0] if checkout_files else None
+    checkout_data = _load_cached_payload(checkout_path)
+    if checkout_data is None or checkout_path is None:
+        log.error(
+            "Startup contract is degraded and no checked-out recovery payload is available."
+        )
+        return initial_data
+
+    original_source = dict(latest_data_source)
+    original_errors = list((contract_health or {}).get("errors") or [])
+    _set_latest_data_source(
+        "checkout_contract_recovery",
+        str(checkout_path),
+        produced_at=checkout_data.get("scrapeTimestamp"),
+    )
+    _prime_latest_payload(checkout_data)
+
+    if bool((contract_health or {}).get("ok")):
+        log.error(
+            "Persistent runtime cache built a degraded canonical contract; "
+            "recovered from checked-out export %s. Initial errors: %s",
+            checkout_path,
+            "; ".join(original_errors[:5]) or "<none reported>",
+        )
+        return checkout_data
+
+    log.error(
+        "Checked-out startup recovery payload also built an invalid contract; "
+        "restoring persistent runtime generation."
+    )
+    _set_latest_data_source(
+        str(original_source.get("type") or "disk_cache"),
+        str(original_source.get("path") or ""),
+        produced_at=original_source.get("producedAt"),
+    )
+    _prime_latest_payload(initial_data)
+    return initial_data
+
+
 def _latest_file(directory: Path, pattern: str) -> Path | None:
     if not directory.exists():
         return None
@@ -3366,6 +3431,7 @@ async def lifespan(app: FastAPI):
     # 1. Load cached data immediately so the dashboard is usable right away
     latest_data = load_from_disk()
     _prime_latest_payload(latest_data)
+    latest_data = _recover_startup_contract_from_checkout(latest_data)
     if latest_data:
         log.info("Dashboard ready with cached data")
     else:

--- a/server.py
+++ b/server.py
@@ -2817,9 +2817,7 @@ def _recover_startup_contract_from_checkout(initial_data: dict | None) -> dict |
     checkout_path = checkout_files[0] if checkout_files else None
     checkout_data = _load_cached_payload(checkout_path)
     if checkout_data is None or checkout_path is None:
-        log.error(
-            "Startup contract is degraded and no checked-out recovery payload is available."
-        )
+        log.error("Startup contract is degraded and no checked-out recovery payload is available.")
         return initial_data
 
     original_source = dict(latest_data_source)

--- a/tests/api/test_degraded_board_recovery.py
+++ b/tests/api/test_degraded_board_recovery.py
@@ -180,6 +180,7 @@ def test_scrape_promotion_has_relative_population_collapse_guard() -> None:
     assert "player_retention < SCRAPE_PLAYER_RETENTION_FLOOR" in text
     assert "PLAYER POPULATION COLLAPSE" in text
 
+
 def _write_marked_payload(path: Path, marker: str, player_count: int = 100) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {

--- a/tests/api/test_degraded_board_recovery.py
+++ b/tests/api/test_degraded_board_recovery.py
@@ -272,4 +272,3 @@ def test_startup_contract_recovery_restores_runtime_if_checkout_is_also_invalid(
     assert calls == ["runtime", "checkout", "runtime"]
     assert srv.latest_data_source["type"] == "disk_cache"
     assert srv.latest_data_source["path"] == str(runtime)
-

--- a/tests/api/test_degraded_board_recovery.py
+++ b/tests/api/test_degraded_board_recovery.py
@@ -179,3 +179,96 @@ def test_scrape_promotion_has_relative_population_collapse_guard() -> None:
     assert "population_collapsed" in text
     assert "player_retention < SCRAPE_PLAYER_RETENTION_FLOOR" in text
     assert "PLAYER POPULATION COLLAPSE" in text
+
+def _write_marked_payload(path: Path, marker: str, player_count: int = 100) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "date": "2026-09-09",
+        "scrapeTimestamp": "2026-09-09T20:00:00+00:00",
+        "marker": marker,
+        "players": {f"Player {i}": {"position": "WR"} for i in range(player_count)},
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_startup_recovers_when_full_size_runtime_builds_degraded_contract(
+    tmp_path, monkeypatch
+) -> None:
+    data_dir = tmp_path / "data"
+    runtime = data_dir / "dynasty_data_2026-09-09.json"
+    checkout = tmp_path / "exports" / "latest" / "dynasty_data_2026-09-09.json"
+    _write_marked_payload(runtime, "runtime", 100)
+    _write_marked_payload(checkout, "checkout", 100)
+
+    monkeypatch.setattr(srv, "DATA_DIR", data_dir)
+    monkeypatch.setattr(srv, "BASE_DIR", tmp_path)
+    monkeypatch.setattr(srv, "contract_health", {})
+    monkeypatch.setattr(srv, "served_source_coverage", {})
+
+    loaded = srv.load_from_disk()
+    assert loaded is not None
+    assert loaded["marker"] == "runtime"
+    assert srv.latest_data_source["type"] == "disk_cache"
+
+    calls: list[str] = []
+
+    def fake_prime(data, *, is_fresh_scrape=False):
+        del is_fresh_scrape
+        marker = data["marker"]
+        calls.append(marker)
+        if marker == "runtime":
+            srv.contract_health = {
+                "ok": False,
+                "errors": ["source_missing:dlfSf", "source_missing:fantasyProsFitzmaurice"],
+            }
+            srv.served_source_coverage = {"dlfSf": 0, "fantasyProsFitzmaurice": 0}
+        else:
+            srv.contract_health = {"ok": True, "errors": []}
+            srv.served_source_coverage = {"dlfSf": 280, "fantasyProsFitzmaurice": 299}
+
+    monkeypatch.setattr(srv, "_prime_latest_payload", fake_prime)
+
+    fake_prime(loaded)
+    recovered = srv._recover_startup_contract_from_checkout(loaded)
+
+    assert recovered is not None
+    assert recovered["marker"] == "checkout"
+    assert calls == ["runtime", "checkout"]
+    assert srv.contract_health["ok"] is True
+    assert srv.latest_data_source["type"] == "checkout_contract_recovery"
+    assert srv.latest_data_source["path"] == str(checkout)
+
+
+def test_startup_contract_recovery_restores_runtime_if_checkout_is_also_invalid(
+    tmp_path, monkeypatch
+) -> None:
+    data_dir = tmp_path / "data"
+    runtime = data_dir / "dynasty_data_2026-09-09.json"
+    checkout = tmp_path / "exports" / "latest" / "dynasty_data_2026-09-09.json"
+    _write_marked_payload(runtime, "runtime", 100)
+    _write_marked_payload(checkout, "checkout", 100)
+
+    monkeypatch.setattr(srv, "DATA_DIR", data_dir)
+    monkeypatch.setattr(srv, "BASE_DIR", tmp_path)
+    monkeypatch.setattr(srv, "contract_health", {})
+
+    loaded = srv.load_from_disk()
+    assert loaded is not None
+
+    calls: list[str] = []
+
+    def fake_prime(data, *, is_fresh_scrape=False):
+        del is_fresh_scrape
+        calls.append(data["marker"])
+        srv.contract_health = {"ok": False, "errors": ["source_missing:dlfSf"]}
+
+    monkeypatch.setattr(srv, "_prime_latest_payload", fake_prime)
+
+    fake_prime(loaded)
+    recovered = srv._recover_startup_contract_from_checkout(loaded)
+
+    assert recovered is loaded
+    assert calls == ["runtime", "checkout", "runtime"]
+    assert srv.latest_data_source["type"] == "disk_cache"
+    assert srv.latest_data_source["path"] == str(runtime)
+


### PR DESCRIPTION
Production follow-up to #1321. The post-merge deploy proved the persistent runtime cache can retain a full raw player population while still building an invalid/source-collapsed canonical contract, so the 75% player-count guard alone does not fire. This hotfix makes startup validate the contract built from the runtime cache, try the checked-out latest export through the same canonical build path when that contract is unhealthy, and keep the checkout generation only if it validates healthy; otherwise it restores the runtime generation. Regression coverage reproduces equal-size runtime/checkout payloads where only the runtime-built contract is degraded, plus the fail-closed case where checkout is also invalid.