### PR TITLE
Fix local Astra readiness preflight

### DIFF
--- a/docs/AGENT_OPERATING_SYSTEM.md
+++ b/docs/AGENT_OPERATING_SYSTEM.md
@@ -48,7 +48,7 @@ Root `CLAUDE.md` contains Claude Code imports for the same shared system, includ
 
 Other provider adapters point to `AI_INSTRUCTIONS.md`; none owns separate semantics.
 
-The existing SessionStart router then reads the same working-tree Agent OS bytes and emits one concise receipt line:
+The existing SessionStart router then reads the same working-tree Agent OS content through Git's normalization rules and emits one concise receipt line:
 
 `AGENT OS LOAD RECEIPT: loaded=<sha> head_blob=<sha|UNKNOWN> repo_head=<sha|UNKNOWN> dirty=<true|false|UNKNOWN> at=<utc>`
 
@@ -58,10 +58,10 @@ It also atomically writes the same provenance to the local ignored file:
 
 The receipt records:
 - `AGENT_OS_PATH`
-- `AGENT_OS_LOADED_BLOB_SHA` — Git blob hash of the exact working-tree bytes read by the receipt harness;
+- `AGENT_OS_LOADED_BLOB_SHA` — Git blob hash of the exact working-tree content read by the receipt harness, after the same clean/filter normalization Git uses for that path;
 - `AGENT_OS_HEAD_BLOB_SHA` — committed `HEAD` blob for the Agent OS, or `UNKNOWN`;
 - `REPO_HEAD_SHA` — repository `HEAD`, or `UNKNOWN`;
-- `AGENT_OS_DIRTY` — `true` when loaded bytes differ from the committed HEAD blob, `false` when they match, otherwise `UNKNOWN`;
+- `AGENT_OS_DIRTY` — `true` when the loaded, Git-normalized working-tree content differs from the committed HEAD blob, `false` when they match, otherwise `UNKNOWN`;
 - `LOADED_AT_UTC`.
 
 For every material LLM/agent session:

--- a/frontend/__tests__/legacy-power-engine-retired.test.js
+++ b/frontend/__tests__/legacy-power-engine-retired.test.js
@@ -10,9 +10,10 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import * as url from "node:url";
 import { describe, expect, it } from "vitest";
 
-const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const ROOT = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), "..");
 
 describe("legacy power engine retirement", () => {
   it("the legacy renderer file does not exist", () => {

--- a/frontend/__tests__/service-worker-public-league-cache.test.js
+++ b/frontend/__tests__/service-worker-public-league-cache.test.js
@@ -1,10 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
+import * as url from "node:url";
 import vm from "node:vm";
 
 import { describe, expect, it, vi } from "vitest";
 
-const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const ROOT = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), "..");
 const SERVICE_WORKER_SOURCE = fs.readFileSync(
   path.join(ROOT, "public", "sw.js"),
   "utf8",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "react-dom": "19.2.8"
       },
       "devDependencies": {
-        "@testing-library/jest-dom": "^7.0.1",
+        "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.3",
         "@testing-library/user-event": "^14.6.7",
         "@vitejs/plugin-react": "^6.1.1",
@@ -1210,9 +1210,9 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
-      "integrity": "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1224,18 +1224,9 @@
         "redent": "^3.0.0"
       },
       "engines": {
-        "node": ">=22",
+        "node": ">=14",
         "npm": ">=6",
         "yarn": ">=1"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": ">=10 <11",
-        "vitest": ">= 0.32"
-      },
-      "peerDependenciesMeta": {
-        "vitest": {
-          "optional": true
-        }
       }
     },
     "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "react-dom": "19.2.8"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^7.0.1",
+    "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.3",
     "@testing-library/user-event": "^14.6.7",
     "@vitejs/plugin-react": "^6.1.1",

--- a/scripts/agent_os_receipt.py
+++ b/scripts/agent_os_receipt.py
@@ -18,13 +18,12 @@ RECEIPT_PATH = RECEIPT_DIR / "latest.env"
 UNKNOWN = "UNKNOWN"
 
 
-def _git_text(*args: str, input_bytes: bytes | None = None) -> str:
+def _git_text(*args: str) -> str:
     """Return stripped git stdout, or UNKNOWN when the fact cannot be proven."""
     try:
         result = subprocess.run(
             ["git", *args],
             cwd=REPO,
-            input=input_bytes,
             capture_output=True,
             timeout=5,
             check=False,
@@ -36,20 +35,18 @@ def _git_text(*args: str, input_bytes: bytes | None = None) -> str:
     return result.stdout.decode(errors="replace").strip()
 
 
-def _loaded_blob_sha(content: bytes | None) -> str:
-    if content is None:
+def _working_tree_blob_sha(path: Path) -> str:
+    """Hash a working-tree file using Git's own clean/filter rules."""
+    try:
+        rel_path = path.relative_to(REPO).as_posix()
+    except ValueError:
         return UNKNOWN
-    return _git_text("hash-object", "--stdin", input_bytes=content)
+    return _git_text("hash-object", rel_path)
 
 
 def build_receipt() -> dict[str, str]:
     """Build receipt fields from observable local repository state only."""
-    try:
-        content = AGENT_OS.read_bytes()
-    except Exception:
-        content = None
-
-    loaded_sha = _loaded_blob_sha(content)
+    loaded_sha = _working_tree_blob_sha(AGENT_OS)
     head_blob_sha = _git_text("rev-parse", f"HEAD:{AGENT_OS_REL.as_posix()}")
     repo_head_sha = _git_text("rev-parse", "HEAD")
 

--- a/tests/deploy/test_backup_root_resolution.py
+++ b/tests/deploy/test_backup_root_resolution.py
@@ -44,6 +44,12 @@ REPO = Path(__file__).resolve().parents[2]
 PROOF = REPO / "deploy" / "diagnostics" / "retention_backup_restore_proof.sh"
 LIB = REPO / "deploy" / "backup" / "backup_root_lib.sh"
 
+if not hasattr(os, "geteuid"):
+    pytest.skip(
+        "Unix uid/permission semantics are not available on Windows",
+        allow_module_level=True,
+    )
+
 pytestmark = pytest.mark.skipif(shutil.which("bash") is None, reason="bash required")
 
 # ONE clock, read ONCE, for the whole module.

--- a/tests/deploy/test_rollback_first_deploy.py
+++ b/tests/deploy/test_rollback_first_deploy.py
@@ -36,14 +36,20 @@ separately by calling the functions directly.
 
 from __future__ import annotations
 
-import grp
 import os
-import pwd
 import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
+
+if not hasattr(os, "geteuid"):
+    pytest.skip(
+        "Unix uid/permission semantics are not available on Windows",
+        allow_module_level=True,
+    )
+grp = pytest.importorskip("grp", reason="Unix group database is not available on Windows")
+pwd = pytest.importorskip("pwd", reason="Unix password database is not available on Windows")
 
 REPO = Path(__file__).resolve().parents[2]
 ROLLBACK = REPO / "deploy" / "rollback.sh"

--- a/tests/deploy/test_runtime_convergence.py
+++ b/tests/deploy/test_runtime_convergence.py
@@ -32,9 +32,7 @@ which the reconciler ignores unless the harness sets
 
 from __future__ import annotations
 
-import grp
 import os
-import pwd
 import re
 import shutil
 import subprocess
@@ -42,6 +40,14 @@ import textwrap
 from pathlib import Path
 
 import pytest
+
+if not hasattr(os, "geteuid"):
+    pytest.skip(
+        "Unix uid/permission semantics are not available on Windows",
+        allow_module_level=True,
+    )
+grp = pytest.importorskip("grp", reason="Unix group database is not available on Windows")
+pwd = pytest.importorskip("pwd", reason="Unix password database is not available on Windows")
 
 REPO = Path(__file__).resolve().parents[2]
 RECONCILER = REPO / "deploy" / "reconcile-runtime-controls.sh"

--- a/tests/docs/test_agent_os_receipt.py
+++ b/tests/docs/test_agent_os_receipt.py
@@ -38,7 +38,10 @@ def _load_receipt_module():
 
 
 def test_agent_os_receipt_matches_loaded_bytes_head_and_repo_state():
-    expected_loaded = _git("hash-object", "--no-filters", str(AGENT_OS))
+    for tmp_receipt in RECEIPT.parent.glob(".latest.*.tmp"):
+        tmp_receipt.unlink()
+
+    expected_loaded = _git("hash-object", "docs/AGENT_OPERATING_SYSTEM.md")
     expected_head_blob = _git("rev-parse", "HEAD:docs/AGENT_OPERATING_SYSTEM.md")
     expected_repo_head = _git("rev-parse", "HEAD")
 
@@ -86,6 +89,91 @@ def test_receipt_degrades_unprovable_state_to_unknown(monkeypatch, tmp_path):
     assert values["AGENT_OS_LOADED_BLOB_SHA"] == "UNKNOWN"
     assert values["AGENT_OS_HEAD_BLOB_SHA"] == "UNKNOWN"
     assert values["REPO_HEAD_SHA"] == "UNKNOWN"
+    assert values["AGENT_OS_DIRTY"] == "UNKNOWN"
+
+
+def test_clean_lf_worktree_reports_not_dirty(monkeypatch, tmp_path):
+    module = _load_receipt_module()
+    repo = tmp_path / "repo"
+    agent_os = repo / "docs" / "AGENT_OPERATING_SYSTEM.md"
+    agent_os.parent.mkdir(parents=True)
+    agent_os.write_text("line one\nline two\n", encoding="utf-8", newline="\n")
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "docs/AGENT_OPERATING_SYSTEM.md"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "add agent os"], cwd=repo, check=True, capture_output=True
+    )
+
+    monkeypatch.setattr(module, "REPO", repo)
+    monkeypatch.setattr(module, "AGENT_OS", agent_os)
+
+    values = module.build_receipt()
+
+    assert values["AGENT_OS_DIRTY"] == "false"
+    assert values["AGENT_OS_LOADED_BLOB_SHA"] == values["AGENT_OS_HEAD_BLOB_SHA"]
+
+
+def test_clean_crlf_worktree_reports_not_dirty_with_git_normalization(monkeypatch, tmp_path):
+    module = _load_receipt_module()
+    repo = tmp_path / "repo"
+    agent_os = repo / "docs" / "AGENT_OPERATING_SYSTEM.md"
+    agent_os.parent.mkdir(parents=True)
+    (repo / ".gitattributes").write_text("*.md text\n", encoding="utf-8")
+    agent_os.write_text("line one\nline two\n", encoding="utf-8", newline="\n")
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "core.autocrlf", "true"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "add", ".gitattributes", "docs/AGENT_OPERATING_SYSTEM.md"], cwd=repo, check=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "add agent os"], cwd=repo, check=True, capture_output=True
+    )
+    agent_os.write_text("line one\r\nline two\r\n", encoding="utf-8", newline="")
+
+    monkeypatch.setattr(module, "REPO", repo)
+    monkeypatch.setattr(module, "AGENT_OS", agent_os)
+
+    values = module.build_receipt()
+
+    assert values["AGENT_OS_DIRTY"] == "false"
+    assert values["AGENT_OS_LOADED_BLOB_SHA"] == values["AGENT_OS_HEAD_BLOB_SHA"]
+
+
+def test_modified_agent_os_reports_dirty(monkeypatch, tmp_path):
+    module = _load_receipt_module()
+    repo = tmp_path / "repo"
+    agent_os = repo / "docs" / "AGENT_OPERATING_SYSTEM.md"
+    agent_os.parent.mkdir(parents=True)
+    agent_os.write_text("original\n", encoding="utf-8")
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "docs/AGENT_OPERATING_SYSTEM.md"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "add agent os"], cwd=repo, check=True, capture_output=True
+    )
+    agent_os.write_text("changed\n", encoding="utf-8")
+
+    monkeypatch.setattr(module, "REPO", repo)
+    monkeypatch.setattr(module, "AGENT_OS", agent_os)
+
+    values = module.build_receipt()
+
+    assert values["AGENT_OS_DIRTY"] == "true"
+    assert values["AGENT_OS_LOADED_BLOB_SHA"] != values["AGENT_OS_HEAD_BLOB_SHA"]
+
+
+def test_unreadable_loaded_hash_reports_unknown(monkeypatch):
+    module = _load_receipt_module()
+    monkeypatch.setattr(module, "_git_text", lambda *args: module.UNKNOWN)
+
+    values = module.build_receipt()
+
+    assert values["AGENT_OS_LOADED_BLOB_SHA"] == "UNKNOWN"
     assert values["AGENT_OS_DIRTY"] == "UNKNOWN"
 
 


### PR DESCRIPTION
## Summary
- hash the Agent OS receipt through Git's normal clean/filter semantics so Windows CRLF checkouts report clean when unchanged
- classify Unix-only deployment test modules as platform-not-applicable on Windows so session-start collection remains meaningful without weakening Linux coverage
- pin @testing-library/jest-dom to the newest verified Node-20-compatible line and fix two Windows path helpers in frontend tests

## Local Verification
- Agent-OS-Receipt: 3e06a07d93136617e8757d9c0fe2f70aeb5f4892
- bash scripts/format_python_changes.sh
- python -m pytest tests/docs/test_agent_os_receipt.py tests/docs/test_agent_operating_system.py tests/docs/test_cross_model_agent_entrypoints.py -q
- python -m pytest --collect-only tests/deploy -q
- python -m pytest --collect-only -q
- npm ci (frontend; no jest-dom engine warning)
- npm test (frontend: 167 files / 2459 tests passed)
- npm run build (frontend; bundle budgets passed)
- bash scripts/agent_session_start.sh (11202 tests collected; receipt dirty=false before commit-time doc change)

## Scope
Harness/test/dependency readiness only. No product code, production verification rules, source authority, Week 1/Game Day gate, or broader Site Steward campaign work changed.